### PR TITLE
FreeBSD/mips64 asan

### DIFF
--- a/contrib/compiler-rt/lib/asan/asan_mapping.h
+++ b/contrib/compiler-rt/lib/asan/asan_mapping.h
@@ -190,7 +190,7 @@ static const u64 kWindowsShadowOffset32 = 3ULL << 28;  // 0x30000000
 #    define SHADOW_OFFSET kPPC64_ShadowOffset64
 #  elif defined(__s390x__)
 #    define SHADOW_OFFSET kSystemZ_ShadowOffset64
-#  elif SANITIZER_FREEBSD
+#  elif SANITIZER_FREEBSD && !defined(__mips64)
 #    define SHADOW_OFFSET kFreeBSD_ShadowOffset64
 #  elif SANITIZER_NETBSD
 #    define SHADOW_OFFSET kNetBSD_ShadowOffset64

--- a/contrib/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+++ b/contrib/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
@@ -117,7 +117,8 @@
 #if SANITIZER_LINUX || SANITIZER_FREEBSD
 # include <utime.h>
 # include <sys/ptrace.h>
-# if defined(__mips64) || defined(__aarch64__) || defined(__arm__)
+# if SANITIZER_LINUX && (defined(__mips64) || defined(__aarch64__) || \
+     defined(__arm__))
 #  include <asm/ptrace.h>
 #  ifdef __arm__
 typedef struct user_fpregs elf_fpregset_t;

--- a/contrib/compiler-rt/lib/sanitizer_common/sanitizer_syscall_generic.inc
+++ b/contrib/compiler-rt/lib/sanitizer_common/sanitizer_syscall_generic.inc
@@ -42,7 +42,7 @@
 # else
 #  define internal_syscall_ptr  syscall
 # endif
-#elif defined(__x86_64__) && (SANITIZER_FREEBSD || SANITIZER_MAC)
+#elif SANITIZER_FREEBSD || (defined(__x86_64__) && SANITIZER_MAC)
 # define internal_syscall __syscall
 # define internal_syscall64 __syscall
 # define internal_syscall_ptr __syscall

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -169,10 +169,12 @@ SUBDIR.${MK_LDNS}+=	libldns
 # The libraries under libclang_rt can only be built by clang, and only make
 # sense to build when clang is enabled at all.  Furthermore, they can only be
 # built for certain architectures.
-.if ${MK_CLANG} != "no" && ${COMPILER_TYPE} == "clang" && \
+.if (${MK_CLANG} != "no" && ${COMPILER_TYPE} == "clang" || \
+    ${MK_CHERI} != "no") && \
     (${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "amd64" || \
     (${MACHINE_CPUARCH} == "arm" && ${MACHINE_ARCH} != "armeb") || \
-    (${MACHINE_CPUARCH} == "i386"))
+    (${MACHINE_CPUARCH} == "i386") || \
+    ${MACHINE_ARCH:Mmips64} != "") && !defined(LIBCHERI)
 _libclang_rt=	libclang_rt
 .endif
 

--- a/lib/libclang_rt/Makefile
+++ b/lib/libclang_rt/Makefile
@@ -1,6 +1,7 @@
 # $FreeBSD$
 
-.if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
+.if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64" || \
+    ${MACHINE_ARCH:Mmips64*} != ""
 SUBDIR+=	include
 SUBDIR+=	asan
 SUBDIR+=	asan-preinit
@@ -9,7 +10,7 @@ SUBDIR+=	asan_dynamic
 SUBDIR+=	safestack
 SUBDIR+=	stats
 SUBDIR+=	stats_client
-.if ${MACHINE_CPUARCH} == "amd64"
+.if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_ARCH:Mmips64*} != ""
 SUBDIR+=	tsan
 SUBDIR+=	tsan_cxx
 .endif

--- a/lib/libclang_rt/Makefile.inc
+++ b/lib/libclang_rt/Makefile.inc
@@ -7,6 +7,8 @@
 .if ${MACHINE_ARCH:Marmv[67]*} != "" && \
     (!defined(CPUTYPE) || ${CPUTYPE:M*soft*} == "")
 CRTARCH?=	armhf
+.elif ${MACHINE_ARCH:Mmips64*} != ""
+CRTARCH?=	mips64
 .else
 CRTARCH?=	${MACHINE_CPUARCH:C/amd64/x86_64/}
 .endif

--- a/sys/mips/mips/machdep.c
+++ b/sys/mips/mips/machdep.c
@@ -406,7 +406,7 @@ mips_vector_init(void)
 void
 mips_postboot_fixup(void)
 {
-	static char fake_preload[256];
+	_Alignas(_Alignof(u_long)) static char fake_preload[256];
 	caddr_t preload_ptr = (caddr_t)&fake_preload[0];
 	size_t size = 0;
 


### PR DESCRIPTION
The fake_preload thing isn't really needed in this branch, but I was building with clang+lld so needed it to boot.  I can just drop it if we are planning to merge upstream again soon (the commits in upstream are in February of this year)