### PR TITLE
Revise machine-dependent/machine-independent split for kernel CHERI support

### DIFF
--- a/bin/cheri_bench/cheri_bench.c
+++ b/bin/cheri_bench/cheri_bench.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * Copyright (c) 2014 Robert M. Norton
  * All rights reserved.
  *
@@ -50,8 +50,8 @@
 
 #if __has_feature(capabilities)
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>
 #include <cheri/cheri_invoke.h>

--- a/bin/cheri_helloworld/cheri_helloworld.c
+++ b/bin/cheri_helloworld/cheri_helloworld.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -36,9 +36,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/helloworld.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -45,8 +45,9 @@
 #include <sys/wait.h>
 
 #ifndef LIST_ONLY
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
 #include <machine/cherireg.h>
 #include <machine/cpuregs.h>
 #include <machine/frame.h>

--- a/bin/cheritest/cheritest_bounds_heap.c
+++ b/bin/cheritest/cheritest_bounds_heap.c
@@ -38,8 +38,8 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <err.h>
 #include <errno.h>

--- a/bin/cheritest/cheritest_bounds_stack.c
+++ b/bin/cheritest/cheritest_bounds_stack.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015 Robert N. M. Watson
+ * Copyright (c) 2015-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -38,8 +38,9 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 

--- a/bin/cheritest/cheritest_ccall.c
+++ b/bin/cheritest/cheritest_ccall.c
@@ -39,10 +39,10 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/cheri_invoke.h>
 #include <cheri/cheri_type.h>

--- a/bin/cheritest/cheritest_cheriabi.c
+++ b/bin/cheritest/cheritest_cheriabi.c
@@ -41,8 +41,9 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2015 Robert N. M. Watson
+ * Copyright (c) 2012-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -39,10 +39,10 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>
 

--- a/bin/cheritest/cheritest_fd.c
+++ b/bin/cheritest/cheritest_fd.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2015 Robert N. M. Watson
+ * Copyright (c) 2012-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -40,11 +40,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest_libcheri.c
+++ b/bin/cheritest/cheritest_libcheri.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2015 Robert N. M. Watson
+ * Copyright (c) 2012-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -40,11 +40,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest_local.c
+++ b/bin/cheritest/cheritest_local.c
@@ -39,11 +39,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2015 Robert N. M. Watson
+ * Copyright (c) 2012-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -39,11 +39,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cherireg.h>
 #include <machine/cpuregs.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>
 

--- a/bin/cheritest/cheritest_string.c
+++ b/bin/cheritest/cheritest_string.c
@@ -1,4 +1,3 @@
-
 /*-
  * Copyright (c) 2012-2014 David T. Chisnall
  * Copyright (c) 2015 SRI International
@@ -38,8 +37,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <string.h>
 

--- a/bin/cheritest/cheritest_syscall.c
+++ b/bin/cheritest/cheritest_syscall.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2013-2015 Robert N. M. Watson
+ * Copyright (c) 2013-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -39,11 +39,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest_trusted_stack.c
+++ b/bin/cheritest/cheritest_trusted_stack.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -38,11 +38,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest_var.c
+++ b/bin/cheritest/cheritest_var.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -39,11 +39,11 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014 Robert N. M. Watson
+ * Copyright (c) 2014, 2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -46,12 +46,12 @@
 #include <sys/ucontext.h>
 #include <sys/wait.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 #include <machine/frame.h>
 #include <machine/trap.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>
 

--- a/bin/cheritest/cheritest_vm_swap.c
+++ b/bin/cheritest/cheritest_vm_swap.c
@@ -28,9 +28,6 @@
  * SUCH DAMAGE.
  */
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -41,6 +38,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include "cheritest.h"
 

--- a/bin/cheritest/cheritest_zlib.c
+++ b/bin/cheritest/cheritest_zlib.c
@@ -55,11 +55,9 @@
 #include <unistd.h>
 #endif
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/sandbox.h>
-
 #include <cheritest-helper.h>
 #include <cheritest-helper-internal.h>
 #include <stdio.h>

--- a/contrib/jemalloc/include/jemalloc/internal/chunk.h
+++ b/contrib/jemalloc/include/jemalloc/internal/chunk.h
@@ -1,7 +1,7 @@
 /******************************************************************************/
 #ifdef JEMALLOC_H_TYPES
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 #endif
 
 /*

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal.h
@@ -158,7 +158,7 @@ static const bool config_cache_oblivious =
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 #endif
 
 #ifndef __CHERI_PURE_CAPABILITY__

--- a/contrib/jemalloc/src/pages.c
+++ b/contrib/jemalloc/src/pages.c
@@ -1,7 +1,7 @@
 #define	JEMALLOC_PAGES_C_
 #include "jemalloc/internal/jemalloc_internal.h"
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 #endif
 
 /******************************************************************************/

--- a/contrib/tcpdump/netdissect.h
+++ b/contrib/tcpdump/netdissect.h
@@ -35,8 +35,8 @@
 #endif
 
 #if __has_feature(capabilities)
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #endif
 
 /* snprintf et al */

--- a/contrib/tcpdump/tcpdump.c
+++ b/contrib/tcpdump/tcpdump.c
@@ -134,9 +134,8 @@ extern int SIZE_BUF;
 #include "print.h"
 
 #if __has_feature(capabilities)
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-#include <machine/cherireg.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #define cheri_string(str)	cheri_ptr((str), strlen(str) + 1)
 #else
 #define	cheri_ptrperm(ptr, len, perm)	(ptr);

--- a/ctsrd/lib/libimagebox/pngbox.c
+++ b/ctsrd/lib/libimagebox/pngbox.c
@@ -35,10 +35,10 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <machine/cpuregs.h>
 
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/sandbox.h>
 
 #include <errno.h>

--- a/ctsrd/libexec/readpng-cheri-helper/readpng-cheri.c
+++ b/ctsrd/libexec/readpng-cheri-helper/readpng-cheri.c
@@ -33,9 +33,9 @@
 #include <sys/capability.h>
 #include <sys/mman.h>
 
-#include <machine/cheri.h>
 #include <machine/sysarch.h>
 
+#include <cheri/cheri.h>
 #include <cheri/cheri_memcpy.h>
 #include <cheri/cheri_system.h>
 

--- a/ctsrd/usr.bin/cheripoint/cheripoint.c
+++ b/ctsrd/usr.bin/cheripoint/cheripoint.c
@@ -34,8 +34,7 @@
 #include <sys/sysctl.h>
 #include <sys/wait.h>
 
-#include <machine/cheri.h>
-
+#include <cheri/cheri.h>
 #include <cheri/sandbox.h>
 
 #include <terasic_mtl.h>

--- a/include/Makefile
+++ b/include/Makefile
@@ -37,7 +37,7 @@ PHDRS=	sched.h _semaphore.h
 LHDRS=	aio.h errno.h fcntl.h linker_set.h poll.h stdatomic.h stdint.h \
 	syslog.h ucontext.h
 
-LDIRS=	bsm cam geom net net80211 netgraph netinet netinet6 \
+LDIRS=	bsm cam cheri geom net net80211 netgraph netinet netinet6 \
 	netipsec netnatm netsmb nfs nfsclient nfsserver sys vm
 
 LSUBDIRS=	cam/ata cam/scsi \

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -32,7 +32,7 @@ __FBSDID("$FreeBSD$");
  */
 #include <sys/mman.h>
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 #endif
 #include <dlfcn.h>
 #include <link.h>

--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -35,7 +35,7 @@
 #include <sys/cdefs.h>
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 #endif
 
 #include <stdlib.h>

--- a/lib/libc/mips/string/memcpy.c
+++ b/lib/libc/mips/string/memcpy.c
@@ -28,8 +28,8 @@
  * SUCH DAMAGE.
  */
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <string.h>
 

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -51,8 +51,8 @@ __FBSDID("$FreeBSD$");
 #include <sys/types.h>
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #endif
 
 #include <ctype.h>

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -54,8 +54,8 @@ __FBSDID("$FreeBSD$");
 #include <sys/types.h>
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #endif
 
 #include <ctype.h>

--- a/lib/libc/string/memcpy_c_tofrom.c
+++ b/lib/libc/string/memcpy_c_tofrom.c
@@ -29,8 +29,9 @@
  */
 
 #include <sys/types.h>
-#include <machine/cheric.h>
 #include <string.h>
+
+#include <cheri/cheric.h>
 
 __capability void *
 memcpy_c_tocap(__capability void *dst, const void *src, size_t len)

