### PR TITLE
Use PC-relative assembly for PIC libc

### DIFF
--- a/contrib/binutils/bfd/elf64-mips.c
+++ b/contrib/binutils/bfd/elf64-mips.c
@@ -1464,6 +1464,48 @@ static reloc_howto_type mips_elf64_howto_table_rela[] =
 	 0x0,			/* src_mask */
 	 0xffffffff,		/* dst_mask */
 	 FALSE),		/* pcrel_offset */
+
+  /* Need to add empty entries from R_MIPS_GLOB_DAT(51) to R_MIPS_PCHI16(64) */
+  EMPTY_HOWTO (52),
+  EMPTY_HOWTO (53),
+  EMPTY_HOWTO (54),
+  EMPTY_HOWTO (55),
+  EMPTY_HOWTO (56),
+  EMPTY_HOWTO (57),
+  EMPTY_HOWTO (58),
+  EMPTY_HOWTO (59),
+  EMPTY_HOWTO (60),
+  EMPTY_HOWTO (61),
+  EMPTY_HOWTO (62),
+  EMPTY_HOWTO (63),
+  /* PC-relative relocations.  */
+  HOWTO (R_MIPS_PCHI16,		/* type */
+	 16,			/* rightshift */
+	 2,			/* size (0 = byte, 1 = short, 2 = long) */
+	 16,			/* bitsize */
+	 TRUE,			/* pc_relative */
+	 0,			/* bitpos */
+	 complain_overflow_signed, /* complain_on_overflow */
+	 _bfd_mips_elf_generic_reloc,   /* special_function */
+	 "R_MIPS_PCHI16",	/* name */
+	 FALSE,			/* partial_inplace */
+	 0,			/* src_mask */
+	 0x0000ffff,		/* dst_mask */
+	 TRUE),			/* pcrel_offset */
+
+  HOWTO (R_MIPS_PCLO16,		/* type */
+	 0,			/* rightshift */
+	 2,			/* size (0 = byte, 1 = short, 2 = long) */
+	 16,			/* bitsize */
+	 TRUE,			/* pc_relative */
+	 0,			/* bitpos */
+	 complain_overflow_dont, /* complain_on_overflow */
+	 _bfd_mips_elf_generic_reloc,   /* special_function */
+	 "R_MIPS_PCLO16",	/* name */
+	 FALSE,			/* partial_inplace */
+	 0,			/* src_mask */
+	 0x0000ffff,		/* dst_mask */
+	 TRUE),			/* pcrel_offset */
 };
 
 static reloc_howto_type mips16_elf64_howto_table_rel[] =
@@ -2206,7 +2248,9 @@ static const struct elf_reloc_map mips_reloc_map[] =
   { BFD_RELOC_MIPS_TLS_TPREL32, R_MIPS_TLS_TPREL32 },
   { BFD_RELOC_MIPS_TLS_TPREL64, R_MIPS_TLS_TPREL64 },
   { BFD_RELOC_MIPS_TLS_TPREL_HI16, R_MIPS_TLS_TPREL_HI16 },
-  { BFD_RELOC_MIPS_TLS_TPREL_LO16, R_MIPS_TLS_TPREL_LO16 }
+  { BFD_RELOC_MIPS_TLS_TPREL_LO16, R_MIPS_TLS_TPREL_LO16 },
+  { BFD_RELOC_HI16_S_PCREL, R_MIPS_PCHI16 },
+  { BFD_RELOC_LO16_PCREL, R_MIPS_PCLO16 }
 };
 
 static const struct elf_reloc_map mips16_reloc_map[] =

