### PR TITLE
Update LG_QUANTUM values for mips64 and cheri128.

### DIFF
--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_types.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_types.h
@@ -93,10 +93,14 @@ typedef int malloc_cpuid_t;
 #    define LG_QUANTUM		4
 #  endif
 #  ifdef __mips__
-#    ifndef __CHERI_PURE_CAPABILITY__
-#    define LG_QUANTUM		3
+#    if defined(__CHERI_PURE_CAPABILITY__) && _MIPS_SZCAP == 256
+#      define LG_QUANTUM	5
+#    elif defined(__CHERI_PURE_CAPABILITY__) && _MIPS_SZCAP == 128
+#      define LG_QUANTUM	4
+#    elif defined(__mips_n32) || defined(__mips_n64)
+#      define LG_QUANTUM	4
 #    else
-#      define LG_QUANTUM		5
+#      define LG_QUANTUM	3
 #    endif
 #  endif
 #  ifdef __or1k__


### PR DESCRIPTION
LG_QUANTUM is supposed to represent the base alignment for a given
platform.  mips64 uses 16-byte stack-alignment by default in LLVM, and
also in FreeBSD (though the final fix for this isn't yet merged to
CheriBSD), so it should be using 4 instead of 3.  Similarly, cheri128
uses 16-byte alignment rather than 32.

This change changes mips64 from 8 to 16, and cheri 128 from 32 to 16.