### PR TITLE
Make signal handlers work with both captable and non-captable binaries

### DIFF
--- a/crypto/heimdal/lib/roken/signal.c
+++ b/crypto/heimdal/lib/roken/signal.c
@@ -48,13 +48,21 @@
  */
 
 ROKEN_LIB_FUNCTION SigAction ROKEN_LIB_CALL
+#ifdef __CHERI_PURE_CAPABILITY__
+cheriabi_signal(int iSig, SigAction pAction, void* cgp)
+#else
 signal(int iSig, SigAction pAction)
+#endif
 {
     struct sigaction saNew, saOld;
 
     saNew.sa_handler = pAction;
     sigemptyset(&saNew.sa_mask);
     saNew.sa_flags = 0;
+#ifdef __CHERI_PURE_CAPABILITY__
+    saNew.sa_cgp = cgp;
+#endif
+
 
     if (iSig == SIGALRM)
 	{

--- a/lib/libc/mips/sys/Symbol.map
+++ b/lib/libc/mips/sys/Symbol.map
@@ -27,6 +27,8 @@ FBSDprivate_1.0 {
 	_sbrk;
 	_end;
 
+	cheriabi_*; /* export the signal/sigaction wrappers */
+
 	/*
 	 * XXX-BD: Export .size.<var> symbols for <var>'s that are undefined
 	 * so rtld can update them.  This is a hack and should be replaced

--- a/lib/libc/sys/sigaction.c
+++ b/lib/libc/sys/sigaction.c
@@ -68,7 +68,10 @@ cheriabi_sigaction(int sig, const struct sigaction *act,
 	 */
 	if (cheri_gettag(act)) {
 		struct sigaction copy;
-		printf("%s: setting cgp for sigaction(%d) to %#p\n", __func__, sig, cgp);
+#if 0
+		printf("%s: setting cgp for sigaction(%d) to %#p\n", __func__,
+		    sig, cgp);
+#endif
 		memcpy(&copy, act, sizeof(copy));
 		copy.sa_cgp = cgp;
 		return (__libc_sigaction(sig, &copy, oact));

--- a/lib/libc/sys/sigaction.c
+++ b/lib/libc/sys/sigaction.c
@@ -67,11 +67,11 @@ cheriabi_sigaction(int sig, const struct sigaction *act,
 	 * so we can safely dereference act if it is tagged.
 	 */
 	if (cheri_gettag(act)) {
-		// printf("%s: setting cgp for sigaction(%d) to %#p\n", __func__, sig, cgp);
 		struct sigaction copy;
+		printf("%s: setting cgp for sigaction(%d) to %#p\n", __func__, sig, cgp);
 		memcpy(&copy, act, sizeof(copy));
 		copy.sa_cgp = cgp;
-		act = &copy;
+		return (__libc_sigaction(sig, &copy, oact));
 	}
 
 	return (__libc_sigaction(sig, act, oact));

--- a/lib/libc/sys/sigaction.c
+++ b/lib/libc/sys/sigaction.c
@@ -34,11 +34,49 @@
 __FBSDID("$FreeBSD$");
 
 #include <sys/types.h>
+/* XXXAR: Hack to hide the static inline declaration for CHERIABI */
+#define _BUILDING_SIGACTION
 #include <signal.h>
+#include <string.h>
+#include <stdio.h>
 #include "libc_private.h"
 
 __weak_reference(__sys_sigaction, __sigaction);
 __weak_reference(sigaction, __libc_sigaction);
+
+#ifdef __CHERI_PURE_CAPABILITY__
+#include <cheri/cheric.h>
+/*
+ * In the CHERIABI case the sigaction declaration is inline so we need the
+ * prototype here
+ */
+int	sigaction(int, const struct sigaction * __restrict,
+	    struct sigaction * __restrict);
+
+/*
+ * In the CHERI pure capability ABI we also need to pass the CALLERS cgp to
+ * the kernel. We do this by changing sigaction into an inline function that
+ * passes cgp in addition to the normal parameters.
+ */
+int
+cheriabi_sigaction(int sig, const struct sigaction *act,
+    struct sigaction *oact, void* cgp)
+{
+	/*
+	 * All the SIG_IGN, SIG_DFL, etc constants won't have the tag bit set
+	 * so we can safely dereference act if it is tagged.
+	 */
+	if (cheri_gettag(act)) {
+		// printf("%s: setting cgp for sigaction(%d) to %#p\n", __func__, sig, cgp);
+		struct sigaction copy;
+		memcpy(&copy, act, sizeof(copy));
+		copy.sa_cgp = cgp;
+		act = &copy;
+	}
+
+	return (__libc_sigaction(sig, act, oact));
+}
+#endif
 
 #pragma weak sigaction
 int

--- a/libexec/rtld-cheri-elf/mips/rtld_machdep.h
+++ b/libexec/rtld-cheri-elf/mips/rtld_machdep.h
@@ -46,8 +46,12 @@ Elf_Addr reloc_jmpslot(Elf_Addr *where, Elf_Addr target,
 #define make_function_pointer(def, defobj)				\
 	((defobj)->relocbase + (def)->st_value)
 
-#define call_initfini_pointer(obj, target)				\
-	(((InitFunc)(cheri_setoffset(cheri_getpcc(), (target))))())
+#define call_initfini_pointer(obj, target)	do {				\
+	InitFunc func = (InitFunc)(cheri_setoffset(cheri_getpcc(), (target)));	\
+	dbg("Calling init func %#p with $ddc=%#p", func, cheri_getdefault());	\
+	dbg("NULL=%#p", NULL);							\
+	func();									\
+} while(false)
 
 #define call_init_pointer(obj, target)					\
 	(((InitArrFunc)(cheri_setoffset(cheri_getpcc(), (target))))	\

--- a/sys/compat/cheriabi/cheriabi.h
+++ b/sys/compat/cheriabi/cheriabi.h
@@ -158,6 +158,8 @@ struct sigaction_c {
 	void * __capability	sa_u;
 	int		sa_flags;
 	sigset_t	sa_mask;
+	/* XXXAR: can we move this up for better layout or will it break? */
+	void * __capability	sa_cgp;
 };
 
 struct thr_param_c {

--- a/sys/compat/cheriabi/cheriabi.h
+++ b/sys/compat/cheriabi/cheriabi.h
@@ -154,11 +154,18 @@ struct jail_c {
 	struct in6_addr * __capability	ip6;
 };
 
+/* Used by old binaries prior to $cgp in signal handler */
+struct sigaction_c_compat {
+	void * __capability	sa_u;
+	int		sa_flags;
+	sigset_t	sa_mask;
+};
+
 struct sigaction_c {
 	void * __capability	sa_u;
 	int		sa_flags;
 	sigset_t	sa_mask;
-	/* XXXAR: can we move this up for better layout or will it break? */
+	/* XXXAR: move this up for better layout once we can break userspace? */
 	void * __capability	sa_cgp;
 };
 

--- a/sys/compat/cheriabi/cheriabi_fill_uap.h
+++ b/sys/compat/cheriabi/cheriabi_fill_uap.h
@@ -5691,42 +5691,8 @@ CHERIABI_SYS_cheriabi___mac_execve_fill_uap(struct thread *td,
 	return (0);
 }
 
-static inline int
-CHERIABI_SYS_cheriabi_sigaction_fill_uap(struct thread *td,
-    struct cheriabi_sigaction_args *uap)
-{
-	void * __capability tmpcap;
-
-	/* [0] int sig */
-	cheriabi_fetch_syscall_arg(td, &tmpcap, 0, CHERIABI_SYS_cheriabi_sigaction_PTRMASK);
-	uap->sig = cheri_getoffset(tmpcap);
-
-	/* [1] _In_opt_ struct sigaction_c * act */
-	{
-		int error;
-		register_t reqperms = (CHERI_PERM_LOAD|CHERI_PERM_LOAD_CAP);
-
-		cheriabi_fetch_syscall_arg(td, &tmpcap, 1, CHERIABI_SYS_cheriabi_sigaction_PTRMASK);
-		error = cheriabi_cap_to_ptr(__DECONST(caddr_t *, &uap->act),
-		    tmpcap, sizeof(*uap->act), reqperms, 1);
-		if (error != 0)
-			return (error);
-	}
-
-	/* [2] _Out_opt_ struct sigaction_c * oact */
-	{
-		int error;
-		register_t reqperms = (CHERI_PERM_STORE|CHERI_PERM_STORE_CAP);
-
-		cheriabi_fetch_syscall_arg(td, &tmpcap, 2, CHERIABI_SYS_cheriabi_sigaction_PTRMASK);
-		error = cheriabi_cap_to_ptr(__DECONST(caddr_t *, &uap->oact),
-		    tmpcap, sizeof(*uap->oact), reqperms, 1);
-		if (error != 0)
-			return (error);
-	}
-
-	return (0);
-}
+static inline int	CHERIABI_SYS_cheriabi_sigaction_fill_uap(struct thread *td,
+    struct cheriabi_sigaction_args *uap);
 
 static inline int
 CHERIABI_SYS_cheriabi_sigreturn_fill_uap(struct thread *td,

--- a/sys/compat/cheriabi/cheriabi_proto.h
+++ b/sys/compat/cheriabi/cheriabi_proto.h
@@ -280,11 +280,6 @@ struct cheriabi___mac_execve_args {
 	char envv_l_[PADL_(void *__capability *)]; void *__capability * envv; char envv_r_[PADR_(void *__capability *)];
 	char mac_p_l_[PADL_(struct mac_c *)]; struct mac_c * mac_p; char mac_p_r_[PADR_(struct mac_c *)];
 };
-struct cheriabi_sigaction_args {
-	char sig_l_[PADL_(int)]; int sig; char sig_r_[PADR_(int)];
-	char act_l_[PADL_(struct sigaction_c *)]; struct sigaction_c * act; char act_r_[PADR_(struct sigaction_c *)];
-	char oact_l_[PADL_(struct sigaction_c *)]; struct sigaction_c * oact; char oact_r_[PADR_(struct sigaction_c *)];
-};
 struct cheriabi_sigreturn_args {
 	char sigcntxp_l_[PADL_(const ucontext_c_t *)]; const ucontext_c_t * sigcntxp; char sigcntxp_r_[PADR_(const ucontext_c_t *)];
 };

--- a/sys/compat/cheriabi/cheriabi_signal.h
+++ b/sys/compat/cheriabi/cheriabi_signal.h
@@ -100,4 +100,14 @@ void siginfo_to_siginfo_c(const siginfo_t *src, struct siginfo_c *dst);
 void * __capability cheriabi_extract_sival(union sigval *sival);
 void cheriabi_free_sival(union sigval *sival);
 
+/* TODO: is this the right location for this struct? */
+struct cheriabi_sigaction_args {
+	int sig;
+	struct sigaction_c *act;
+	struct sigaction_c *oact;
+	size_t actsz;
+	size_t oactsz;
+};
+
+
 #endif /* _COMPAT_CHERIABI_CHERIABI_SIGNAL_H_ */

--- a/sys/compat/cheriabi/cheriabi_sysargmap.h
+++ b/sys/compat/cheriabi/cheriabi_sysargmap.h
@@ -223,7 +223,6 @@
 #define	CHERIABI_SYS_extattr_get_link_PTRMASK	(0x0 | 0x1 | 0x4 | 0x8)
 #define	CHERIABI_SYS_extattr_delete_link_PTRMASK	(0x0 | 0x1 | 0x4)
 #define	CHERIABI_SYS_cheriabi___mac_execve_PTRMASK	(0x0 | 0x1 | 0x2 | 0x4 | 0x8)
-#define	CHERIABI_SYS_cheriabi_sigaction_PTRMASK	(0x0 | 0x2 | 0x4)
 #define	CHERIABI_SYS_cheriabi_sigreturn_PTRMASK	(0x0 | 0x1)
 #define	CHERIABI_SYS_cheriabi_getcontext_PTRMASK	(0x0 | 0x1)
 #define	CHERIABI_SYS_cheriabi_setcontext_PTRMASK	(0x0 | 0x1)

--- a/sys/compat/cheriabi/cheriabi_sysstubs.h
+++ b/sys/compat/cheriabi/cheriabi_sysstubs.h
@@ -18,8 +18,8 @@
 struct __wrusage;
 struct acl;
 struct aiocb;
-struct auditinfo;
 struct auditinfo_addr;
+struct auditinfo;
 struct ffclock_estimate;
 struct fhandle;
 struct iovec;

--- a/sys/compat/cheriabi/syscalls.master
+++ b/sys/compat/cheriabi/syscalls.master
@@ -855,7 +855,7 @@
 				    _In_ void * __capability *envv, \
 				    _In_ struct mac_c *mac_p); }
 ; NOPARSE to allow compatibility with old CheriABI binaries that don't have sa_cgp
-416	AUE_SIGACTION	STD|NOPARSE	{ int cheriabi_sigaction(int sig, \
+416	AUE_SIGACTION	NOARGS|NOPARSE	{ int cheriabi_sigaction(int sig, \
 				    _In_opt_ struct sigaction_c *act, \
 				    _Out_opt_ struct sigaction_c *oact); }
 417	AUE_SIGRETURN	STD	{ int cheriabi_sigreturn( \

--- a/sys/compat/cheriabi/syscalls.master
+++ b/sys/compat/cheriabi/syscalls.master
@@ -854,7 +854,8 @@
 				    _In_ void * __capability *argv, \
 				    _In_ void * __capability *envv, \
 				    _In_ struct mac_c *mac_p); }
-416	AUE_SIGACTION	STD	{ int cheriabi_sigaction(int sig, \
+; NOPARSE to allow compatibility with old CheriABI binaries that don't have sa_cgp
+416	AUE_SIGACTION	STD|NOPARSE	{ int cheriabi_sigaction(int sig, \
 				    _In_opt_ struct sigaction_c *act, \
 				    _Out_opt_ struct sigaction_c *oact); }
 417	AUE_SIGRETURN	STD	{ int cheriabi_sigreturn( \

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -783,7 +783,7 @@ kern_sigaction_cap(struct thread *td, int sig, const struct sigaction *act,
 		if (cap != NULL) {
 			ps->ps_sigcap[_SIG_IDX(sig)] = newhandler;
 			ps->ps_sigglobals[_SIG_IDX(sig)] = newglobals;
-			printf("Setting cheri signal handler:\n");
+			printf("Setting cheri signal handler for %d:\n", sig);
 			printf("newhandler -- "); CHERI_PRINT_PTR(newhandler);
 			printf("newglobals -- "); CHERI_PRINT_PTR(newglobals);
 		}

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -466,8 +466,6 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	int sig;
 	int oonstack;
 
-	printf("%s\n", __func__);
-
 	td = curthread;
 	p = td->td_proc;
 	PROC_LOCK_ASSERT(p, MA_OWNED);
@@ -484,6 +482,9 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	 */
 	regs = td->td_frame;
 	oonstack = sigonstack((vaddr_t)regs->csp);
+
+	printf("%s(%d)\n", __func__, sig);
+
 
 	/*
 	 * CHERI affects signal delivery in the following ways:
@@ -710,7 +711,7 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	printf("$c12: "); CHERI_PRINT_PTR(regs->c12);
 	printf("$c17: "); CHERI_PRINT_PTR(regs->c17);
 	printf("$pcc: "); CHERI_PRINT_PTR(regs->pcc);
-	printf("$pc: %016lx", regs->pc);
+	printf("$pc: %016lx\n", regs->pc);
 }
 
 static void

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -466,6 +466,8 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	int sig;
 	int oonstack;
 
+	printf("%s\n", __func__);
+
 	td = curthread;
 	p = td->td_proc;
 	PROC_LOCK_ASSERT(p, MA_OWNED);
@@ -708,7 +710,7 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	printf("$c12: "); CHERI_PRINT_PTR(regs->c12);
 	printf("$c17: "); CHERI_PRINT_PTR(regs->c17);
 	printf("$pcc: "); CHERI_PRINT_PTR(regs->pcc);
-	printf("$pc: %016lx\n", regs->pc);
+	printf("$pc: %016lx", regs->pc);
 }
 
 static void

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -689,6 +689,7 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	regs->pc = (register_t)(intptr_t)catcher;
 	regs->csp = (__cheri_tocap void * __capability)(void*)sfp;
 	regs->c12 = psp->ps_sigcap[_SIG_IDX(sig)];
+	regs->idc = psp->ps_sigglobals[_SIG_IDX(sig)];
 	regs->c17 = td->td_pcb->pcb_cherisignal.csig_sigcode;
 	regs->ddc = csigp->csig_ddc;
 	/*
@@ -697,9 +698,17 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	 *
 	 * TODO: remove csigp->csig_idc
 	 */
-	if (cheri_is_sandboxed)
+	if (cheri_is_sandboxed && regs->idc == NULL)
 		regs->idc = csigp->csig_idc;
 	regs->pcc = csigp->csig_pcc;
+	printf("Delivering signal %d\n", sig);
+	printf("$idc: "); CHERI_PRINT_PTR(regs->idc);
+	printf("$ddc: "); CHERI_PRINT_PTR(regs->ddc);
+	printf("$csp: "); CHERI_PRINT_PTR(regs->csp);
+	printf("$c12: "); CHERI_PRINT_PTR(regs->c12);
+	printf("$c17: "); CHERI_PRINT_PTR(regs->c17);
+	printf("$pcc: "); CHERI_PRINT_PTR(regs->pcc);
+	printf("$pc: %016lx\n", regs->pc);
 }
 
 static void

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -491,7 +491,7 @@ __sighandler_t *cheriabi_signal(int, __sighandler_t *, void*);
  * XXXAR: We need to pass the caller's $cgp to the kernel.
  * See comment on sigaction() for more details
  */
-static inline __always_inline __sighandler_t *
+static __inline __always_inline __sighandler_t *
 signal(int sig, __sighandler_t *handler)
 {
 	return cheriabi_signal(sig, handler,

--- a/sys/sys/signalvar.h
+++ b/sys/sys/signalvar.h
@@ -74,6 +74,7 @@ struct sigacts {
 	struct mtx ps_mtx;
 #ifdef COMPAT_CHERIABI
 	void * __capability ps_sigcap[_SIG_MAXSIG];	/* CheriABI handlers */
+	void * __capability ps_sigglobals[_SIG_MAXSIG];	/* CheriABI $cgp values */
 #endif
 };
 

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -260,7 +260,7 @@ int	kern_sigaction(struct thread *td, int sig, const struct sigaction *act,
 	    struct sigaction *oact, int flags);
 int	kern_sigaction_cap(struct thread *td, int sig,
 	    const struct sigaction *act, struct sigaction *oact, int flags,
-	    void * __CAPABILITY *cap);
+	    void * __CAPABILITY *cap, void * __CAPABILITY *capglobals);
 int	kern_sigaltstack(struct thread *td, stack_t *ss, stack_t *oss);
 int	kern_sigprocmask(struct thread *td, int how,
 	    sigset_t *set, sigset_t *oset, int flags);


### PR DESCRIPTION
For dynamically linked cap-table binaries we need a different $cgp for every library.

Unfortunately we can't just use the $cgp in sigaction since that will be libc.so instead of the main binary so I use an inline function that passes the callers $cgp instead.
With this change I can cap-table binaries that use signals correctly when using a non-captable kernel.
It also runs non-captable binaries build with the changes to sigaction and old ones.

I am not entirely sure if the changes I made to the cheriabi argument parsing and syscalls.master are correct, but it seems to work. I have verified that these changes work with all three kinds of binaries so we can avoid a flag day.

I'll remove the debug output and rebase before committing.