--- a/lib/libc/string/strncpy_c.c
+++ b/lib/libc/string/strncpy_c.c
@@ -32,7 +32,8 @@
 #include "strncpy.c"
 
 #include <sys/types.h>
-#include <machine/cheric.h>
+
+#include <cheri/cheric.h>
 
 char *
 strncpy_c_fromcap(char *dst, __CAPABILITY const char *src, size_t n)

--- a/lib/libc_cheri/cheri_clock_gettime.c
+++ b/lib/libc_cheri/cheri_clock_gettime.c
@@ -30,9 +30,8 @@
 
 #include <sys/time.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_system.h>
 
 #include <time.h>

--- a/lib/libc_cheri/cheri_printf.c
+++ b/lib/libc_cheri/cheri_printf.c
@@ -2,7 +2,7 @@
  * Copyright (c) 1986, 1988, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
  * (c) UNIX System Laboratories, Inc.
- * Copyright (c) 2011, 2014 Robert N. M. Watson
+ * Copyright (c) 2011, 2014, 2016 Robert N. M. Watson
  *
  * All or some portions of this file are derived from material licensed
  * to the University of California by American Telephone and Telegraph
@@ -40,9 +40,8 @@
 
 #include <sys/param.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_system.h>
 
 #include <inttypes.h>

--- a/lib/libc_cheri/cheri_put.c
+++ b/lib/libc_cheri/cheri_put.c
@@ -30,9 +30,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_system.h>
 
 #include <errno.h>

--- a/lib/libc_cheri/cheri_stdio.c
+++ b/lib/libc_cheri/cheri_stdio.c
@@ -30,9 +30,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_system.h>
 
 #include <errno.h>

--- a/lib/libc_cheri/cheri_system_stub.c
+++ b/lib/libc_cheri/cheri_system_stub.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -31,9 +31,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri_system.h>
 
 struct cheri_object _cheri_system_object;

--- a/lib/libc_cheri/fastmalloc.c
+++ b/lib/libc_cheri/fastmalloc.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014 SRI International
- * Copyright (c) 2012 Robert N. M. Watson
+ * Copyright (c) 2012, 2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -32,8 +32,8 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #ifdef MALLOC_DEBUG
 #include <stdint.h>

--- a/lib/libc_cheri/heap.c
+++ b/lib/libc_cheri/heap.c
@@ -47,8 +47,8 @@ static char *rcsid = "$FreeBSD$";
 #include <sys/param.h>
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <stdlib.h>

--- a/lib/libcheri/cheri_enter.c
+++ b/lib/libcheri/cheri_enter.c
@@ -38,8 +38,8 @@
 #include <sys/param.h>
 #include <sys/mman.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/lib/libcheri/cheri_fd.c
+++ b/lib/libcheri/cheri_fd.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -31,8 +31,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <errno.h>
 #include <stdio.h>

--- a/lib/libcheri/cheri_invoke.3
+++ b/lib/libcheri/cheri_invoke.3
@@ -1,5 +1,5 @@
 .\"-
-.\" Copyright (c) 2014 Robert N. M. Watson
+.\" Copyright (c) 2014, 2016 Robert N. M. Watson
 .\" All rights reserved.
 .\"
 .\" This software was developed by SRI International and the University of
@@ -27,7 +27,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd "January 3, 2014"
+.Dd "May 28, 2016"
 .Dt CHERI_INVOKE 3
 .Os
 .Sh NAME
@@ -36,9 +36,9 @@
 .Sh LIBRARY
 .Lb libcheri
 .Sh SYNOPSIS
-.In machine/cheri.h
-.In machine/cheric.h
-.In cheri_invoke.h
+.In cheri/cheri.h
+.In cheri/cheric.h
+.In cheri/cheri_invoke.h
 #if __has_feature(capabilities)
 .Ft register_t
 .Fo cheri_invoke

--- a/lib/libcheri/cheri_system.c
+++ b/lib/libcheri/cheri_system.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -31,8 +31,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/libcheri/cheri_type.c
+++ b/lib/libcheri/cheri_type.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -37,8 +37,9 @@
 #include <sys/types.h>
 #include <sys/param.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
 #include <machine/sysarch.h>
 
 #include <assert.h>

--- a/lib/libcheri/libcheri.3
+++ b/lib/libcheri/libcheri.3
@@ -27,7 +27,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd "April 19, 2016"
+.Dd "May 28, 2016"
 .Dt LIBCHERI 3
 .Os
 .Sh NAME
@@ -46,9 +46,9 @@
 .Sh LIBRARY
 .Lb libcheri
 .Sh SYNOPSIS
-.In machine/cheri.h
-.In machine/cheric.h
-.In sandbox.h
+.In cheri/cheri.h
+.In cheri/cheric.h
+.In cheri/sandbox.h
 .Ft int
 .Fo sandbox_class_new
 .Fa "const char *path"

--- a/lib/libcheri/libcheri_stat.c
+++ b/lib/libcheri/libcheri_stat.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2013 Robert N. M. Watson
+ * Copyright (c) 2013, 2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -32,8 +32,8 @@
 #include <sys/exec.h>
 #include <sys/sysctl.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <err.h>
 #include <errno.h>

--- a/lib/libcheri/mips64/cheri_stack.c
+++ b/lib/libcheri/mips64/cheri_stack.c
@@ -40,8 +40,9 @@
 #include <sys/time.h>
 #include <sys/ucontext.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
 #include <machine/cpuregs.h>
 #include <machine/regnum.h>
 #include <machine/sysarch.h>

--- a/lib/libcheri/sandbox.c
+++ b/lib/libcheri/sandbox.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2015 Robert N. M. Watson
+ * Copyright (c) 2012-2016 Robert N. M. Watson
  * Copyright (c) 2015 SRI International
  * All rights reserved.
  *
@@ -41,8 +41,8 @@
 #include <sys/stat.h>
 #include <sys/sysctl.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <err.h>

--- a/lib/libcheri/sandbox_loader.c
+++ b/lib/libcheri/sandbox_loader.c
@@ -40,8 +40,8 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <err.h>

--- a/lib/libcheri/sandbox_methods.c
+++ b/lib/libcheri/sandbox_methods.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014-2015 SRI International
- * Copyright (c) 2015 Robert N. M. Watson
+ * Copyright (c) 2015-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -33,8 +33,8 @@
 #include <sys/mman.h>
 #include <sys/param.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <elf.h>

--- a/lib/libhelloworld/compartment/helloworld.c
+++ b/lib/libhelloworld/compartment/helloworld.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * Copyright (c) 2015 SRI International
  * All rights reserved.
  *
@@ -32,9 +32,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/cheri_invoke.h>

--- a/lib/libhelloworld/helloworld.c
+++ b/lib/libhelloworld/helloworld.c
@@ -28,8 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include <machine/cheri.h>
-
+#include <cheri/cheri.h>
 #include <cheri/sandbox.h>
 
 #include <err.h>

--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -48,8 +48,8 @@ static char *rcsid = "$FreeBSD$";
 #include <sys/types.h>
 #include <sys/mman.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <stdlib.h>

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -47,8 +47,8 @@ static char *rcsid = "$FreeBSD$";
 #include <sys/param.h>
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/lib/libpng_sb/libpng_sb.c
+++ b/lib/libpng_sb/libpng_sb.c
@@ -30,9 +30,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/sandbox.h>

--- a/lib/libthr/arch/mips/include/pthread_md.h
+++ b/lib/libthr/arch/mips/include/pthread_md.h
@@ -35,7 +35,7 @@
 
 #include <sys/types.h>
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 #endif
 #include <machine/sysarch.h>
 #include <machine/tls.h>

--- a/lib/libz-cheri/inflate.c
+++ b/lib/libz-cheri/inflate.c
@@ -84,7 +84,7 @@
 #include "inftrees.h"
 #include "inflate.h"
 #include "inffast.h"
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 
 #ifdef MAKEFIXED
 #  ifndef BUILDFIXED

--- a/lib/libz-cheri/zconf-cheri.h
+++ b/lib/libz-cheri/zconf-cheri.h
@@ -519,8 +519,8 @@ typedef uLong FAR uLongf;
 #ifdef __FreeBSD__
 #include <sys/cdefs.h>
 #if __has_feature(capabilities)
-#include <machine/cheric.h>
-#include <machine/cherireg.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #else
 #define __capability
 #define cheri_ptrperm(a, b)	(a)

--- a/libexec/cheri_bench-helper/cheri_bench-helper.c
+++ b/libexec/cheri_bench-helper/cheri_bench-helper.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -31,9 +31,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/cheri_invoke.h>

