### PR TITLE
Don't unconditionally overwrite $c11 in cheri_sendsig

### DIFF
--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -18,9 +18,11 @@ SRCS+=	cheritest_bounds_globals.c					\
 	cheritest_registers.c						\
 	cheritest_sandbox.S						\
 	cheritest_sealcap.c						\
+	cheritest_setjmp.c						\
 	cheritest_signal.c						\
 	cheritest_string.c						\
 	cheritest_syscall.c						\
+	cheritest_thread.c						\
 	cheritest_util.c						\
 	cheritest_vm.c							\
 	cheritest_vm_swap.c						\
@@ -68,7 +70,7 @@ WANT_DUMP=	yes
 LIBADD= 	cheri z
 .endif
 
-LIBADD+=	xo util
+LIBADD+=	xo util pthread
 
 NO_SHARED?=	YES
 

--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -18,6 +18,7 @@ SRCS+=	cheritest_bounds_globals.c					\
 	cheritest_registers.c						\
 	cheritest_sandbox.S						\
 	cheritest_sealcap.c						\
+	cheritest_signal.c						\
 	cheritest_string.c						\
 	cheritest_syscall.c						\
 	cheritest_util.c						\

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1229,16 +1229,29 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_flags = CT_FLAG_SANDBOX, },
 
 	/*
+	 * setjmp/longjmp tests.
+	 */
+	{ .ct_name = "test_setjmp",
+	  .ct_desc = "Check setjmp and multiple longjmp calls return the right values and restore state",
+	  .ct_func = test_setjmp },
+
+	/*
 	 * Tests ensuring that signal handlers work. Only really relevant when
 	 * using the pure-capability ABI, but might as well run them
 	 * unconditionally.
 	 */
 	{ .ct_name = "test_signal_handler_usr1",
-	  .ct_desc = "Install a signal handler (sa_handler) or SIGUSR1 and check it works",
+	  .ct_desc = "install a signal handler (sa_handler) or sigusr1 and check it works",
 	  .ct_func = test_signal_handler_usr1 },
 	{ .ct_name = "test_signal_sigaction_usr1",
 	  .ct_desc = "Install a signal handler (sa_sigaction) for SIGUSR1 and check it works",
 	  .ct_func = test_signal_sigaction_usr1 },
