### PR TITLE
Turn off per-thread tracing when the traced process crashes

### DIFF
--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -134,7 +134,6 @@ extern u_int qemu_trace_perthread;
 static void
 stop_cheri_perthread_trace(struct thread *td)
 {
-	printf("Checking whether tracing should be disabled after exception...");
 	if (qemu_trace_perthread && (td->td_md.md_flags & MDTD_QTRACE)) {
 		/*
 		 * If we are currently tracing per-thread and the traced process
@@ -143,9 +142,6 @@ stop_cheri_perthread_trace(struct thread *td)
 		 */
 		CHERI_STOP_TRACE;
 		td->td_md.md_flags &= ~MDTD_QTRACE;
-		printf(" Turned off\n");
-	} else {
-		printf(" No change\n");
 	}
 }
 #endif

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -142,6 +142,7 @@ stop_cheri_perthread_trace(struct thread *td)
 		 * turn on and off tracing in swtch.S will no be reached.
 		 */
 		CHERI_STOP_TRACE;
+		td->td_md.md_flags &= ~MDTD_QTRACE;
 		printf(" Turned off\n");
 	} else {
 		printf(" No change\n");

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -127,6 +127,28 @@ SYSCTL_INT(_machdep, OID_AUTO, log_cheri_exceptions, CTLFLAG_RW,
 int log_cheri_registers = 1;
 SYSCTL_INT(_machdep, OID_AUTO, log_cheri_registers, CTLFLAG_RW,
     &log_cheri_registers, 1, "Print CHERI registers for non-CHERI exceptions");
+
+#ifdef CPU_QEMU_MALTA
+extern u_int qemu_trace_perthread;
+
+static void
+stop_cheri_perthread_trace(struct thread *td)
+{
+	printf("Checking whether tracing should be disabled after exception...");
+	if (qemu_trace_perthread && (td->td_md.md_flags & MDTD_QTRACE)) {
+		/*
+		 * If we are currently tracing per-thread and the traced process
+		 * crashed we have to stop tracing here because the logic to
+		 * turn on and off tracing in swtch.S will no be reached.
+		 */
+		CHERI_STOP_TRACE;
+		printf(" Turned off\n");
+	} else {
+		printf(" No change\n");
+	}
+}
+#endif
+
 #endif
 
 #define	lbu_macro(data, addr)						\
@@ -376,6 +398,7 @@ char *access_name[] = {
 #endif
 
 };
+
 
 #ifdef	CPU_CNMIPS
 #include <machine/octeon_cop2.h>
@@ -1307,6 +1330,24 @@ err:
 	ksi.ksi_code = ucode;
 	ksi.ksi_addr = (void *)addr;
 	ksi.ksi_trapno = type;
+
+#if defined(CPU_CHERI) && defined(CPU_QEMU_MALTA)
+	PROC_LOCK(p);
+	if ((sigprop(i) & SIGPROP_KILL) && (p->p_flag & P_TRACED) == 0) {
+		/*
+		 * If the process is about to be terminated we have to stop
+		 * the per-thread trace here, as otherwise it will continue
+		 * until the next time cpu_switch() is called.
+		 *
+		 * XXXAR: is this correct? check and locking taken from kern_sig.c
+		 */
+		mtx_lock(&p->p_sigacts->ps_mtx);
+		if (!SIGISMEMBER(p->p_sigacts->ps_sigcatch, i))
+			stop_cheri_perthread_trace(td);
+		mtx_unlock(&p->p_sigacts->ps_mtx);
+	}
+	PROC_UNLOCK(p);
+#endif
 	trapsignal(td, &ksi);
 out:
 


### PR DESCRIPTION
I originally added this as part of the `qtrace -u` user only tracing support but it seems it was never merged.

I doubt the location where the tracing is being turned off is correct but I believe this is still needed.