### PR TITLE
Fix casueword{,32}_c zeroing destination

### DIFF
--- a/sys/mips/mips/support.S
+++ b/sys/mips/mips/support.S
@@ -720,11 +720,10 @@ LEAF(casueword32_c)
 	PTR_L	v1, PC_CURPCB(v1)
 	PTR_S	v0, U_PCB_ONFAULT(v1)
 1:
-	move	t0, a2
 	cllw	t1, $c3			# load word
 	bne	a0, t1, 2f
 	nop
-	cscw	t0, zero, $c3		# store word
+	cscw	t0, a2, $c3		# store word
 	beqz	t0, 1b
 	nop
 	j	3f
@@ -747,11 +746,10 @@ XLEAF(casueword_c)
 	PTR_L	v1, PC_CURPCB(v1)
 	PTR_S	v0, U_PCB_ONFAULT(v1)
 1:
-	move	t0, a2
 	clld	t1, $c3			# load double word
 	bne	a0, t1, 2f
 	nop
-	cscd	t0, zero, $c3		# store double word
+	cscd	t0, a2, $c3		# store double word
 	beqz	t0, 1b
 	nop
 	j	3f


### PR DESCRIPTION
The second argument to Capability Store Conditional instructions is the value to store, not an offset, with the first one being where the boolean result is placed. Since we can do store conditionals without clobbering the source, unlike standard MIPS, we also no longer need to make a copy of the new value input and can just use a2 directly.

This was causing contested locks to have their owner cleared if subject to unfortunate timings, as casueword32_c is used to set the UMUTEX_CONTESTED flag on the owner when performing a UMTX_OP_MUTEX_WAIT.