### PR TITLE
Replace most manipulations of struct iovec with macros

### DIFF
--- a/lib/libproc/Makefile
+++ b/lib/libproc/Makefile
@@ -17,7 +17,7 @@ INCS=	libproc.h
 
 CFLAGS+=	-I${.CURDIR}
 
-.if ${MK_CXX} == "no" || defined(LIBCHERI)
+.if ${MK_CXX} == "no"
 CFLAGS+=	-DNO_CXA_DEMANGLE
 .elif ${MK_LIBCPLUSPLUS} != "no"
 LIBADD+=		cxxrt
@@ -41,11 +41,8 @@ SHLIB_MAJOR=	4
 
 MAN=
 
-.ifndef LIBCHERI
-# requires C++
 .if ${MK_TESTS} != "no"
 SUBDIR+=	tests
-.endif
 .endif
 
 .include <bsd.lib.mk>

--- a/lib/libucl/Makefile
+++ b/lib/libucl/Makefile
@@ -28,11 +28,4 @@ CFLAGS+=	-I${LIBUCL}/include \
 		-I${LIBUCL}/uthash \
 		-I${LIBUCL}/klib
 
-# FIXME: for some reason clang crashes at -O0
-# We can't change CHERI_OPTIMIZATION_FLAGS as the value set on the command line
-# overrides any value set here. We need to use _CHERI_CFLAGS instead as it gets
-# added right at the end of the compilation command and therefore overrides
-# whatever CHERI_OPTIMIZATION_FLAGS sets
-_CHERI_CFLAGS+=-O2
-
 .include <bsd.lib.mk>

--- a/share/mk/src.libnames.mk
+++ b/share/mk/src.libnames.mk
@@ -278,7 +278,7 @@ _DP_radius=	crypto
 .endif
 _DP_rtld_db=	elf procstat
 _DP_procstat=	kvm util elf
-.if ${MK_CXX} == "yes" && !defined(LIBCHERI)
+.if ${MK_CXX} == "yes"
 .if ${MK_LIBCPLUSPLUS} != "no"
 _DP_proc=	cxxrt
 .else

--- a/sys/amd64/amd64/uio_machdep.c
+++ b/sys/amd64/amd64/uio_machdep.c
@@ -115,8 +115,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			    &vaddr, 1, TRUE);
 			mapped = FALSE;
 		}
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/amd64/linux32/linux32_machdep.c
+++ b/sys/amd64/linux32/linux32_machdep.c
@@ -165,8 +165,7 @@ linux32_copyinuio(struct l_iovec32 *iovp, l_ulong iovcnt, struct uio **uiop)
 			free(uio, M_IOV);
 			return (error);
 		}
-		iov[i].iov_base = PTRIN(iov32.iov_base);
-		iov[i].iov_len = iov32.iov_len;
+		IOVEC_INIT(&iov[i], PTRIN(iov32.iov_base), iov32.iov_len);
 	}
 	uio->uio_iov = iov;
 	uio->uio_iovcnt = iovcnt;
@@ -205,8 +204,7 @@ linux32_copyiniov(struct l_iovec32 *iovp32, l_ulong iovcnt, struct iovec **iovp,
 			free(iov, M_IOV);
 			return (error);
 		}
-		iov[i].iov_base = PTRIN(iov32.iov_base);
-		iov[i].iov_len = iov32.iov_len;
+		IOVEC_INIT(&iov[i], PTRIN(iov32.iov_base), iov32.iov_len);
 	}
 	*iovp = iov;
 	return(0);

