### PR TITLE
Enable tmpfs

### DIFF
--- a/sys/mips/conf/CHERI_MALTA64
+++ b/sys/mips/conf/CHERI_MALTA64
@@ -20,3 +20,4 @@ options 	KTRACE
 options 	CPU_CHERI
 options 	COMPAT_CHERIABI
 options 	KSTACK_LARGE_PAGE
+options 	TMPFS

--- a/sys/mips/conf/CHERI_TEMPLATE
+++ b/sys/mips/conf/CHERI_TEMPLATE
@@ -10,3 +10,5 @@ options 	COMPAT_CHERIABI
 options       CPU_CHERI_HW_CCALL_CHECKS
 options       CPU_CHERI_HW_RCLEAR
 options       CPU_CHERI_HW_CCLEAR
+
+options 	TMPFS

--- a/sys/mips/conf/CHERI_TEMPLATE
+++ b/sys/mips/conf/CHERI_TEMPLATE
@@ -7,8 +7,8 @@
 options 	CPU_CHERI
 options 	COMPAT_CHERIABI
 
-options       CPU_CHERI_HW_CCALL_CHECKS
-options       CPU_CHERI_HW_RCLEAR
-options       CPU_CHERI_HW_CCLEAR
+options 	CPU_CHERI_HW_CCALL_CHECKS
+options 	CPU_CHERI_HW_RCLEAR
+options 	CPU_CHERI_HW_CCLEAR
 
 options 	TMPFS


### PR DESCRIPTION
This means I can now add /tmp as tmpfs to /etc/fstab and get CHERIBSD
to boot up faster on QEMU. This is better than adding tmpmfs="YES" to
/etc/rc.conf as that only creates a 20 MB ramdisk for /tmp.