### PR TITLE
Use ELF e_flags to detect CHERI binaries

### DIFF
--- a/contrib/binutils/bfd/elfxx-mips.c
+++ b/contrib/binutils/bfd/elfxx-mips.c
@@ -5081,6 +5081,8 @@ elf_mips_abi_name (bfd *abfd)
       return "EABI32";
     case E_MIPS_ABI_EABI64:
       return "EABI64";
+    case E_MIPS_ABI_CHERIABI:
+      return "CheriABI";
     default:
       return "unknown abi";
     }
@@ -11343,6 +11345,8 @@ _bfd_mips_elf_print_private_bfd_data (bfd *abfd, void *ptr)
     fprintf (file, _(" [abi=EABI32]"));
   else if ((elf_elfheader (abfd)->e_flags & EF_MIPS_ABI) == E_MIPS_ABI_EABI64)
     fprintf (file, _(" [abi=EABI64]"));
+  else if ((elf_elfheader (abfd)->e_flags & EF_MIPS_ABI) == E_MIPS_ABI_CHERIABI)
+    fprintf (file, _(" [abi=CheriABI]"));
   else if ((elf_elfheader (abfd)->e_flags & EF_MIPS_ABI))
     fprintf (file, _(" [abi unknown]"));
   else if (ABI_N32_P (abfd))
@@ -11375,6 +11379,11 @@ _bfd_mips_elf_print_private_bfd_data (bfd *abfd, void *ptr)
 
   if (elf_elfheader (abfd)->e_flags & EF_MIPS_ARCH_ASE_MDMX)
     fprintf (file, " [mdmx]");
+
+  if ((elf_elfheader (abfd)->e_flags & EF_MIPS_MACH) == E_MIPS_MACH_CHERI128)
+    fprintf (file, " [cheri128]");
+  else if ((elf_elfheader (abfd)->e_flags & EF_MIPS_MACH) == E_MIPS_MACH_CHERI256)
+    fprintf (file, " [cheri256]");
 
   if (elf_elfheader (abfd)->e_flags & EF_MIPS_ARCH_ASE_M16)
     fprintf (file, " [mips16]");

--- a/contrib/binutils/include/elf/mips.h
+++ b/contrib/binutils/include/elf/mips.h
@@ -200,6 +200,9 @@ END_RELOC_NUMBERS (R_MIPS_maxext)
 /* EABI in 64 bit mode */
 #define E_MIPS_ABI_EABI64       0x00004000
 
+/* CheriABI */
+#define E_MIPS_ABI_CHERIABI     0x00005000
+
 
 /* Machine variant if we know it.  This field was invented at Cygnus,
    but it is hoped that other vendors will adopt it.  If some standard
@@ -222,6 +225,8 @@ END_RELOC_NUMBERS (R_MIPS_maxext)
 #define E_MIPS_MACH_5400	0x00910000
 #define E_MIPS_MACH_5500	0x00980000
 #define E_MIPS_MACH_9000	0x00990000
+#define E_MIPS_MACH_CHERI128	0x00c10000
+#define E_MIPS_MACH_CHERI256	0x00c20000
 
 /* Processor specific section indices.  These sections do not actually
    exist.  Symbols with a st_shndx field corresponding to one of these

--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -2251,6 +2251,8 @@ dump_eflags(struct readelf *re, uint64_t e_flags)
 		case 0x99: printf(", 9000"); break;
 		case 0xa0: printf(", loongson-2e"); break;
 		case 0xa1: printf(", loongson-2f"); break;
+		case 0xc1: printf(", cheri128"); break;
+		case 0xc2: printf(", cheri256"); break;
 		default: break;
 		}
 		switch ((e_flags & 0x0000F000) >> 12) {
@@ -2258,6 +2260,7 @@ dump_eflags(struct readelf *re, uint64_t e_flags)
 		case 2: printf(", o64"); break;
 		case 3: printf(", eabi32"); break;
 		case 4: printf(", eabi64"); break;
+		case 5: printf(", cheriabi"); break;
 		default: break;
 		}
 		edesc = mips_eflags_desc;

--- a/contrib/file/magic/Magdir/elf
+++ b/contrib/file/magic/Magdir/elf
@@ -27,6 +27,9 @@
 >0	lelong&0xf0000000	0x80000000	MIPS64 rel2
 >0	lelong&0xf0000000	0x90000000	MIPS32 rel6
 >0	lelong&0xf0000000	0xa0000000	MIPS64 rel6
+>0	lelong&0x00ff0000	0x00c10000	with CHERI-128
+>0	lelong&0x00ff0000	0x00c20000	with CHERI-256
+>0	lelong&0x0000f000	0x00005000	(CheriABI)
 
 0	name		elf-sparc
 >0	lelong&0x00ffff00	0x00000100	V8+ Required,

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1680,17 +1680,22 @@ __elfN(puthdr)(struct thread *td, void *hdr, size_t hdrsize, int numsegs,
 #if defined(COMPAT_FREEBSD32) && __ELF_WORD_SIZE == 32
 	ehdr->e_machine = ELF_ARCH32;
 #else
-#ifdef CPU_CHERI
-	if (td->td_proc->p_sysent->sv_flags & SV_CHERI)
-		ehdr->e_machine = EM_MIPS_CHERI;
-	else
-#endif
 	ehdr->e_machine = ELF_ARCH;
 #endif
 	ehdr->e_version = EV_CURRENT;
 	ehdr->e_entry = 0;
 	ehdr->e_phoff = sizeof(Elf_Ehdr);
+#ifdef CPU_CHERI
+	if (td->td_proc->p_sysent->sv_flags & SV_CHERI) {
+		ehdr->e_flags |= EF_MIPS_ABI_CHERIABI;
+	}
+	if (CHERICAP_SIZE == 16)
+		ehdr->e_flags |= EF_MIPS_MACH_CHERI128;
+	else if (CHERICAP_SIZE == 32)
+		ehdr->e_flags |= EF_MIPS_MACH_CHERI256;
+#else
 	ehdr->e_flags = 0;
+#endif
 	ehdr->e_ehsize = sizeof(Elf_Ehdr);
 	ehdr->e_phentsize = sizeof(Elf_Phdr);
 	ehdr->e_shentsize = sizeof(Elf_Shdr);

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -926,7 +926,8 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 			 * and gets mapped RO by the appropriate startup
 			 * code after initalization.
 			 */