--- a/libexec/cheritest-helper/cheritest-helper.c
+++ b/libexec/cheritest-helper/cheritest-helper.c
@@ -32,9 +32,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/cheri_invoke.h>

--- a/libexec/libpng_sb-helper/libpng_sb-helper.c
+++ b/libexec/libpng_sb-helper/libpng_sb-helper.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Robert N. M. Watson
+ * Copyright (c) 2014-2016 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -32,9 +32,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_enter.h>
 #include <cheri/cheri_fd.h>
 #include <cheri/cheri_invoke.h>

--- a/libexec/rtld-cheri-elf/map_object.c
+++ b/libexec/rtld-cheri-elf/map_object.c
@@ -29,7 +29,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 
 #include <errno.h>
 #include <stddef.h>

--- a/libexec/rtld-cheri-elf/mips/reloc.c
+++ b/libexec/rtld-cheri-elf/mips/reloc.c
@@ -39,7 +39,8 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <inttypes.h>
 
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
+
 #include <machine/sysarch.h>
 #include <machine/tls.h>
 

--- a/libexec/rtld-cheri-elf/rtld.c
+++ b/libexec/rtld-cheri-elf/rtld.c
@@ -44,7 +44,7 @@
 #include <sys/utsname.h>
 #include <sys/ktrace.h>
 
-#include <machine/cheric.h>
+#include <cheri/cheric.h>
 
 #include <dlfcn.h>
 #include <err.h>

--- a/libexec/rtld-cheri-elf/rtld_printf.c
+++ b/libexec/rtld-cheri-elf/rtld_printf.c
@@ -36,14 +36,15 @@
  */
 
 #include <sys/param.h>
-#include <machine/cheri.h>
-#include <machine/cheric.h>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <string.h>
 #include <unistd.h>
 #include "rtld_printf.h"
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #define MAXNBUF	(sizeof(intmax_t) * NBBY + 1)
 

--- a/libexec/tcpdump-helper/tcpdump-helper.c
+++ b/libexec/tcpdump-helper/tcpdump-helper.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2014-2015 SRI International
- * Copyright (c) 2012-2015 Robert N. M. Watson
+ * Copyright (c) 2012-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -58,9 +58,8 @@
 
 #include <sys/types.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
-
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 #include <cheri/cheri_system.h>
 #include <cheri/cheri_invoke.h>
 

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -1,0 +1,214 @@
+/*-
+ * Copyright (c) 2011-2016 Robert N. M. Watson
+ * Copyright (c) 2015 SRI International
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _SYS_CHERI_H_
+#define	_SYS_CHERI_H_
+
+#ifdef _KERNEL
+#include <sys/sysctl.h>		/* SYSCTL_DECL() */
+#include <sys/systm.h>		/* CTASSERT() */
+#endif
+
+#include <sys/types.h>
+
+#include <machine/cherireg.h>	/* CHERICAP_SIZE. */
+
+/*
+ * Canonical C-language representation of a capability for compilers that
+ * don't support capabilities directly.  The in-memory layout is sensitive to
+ * the microarchitecture, and hence treated as opaque.  Fields must be
+ * accessed via the ISA.
+ */
+struct chericap {
+	uint8_t		c_data[CHERICAP_SIZE];
+} __packed __aligned(CHERICAP_SIZE);
+#ifdef _KERNEL
+CTASSERT(sizeof(struct chericap) == CHERICAP_SIZE);
+#endif
+
+/*
+ * Canonical C-language representation of a CHERI object capability -- code and
+ * data capabilities in registers or memory.
+ */
+struct cheri_object {
+#if !defined(_KERNEL) && __has_feature(capabilities)
+	__capability void	*co_codecap;
+	__capability void	*co_datacap;
+#else
+	struct chericap		 co_codecap;
+	struct chericap		 co_datacap;
+#endif
+};
+
+#if !defined(_KERNEL) && __has_feature(capabilities)
+#define	CHERI_OBJECT_INIT_NULL	{NULL, NULL}
+#define	CHERI_OBJECT_ISNULL(co)	\
+    ((co).co_codecap == NULL && (co).co_datacap == NULL)
+#endif
+
+/*
+ * Data structure describing CHERI's sigaltstack-like extensions to signal
+ * delivery.  In the event that a thread takes a signal when $pcc doesn't hold
+ * CHERI_PERM_SYSCALL, we will need to install new $pcc, $ddc, $stc, and $idc
+ * state, and move execution to the per-thread alternative stack, whose
+ * pointer should (presumably) be relative to the $ddc/$stc defined here.
+ */
+struct cheri_signal {
+#if !defined(_KERNEL) && __has_feature(capabilities)
+	__capability void	*csig_pcc;
+	__capability void	*csig_ddc;
+	__capability void	*csig_stc;
+	__capability void	*csig_idc;
+	__capability void	*csig_default_stack;
+	__capability void	*csig_sigcode;
+#else
+	struct chericap		 csig_pcc;
+	struct chericap		 csig_ddc;
+	struct chericap		 csig_stc;
+	struct chericap		 csig_idc;
+	struct chericap		 csig_default_stack;
+	struct chericap		 csig_sigcode;
+#endif
+};
+
+/*
+ * Per-thread CHERI CCall/CReturn stack, which preserves the calling PC/PCC/
+ * IDC across CCall so that CReturn can restore them.
+ *
+ * XXXRW: This is a very early experiment -- it's not clear if this idea will
+ * persist in its current form, or at all.  For more complex userspace
+ * language, there's a reasonable expectation that it, rather than the kernel,
+ * will want to manage the idea of a "trusted stack".
+ *
+ * XXXRW: This is currently part of the kernel-user ABI due to the
+ * CHERI_GET_STACK and CHERI_SET_STACK sysarch() calls.  In due course we need
+ * to revise those APIs and differentiate the kernel-internal representation
+ * from the public one.
+ */
+struct cheri_stack_frame {
+	register_t	_csf_pad0;	/* Used to be MIPS program counter. */
+	register_t	_csf_pad1;
+	register_t	_csf_pad2;
+	register_t	_csf_pad3;
+#if !defined(_KERNEL) && __has_feature(capabilities)
+	__capability void	*csf_pcc;
+	__capability void	*csf_idc;
+#else
+	struct chericap	csf_pcc;
+	struct chericap	csf_idc;
+#endif
+};
+
+#define	CHERI_STACK_DEPTH	8	/* XXXRW: 8 is a nice round number. */
+struct cheri_stack {
+	register_t	cs_tsp;		/* Byte offset, not frame index. */
+	register_t	cs_tsize;	/* Stack size, in bytes. */
+	register_t	_cs_pad0;
+	register_t	_cs_pad1;
+	struct cheri_stack_frame	cs_frames[CHERI_STACK_DEPTH];
+} __aligned(CHERICAP_SIZE);
+
+#define	CHERI_FRAME_SIZE	sizeof(struct cheri_stack_frame)
+#define	CHERI_STACK_SIZE	(CHERI_STACK_DEPTH * CHERI_FRAME_SIZE)
+
+/*
+ * APIs that act on C language representations of capabilities -- but not
+ * capabilities themselves.
+ */
+#ifdef _KERNEL
+void	cheri_capability_copy(struct chericap *cp_to,
+	    struct chericap *cp_from);
+void	cheri_capability_set(struct chericap *cp, uint32_t uperms,
+	    void *otype, void *basep, size_t length, off_t off);
+void	cheri_capability_set_null(struct chericap *cp);
+void	cheri_capability_setoffset(struct chericap *cp, register_t offset);
+
+/*
+ * CHERI capability utility functions.
+ */
+void	 cheri_bcopy(void *src, void *dst, size_t len);
+void	*cheri_memcpy(void *dst, void *src, size_t len);
+
+/*
+ * CHERI context management functions.
+ */
+struct cheri_frame;
+struct thread;
+struct trapframe;
+const char	*cheri_exccode_string(uint8_t exccode);
+void	cheri_exec_setregs(struct thread *td, u_long entry_addr);
+void	cheri_log_cheri_frame(struct trapframe *frame);
+void	cheri_log_exception(struct trapframe *frame, int trap_type);
+void	cheri_log_exception_registers(struct trapframe *frame);
+int	cheri_syscall_authorize(struct thread *td, u_int code,
+	    int nargs, register_t *args);
+int	cheri_signal_sandboxed(struct thread *td);
+void	cheri_sendsig(struct thread *td);
+void	cheri_trapframe_from_cheriframe(struct trapframe *frame,
+	    struct cheri_frame *cfp);
+void	cheri_trapframe_to_cheriframe(struct trapframe *frame,
+	    struct cheri_frame *cfp);
+
+/*
+ * Functions to set up and manipulate CHERI contexts and stacks.
+ */
+struct pcb;
+struct sysarch_args;
+void	cheri_signal_copy(struct pcb *dst, struct pcb *src);
+void	cheri_stack_copy(struct pcb *dst, struct pcb *src);
+void	cheri_stack_init(struct pcb *pcb);
+int	cheri_stack_unwind(struct thread *td, struct trapframe *tf,
+	    int signum);
+int	cheri_sysarch_getstack(struct thread *td, struct sysarch_args *uap);
+int	cheri_sysarch_gettypecap(struct thread *td, struct sysarch_args *uap);
+int	cheri_sysarch_setstack(struct thread *td, struct sysarch_args *uap);
+void	cheri_typecap_copy(struct pcb *dst, struct pcb *src);
+
+/*
+ * Global sysctl definitions.
+ */
+SYSCTL_DECL(_security_cheri);
+SYSCTL_DECL(_security_cheri_stats);
+extern u_int	security_cheri_debugger_on_sandbox_signal;
+extern u_int	security_cheri_debugger_on_sandbox_syscall;
+extern u_int	security_cheri_debugger_on_sandbox_unwind;
+extern u_int	security_cheri_debugger_on_sigprot;
+extern u_int	security_cheri_sandboxed_signals;
+extern u_int	security_cheri_syscall_violations;
+#endif /* !_KERNEL */
+
+/*
+ * Nested include of machine-dependent definitions, which likely depend on
+ * first having defined chericap.h.
+ */
+#include <machine/cheri.h>
+
+#endif /* _SYS_CHERI_H_ */

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -203,6 +203,18 @@ extern u_int	security_cheri_debugger_on_sandbox_unwind;
 extern u_int	security_cheri_debugger_on_sigprot;
 extern u_int	security_cheri_sandboxed_signals;
 extern u_int	security_cheri_syscall_violations;