--- a/contrib/binutils/bfd/elfxx-mips.c
+++ b/contrib/binutils/bfd/elfxx-mips.c
@@ -4335,6 +4335,16 @@ mips_elf_calculate_relocation (bfd *abfd, bfd *input_bfd,
       value &= howto->dst_mask;
       break;
 
+    case R_MIPS_PCHI16:
+      /* XXXAR: overflow check? */
+      value = mips_elf_high(symbol + addend - p);
+      value &= howto->dst_mask;
+      break;
+    case R_MIPS_PCLO16:
+      value = symbol + addend - p;
+      value &= howto->dst_mask;
+      break;
+
     case R_MIPS16_26:
       /* The calculation for R_MIPS16_26 is just the same as for an
 	 R_MIPS_26.  It's only the storage of the relocated field into

--- a/contrib/binutils/include/elf/mips.h
+++ b/contrib/binutils/include/elf/mips.h
@@ -88,7 +88,12 @@ START_RELOC_NUMBERS (elf_mips_reloc_type)
   RELOC_NUMBER (R_MIPS_TLS_TPREL_HI16, 49)
   RELOC_NUMBER (R_MIPS_TLS_TPREL_LO16, 50)
   RELOC_NUMBER (R_MIPS_GLOB_DAT, 51)
-  FAKE_RELOC (R_MIPS_max, 52)
+
+  /* PC relative relocations */
+  RELOC_NUMBER (R_MIPS_PCHI16, 64)
+  RELOC_NUMBER (R_MIPS_PCLO16, 65)
+
+  FAKE_RELOC (R_MIPS_max, 66)
   /* These relocs are used for the mips16.  */
   FAKE_RELOC (R_MIPS16_min, 100)
   RELOC_NUMBER (R_MIPS16_26, 100)

--- a/lib/libc/gen/setjmperr.c
+++ b/lib/libc/gen/setjmperr.c
@@ -45,7 +45,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 #include "un-namespace.h"
 
-void
+__attribute__((visibility("protected"))) void
 longjmperror(void)
 {
 #define	ERRMSG	"longjmp botch.\n"

--- a/lib/libc/mips/SYS.h
+++ b/lib/libc/mips/SYS.h
@@ -107,17 +107,28 @@
  *
  * FIXME: if the difference is at a 16 bit boundary this calculation is wrong.
  */
-# define PIC_TAILCALL(l)			\
-	lui		t9, %pcrel_hi(l);	\
-	daddiu		t9, t9, %pcrel_lo(l);	\
-	daddiu		t9, t9, -8;		\
-	cgetpcc		$c12;			\
-	cincoffset	$c12, $c12, t9;		\
-	cjr		$c12;
+# define PIC_LOAD_CODE_PTR(capreg, gpr, l)		\
+	lui		gpr, %pcrel_hi(l);		\
+	daddiu		gpr, gpr, %pcrel_lo(l);		\
+	daddiu		gpr, gpr, -8;			\
+	cgetpcc		capreg;				\
+	cincoffset	capreg, capreg, t9;
+# define PIC_TAILCALL(l)				\
+	PIC_LOAD_CODE_PTR($c12, t9, _C_LABEL(l))	\
+	cjr $c12;
+# define PIC_CALL(l)					\
+	PIC_LOAD_CODE_PTR($c12, t9, _C_LABEL(l))	\
+	cjalr $c12, $c17;				\
+	nop;
 # define PIC_RETURN()		cjr $c17
 #else
 # define PIC_PROLOGUE(x)
 # define PIC_TAILCALL(l)	j _C_LABEL(l)
+# define PIC_CALL(l)				\
+	dla			t9, l;		\
+	cgetpccsetoffset	$c12, t9;	\
+	cjalr			$c12, $c17;	\
+	nop
 # define PIC_RETURN()		cjr $c17
 #endif
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */

--- a/lib/libc/mips/SYS.h
+++ b/lib/libc/mips/SYS.h
@@ -112,7 +112,7 @@
 	daddiu		gpr, gpr, %pcrel_lo(l);		\
 	daddiu		gpr, gpr, -8;			\
 	cgetpcc		capreg;				\
-	cincoffset	capreg, capreg, t9;
+	cincoffset	capreg, capreg, gpr;
 # define PIC_TAILCALL(l)				\
 	PIC_LOAD_CODE_PTR($c12, t9, _C_LABEL(l))	\
 	cjr $c12;

--- a/lib/libc/mips/gen/Makefile.inc
+++ b/lib/libc/mips/gen/Makefile.inc
@@ -11,7 +11,7 @@ SRCS+=	_ctx_start.S _set_tp.c makecontext.c \
 	trivial-getcontextx.c
 
 .if defined(LIBCHERI)
-SRCS+=	_setjmp_c.S setjmp_c.S
+SRCS+=	_setjmp_c.S setjmp_c.S cheriabi_pic_wrappers.c
 .else
 SRCS+=	_setjmp.S setjmp.S
 .endif

--- a/lib/libc/mips/gen/_ctx_start.S
+++ b/lib/libc/mips/gen/_ctx_start.S
@@ -25,6 +25,7 @@
  */
 
 #include <machine/asm.h>
+#include "SYS.h"
 __FBSDID("$FreeBSD$");
 
 /*
@@ -34,8 +35,11 @@ ENTRY(_ctx_start)
 	jalr	t9
 
 	move	a0, s0
+#ifndef __CHERI_PURE_CAPABILITY__
 	PTR_LA	t9, _ctx_done
 	jalr	t9
-
+#else
+	PIC_CALL(_ctx_done)
+#endif
 	break	0
 END(_ctx_start)

--- a/lib/libc/mips/gen/_setjmp_c.S
+++ b/lib/libc/mips/gen/_setjmp_c.S
@@ -221,11 +221,6 @@ botch:
 	 * our caller's GP.
 	 */
 	ld		v1, 0(zero)
-	PTR_LA		t9, _C_LABEL(longjmperror)
-	cgetpcc		$c12
-	csetoffset	$c12, $c12, t9
-	cjalr		$c12, $c17
-	nop
-
+	PIC_CALL(longjmperror)
 	PIC_TAILCALL(abort)
 END(_longjmp)

--- a/lib/libc/mips/gen/_setjmp_c.S
+++ b/lib/libc/mips/gen/_setjmp_c.S
@@ -59,8 +59,8 @@ __FBSDID("$FreeBSD$");
 
 #define SETJMP_FRAME_SIZE	(CALLFRAME_SIZ + _MIPS_SZCAP/8)
 
-
 NESTED(_setjmp, SETJMP_FRAME_SIZE, ra)
+	.protected _C_LABEL(_setjmp)
 	.set	noreorder
 
 	li		v0, _JB_MAGIC__SETJMP
@@ -131,8 +131,8 @@ NESTED(_setjmp, SETJMP_FRAME_SIZE, ra)
 END(_setjmp)
 
 #define LONGJMP_FRAME_SIZE	(CALLFRAME_SIZ + _MIPS_SZCAP/8)
-
 NESTED(_longjmp, LONGJMP_FRAME_SIZE, ra)
+	.protected _C_LABEL(_longjmp)
 	.mask	0xc0000000, (CALLFRAME_RA - CALLFRAME_SIZ)
 	PTR_SUBU	sp, sp, LONGJMP_FRAME_SIZE	# allocate stack frame
 

--- a/lib/libc/mips/gen/_setjmp_c.S
+++ b/lib/libc/mips/gen/_setjmp_c.S
@@ -221,6 +221,6 @@ botch:
 	 * our caller's GP.
 	 */
 	ld		v1, 0(zero)
-	PIC_CALL(longjmperror)
-	PIC_TAILCALL(abort)
+	PIC_CALL(__cheriabi_longjmperror)
+	PIC_TAILCALL(__cheriabi_abort)
 END(_longjmp)

--- a/lib/libc/mips/gen/cheriabi_pic_wrappers.c
+++ b/lib/libc/mips/gen/cheriabi_pic_wrappers.c
@@ -54,7 +54,7 @@
 void __hidden
 __cheriabi_longjmperror(void)
 {
-	return longjmperror();
+	longjmperror();
 }
 
 int __hidden
@@ -66,6 +66,6 @@ __cheriabi_sigprocmask(int how, const sigset_t *set, sigset_t *oset)
 void __dead2 __hidden
 __cheriabi_abort(void)
 {
-	return abort();
+	abort();
 }
 #endif

--- a/lib/libc/mips/gen/setjmp_c.S
+++ b/lib/libc/mips/gen/setjmp_c.S
@@ -59,8 +59,8 @@ __FBSDID("$FreeBSD$");
 
 #define SETJMP_FRAME_SIZE	(CALLFRAME_SIZ + _MIPS_SZCAP/8)
 
-
 NESTED(setjmp, SETJMP_FRAME_SIZE, ra)
+	.protected _C_LABEL(setjmp)
 	.mask	0xc0000000, (CALLFRAME_RA - CALLFRAME_SIZ)
 	PTR_SUBU sp, sp, SETJMP_FRAME_SIZE	# allocate stack frame
 
@@ -78,7 +78,7 @@ NESTED(setjmp, SETJMP_FRAME_SIZE, ra)
 	csetoffset	$c3, $c3, t0			# oset
 	cfromptr	$c4, $c3, zero			# set == NULL
 	li		a0, 1				# SIG_SETBLOCK
-	PTR_LA		t9, _C_LABEL(sigprocmask)	# get current signal mask
+	PTR_LA		t9, _C_LABEL(__libc_sigprocmask)	# get current signal mask
 	dla		t0, 1f
 1:	cgetpcc		$c12
 	cgetoffset	t1, $c12
@@ -166,6 +166,7 @@ END(setjmp)
 #define LONGJMP_FRAME_SIZE	(CALLFRAME_SIZ + _MIPS_SZCAP/8)
 
 NESTED(longjmp, LONGJMP_FRAME_SIZE, ra)
+	.protected _C_LABEL(longjmp)
 	.mask	0xc0000000, (CALLFRAME_RA - CALLFRAME_SIZ)
 	PTR_SUBU	sp, sp, LONGJMP_FRAME_SIZE	# allocate stack frame
 
@@ -186,7 +187,7 @@ NESTED(longjmp, LONGJMP_FRAME_SIZE, ra)
 	csetoffset	$c3, $c3, t0			# set
 	cfromptr	$c4, $c3, zero			# oset == NULL
 	li		a0, 3				# SIG_SETMASK
-	PTR_LA		t9, _C_LABEL(sigprocmask)	# set current signal mask
+	PTR_LA		t9, _C_LABEL(__libc_sigprocmask)# set current signal mask
 	cgetpcc		$c12
 	csetoffset	$c12, $c12, t9
 	cjalr		$c12, $c17

--- a/lib/libc/mips/gen/setjmp_c.S
+++ b/lib/libc/mips/gen/setjmp_c.S
@@ -78,15 +78,7 @@ NESTED(setjmp, SETJMP_FRAME_SIZE, ra)
 	csetoffset	$c3, $c3, t0			# oset
 	cfromptr	$c4, $c3, zero			# set == NULL
 	li		a0, 1				# SIG_SETBLOCK
-	PTR_LA		t9, _C_LABEL(__libc_sigprocmask)	# get current signal mask
-	dla		t0, 1f
-1:	cgetpcc		$c12
-	cgetoffset	t1, $c12
-	dsub		t0, t1, t0
-	csetoffset	$c12, $c12, t0
-	cincoffset	$c12, $c12, t9
-	cjalr		$c12, $c17
-	nop
+	PIC_CALL(__libc_sigprocmask)			# get current signal mask
 
 	move		sp, s8
 
@@ -187,11 +179,7 @@ NESTED(longjmp, LONGJMP_FRAME_SIZE, ra)
 	csetoffset	$c3, $c3, t0			# set
 	cfromptr	$c4, $c3, zero			# oset == NULL
 	li		a0, 3				# SIG_SETMASK
-	PTR_LA		t9, _C_LABEL(__libc_sigprocmask)# set current signal mask
-	cgetpcc		$c12
-	csetoffset	$c12, $c12, t9
-	cjalr		$c12, $c17
-	nop
+	PIC_CALL(__libc_sigprocmask)			# set current signal mask
 
 	move		sp, s8
 
@@ -269,11 +257,7 @@ botch:
 	 * our caller's GP.
 	 */
 	ld		v1, 0(zero)
-	PTR_LA		t9, _C_LABEL(longjmperror)
-	cgetpcc		$c12
-	csetoffset	$c12, $c12, t9
-	cjalr		$c12, $c17
-	nop
+	PIC_CALL(longjmperror)
 
 	PIC_TAILCALL(abort)
 END(longjmp)

--- a/lib/libc/mips/gen/setjmp_c.S
+++ b/lib/libc/mips/gen/setjmp_c.S
@@ -78,7 +78,7 @@ NESTED(setjmp, SETJMP_FRAME_SIZE, ra)
 	csetoffset	$c3, $c3, t0			# oset
 	cfromptr	$c4, $c3, zero			# set == NULL
 	li		a0, 1				# SIG_SETBLOCK
-	PIC_CALL(__libc_sigprocmask)			# get current signal mask
+	PIC_CALL(__cheriabi_sigprocmask)			# get current signal mask
 
 	move		sp, s8
 
@@ -179,7 +179,7 @@ NESTED(longjmp, LONGJMP_FRAME_SIZE, ra)
 	csetoffset	$c3, $c3, t0			# set
 	cfromptr	$c4, $c3, zero			# oset == NULL
 	li		a0, 3				# SIG_SETMASK
-	PIC_CALL(__libc_sigprocmask)			# set current signal mask
+	PIC_CALL(__cheriabi_sigprocmask)		# set current signal mask
 
 	move		sp, s8
 
@@ -257,7 +257,6 @@ botch:
 	 * our caller's GP.
 	 */
 	ld		v1, 0(zero)
-	PIC_CALL(longjmperror)
-
-	PIC_TAILCALL(abort)
+	PIC_CALL(__cheriabi_longjmperror)
+	PIC_TAILCALL(__cheriabi_abort)
 END(longjmp)

--- a/lib/libc/mips/gen/sigsetjmp.S
+++ b/lib/libc/mips/gen/sigsetjmp.S
@@ -60,8 +60,12 @@ __FBSDID("$FreeBSD$");
 
 LEAF(sigsetjmp)
 	PIC_PROLOGUE(sigsetjmp)
-
+#ifndef __CHERI_PURE_CAPABILITY__
 	bne	a1, zero, 1f			# do saving of signal mask?
+#else
+	/* The first argument is a capability so v is passed in a0 instead */
+	bne	a0, zero, 1f
+#endif
 	PIC_TAILCALL(_setjmp)
 
 1:	PIC_TAILCALL(setjmp)
@@ -69,6 +73,7 @@ END(sigsetjmp)
 
 LEAF(siglongjmp)
 	PIC_PROLOGUE(siglongjmp)
+	# FIXME: this looks like it won't work with CheriABI
 	REG_L	t0, (_JB_MAGIC  * SZREG)(a0)
 	REG_LI	t1, _JB_MAGIC__SETJMP
 	bne	t0, t1, 1f			# setjmp or _setjmp magic?

--- a/lib/libc/mips/sys/cerror.S
+++ b/lib/libc/mips/sys/cerror.S
@@ -47,6 +47,7 @@ __FBSDID("$FreeBSD$");
 	.globl	_C_LABEL(__error)
 NESTED_NOPROFILE(__cerror, CALLFRAME_SIZ, ra)
 #ifndef __CHERI_PURE_CAPABILITY__
+	.protected	_C_LABEL(__cerror)
 	.mask	0x80000000, (CALLFRAME_RA - CALLFRAME_SIZ)
 	SETUP_GP
 	PTR_SUBU	sp, sp, CALLFRAME_SIZ

--- a/lib/libc/mips/sys/cerror.S
+++ b/lib/libc/mips/sys/cerror.S
@@ -82,19 +82,7 @@ NESTED_NOPROFILE(__cerror, CALLFRAME_SIZ, ra)
 	csc		$c17, sp, CALLFRAME_C17($c11)
 	move		s8, sp
 
-	dla		t9, _C_LABEL(__error)   # locate address of errno
-#ifdef PIC
-	dla		t0, 1f
-1:	cgetpcc		$c12
-	cgetoffset	t1, $c12
-	dsub		t0, t1, t0
-	csetoffset	$c12, $c12, t0
-	cincoffset	$c12, $c12, t9
-#else
-	cgetpccsetoffset $c12, t9
-#endif
-	cjalr		$c12, $c17
-	nop
+	PIC_CALL(__error)	# locate address of errno
 
 	move		sp, s8
 	cld		t0, sp, CALLFRAME_S0($c11)

--- a/lib/libc/stdlib/abort.c
+++ b/lib/libc/stdlib/abort.c
@@ -43,7 +43,7 @@ __FBSDID("$FreeBSD$");
 
 #include "libc_private.h"
 
-void
+__attribute__((visibility("protected"))) void
 abort(void)
 {
 	struct sigaction act;

--- a/lib/libc/sys/__error.c
+++ b/lib/libc/sys/__error.c
@@ -52,7 +52,7 @@ __set_error_selector(int *(*arg)(void))
 	__error_selector = arg;
 }
 
-int *
+__attribute__((visibility("protected"))) int *
 __error(void)
 {
 


### PR DESCRIPTION
I can successfully run /bin/helloworld after these changes but not before (I tested this before John pushed fixes to the existing assembly for rtld-cheri-elf) so I am fairly confident that this change is correct.