### PR TITLE
Add an easy way to override optimization level for CHERI compilation

### DIFF
--- a/lib/libucl/Makefile
+++ b/lib/libucl/Makefile
@@ -28,4 +28,11 @@ CFLAGS+=	-I${LIBUCL}/include \
 		-I${LIBUCL}/uthash \
 		-I${LIBUCL}/klib
 
+# FIXME: for some reason clang crashes at -O0
+# We can't change CHERI_OPTIMIZATION_FLAGS as the value set on the command line
+# overrides any value set here. We need to use _CHERI_CFLAGS instead as it gets
+# added right at the end of the compilation command and therefore overrides
+# whatever CHERI_OPTIMIZATION_FLAGS sets
+_CHERI_CFLAGS+=-O2
+
 .include <bsd.lib.mk>

--- a/share/mk/bsd.cheri.mk
+++ b/share/mk/bsd.cheri.mk
@@ -62,7 +62,7 @@ OBJCOPY:=	objcopy
 _CHERI_CC+=	-mabi=sandbox -mxgot
 LIBDIR:=	/usr/libcheri
 ROOTOBJDIR=	${.OBJDIR:S,${.CURDIR},,}${SRCTOP}/worldcheri${SRCTOP}
-CFLAGS+=	-O2 -ftls-model=local-exec
+CFLAGS+=	${CHERI_OPTIMIZATION_FLAGS:U-O2} -ftls-model=local-exec
 .if ${MK_CHERI_LINKER} == "yes"
 _CHERI_CC+=	-cheri-linker
 CFLAGS+=	-Wno-error


### PR DESCRIPTION
This makes it easy for me get a -O0 build of the CheriABI libraries+binaries by running `make CHERI_OPTFLAGS=-O0 buildworld`.