### PR TITLE
Fix for morecore

### DIFF
--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -219,6 +219,7 @@ morecore(int bucket)
 		buf += sz;
 		op = op->ov_next;
 	}
+	op->ov_next = NULL;
 }
 
 static union overhead *


### PR DESCRIPTION
Had to do that in CheriOS, else op->ov_next can be a non-NULL not valid pointer.
It is checked against NULL and since it is not NULL, is dereferenced, triggering a tag violation.