### PR TITLE
Rewrite atomic.h in C.

### DIFF
--- a/sys/cddl/compat/opensolaris/kern/opensolaris_atomic.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_atomic.c
@@ -46,7 +46,7 @@ MTX_SYSINIT(atomic, &atomic_mtx, "atomic", MTX_DEF);
 static pthread_mutex_t atomic_mtx;
 
 static __attribute__((constructor)) void
-atomic_init(void)
+atomic_init_fn(void)
 {
 	pthread_mutex_init(&atomic_mtx, NULL);
 }


### PR DESCRIPTION
Tweak an opensolaris compat file to not use the name of a C standard
macro as a function name.

This should be more maintainable for CHERIBSD, as it's a single version of the functions for MIPS and CHERI and will adapt as new atomics are added in the compiler.
