### PR TITLE
Various setjmp/longjmp fixes (Closes: #198)

### DIFF
--- a/lib/libc/mips/gen/_setjmp.S
+++ b/lib/libc/mips/gen/_setjmp.S
@@ -115,29 +115,21 @@ LEAF(_setjmp)
 	INT_S	v0, (_JB_FPREG_FCSR * SZREG)(a0)
 #endif /* ! __mips_soft_float */
 #if defined(__CHERI__)
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	csc		$c11, zero, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	csc		$c12, zero, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	csc		$c13, zero, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	csc		$c14, zero, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	csc		$c15, zero, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	csc		$c16, zero, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	csc		$c17, zero, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	csc		$c18, zero, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	csc		$c19, zero, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	csc		$c20, zero, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	csc		$c21, zero, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	csc		$c22, zero, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	csc		$c23, zero, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	csc		$c24, zero, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	cgetdefault	$c4
+	csc		$c11, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c4)
+	csc		$c12, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c4)
+	csc		$c13, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c4)
+	csc		$c14, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c4)
+	csc		$c15, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c4)
+	csc		$c16, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c4)
+	csc		$c17, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c4)
+	csc		$c18, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c4)
+	csc		$c19, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c4)
+	csc		$c20, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c4)
+	csc		$c21, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c4)
+	csc		$c22, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c4)
+	csc		$c23, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c4)
+	csc		$c24, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c4)
 #endif
 	REG_EPILOGUE
 
@@ -208,29 +200,21 @@ LEAF(_longjmp)
 #endif
 #endif	/* ! __mips_soft_float */
 #if defined(__CHERI__)
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	clc		$c11, zero, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	clc		$c12, zero, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	clc		$c13, zero, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	clc		$c14, zero, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	clc		$c15, zero, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	clc		$c16, zero, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	clc		$c17, zero, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	clc		$c18, zero, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	clc		$c19, zero, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	clc		$c20, zero, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	clc		$c21, zero, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	clc		$c22, zero, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	clc		$c23, zero, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	clc		$c24, zero, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	cgetdefault	$c4
+	clc		$c11, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c4)
+	clc		$c12, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c4)
+	clc		$c13, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c4)
+	clc		$c14, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c4)
+	clc		$c15, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c4)
+	clc		$c16, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c4)
+	clc		$c17, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c4)
+	clc		$c18, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c4)
+	clc		$c19, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c4)
+	clc		$c20, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c4)
+	clc		$c21, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c4)
+	clc		$c22, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c4)
+	clc		$c23, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c4)
+	clc		$c24, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c4)
 #endif
 
 	REG_EPILOGUE

