### PR TITLE
sendmail: Make initsetproctitle a no-op if using the builtin setproctitle

### DIFF
--- a/contrib/sendmail/src/conf.c
+++ b/contrib/sendmail/src/conf.c
@@ -2437,9 +2437,9 @@ typedef unsigned int	*pt_entry_t;
 **	This allows "ps" listings to give more useful information.
 */
 
+#if SPT_TYPE != SPT_BUILTIN
 static char	**Argv = NULL;		/* pointer to argument vector */
 static char	*LastArgv = NULL;	/* end of argv */
-#if SPT_TYPE != SPT_BUILTIN
 static void	setproctitle __P((const char *, ...));
 #endif /* SPT_TYPE != SPT_BUILTIN */
 
@@ -2449,6 +2449,7 @@ initsetproctitle(argc, argv, envp)
 	char **argv;
 	char **envp;
 {
+#if SPT_TYPE != SPT_BUILTIN
 	register int i;
 	int align;
 	extern char **environ;
@@ -2497,6 +2498,7 @@ initsetproctitle(argc, argv, envp)
 		if (LastArgv + 1 == envp[i])
 			LastArgv = envp[i] + SPT_ALIGN(strlen(envp[i]), align);
 	}
+#endif /* SPT_TYPE != SPT_BUILTIN */
 }
 
 #if SPT_TYPE != SPT_BUILTIN


### PR DESCRIPTION
The pointer comparison for (LastArgv + 1 == argv[i]) means that LLVM decides to use LastArgv+1 in place of argv[i] in the subsequent strlen call, but since LastArgv points to the end of argv[i-1] (which has strict bounds on just that string) this immediately leads to a length violation. This behaviour is somewhat surprising and it is unclear what should happen here, but since CheriBSD is using libc's builtin setproctitle the results of this initialisation are unused, so we can just skip it.