### PR TITLE
_setjmp_c.S: Move instruction into missing delay slot like on MIPS

### DIFF
--- a/lib/libc/mips/gen/_setjmp_c.S
+++ b/lib/libc/mips/gen/_setjmp_c.S
@@ -126,8 +126,8 @@ NESTED(_setjmp, SETJMP_FRAME_SIZE, ra)
 	cgetdefault	$c4
 	csc		$c4, t1, (_JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
 
-	move		v0, zero
 	cjr		$c17
+	move		v0, zero
 END(_setjmp)
 
 #define LONGJMP_FRAME_SIZE	(CALLFRAME_SIZ + _MIPS_SZCAP/8)


### PR DESCRIPTION
Confusingly, _setjmp is noreorder, but setjmp is reorder. This means that the assembly in _setjmp has delay slots exposed, which must be filled. Otherwise, the first instruction in the next function is run, which in this case sets up a stack frame, causing stack corruption. Thankfully this was caught by a length violation of PCC in my fork.

Standard MIPS also has this difference between setjmp and _setjmp, but correctly fills this delay slot (also with the move pseudo-instruction).