### PR TITLE
Fixes for CHERIABI pthreads

### DIFF
--- a/lib/libthr/thread/thr_attr.c
+++ b/lib/libthr/thread/thr_attr.c
@@ -290,6 +290,19 @@ _pthread_attr_getstack(const pthread_attr_t * __restrict attr,
 	else {
 		/* Return the stack address and size */
 		*stackaddr = (*attr)->stackaddr_attr;
+#ifdef __CHERI_PURE_CAPABILITY__
+		/*
+		 * Return an invalid capability to the threads stack as we don't
+		 * want other threads being able to write to arbitrary stacks.
+		 *
+		 * XXX-AR: maybe we should allow this and simply treat
+		 * pthread_attr_getstack() as an unsafe API.
+		 *
+		 * XXX-AR: we would also need to fix stackaddr to be a valid
+		 * capability for the main thread as asymmetric API would be bad
+		 */
+		cheri_cleartag(*stackaddr);
+#endif
 		*stacksize = (*attr)->stacksize_attr;
 		ret = 0;
 	}
@@ -309,6 +322,19 @@ _pthread_attr_getstackaddr(const pthread_attr_t *attr, void **stackaddr)
 	else {
 		/* Return the stack address: */
 		*stackaddr = (*attr)->stackaddr_attr;
+#ifdef __CHERI_PURE_CAPABILITY__
+		/*
+		 * Return an invalid capability to the threads stack as we don't
+		 * want other threads being able to write to arbitrary stacks.
+		 *
+		 * XXX-AR: maybe we should allow this and simply treat
+		 * pthread_attr_getstackaddr() as an unsafe API
+		 *
+		 * XXX-AR: we would also need to fix stackaddr to be a valid
+		 * capability for the main thread as asymmetric API would be bad
+		 */
+		cheri_cleartag(*stackaddr);
+#endif
 		ret = 0;
 	}
 	return(ret);

--- a/lib/libthr/thread/thr_create.c
+++ b/lib/libthr/thread/thr_create.c
@@ -156,6 +156,12 @@ _pthread_create(pthread_t * thread, const pthread_attr_t * attr,
 	param.arg = new_thread;
 	param.stack_base = new_thread->attr.stackaddr_attr;
 	param.stack_size = new_thread->attr.stacksize_attr;
+#ifdef __CHERI_PURE_CAPABILITY__
+	THR_ASSERT(cheri_gettag(param.stack_base) == 1,
+	    "stack_base must be a valid capability");
+	THR_ASSERT(cheri_getlen(param.stack_base) == param.stack_size,
+	    "param.stack_base length should be param.stack_size!");
+#endif
 	param.tls_base = (char *)new_thread->tcb;
 	param.tls_size = sizeof(struct tcb);
 	param.child_tid = &new_thread->tid;

--- a/lib/libthr/thread/thr_exit.c
+++ b/lib/libthr/thread/thr_exit.c
@@ -116,6 +116,13 @@ _Unwind_GetCFA(struct _Unwind_Context *context)
 #pragma weak _Unwind_ForcedUnwind
 #endif /* PIC */
 
+#ifndef __CHERI_PURE_CAPABILITY__
+#define WEAK_SYMBOL_NONNULL(sym) ((sym) != NULL)
+#else
+/* Work around https://github.com/CTSRD-CHERI/llvm/issues/167 */
+#define WEAK_SYMBOL_NONNULL(sym) ((vaddr_t)(sym) != (vaddr_t)0)
+#endif
+
 static void
 thread_unwind_cleanup(_Unwind_Reason_Code code, struct _Unwind_Exception *e)
 {
@@ -229,7 +236,7 @@ _pthread_exit_mask(void *status, sigset_t *mask)
 #ifdef PIC
 	if (uwl_forcedunwind != NULL) {
 #else
-	if (_Unwind_ForcedUnwind != NULL) {
+	if (WEAK_SYMBOL_NONNULL(_Unwind_ForcedUnwind)) {
 #endif
 		if (curthread->unwind_disabled) {
 			if (message_printed == 0) {

--- a/lib/libthr/thread/thr_init.c
+++ b/lib/libthr/thread/thr_init.c
@@ -452,6 +452,7 @@ init_private(void)
 	size_t len;
 	int mib[2];
 	char *env, *env_bigstack, *env_splitstack;
+	vaddr_t usrstack_addr;
 
 	_thr_umutex_init(&_mutex_static_lock);
 	_thr_umutex_init(&_cond_static_lock);
@@ -476,9 +477,12 @@ init_private(void)
 		/* Find the stack top */
 		mib[0] = CTL_KERN;
 		mib[1] = KERN_USRSTACK;
-		len = sizeof (_usrstack);
-		if (sysctl(mib, 2, &_usrstack, &len, NULL, 0) == -1)
+		/* The sysctl returns a vaddr_t and not a pointer so we can't
+		 * use _usrstack as the argument on CHERIABI */
+		len = sizeof (usrstack_addr);
+		if (sysctl(mib, 2, &usrstack_addr, &len, NULL, 0) == -1)
 			PANIC("Cannot get kern.usrstack from sysctl");
+		_usrstack = (char*)usrstack_addr;
 		env_bigstack = getenv("LIBPTHREAD_BIGSTACK_MAIN");
 		env_splitstack = getenv("LIBPTHREAD_SPLITSTACK_MAIN");
 		if (env_bigstack != NULL || env_splitstack == NULL) {

--- a/lib/libthr/thread/thr_init.c
+++ b/lib/libthr/thread/thr_init.c
@@ -58,7 +58,15 @@
 #include "libc_private.h"
 #include "thr_private.h"
 
-char		*_usrstack;
+/*
+ * The variable _usrstack is the address of the main thread's stack. It is not a
+ * valid pointer on CHERIABI, as sysctl kern.usrstack returns a virtual address
+ * and not a capability. However, we don't need to use it as a pointer anyway as
+ * there is no need to group stacks together and add guard pages on CHERABI.
+ * In CHERIABI _usrstack is only used to initialize stackaddr_attr for the main
+ * thread.
+ */
+vaddr_t		_usrstack;
 struct pthread	*_thr_initial;
 int		_libthr_debug;
 int		_thread_event_mask;
@@ -392,6 +400,15 @@ init_main_thread(struct pthread *thread)
 	thr_self(&thread->tid);
 	thread->attr = _pthread_attr_default;
 	/*
+	 * There is no need to allocate a red zone in CHERIABI as we are
+	 * protected through the use of capabilities.
+	 *
+	 * XXX-AR: If we decide to add it we will need to derive the correct
+	 * capability from somewhere else because _usrstack not a valid
+	 * capability.
+	 */
+#ifndef __CHERI_PURE_CAPABILITY__
+	/*
 	 * Set up the thread stack.
 	 *
 	 * Create a red zone below the main stack.  All other stacks
@@ -400,11 +417,12 @@ init_main_thread(struct pthread *thread)
 	 * resource limits, so this stack needs an explicitly mapped
 	 * red zone to protect the thread stack that is just beyond.
 	 */
-	if (mmap(_usrstack - _thr_stack_initial -
-	    _thr_guard_default, _thr_guard_default, 0, MAP_ANON,
+	/* XXX-AR: use PROT_NONE here */
+	if (mmap((void*)(_usrstack - _thr_stack_initial -
+	    _thr_guard_default), _thr_guard_default, 0, MAP_ANON,
 	    -1, 0) == MAP_FAILED)
 		PANIC("Cannot allocate red zone for initial thread");
-
+#endif
 	/*
 	 * Mark the stack as an application supplied stack so that it
 	 * isn't deallocated.
@@ -414,7 +432,14 @@ init_main_thread(struct pthread *thread)
 	 *       actually free() it; it just puts it in the free
 	 *       stack queue for later reuse.
 	 */
-	thread->attr.stackaddr_attr = _usrstack - _thr_stack_initial;
+
+	thread->attr.stackaddr_attr = (void*)(uintptr_t)(_usrstack -
+	    _thr_stack_initial);
+#ifdef __CHERI_PURE_CAPABILITY__
+	/* In CHERIABI stackaddr_attr can't be dereferenced */
+	THR_ASSERT(cheri_gettag(thread->attr.stackaddr_attr) == 0,
+	    "thread->attr.stackaddr_attr should not be a capability");
+#endif
 	thread->attr.stacksize_attr = _thr_stack_initial;
 	thread->attr.guardsize_attr = _thr_guard_default;
 	thread->attr.flags |= THR_STACK_USER;
@@ -439,7 +464,7 @@ init_main_thread(struct pthread *thread)
 	thread->attr.prio = sched_param.sched_priority;
 
 #ifdef _PTHREAD_FORCED_UNWIND
-	thread->unwind_stackend = _usrstack;
+	thread->unwind_stackend = (void*)(uintptr_t)_usrstack;
 #endif
 
 	/* Others cleared to zero by thr_alloc() */
@@ -452,7 +477,6 @@ init_private(void)
 	size_t len;
 	int mib[2];
 	char *env, *env_bigstack, *env_splitstack;
-	vaddr_t usrstack_addr;
 
 	_thr_umutex_init(&_mutex_static_lock);
 	_thr_umutex_init(&_cond_static_lock);
@@ -477,12 +501,13 @@ init_private(void)
 		/* Find the stack top */
 		mib[0] = CTL_KERN;
 		mib[1] = KERN_USRSTACK;
-		/* The sysctl returns a vaddr_t and not a pointer so we can't
-		 * use _usrstack as the argument on CHERIABI */
-		len = sizeof (usrstack_addr);
-		if (sysctl(mib, 2, &usrstack_addr, &len, NULL, 0) == -1)
+		/*
+		 * The sysctl returns a vaddr_t and not a pointer so _usrstack
+		 * must not be a pointer on CHERIABI
+		 */
+		len = sizeof (_usrstack);
+		if (sysctl(mib, 2, &_usrstack, &len, NULL, 0) == -1)
 			PANIC("Cannot get kern.usrstack from sysctl");
-		_usrstack = (char*)usrstack_addr;
 		env_bigstack = getenv("LIBPTHREAD_BIGSTACK_MAIN");
 		env_splitstack = getenv("LIBPTHREAD_SPLITSTACK_MAIN");
 		if (env_bigstack != NULL || env_splitstack == NULL) {
@@ -494,7 +519,11 @@ init_private(void)
 		sysctlbyname("kern.smp.cpus", &_thr_is_smp, &len, NULL, 0);
 		_thr_is_smp = (_thr_is_smp > 1);
 		_thr_page_size = getpagesize();
+#ifndef __CHERI_PURE_CAPABILITY__
 		_thr_guard_default = _thr_page_size;
+#else
+		_thr_guard_default = 0; /* no need for red zone in CHERIABI */
+#endif
 		_pthread_attr_default.guardsize_attr = _thr_guard_default;
 		_pthread_attr_default.stacksize_attr = _thr_stack_default;
 		env = getenv("LIBPTHREAD_SPINLOOPS");

--- a/lib/libthr/thread/thr_private.h
+++ b/lib/libthr/thread/thr_private.h
@@ -674,7 +674,7 @@ extern int __isthreaded;
  * Global variables for the pthread kernel.
  */
 
-extern char		*_usrstack __hidden;
+extern vaddr_t		_usrstack __hidden;
 extern struct pthread	*_thr_initial __hidden;
 
 /* For debugger */

--- a/lib/libthr/thread/thr_stack.c
+++ b/lib/libthr/thread/thr_stack.c
@@ -62,6 +62,7 @@ static LIST_HEAD(, stack)	dstackq = LIST_HEAD_INITIALIZER(dstackq);
  */
 static LIST_HEAD(, stack)	mstackq = LIST_HEAD_INITIALIZER(mstackq);
 
+#ifndef __CHERI_PURE_CAPABILITY__
 /**
  * Base address of the last stack allocated (including its red zone, if
  * there is one).  Stacks are allocated contiguously, starting beyond the
@@ -113,11 +114,17 @@ static LIST_HEAD(, stack)	mstackq = LIST_HEAD_INITIALIZER(mstackq);
  *    |                                   |
  *    +-----------------------------------+ <-- start of main thread stack
  *                                              (USRSTACK)
- * high memory
+ * high memory.
+ *
+ * This is not used in CHERIABI, instead we let mmap() decide where to place the
+ * stacks for each of the threads as we do not need red zones here.
+ *
+ * XXX-AR: would it make sense to group the stacks together so that they can
+ * be found more easily by the debugger?
  *
  */
 static char *last_stack = NULL;
-
+#endif /* !defined(__CHERI_PURE_CAPABILITY__) */
 /*
  * Round size up to the nearest multiple of
  * _thr_page_size.
@@ -246,13 +253,20 @@ _thr_stack_alloc(struct pthread_attr *attr)
 		THREAD_LIST_UNLOCK(curthread);
 	}
 	else {
+#ifdef __CHERI_PURE_CAPABILITY__
+		/*
+		 * Grouping stacks together is not useful on CHERIABI, we let
+		 * let mmap() decide where to allocate
+		 */
+		stackaddr = NULL;
+#else /* !defined(__CHERI_PURE_CAPABILITY__) */
 		/*
 		 * Allocate a stack from or below usrstack, depending
 		 * on the LIBPTHREAD_BIGSTACK_MAIN env variable.
 		 */
 		if (last_stack == NULL)
-			last_stack = _usrstack - _thr_stack_initial -
-			    _thr_guard_default;
+			last_stack = (void*)(_usrstack - _thr_stack_initial -
+			    _thr_guard_default);
 
 		/* Allocate a new stack. */
 		stackaddr = last_stack - stacksize - guardsize;
@@ -268,6 +282,7 @@ _thr_stack_alloc(struct pthread_attr *attr)
 
 		/* Release the lock before mmap'ing it. */
 		THREAD_LIST_UNLOCK(curthread);
+#endif /* !defined(__CHERI_PURE_CAPABILITY__) */
 
 		/* Map the stack and guard page together, and split guard
 		   page from allocated space: */
@@ -276,6 +291,10 @@ _thr_stack_alloc(struct pthread_attr *attr)
 		if (stackaddr == MAP_FAILED) {
 			stackaddr = NULL;
 		} else if (guardsize > 0) {
+#ifdef __CHERI_PURE_CAPABILITY__
+			stderr_debug("Requesting guard size of 0%lx bytes, this"
+			    "is not required on CHERIABI\n", guardsize);
+#endif
 			if (mprotect(stackaddr, guardsize, PROT_NONE) == 0) {
 				stackaddr += guardsize;
 			} else {

--- a/lib/libthr/thread/thr_stack.c
+++ b/lib/libthr/thread/thr_stack.c
@@ -279,10 +279,10 @@ _thr_stack_alloc(struct pthread_attr *attr)
 		 * the adjacent thread stack.
 		 */
 		last_stack -= (stacksize + guardsize);
+#endif /* !defined(__CHERI_PURE_CAPABILITY__) */
 
 		/* Release the lock before mmap'ing it. */
 		THREAD_LIST_UNLOCK(curthread);
-#endif /* !defined(__CHERI_PURE_CAPABILITY__) */
 
 		/* Map the stack and guard page together, and split guard
 		   page from allocated space: */

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -893,7 +893,9 @@ int
 cheriabi_set_user_tls(struct thread *td, struct chericap *tls_base)
 {
 	int error;
+	/* XXX-AR: add a TLS alignment check here */
 
+	td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE_C;
 	/*
 	 * Don't require any particular permissions or size and allow NULL.
 	 * If the caller passes nonsense, they just get nonsense results.
@@ -903,6 +905,10 @@ cheriabi_set_user_tls(struct thread *td, struct chericap *tls_base)
 	if (error)
 		return (error);
 	cheri_capability_copy(&td->td_md.md_tls_cap, tls_base);
+	/*
+	 * XXX-AR: Why does MIPS cpu_set_user_tls also have a check for
+	 * curthread == td, but cheriabi_set_user_tls() doesn't
+	 */
 
 	/* XXX: should support a crdhwr version */
 	if (cpuinfo.userlocal_reg == true) {

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -595,8 +595,9 @@ cpu_set_user_tls(struct thread *td, void *tls_base)
 	else
 #endif
 #if defined (COMPAT_CHERIABI)
+	/* XXX-AR: should cheriabi_set_user_tls just delegate to this function? */
 	if (td->td_proc && SV_PROC_FLAG(td->td_proc, SV_CHERI))
-		td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE_C;
+		panic("cpu_set_user_tls(%p) should not be called from CHERIABI\n", td);
 	else
 #endif
 	td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE;

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -326,19 +326,6 @@ cpu_thread_alloc(struct thread *td)
 	td->td_pcb = (struct pcb *)(td->td_kstack +
 	    td->td_kstack_pages * PAGE_SIZE) - 1;
 	td->td_frame = &td->td_pcb->pcb_regs;
-
-#if defined(__mips_n64) && defined(COMPAT_FREEBSD32)
-	if (td->td_proc && SV_PROC_FLAG(td->td_proc, SV_ILP32)
-		td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE32;
-	else
-#endif
-#if defined (COMPAT_CHERIABI)
-	if (td->td_proc && SV_PROC_FLAG(td->td_proc, SV_CHERI))
-		td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE_C;
-	else
-#endif
-	td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE;
-
 #ifdef KSTACK_LARGE_PAGE
 	/* Just one entry for one large kernel page. */
 	pte = pmap_pte(kernel_pmap, td->td_kstack);
@@ -602,6 +589,17 @@ int
 cpu_set_user_tls(struct thread *td, void *tls_base)
 {
 
+#if defined(__mips_n64) && defined(COMPAT_FREEBSD32)
+	if (td->td_proc && SV_PROC_FLAG(td->td_proc, SV_ILP32)
+		td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE32;
+	else
+#endif
+#if defined (COMPAT_CHERIABI)
+	if (td->td_proc && SV_PROC_FLAG(td->td_proc, SV_CHERI))
+		td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE_C;
+	else
+#endif
+	td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET + TLS_TCB_SIZE;
 	td->td_md.md_tls = (char*)tls_base;
 	if (td == curthread && cpuinfo.userlocal_reg == true) {
 		mips_wr_userlocal((unsigned long)tls_base +


### PR DESCRIPTION
With these patches it is now possible to run a program using that uses pthreads.

There are probably still some parts of pthreads that won't work correctly but creating threads, joining and mutexes appear to work.

There is still one strange case where `pthread_join()` will return `EDEADLK` due to this code in thr_join.c:
```
if (pthread == curthread)
  return (EDEADLK);
```
However, the debug output shows that the two are clearly different:
```
---Main thread 0x16043f000 waiting for thread 0x16043fe00 to join
join: EDEADLK pthread = 16043fe00, curthread = 16043fe00
```

This seems to only happen the first time the binary is run, so it could be caused by some TLS bug.
Could be related to #130

