### PR TITLE
Avoid implicit CToPtr instructions in the kernel

### DIFF
--- a/sys/compat/cheriabi/cheriabi_ioctl.c
+++ b/sys/compat/cheriabi/cheriabi_ioctl.c
@@ -99,7 +99,7 @@ cheriabi_ioctl(struct thread *td, struct cheriabi_ioctl_args *uap)
 	if (size > 0) {
 		if (com & IOC_VOID) {
 			/* Integer argument. */
-			arg = (intptr_t)uap->data;
+			arg = (__cheri_addr intptr_t)uap->data;
 			data = (void *)&arg;
 			size = 0;
 		} else {

--- a/sys/compat/cheriabi/cheriabi_mmap.c
+++ b/sys/compat/cheriabi/cheriabi_mmap.c
@@ -80,7 +80,7 @@ cap_covers_pages(const void * __capability cap, size_t size)
 	size_t pageoff;
 
 	addr = cap;
-	pageoff = ((vaddr_t)addr & PAGE_MASK);
+	pageoff = ((__cheri_addr vaddr_t)addr & PAGE_MASK);
 	addr -= pageoff;
 	size += pageoff;
 	size = (vm_size_t)round_page(size);

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -1004,7 +1004,7 @@ kevent_copyout(void *arg, kkevent_t *kevp, int count)
 		ks_n[i].flags = kevp[i].flags;
 		ks_n[i].fflags = kevp[i].fflags;
 		ks_n[i].data = kevp[i].data;
-		ks_n[i].udata = (void *)(uintptr_t)kevp[i].udata;
+		ks_n[i].udata = (void *)(__cheri_addr vaddr_t)kevp[i].udata;
 		memcpy(&ks_n[i].ext[0], &kevp->ext[0], sizeof(kevp->ext));
 	}
 	error = copyout(ks_n, uap->eventlist, count * sizeof(*ks_n));
@@ -1069,7 +1069,7 @@ kevent11_copyout(void *arg, kkevent_t *kevp, int count)
 		kev11.flags = kevp->flags;
 		kev11.fflags = kevp->fflags;
 		kev11.data = kevp->data;
-		kev11.udata = (void *)(uintptr_t)kevp->udata;
+		kev11.udata = (void *)(__cheri_addr vaddr_t)kevp->udata;
 		error = copyout(&kev11, uap->eventlist, sizeof(kev11));
 		if (error != 0)
 			break;

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -1906,14 +1906,14 @@ get_proc_vector_cheriabi(struct thread *td, struct proc *p,
 		return (ENOMEM);
 	switch (type) {
 	case PROC_ARG:
-		vptr = (vm_offset_t)pss.ps_argvstr;
+		vptr = (__cheri_addr vm_offset_t)pss.ps_argvstr;
 		vsize = pss.ps_nargvstr;
 		if (vsize > ARG_MAX)
 			return (ENOEXEC);
 		size = vsize * sizeof(void * __capability);
 		break;
 	case PROC_ENV:
-		vptr = (vm_offset_t)pss.ps_envstr;
+		vptr = (__cheri_addr vm_offset_t)pss.ps_envstr;
 		vsize = pss.ps_nenvstr;
 		if (vsize > ARG_MAX)
 			return (ENOEXEC);
@@ -1924,7 +1924,7 @@ get_proc_vector_cheriabi(struct thread *td, struct proc *p,
 		 * The aux array is just above env array on the stack. Check
 		 * that the address is naturally aligned.
 		 */
-		vptr = (vm_offset_t)pss.ps_envstr +
+		vptr = (__cheri_addr vm_offset_t)pss.ps_envstr +
 			(pss.ps_nenvstr + 1) * sizeof(void * __capability);
 #if __ELF_WORD_SIZE == 64
 		if (vptr % sizeof(uint64_t) != 0)

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -678,7 +678,7 @@ sigonstack(size_t sp)
 		(td->td_sigstk.ss_flags & SS_ONSTACK) :
 		((sp - (size_t)td->td_sigstk.ss_sp) < td->td_sigstk.ss_size))
 #else
-	    ((sp - (size_t)td->td_sigstk.ss_sp) < td->td_sigstk.ss_size)
+	    ((sp - (__cheri_addr size_t)td->td_sigstk.ss_sp) < td->td_sigstk.ss_size)
 #endif
 	    : 0);
 }
@@ -907,7 +907,7 @@ sys_sigaction(struct thread *td, struct sigaction_args *uap)
 	if (oactp && !error) {
 #if __has_feature(capabilities)
 		memset(&oact_n, 0, sizeof(oact_n));
-		oact_n.sa_handler = (void *)(vaddr_t)oactp->sa_handler;
+		oact_n.sa_handler = (void *)(__cheri_addr vaddr_t)oactp->sa_handler;
 		oact_n.sa_flags = oactp->sa_flags;
 		oact_n.sa_mask = oactp->sa_mask;
 #else

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -932,13 +932,13 @@ umtx_key_get(const void * __capability addr, int type, int share,
 	if (share == THREAD_SHARE) {
 		key->shared = 0;
 		key->info.private.vs = td->td_proc->p_vmspace;
-		key->info.private.addr = (vaddr_t)addr;
+		key->info.private.addr = (__cheri_addr vaddr_t)addr;
 	} else {
 		MPASS(share == PROCESS_SHARE || share == AUTO_SHARE);
 		map = &td->td_proc->p_vmspace->vm_map;
-		if (vm_map_lookup(&map, (vm_offset_t)addr, VM_PROT_WRITE,
-		    &entry, &key->info.shared.object, &pindex, &prot,
-		    &wired) != KERN_SUCCESS) {
+		if (vm_map_lookup(&map, (__cheri_addr vm_offset_t)addr,
+		    VM_PROT_WRITE, &entry, &key->info.shared.object, &pindex,
+		    &prot, &wired) != KERN_SUCCESS) {
 			return (EFAULT);
 		}
 
@@ -946,13 +946,13 @@ umtx_key_get(const void * __capability addr, int type, int share,
 		    (share == AUTO_SHARE &&
 		     VM_INHERIT_SHARE == entry->inheritance)) {
 			key->shared = 1;
-			key->info.shared.offset = (vm_offset_t)addr -
+			key->info.shared.offset = (__cheri_addr vm_offset_t)addr -
 			    entry->start + entry->offset;
 			vm_object_reference(key->info.shared.object);
 		} else {
 			key->shared = 0;
 			key->info.private.vs = td->td_proc->p_vmspace;
-			key->info.private.addr = (vaddr_t)addr;
+			key->info.private.addr = (__cheri_addr vaddr_t)addr;
 		}
 		vm_map_lookup_done(map, entry);
 	}
@@ -3962,7 +3962,7 @@ umtx_shm_alive(struct thread *td, void * __capability addr)
 	boolean_t wired;
 
 	map = &td->td_proc->p_vmspace->vm_map;
-	res = vm_map_lookup(&map, (uintptr_t)addr, VM_PROT_READ, &entry,
+	res = vm_map_lookup(&map, (__cheri_addr vaddr_t)addr, VM_PROT_READ, &entry,
 	    &object, &pindex, &prot, &wired);
 	if (res != KERN_SUCCESS)
 		return (EFAULT);
@@ -4240,7 +4240,7 @@ __umtx_op_lock_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    uap->uaddr2, (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
@@ -4338,7 +4338,7 @@ __umtx_op_rw_rdlock_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 		error = do_rw_rdlock(td, uap->obj, uap->val, 0);
 	} else {
 		error = umtx_copyin_umtx_time(
-		    uap->uaddr2, (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		error = do_rw_rdlock(td, uap->obj, uap->val, &timeout);
@@ -4357,7 +4357,7 @@ __umtx_op_rw_wrlock_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 		error = do_rw_wrlock(td, uap->obj, 0);
 	} else {
 		error = umtx_copyin_umtx_time(
-		    uap->uaddr2, (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 
@@ -4392,7 +4392,7 @@ __umtx_op_sem2_wait_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 		uasize = 0;
 		tm_p = NULL;
 	} else {
-		uasize = (size_t)uap->uaddr1;
+		uasize = (__cheri_addr size_t)uap->uaddr1;
 		error = umtx_copyin_umtx_time(uap->uaddr2, uasize, &timeout);
 		if (error != 0)
 			return (error);

--- a/sys/kern/subr_sglist.c
+++ b/sys/kern/subr_sglist.c
@@ -126,7 +126,7 @@ _sglist_append_buf(struct sglist *sg, void * __capability buf, size_t len,
 		return (0);
 
 	/* Do the first page.  It may have an offset. */
-	vaddr = (vm_offset_t)buf;
+	vaddr = (__cheri_addr vm_offset_t)buf;
 	offset = vaddr & PAGE_MASK;
 	if (pmap != NULL)
 		paddr = pmap_extract(pmap, vaddr);

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -859,7 +859,7 @@ pipe_build_write_buffer(wpipe, uio)
                 size = uio->uio_iov->iov_len;
 
 	if ((i = vm_fault_quick_hold_pages(&curproc->p_vmspace->vm_map,
-	    (vm_offset_t)uio->uio_iov->iov_base, size, VM_PROT_READ,
+	    (__cheri_addr vm_offset_t)uio->uio_iov->iov_base, size, VM_PROT_READ,
 	    wpipe->pipe_map.ms, PIPENPAGES)) < 0)
 		return (EFAULT);
 
@@ -868,7 +868,7 @@ pipe_build_write_buffer(wpipe, uio)
  */
 	wpipe->pipe_map.npages = i;
 	wpipe->pipe_map.pos =
-	    ((vm_offset_t) uio->uio_iov->iov_base) & PAGE_MASK;
+	    ((__cheri_addr vm_offset_t) uio->uio_iov->iov_base) & PAGE_MASK;
 	wpipe->pipe_map.cnt = size;
 
 /*

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -1263,8 +1263,8 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 		td2->td_dbgflags |= TDB_USERWR;
 		PROC_UNLOCK(p);
 		error = 0;
-		if (proc_writemem(td, p, (off_t)(uintptr_t)addr, &data,
-		    sizeof(int)) != sizeof(int))
+		if (proc_writemem(td, p, (off_t)(__cheri_addr uintptr_t)addr,
+		    &data, sizeof(int)) != sizeof(int))
 			error = ENOMEM;
 		else
 			CTR3(KTR_PTRACE, "PT_WRITE: pid %d: %p <= %#x",
@@ -1276,8 +1276,8 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 	case PT_READ_D:
 		PROC_UNLOCK(p);
 		error = tmp = 0;
-		if (proc_readmem(td, p, (off_t)(uintptr_t)addr, &tmp,
-		    sizeof(int)) != sizeof(int))
+		if (proc_readmem(td, p, (off_t)(__cheri_addr uintptr_t)addr,
+		    &tmp, sizeof(int)) != sizeof(int))
 			error = ENOMEM;
 		else
 			CTR3(KTR_PTRACE, "PT_READ: pid %d: %p >= %#x",

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -382,7 +382,7 @@ kern_shmdt_locked(struct thread *td, const void * __capability shmaddr)
 	AUDIT_ARG_SVIPC_ID(shmmap_s->shmid);
 	for (i = 0; i < shminfo.shmseg; i++, shmmap_s++) {
 		if (shmmap_s->shmid != -1 &&
-		    shmmap_s->va == (vm_offset_t)shmaddr) {
+		    shmmap_s->va == (__cheri_addr vm_offset_t)shmaddr) {
 			break;
 		}
 	}
@@ -483,26 +483,26 @@ kern_shmat_locked(struct thread *td, int shmid,
 #ifdef COMPAT_CHERIABI
 		if (SV_CURPROC_FLAG(SV_CHERI)) {
 			if ((shmflg & SHM_RND) != 0)
-				attach_va = rounddown2((vm_offset_t)shmaddr,
+				attach_va = rounddown2((__cheri_addr vm_offset_t)shmaddr,
 				    CHERI_SHMLBA);
-			else if (((vm_offset_t)shmaddr & (SHMLBA-1)) == 0 &&
-			    ((vm_offset_t)shmaddr & CHERI_ALIGN_MASK(size))
+			else if (((__cheri_addr vm_offset_t)shmaddr & (SHMLBA-1)) == 0 &&
+			    ((__cheri_addr vm_offset_t)shmaddr & CHERI_ALIGN_MASK(size))
 			    == 0)
-				attach_va = (vm_offset_t)shmaddr;
+				attach_va = (__cheri_addr vm_offset_t)shmaddr;
 			else
 				return (EINVAL);
 		} else
 #endif
 		{
 			if ((shmflg & SHM_RND) != 0)
-				attach_va = rounddown2((vm_offset_t)shmaddr, SHMLBA);
-			else if (((vm_offset_t)shmaddr & (SHMLBA-1)) == 0)
-				attach_va = (vm_offset_t)shmaddr;
+				attach_va = rounddown2((__cheri_addr vm_offset_t)shmaddr, SHMLBA);
+			else if (((__cheri_addr vm_offset_t)shmaddr & (SHMLBA-1)) == 0)
+				attach_va = (__cheri_addr vm_offset_t)shmaddr;
 			else
 				return (EINVAL);
 		}
 		shmaddr = (const char * __capability)shmaddr -
-		    ((vm_offset_t)shmaddr - attach_va);
+		    ((__cheri_addr vm_offset_t)shmaddr - attach_va);
 		/*
 		 * Check that shmaddr (as adjusted for SHM_RND) has
 		 * enough space for a mapping.  For CheriABI this means

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -1070,7 +1070,7 @@ kern_recvit(struct thread *td, int s, kmsghdr_t *mp, enum uio_seg fromseg,
 			len -= tocopy;
 			m = m->m_next;
 		}
-		mp->msg_controllen = (vaddr_t)ctlbuf - (vaddr_t)mp->msg_control;
+		mp->msg_controllen = (__cheri_addr vaddr_t)ctlbuf - (__cheri_addr vaddr_t)mp->msg_control;
 	}
 out:
 	fdrop(fp, td);

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1104,7 +1104,7 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 		}
 		if (len > io_hold_cnt * PAGE_SIZE)
 			len = io_hold_cnt * PAGE_SIZE;
-		addr = (vaddr_t)uio_clone->uio_iov->iov_base;
+		addr = (__cheri_addr vaddr_t)uio_clone->uio_iov->iov_base;
 		end = round_page(addr + len);
 		if (end < addr) {
 			error = EFAULT;

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -346,7 +346,7 @@ cheriabi_get_mcontext(struct thread *td, mcontext_c_t *mcp, int flags)
 
 	tp = td->td_frame;
 	PROC_LOCK(curthread->td_proc);
-	mcp->mc_onstack = sigonstack((vaddr_t)tp->csp);
+	mcp->mc_onstack = sigonstack((__cheri_addr vaddr_t)tp->csp);
 	PROC_UNLOCK(curthread->td_proc);
 	bcopy((void *)&td->td_frame->zero, (void *)&mcp->mc_regs,
 	    sizeof(mcp->mc_regs));
@@ -450,7 +450,7 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	 * pointer and bounds...?
 	 */
 	regs = td->td_frame;
-	oonstack = sigonstack((vaddr_t)regs->csp);
+	oonstack = sigonstack((__cheri_addr vaddr_t)regs->csp);
 
 	/*
 	 * CHERI affects signal delivery in the following ways:
@@ -580,10 +580,10 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 		 * on the safe side.
 		 */
 		regs->c3 = cheri_capability_build_user_data(
-		    CHERI_CAP_USER_DATA_PERMS, (vaddr_t)&sfp->sf_si,
+		    CHERI_CAP_USER_DATA_PERMS, (__cheri_addr vaddr_t)&sfp->sf_si,
 		    sizeof(sfp->sf_si), 0);
 		regs->c4 = cheri_capability_build_user_data(
-		    CHERI_CAP_USER_DATA_PERMS, (vaddr_t)&sfp->sf_uc,
+		    CHERI_CAP_USER_DATA_PERMS, (__cheri_addr vaddr_t)&sfp->sf_uc,
 		    sizeof(sfp->sf_uc), 0);
 		/* sf.sf_ahu.sf_action = (__siginfohandler_t *)catcher; */
 
@@ -646,7 +646,7 @@ cheriabi_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	 * in.  As we don't install this in the CHERI frame on the user stack,
 	 * it will be (generally) be removed automatically on sigreturn().
 	 */
-	regs->pc = (register_t)(intptr_t)catcher;
+	regs->pc = (register_t)(__cheri_addr vaddr_t)catcher;
 	regs->pcc = catcher;
 	regs->csp = sfp;
 	regs->c12 = catcher;

--- a/sys/mips/mips/mem.c
+++ b/sys/mips/mips/mem.c
@@ -101,7 +101,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			v = uio->uio_offset;
 
 			off = uio->uio_offset & PAGE_MASK;
-			cnt = PAGE_SIZE - ((vm_offset_t)iov->iov_base &
+			cnt = PAGE_SIZE - ((__cheri_addr vm_offset_t)iov->iov_base &
 			    PAGE_MASK);
 			cnt = min(cnt, PAGE_SIZE - off);
 			cnt = min(cnt, iov->iov_len);

--- a/sys/mips/mips/pm_machdep.c
+++ b/sys/mips/mips/pm_machdep.c
@@ -204,7 +204,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	/* Allocate and validate space for the signal handler context. */
 	if ((td->td_pflags & TDP_ALTSTACK) != 0 && !oonstack &&
 	    SIGISMEMBER(psp->ps_sigonstack, sig)) {
-		sp = (vm_offset_t)((uintptr_t)td->td_sigstk.ss_sp +
+		sp = (vm_offset_t)((__cheri_addr vaddr_t)td->td_sigstk.ss_sp +
 		    td->td_sigstk.ss_size);
 	} else {
 #ifdef CPU_CHERI

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -452,7 +452,7 @@ fetch_instr_near_pc(struct trapframe *frame, register_t offset_from_pc, int32_t 
 		    "faulting instruction from %p\n",  __func__, p->p_pid,
 		    (long)td->td_tid, p->p_comm,
 		    p->p_ucred ? p->p_ucred->cr_uid : -1,
-		    (void*)(vaddr_t)(bad_inst_ptr));
+		    (void*)(__cheri_addr vaddr_t)(bad_inst_ptr));
 	}
 	/* Should this be a kerncap instead instead of being indirected by $pcc? */
 	vaddr = frame->pc + offset_from_pc;

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -56,7 +56,7 @@ __FBSDID("$FreeBSD$");
 #include <machine/cache.h>
 
 #ifdef CPU_CHERI
-#define	CAP_ALIGNED(x)	((vaddr_t)(x) % CHERICAP_SIZE == 0)
+#define	CAP_ALIGNED(x)	((x) % CHERICAP_SIZE == 0)
 #endif
 
 /*
@@ -126,8 +126,8 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 #ifdef CPU_CHERI
-			if (CAP_ALIGNED(cp) &&
-			    CAP_ALIGNED(iov->iov_base) &&
+			if (CAP_ALIGNED((vaddr_t)cp) &&
+			    CAP_ALIGNED((__cheri_addr vaddr_t)iov->iov_base) &&
 			    CAP_ALIGNED(cnt)) {
 				if (uio->uio_rw == UIO_READ)
 					cheri_bcopy(cp,

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -503,7 +503,7 @@ cpu_set_upcall(struct thread *td, void (*entry)(void *), void *arg,
 	struct trapframe *tf;
 	register_t sp;
 
-	sp = (((intptr_t)stack->ss_sp + stack->ss_size) & ~(STACK_ALIGN - 1)) -
+	sp = (((__cheri_addr vaddr_t)stack->ss_sp + stack->ss_size) & ~(STACK_ALIGN - 1)) -
 	    CALLFRAME_SIZ;
 
 	/*


### PR DESCRIPTION
Implicit CToPtr is really confusing because it returns 0 if the value
is not within the bounds of $ddc. I think in all of these cases we
actually want to be storing the vaddr since it would be nice to no
longer include all of userspace in the kernel $ddc.

I found these cases by adding a new warning to clang that triggers
for (most) CToPtr uses.

---

I think quite a few of these changes could be avoided if we change the behaviour of casting from `void*__capability` to integer types in the hybrid ABI.
In the pure ABI these will always return the address, but in the hybrid ABI it will be whatever CToPtr returns.
I think returning 0 instead of the address is rarely useful. I guess one argument is that if you get the address and then DDC changes you could accidentally access something that CToPtr would have prevented. However, if $ddc doesn't change (which I believe is more common) we then get a sensible length violation on access with a MIPS load (and an address that can be used for debugging) instead of a NULL dereference which could be anything.

The current CToPtr behaviour is just weird and confusing and I think it would even be better if it trapped instead of returning NULL. We can get the same behaviour with CTestSubSet and a conditional move so I don't think having a special instruction for this makes much sense.

---

Should I change clang to align hybrid and purecap ABI here or just keep the warning and fix all the cases (which might be quite a lot more in userspace, I only did the kernel for now).