+	{ .ct_name = "test_signal_sigaltstack",
+	  .ct_desc = "Check signal handlers use the alternate stack when enabled",
+	  .ct_func = test_signal_sigaltstack },
+	{ .ct_name = "test_signal_sigaltstack_disable",
+	  .ct_desc = "Check signal handlers don't use a given alternate stack when re-disabled",
+	  .ct_func = test_signal_sigaltstack_disable },
 
 	/*
 	 * Standard library string tests.
@@ -1255,6 +1268,19 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_string_memmove_c",
 	  .ct_desc = "Test explicit capability memmove",
 	  .ct_func = test_string_memmove_c },
+
+	/*
+	 * Threading tests.
+	 */
+	{ .ct_name = "test_thread_access_globals",
+	  .ct_desc = "Check threads can access globals",
+	  .ct_func = test_thread_access_globals },
+	{ .ct_name = "test_thread_arg_write",
+	  .ct_desc = "Check threads can use their arguments",
+	  .ct_func = test_thread_arg_write },
+	{ .ct_name = "test_thread_return_value",
+	  .ct_desc = "Check thread return values can be retrieved by pthread_join",
+	  .ct_func = test_thread_return_value },
 
 	/*
 	 * zlib tests.

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1229,6 +1229,18 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_flags = CT_FLAG_SANDBOX, },
 
 	/*
+	 * Tests ensuring that signal handlers work. Only really relevant when
+	 * using the pure-capability ABI, but might as well run them
+	 * unconditionally.
+	 */
+	{ .ct_name = "test_signal_handler_usr1",
+	  .ct_desc = "Install a signal handler (sa_handler) or SIGUSR1 and check it works",
+	  .ct_func = test_signal_handler_usr1 },
+	{ .ct_name = "test_signal_sigaction_usr1",
+	  .ct_desc = "Install a signal handler (sa_sigaction) for SIGUSR1 and check it works",
+	  .ct_func = test_signal_sigaction_usr1 },
+
+	/*
 	 * Standard library string tests.
 	 */
 	{ .ct_name = "test_string_memcpy",

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -371,6 +371,10 @@ void	test_sandbox_var_constructor(const struct cheri_test *ctp);
 /* cheritest_sealcap.c */
 void	test_sealcap_sysarch(const struct cheri_test *ctp);
 
+/* cheritest_signal.c */
+void	test_signal_handler_usr1(const struct cheri_test *ctp);
+void	test_signal_sigaction_usr1(const struct cheri_test *ctp);
+
 /* cheritest_string.c */
 void	test_string_memcpy(const struct cheri_test *ctp);
 void	test_string_memcpy_c(const struct cheri_test *ctp);

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -371,9 +371,14 @@ void	test_sandbox_var_constructor(const struct cheri_test *ctp);
 /* cheritest_sealcap.c */
 void	test_sealcap_sysarch(const struct cheri_test *ctp);
 
+/* cheritest_setjmp.c */
+void	test_setjmp(const struct cheri_test *ctp);
+
 /* cheritest_signal.c */
 void	test_signal_handler_usr1(const struct cheri_test *ctp);
 void	test_signal_sigaction_usr1(const struct cheri_test *ctp);
+void	test_signal_sigaltstack(const struct cheri_test *ctp);
+void	test_signal_sigaltstack_disable(const struct cheri_test *ctp);
 
 /* cheritest_string.c */
 void	test_string_memcpy(const struct cheri_test *ctp);
@@ -393,6 +398,11 @@ void	test_initregs_idc(const struct cheri_test *ctp);
 void	test_initregs_pcc(const struct cheri_test *ctp);
 void	test_copyregs(const struct cheri_test *ctp);
 void	test_listregs(const struct cheri_test *ctp);
+
+/* cheritest_thread.c */
+void	test_thread_access_globals(const struct cheri_test *ctp);
+void	test_thread_arg_write(const struct cheri_test *ctp);
+void	test_thread_return_value(const struct cheri_test *ctp);
 
 /* cheritest_vm.c */
 void	cheritest_vm_tag_mmap_anon(const struct cheri_test *ctp __unused);

--- a/bin/cheritest/cheritest_setjmp.c
+++ b/bin/cheritest/cheritest_setjmp.c
@@ -1,0 +1,109 @@
+/*-
+ * Copyright (c) 2017 James Clarke
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#if !__has_feature(capabilities)
+#error "This code requires a CHERI-aware compiler"
+#endif
+
+#include <sys/types.h>
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
+#include <setjmp.h>
+
+#include "cheritest.h"
+
+#define	CAP(x)	((__capability void*)(x))
+
+__attribute__((noinline))
+static void
+do_longjmp(jmp_buf env, int val)
+{
+	longjmp(env, val);
+}
+
+void
+test_setjmp(const struct cheri_test *ctp __unused)
+{
+	jmp_buf env;
+
+	/* No need to check global data accesses work; by calling longjmp after a
+	 * longjmp we check that we can still get function capabilities from the
+	 * MCT. The load for do_longjmp's entry point could have been hoisted to
+	 * before the setjmp, but since it isn't inlined, its own load of a
+	 * capability for longjmp will have to come after setjmp has returned. */
+
+	/* Must be volatile; reading non-volatile stack-local variables which have
+	 * been modified between the setjmp and longjmp calls is undefined
+	 * behaviour (if they happen to be stored in registers, they will be
+	 * restored to that register's value at the first call to setjmp). */
+	volatile int saw_zero = 0;
+	volatile int saw_one = 0;
+	volatile int saw_two = 0;
+
+	int val = setjmp(env);
+	switch (val) {
+	case 0:
+		if (saw_zero)
+			cheritest_failure_errx("setjmp returned 0 after returning 0");
+		if (saw_one)
+			cheritest_failure_errx("setjmp returned 0 after returning 1");
+		if (saw_two)
+			cheritest_failure_errx("setjmp returned 0 after returning 2");
+		saw_zero = 1;
+		do_longjmp(env, 1);
+		cheritest_failure_errx("longjmp(env, 1) returned");
+	case 1:
+		if (!saw_zero)
+			cheritest_failure_errx("setjmp returned 1 before returning 0");
+		if (saw_one)
+			cheritest_failure_errx("setjmp returned 1 after returning 1");
+		if (saw_two)
+			cheritest_failure_errx("setjmp returned 1 after returning 2");
+		saw_one = 1;
+		do_longjmp(env, 2);
+		cheritest_failure_errx("longjmp(env, 2) returned");
+	case 2:
+		if (!saw_zero)
+			cheritest_failure_errx("setjmp returned 2 before returning 0");
+		if (!saw_one)
+			cheritest_failure_errx("setjmp returned 2 before returning 1");
+		if (saw_two)
+			cheritest_failure_errx("setjmp returned 2 after returning 2");
+		break;
+	default:
+		cheritest_failure_errx("setjmp returned unexpected value %d", val);
+	}
+
+	cheritest_success();
+}