--- a/sys/arm/arm/uio_machdep.c
+++ b/sys/arm/arm/uio_machdep.c
@@ -110,8 +110,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		}
 		sf_buf_free(sf);
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -115,8 +115,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			    &vaddr, 1, TRUE);
 			mapped = FALSE;
 		}
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/cam/ctl/ctl_backend_block.c
+++ b/sys/cam/ctl/ctl_backend_block.c
@@ -653,10 +653,8 @@ ctl_be_block_dispatch_file(struct ctl_be_block_lun *be_lun,
 	xuio.uio_iovcnt = beio->num_segs;
 	xuio.uio_td = curthread;
 
-	for (i = 0, xiovec = xuio.uio_iov; i < xuio.uio_iovcnt; i++, xiovec++) {
-		xiovec->iov_base = beio->sg_segs[i].addr;
-		xiovec->iov_len = beio->sg_segs[i].len;
-	}
+	for (i = 0, xiovec = xuio.uio_iov; i < xuio.uio_iovcnt; i++, xiovec++)
+		IOVEC_INIT(xiovec, beio->sg_segs[i].addr, beio->sg_segs[i].len);
 
 	binuptime(&beio->ds_t0);
 	mtx_lock(&be_lun->io_lock);
@@ -884,10 +882,8 @@ ctl_be_block_dispatch_zvol(struct ctl_be_block_lun *be_lun,
 	xuio.uio_iovcnt = beio->num_segs;
 	xuio.uio_td = curthread;
 
-	for (i = 0, xiovec = xuio.uio_iov; i < xuio.uio_iovcnt; i++, xiovec++) {
-		xiovec->iov_base = beio->sg_segs[i].addr;
-		xiovec->iov_len = beio->sg_segs[i].len;
-	}
+	for (i = 0, xiovec = xuio.uio_iov; i < xuio.uio_iovcnt; i++, xiovec++)
+		IOVEC_INIT(xiovec, beio->sg_segs[i].addr, beio->sg_segs[i].len);
 
 	binuptime(&beio->ds_t0);
 	mtx_lock(&be_lun->io_lock);

--- a/sys/cam/ctl/ctl_ha.c
+++ b/sys/cam/ctl/ctl_ha.c
@@ -294,7 +294,7 @@ ctl_ha_rx_thread(void *arg)
 		SOCKBUF_UNLOCK(&so->so_rcv);
 
 		if (wire_hdr.length == 0) {
-			IOVEC_INIT_OBJ(&iov, &wire_hdr);
+			IOVEC_INIT_OBJ(&iov, wire_hdr);
 			uio.uio_iov = &iov;
 			uio.uio_iovcnt = 1;
 			uio.uio_rw = UIO_READ;

--- a/sys/cam/ctl/ctl_ha.c
+++ b/sys/cam/ctl/ctl_ha.c
@@ -294,8 +294,7 @@ ctl_ha_rx_thread(void *arg)
 		SOCKBUF_UNLOCK(&so->so_rcv);
 
 		if (wire_hdr.length == 0) {
-			iov.iov_base = &wire_hdr;
-			iov.iov_len = sizeof(wire_hdr);
+			IOVEC_INIT_OBJ(&iov, &wire_hdr);
 			uio.uio_iov = &iov;
 			uio.uio_iovcnt = 1;
 			uio.uio_rw = UIO_READ;
@@ -703,8 +702,7 @@ ctl_ha_msg_recv(ctl_ha_channel channel, void *addr, size_t len,
 	if (!softc->ha_connected)
 		return (CTL_HA_STATUS_DISCONNECT);
 
-	iov.iov_base = addr;
-	iov.iov_len = len;
+	IOVEC_INIT(&iov, addr, len);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_rw = UIO_READ;

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
@@ -161,8 +161,7 @@ kobj_read_file_vnode(struct _buf *file, char *buf, unsigned size, unsigned off)
 	bzero(&aiov, sizeof(aiov));
 	bzero(&auio, sizeof(auio));
 
-	aiov.iov_base = buf;
-	aiov.iov_len = size;
+	IOVEC_INIT(&aiov, buf, size);
 
 	auio.uio_iov = &aiov;
 	auio.uio_offset = (off_t)off;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu.c
@@ -1112,8 +1112,7 @@ dmu_xuio_add(xuio_t *xuio, arc_buf_t *abuf, offset_t off, size_t n)
 	ASSERT(i < priv->cnt);
 	ASSERT(off + n <= arc_buf_lsize(abuf));
 	iov = uio->uio_iov + i;
-	iov->iov_base = (char *)abuf->b_data + off;
-	iov->iov_len = n;
+	IOVEC_INIT(iov, (char *)abuf->b_data + off, n);
 	priv->bufs[i] = abuf;
 	return (0);
 }

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
@@ -54,8 +54,7 @@ write_bytes(struct diffarg *da)
 	struct uio auio;
 	struct iovec aiov;
 
-	aiov.iov_base = (caddr_t)&da->da_ddr;
-	aiov.iov_len = sizeof (da->da_ddr);
+	IOVEC_INIT_OBJ(&aiov, (caddr_t)&da->da_ddr);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = aiov.iov_len;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
@@ -54,7 +54,7 @@ write_bytes(struct diffarg *da)
 	struct uio auio;
 	struct iovec aiov;
 
-	IOVEC_INIT_OBJ(&aiov, (caddr_t)&da->da_ddr);
+	IOVEC_INIT_OBJ(&aiov, da->da_ddr);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = aiov.iov_len;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_send.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_send.c
@@ -122,8 +122,7 @@ dump_bytes(dmu_sendarg_t *dsp, void *buf, int len)
 
 	ASSERT0(len % 8);
 
-	aiov.iov_base = buf;
-	aiov.iov_len = len;
+	IOVEC_INIT(&aiov, buf, len);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = len;
@@ -1918,8 +1917,7 @@ restore_bytes(struct receive_arg *ra, void *buf, int len, off_t off, ssize_t *re
 	struct iovec aiov;
 	int error;
 
-	aiov.iov_base = buf;
-	aiov.iov_len = len;
+	IOVEC_INIT(&aiov, buf, len);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = len;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
@@ -2586,8 +2586,7 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, int *eofp, int *ncookies, u_lon
 		*ncookies -= ncooks;
 
 	if (uio->uio_segflg == UIO_SYSSPACE && uio->uio_iovcnt == 1) {
-		iovp->iov_base += outcount;
-		iovp->iov_len -= outcount;
+		IOVEC_ADVANCE(iovp, outcount);
 		uio->uio_resid -= outcount;
 	} else if (error = uiomove(outbuf, (long)outcount, UIO_READ, uio)) {
 		/*

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
@@ -5786,7 +5786,7 @@ vop_listextattr {
 	do {
 		u_char nlen;
 
-		IOVEC_INIT_OBJ(&aiov, (void *)dirbuf);
+		IOVEC_INIT_OBJ(&aiov, dirbuf);
 		auio.uio_resid = sizeof(dirbuf);
 		error = VOP_READDIR(vp, &auio, ap->a_cred, &eof, NULL, NULL);
 		done = sizeof(dirbuf) - auio.uio_resid;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
@@ -5787,8 +5787,7 @@ vop_listextattr {
 	do {
 		u_char nlen;
 
-		aiov.iov_base = (void *)dirbuf;
-		aiov.iov_len = sizeof(dirbuf);
+		IOVEC_INIT_OBJ(&aiov, (void *)dirbuf);
 		auio.uio_resid = sizeof(dirbuf);
 		error = VOP_READDIR(vp, &auio, ap->a_cred, &eof, NULL, NULL);
 		done = sizeof(dirbuf) - auio.uio_resid;

--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -378,10 +378,8 @@ int
 cloudabi_sys_file_readdir(struct thread *td,
     struct cloudabi_sys_file_readdir_args *uap)
 {
-	struct iovec iov = {
-		.iov_base = uap->buf,
-		.iov_len = uap->buf_len
-	};
+	struct iovec iov;
+	IOVEC_INIT(&iov, uap->buf, uap->buf_len);
 	struct uio uio = {
 		.uio_iov = &iov,
 		.uio_iovcnt = 1,
@@ -417,10 +415,8 @@ cloudabi_sys_file_readdir(struct thread *td,
 	offset = uap->cookie;
 	vp = fp->f_vnode;
 	while (uio.uio_resid > 0) {
-		struct iovec readiov = {
-			.iov_base = readbuf,
-			.iov_len = MAXBSIZE
-		};
+		struct iovec readiov;
+		IOVEC_INIT(&readiov, readbuf, MAXBSIZE);
 		struct uio readuio = {
 			.uio_iov = &readiov,
 			.uio_iovcnt = 1,

--- a/sys/compat/cloudabi/cloudabi_random.c
+++ b/sys/compat/cloudabi/cloudabi_random.c
@@ -36,10 +36,8 @@ int
 cloudabi_sys_random_get(struct thread *td,
     struct cloudabi_sys_random_get_args *uap)
 {
-	struct iovec iov = {
-		.iov_base = uap->buf,
-		.iov_len = uap->buf_len
-	};
+	struct iovec iov;
+	IOVEC_INIT(&iov, uap->buf, uap->buf_len);
 	struct uio uio = {
 		.uio_iov = &iov,
 		.uio_iovcnt = 1,

--- a/sys/compat/cloudabi32/cloudabi32_fd.c
+++ b/sys/compat/cloudabi32/cloudabi32_fd.c
@@ -71,8 +71,7 @@ cloudabi32_copyinuio(const cloudabi32_iovec_t *iovp, size_t iovcnt,
 			free(uio, M_IOV);
 			return (error);
 		}
-		iov[i].iov_base = TO_PTR(iovobj.buf);
-		iov[i].iov_len = iovobj.buf_len;
+		IOVEC_INIT(&iov[i], TO_PTR(iovobj.buf), iovobj.buf_len);
 		if (iov[i].iov_len > INT32_MAX - uio->uio_resid) {
 			free(uio, M_IOV);
 			return (EINVAL);

--- a/sys/compat/cloudabi32/cloudabi32_sock.c
+++ b/sys/compat/cloudabi32/cloudabi32_sock.c
@@ -69,8 +69,7 @@ cloudabi32_sys_sock_recv(struct thread *td,
 			free(iov, M_SOCKET);
 			return (error);
 		}
-		iov[i].iov_base = TO_PTR(iovobj.buf);
-		iov[i].iov_len = iovobj.buf_len;
+		IOVEC_INIT(&iov[i], TO_PTR(iovobj.buf), iovobj.buf_len);
 	}
 
 	error = cloudabi_sock_recv(td, uap->sock, iov, ri.ri_data_len,
@@ -113,8 +112,7 @@ cloudabi32_sys_sock_send(struct thread *td,
 			free(iov, M_SOCKET);
 			return (error);
 		}
-		iov[i].iov_base = TO_PTR(iovobj.buf);
-		iov[i].iov_len = iovobj.buf_len;
+		IOVEC_INIT(&iov[i], TO_PTR(iovobj.buf), iovobj.buf_len);
 	}
 
 	error = cloudabi_sock_send(td, uap->sock, iov, si.si_data_len,

--- a/sys/compat/cloudabi64/cloudabi64_fd.c
+++ b/sys/compat/cloudabi64/cloudabi64_fd.c
@@ -71,8 +71,7 @@ cloudabi64_copyinuio(const cloudabi64_iovec_t *iovp, size_t iovcnt,
 			free(uio, M_IOV);
 			return (error);
 		}
-		iov[i].iov_base = TO_PTR(iovobj.buf);
-		iov[i].iov_len = iovobj.buf_len;
+		IOVEC_INIT(&iov[i], TO_PTR(iovobj.buf), iovobj.buf_len);
 		if (iov[i].iov_len > INT64_MAX - uio->uio_resid) {
 			free(uio, M_IOV);
 			return (EINVAL);

--- a/sys/compat/cloudabi64/cloudabi64_sock.c
+++ b/sys/compat/cloudabi64/cloudabi64_sock.c
@@ -69,8 +69,7 @@ cloudabi64_sys_sock_recv(struct thread *td,
 			free(iov, M_SOCKET);
 			return (error);
 		}
-		iov[i].iov_base = TO_PTR(iovobj.buf);
-		iov[i].iov_len = iovobj.buf_len;
+		IOVEC_INIT(&iov[i], TO_PTR(iovobj.buf), iovobj.buf_len);
 	}
 
 	error = cloudabi_sock_recv(td, uap->sock, iov, ri.ri_data_len,
@@ -113,8 +112,7 @@ cloudabi64_sys_sock_send(struct thread *td,
 			free(iov, M_SOCKET);
 			return (error);
 		}
-		iov[i].iov_base = TO_PTR(iovobj.buf);
-		iov[i].iov_len = iovobj.buf_len;
+		IOVEC_INIT(&iov[i], TO_PTR(iovobj.buf), iovobj.buf_len);
 	}
 
 	error = cloudabi_sock_send(td, uap->sock, iov, si.si_data_len,

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -883,8 +883,7 @@ freebsd32_copyinuio(struct iovec32 *iovp, u_int iovcnt, struct uio **uiop)
 			free(uio, M_IOV);
 			return (error);
 		}
-		iov[i].iov_base = PTRIN(iov32.iov_base);
-		iov[i].iov_len = iov32.iov_len;
+		IOVEC_INIT(&iov[i], PTRIN(iov32.iov_base), iov32.iov_len);
 	}
 	uio->uio_iov = iov;
 	uio->uio_iovcnt = iovcnt;
@@ -979,8 +978,7 @@ freebsd32_copyiniov(struct iovec32 *iovp32, u_int iovcnt, struct iovec **iovp,
 			free(iov, M_IOV);
 			return (error);
 		}
-		iov[i].iov_base = PTRIN(iov32.iov_base);
-		iov[i].iov_len = iov32.iov_len;
+		IOVEC_INIT(&iov[i], PTRIN(iov32.iov_base), iov32.iov_len);
 	}
 	*iovp = iov;
 	return (0);
@@ -1335,8 +1333,7 @@ freebsd32_recvfrom(struct thread *td,
 	msg.msg_name = PTRIN(uap->from);
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
-	aiov.iov_base = PTRIN(uap->buf);
-	aiov.iov_len = uap->len;
+	IOVEC_INIT(&aiov, PTRIN(uap->buf), uap->len);
 	msg.msg_control = NULL;
 	msg.msg_flags = uap->flags;
 	error = kern_recvit(td, uap->s, &msg, UIO_USERSPACE, NULL);

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -2523,8 +2523,7 @@ linux_getrandom(struct thread *td, struct linux_getrandom_args *args)
 	if (args->count > INT_MAX)
 		args->count = INT_MAX;
 
-	iov.iov_base = args->buf;
-	iov.iov_len = args->count;
+	IOVEC_INIT(&iov, args->buf, args->count);
 
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;

--- a/sys/compat/linux/linux_socket.c
+++ b/sys/compat/linux/linux_socket.c
@@ -685,8 +685,7 @@ linux_sendto_hdrincl(struct thread *td, struct linux_sendto_args *linux_args)
 	msg.msg_iovlen = 1;
 	msg.msg_control = NULL;
 	msg.msg_flags = 0;
-	aiov[0].iov_base = (char *)packet;
-	aiov[0].iov_len = linux_args->len;
+	IOVEC_INIT(&aiov[0], packet, linux_args->len);
 	error = linux_sendit(td, linux_args->s, &msg, linux_args->flags,
 	    NULL, UIO_SYSSPACE);
 goout:
@@ -1030,8 +1029,7 @@ linux_sendto(struct thread *td, struct linux_sendto_args *args)
 	msg.msg_iovlen = 1;
 	msg.msg_control = NULL;
 	msg.msg_flags = 0;
-	aiov.iov_base = PTRIN(args->msg);
-	aiov.iov_len = args->len;
+	IOVEC_INIT(&aiov, PTRIN(args->msg), args->len);
 	return (linux_sendit(td, args->s, &msg, args->flags, NULL,
 	    UIO_USERSPACE));
 }
@@ -1057,8 +1055,7 @@ linux_recvfrom(struct thread *td, struct linux_recvfrom_args *args)
 	msg.msg_name = (struct sockaddr * __restrict)PTRIN(args->from);
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
-	aiov.iov_base = PTRIN(args->buf);
-	aiov.iov_len = args->len;
+	IOVEC_INIT(&aiov, PTRIN(args->buf), args->len);
 	msg.msg_control = 0;
 	msg.msg_flags = linux_to_bsd_msg_flags(args->flags);
 

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -889,9 +889,7 @@ linux_dev_read(struct cdev *dev, struct uio *uio, int ioflag)
 		bytes = filp->f_op->read(filp, uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset);
 		if (bytes >= 0) {
-			uio->uio_iov->iov_base =
-			    ((uint8_t *)uio->uio_iov->iov_base) + bytes;
-			uio->uio_iov->iov_len -= bytes;
+			IOVEC_ADVANCE(uio->uio_iov, bytes);
 			uio->uio_resid -= bytes;
 		} else {
 			error = -bytes;
@@ -931,9 +929,7 @@ linux_dev_write(struct cdev *dev, struct uio *uio, int ioflag)
 		bytes = filp->f_op->write(filp, uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset);
 		if (bytes >= 0) {
-			uio->uio_iov->iov_base =
-			    ((uint8_t *)uio->uio_iov->iov_base) + bytes;
-			uio->uio_iov->iov_len -= bytes;
+			IOVEC_ADVANCE(uio->uio_iov, bytes);
 			uio->uio_resid -= bytes;
 		} else {
 			error = -bytes;
@@ -1252,9 +1248,7 @@ linux_file_read(struct file *file, struct uio *uio, struct ucred *active_cred,
 		bytes = filp->f_op->read(filp, uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset);
 		if (bytes >= 0) {
-			uio->uio_iov->iov_base =
-			    ((uint8_t *)uio->uio_iov->iov_base) + bytes;
-			uio->uio_iov->iov_len -= bytes;
+			IOVEC_ADVANCE(uio->uio_iov, bytes);
 			uio->uio_resid -= bytes;
 		} else
 			error = -bytes;

--- a/sys/dev/beri/virtio/virtio.c
+++ b/sys/dev/beri/virtio/virtio.c
@@ -113,9 +113,9 @@ _vq_record(uint32_t offs, int i, volatile struct vring_desc *vd,
 	if (i >= n_iov)
 		return;
 
-	iov[i].iov_base = paddr_map(offs, be64toh(vd->addr),
-				be32toh(vd->len));
-	iov[i].iov_len = be32toh(vd->len);
+	IOVEC_INIT(&iov[i],
+	    paddr_map(offs, be64toh(vd->addr), be32toh(vd->len)),
+	    be32toh(vd->len));
 	if (flags != NULL)
 		flags[i] = be16toh(vd->flags);
 }
@@ -252,8 +252,7 @@ getcopy(struct iovec *iov, int n)
 
 	tiov = malloc(n * sizeof(struct iovec), M_DEVBUF, M_NOWAIT);
 	for (i = 0; i < n; i++) {
-		tiov[i].iov_base = iov[i].iov_base;
-		tiov[i].iov_len = iov[i].iov_len;
+		IOVEC_INIT(&tiov[i], iov[i].iov_base, iov[i].iov_len);
 	}
 
 	return (tiov);

--- a/sys/dev/cxgbe/iw_cxgbe/cm.c
+++ b/sys/dev/cxgbe/iw_cxgbe/cm.c
@@ -1856,8 +1856,8 @@ process_mpa_request(struct c4iw_ep *ep)
 	if (state != MPA_REQ_WAIT)
 		return 0;
 
-	iov.iov_base = &ep->mpa_pkt[ep->mpa_pkt_len];
-	iov.iov_len = sizeof(ep->mpa_pkt) - ep->mpa_pkt_len;
+	IOVEC_INIT(&iov, &ep->mpa_pkt[ep->mpa_pkt_len],
+	    sizeof(ep->mpa_pkt) - ep->mpa_pkt_len);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/dev/cxgbe/tom/t4_ddp.c
+++ b/sys/dev/cxgbe/tom/t4_ddp.c
@@ -1630,8 +1630,7 @@ sbcopy:
 		struct uio uio;
 		int error;
 
-		iov[0].iov_base = mtod(m, void *);
-		iov[0].iov_len = m->m_len;
+		IOVEC_INIT(&iov[0], mtod(m, void *), m->m_len);
 		if (iov[0].iov_len > resid)
 			iov[0].iov_len = resid;
 		uio.uio_iov = iov;

--- a/sys/dev/filemon/filemon_wrapper.c
+++ b/sys/dev/filemon/filemon_wrapper.c
@@ -53,8 +53,7 @@ filemon_output(struct filemon *filemon, char *msg, size_t len)
 	if (filemon->fp == NULL)
 		return;
 
-	aiov.iov_base = msg;
-	aiov.iov_len = len;
+	IOVEC_INIT(&aiov, msg, len);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = len;

--- a/sys/dev/firewire/firewire.c
+++ b/sys/dev/firewire/firewire.c
@@ -1858,8 +1858,7 @@ fw_rcv_copy(struct fw_rcv_buf *rb)
 	/* Copy header */
 	p = (u_char *)&rb->xfer->recv.hdr;
 	bcopy(rb->vec->iov_base, p, tinfo->hdr_len);
-	rb->vec->iov_base = (u_char *)rb->vec->iov_base + tinfo->hdr_len;
-	rb->vec->iov_len -= tinfo->hdr_len;
+	IOVEC_ADVANCE(rb->vec, tinfo->hdr_len);
 
 	/* Copy payload */
 	p = (u_char *)rb->xfer->recv.payload;

--- a/sys/dev/firewire/fwohci.c
+++ b/sys/dev/firewire/fwohci.c
@@ -2810,13 +2810,11 @@ fwohci_arcv(struct fwohci_softc *sc, struct fwohci_dbch *dbch, int count)
 						goto err;
 					}
 					offset = sizeof(pktbuf);
-					vec[0].iov_base = (char *)&pktbuf;
-					vec[0].iov_len = offset;
+					IOVEC_INIT(&vec[0], &pktbuf, offset);
 				} else {
 					/* splitted in payload */
 					offset = rlen;
-					vec[0].iov_base = buf;
-					vec[0].iov_len = rlen;
+					IOVEC_INIT(&vec[0], buf, rlen);
 				}
 				fp=(struct fw_pkt *)vec[0].iov_base;
 				nvec = 1;
@@ -2863,8 +2861,7 @@ fwohci_arcv(struct fwohci_softc *sc, struct fwohci_dbch *dbch, int count)
 					}
 					goto out;
 				}
-				vec[nvec].iov_base = ld;
-				vec[nvec].iov_len = plen;
+				IOVEC_INIT(&vec[nvec], ld, plen);
 				nvec++;
 				ld += plen;
 			}

--- a/sys/dev/hwpmc/hwpmc_logging.c
+++ b/sys/dev/hwpmc/hwpmc_logging.c
@@ -318,8 +318,8 @@ pmclog_loop(void *arg)
 		    lb->plb_base, lb->plb_ptr);
 		/* change our thread's credentials before issuing the I/O */
 
-		aiov.iov_base = lb->plb_base;
-		aiov.iov_len  = nbytes = lb->plb_ptr - lb->plb_base;
+		nbytes = lb->plb_ptr - lb->plb_base;
+		IOVEC_INIT(&aiov, lb->plb_base, nbytes);
 
 		auio.uio_iov    = &aiov;
 		auio.uio_iovcnt = 1;

--- a/sys/dev/hyperv/vmbus/vmbus_chan.c
+++ b/sys/dev/hyperv/vmbus/vmbus_chan.c
@@ -1034,12 +1034,9 @@ vmbus_chan_send(struct vmbus_channel *chan, uint16_t type, uint16_t flags,
 	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_tlen, pad_pktlen);
 	pkt.cp_hdr.cph_xactid = xactid;
 
-	iov[0].iov_base = &pkt;
-	iov[0].iov_len = hlen;
-	iov[1].iov_base = data;
-	iov[1].iov_len = dlen;
-	iov[2].iov_base = &pad;
-	iov[2].iov_len = pad_pktlen - pktlen;
+	IOVEC_INIT(&iov[0], &pkt, hlen);
+	IOVEC_INIT(&iov[1], data, dlen);
+	IOVEC_INIT(&iov[2], &pad, pad_pktlen - pktlen);
 
 	error = vmbus_txbr_write(&chan->ch_txbr, iov, 3, &send_evt);
 	if (!error && send_evt)
