### PR TITLE
Fix building CHERI world without KERBEROS and CDDL options

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -1010,6 +1010,56 @@ INTERNAL_LIB_DIRS=				\
 	usr.sbin/ntp/libparse
 .endif
 
+_cheri_libs=lib/csu lib/libgcc_eh lib/libcompiler_rt lib/libc \
+	    lib/libc_nonshared lib/libgcc_s lib/libthr lib/libz lib/libbz2 \
+	    lib/liblzma lib/libexpat secure/lib/libcrypto lib/libsbuf \
+	    lib/libelf lib/libkvm lib/ncurses/ncurses lib/ncurses/ncursesw \
+	    secure/lib/libssl lib/libmd lib/libutil lib/libprocstat \
+	    lib/librtld_db cddl/lib/libctf lib/libkiconv lib/libpam/libpam \
+	    lib/libcom_err lib/libcrypt
+
+.if ${MK_KERBEROS} != "no"
+_cheri_libs+=kerberos5/lib/libroken kerberos5/lib/libasn1 kerberos5/lib/libwind \
+	     kerberos5/lib/libhx509 kerberos5/lib/libheimbase \
+	     kerberos5/lib/libheimipcc kerberos5/lib/libkrb5
+.endif
+
+_cheri_libs+=lib/libopie lib/libradius lib/libtacplus lib/libypclnt \
+	     lib/libldns secure/lib/libssh lib/msun lib/libnv lib/libcheri \
+	     gnu/lib/libdialog lib/libfigpar
+.if ${MK_KERBEROS} != "no"
+_cheri_libs+=lib/libgssapi
+.endif
+.if ${MK_CDDL} != "no"
+_cheri_libs+=cddl/lib/libnvpair cddl/lib/libumem cddl/lib/libuutil \
+	     cddl/lib/libzfs_core cddl/lib/libavl
+.endif
+.if ${MK_KERBEROS} != "no"
+_cheri_libs+=kerberos5/lib/libheimntlm
+.endif
+_cheri_libs+=lib/libsqlite3
+.if ${MK_KERBEROS} != "no"
+_cheri_libs+=kerberos5/lib/libhdb
+.endif
+_cheri_libs+=usr.bin/lex/lib lib/libcxxrt lib/libc++ lib ${LOCAL_LIB_DIRS}
+.if ${MK_CDDL} != "no"
+_cheri_libs+=cddl/lib
+.endif
+_cheri_libs+=gnu/lib secure/lib
+.if ${MK_KERBEROS} != "no"
+_cheri_libs+=kerberos5/lib
+.endif
+_cheri_libs+=${INTERNAL_INC_DIRS} ${INTERNAL_LIB_DIRS}
+
+_cheri_test_libs=lib/csu lib ${LOCAL_LIB_DIRS}
+.if ${MK_CDDL} != "no"
+_cheri_test_libs+=cddl/lib
+.endif
+_cheri_test_libs+=gnu/lib secure/lib
+.if ${MK_KERBEROS} != "no"
+_cheri_test_libs+=kerberos5/lib
+.endif
+
 buildcheri:
 	@echo
 	@echo "--------------------------------------------------------------"
@@ -1025,7 +1075,7 @@ buildcheri:
 	    ${_t}
 .endfor
 .endfor
-.for _lib in lib/csu lib/libgcc_eh lib/libcompiler_rt lib/libc lib/libc_nonshared lib/libgcc_s lib/libthr lib/libz lib/libbz2 lib/liblzma lib/libexpat secure/lib/libcrypto lib/libsbuf lib/libelf lib/libkvm lib/ncurses/ncurses lib/ncurses/ncursesw secure/lib/libssl lib/libmd lib/libutil lib/libprocstat lib/librtld_db cddl/lib/libctf lib/libkiconv lib/libpam/libpam lib/libcom_err lib/libcrypt kerberos5/lib/libroken kerberos5/lib/libasn1 kerberos5/lib/libwind kerberos5/lib/libhx509 kerberos5/lib/libheimbase kerberos5/lib/libheimipcc kerberos5/lib/libkrb5 lib/libopie lib/libradius lib/libtacplus lib/libypclnt lib/libldns secure/lib/libssh lib/msun lib/libnv lib/libcheri gnu/lib/libdialog lib/libfigpar lib/libgssapi cddl/lib/libnvpair cddl/lib/libumem cddl/lib/libuutil cddl/lib/libzfs_core cddl/lib/libavl kerberos5/lib/libheimntlm lib/libsqlite3 kerberos5/lib/libhdb usr.bin/lex/lib lib/libcxxrt lib/libc++ lib ${LOCAL_LIB_DIRS} cddl/lib gnu/lib secure/lib kerberos5/lib ${INTERNAL_INC_DIRS} ${INTERNAL_LIB_DIRS}
+.for _lib in ${_cheri_libs}
 	${_+_}@${ECHODIR} "===> ${_lib} (obj,all,install)"; \
 		cd ${.CURDIR}/${_lib} && \
 		    if [ -z "${NO_OBJ}" ]; then ${LIBCHERIWMAKE} DIRPRFX=${_lib}/ obj; fi && \
@@ -1033,7 +1083,7 @@ buildcheri:
 		    ${LIBCHERIWMAKE} MK_TESTS=no DIRPRFX=${_lib}/ install
 .endfor
 .if ${MK_TESTS} == "yes"
-.for _lib in lib/csu lib ${LOCAL_LIB_DIRS} cddl/lib gnu/lib secure/lib kerberos5/lib
+.for _lib in ${_cheri_test_libs}
 		cd ${.CURDIR}/${_lib} && \
 		    ${LIBCHERIWMAKE} DIRPRFX=${_lib}/ all
 .endfor


### PR DESCRIPTION
I'm not sure if there is a better way that avoids all the `if ${MK_FOO}`