+
+/*
+ * Functions exposed to machine-independent code that must interact with
+ * CHERI-specific features; e.g., ktrace.
+ */
+struct ktr_ccall;
+struct ktr_creturn;
+struct ktr_cexception;
+void	ktrccall_mdfill(struct pcb *pcb, struct ktr_ccall *kc);
+void	ktrcreturn_mdfill(struct pcb *pcb, struct ktr_creturn *kr);
+void	ktrcexception_mdfill(struct trapframe *frame,
+	    struct ktr_cexception *ke);
 #endif /* !_KERNEL */
 
 /*

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -1,0 +1,82 @@
+/*-
+ * Copyright (c) 2011-2016 Robert N. M. Watson
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "opt_ddb.h"
+
+#include <sys/param.h>
+#include <sys/kernel.h>
+#include <sys/sysctl.h>
+
+#include <cheri/cheri.h>
+
+#include <machine/cherireg.h>
+
+SYSCTL_NODE(_security, OID_AUTO, cheri, CTLFLAG_RD, 0,
+    "CHERI settings and statistics");
+
+static u_int cheri_capability_size = CHERICAP_SIZE;
+SYSCTL_UINT(_security_cheri, OID_AUTO, capability_size, CTLFLAG_RD,
+    &cheri_capability_size, 0, "Size of a CHERI capability");
+
+SYSCTL_NODE(_security_cheri, OID_AUTO, stats, CTLFLAG_RD, 0,
+    "CHERI statistics");
+
+/* XXXRW: Should possibly be u_long. */
+u_int	security_cheri_syscall_violations;
+SYSCTL_UINT(_security_cheri, OID_AUTO, syscall_violations, CTLFLAG_RD,
+    &security_cheri_syscall_violations, 0, "Number of system calls blocked");
+
+u_int	security_cheri_sandboxed_signals;
+SYSCTL_UINT(_security_cheri, OID_AUTO, sandboxed_signals, CTLFLAG_RD,
+    &security_cheri_sandboxed_signals, 0, "Number of signals in sandboxes");
+
+/*
+ * A set of sysctls that cause the kernel debugger to enter following a policy
+ * violation or signal delivery due to CHERI or while in a sandbox.
+ */
+u_int	security_cheri_debugger_on_sandbox_signal;
+SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_signal, CTLFLAG_RW,
+    &security_cheri_debugger_on_sandbox_signal, 0,
+    "Enter KDB when a signal is delivered while in a sandbox");
+
+u_int	security_cheri_debugger_on_sandbox_syscall;
+SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_syscall, CTLFLAG_RW,
+    &security_cheri_debugger_on_sandbox_syscall, 0,
+    "Enter KDB when a syscall is rejected while in a sandbox");
+
+u_int	security_cheri_debugger_on_sandbox_unwind;
+SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_unwind, CTLFLAG_RW,
+    &security_cheri_debugger_on_sandbox_unwind, 0,
+    "Enter KDB when a sandbox is auto-unwound due to a signal");
+
+u_int	security_cheri_debugger_on_sigprot;
+SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sigprot, CTLFLAG_RW,
+    &security_cheri_debugger_on_sigprot, 0,
+    "Enter KDB when SIGPROT is delivered to an unsandboxed thread");

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -1,0 +1,192 @@
+/*-
+ * Copyright (c) 2013-2016 Robert N. M. Watson
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _SYS_CHERIC_H_
+#define	_SYS_CHERIC_H_
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+#include <machine/cherireg.h>	/* Permission definitions. */
+
+#if !defined(_KERNEL) && __has_feature(capabilities)
+/*
+ * Programmer-friendly macros for CHERI-aware C code -- requires use of
+ * CHERI-aware Clang/LLVM, and full capability context switching, so not yet
+ * usable in the kernel.
+ */
+#define	cheri_getlen(x)		__builtin_cheri_get_cap_length(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_getbase(x)	__builtin_cheri_get_cap_base(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_getoffset(x)	__builtin_cheri_cap_offset_get(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_getperm(x)	__builtin_cheri_get_cap_perms(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_getsealed(x)	__builtin_cheri_get_cap_sealed(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_gettag(x)		__builtin_cheri_get_cap_tag(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_gettype(x)	__builtin_cheri_get_cap_type(		\
+				    __DECONST(__capability void *, (x)))
+
+#define	cheri_andperm(x, y)	__builtin_cheri_and_cap_perms(		\
+				    __DECONST(__capability void *, (x)), (y))
+#define	cheri_cleartag(x)	__builtin_cheri_clear_cap_tag(		\
+				    __DECONST(__capability void *, (x)))
+#define	cheri_incoffset(x, y)	__builtin_cheri_cap_offset_increment(	\
+				    __DECONST(__capability void *, (x)), (y))
+#define	cheri_setoffset(x, y)	__builtin_cheri_cap_offset_set(		\
+				    __DECONST(__capability void *, (x)), (y))
+
+#define	cheri_seal(x, y)	__builtin_cheri_seal_cap(		 \
+				    __DECONST(__capability void *, (x)), \
+				    __DECONST(__capability void *, (y)))
+#define	cheri_unseal(x, y)	__builtin_cheri_unseal_cap(		 \
+				    __DECONST(__capability void *, (x)), \
+				    __DECONST(__capability void *, (y)))
+
+#define	cheri_getcause()	__builtin_cheri_get_cause()
+#define	cheri_setcause(x)	__builtin_cheri_set_cause(x)
+
+#define	cheri_ccheckperm(c, p)	__builtin_cheri_check_perms(		\
+				    __DECONST(__capability void *, (c)), (p))
+#define	cheri_cchecktype(c, t)	__builtin_cheri_check_type(		\
+				    __DECONST(__capability void *, (c)), (t))
+
+#define	cheri_getdefault()	__builtin_cheri_get_global_data_cap()
+#define	cheri_getidc()		__builtin_cheri_get_invoke_data_cap()
+#define	cheri_getkr0c()		__builtin_cheri_get_kernel_cap1()
+#define	cheri_getkr1c()		__builtin_cheri_get_kernel_cap2()
+#define	cheri_getkcc()		__builtin_cheri_get_kernel_code_cap()
+#define	cheri_getkdc()		__builtin_cheri_get_kernel_data_cap()
+#define	cheri_getepcc()		__builtin_cheri_get_exception_program_counter_cap()
+#define	cheri_getpcc()		__builtin_cheri_get_program_counter_cap()
+#define	cheri_getstack()	__builtin_memcap_stack_get()
+
+#define	cheri_local(c)		cheri_andperm((c), ~CHERI_PERM_GLOBAL)
+
+#define	cheri_csetbounds(x, y)	__builtin_memcap_bounds_set(		\
+				    __DECONST(__capability void *, (x)), (y))
+
+/*
+ * Two variations on cheri_ptr() based on whether we are looking for a code or
+ * data capability.  The compiler's use of CFromPtr will be with respect to
+ * $ddc or $pcc depending on the type of the pointer derived, so we need to
+ * use types to differentiate the two versions at compile time.  We don't
+ * provide the full set of function variations for code pointers as they
+ * haven't proven necessary as yet.
+ *
+ * XXXRW: Ideally, casting via a function pointer would cause the compiler to
+ * derive the capability using CFromPtr on $pcc rather than on $ddc.  This
+ * appears not currently to be the case, so manually derive using
+ * cheri_getpcc() for now.
+ */
+static __inline __capability void *
+cheri_codeptr(const void *ptr, size_t len)
+{
+#ifdef NOTYET
+	__capability void (*c)(void) = ptr;
+#else
+	__capability void *c = cheri_setoffset(cheri_getpcc(),
+	    (register_t)ptr);
+#endif
+
+	/* Assume CFromPtr without base set, availability of CSetBounds. */
+	return (cheri_csetbounds(c, len));
+}
+
+static __inline __capability void *
+cheri_codeptrperm(const void *ptr, size_t len, register_t perm)
+{
+
+	return (cheri_andperm(cheri_codeptr(ptr, len),
+	    perm | CHERI_PERM_GLOBAL));
+}
+
+static __inline __capability void *
+cheri_ptr(const void *ptr, size_t len)
+{
+
+	/* Assume CFromPtr without base set, availability of CSetBounds. */
+	return (cheri_csetbounds((const __capability void *)ptr, len));
+}
+
+static __inline __capability void *
+cheri_ptrperm(const void *ptr, size_t len, register_t perm)
+{
+
+	return (cheri_andperm(cheri_ptr(ptr, len), perm | CHERI_PERM_GLOBAL));
+}
+
+static __inline __capability void *
+cheri_ptrpermoff(const void *ptr, size_t len, register_t perm, off_t off)
+{
+
+	return (cheri_setoffset(cheri_ptrperm(ptr, len, perm), off));
+}
+
+/*
+ * Construct a capability suitable to describe a type identified by 'ptr';
+ * set it to zero-length with the offset equal to the base.  The caller must
+ * provide a root capability (in the old world order, derived from $ddc, but
+ * in the new world order, likely extracted from the kernel using sysarch(2)).
+ *
+ * The caller may wish to assert various properties about the returned
+ * capability, including that CHERI_PERM_SEAL is set.
+ */
+static __inline __capability void *
+cheri_maketype(__capability void *root_type, register_t type)
+{
+	__capability void *c;
+
+	c = root_type;
+	c = cheri_setoffset(c, type);	/* Set type as desired. */
+	c = cheri_csetbounds(c, 1);	/* ISA implies length of 1. */
+	c = cheri_andperm(c, CHERI_PERM_GLOBAL | CHERI_PERM_SEAL); /* Perms. */
+	return (c);
+}
+
+static __inline __capability void *
+cheri_zerocap(void)
+{
+	return (__capability void *)0;
+}
+
+#define CHERI_PRINT_PTR(ptr)						\
+	printf("%s: " #ptr " b:%016jx l:%016zx o:%jx\n", __func__,	\
+	   cheri_getbase((const __capability void *)(ptr)),		\
+	   cheri_getlen((const __capability void *)(ptr)),		\
+	   cheri_getoffset((const __capability void *)(ptr)))
+#endif
+
+#include <machine/cheric.h>
+
+#endif /* _SYS_CHERIC_H_ */