@@ -1071,14 +1068,10 @@ vmbus_chan_send_sglist(struct vmbus_channel *chan,
 	pkt.cp_rsvd = 0;
 	pkt.cp_gpa_cnt = sglen;
 
-	iov[0].iov_base = &pkt;
-	iov[0].iov_len = sizeof(pkt);
-	iov[1].iov_base = sg;
-	iov[1].iov_len = sizeof(struct vmbus_gpa) * sglen;
-	iov[2].iov_base = data;
-	iov[2].iov_len = dlen;
-	iov[3].iov_base = &pad;
-	iov[3].iov_len = pad_pktlen - pktlen;
+	IOVEC_INIT_OBJ(&iov[0], &pkt);
+	IOVEC_INIT(&iov[1], sg, sizeof(struct vmbus_gpa) * sglen);
+	IOVEC_INIT(&iov[2], data, dlen);
+	IOVEC_INIT(&iov[3], &pad, pad_pktlen - pktlen);
 
 	error = vmbus_txbr_write(&chan->ch_txbr, iov, 4, &send_evt);
 	if (!error && send_evt)
@@ -1112,14 +1105,11 @@ vmbus_chan_send_prplist(struct vmbus_channel *chan,
 	pkt.cp_rsvd = 0;
 	pkt.cp_range_cnt = 1;
 
-	iov[0].iov_base = &pkt;
-	iov[0].iov_len = sizeof(pkt);
-	iov[1].iov_base = prp;
-	iov[1].iov_len = __offsetof(struct vmbus_gpa_range, gpa_page[prp_cnt]);
-	iov[2].iov_base = data;
-	iov[2].iov_len = dlen;
-	iov[3].iov_base = &pad;
-	iov[3].iov_len = pad_pktlen - pktlen;
+	IOVEC_INIT_OBJ(&iov[0], &pkt);
+	IOVEC_INIT(&iov[1], prp,
+	    __offsetof(struct vmbus_gpa_range, gpa_page[prp_cnt]));
+	IOVEC_INIT(&iov[2], data, dlen);
+	IOVEC_INIT(&iov[3], &pad, pad_pktlen - pktlen);
 
 	error = vmbus_txbr_write(&chan->ch_txbr, iov, 4, &send_evt);
 	if (!error && send_evt)

--- a/sys/dev/hyperv/vmbus/vmbus_chan.c
+++ b/sys/dev/hyperv/vmbus/vmbus_chan.c
@@ -1068,7 +1068,7 @@ vmbus_chan_send_sglist(struct vmbus_channel *chan,
 	pkt.cp_rsvd = 0;
 	pkt.cp_gpa_cnt = sglen;
 
-	IOVEC_INIT_OBJ(&iov[0], &pkt);
+	IOVEC_INIT_OBJ(&iov[0], pkt);
 	IOVEC_INIT(&iov[1], sg, sizeof(struct vmbus_gpa) * sglen);
 	IOVEC_INIT(&iov[2], data, dlen);
 	IOVEC_INIT(&iov[3], &pad, pad_pktlen - pktlen);
@@ -1105,7 +1105,7 @@ vmbus_chan_send_prplist(struct vmbus_channel *chan,
 	pkt.cp_rsvd = 0;
 	pkt.cp_range_cnt = 1;
 
-	IOVEC_INIT_OBJ(&iov[0], &pkt);
+	IOVEC_INIT_OBJ(&iov[0], pkt);
 	IOVEC_INIT(&iov[1], prp,
 	    __offsetof(struct vmbus_gpa_range, gpa_page[prp_cnt]));
 	IOVEC_INIT(&iov[2], data, dlen);

--- a/sys/dev/iicbus/iic.c
+++ b/sys/dev/iicbus/iic.c
@@ -434,8 +434,7 @@ iicioctl(struct cdev *dev, u_long cmd, caddr_t data, int flags, struct thread *t
 			error = EINVAL;
 			break;
 		}
-		uvec.iov_base = s->buf;
-		uvec.iov_len = s->count;
+		IOVEC_INIT(&uvec, s->buf, s->count);
 		ubuf.uio_iov = &uvec;
 		ubuf.uio_iovcnt = 1;
 		ubuf.uio_segflg = UIO_USERSPACE;
@@ -451,8 +450,7 @@ iicioctl(struct cdev *dev, u_long cmd, caddr_t data, int flags, struct thread *t
 			error = EINVAL;
 			break;
 		}
-		uvec.iov_base = s->buf;
-		uvec.iov_len = s->count;
+		IOVEC_INIT(&uvec, s->buf, s->count);
 		ubuf.uio_iov = &uvec;
 		ubuf.uio_iovcnt = 1;
 		ubuf.uio_segflg = UIO_USERSPACE;

--- a/sys/dev/iscsi/icl_soft.c
+++ b/sys/dev/iscsi/icl_soft.c
@@ -180,8 +180,7 @@ icl_conn_receive_buf(struct icl_conn *ic, void *buf, size_t len)
 	so = ic->ic_socket;
 
 	memset(&uio, 0, sizeof(uio));
-	iov[0].iov_base = buf;
-	iov[0].iov_len = len;
+	IOVEC_INIT(&iov[0], buf, len);
 	uio.uio_iov = iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/dev/iscsi_initiator/isc_soc.c
+++ b/sys/dev/iscsi_initiator/isc_soc.c
@@ -198,7 +198,7 @@ isc_sendPDU(isc_session_t *sp, pduq_t *pq)
      uio->uio_td = sp->td;
      uio->uio_iov = iv = pq->iov;
 
-     IOVEC_INIT_OBJ(iv, &pp->ipdu);
+     IOVEC_INIT_OBJ(iv, pp->ipdu);
      uio->uio_resid = iv->iov_len;
      iv++;
      if(ISOK2DIG(sp->hdrDigest, pp))

--- a/sys/dev/iscsi_initiator/isc_soc.c
+++ b/sys/dev/iscsi_initiator/isc_soc.c
@@ -198,15 +198,13 @@ isc_sendPDU(isc_session_t *sp, pduq_t *pq)
      uio->uio_td = sp->td;
      uio->uio_iov = iv = pq->iov;
 
-     iv->iov_base = &pp->ipdu;
-     iv->iov_len = sizeof(union ipdu_u);
+     IOVEC_INIT_OBJ(iv, &pp->ipdu);
      uio->uio_resid = iv->iov_len;
      iv++;
      if(ISOK2DIG(sp->hdrDigest, pp))
 	  pq->pdu.hdr_dig = sp->hdrDigest(&pp->ipdu, sizeof(union ipdu_u), 0);
      if(pp->ahs_len) {
-	  iv->iov_base = pp->ahs_addr;
-	  iv->iov_len = pp->ahs_len;
+	  IOVEC_INIT(iv, pp->ahs_addr, pp->ahs_len)
 	  uio->uio_resid += iv->iov_len;
 	  iv++;
 	  if(ISOK2DIG(sp->hdrDigest, pp))
@@ -214,22 +212,19 @@ isc_sendPDU(isc_session_t *sp, pduq_t *pq)
      }
      if(ISOK2DIG(sp->hdrDigest, pp)) {
 	  debug(3, "hdr_dig=%04x", htonl(pp->hdr_dig));
-	  iv->iov_base = &pp->hdr_dig;
-	  iv->iov_len = sizeof(int);
+	  IOVEC_INIT_OBJ(iv, &pp->hdr_dig);
 	  uio->uio_resid += iv->iov_len ;
 	  iv++;
      }
      if(pq->pdu.ds_addr &&  pp->ds_len) {
-	  iv->iov_base = pp->ds_addr;
-	  iv->iov_len = pp->ds_len;
+	  IOVEC_INIT(iv, pp->ds_addr, pp->ds_len);
 	  while(iv->iov_len & 03) // the specs say it must be int aligned
 	       iv->iov_len++;
 	  uio->uio_resid += iv->iov_len ;
 	  iv++;
 	  if(ISOK2DIG(sp->dataDigest, pp)) {
 	       pp->ds_dig = sp->dataDigest(pp->ds, pp->ds_len, 0);
-	       iv->iov_base = &pp->ds_dig;
-	       iv->iov_len = sizeof(pp->ds_dig);
+	       IOVEC_INIT_OBJ(iv, &pp->ds_dig);
 	       uio->uio_resid += iv->iov_len ;
 	       iv++;
 	  }
@@ -390,15 +385,13 @@ so_recv(isc_session_t *sp, pduq_t *pq)
 	  pp->ahs_len = bhs->AHSLength * 4;
 	  len += pp->ahs_len;
 	  pp->ahs_addr = malloc(pp->ahs_len, M_TEMP, M_WAITOK); // XXX: could get stuck here
-	  iov->iov_base = pp->ahs_addr;
-	  iov->iov_len = pp->ahs_len;
+	  IOVEC_INIT(iov, pp->ahs_addr, pp->ahs_len);
 	  uio->uio_iovcnt++;
 	  iov++;
      }
      if(ISOK2DIG(sp->hdrDigest, pp)) {
 	  len += sizeof(pp->hdr_dig);
-	  iov->iov_base = &pp->hdr_dig;
-	  iov->iov_len = sizeof(pp->hdr_dig);
+	  IOVEC_INIT_OBJ(iov, &pp->hdr_dig);
 	  uio->uio_iovcnt++;
      }
      if(len) {

--- a/sys/dev/iscsi_initiator/isc_soc.c
+++ b/sys/dev/iscsi_initiator/isc_soc.c
@@ -260,10 +260,7 @@ isc_sendPDU(isc_session_t *sp, pduq_t *pq)
 	  len -= uio->uio_resid;
 	  while(uio->uio_iovcnt > 0) {
 	       if(iv->iov_len > len) {
-		    caddr_t bp = (caddr_t)iv->iov_base;
-
-		    iv->iov_len -= len;
-		    iv->iov_base = (void *)&bp[len];
+		    IOVEC_ADVANCE(iv, len);
 		    break;
 	       }
 	       len -= iv->iov_len;

--- a/sys/dev/mpr/mpr_sas.c
+++ b/sys/dev/mpr/mpr_sas.c
@@ -3228,10 +3228,8 @@ mprsas_send_smpcmd(struct mprsas_softc *sassc, union ccb *ccb, uint64_t sasaddr)
 	 */
 	cm->cm_uio.uio_rw = UIO_WRITE;
 
-	cm->cm_iovec[0].iov_base = request;
-	cm->cm_iovec[0].iov_len = le16toh(req->RequestDataLength);
-	cm->cm_iovec[1].iov_base = response;
-	cm->cm_iovec[1].iov_len = ccb->smpio.smp_response_len;
+	IOVEC_INIT(&cm->cm_iovec[0], request, le16toh(req->RequestDataLength));
+	IOVEC_INIT(&cm->cm_iovec[1], response, ccb->smpio.smp_response_len);
 
 	cm->cm_uio.uio_resid = cm->cm_iovec[0].iov_len +
 			       cm->cm_iovec[1].iov_len;

--- a/sys/dev/mps/mps_sas.c
+++ b/sys/dev/mps/mps_sas.c
@@ -2962,10 +2962,8 @@ mpssas_send_smpcmd(struct mpssas_softc *sassc, union ccb *ccb, uint64_t sasaddr)
 	 */
 	cm->cm_uio.uio_rw = UIO_WRITE;
 
-	cm->cm_iovec[0].iov_base = request;
-	cm->cm_iovec[0].iov_len = le16toh(req->RequestDataLength);
-	cm->cm_iovec[1].iov_base = response;
-	cm->cm_iovec[1].iov_len = ccb->smpio.smp_response_len;
+	IOVEC_INIT(&cm->cm_iovec[0], request, le16toh(req->RequestDataLength));
+	IOVEC_INIT(&cm->cm_iovec[1], response, ccb->smpio.smp_response_len);
 
 	cm->cm_uio.uio_resid = cm->cm_iovec[0].iov_len +
 			       cm->cm_iovec[1].iov_len;

--- a/sys/dev/nand/nandsim_swap.c
+++ b/sys/dev/nand/nandsim_swap.c
@@ -206,8 +206,7 @@ swap_file_write(struct chip_swap *swap, struct block_state *blk_state)
 	bzero(&aiov, sizeof(aiov));
 	bzero(&auio, sizeof(auio));
 
-	aiov.iov_base = blk_space->blk_ptr;
-	aiov.iov_len = swap->blk_size;
+	IOVEC_INIT(&aiov, blk_space->blk_ptr, swap->blk_size);
 	td = curthread;
 	vp = swap->swap_vp;
 
@@ -248,8 +247,7 @@ swap_file_read(struct chip_swap *swap, struct block_state *blk_state)
 	bzero(&aiov, sizeof(aiov));
 	bzero(&auio, sizeof(auio));
 
-	aiov.iov_base = blk_space->blk_ptr;
-	aiov.iov_len = swap->blk_size;
+	IOVEC_INIT(&aiov, blk_space->blk_ptr, swap->blk_size);
 	td = curthread;
 	vp = swap->swap_vp;
 

--- a/sys/dev/proto/proto_busdma.c
+++ b/sys/dev/proto/proto_busdma.c
@@ -284,8 +284,8 @@ proto_busdma_md_load(struct proto_busdma *busdma, struct proto_md *md,
 	pmap_t pmap;
 	int error;
 
-	iov.iov_base = (void *)(uintptr_t)ioc->u.md.virt_addr;
-	iov.iov_len = ioc->u.md.virt_size;
+	IOVEC_INIT(&iov, (void *)(uintptr_t)ioc->u.md.virt_addr,
+	    ioc->u.md.virt_size);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/dev/xen/xenstore/xenstore.c
+++ b/sys/dev/xen/xenstore/xenstore.c
@@ -1377,7 +1377,6 @@ xs_write(struct xs_transaction t, const char *dir, const char *node,
 
 	IOVEC_INIT(&iovec[0], __DECONST(void *, sbuf_data(path)),
 	    sbuf_len(path) + 1);
-	/* XXX-BD: no space for NUL? */
 	IOVEC_INIT(&iovec[1], __DECONST(void *, string), strlen(string));
 
 	error = xs_talkv(t, XS_WRITE, iovec, 2, NULL, NULL);

--- a/sys/dev/xen/xenstore/xenstore.c
+++ b/sys/dev/xen/xenstore/xenstore.c
@@ -951,8 +951,7 @@ xs_single(struct xs_transaction t, enum xsd_sockmsg_type request_type,
 {
 	struct iovec iovec;
 
-	iovec.iov_base = (void *)(uintptr_t)body;
-	iovec.iov_len = strlen(body) + 1;
+	IOVEC_INIT_STR(&iovec, __DECONST(void *, body));
 
 	return (xs_talkv(t, request_type, &iovec, 1, len, result));
 }
@@ -972,10 +971,8 @@ xs_watch(const char *path, const char *token)
 {
 	struct iovec iov[2];
 
-	iov[0].iov_base = (void *)(uintptr_t) path;
-	iov[0].iov_len = strlen(path) + 1;
-	iov[1].iov_base = (void *)(uintptr_t) token;
-	iov[1].iov_len = strlen(token) + 1;
+	IOVEC_INIT_STR(&iov[0], __DECONST(void *, path));
+	IOVEC_INIT_STR(&iov[1], __DECONST(void *, token));
 
 	return (xs_talkv(XST_NIL, XS_WATCH, iov, 2, NULL, NULL));
 }
@@ -994,10 +991,8 @@ xs_unwatch(const char *path, const char *token)
 {
 	struct iovec iov[2];
 
-	iov[0].iov_base = (void *)(uintptr_t) path;
-	iov[0].iov_len = strlen(path) + 1;
-	iov[1].iov_base = (void *)(uintptr_t) token;
-	iov[1].iov_len = strlen(token) + 1;
+	IOVEC_INIT_STR(&iov[0], __DECONST(void *, path));
+	IOVEC_INIT_STR(&iov[1], __DECONST(void *, token));
 
 	return (xs_talkv(XST_NIL, XS_UNWATCH, iov, 2, NULL, NULL));
 }
@@ -1380,10 +1375,10 @@ xs_write(struct xs_transaction t, const char *dir, const char *node,
 
 	path = xs_join(dir, node);
 
-	iovec[0].iov_base = (void *)(uintptr_t) sbuf_data(path);
-	iovec[0].iov_len = sbuf_len(path) + 1;
-	iovec[1].iov_base = (void *)(uintptr_t) string;
-	iovec[1].iov_len = strlen(string);
+	IOVEC_INIT(&iovec[0], __DECONST(void *, sbuf_data(path)),
+	    sbuf_len(path) + 1);
+	/* XXX-BD: no space for NUL? */
+	IOVEC_INIT(&iovec[1], __DECONST(void *, string), strlen(string));
 
 	error = xs_talkv(t, XS_WRITE, iovec, 2, NULL, NULL);
 	sbuf_delete(path);

--- a/sys/fs/cd9660/cd9660_vnops.c
+++ b/sys/fs/cd9660/cd9660_vnops.c
@@ -735,8 +735,7 @@ cd9660_readlink(ap)
 		return (error);
 	}
 	uio->uio_resid -= symlen;
-	uio->uio_iov->iov_base = (char *)uio->uio_iov->iov_base + symlen;
-	uio->uio_iov->iov_len -= symlen;
+	IOVEC_ADVANCE(uio->uio_iov, symlen);
 	return (0);
 }
 

--- a/sys/fs/cd9660/cd9660_vnops.c
+++ b/sys/fs/cd9660/cd9660_vnops.c
@@ -213,8 +213,7 @@ cd9660_getattr(ap)
 		char *cp;
 
 		cp = malloc(MAXPATHLEN, M_TEMP, M_WAITOK);
-		aiov.iov_base = cp;
-		aiov.iov_len = MAXPATHLEN;
+		IOVEC_INIT(&aiov, cp, MAXPATHLEN);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;

--- a/sys/fs/cuse/cuse.c
+++ b/sys/fs/cuse/cuse.c
@@ -816,10 +816,8 @@ cuse_proc2proc_copy(struct proc *proc_s, vm_offset_t data_s,
 	proc_cur = td->td_proc;
 
 	if (proc_cur == proc_d) {
-		struct iovec iov = {
-			.iov_base = (caddr_t)data_d,
-			.iov_len = len,
-		};
+		struct iovec iov;
+		IOVEC_INIT(&iov, (void *)data_d, len);
 		struct uio uio = {
 			.uio_iov = &iov,
 			.uio_iovcnt = 1,
@@ -835,10 +833,8 @@ cuse_proc2proc_copy(struct proc *proc_s, vm_offset_t data_s,
 		PRELE(proc_s);
 
 	} else if (proc_cur == proc_s) {
-		struct iovec iov = {
-			.iov_base = (caddr_t)data_s,
-			.iov_len = len,
-		};
+		struct iovec iov;
+		IOVEC_INIT(&iov, (void *)data_s, len);
 		struct uio uio = {
 			.uio_iov = &iov,
 			.uio_iovcnt = 1,

--- a/sys/fs/ext2fs/ext2_htree.c
+++ b/sys/fs/ext2fs/ext2_htree.c
@@ -400,8 +400,7 @@ ext2_htree_append_block(struct vnode *vp, char *data,
 
 	auio.uio_offset = cursize;
 	auio.uio_resid = blksize;
-	aiov.iov_len = blksize;
-	aiov.iov_base = data;
+	IOVEC_INIT(&aiov, data, blksize);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_rw = UIO_WRITE;

--- a/sys/fs/ext2fs/ext2_lookup.c
+++ b/sys/fs/ext2fs/ext2_lookup.c
@@ -918,8 +918,7 @@ ext2_direnter(struct inode *ip, struct vnode *dvp, struct componentname *cnp)
 		auio.uio_offset = dp->i_offset;
 		newdir.e2d_reclen = DIRBLKSIZ;
 		auio.uio_resid = newentrysize;
-		aiov.iov_len = newentrysize;
-		aiov.iov_base = (caddr_t)&newdir;
+		IOVEC_INIT(&aiov, &newdir, newentrysize);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_rw = UIO_WRITE;

--- a/sys/fs/fuse/fuse_io.c
+++ b/sys/fs/fuse/fuse_io.c
@@ -644,8 +644,8 @@ fuse_io_strategy(struct vnode *vp, struct buf *bp)
 	KASSERT(!(bp->b_flags & B_DONE),
 	    ("fuse_io_strategy: bp %p already marked done", bp));
 	if (bp->b_iocmd == BIO_READ) {
-		io.iov_len = uiop->uio_resid = bp->b_bcount;
-		io.iov_base = bp->b_data;
+		IOVEC_INIT(&io, bp->b_data, bp->b_bcount);
+		uiop->uio_resid = bp->b_bcount;
 		uiop->uio_rw = UIO_READ;
 
 		uiop->uio_offset = ((off_t)bp->b_blkno) * biosize;
@@ -698,11 +698,11 @@ fuse_io_strategy(struct vnode *vp, struct buf *bp)
 				(off_t)bp->b_blkno * biosize;
 
 		if (bp->b_dirtyend > bp->b_dirtyoff) {
-			io.iov_len = uiop->uio_resid = bp->b_dirtyend
-			    - bp->b_dirtyoff;
+			uiop->uio_resid = bp->b_dirtyend - bp->b_dirtyoff;
 			uiop->uio_offset = (off_t)bp->b_blkno * biosize
 			    + bp->b_dirtyoff;
-			io.iov_base = (char *)bp->b_data + bp->b_dirtyoff;
+			IOVEC_INIT(&io, (char *)bp->b_data + bp->b_dirtyoff,
+			    uiop->uio_resid);
 			uiop->uio_rw = UIO_WRITE;
 
 			error = fuse_write_directbackend(vp, uiop, cred, fufh);

--- a/sys/fs/fuse/fuse_vnops.c
+++ b/sys/fs/fuse/fuse_vnops.c
@@ -1797,8 +1797,7 @@ fuse_vnop_getpages(struct vop_getpages_args *ap)
 	VM_CNT_ADD(v_vnodepgsin, npages);
 
 	count = npages << PAGE_SHIFT;
-	iov.iov_base = (caddr_t)kva;
-	iov.iov_len = count;
+	IOVEC_INIT(&iov, (void *)kva, count);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = IDX_TO_OFF(pages[0]->pindex);
@@ -1930,8 +1929,7 @@ fuse_vnop_putpages(struct vop_putpages_args *ap)
 	VM_CNT_INC(v_vnodeout);
 	VM_CNT_ADD(v_vnodepgsout, count);
 
-	iov.iov_base = (caddr_t)kva;
-	iov.iov_len = count;
+	IOVEC_INIT(&iov, bp->b_data, count);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = offset;

--- a/sys/fs/nfs/nfs_commonsubs.c
+++ b/sys/fs/nfs/nfs_commonsubs.c
@@ -251,9 +251,7 @@ nfsm_mbufuio(struct nfsrv_descript *nd, struct uio *uiop, int siz)
 			uiop->uio_iovcnt--;
 			uiop->uio_iov++;
 		} else {
-			uiop->uio_iov->iov_base = (void *)
-				((char *)uiop->uio_iov->iov_base + uiosiz);
-			uiop->uio_iov->iov_len -= uiosiz;
+			IOVEC_ADVANCE(uiop->uio_iov, uiosiz);
 		}
 		siz -= uiosiz;
 	}

--- a/sys/fs/nfsclient/nfs_clbio.c
+++ b/sys/fs/nfsclient/nfs_clbio.c
@@ -773,9 +773,7 @@ do_sync:
 				uiop->uio_iovcnt--;
 				uiop->uio_iov++;
 			} else {
-				uiop->uio_iov->iov_base =
-					(char *)uiop->uio_iov->iov_base + size;
-				uiop->uio_iov->iov_len -= size;
+				IOVEC_ADVANCE(uiop->uio_iov, size);
 			}
 		}
 	} else {
@@ -854,9 +852,7 @@ err_free:
 				uiop->uio_iovcnt--;
 				uiop->uio_iov++;
 			} else {
-				uiop->uio_iov->iov_base =
-					(char *)uiop->uio_iov->iov_base + size;
-				uiop->uio_iov->iov_len -= size;
+				IOVEC_ADVANCE(uiop->uio_iov, size);
 			}
 		}
 	}

--- a/sys/fs/nfsclient/nfs_clcomsubs.c
+++ b/sys/fs/nfsclient/nfs_clcomsubs.c
@@ -260,7 +260,7 @@ nfsm_uiombuf(struct nfsrv_descript *nd, struct uio *uiop, int siz)
 	struct mbuf *mp, *mp2;
 	int xfer, left, mlen;
 	int uiosiz, clflg, rem;
-	char *cp, *tcp;
+	char *cp;
 
 	KASSERT(uiop->uio_iovcnt == 1, ("nfsm_uiotombuf: iovcnt != 1"));
 
@@ -309,10 +309,7 @@ nfsm_uiombuf(struct nfsrv_descript *nd, struct uio *uiop, int siz)
 			uiop->uio_offset += xfer;
 			uiop->uio_resid -= xfer;
 		}
-		tcp = (char *)uiop->uio_iov->iov_base;
-		tcp += uiosiz;
-		uiop->uio_iov->iov_base = (void *)tcp;
-		uiop->uio_iov->iov_len -= uiosiz;
+		IOVEC_ADVANCE(uiop->uio_iov, uiosiz);
 		siz -= uiosiz;
 	}
 	if (rem > 0) {

--- a/sys/fs/nfsclient/nfs_clvnops.c
+++ b/sys/fs/nfsclient/nfs_clvnops.c
@@ -447,8 +447,7 @@ nfs_access(struct vop_access_args *ap)
 			char buf[1];
 
 			mtx_unlock(&np->n_mtx);
-			aiov.iov_base = buf;
-			aiov.iov_len = 1;
+			IOVEC_INIT(&aiov, buf, 1);
 			auio.uio_iov = &aiov;
 			auio.uio_iovcnt = 1;
 			auio.uio_offset = 0;
@@ -462,8 +461,8 @@ nfs_access(struct vop_access_args *ap)
 			else if (vp->v_type == VDIR) {
 				char* bp;
 				bp = malloc(NFS_DIRBLKSIZ, M_TEMP, M_WAITOK);
-				aiov.iov_base = bp;
-				aiov.iov_len = auio.uio_resid = NFS_DIRBLKSIZ;
+				IOVEC_INIT(&aiov, bp, NFS_DIRBLKSIZ);
+				auio.uio_resid = NFS_DIRBLKSIZ;
 				error = ncl_readdirrpc(vp, &auio, ap->a_cred,
 				    ap->a_td);
 				free(bp, M_TEMP);

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -456,8 +456,7 @@ nfsvno_namei(struct nfsrv_descript *nd, struct nameidata *ndp,
 			cp = uma_zalloc(namei_zone, M_WAITOK);
 		else
 			cp = cnp->cn_pnbuf;
-		aiov.iov_base = cp;
-		aiov.iov_len = MAXPATHLEN;
+		IOVEC_INIT(&aiov, cp, MAXPATHLEN);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;
@@ -592,8 +591,7 @@ nfsvno_readlink(struct vnode *vp, struct ucred *cred, struct thread *p,
 		} else {
 			len += mp->m_len;
 		}
-		ivp->iov_base = mtod(mp, caddr_t);
-		ivp->iov_len = mp->m_len;
+		IOVEC_INIT(ivp, mtod(mp, caddr_t), mp->m_len);
 		i++;
 		ivp++;
 	}
@@ -670,8 +668,7 @@ nfsvno_read(struct vnode *vp, off_t off, int cnt, struct ucred *cred,
 			panic("nfsvno_read iov");
 		siz = min(M_TRAILINGSPACE(m), left);
 		if (siz > 0) {
-			iv->iov_base = mtod(m, caddr_t) + m->m_len;
-			iv->iov_len = siz;
+			IOVEC_INIT(iv, mtod(m, caddr_t) + m->m_len, siz);
 			m->m_len += siz;
 			left -= siz;
 			iv++;
@@ -738,8 +735,7 @@ nfsvno_write(struct vnode *vp, off_t off, int retlen, int cnt, int stable,
 			panic("nfsvno_write");
 		if (i > 0) {
 			i = min(i, len);
-			ivp->iov_base = cp;
-			ivp->iov_len = i;
+			IOVEC_INIT(ivp, cp, i);
 			ivp++;
 			len -= i;
 		}
@@ -1642,8 +1638,7 @@ again:
 		cookies = NULL;
 	}
 
-	iv.iov_base = rbuf;
-	iv.iov_len = siz;
+	IOVEC_INIT(&iv, rbuf, siz);
 	io.uio_iov = &iv;
 	io.uio_iovcnt = 1;
 	io.uio_offset = (off_t)off;
@@ -1920,8 +1915,7 @@ again:
 		cookies = NULL;
 	}
 
-	iv.iov_base = rbuf;
-	iv.iov_len = siz;
+	IOVEC_INIT(&iv, rbuf, siz);
 	io.uio_iov = &iv;
 	io.uio_iovcnt = 1;
 	io.uio_offset = (off_t)off;

--- a/sys/fs/smbfs/smbfs_io.c
+++ b/sys/fs/smbfs/smbfs_io.c
@@ -323,8 +323,8 @@ smbfs_doio(struct vnode *vp, struct buf *bp, struct ucred *cr, struct thread *td
 	smb_makescred(scred, td, cr);
 
 	if (bp->b_iocmd == BIO_READ) {
-	    io.iov_len = uiop->uio_resid = bp->b_bcount;
-	    io.iov_base = bp->b_data;
+	    IOVEC_INIT(&io, bp->b_data, bp->b_bcount);
+	    uiop->uio_resid = bp->b_bcount;
 	    uiop->uio_rw = UIO_READ;
 	    switch (vp->v_type) {
 	      case VREG:
@@ -352,9 +352,9 @@ smbfs_doio(struct vnode *vp, struct buf *bp, struct ucred *cr, struct thread *td
 		bp->b_dirtyend = np->n_size - (bp->b_blkno * DEV_BSIZE);
 
 	    if (bp->b_dirtyend > bp->b_dirtyoff) {
-		io.iov_len = uiop->uio_resid = bp->b_dirtyend - bp->b_dirtyoff;
+		uiop->uio_resid = bp->b_dirtyend - bp->b_dirtyoff;
 		uiop->uio_offset = ((off_t)bp->b_blkno) * DEV_BSIZE + bp->b_dirtyoff;
-		io.iov_base = (char *)bp->b_data + bp->b_dirtyoff;
+		IOVEC_INIT(&io, (char *)bp->b_data + bp->b_dirtyoff, uiop->uio_resid);
 		uiop->uio_rw = UIO_WRITE;
 		error = smb_write(smp->sm_share, np->n_fid, uiop, scred);
 
@@ -474,8 +474,7 @@ smbfs_getpages(ap)
 	VM_CNT_ADD(v_vnodepgsin, npages);
 
 	count = npages << PAGE_SHIFT;
-	iov.iov_base = (caddr_t) kva;
-	iov.iov_len = count;
+	IOVEC_INIT(&iov, bp->bp_data, count);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = IDX_TO_OFF(pages[0]->pindex);
@@ -598,8 +597,7 @@ smbfs_putpages(ap)
 	VM_CNT_INC(v_vnodeout);
 	VM_CNT_ADD(v_vnodepgsout, count);
 
-	iov.iov_base = (caddr_t) kva;
-	iov.iov_len = count;
+	IOVEC_INIT(&iov, bp->b_data, count);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = IDX_TO_OFF(pages[0]->pindex);

--- a/sys/fs/udf/udf_vnops.c
+++ b/sys/fs/udf/udf_vnops.c
@@ -907,8 +907,7 @@ udf_readlink(struct vop_readlink_args *ap)
 	node = VTON(vp);
 	len = le64toh(node->fentry->inf_len);
 	buf = malloc(len, M_DEVBUF, M_WAITOK);
-	iov[0].iov_len = len;
-	iov[0].iov_base = buf;
+	IOVEC_INIT(&iov[0], buf, len);
 	uio.uio_iov = iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/fs/unionfs/union_subr.c
+++ b/sys/fs/unionfs/union_subr.c
@@ -988,8 +988,7 @@ unionfs_copyfile_core(struct vnode *lvp, struct vnode *uvp,
 
 		uio.uio_iov = &iov;
 		uio.uio_iovcnt = 1;
-		iov.iov_base = buf;
-		iov.iov_len = MAXBSIZE;
+		IOVEC_INIT(&iov, buf, MAXBSIZE);
 		uio.uio_resid = iov.iov_len;
 		uio.uio_rw = UIO_READ;
 
@@ -1002,8 +1001,7 @@ unionfs_copyfile_core(struct vnode *lvp, struct vnode *uvp,
 		while (bufoffset < count) {
 			uio.uio_iov = &iov;
 			uio.uio_iovcnt = 1;
-			iov.iov_base = buf + bufoffset;
-			iov.iov_len = count - bufoffset;
+			IOVEC_INIT(&iov, buf + bufoffset, count - bufoffset);
 			uio.uio_offset = offset + bufoffset;
 			uio.uio_resid = iov.iov_len;
 			uio.uio_rw = UIO_WRITE;
@@ -1150,8 +1148,7 @@ unionfs_check_rmdir(struct vnode *vp, struct ucred *cred, struct thread *td)
 	error = mac_vnode_check_readdir(td->td_ucred, lvp);
 #endif
 	while (!error && !eofflag) {
-		iov.iov_base = buf;
-		iov.iov_len = sizeof(buf);
+		IOVEC_INIT_OBJ(&iov, buf);
 		uio.uio_iov = &iov;
 		uio.uio_iovcnt = 1;
 		uio.uio_resid = iov.iov_len;

--- a/sys/i386/i386/uio_machdep.c
+++ b/sys/i386/i386/uio_machdep.c
@@ -112,8 +112,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		}
 		sf_buf_free(sf);
 		sched_unpin();
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/i386/ibcs2/ibcs2_misc.c
+++ b/sys/i386/ibcs2/ibcs2_misc.c
@@ -348,8 +348,7 @@ ibcs2_getdents(struct thread *td, struct ibcs2_getdents_args *uap)
 	buf = malloc(buflen, M_TEMP, M_WAITOK);
 	vn_lock(vp, LK_SHARED | LK_RETRY);
 again:
-	aiov.iov_base = buf;
-	aiov.iov_len = buflen;
+	IOVEC_INIT(&aiov, buf, buflen);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_rw = UIO_READ;
@@ -507,8 +506,7 @@ ibcs2_read(struct thread *td, struct ibcs2_read_args *uap)
 	buf = malloc(buflen, M_TEMP, M_WAITOK);
 	vn_lock(vp, LK_SHARED | LK_RETRY);
 again:
-	aiov.iov_base = buf;
-	aiov.iov_len = buflen;
+	IOVEC_INIT(&aiov, buf, buflen);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_rw = UIO_READ;

--- a/sys/kern/kern_alq.c
+++ b/sys/kern/kern_alq.c
@@ -310,6 +310,7 @@ alq_doio(struct alq *alq)
 	struct thread *td;
 	struct mount *mp;
 	struct vnode *vp;
+	void *write_start;
 	struct uio auio;
 	struct iovec aiov[2];
 	int totlen;
@@ -328,26 +329,28 @@ alq_doio(struct alq *alq)
 	bzero(&auio, sizeof(auio));
 
 	/* Start the write from the location of our buffer tail pointer. */
-	aiov[0].iov_base = alq->aq_entbuf + alq->aq_writetail;
+	write_start = alq->aq_entbuf + alq->aq_writetail;
 
 	if (alq->aq_writetail < alq->aq_writehead) {
 		/* Buffer not wrapped. */
-		totlen = aiov[0].iov_len = alq->aq_writehead - alq->aq_writetail;
+		IOVEC_INIT(&aiov[0], write_start,
+		    alq->aq_writehead - alq->aq_writetail);
+		totlen = aiov[0].iov_len;
 	} else if (alq->aq_writehead == 0) {
 		/* Buffer not wrapped (special case to avoid an empty iov). */
-		totlen = aiov[0].iov_len = alq->aq_buflen - alq->aq_writetail -
-		    wrapearly;
+		IOVEC_INIT(&aiov[0], write_start,
+		    alq->aq_buflen - alq->aq_writetail - wrapearly);
+		totlen = aiov[0].iov_len;
 	} else {
 		/*
 		 * Buffer wrapped, requires 2 aiov entries:
 		 * - first is from writetail to end of buffer
 		 * - second is from start of buffer to writehead
 		 */
-		aiov[0].iov_len = alq->aq_buflen - alq->aq_writetail -
-		    wrapearly;
+		IOVEC_INIT(&aiov[0], write_start,
+		    alq->aq_buflen - alq->aq_writetail - wrapearly);
 		iov++;
-		aiov[1].iov_base = alq->aq_entbuf;
-		aiov[1].iov_len =  alq->aq_writehead;
+		IOVEC_INIT(&aiov[1], alq->aq_entbuf, alq->aq_writehead);
 		totlen = aiov[0].iov_len + aiov[1].iov_len;
 	}
 

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -990,16 +990,14 @@ kern_kevent_generic(struct thread *td, struct g_kevent_args *uap,
 #ifdef KTRACE
 	if (KTRPOINT(td, KTR_GENIO)) {
 		kgio = ktr_geniosize;
-		ktriov.iov_base = uap->changelist;
-		ktriov.iov_len = kev_iovlen(uap->nchanges, kgio,
-		    k_ops->kevent_size);
+		IOVEC_INIT(&ktriov, uap->changelist,
+		    kev_iovlen(uap->nchanges, kgio, k_ops->kevent_size));
 		ktruio = (struct uio){ .uio_iov = &ktriov, .uio_iovcnt = 1,
 		    .uio_segflg = UIO_USERSPACE, .uio_rw = UIO_READ,
 		    .uio_td = td };
 		ktruioin = cloneuio(&ktruio);
-		ktriov.iov_base = uap->eventlist;
-		ktriov.iov_len = kev_iovlen(uap->nevents, kgio,
-		    k_ops->kevent_size);
+		IOVEC_INIT(&ktriov, uap->eventlist,
+		    kev_iovlen(uap->nevents, kgio, k_ops->kevent_size));
 		ktriov.iov_len = uap->nevents * k_ops->kevent_size;
 		ktruioout = cloneuio(&ktruio);
 	}

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -345,7 +345,7 @@ kern_jail(struct thread *td, struct jail *j)
 		IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 		opt.uio_iovcnt++;
 		enforce_statfs = jail_default_enforce_statfs;
-		IOVEC_INIT_OBJ(&optiov[opt.uio_iovcnt], &enforce_statfs);
+		IOVEC_INIT_OBJ(&optiov[opt.uio_iovcnt], enforce_statfs);
 		opt.uio_iovcnt++;
 	}
 

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -313,6 +313,7 @@ kern_jail(struct thread *td, struct jail *j)
 			    )];
 	struct uio opt;
 	char *u_path, *u_hostname, *u_name;
+	char *optstr;
 #ifdef INET
 	uint32_t ip4s;
 	struct in_addr *u_ip4;
@@ -335,19 +336,16 @@ kern_jail(struct thread *td, struct jail *j)
 	/* Set permissions for top-level jails from sysctls. */
 	if (!jailed(td->td_ucred)) {
 		for (fi = 0; fi < nitems(pr_allow_names); fi++) {
-			optiov[opt.uio_iovcnt].iov_base =
-			    (jail_default_allow & (1 << fi))
+			optstr = (jail_default_allow & (1 << fi))
 			    ? pr_allow_names[fi] : pr_allow_nonames[fi];
-			optiov[opt.uio_iovcnt].iov_len =
-			    strlen(optiov[opt.uio_iovcnt].iov_base) + 1;
+			IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 			opt.uio_iovcnt += 2;
 		}
-		optiov[opt.uio_iovcnt].iov_base = "enforce_statfs";
-		optiov[opt.uio_iovcnt].iov_len = sizeof("enforce_statfs");
+		optstr = "enforce_statfs";
+		IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 		opt.uio_iovcnt++;
 		enforce_statfs = jail_default_enforce_statfs;
-		optiov[opt.uio_iovcnt].iov_base = &enforce_statfs;
-		optiov[opt.uio_iovcnt].iov_len = sizeof(enforce_statfs);
+		IOVEC_INIT_OBJ(&optiov[opt.uio_iovcnt], &enforce_statfs);
 		opt.uio_iovcnt++;
 	}
 
@@ -382,35 +380,31 @@ kern_jail(struct thread *td, struct jail *j)
 	u_ip6 = (struct in6_addr *)(u_name + MAXHOSTNAMELEN);
 #endif
 #endif
-	optiov[opt.uio_iovcnt].iov_base = "path";
-	optiov[opt.uio_iovcnt].iov_len = sizeof("path");
+	optstr = "path";
+	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
-	optiov[opt.uio_iovcnt].iov_base = u_path;
-	error = copyinstr(j->path, u_path, MAXPATHLEN,
-	    &optiov[opt.uio_iovcnt].iov_len);
+	error = copyinstr(j->path, u_path, MAXPATHLEN, &tmplen);
 	if (error) {
 		free(u_path, M_TEMP);
 		return (error);
 	}
+	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_path, tmplen);
 	opt.uio_iovcnt++;
-	optiov[opt.uio_iovcnt].iov_base = "host.hostname";
-	optiov[opt.uio_iovcnt].iov_len = sizeof("host.hostname");
+	optstr = "host.hostname";
+	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
-	optiov[opt.uio_iovcnt].iov_base = u_hostname;
-	error = copyinstr(j->hostname, u_hostname, MAXHOSTNAMELEN,
-	    &optiov[opt.uio_iovcnt].iov_len);
+	error = copyinstr(j->hostname, u_hostname, MAXHOSTNAMELEN, &tmplen);
+	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_hostname, tmplen);
 	if (error) {
 		free(u_path, M_TEMP);
 		return (error);
 	}
 	opt.uio_iovcnt++;
 	if (j->jailname != NULL) {
-		optiov[opt.uio_iovcnt].iov_base = "name";
-		optiov[opt.uio_iovcnt].iov_len = sizeof("name");
+		optstr = "name";
+		IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 		opt.uio_iovcnt++;
-		optiov[opt.uio_iovcnt].iov_base = u_name;
-		error = copyinstr(j->jailname, u_name, MAXHOSTNAMELEN,
-		    &optiov[opt.uio_iovcnt].iov_len);
+		IOVEC_INIT(&optiov[opt.uio_iovcnt], u_name, tmplen);
 		if (error) {
 			free(u_path, M_TEMP);
 			return (error);
@@ -418,11 +412,11 @@ kern_jail(struct thread *td, struct jail *j)
 		opt.uio_iovcnt++;
 	}
 #ifdef INET
-	optiov[opt.uio_iovcnt].iov_base = "ip4.addr";
-	optiov[opt.uio_iovcnt].iov_len = sizeof("ip4.addr");
+	optstr = "ip4.addr";
+	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
-	optiov[opt.uio_iovcnt].iov_base = u_ip4;
-	optiov[opt.uio_iovcnt].iov_len = ip4s * sizeof(struct in_addr);
+	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_ip4,
+	    ip4s * sizeof(struct in_addr));
 	if (j->version == 0)
 		u_ip4->s_addr = j->ip4s;
 	else {
@@ -435,11 +429,11 @@ kern_jail(struct thread *td, struct jail *j)
 	opt.uio_iovcnt++;
 #endif
 #ifdef INET6
-	optiov[opt.uio_iovcnt].iov_base = "ip6.addr";
-	optiov[opt.uio_iovcnt].iov_len = sizeof("ip6.addr");
+	optstr = "ip6.addr";
+	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
-	optiov[opt.uio_iovcnt].iov_base = u_ip6;
-	optiov[opt.uio_iovcnt].iov_len = j->ip6s * sizeof(struct in6_addr);
+	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_ip6,
+	    j->ip6s * sizeof(struct in6_addr));
 	error = copyin(j->ip6, u_ip6, optiov[opt.uio_iovcnt].iov_len);
 	if (error) {
 		free(u_path, M_TEMP);

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -394,21 +394,22 @@ kern_jail(struct thread *td, struct jail *j)
 	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
 	error = copyinstr(j->hostname, u_hostname, MAXHOSTNAMELEN, &tmplen);
-	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_hostname, tmplen);
 	if (error) {
 		free(u_path, M_TEMP);
 		return (error);
 	}
+	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_hostname, tmplen);
 	opt.uio_iovcnt++;
 	if (j->jailname != NULL) {
 		optstr = "name";
 		IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 		opt.uio_iovcnt++;
-		IOVEC_INIT(&optiov[opt.uio_iovcnt], u_name, tmplen);
+		error = copyinstr(j->jailname, u_name, MAXHOSTNAMELEN, &tmplen);
 		if (error) {
 			free(u_path, M_TEMP);
 			return (error);
 		}
+		IOVEC_INIT(&optiov[opt.uio_iovcnt], u_name, tmplen);
 		opt.uio_iovcnt++;
 	}
 #ifdef INET

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -1253,22 +1253,19 @@ ktr_writerequest(struct thread *td, struct ktr_request *req)
 	auio.uio_offset = 0;
 	auio.uio_segflg = UIO_SYSSPACE;
 	auio.uio_rw = UIO_WRITE;
-	aiov[0].iov_base = (caddr_t)kth;
-	aiov[0].iov_len = sizeof(struct ktr_header);
+	IOVEC_INIT_OBJ(&aiov[0], kth);
 	auio.uio_resid = sizeof(struct ktr_header);
 	auio.uio_iovcnt = 1;
 	auio.uio_td = td;
 	if (datalen != 0) {
-		aiov[1].iov_base = (caddr_t)&req->ktr_data;
-		aiov[1].iov_len = datalen;
+		IOVEC_INIT(&aiov[1], &req->ktr_data, datalen);
 		auio.uio_resid += datalen;
 		auio.uio_iovcnt++;
 		kth->ktr_len += datalen;
 	}
 	if (buflen != 0) {
 		KASSERT(req->ktr_buffer != NULL, ("ktrace: nothing to write"));
-		aiov[auio.uio_iovcnt].iov_base = req->ktr_buffer;
-		aiov[auio.uio_iovcnt].iov_len = buflen;
+		IOVEC_INIT(&aiov[auio.uio_iovcnt], req->ktr_buffer, buflen);
 		auio.uio_resid += buflen;
 		auio.uio_iovcnt++;
 	}

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -1253,7 +1253,7 @@ ktr_writerequest(struct thread *td, struct ktr_request *req)
 	auio.uio_offset = 0;
 	auio.uio_segflg = UIO_SYSSPACE;
 	auio.uio_rw = UIO_WRITE;
-	IOVEC_INIT_OBJ(&aiov[0], kth);
+	IOVEC_INIT(&aiov[0], kth, sizeof(struct ktr_header));
 	auio.uio_resid = sizeof(struct ktr_header);
 	auio.uio_iovcnt = 1;
 	auio.uio_td = td;

--- a/sys/kern/kern_physio.c
+++ b/sys/kern/kern_physio.c
@@ -203,9 +203,7 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 			iolen = bp->bio_length - bp->bio_resid;
 			if (iolen == 0 && !(bp->bio_flags & BIO_ERROR))
 				goto doerror;	/* EOF */
-			uio->uio_iov[i].iov_len -= iolen;
-			uio->uio_iov[i].iov_base =
-			    (char *)uio->uio_iov[i].iov_base + iolen;
+			IOVEC_ADVANCE(&uio->uio_iov[i], iolen);
 			uio->uio_resid -= iolen;
 			uio->uio_offset += iolen;
 			if (bp->bio_flags & BIO_ERROR) {

--- a/sys/kern/subr_mchain.c
+++ b/sys/kern/subr_mchain.c
@@ -292,9 +292,7 @@ mb_put_uio(struct mbchain *mbp, struct uio *uiop, int size)
 			return (error);
 		uiop->uio_offset += left;
 		uiop->uio_resid -= left;
-		uiop->uio_iov->iov_base =
-		    (char *)uiop->uio_iov->iov_base + left;
-		uiop->uio_iov->iov_len -= left;
+		IOVEC_ADVANCE(uiop->uio_iov, left);
 		size -= left;
 	}
 	return (0);
@@ -546,9 +544,7 @@ md_get_uio(struct mdchain *mdp, struct uio *uiop, int size)
 			return (error);
 		uiop->uio_offset += left;
 		uiop->uio_resid -= left;
-		uiop->uio_iov->iov_base =
-		    (char *)uiop->uio_iov->iov_base + left;
-		uiop->uio_iov->iov_len -= left;
+		IOVEC_ADVANCE(uiop->uio_iov, left);
 		size -= left;
 	}
 	return (0);

--- a/sys/kern/subr_sglist.c
+++ b/sys/kern/subr_sglist.c
@@ -543,8 +543,7 @@ sglist_consume_uio(struct sglist *sg, struct uio *uio, size_t resid)
 		 * then break out of the loop.
 		 */
 		error = _sglist_append_buf(sg, iov->iov_base, len, pmap, &done);
-		iov->iov_base = (char *)iov->iov_base + done;
-		iov->iov_len -= done;
+		IOVEC_ADVANCE(iov, done);
 		uio->uio_resid -= done;
 		uio->uio_offset += done;
 		resid -= done;

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -262,8 +262,7 @@ uiomove_faultflag(void *cp, int n, struct uio *uio, int nofault)
 		case UIO_NOCOPY:
 			break;
 		}
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		cp = (char *)cp + cnt;
@@ -332,8 +331,7 @@ again:
 	case UIO_NOCOPY:
 		break;
 	}
-	iov->iov_base = (char *)iov->iov_base + 1;
-	iov->iov_len--;
+	IOVEC_ADVANCE(iov, 1);
 	uio->uio_resid--;
 	uio->uio_offset++;
 	return (0);

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -101,8 +101,7 @@ physcopyin(void *src, vm_paddr_t dst, size_t len)
 	struct uio uio;
 	int i;
 
-	iov[0].iov_base = src;
-	iov[0].iov_len = len;
+	IOVEC_INIT(&iov[0], src, len);
 	uio.uio_iov = iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;
@@ -122,8 +121,7 @@ physcopyout(vm_paddr_t src, void *dst, size_t len)
 	struct uio uio;
 	int i;
 
-	iov[0].iov_base = dst;
-	iov[0].iov_len = len;
+	IOVEC_INIT(&iov[0], dst, len);
 	uio.uio_iov = iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -197,8 +197,7 @@ sys_read(td, uap)
 
 	if (uap->nbyte > IOSIZE_MAX)
 		return (EINVAL);
-	aiov.iov_base = uap->buf;
-	aiov.iov_len = uap->nbyte;
+	IOVEC_INIT(&aiov, uap->buf, uap->nbyte);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = uap->nbyte;
@@ -235,8 +234,7 @@ kern_pread(struct thread *td, int fd, void *buf, size_t nbyte, off_t offset)
 
 	if (nbyte > IOSIZE_MAX)
 		return (EINVAL);
-	aiov.iov_base = buf;
-	aiov.iov_len = nbyte;
+	IOVEC_INIT(&aiov, buf, nbyte);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = nbyte;
@@ -411,8 +409,7 @@ sys_write(td, uap)
 
 	if (uap->nbyte > IOSIZE_MAX)
 		return (EINVAL);
-	aiov.iov_base = (void *)(uintptr_t)uap->buf;
-	aiov.iov_len = uap->nbyte;
+	IOVEC_INIT(&aiov, __DECONST(void *, uap->buf), uap->nbyte);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = uap->nbyte;
@@ -450,8 +447,7 @@ kern_pwrite(struct thread *td, int fd, const void *buf, size_t nbyte,
 
 	if (nbyte > IOSIZE_MAX)
 		return (EINVAL);
-	aiov.iov_base = (void *)(uintptr_t)buf;
-	aiov.iov_len = nbyte;
+	IOVEC_INIT(&aiov, __DECONST(void *, buf), nbyte);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_resid = nbyte;

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -867,8 +867,7 @@ pipe_build_write_buffer(wpipe, uio)
  * and update the uio data
  */
 
-	uio->uio_iov->iov_len -= size;
-	uio->uio_iov->iov_base = (char *)uio->uio_iov->iov_base + size;
+	IOVEC_ADVANCE(uio->uio_iov, size);
 	if (uio->uio_iov->iov_len == 0)
 		uio->uio_iov++;
 	uio->uio_resid -= size;

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -913,8 +913,7 @@ pipe_clone_write_buffer(wpipe)
 	wpipe->pipe_state &= ~PIPE_DIRECTW;
 
 	PIPE_UNLOCK(wpipe);
-	iov.iov_base = wpipe->pipe_buffer.buffer;
-	iov.iov_len = size;
+	IOVEC_INIT(&iov, wpipe->pipe_buffer.buffer, size);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -368,8 +368,7 @@ proc_iop(struct thread *td, struct proc *p, vm_offset_t va, void *buf,
 	MPASS(len < SSIZE_MAX);
 	slen = (ssize_t)len;
 
-	iov.iov_base = (caddr_t)buf;
-	iov.iov_len = len;
+	IOVEC_INIT(&iov, buf, len);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = va;
@@ -1261,16 +1260,15 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void *addr, int data)
 #ifdef COMPAT_FREEBSD32
 		if (wrap32) {
 			piod32 = addr;
-			iov.iov_base = (void *)(uintptr_t)piod32->piod_addr;
-			iov.iov_len = piod32->piod_len;
+			IOVEC_INIT(&iov, (void *)(uintptr_t)piod32->piod_addr,
+			    piod32->piod_len);
 			uio.uio_offset = (off_t)(uintptr_t)piod32->piod_offs;
 			uio.uio_resid = piod32->piod_len;
 		} else
 #endif
 		{
 			piod = addr;
-			iov.iov_base = piod->piod_addr;
-			iov.iov_len = piod->piod_len;
+			IOVEC_INIT(&iov, piod->piod_addr, piod->piod_len);
 			uio.uio_offset = (off_t)(uintptr_t)piod->piod_offs;
 			uio.uio_resid = piod->piod_len;
 		}

--- a/sys/kern/sys_socket.c
+++ b/sys/kern/sys_socket.c
@@ -594,8 +594,7 @@ retry:
 
 	done = job->aio_done;
 	cnt = job->uaiocb.aio_nbytes - done;
-	iov.iov_base = (void *)((uintptr_t)job->uaiocb.aio_buf + done);
-	iov.iov_len = cnt;
+	IOVEC_INIT(&iov, (void *)((uintptr_t)job->uaiocb.aio_buf + done), cnt);
 	uio.uio_iov = &iov;
 	uio.uio_iovcnt = 1;
 	uio.uio_offset = 0;

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -813,8 +813,7 @@ sys_sendto(struct thread *td, struct sendto_args *uap)
 #ifdef COMPAT_OLDSOCK
 	msg.msg_flags = 0;
 #endif
-	aiov.iov_base = uap->buf;
-	aiov.iov_len = uap->len;
+	IOVEC_INIT(&aiov, uap->buf, uap->len);
 	return (sendit(td, uap->s, &msg, uap->flags));
 }
 
@@ -829,8 +828,7 @@ osend(struct thread *td, struct osend_args *uap)
 	msg.msg_namelen = 0;
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
-	aiov.iov_base = uap->buf;
-	aiov.iov_len = uap->len;
+	IOVEC_INIT(&aiov, uap->buf, uap->len);
 	msg.msg_control = 0;
 	msg.msg_flags = 0;
 	return (sendit(td, uap->s, &msg, uap->flags));
@@ -1073,8 +1071,7 @@ sys_recvfrom(struct thread *td, struct recvfrom_args *uap)
 	msg.msg_name = uap->from;
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
-	aiov.iov_base = uap->buf;
-	aiov.iov_len = uap->len;
+	IOVEC_INIT(&aiov, uap->buf, uap->len);
 	msg.msg_control = 0;
 	msg.msg_flags = uap->flags;
 	error = recvit(td, uap->s, &msg, uap->fromlenaddr);
@@ -1103,8 +1100,7 @@ orecv(struct thread *td, struct orecv_args *uap)
 	msg.msg_namelen = 0;
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
-	aiov.iov_base = uap->buf;
-	aiov.iov_len = uap->len;
+	IOVEC_INIT(&aiov, uap->buf, uap->len);
 	msg.msg_control = 0;
 	msg.msg_flags = uap->flags;
 	return (recvit(td, uap->s, &msg, NULL));

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -780,8 +780,7 @@ aio_process_rw(struct kaiocb *job)
 	cb = &job->uaiocb;
 	fp = job->fd_file;
 
-	aiov.iov_base = (void *)(uintptr_t)cb->aio_buf;
-	aiov.iov_len = cb->aio_nbytes;
+	IOVEC_INIT(&aiov, __DEVOLATILE(void *, cb->aio_buf), cb->aio_nbytes);
 
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;

--- a/sys/kern/vfs_default.c
+++ b/sys/kern/vfs_default.c
@@ -279,8 +279,7 @@ get_next_dirent(struct vnode *vp, struct dirent **dpp, char *dirbuf,
 	KASSERT(vp->v_type == VDIR, ("vp %p is not a directory", vp));
 
 	if (*len == 0) {
-		iov.iov_base = dirbuf;
-		iov.iov_len = dirbuflen;
+		IOVEC_INIT(&iov, dirbuf, dirbuflen);
 
 		uio.uio_iov = &iov;
 		uio.uio_iovcnt = 1;
@@ -1015,8 +1014,7 @@ vop_stdallocate(struct vop_allocate_args *ap)
 		if (cur > len)
 			cur = len;
 		if (offset < fsize) {
-			aiov.iov_base = buf;
-			aiov.iov_len = cur;
+			IOVEC_INIT(&aiov, buf, cur);
 			auio.uio_iov = &aiov;
 			auio.uio_iovcnt = 1;
 			auio.uio_offset = offset;
@@ -1035,8 +1033,7 @@ vop_stdallocate(struct vop_allocate_args *ap)
 			bzero(buf, cur);
 		}
 
-		aiov.iov_base = buf;
-		aiov.iov_len = cur;
+		IOVEC_INIT(&aiov, buf, cur);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = offset;

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -170,8 +170,7 @@ extattr_set_vp(struct vnode *vp, int attrnamespace, const char *attrname,
 		return (error);
 	vn_lock(vp, LK_EXCLUSIVE | LK_RETRY);
 
-	aiov.iov_base = data;
-	aiov.iov_len = nbytes;
+	IOVEC_INIT(&aiov, data, nbytes);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_offset = 0;
@@ -339,8 +338,7 @@ extattr_get_vp(struct vnode *vp, int attrnamespace, const char *attrname,
 	sizep = NULL;
 	cnt = 0;
 	if (data != NULL) {
-		aiov.iov_base = data;
-		aiov.iov_len = nbytes;
+		IOVEC_INIT(&aiov, data, nbytes);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;
@@ -642,8 +640,7 @@ extattr_list_vp(struct vnode *vp, int attrnamespace, void *data,
 	sizep = NULL;
 	cnt = 0;
 	if (data != NULL) {
-		aiov.iov_base = data;
-		aiov.iov_len = nbytes;
+		IOVEC_INIT(&aiov, data, nbytes);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;

--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -494,8 +494,7 @@ namei(struct nameidata *ndp)
 			cp = uma_zalloc(namei_zone, M_WAITOK);
 		else
 			cp = cnp->cn_pnbuf;
-		aiov.iov_base = cp;
-		aiov.iov_len = MAXPATHLEN;
+		IOVEC_INIT(&aiov, cp, MAXPATHLEN);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -1914,8 +1914,10 @@ mount_arg(struct mntarg *ma, const char *name, const void *val, int len)
 	IOVEC_INIT_STR(&ma->v[ma->len], __DECONST(void *, name));
 	ma->len++;
 
-	IOVEC_INIT(&ma->v[ma->len], __DECONST(void *, val),
-	    len < 0 ? strlen(val) + 1 : len);
+	if (len < 0)
+		IOVEC_INIT_STR(&ma->v[ma->len], __DECONST(void *, val));
+	else
+		IOVEC_INIT(&ma->v[ma->len], len);
 	ma->len++;
 	return (ma);
 }

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -1915,9 +1915,9 @@ mount_arg(struct mntarg *ma, const char *name, const void *val, int len)
 	ma->len++;
 
 	if (len < 0)
-		IOVEC_INIT_STR(&ma->v[ma->len], __DECONST(void *, val));
+		IOVEC_INIT_STR(&ma->v[ma->len], __DECONST(char *, val));
 	else
-		IOVEC_INIT(&ma->v[ma->len], len);
+		IOVEC_INIT(&ma->v[ma->len], __DECONST(char *, val), len);
 	ma->len++;
 	return (ma);
 }

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -1849,8 +1849,7 @@ mount_argf(struct mntarg *ma, const char *name, const char *fmt, ...)
 
 	ma->v = realloc(ma->v, sizeof *ma->v * (ma->len + 2),
 	    M_MOUNT, M_WAITOK);
-	ma->v[ma->len].iov_base = (void *)(uintptr_t)name;
-	ma->v[ma->len].iov_len = strlen(name) + 1;
+	IOVEC_INIT_STR(&ma->v[ma->len], __DECONST(void *, name));
 	ma->len++;
 
 	sb = sbuf_new_auto();
@@ -1864,8 +1863,7 @@ mount_argf(struct mntarg *ma, const char *name, const char *fmt, ...)
 	bcopy(sbuf_data(sb), maa + 1, len);
 	sbuf_delete(sb);
 
-	ma->v[ma->len].iov_base = maa + 1;
-	ma->v[ma->len].iov_len = len;
+	IOVEC_INIT(&ma->v[ma->len], maa + 1, len);
 	ma->len++;
 
 	return (ma);
@@ -1913,15 +1911,11 @@ mount_arg(struct mntarg *ma, const char *name, const void *val, int len)
 
 	ma->v = realloc(ma->v, sizeof *ma->v * (ma->len + 2),
 	    M_MOUNT, M_WAITOK);
-	ma->v[ma->len].iov_base = (void *)(uintptr_t)name;
-	ma->v[ma->len].iov_len = strlen(name) + 1;
+	IOVEC_INIT_STR(&ma->v[ma->len], __DECONST(void *, name));
 	ma->len++;
 
-	ma->v[ma->len].iov_base = (void *)(uintptr_t)val;
-	if (len < 0)
-		ma->v[ma->len].iov_len = strlen(val) + 1;
-	else
-		ma->v[ma->len].iov_len = len;
+	IOVEC_INIT(&ma->v[ma->len], __DECONST(void *, val),
+	    len < 0 ? strlen(val) + 1 : len);
 	ma->len++;
 	return (ma);
 }

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -2525,8 +2525,7 @@ kern_readlinkat(struct thread *td, int fd, char *path, enum uio_seg pathseg,
 	if (vp->v_type != VLNK)
 		error = EINVAL;
 	else {
-		aiov.iov_base = buf;
-		aiov.iov_len = count;
+		IOVEC_INIT(&aiov, buf, count);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = 0;
@@ -4006,8 +4005,7 @@ unionread:
 		error = EINVAL;
 		goto fail;
 	}
-	aiov.iov_base = buf;
-	aiov.iov_len = count;
+	IOVEC_INIT(&aiov, buf, count);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_rw = UIO_READ;

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1211,11 +1211,11 @@ vn_io_fault_uiomove(char *data, int xfersize, struct uio *uio)
 
 	KASSERT(uio->uio_iovcnt == 1, ("uio_iovcnt %d", uio->uio_iovcnt));
 	transp_uio.uio_iov = &transp_iov[0];
-	IOVEC_INIT(&transp_iov[0], data, xfersize);
 	transp_uio.uio_iovcnt = 1;
 	if (xfersize > uio->uio_resid)
 		xfersize = uio->uio_resid;
-	transp_uio.uio_resid = transp_iov[0].iov_len;
+	IOVEC_INIT(&transp_iov[0], data, xfersize);
+	transp_uio.uio_resid = xfersize;
 	transp_uio.uio_offset = 0;
 	transp_uio.uio_segflg = UIO_SYSSPACE;
 	/*

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1125,9 +1125,7 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 		vm_page_unhold_pages(ma, cnt);
 		adv = len - short_uio.uio_resid;
 
-		uio_clone->uio_iov->iov_base =
-		    (char *)uio_clone->uio_iov->iov_base + adv;
-		uio_clone->uio_iov->iov_len -= adv;
+		IOVEC_ADVANCE(uio_clone->uio_iov, adv);
 		uio_clone->uio_resid -= adv;
 		uio_clone->uio_offset += adv;
 
@@ -1246,8 +1244,7 @@ vn_io_fault_uiomove(char *data, int xfersize, struct uio *uio)
 	KASSERT(td->td_ma_cnt >= pgadv, ("consumed pages %d %d", td->td_ma_cnt,
 	    pgadv));
 	td->td_ma_cnt -= pgadv;
-	uio->uio_iov->iov_base = (char *)uio->uio_iov->iov_base + adv;
-	uio->uio_iov->iov_len -= adv;
+	IOVEC_ADVANCE(uio->uio_iov, adv);
 	uio->uio_resid -= adv;
 	uio->uio_offset += adv;
 	return (error);
@@ -1284,8 +1281,7 @@ vn_io_fault_pgmove(vm_page_t ma[], vm_offset_t offset, int xfersize,
 	KASSERT(td->td_ma_cnt >= pgadv, ("consumed pages %d %d", td->td_ma_cnt,
 	    pgadv));
 	td->td_ma_cnt -= pgadv;
-	uio->uio_iov->iov_base = (char *)(iov_base + cnt);
-	uio->uio_iov->iov_len -= cnt;
+	IOVEC_ADVANCE(uio->uio_iov, cnt);
 	uio->uio_resid -= cnt;
 	uio->uio_offset += cnt;
 	return (0);

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -530,8 +530,7 @@ vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base, int len, off_t offset,
 
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = base;
-	aiov.iov_len = len;
+	IOVEC_INIT(&aiov, base, len);
 	auio.uio_resid = len;
 	auio.uio_offset = offset;
 	auio.uio_segflg = segflg;
@@ -1115,9 +1114,9 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 			break;
 		}
 		short_uio.uio_iov = &short_iovec[0];
-		short_iovec[0].iov_base = (void *)addr;
+		IOVEC_INIT(&short_iovec[0], (void *)addr, len);
 		short_uio.uio_iovcnt = 1;
-		short_uio.uio_resid = short_iovec[0].iov_len = len;
+		short_uio.uio_resid = len;
 		short_uio.uio_offset = uio_clone->uio_offset;
 		td->td_ma = ma;
 		td->td_ma_cnt = cnt;
@@ -1213,12 +1212,12 @@ vn_io_fault_uiomove(char *data, int xfersize, struct uio *uio)
 		return (uiomove(data, xfersize, uio));
 
 	KASSERT(uio->uio_iovcnt == 1, ("uio_iovcnt %d", uio->uio_iovcnt));
-	transp_iov[0].iov_base = data;
 	transp_uio.uio_iov = &transp_iov[0];
+	IOVEC_INIT(&transp_iov[0], data, xfersize);
 	transp_uio.uio_iovcnt = 1;
 	if (xfersize > uio->uio_resid)
 		xfersize = uio->uio_resid;
-	transp_uio.uio_resid = transp_iov[0].iov_len = xfersize;
+	transp_uio.uio_resid = transp_iov[0].iov_len;
 	transp_uio.uio_offset = 0;
 	transp_uio.uio_segflg = UIO_SYSSPACE;
 	/*
@@ -1932,8 +1931,7 @@ vn_extattr_get(struct vnode *vp, int ioflg, int attrnamespace,
 	struct iovec	iov;
 	int	error;
 
-	iov.iov_len = *buflen;
-	iov.iov_base = buf;
+	IOVEC_INIT(&iov, buf, *buflen);
 
 	auio.uio_iov = &iov;
 	auio.uio_iovcnt = 1;
@@ -1974,8 +1972,7 @@ vn_extattr_set(struct vnode *vp, int ioflg, int attrnamespace,
 	struct mount	*mp;
 	int	error;
 
-	iov.iov_len = buflen;
-	iov.iov_base = buf;
+	IOVEC_INIT(&iov, buf, buflen);
 
 	auio.uio_iov = &iov;
 	auio.uio_iovcnt = 1;

--- a/sys/mips/cavium/cryptocteon/cryptocteon.c
+++ b/sys/mips/cavium/cryptocteon/cryptocteon.c
@@ -446,8 +446,8 @@ cryptocteon_process(device_t dev, struct cryptop *crp, int hint)
 		iovlen = 0;
 
 		while (m != NULL) {
-			od->octo_iov[iovcnt].iov_base = mtod(m, void *);
-			od->octo_iov[iovcnt].iov_len = m->m_len;
+			IOVEC_INIT(&od->octo_iov[iovcnt], mtod(m, void *),
+			    m->m_len);
 
 			m = m->m_next;
 			iovlen += od->octo_iov[iovcnt++].iov_len;
@@ -455,15 +455,15 @@ cryptocteon_process(device_t dev, struct cryptop *crp, int hint)
 	} else if (crp->crp_flags & CRYPTO_F_IOV) {
 		iovlen = 0;
 		for (iovcnt = 0; iovcnt < uiop->uio_iovcnt; iovcnt++) {
-			od->octo_iov[iovcnt].iov_base = uiop->uio_iov[iovcnt].iov_base;
-			od->octo_iov[iovcnt].iov_len = uiop->uio_iov[iovcnt].iov_len;
+			IOVEC_INIT(&od->octo_iov[iovcnt],
+			    uiop->uio_iov[iovcnt].iov_base,
+			    uiop->uio_iov[iovcnt].iov_len);
 
 			iovlen += od->octo_iov[iovcnt].iov_len;
 		}
 	} else {
 		iovlen = crp->crp_ilen;
-		od->octo_iov[0].iov_base = crp->crp_buf;
-		od->octo_iov[0].iov_len = crp->crp_ilen;
+		IOVEC_INIT(&uiop->uio_iov[0], crp->crp_buf, crp->crp_ilen);
 		iovcnt = 1;
 	}
 

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -145,8 +145,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			sf_buf_free(sf);
 		else
 			mips_dcache_wbinv_range((vm_offset_t)cp, cnt);
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/netinet/sctp_syscalls.c
+++ b/sys/netinet/sctp_syscalls.c
@@ -242,8 +242,7 @@ sys_sctp_generic_sendmsg (td, uap)
 		ktrsockaddr(to);
 #endif
 
-	iov[0].iov_base = uap->msg;
-	iov[0].iov_len = uap->mlen;
+	IOVEC_INIT(&iov[0], uap->msg, uap->mlen);
 
 	so = (struct socket *)fp->f_data;
 	if (so->so_proto->pr_protocol != IPPROTO_SCTP) {

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -312,8 +312,7 @@ nsmb_dev_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int flag, struct thre
 			error = ENOTCONN;
 			goto out;
 	 	}
-		iov.iov_base = rwrq->ioc_base;
-		iov.iov_len = rwrq->ioc_cnt;
+		IOVEC_INIT(&iov, rwrq->ioc_base, rwrq->ioc_cnt);
 		auio.uio_iov = &iov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = rwrq->ioc_offset;

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -295,8 +295,7 @@ nbssn_recvhdr(struct nbpcb *nbp, int *lenp,
 	u_int32_t len;
 	int error;
 
-	aio.iov_base = (caddr_t)&len;
-	aio.iov_len = sizeof(len);
+	IOVEC_INIT_OBJ(&aio, &len);
 	auio.uio_iov = &aio;
 	auio.uio_iovcnt = 1;
 	auio.uio_segflg = UIO_SYSSPACE;

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -295,7 +295,7 @@ nbssn_recvhdr(struct nbpcb *nbp, int *lenp,
 	u_int32_t len;
 	int error;
 
-	IOVEC_INIT_OBJ(&aio, &len);
+	IOVEC_INIT_OBJ(&aio, len);
 	auio.uio_iov = &aio;
 	auio.uio_iovcnt = 1;
 	auio.uio_segflg = UIO_SYSSPACE;

--- a/sys/nfs/bootp_subr.c
+++ b/sys/nfs/bootp_subr.c
@@ -725,8 +725,7 @@ bootpc_call(struct bootpc_globalcontext *gctx, struct thread *td)
 				ifctx->sentmsg = 1;
 			}
 
-			aio.iov_base = (caddr_t) &ifctx->call;
-			aio.iov_len = sizeof(ifctx->call);
+			IOVEC_INIT_OBJ(&aio, &ifctx->call);
 
 			auio.uio_iov = &aio;
 			auio.uio_iovcnt = 1;
@@ -780,8 +779,7 @@ bootpc_call(struct bootpc_globalcontext *gctx, struct thread *td)
 		 */
 		atimo = timo + time_second;
 		while (time_second < atimo) {
-			aio.iov_base = (caddr_t) &gctx->reply;
-			aio.iov_len = sizeof(gctx->reply);
+			IOVEC_INIT_OBJ(&aio, &gctx->reply);
 
 			auio.uio_iov = &aio;
 			auio.uio_iovcnt = 1;

--- a/sys/nfs/bootp_subr.c
+++ b/sys/nfs/bootp_subr.c
@@ -725,7 +725,7 @@ bootpc_call(struct bootpc_globalcontext *gctx, struct thread *td)
 				ifctx->sentmsg = 1;
 			}
 
-			IOVEC_INIT_OBJ(&aio, &ifctx->call);
+			IOVEC_INIT_OBJ(&aio, ifctx->call);
 
 			auio.uio_iov = &aio;
 			auio.uio_iovcnt = 1;

--- a/sys/opencrypto/criov.c
+++ b/sys/opencrypto/criov.c
@@ -224,8 +224,7 @@ crypto_mbuftoiov(struct mbuf *mbuf, struct iovec **iovptr, int *cnt,
 			memcpy(iov, *iovptr, sizeof *iov * i);
 		}
 
-		iov[i].iov_base = m->m_data;
-		iov[i].iov_len = m->m_len;
+		IOVEC_INIT(&iov[i], m->m_data, m->m_len);
 
 		i++;
 		m = m->m_next;

--- a/sys/opencrypto/cryptodev.c
+++ b/sys/opencrypto/cryptodev.c
@@ -716,13 +716,12 @@ cryptodev_op(
 	cse->uio.uio_segflg = UIO_SYSSPACE;
 	cse->uio.uio_rw = UIO_WRITE;
 	cse->uio.uio_td = td;
-	cse->uio.uio_iov[0].iov_len = cop->len;
 	if (cse->thash) {
-		cse->uio.uio_iov[0].iov_len += cse->thash->hashsize;
 		cse->uio.uio_resid += cse->thash->hashsize;
 	}
-	cse->uio.uio_iov[0].iov_base = malloc(cse->uio.uio_iov[0].iov_len,
-	    M_XDATA, M_WAITOK);
+	IOVEC_INIT(&cse->uio.uio_iov[0],
+	    malloc(cse->uio.uio_resid, M_XDATA, M_WAITOK),
+	    cse->uio.uio_resid);
 
 	crp = crypto_getreq((cse->txform != NULL) + (cse->thash != NULL));
 	if (crp == NULL) {
@@ -902,10 +901,8 @@ cryptodev_aead(
 	uio->uio_segflg = UIO_SYSSPACE;
 	uio->uio_rw = UIO_WRITE;
 	uio->uio_td = td;
-	uio->uio_iov[0].iov_len = uio->uio_resid;
-
-	uio->uio_iov[0].iov_base = malloc(uio->uio_iov[0].iov_len,
-	    M_XDATA, M_WAITOK);
+	IOVEC_INIT(&uio->uio_iov[0],
+	    malloc(uio->uio_iov[0].iov_len, M_XDATA, M_WAITOK), uio->uio_resid);
 
 	crp = crypto_getreq(2);
 	if (crp == NULL) {

--- a/sys/opencrypto/cryptosoft.c
+++ b/sys/opencrypto/cryptosoft.c
@@ -156,8 +156,7 @@ swcr_encdec(struct cryptodesc *crd, struct swcr_data *sw, caddr_t buf,
 	} else if ((flags & CRYPTO_F_IOV) != 0)
 		uio = (struct uio *)buf;
 	else {
-		iov[0].iov_base = buf;
-		iov[0].iov_len = crd->crd_skip + crd->crd_len;
+		IOVEC_INIT(&iov[0], buf, crd->crd_skip + crd->crd_len);
 		uio->uio_iov = iov;
 		uio->uio_iovcnt = 1;
 	}

--- a/sys/powerpc/powerpc/uio_machdep.c
+++ b/sys/powerpc/powerpc/uio_machdep.c
@@ -117,8 +117,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 				break;
 		}
 		sf_buf_free(sf);
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -115,8 +115,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			    &vaddr, 1, TRUE);
 			mapped = FALSE;
 		}
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/sparc64/sparc64/uio_machdep.c
+++ b/sys/sparc64/sparc64/uio_machdep.c
@@ -125,8 +125,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		}
 		if (sf != NULL)
 			sf_buf_free(sf);
-		iov->iov_base = (char *)iov->iov_base + cnt;
-		iov->iov_len -= cnt;
+		IOVEC_ADVANCE(iov, cnt);
 		uio->uio_resid -= cnt;
 		uio->uio_offset += cnt;
 		offset += cnt;

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -55,4 +55,13 @@ do {									\
 #define	IOVEC_INIT_OBJ(iovp, objp)					\
 	IOVEC_INIT(iovp, objp, sizeof(*(objp)))
 
+#define	IOVEC_ADVANCE(iovp, amt)					\
+do {									\
+	size_t amount = (amt);						\
+	KASSERT(amount <= (iovp)->iov_len, ("%s: amount %zu > iov_len	\
+	    %zu", __func__, amount, (iovp)->iov_len));			\
+	(iovp)->iov_base = (char *)((iovp)->iov_base) + (amt);		\
+	(iovp)->iov_len -= (amt);					\
+} while(0)
+
 #endif /* !_SYS__IOVEC_H_ */

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -45,4 +45,14 @@ struct iovec {
 	size_t	 iov_len;	/* Length. */
 };
 
+#define	IOVEC_INIT(iovp, base, len)					\
+do {									\
+	(iovp)->iov_base = (base);					\
+	(iovp)->iov_len = (len);					\
+} while(0)
+#define	IOVEC_INIT_STR(iovp, str)					\
+	IOVEC_INIT(iovp, str, strlen(str) + 1)
+#define	IOVEC_INIT_OBJ(iovp, objp)					\
+	IOVEC_INIT(iovp, objp, sizeof(*(objp)))
+
 #endif /* !_SYS__IOVEC_H_ */

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -45,18 +45,16 @@ struct iovec {
 	size_t	 iov_len;	/* Length. */
 };
 
-#define	IOVEC_INIT(iovp, base, len)					\
-do {									\
+#define	IOVEC_INIT(iovp, base, len)	do {				\
 	(iovp)->iov_base = (base);					\
 	(iovp)->iov_len = (len);					\
 } while(0)
 #define	IOVEC_INIT_STR(iovp, str)					\
 	IOVEC_INIT(iovp, str, strlen(str) + 1)
-#define	IOVEC_INIT_OBJ(iovp, objp)					\
-	IOVEC_INIT(iovp, objp, sizeof(*(objp)))
+#define	IOVEC_INIT_OBJ(iovp, obj)					\
+	IOVEC_INIT(iovp, &(obj), sizeof(obj))
 
-#define	IOVEC_ADVANCE(iovp, amt)					\
-do {									\
+#define	IOVEC_ADVANCE(iovp, amt)	do {				\
 	size_t amount = (amt);						\
 	KASSERT(amount <= (iovp)->iov_len, ("%s: amount %zu > iov_len	\
 	    %zu", __func__, amount, (iovp)->iov_len));			\

--- a/sys/ufs/ffs/ffs_snapshot.c
+++ b/sys/ufs/ffs/ffs_snapshot.c
@@ -756,8 +756,7 @@ out1:
 	 */
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = (void *)snapblklist;
-	aiov.iov_len = snaplistsize * sizeof(daddr_t);
+	IOVEC_INIT(&aiov, snapblklist, snaplistsize * sizeof(daddr_t));
 	auio.uio_resid = aiov.iov_len;
 	auio.uio_offset = ip->i_size;
 	auio.uio_segflg = UIO_SYSSPACE;
@@ -2045,8 +2044,7 @@ ffs_snapshot_mount(mp)
 	 */
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = (void *)&snaplistsize;
-	aiov.iov_len = sizeof(snaplistsize);
+	IOVEC_INIT(&aiov, &snaplistsize, sizeof(snaplistsize));
 	auio.uio_resid = aiov.iov_len;
 	auio.uio_offset =
 	    lblktosize(fs, howmany(fs->fs_size, fs->fs_frag));
@@ -2062,8 +2060,7 @@ ffs_snapshot_mount(mp)
 	snapblklist = malloc(snaplistsize * sizeof(daddr_t),
 	    M_UFSMNT, M_WAITOK);
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = snapblklist;
-	aiov.iov_len = snaplistsize * sizeof (daddr_t);
+	IOVEC_INIT(&aiov, snapblklist, snaplistsize * sizeof (daddr_t));
 	auio.uio_resid = aiov.iov_len;
 	auio.uio_offset -= sizeof(snaplistsize);
 	if ((error = VOP_READ(vp, &auio, IO_UNIT, td->td_ucred)) != 0) {

--- a/sys/ufs/ffs/ffs_suspend.c
+++ b/sys/ufs/ffs/ffs_suspend.c
@@ -157,9 +157,7 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 				if (error != 0)
 					goto out;
 			}
-			uio->uio_iov[i].iov_base =
-			    (char *)uio->uio_iov[i].iov_base + len;
-			uio->uio_iov[i].iov_len -= len;
+			IOVEC_ADVANCE(&uio->uio_iov[i], len);
 			uio->uio_resid -= len;
 			uio->uio_offset += len;
 		}

--- a/sys/ufs/ffs/ffs_vnops.c
+++ b/sys/ufs/ffs/ffs_vnops.c
@@ -1151,8 +1151,7 @@ ffs_rdextattr(u_char **p, struct vnode *vp, struct thread *td, int extra)
 
 	eae = malloc(easize + extra, M_TEMP, M_WAITOK);
 
-	liovec.iov_base = eae;
-	liovec.iov_len = easize;
+	IOVEC_INIT(&liovec, eae, easize);
 	luio.uio_iov = &liovec;
 	luio.uio_iovcnt = 1;
 	luio.uio_offset = 0;
@@ -1252,8 +1251,7 @@ ffs_close_ea(struct vnode *vp, int commit, struct ucred *cred, struct thread *td
 		ASSERT_VOP_ELOCKED(vp, "ffs_close_ea commit");
 		if (cred == NOCRED)
 			cred =  vp->v_mount->mnt_cred;
-		liovec.iov_base = ip->i_ea_area;
-		liovec.iov_len = ip->i_ea_len;
+		IOVEC_INIT(&liovec, ip->i_ea_area, ip->i_ea_len);
 		luio.uio_iov = &liovec;
 		luio.uio_iovcnt = 1;
 		luio.uio_offset = 0;

--- a/sys/ufs/ufs/ufs_extattr.c
+++ b/sys/ufs/ufs/ufs_extattr.c
@@ -619,7 +619,7 @@ ufs_extattr_enable(struct ufsmount *ump, int attrnamespace,
 
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	IOVEC_INIT_OBJ(&aiov, &attribute->uele_fileheader);
+	IOVEC_INIT_OBJ(&aiov, attribute->uele_fileheader);
 	auio.uio_resid = sizeof(struct ufs_extattr_fileheader);
 	auio.uio_offset = (off_t) 0;
 	auio.uio_segflg = UIO_SYSSPACE;

--- a/sys/ufs/ufs/ufs_extattr.c
+++ b/sys/ufs/ufs/ufs_extattr.c
@@ -392,8 +392,7 @@ ufs_extattr_iterate_directory(struct ufsmount *ump, struct vnode *dvp,
 
 	while (!eofflag) {
 		auio.uio_resid = DIRBLKSIZ;
-		aiov.iov_base = dirbuf;
-		aiov.iov_len = DIRBLKSIZ;
+		IOVEC_INIT(&aiov, dirbuf, DIRBLKSIZ);
 		error = ufs_readdir(&vargs);
 		if (error) {
 			printf("ufs_extattr_iterate_directory: ufs_readdir "
@@ -620,8 +619,7 @@ ufs_extattr_enable(struct ufsmount *ump, int attrnamespace,
 
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = (caddr_t) &attribute->uele_fileheader;
-	aiov.iov_len = sizeof(struct ufs_extattr_fileheader);
+	IOVEC_INIT_OBJ(&aiov, &attribute->uele_fileheader);
 	auio.uio_resid = sizeof(struct ufs_extattr_fileheader);
 	auio.uio_offset = (off_t) 0;
 	auio.uio_segflg = UIO_SYSSPACE;
@@ -884,8 +882,7 @@ ufs_extattr_get(struct vnode *vp, int attrnamespace, const char *name,
 	 * how much.
 	 */
 	bzero(&ueh, sizeof(struct ufs_extattr_header));
-	local_aiov.iov_base = (caddr_t) &ueh;
-	local_aiov.iov_len = sizeof(struct ufs_extattr_header);
+	IOVEC_INIT_OBJ(&local_aiov, &ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_READ;
@@ -1093,8 +1090,7 @@ ufs_extattr_set(struct vnode *vp, int attrnamespace, const char *name,
 	ueh.ueh_len = uio->uio_resid;
 	ueh.ueh_flags = UFS_EXTATTR_ATTR_FLAG_INUSE;
 	ueh.ueh_i_gen = ip->i_gen;
-	local_aiov.iov_base = (caddr_t) &ueh;
-	local_aiov.iov_len = sizeof(struct ufs_extattr_header);
+	IOVEC_INIT_OBJ(&local_aiov, &ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_WRITE;
@@ -1191,8 +1187,7 @@ ufs_extattr_rm(struct vnode *vp, int attrnamespace, const char *name,
 	 */
 	bzero(&ueh, sizeof(struct ufs_extattr_header));
 
-	local_aiov.iov_base = (caddr_t) &ueh;
-	local_aiov.iov_len = sizeof(struct ufs_extattr_header);
+	IOVEC_INIT_OBJ(&local_aiov, &ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_READ;
@@ -1237,8 +1232,7 @@ ufs_extattr_rm(struct vnode *vp, int attrnamespace, const char *name,
 	ueh.ueh_flags = 0;
 	ueh.ueh_len = 0;
 
-	local_aiov.iov_base = (caddr_t) &ueh;
-	local_aiov.iov_len = sizeof(struct ufs_extattr_header);
+	IOVEC_INIT_OBJ(&local_aiov, &ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_WRITE;

--- a/sys/ufs/ufs/ufs_quota.c
+++ b/sys/ufs/ufs/ufs_quota.c
@@ -1219,7 +1219,7 @@ dqopen(struct vnode *vp, struct ufsmount *ump, int type)
 	ASSERT_VOP_LOCKED(vp, "dqopen");
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	IOVEC_INIT_OBJ(&aiov, &dqh);
+	IOVEC_INIT_OBJ(&aiov, dqh);
 	auio.uio_resid = sizeof(dqh);
 	auio.uio_offset = 0;
 	auio.uio_segflg = UIO_SYSSPACE;

--- a/sys/ufs/ufs/ufs_quota.c
+++ b/sys/ufs/ufs/ufs_quota.c
@@ -1219,8 +1219,7 @@ dqopen(struct vnode *vp, struct ufsmount *ump, int type)
 	ASSERT_VOP_LOCKED(vp, "dqopen");
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = &dqh;
-	aiov.iov_len = sizeof(dqh);
+	IOVEC_INIT_OBJ(&aiov, &dqh);
 	auio.uio_resid = sizeof(dqh);
 	auio.uio_offset = 0;
 	auio.uio_segflg = UIO_SYSSPACE;
@@ -1405,8 +1404,7 @@ hfound:		DQI_LOCK(dq);
 	}
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = buf;
-	aiov.iov_len = recsize;
+	IOVEC_INIT(&aiov, buf, recsize);
 	auio.uio_resid = recsize;
 	auio.uio_offset = base + id * recsize;
 	auio.uio_segflg = UIO_SYSSPACE;
@@ -1599,8 +1597,7 @@ dqsync(struct vnode *vp, struct dquot *dq)
 
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	aiov.iov_base = buf;
-	aiov.iov_len = recsize;
+	IOVEC_INIT(&aiov, buf, recsize);
 	auio.uio_resid = recsize;
 	auio.uio_offset = base + dq->dq_id * recsize;
 	auio.uio_segflg = UIO_SYSSPACE;

--- a/sys/vm/vnode_pager.c
+++ b/sys/vm/vnode_pager.c
@@ -636,8 +636,7 @@ vnode_pager_input_old(vm_object_t object, vm_page_t m)
 		 */
 		sf = sf_buf_alloc(m, 0);
 
-		aiov.iov_base = (caddr_t)sf_buf_kva(sf);
-		aiov.iov_len = size;
+		IOVEC_INIT(&aiov, (void *)sf_buf_kva(sf), size);
 		auio.uio_iov = &aiov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = IDX_TO_OFF(m->pindex);


### PR DESCRIPTION
Virtually all manipulations of struct iovec are setting a new set of values (which should have bounds if `iov_base` is a capability) or increments (which requires a cast `iov_base` to `char *` or `char * __capability` if it is a capability).  Replacing most of these with macros allows bounds to be set and cast differences to be hidden.