--- a/bin/cheritest/cheritest_signal.c
+++ b/bin/cheritest/cheritest_signal.c
@@ -77,12 +77,14 @@ test_signal_handler_usr1(const struct cheri_test *ctp __unused)
 }
 
 static int sigaction_signum;
+static int sigaction_info_si_signo;
 static int sigaction_info_si_code;
 
 static void
 sigaction_handler(int signum, siginfo_t *siginfo, void *context)
 {
 	sigaction_signum = signum;
+	sigaction_info_si_signo = siginfo->si_signo;
 	sigaction_info_si_code = siginfo->si_code;
 }
 
@@ -102,8 +104,10 @@ test_signal_sigaction_usr1(const struct cheri_test *ctp __unused)
 
 	if (sigaction_signum != SIGUSR1)
 		cheritest_failure_errx("sigaction_signum (%d) != SIGUSR1 (%d)", sigaction_signum, SIGUSR1);
-	if (sigaction_info_si_code != SIGUSR1)
-		cheritest_failure_errx("sigaction_info_si_code (%d) != SIGUSR1 (%d)", sigaction_info_si_code, SIGUSR1);
+	if (sigaction_info_si_signo != SIGUSR1)
+		cheritest_failure_errx("sigaction_info_si_signo (%d) != SIGUSR1 (%d)", sigaction_info_si_signo, SIGUSR1);
+	if (sigaction_info_si_code != SI_USER)
+		cheritest_failure_errx("sigaction_info_si_code (%d) != SI_USER (%d)", sigaction_info_si_code, SI_USER);
 
 	cheritest_success();
 }