--- a/sys/compat/cheriabi/cheriabi.h
+++ b/sys/compat/cheriabi/cheriabi.h
@@ -34,7 +34,7 @@
 #ifndef _COMPAT_CHERIABI_CHERIABI_H_
 #define _COMPAT_CHERIABI_CHERIABI_H_
 
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 
 #define CP(src,dst,fld) do { (dst).fld = (src).fld; } while (0)
 

--- a/sys/compat/cheriabi/cheriabi_misc.c
+++ b/sys/compat/cheriabi/cheriabi_misc.c
@@ -104,10 +104,11 @@ __FBSDID("$FreeBSD$");
 #include <vm/vm_extern.h>
 
 #include <machine/cpu.h>
-#include <machine/cheri.h>
 #include <machine/elf.h>
 
 #include <security/audit/audit.h>
+
+#include <cheri/cheri.h>
 
 #include <compat/cheriabi/cheriabi.h>
 #include <compat/cheriabi/cheriabi_util.h>

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -245,11 +245,15 @@ cddl/contrib/opensolaris/uts/common/zmod/trees.c			optional zfs compile-with "${
 cddl/contrib/opensolaris/uts/common/zmod/zmod.c				optional zfs compile-with "${ZFS_C}"
 cddl/contrib/opensolaris/uts/common/zmod/zmod_subr.c			optional zfs compile-with "${ZFS_C}"
 cddl/contrib/opensolaris/uts/common/zmod/zutil.c			optional zfs compile-with "${ZFS_C}"
+
+# CHERI and CHERI-compat related files
+cheri/cheri_sysctl.c			optional cpu_cheri
 compat/cheriabi/cheriabi_ioctl.c	optional compat_cheriabi
 compat/cheriabi/cheriabi_mac.c		optional compat_cheriabi
 compat/cheriabi/cheriabi_misc.c		optional compat_cheriabi
 compat/cheriabi/cheriabi_syscalls.c	optional compat_cheriabi
 compat/cheriabi/cheriabi_sysent.c	optional compat_cheriabi
+
 # dtrace specific
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c	optional dtrace compile-with "${DTRACE_C}" \
 							warning "kernel contains CDDL licensed DTRACE"

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -85,7 +85,7 @@ __FBSDID("$FreeBSD$");
 #endif
 
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 #ifdef COMPAT_CHERIABI

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -92,7 +92,7 @@ __FBSDID("$FreeBSD$");
  * XXXRW: We're not quite doing this in the right place, hence the header;
  * need to work on that.
  */
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 #include <machine/cpu.h>

--- a/sys/kern/subr_syscall.c
+++ b/sys/kern/subr_syscall.c
@@ -52,7 +52,7 @@ __FBSDID("$FreeBSD$");
 #include <security/audit/audit.h>
 
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 static inline int

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -40,8 +40,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/cherireg.h>
 #include <machine/pcb.h>
 #include <machine/proc.h>

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -63,49 +63,6 @@
  * call, and reload them afterwards.
  */
 
-SYSCTL_NODE(_security, OID_AUTO, cheri, CTLFLAG_RD, 0,
-    "CHERI settings and statistics");
-
-static u_int cheri_capability_size = CHERICAP_SIZE;
-SYSCTL_UINT(_security_cheri, OID_AUTO, capability_size, CTLFLAG_RD,
-    &cheri_capability_size, 0, "Size of a CHERI capability");
-
-SYSCTL_NODE(_security_cheri, OID_AUTO, stats, CTLFLAG_RD, 0,
-    "CHERI statistics");
-
-/* XXXRW: Should possibly be u_long. */
-u_int	security_cheri_syscall_violations;
-SYSCTL_UINT(_security_cheri, OID_AUTO, syscall_violations, CTLFLAG_RD,
-    &security_cheri_syscall_violations, 0, "Number of system calls blocked");
-
-u_int	security_cheri_sandboxed_signals;
-SYSCTL_UINT(_security_cheri, OID_AUTO, sandboxed_signals, CTLFLAG_RD,
-    &security_cheri_sandboxed_signals, 0, "Number of signals in sandboxes");
-
-/*
- * A set of sysctls that cause the kernel debugger to enter following a policy
- * violation or signal delivery due to CHERI or while in a sandbox.
- */
-u_int	security_cheri_debugger_on_sandbox_signal;
-SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_signal, CTLFLAG_RW,
-    &security_cheri_debugger_on_sandbox_signal, 0,
-    "Enter KDB when a signal is delivered while in a sandbox");
-
-u_int	security_cheri_debugger_on_sandbox_syscall;
-SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_syscall, CTLFLAG_RW,
-    &security_cheri_debugger_on_sandbox_syscall, 0,
-    "Enter KDB when a syscall is rejected while in a sandbox");
-
-u_int	security_cheri_debugger_on_sandbox_unwind;
-SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_unwind, CTLFLAG_RW,
-    &security_cheri_debugger_on_sandbox_unwind, 0,
-    "Enter KDB when a sandbox is auto-unwound due to a signal");
-
-u_int	security_cheri_debugger_on_sigprot;
-SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sigprot, CTLFLAG_RW,
-    &security_cheri_debugger_on_sigprot, 0,
-    "Enter KDB when SIGPROT is delivered to an unsandboxed thread");
-
 static void	cheri_capability_set_user_ddc(struct chericap *);
 static void	cheri_capability_set_user_stc(struct chericap *);
 static void	cheri_capability_set_user_pcc(struct chericap *);

