### PR TITLE
cheritest: XFAIL cheritest_vm_notag_tmpfile_shared if /tmp is tmpfs

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -445,7 +445,7 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_mips_exccode = T_C2E,
 	  .ct_cp2_exccode = CHERI_EXCCODE_TLBSTORE,
-	  .ct_check_xfail = xfail_need_writable_tmp, },
+	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp, },
 
 	{ .ct_name = "cheritest_vm_tag_tmpfile_private",
 	  .ct_desc = "check tags are stored for tmpfile() MAP_PRIVATE pages",

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -336,6 +336,7 @@ void	cheritest_vm_tag_tmpfile_private_prefault(const struct cheri_test *ctp
 void	cheritest_vm_cow_read(const struct cheri_test *ctp);
 void	cheritest_vm_cow_write(const struct cheri_test *ctp);
 const char	*xfail_need_writable_tmp(const char *name);
+const char	*xfail_need_writable_non_tmpfs_tmp(const char *name);
 
 /* cheritest_vm_swap.c */
 void	cheritest_vm_swap(const struct cheri_test *ctp __unused);

--- a/bin/cheritest/cheritest_list_only.h
+++ b/bin/cheritest/cheritest_list_only.h
@@ -219,6 +219,7 @@
 
 #define	xfail_swap_required				NULL
 #define	xfail_need_writable_tmp				NULL
+#define	xfail_need_writable_non_tmpfs_tmp		NULL
 
 #ifdef CHERI_C_TESTS
 #define DECLARE_TEST(name, desc)				\

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -40,6 +40,7 @@
 
 #include <sys/types.h>
 #include <sys/mman.h>
+#include <sys/mount.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/ucontext.h>
@@ -310,6 +311,20 @@ xfail_need_writable_tmp(const char *name __unused)
 	}
 	reason = "/tmp is not writable";
 	return (reason);
+}
+
+const char*
+xfail_need_writable_non_tmpfs_tmp(const char *name)
+{
+	struct statfs info;
+
+	if (statfs("/tmp", &info) != 0) {
+		cheritest_failure_err("statfs /tmp");
+	}
+	if (strcmp(info.f_fstypename, "tmpfs") == 0) {
+		return ("cheritest_vm_notag_tmpfile_shared needs non-tmpfs /tmp");
+	}
+	return (xfail_need_writable_tmp(name));
 }
 
 /*


### PR DESCRIPTION
If the file is on tmpfs the tag bit will be discarded instead of an
exception being raised.