### PR TITLE
Fix cheritest_failure_err() not appending strerror(errno)

### DIFF
--- a/bin/cheritest/cheritest_util.c
+++ b/bin/cheritest/cheritest_util.c
@@ -77,7 +77,7 @@ vcheritest_failure_err(const char *msg, va_list ap)
 		return;
 	if ((size_t)len >= buflen)	/* No room for further strings. */
 		return;
-	vsnprintf(ccsp->ccs_testresult_str + len, buflen - len, ": %s",
+	snprintf(ccsp->ccs_testresult_str + len, buflen - len, ": %s",
 	    strerror(errno));
 }
 


### PR DESCRIPTION
vsnprintf() expects a va_list to be passed and not varargs