--- a/sys/mips/cheri/cheri_debug.c
+++ b/sys/mips/cheri/cheri_debug.c
@@ -39,8 +39,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/pcb.h>
 #include <machine/sysarch.h>
 

--- a/sys/mips/cheri/cheri_exception.c
+++ b/sys/mips/cheri/cheri_exception.c
@@ -37,8 +37,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/pcb.h>
 #include <machine/sysarch.h>
 

--- a/sys/mips/cheri/cheri_signal.c
+++ b/sys/mips/cheri/cheri_signal.c
@@ -37,8 +37,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/pcb.h>
 #include <machine/sysarch.h>
 

--- a/sys/mips/cheri/cheri_stack.c
+++ b/sys/mips/cheri/cheri_stack.c
@@ -42,8 +42,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/pcb.h>
 #include <machine/sysarch.h>
 

--- a/sys/mips/cheri/cheri_syscall.c
+++ b/sys/mips/cheri/cheri_syscall.c
@@ -39,8 +39,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/pcb.h>
 #include <machine/sysarch.h>
 

--- a/sys/mips/cheri/cheri_test.c
+++ b/sys/mips/cheri/cheri_test.c
@@ -40,8 +40,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/cherireg.h>
 #include <machine/pcb.h>
 #include <machine/proc.h>

--- a/sys/mips/cheri/cheri_typecap.c
+++ b/sys/mips/cheri/cheri_typecap.c
@@ -42,8 +42,9 @@
 #include <ddb/ddb.h>
 #include <sys/kdb.h>
 
+#include <cheri/cheri.h>
+
 #include <machine/atomic.h>
-#include <machine/cheri.h>
 #include <machine/pcb.h>
 #include <machine/sysarch.h>
 

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -80,7 +80,8 @@
 #include <sys/uuid.h>
 #include <netinet/sctp.h>
 
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
+
 #include <machine/cpuinfo.h>
 #include <machine/md_var.h>
 #include <machine/pcb.h>

--- a/sys/mips/include/cheri.h
+++ b/sys/mips/include/cheri.h
@@ -38,40 +38,8 @@
 #endif
 
 #include <machine/cherireg.h>
+
 #include <sys/types.h>
-
-/*
- * Canonical C-language representation of a capability for compilers that
- * don't support capabilities directly.  The in-memory layout is sensitive to
- * the microarchitecture, and hence treated as opaque.  Fields must be
- * accessed via the ISA.
- */
-struct chericap {
-	uint8_t		c_data[CHERICAP_SIZE];
-} __packed __aligned(CHERICAP_SIZE);
-#ifdef _KERNEL
-CTASSERT(sizeof(struct chericap) == CHERICAP_SIZE);
-#endif
-
-/*
- * Canonical C-language representation of a CHERI object capability -- code
- * and data capabilities in registers or memory.
- */
-struct cheri_object {
-#if !defined(_KERNEL) && __has_feature(capabilities)
-	__capability void	*co_codecap;
-	__capability void	*co_datacap;
-#else
-	struct chericap		 co_codecap;
-	struct chericap		 co_datacap;
-#endif
-};
-
-#if !defined(_KERNEL) && __has_feature(capabilities)
-#define	CHERI_OBJECT_INIT_NULL	{NULL, NULL}
-#define	CHERI_OBJECT_ISNULL(co)	\
-    ((co).co_codecap == NULL && (co).co_datacap == NULL)
-#endif
 
 /*
  * In the past, struct cheri_frame was the in-kernel and kernel<->user
@@ -151,71 +119,6 @@ struct cheri_kframe {
 	struct chericap ckf_c24;
 };
 #endif
-
-/*
- * Data structure describing CHERI's sigaltstack-like extensions to signal
- * delivery.  In the event that a thread takes a signal when $pcc doesn't hold
- * CHERI_PERM_SYSCALL, we will need to install new $pcc, $ddc, $stc, and $idc
- * state, and move execution to the per-thread alternative stack, whose
- * pointer should (presumably) be relative to the $ddc/$stc defined here.
- */
-struct cheri_signal {
-#if !defined(_KERNEL) && __has_feature(capabilities)
-	__capability void	*csig_pcc;
-	__capability void	*csig_ddc;
-	__capability void	*csig_stc;
-	__capability void	*csig_idc;
-	__capability void	*csig_default_stack;
-	__capability void	*csig_sigcode;
-#else
-	struct chericap		 csig_pcc;
-	struct chericap		 csig_ddc;
-	struct chericap		 csig_stc;
-	struct chericap		 csig_idc;
-	struct chericap		 csig_default_stack;
-	struct chericap		 csig_sigcode;
-#endif
-};
-
-/*
- * Per-thread CHERI CCall/CReturn stack, which preserves the calling PC/PCC/
- * IDC across CCall so that CReturn can restore them.
- *
- * XXXRW: This is a very early experiment -- it's not clear if this idea will
- * persist in its current form, or at all.  For more complex userspace
- * language, there's a reasonable expectation that it, rather than the kernel,
- * will want to manage the idea of a "trusted stack".
- *
- * XXXRW: This is currently part of the kernel-user ABI due to the
- * CHERI_GET_STACK and CHERI_SET_STACK sysarch() calls.  In due course we need
- * to revise those APIs and differentiate the kernel-internal representation
- * from the public one.
- */
-struct cheri_stack_frame {
-	register_t	_csf_pad0;	/* Used to be MIPS program counter. */
-	register_t	_csf_pad1;
-	register_t	_csf_pad2;
-	register_t	_csf_pad3;
-#if !defined(_KERNEL) && __has_feature(capabilities)
-	__capability void	*csf_pcc;
-	__capability void	*csf_idc;
-#else
-	struct chericap	csf_pcc;
-	struct chericap	csf_idc;
-#endif
-};
-
-#define	CHERI_STACK_DEPTH	8	/* XXXRW: 8 is a nice round number. */
-struct cheri_stack {
-	register_t	cs_tsp;		/* Byte offset, not frame index. */
-	register_t	cs_tsize;	/* Stack size, in bytes. */
-	register_t	_cs_pad0;
-	register_t	_cs_pad1;
-	struct cheri_stack_frame	cs_frames[CHERI_STACK_DEPTH];
-} __aligned(CHERICAP_SIZE);
-
-#define	CHERI_FRAME_SIZE	sizeof(struct cheri_stack_frame)
-#define	CHERI_STACK_SIZE	(CHERI_STACK_DEPTH * CHERI_FRAME_SIZE)
 
 /*
  * CHERI capability register manipulation macros.
@@ -748,6 +651,10 @@ struct cheri_stack {
 		    "i" (cb));						\
 } while (0)
 
+/*
+ * Utility functions for the kernel -- as they depend on $kdc.
+ */
+#ifdef _KERNEL
 static inline void
 cheri_capability_load(u_int crn_to, struct chericap *cp)
 {
@@ -761,6 +668,7 @@ cheri_capability_store(u_int crn_from, struct chericap *cp)
 
         CHERI_CSC(crn_from, CHERI_CR_KDC, cp, 0);
 }
+#endif
 
 /*
  * Routines for measuring time -- depends on a later MIPS userspace cycle
@@ -834,68 +742,8 @@ cheri_get_cyclecount(void)
 	db_printf("$c%02u: ", num);					\
 	DB_CHERI_CAP_PRINT(crn);					\
 } while (0)
-#endif /* !_KERNEL */
+#endif /* !DDB */
 