--- a/lib/libc/mips/gen/_setjmp_c.S
+++ b/lib/libc/mips/gen/_setjmp_c.S
@@ -109,32 +109,23 @@ NESTED(_setjmp, SETJMP_FRAME_SIZE, _FRAME_RETURN_REG)
 	csdc1	$f30, zero, (_JB_FPREG_F30 * SZREG)($c3)
 	csdc1	$f31, zero, (_JB_FPREG_F31 * SZREG)($c3)
 #endif	/* ! __mips_soft_float */
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	csc		$c11, t1, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	csc		$c12, t1, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	csc		$c13, t1, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	csc		$c14, t1, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	csc		$c15, t1, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	csc		$c16, t1, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	csc		$c17, t1, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	csc		$c18, t1, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	csc		$c19, t1, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	csc		$c20, t1, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	csc		$c21, t1, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	csc		$c22, t1, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	csc		$c23, t1, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	csc		$c24, t1, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
-	csc		$c25, t1, (_JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
+	csc		$c11, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
+	csc		$c12, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
+	csc		$c13, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
+	csc		$c14, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
+	csc		$c15, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
+	csc		$c16, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
+	csc		$c17, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
+	csc		$c18, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
+	csc		$c19, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
+	csc		$c20, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
+	csc		$c21, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
+	csc		$c22, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
+	csc		$c23, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
+	csc		$c24, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	csc		$c25, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
 	cgetdefault	$c4
-	csc		$c4, t1, (_JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
+	csc		$c4, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
 
 	cjr		$c17
 	move		v0, zero
@@ -211,31 +202,22 @@ NESTED(_longjmp, LONGJMP_FRAME_SIZE, _FRAME_RETURN_REG)
 	cldc1		$f30, zero, (_JB_FPREG_F30 * SZREG)($c3)
 	cldc1		$f31, zero, (_JB_FPREG_F31 * SZREG)($c3)
 #endif	/* ! __mips_soft_float */
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	clc		$c11, t1, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	clc		$c12, t1, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	clc		$c13, t1, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	clc		$c14, t1, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	clc		$c15, t1, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	clc		$c16, t1, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	clc		$c17, t1, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	clc		$c18, t1, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	clc		$c19, t1, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	clc		$c20, t1, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	clc		$c21, t1, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	clc		$c22, t1, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	clc		$c23, t1, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	clc		$c24, t1, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
-	clc		$c25, t1, (_JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
-	clc		$c4, t1, (_JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
+	clc		$c11, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
+	clc		$c12, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
+	clc		$c13, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
+	clc		$c14, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
+	clc		$c15, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
+	clc		$c16, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
+	clc		$c17, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
+	clc		$c18, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
+	clc		$c19, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
+	clc		$c20, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
+	clc		$c21, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
+	clc		$c22, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
+	clc		$c23, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
+	clc		$c24, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	clc		$c25, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
+	clc		$c4, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
 	csetdefault	$c4
 
 	/* Install $a0 as the return value from setjmp(). */

--- a/lib/libc/mips/gen/setjmp.S
+++ b/lib/libc/mips/gen/setjmp.S
@@ -137,33 +137,25 @@ NESTED(setjmp, SETJMP_FRAME_SIZE, ra)
 #endif
 #endif	/* ! __mips_soft_float */
 #if defined(__CHERI__)
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
 	/*
 	 * XXX-BD: Should we be saving $c0 and $pcc or just assuming they
 	 * are untouched?
 	 */
-	csc		$c11, zero, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	csc		$c12, zero, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	csc		$c13, zero, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	csc		$c14, zero, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	csc		$c15, zero, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	csc		$c16, zero, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	csc		$c17, zero, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	csc		$c18, zero, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	csc		$c19, zero, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	csc		$c20, zero, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	csc		$c21, zero, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	csc		$c22, zero, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	csc		$c23, zero, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	csc		$c24, zero, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	cgetdefault	$c4
+	csc		$c11, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c4)
+	csc		$c12, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c4)
+	csc		$c13, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c4)
+	csc		$c14, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c4)
+	csc		$c15, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c4)
+	csc		$c16, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c4)
+	csc		$c17, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c4)
+	csc		$c18, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c4)
+	csc		$c19, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c4)
+	csc		$c20, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c4)
+	csc		$c21, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c4)
+	csc		$c22, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c4)
+	csc		$c23, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c4)
+	csc		$c24, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c4)
 #endif
 
 	move	v0, zero
@@ -250,29 +242,21 @@ NESTED(longjmp, LONGJMP_FRAME_SIZE, ra)
 #endif
 #endif	/* ! __mips_soft_float */
 #if defined(__CHERI__)
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	clc		$c11, zero, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	clc		$c12, zero, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	clc		$c13, zero, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	clc		$c14, zero, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	clc		$c15, zero, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	clc		$c16, zero, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	clc		$c17, zero, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	clc		$c18, zero, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	clc		$c19, zero, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	clc		$c20, zero, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	clc		$c21, zero, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	clc		$c22, zero, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	clc		$c23, zero, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	clc		$c24, zero, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	cgetdefault	$c4
+	clc		$c11, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c4)
+	clc		$c12, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c4)
+	clc		$c13, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c4)
+	clc		$c14, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c4)
+	clc		$c15, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c4)
+	clc		$c16, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c4)
+	clc		$c17, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c4)
+	clc		$c18, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c4)
+	clc		$c19, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c4)
+	clc		$c20, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c4)
+	clc		$c21, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c4)
+	clc		$c22, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c4)
+	clc		$c23, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c4)
+	clc		$c24, a0, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c4)
 #endif
 
 	move	v0, a1

