### PR TITLE
Remove padding in __res_state._u when in sandbox mode

### DIFF
--- a/include/resolv.h
+++ b/include/resolv.h
@@ -179,7 +179,10 @@ struct __res_state {
 	u_int	_pad;			/*%< make _u 64 bit aligned */
 	union {
 		/* On an 32-bit arch this means 512b total. */
-		char	pad[72 - 4*sizeof (int) - 3*sizeof (void *)];
+		/* Evil nonsensical padding that breaks CHERI sandbox mode... */
+#ifndef __CHERI_SANDBOX__
+		char    pad[72 - 4*sizeof (int) - 3*sizeof (void *)];
+#endif
 		struct {
 			u_int16_t		nscount;
 			u_int16_t		nstimes[MAXNS];	/*%< ms. */


### PR DESCRIPTION
This strange padding array's size was underflowing in sandbox mode.
Since it also seems to make very little sense, let's remove it.