-/*
- * APIs that act on C language representations of capabilities -- but not
- * capabilities themselves.
- */
-void	cheri_capability_copy(struct chericap *cp_to,
-	    struct chericap *cp_from);
-void	cheri_capability_set(struct chericap *cp, uint32_t uperms,
-	    void *otype, void *basep, size_t length, off_t off);
-void	cheri_capability_set_null(struct chericap *cp);
-void	cheri_capability_setoffset(struct chericap *cp, register_t offset);
-
-/*
- * CHERI capability utility functions.
- */
-void	 cheri_bcopy(void *src, void *dst, size_t len);
-void	*cheri_memcpy(void *dst, void *src, size_t len);
-
-/*
- * CHERI context management functions.
- */
-const char	*cheri_exccode_string(uint8_t exccode);
-void	cheri_exec_setregs(struct thread *td, u_long entry_addr);
-void	cheri_log_cheri_frame(struct trapframe *frame);
-void	cheri_log_exception(struct trapframe *frame, int trap_type);
-void	cheri_log_exception_registers(struct trapframe *frame);
-int	cheri_syscall_authorize(struct thread *td, u_int code,
-	    int nargs, register_t *args);
-int	cheri_signal_sandboxed(struct thread *td);
-void	cheri_sendsig(struct thread *td);
-void	cheri_trapframe_from_cheriframe(struct trapframe *frame,
-	    struct cheri_frame *cfp);
-void	cheri_trapframe_to_cheriframe(struct trapframe *frame,
-	    struct cheri_frame *cfp);
-
-/*
- * Functions to set up and manipulate CHERI contexts and stacks.
- */
-struct pcb;
-struct sysarch_args;
-void	cheri_signal_copy(struct pcb *dst, struct pcb *src);
-void	cheri_stack_copy(struct pcb *dst, struct pcb *src);
-void	cheri_stack_init(struct pcb *pcb);
-int	cheri_stack_unwind(struct thread *td, struct trapframe *tf,
-	    int signum);
-int	cheri_sysarch_getstack(struct thread *td, struct sysarch_args *uap);
-int	cheri_sysarch_gettypecap(struct thread *td, struct sysarch_args *uap);
-int	cheri_sysarch_setstack(struct thread *td, struct sysarch_args *uap);
-void	cheri_typecap_copy(struct pcb *dst, struct pcb *src);
-
-/*
- * Global sysctl definitions.
- */
-SYSCTL_DECL(_security_cheri);
-SYSCTL_DECL(_security_cheri_stats);
-extern u_int	security_cheri_debugger_on_sandbox_signal;
-extern u_int	security_cheri_debugger_on_sandbox_syscall;
-extern u_int	security_cheri_debugger_on_sandbox_unwind;
-extern u_int	security_cheri_debugger_on_sigprot;
-extern u_int	security_cheri_sandboxed_signals;
-extern u_int	security_cheri_syscall_violations;
 #endif /* !_KERNEL */
 
 #endif /* _MIPS_INCLUDE_CHERI_H_ */

--- a/sys/mips/include/cheriasm.h
+++ b/sys/mips/include/cheriasm.h
@@ -77,11 +77,12 @@
 #define	CHERI_REG_EPCC	$c31	/* Exception program counter capability. */
 
 /*
- * The kernel maintains a CHERI micro-ABI preserving two registers, $c11 and
- * $c12, for use by kernel threads.  Label them here for consistency.
+ * In kernel inline assembly, employee these two caller-save registers.  This
+ * means that we don't need to worry about preserving prior values -- as long
+ * as there is no direct use of a capability register in a function.
  */