--- a/lib/libc/mips/gen/setjmp_c.S
+++ b/lib/libc/mips/gen/setjmp_c.S
@@ -134,32 +134,23 @@ NESTED(setjmp, SETJMP_FRAME_SIZE, _FRAME_RETURN_REG)
 	csdc1	$f30, zero, (_JB_FPREG_F30 * SZREG)($c3)
 	csdc1	$f31, zero, (_JB_FPREG_F31 * SZREG)($c3)
 #endif	/* ! __mips_soft_float */
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	csc		$c11, t1, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	csc		$c12, t1, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	csc		$c13, t1, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	csc		$c14, t1, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	csc		$c15, t1, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	csc		$c16, t1, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	csc		$c17, t1, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	csc		$c18, t1, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	csc		$c19, t1, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	csc		$c20, t1, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	csc		$c21, t1, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	csc		$c22, t1, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	csc		$c23, t1, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	csc		$c24, t1, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
-	csc		$c25, t1, (_JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
+	csc		$c11, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
+	csc		$c12, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
+	csc		$c13, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
+	csc		$c14, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
+	csc		$c15, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
+	csc		$c16, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
+	csc		$c17, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
+	csc		$c18, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
+	csc		$c19, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
+	csc		$c20, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
+	csc		$c21, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
+	csc		$c22, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
+	csc		$c23, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
+	csc		$c24, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	csc		$c25, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
 	cgetdefault	$c4
-	csc		$c4, t1, (_JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
+	csc		$c4, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
 
 	move		v0, zero
 	cjr		$c17
@@ -235,30 +226,23 @@ NESTED(longjmp, LONGJMP_FRAME_SIZE, _FRAME_RETURN_REG)
 	cldc1		$f30, zero, (_JB_FPREG_F30 * SZREG)($c3)
 	cldc1		$f31, zero, (_JB_FPREG_F31 * SZREG)($c3)
 #endif	/* ! __mips_soft_float */
-	/* jmp_buf is 64-bit aligned, so we need to round it up. */
-	cgetbase	t0, $c3
-	cgetoffset	t1, $c3
-	daddu		t1, t0, t1
-	daddiu		t0, t1, ((_JB_CHERI_START * SZREG) + _MIPS_SZCAP/8 - SZREG)
-	li		t2, _MIPS_CAP_ALIGN_MASK
-	and		t2, t2, t0
-	dsubu		t1, t2, t1
-
-	clc		$c11, t1, (_JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
-	clc		$c12, t1, (_JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
-	clc		$c13, t1, (_JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
-	clc		$c14, t1, (_JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
-	clc		$c15, t1, (_JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
-	clc		$c16, t1, (_JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
-	clc		$c17, t1, (_JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
-	clc		$c18, t1, (_JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
-	clc		$c19, t1, (_JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
-	clc		$c20, t1, (_JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
-	clc		$c21, t1, (_JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
-	clc		$c22, t1, (_JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
-	clc		$c23, t1, (_JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
-	clc		$c24, t1, (_JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
-	clc		$c25, t1, (_JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
+	clc		$c11, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C11 * _MIPS_SZCAP/8)($c3)
+	clc		$c12, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C12 * _MIPS_SZCAP/8)($c3)
+	clc		$c13, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C13 * _MIPS_SZCAP/8)($c3)
+	clc		$c14, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C14 * _MIPS_SZCAP/8)($c3)
+	clc		$c15, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C15 * _MIPS_SZCAP/8)($c3)
+	clc		$c16, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C16 * _MIPS_SZCAP/8)($c3)
+	clc		$c17, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C17 * _MIPS_SZCAP/8)($c3)
+	clc		$c18, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C18 * _MIPS_SZCAP/8)($c3)
+	clc		$c19, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C19 * _MIPS_SZCAP/8)($c3)
+	clc		$c20, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C20 * _MIPS_SZCAP/8)($c3)
+	clc		$c21, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C21 * _MIPS_SZCAP/8)($c3)
+	clc		$c22, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C22 * _MIPS_SZCAP/8)($c3)
+	clc		$c23, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C23 * _MIPS_SZCAP/8)($c3)
+	clc		$c24, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C24 * _MIPS_SZCAP/8)($c3)
+	clc		$c25, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_C25 * _MIPS_SZCAP/8)($c3)
+	clc		$c4, zero, ((_JB_CHERI_START * SZREG) + _JB_CHERI_DDC * _MIPS_SZCAP/8)($c3)
+	csetdefault	$c4
 
 	/* Install $a0 as the return value from setjmp(). */
 	move		v0, a0

--- a/sys/mips/include/setjmp.h
+++ b/sys/mips/include/setjmp.h
@@ -40,6 +40,11 @@
 #include <sys/cdefs.h>
 
 #define	_JBLEN	95		/* size, in longs (or long longs), of a jmp_buf */
+#ifdef __mips_n32
+#define	_JBTYPE	long long
+#else
+#define	_JBTYPE	long
+#endif
 
 /*
  * jmp_buf and sigjmp_buf are encapsulated in different structs to force
@@ -49,17 +54,27 @@
 #ifndef _LOCORE
 #ifndef __ASSEMBLER__
 #if __BSD_VISIBLE || __POSIX_VISIBLE || __XSI_VISIBLE
-#ifdef __mips_n32
-typedef struct _sigjmp_buf { long long _sjb[_JBLEN + 1]; } sigjmp_buf[1];
+#ifdef __CHERI__
+typedef struct _sigjmp_buf {
+	union {
+		_JBTYPE _sjb[_JBLEN + 1];
+		void * __capability _sjb_c[(_JBLEN + 1)/(_MIPS_SZCAP/sizeof(_JBTYPE))];
+	};
+} sigjmp_buf[1];
 #else
-typedef struct _sigjmp_buf { long _sjb[_JBLEN + 1]; } sigjmp_buf[1];
+typedef struct _sigjmp_buf { _JBTYPE _sjb[_JBLEN + 1]; } sigjmp_buf[1];
 #endif
 #endif
 
-#ifdef __mips_n32
-typedef struct _jmp_buf { long long _jb[_JBLEN + 1]; } jmp_buf[1];
+#ifdef __CHERI__
+typedef struct _jmp_buf {
+	union {
+		_JBTYPE _jb[_JBLEN + 1];
+		void * __capability _jb_c[(_JBLEN + 1)/(_MIPS_SZCAP/sizeof(_JBTYPE))];
+	};
+} jmp_buf[1];
 #else
-typedef struct _jmp_buf { long _jb[_JBLEN + 1]; } jmp_buf[1];
+typedef struct _jmp_buf { _JBTYPE _jb[_JBLEN + 1]; } jmp_buf[1];
 #endif
 #endif /* __ASSEMBLER__ */
 #endif /* _LOCORE */


### PR DESCRIPTION
Firstly, (sig)jmp_buf's contents is turned into a union on CHERI to ensure the correct alignment, that tag bits are propagated when copied around (needed for csh) and that capabilities are always at the right aligned location within the buffer even when copied to a different buffer.

In the process, the broken CHERI code for the hybrid versions was fixed to use a0 for the incoming address rather than the garbage $c3, and the purecap longjmp gained a missing DDC restore.

Note that `(_)setjmp.S` are not compiled with `_CHERI_CC` and so the `__CHERI__` code is not included (despite https://github.com/CTSRD-CHERI/llvm/issues/125 potentially being fixed), which explains why they never faulted or corrupted anything (though does mean using capability registers around setjmp is currently broken).