--- a/bin/cheritest/cheritest_signal.c
+++ b/bin/cheritest/cheritest_signal.c
@@ -1,0 +1,109 @@
+/*-
+ * Copyright (c) 2017 James Clarke
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#if !__has_feature(capabilities)
+#error "This code requires a CHERI-aware compiler"
+#endif
+
+#include <sys/types.h>
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "cheritest.h"
+
+#define	CAP(x)	((__capability void*)(x))
+
+static int handler_signum;
+
+static void
+handler(int signum)
+{
+	handler_signum = signum;
+}
+
+void
+test_signal_handler_usr1(const struct cheri_test *ctp __unused)
+{
+	struct sigaction sa;
+	sa.sa_handler = handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	if (sigaction(SIGUSR1, &sa, NULL) != 0)
+		cheritest_failure_errx("sigaction failed: %s", strerror(errno));
+
+	handler_signum = 0;
+	if (kill(getpid(), SIGUSR1) != 0)
+		cheritest_failure_errx("kill(getpid(), SIGUSR1) failed: %s", strerror(errno));
+
+	if (handler_signum != SIGUSR1)
+		cheritest_failure_errx("handler_signum (%d) != SIGUSR1 (%d)", handler_signum, SIGUSR1);
+
+	cheritest_success();
+}
+
+static int sigaction_signum;
+static int sigaction_info_si_code;
+
+static void
+sigaction_handler(int signum, siginfo_t *siginfo, void *context)
+{
+	sigaction_signum = signum;
+	sigaction_info_si_code = siginfo->si_code;
+}
+
+void
+test_signal_sigaction_usr1(const struct cheri_test *ctp __unused)
+{
+	struct sigaction sa;
+	sa.sa_sigaction = sigaction_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_SIGINFO;
+	if (sigaction(SIGUSR1, &sa, NULL) != 0)
+		cheritest_failure_errx("sigaction failed: %s", strerror(errno));
+
+	sigaction_signum = 0;
+	if (kill(getpid(), SIGUSR1) != 0)
+		cheritest_failure_errx("kill(getpid(), SIGUSR1) failed: %s", strerror(errno));
+
+	if (sigaction_signum != SIGUSR1)
+		cheritest_failure_errx("sigaction_signum (%d) != SIGUSR1 (%d)", sigaction_signum, SIGUSR1);
+	if (sigaction_info_si_code != SIGUSR1)
+		cheritest_failure_errx("sigaction_info_si_code (%d) != SIGUSR1 (%d)", sigaction_info_si_code, SIGUSR1);
+
+	cheritest_success();
+}

--- a/bin/cheritest/cheritest_thread.c
+++ b/bin/cheritest/cheritest_thread.c
@@ -1,0 +1,125 @@
+/*-
+ * Copyright (c) 2017 James Clarke
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#if !__has_feature(capabilities)
+#error "This code requires a CHERI-aware compiler"
+#endif
+
+#include <sys/types.h>
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "cheritest.h"
+
+#define	CAP(x)	((__capability void*)(x))
+
+static int thread_global;
+
+static void *
+access_globals(void *arg __unused)
+{
+	thread_global = 0x910b41;
+	return NULL;
+}
+
+void
+test_thread_access_globals(const struct cheri_test *ctp __unused)
+{
+	pthread_t thread;
+
+	thread_global = 0xdead;
+	if (pthread_create(&thread, NULL, access_globals, NULL) != 0)
+		cheritest_failure_errx("pthread_create failed: %s", strerror(errno));
+
+	if (pthread_join(thread, NULL) != 0)
+		cheritest_failure_errx("pthread_join failed: %s", strerror(errno));
+
+	if (thread_global != 0x910b41)
+		cheritest_failure_errx("thread_global (0x%x) != 0x910b41", thread_global);
+
+	cheritest_success();
+}
+
+static void *
+arg_write(void *arg)
+{
+	*(int *)arg = 0x900d;
+	return NULL;
+}
+
+void
+test_thread_arg_write(const struct cheri_test *ctp __unused)
+{
+	pthread_t thread;
+	int arg = 0xbad;
+
+	if (pthread_create(&thread, NULL, arg_write, &arg) != 0)
+		cheritest_failure_errx("pthread_create failed: %s", strerror(errno));
+
+	if (pthread_join(thread, NULL) != 0)
+		cheritest_failure_errx("pthread_join failed: %s", strerror(errno));
+
+	if (arg != 0x900d)
+		cheritest_failure_errx("arg (0x%x) != 0x900d", arg);
+
+	cheritest_success();
+}
+
+static void *
+return_value(void *arg __unused)
+{
+	return (void *)(uintptr_t)0x900d;
+}
+
+void
+test_thread_return_value(const struct cheri_test *ctp __unused)
+{
+	pthread_t thread;
+	void *retval = (void *)(uintptr_t)0xbad;
+
+	if (pthread_create(&thread, NULL, return_value, NULL) != 0)
+		cheritest_failure_errx("pthread_create failed: %s", strerror(errno));
+
+	if (pthread_join(thread, &retval) != 0)
+		cheritest_failure_errx("pthread_join failed: %s", strerror(errno));
+
+	if ((size_t)retval != 0x900d)
+		cheritest_failure_errx("retval (0x%zx) != 0x900d", (size_t)retval);
+
+	cheritest_success();
+}

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -172,7 +172,7 @@ void	cheri_newthread_setregs(struct thread *td);
 int	cheri_syscall_authorize(struct thread *td, u_int code,
 	    int nargs, register_t *args);
 int	cheri_signal_sandboxed(struct thread *td);
-void	cheri_sendsig(struct thread *td);
+void	cheri_sendsig(struct thread *td, int change_stc);
 void	cheri_trapframe_from_cheriframe(struct trapframe *frame,
 	    struct cheri_frame *cfp);
 void	cheri_trapframe_to_cheriframe(struct trapframe *frame,

--- a/sys/mips/cheri/cheri_signal.c
+++ b/sys/mips/cheri/cheri_signal.c
@@ -66,7 +66,7 @@ cheri_signal_copy(struct pcb *dst, struct pcb *src)
  * state will be restored by default.
  */
 void