-#define	CHERI_REG_CTEMP0	CHERI_REG_C11	/* C capability manipulation. */
-#define	CHERI_REG_CTEMP1	CHERI_REG_C12	/* C capability manipulation. */
+#define	CHERI_REG_CTEMP0	CHERI_REG_C13	/* C capability manipulation. */
+#define	CHERI_REG_CTEMP1	CHERI_REG_C14	/* C capability manipulation. */
 
 /*
  * Where to save the user $ddc during low-level exception handling.  Possibly

--- a/sys/mips/include/cheric.h
+++ b/sys/mips/include/cheric.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2013-2015 Robert N. M. Watson
+ * Copyright (c) 2013-2016 Robert N. M. Watson
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -33,152 +33,9 @@
 
 #include <sys/cdefs.h>
 
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 
 #if !defined(_KERNEL) && __has_feature(capabilities)
-/*
- * Programmer-friendly macros for CHERI-aware C code -- requires use of
- * CHERI-aware Clang/LLVM, and full CP2 context switching, so not yet usable
- * in the kernel.
- */
-#define	cheri_getlen(x)		__builtin_cheri_get_cap_length(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_getbase(x)	__builtin_cheri_get_cap_base(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_getoffset(x)	__builtin_cheri_cap_offset_get(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_getperm(x)	__builtin_cheri_get_cap_perms(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_getsealed(x)	__builtin_cheri_get_cap_sealed(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_gettag(x)		__builtin_cheri_get_cap_tag(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_gettype(x)	__builtin_cheri_get_cap_type(		\
-				    __DECONST(__capability void *, (x)))
-
-#define	cheri_andperm(x, y)	__builtin_cheri_and_cap_perms(		\
-				    __DECONST(__capability void *, (x)), (y))
-#define	cheri_cleartag(x)	__builtin_cheri_clear_cap_tag(		\
-				    __DECONST(__capability void *, (x)))
-#define	cheri_incoffset(x, y)	__builtin_cheri_cap_offset_increment(	\
-				    __DECONST(__capability void *, (x)), (y))
-#define	cheri_setoffset(x, y)	__builtin_cheri_cap_offset_set(		\
-				    __DECONST(__capability void *, (x)), (y))
-
-#define	cheri_seal(x, y)	__builtin_cheri_seal_cap(		 \
-				    __DECONST(__capability void *, (x)), \
-				    __DECONST(__capability void *, (y)))
-#define	cheri_unseal(x, y)	__builtin_cheri_unseal_cap(		 \
-				    __DECONST(__capability void *, (x)), \
-				    __DECONST(__capability void *, (y)))
-
-#define	cheri_getcause()	__builtin_cheri_get_cause()
-#define	cheri_setcause(x)	__builtin_cheri_set_cause(x)
-
-#define	cheri_ccheckperm(c, p)	__builtin_cheri_check_perms(		\
-				    __DECONST(__capability void *, (c)), (p))
-#define	cheri_cchecktype(c, t)	__builtin_cheri_check_type(		\
-				    __DECONST(__capability void *, (c)), (t))
-
-#define	cheri_getdefault()	__builtin_cheri_get_global_data_cap()
-#define	cheri_getidc()		__builtin_cheri_get_invoke_data_cap()
-#define	cheri_getkr0c()		__builtin_cheri_get_kernel_cap1()
-#define	cheri_getkr1c()		__builtin_cheri_get_kernel_cap2()
-#define	cheri_getkcc()		__builtin_cheri_get_kernel_code_cap()
-#define	cheri_getkdc()		__builtin_cheri_get_kernel_data_cap()
-#define	cheri_getepcc()		__builtin_cheri_get_exception_program_counter_cap()
-#define	cheri_getpcc()		__builtin_cheri_get_program_counter_cap()
-#define	cheri_getstack()	__builtin_memcap_stack_get()
-
-#define	cheri_local(c)		cheri_andperm((c), ~CHERI_PERM_GLOBAL)
-
-#define	cheri_csetbounds(x, y)	__builtin_memcap_bounds_set(		\
-				    __DECONST(__capability void *, (x)), (y))
-
-/*
- * Two variations on cheri_ptr() based on whether we are looking for a code or
- * data capability.  The compiler's use of CFromPtr will be with respect to
- * $ddc or $pcc depending on the type of the pointer derived, so we need to
- * use types to differentiate the two versions at compile time.  We don't
- * provide the full set of function variations for code pointers as they
- * haven't proven necessary as yet.
- *
- * XXXRW: Ideally, casting via a function pointer would cause the compiler to
- * derive the capability using CFromPtr on $pcc rather than on $ddc.  This
- * appears not currently to be the case, so manually derive using
- * cheri_getpcc() for now.
- */
-static __inline __capability void *
-cheri_codeptr(const void *ptr, size_t len)
-{
-#ifdef NOTYET
-	__capability void (*c)(void) = ptr;
-#else
-	__capability void *c = cheri_setoffset(cheri_getpcc(),
-	    (register_t)ptr);
-#endif
-
-	/* Assume CFromPtr without base set, availability of CSetBounds. */
-	return (cheri_csetbounds(c, len));
-}
-
-static __inline __capability void *
-cheri_codeptrperm(const void *ptr, size_t len, register_t perm)
-{
-
-	return (cheri_andperm(cheri_codeptr(ptr, len),
-	    perm | CHERI_PERM_GLOBAL));
-}
-
-static __inline __capability void *
-cheri_ptr(const void *ptr, size_t len)
-{
-
-	/* Assume CFromPtr without base set, availability of CSetBounds. */
-	return (cheri_csetbounds((const __capability void *)ptr, len));
-}
-
-static __inline __capability void *
-cheri_ptrperm(const void *ptr, size_t len, register_t perm)
-{
-
-	return (cheri_andperm(cheri_ptr(ptr, len), perm | CHERI_PERM_GLOBAL));
-}
-
-static __inline __capability void *
-cheri_ptrpermoff(const void *ptr, size_t len, register_t perm, off_t off)
-{
-
-	return (cheri_setoffset(cheri_ptrperm(ptr, len, perm), off));
-}
-
-/*
- * Construct a capability suitable to describe a type identified by 'ptr';
- * set it to zero-length with the offset equal to the base.  The caller must
- * provide a root capability (in the old world order, derived from $ddc, but
- * in the new world order, likely extracted from the kernel using sysarch(2)).
- *
- * The caller may wish to assert various properties about the returned
- * capability, including that CHERI_PERM_SEAL is set.
- */
-static __inline __capability void *
-cheri_maketype(__capability void *root_type, register_t type)
-{
-	__capability void *c;
-
-	c = root_type;
-	c = cheri_setoffset(c, type);	/* Set type as desired. */
-	c = cheri_csetbounds(c, 1);	/* ISA implies length of 1. */
-	c = cheri_andperm(c, CHERI_PERM_GLOBAL | CHERI_PERM_SEAL); /* Perms. */
-	return (c);
-}
-
-static __inline __capability void *
-cheri_zerocap(void)
-{
-	return (__capability void *)0;
-}
-
 #define	cheri_getreg(x) ({						\
 	__capability void *_cap;					\
 	__asm __volatile ("cmove %0, $c" #x : "=C" (_cap));		\
@@ -193,11 +50,5 @@ cheri_zerocap(void)
 		__asm __volatile ("cmove $c" #x ", %0" : : "C" (cap));  \
 } while (0)
 #endif
-
-#define CHERI_PRINT_PTR(ptr)						\
-	printf("%s: " #ptr " b:%016jx l:%016zx o:%jx\n", __func__,	\
-	   cheri_getbase((const __capability void *)(ptr)),		\
-	   cheri_getlen((const __capability void *)(ptr)),		\
-	   cheri_getoffset((const __capability void *)(ptr)))
 
 #endif /* _MIPS_INCLUDE_CHERIC_H_ */

--- a/sys/mips/include/cherireg.h
+++ b/sys/mips/include/cherireg.h
@@ -283,8 +283,8 @@
 #define	CHERI_CR_C31	31
 #define	CHERI_CR_EPCC	CHERI_CR_C31
 
-#define	CHERI_CR_CTEMP0	CHERI_CR_C11	/* C capability manipulation. */
-#define	CHERI_CR_CTEMP1	CHERI_CR_C12	/* C capability manipulation. */
+#define	CHERI_CR_CTEMP0	CHERI_CR_C13	/* C capability manipulation. */
+#define	CHERI_CR_CTEMP1	CHERI_CR_C14	/* C capability manipulation. */
 #define	CHERI_CR_SEC0	CHERI_CR_KR2C	/* Saved $c0 in exception handler. */
 
 /*

--- a/sys/mips/include/frame.h
+++ b/sys/mips/include/frame.h
@@ -66,9 +66,8 @@
 #ifndef _MACHINE_FRAME_H_
 #define	_MACHINE_FRAME_H_
 
-
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 /* Note: This must also match regnum.h and regdef.h */

--- a/sys/mips/include/pcb.h
+++ b/sys/mips/include/pcb.h
@@ -155,7 +155,7 @@
 #ifndef LOCORE
 #include <machine/frame.h>
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 /*

--- a/sys/mips/include/proc.h
+++ b/sys/mips/include/proc.h
@@ -40,7 +40,7 @@
 #define	_MACHINE_PROC_H_
 
 #ifdef	CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 #ifdef	CPU_CNMIPS
 #include <machine/octeon_cop2.h>

--- a/sys/mips/include/ucontext.h
+++ b/sys/mips/include/ucontext.h
@@ -44,7 +44,7 @@
 #endif
 
 #if defined(COMPAT_CHERIABI) || defined(__CHERI_PURE_CAPABILITY__)
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 typedef struct	__mcontext {

--- a/sys/mips/mips/machdep.c
+++ b/sys/mips/mips/machdep.c
@@ -81,9 +81,6 @@ __FBSDID("$FreeBSD$");
 #include <machine/asm.h>
 #include <machine/bootinfo.h>
 #include <machine/cache.h>
-#ifdef CPU_CHERI
-#include <machine/cheri.h>
-#endif
 #include <machine/clock.h>
 #include <machine/cpu.h>
 #include <machine/cpuregs.h>
@@ -95,6 +92,10 @@ __FBSDID("$FreeBSD$");
 #ifdef DDB
 #include <sys/kdb.h>
 #include <ddb/ddb.h>
+#endif
+
+#ifdef CPU_CHERI
+#include <cheri/cheri.h>
 #endif
 
 #include <sys/random.h>

--- a/sys/mips/mips/pm_machdep.c
+++ b/sys/mips/mips/pm_machdep.c
@@ -71,7 +71,7 @@ __FBSDID("$FreeBSD$");
 #include <fs/procfs/procfs.h>
 
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 #include <ddb/ddb.h>

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -75,7 +75,6 @@ __FBSDID("$FreeBSD$");
 #include <net/netisr.h>
 
 #include <machine/trap.h>
-#include <machine/cheri.h>
 #include <machine/cpu.h>
 #include <machine/pte.h>
 #include <machine/pmap.h>
@@ -85,6 +84,10 @@ __FBSDID("$FreeBSD$");
 #include <machine/regnum.h>
 #include <machine/tlb.h>
 #include <machine/tls.h>
+
+#ifdef CPU_CHERI
+#include <cheri/cheri.h>
+#endif
 
 #ifdef DDB
 #include <machine/db_machdep.h>

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -60,9 +60,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/vmem.h>
 
 #include <machine/cache.h>
-#ifdef CPU_CHERI
-#include <machine/cheri.h>
-#endif
 #include <machine/clock.h>
 #include <machine/cpu.h>
 #include <machine/cpufunc.h>
@@ -70,6 +67,10 @@ __FBSDID("$FreeBSD$");
 #include <machine/md_var.h>
 #include <machine/pcb.h>
 #include <machine/tls.h>
+
+#ifdef CPU_CHERI
+#include <cheri/cheri.h>
+#endif
 
 #include <vm/vm.h>
 #include <vm/vm_extern.h>

--- a/sys/sys/signalvar.h
+++ b/sys/sys/signalvar.h
@@ -39,7 +39,7 @@
 #include <sys/signal.h>
 
 #ifdef COMPAT_CHERIABI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 /*

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -121,7 +121,7 @@ __FBSDID("$FreeBSD$");
  * another day.
  */
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 /*

--- a/sys/vm/uma.h
+++ b/sys/vm/uma.h
@@ -38,8 +38,9 @@
 
 #include <sys/param.h>		/* For NULL */
 #include <sys/malloc.h>		/* For M_* */
+
 #ifdef CPU_CHERI
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 #endif
 
 /* User visible parameters */

--- a/usr.bin/qtrace/qtrace.c
+++ b/usr.bin/qtrace/qtrace.c
@@ -31,7 +31,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include <machine/cheri.h>
+#include <cheri/cheri.h>
 
 #include <err.h>
 #include <stdlib.h>

--- a/usr.sbin/tcpdump/cheri_tcpdump/print.c
+++ b/usr.sbin/tcpdump/cheri_tcpdump/print.c
@@ -37,8 +37,8 @@
 #include <sys/queue.h>
 #include <sys/ucontext.h>
 
-#include <machine/cheri.h>
-#include <machine/cheric.h>
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
 
 #include <net/bpf.h>
 #include <net/ethernet.h>


### PR DESCRIPTION
This branch contains an initial experiment in creating a  ```sys/cheri``` tree to hold machine-independent CHERI headers and code. On the header front, content is drawn from the existing ```mips/include/cheri.h``` and ```mips/include/cheric.h```, and a small amount of code is also shifted from ```mips/cheri/cheri.c```. The majority of the remainder of the code in ```sys/mips/cheri``` incorporates moderately strong architectural elements (e.g., as relates to CHERI registers) and may need greater refactoring before it could be shifted to the machine-independent side.