### PR TITLE
Fix -g flag of atsectl

### DIFF
--- a/tools/tools/atsectl/atsectl.c
+++ b/tools/tools/atsectl/atsectl.c
@@ -204,7 +204,7 @@ _set(uint8_t *eaddr)
 		if (gflag == 0)
 			eaddr[0] |= 2;
 		else
-			eaddr[1] &= ~2;
+			eaddr[0] &= ~2;
 	} else {
 		int e;
 


### PR DESCRIPTION
Previously atsectl -gu would clear the wrong bit and generate a MAC
starting with 00:05:ed (Technikum Joanneum GmbH) instead of the correct
00:07:ed prefix.