-cheri_sendsig(struct thread *td)
+cheri_sendsig(struct thread *td, int change_stc)
 {
 	struct trapframe *frame;
 	struct cheri_signal *csigp;
@@ -74,7 +74,8 @@ cheri_sendsig(struct thread *td)
 	frame = &td->td_pcb->pcb_regs;
 	csigp = &td->td_pcb->pcb_cherisignal;
 	cheri_capability_copy(&frame->ddc, &csigp->csig_ddc);
-	cheri_capability_copy(&frame->stc, &csigp->csig_stc);
+	if (change_stc)
+		cheri_capability_copy(&frame->stc, &csigp->csig_stc);
 	cheri_capability_copy(&frame->idc, &csigp->csig_idc);
 	cheri_capability_copy(&frame->pcc, &csigp->csig_pcc);
 }

--- a/sys/mips/mips/pm_machdep.c
+++ b/sys/mips/mips/pm_machdep.c
@@ -108,6 +108,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 #endif
 	int sig;
 	int oonstack;
+	int change_stc;
 
 	td = curthread;
 	p = td->td_proc;
@@ -202,6 +203,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	    SIGISMEMBER(psp->ps_sigonstack, sig)) {
 		sp = (vm_offset_t)((uintptr_t)td->td_sigstk.ss_sp +
 		    td->td_sigstk.ss_size);
+		change_stc = 1;
 	} else {
 #ifdef CPU_CHERI
 		/*
@@ -221,6 +223,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 		}
 #endif
 		sp = (vm_offset_t)regs->sp;
+		change_stc = 0;
 	}
 #ifdef CPU_CHERI
 	cp2_len = sizeof(*cfp);
@@ -296,7 +299,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	 * in.  As we don't install this in the CHERI frame on the user stack,
 	 * it will be (genrally) be removed automatically on sigreturn().
 	 */
-	cheri_sendsig(td);
+	cheri_sendsig(td, change_stc);
 #endif
 
 	regs->pc = (register_t)(intptr_t)catcher;


### PR DESCRIPTION
Currently cheri_sendsig will always overwrite $c11 with the alternate stack, but the calling functions decide whether they want to use the alternate stack or not. If they don't want to, they don't adjust $sp, which is then an invalid offset if $c11 gets changed.

This also includes some new tests for signal handling, threading and setjmp/longjmp. The non-threading ones are included because they were committed in the same commit as the signal tests (which made some sense given the other changes I have had to make to my fork), but I can remove them (either as a separate commit or a separate pull request) if desired.