-			if (brand_info->machine == EM_MIPS_CHERI &&
+			/* XXXAR: use PT_GNU_RELRO once we change to lld? */
+			if ((brand_info->sysvec->sv_flags & SV_CHERI) &&
 			    !(prot & PF_W)) {
 				prot |= PF_W;
 				/*

--- a/sys/mips/include/elf.h
+++ b/sys/mips/include/elf.h
@@ -90,11 +90,7 @@
 #else
 #define ELF_TARG_DATA	ELFDATA2LSB
 #endif
-#ifndef __CHERI_PURE_CAPABILITY__
 #define	ELF_TARG_MACH	EM_MIPS
-#else
-#define	ELF_TARG_MACH	EM_MIPS_CHERI
-#endif
 #define	ELF_TARG_VER	1
 
 /*
@@ -261,5 +257,10 @@ __ElfType(Auxinfo);
 #define	EF_MIPS_ABI_O64		0x00002000
 #define	EF_MIPS_ABI_EABI32	0x00003000
 #define	EF_MIPS_ABI_EABI64	0x00004000
+#define	EF_MIPS_ABI_CHERIABI	0x00005000
+
+#define	EF_MIPS_MACH_CHERI128	0x00C10000	/* 128 bit CHERI */
+#define	EF_MIPS_MACH_CHERI256	0x00C20000	/* 256 bit CHERI */
+#define	EF_MIPS_MACH		0x00FF0000	/* Machine */
 
 #endif /* __MIPS_ELF_H */

--- a/sys/mips/mips/elf_machdep.c
+++ b/sys/mips/mips/elf_machdep.c
@@ -84,6 +84,16 @@ struct sysentvec elf64_freebsd_sysvec = {
 	.sv_trap	= NULL,
 };
 
+#ifdef CPU_CHERI
+static boolean_t mips_elf_header_supported(struct image_params * imgp)
+{
+	const Elf_Ehdr *hdr = (const Elf_Ehdr *)imgp->image_header;
+	if ((hdr->e_flags & EF_MIPS_ABI) == EF_MIPS_ABI_CHERIABI)
+		return FALSE;
+	return TRUE;
+}
+#endif
+
 static Elf64_Brandinfo freebsd_brand_info = {
 	.brand		= ELFOSABI_FREEBSD,
 	.machine	= EM_MIPS,
@@ -93,7 +103,10 @@ static Elf64_Brandinfo freebsd_brand_info = {
 	.sysvec		= &elf64_freebsd_sysvec,
 	.interp_newpath	= NULL,
 	.brand_note	= &elf64_freebsd_brandnote,
-	.flags		= BI_BRAND_NOTE
+	.flags		= BI_BRAND_NOTE,
+#ifdef CPU_CHERI
+	.header_supported = mips_elf_header_supported
+#endif
 };
 
 SYSINIT(elf64, SI_SUB_EXEC, SI_ORDER_ANY,


### PR DESCRIPTION
We now use the ELF e_flags field to detect CheriABI (using EF_MIPS_ABI_CHERIABI)  instead of comparing e_machine to EM_MIPS_CHERI. 

We can now also detect whether a binary has been compiled for CHERI 128 or 256 by looking at the e_flags EF_MIPS_MACH field: I added EF_MIPS_MACH_CHERI128 (0x00c10000) and EF_MIPS_MACH_CHERI128 (0x00c20000). The kernel will now check this and reject incompatible binaries. Old binaries with EM_MIPS_CHERI will still work but we should remove this support at some point in the future.

I have tested this both with pre-merge CHERI-clang with added e_flags (branch cheri-eflags38 in https://github.com/RichardsonAlex/llvm-cheri and https://github.com/RichardsonAlex/clang-cheri) and binaries generated with a compiler from the current master branch.