### PR TITLE
Make smb use capabilities for IO.

### DIFF
--- a/sys/fs/smbfs/smbfs_smb.c
+++ b/sys/fs/smbfs/smbfs_smb.c
@@ -105,7 +105,8 @@ smbfs_smb_lockandx(struct smbnode *np, int op, u_int32_t pid, off_t start, off_t
 	mb_put_uint8(mbp, 0xff);	/* secondary command */
 	mb_put_uint8(mbp, 0);		/* MBZ */
 	mb_put_uint16le(mbp, 0);
-	mb_put_mem(mbp, (caddr_t)&np->n_fid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
+	    2, MB_MSYSTEM);
 	mb_put_uint8(mbp, ltype);	/* locktype */
 	mb_put_uint8(mbp, 0);		/* oplocklevel - 0 seems is NO_OPLOCK */
 	mb_put_uint32le(mbp, 0);	/* timeout - break immediately */
@@ -284,7 +285,8 @@ smbfs_smb_seteof(struct smbnode *np, int64_t newsize, struct smb_cred *scred)
 		return error;
 	mbp = &t2p->t2_tparam;
 	mb_init(mbp);
-	mb_put_mem(mbp, (caddr_t)&np->n_fid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
+	    2, MB_MSYSTEM);
 	mb_put_uint16le(mbp, SMB_SET_FILE_END_OF_FILE_INFO);
 	mb_put_uint32le(mbp, 0);
 	mbp = &t2p->t2_tdata;
@@ -315,7 +317,8 @@ smb_smb_flush(struct smbnode *np, struct smb_cred *scred)
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&np->n_fid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
+	    2, MB_MSYSTEM);
 	smb_rq_wend(rqp);
 	smb_rq_bstart(rqp);
 	smb_rq_bend(rqp);
@@ -352,7 +355,8 @@ smbfs_smb_setfsize(struct smbnode *np, int64_t newsize, struct smb_cred *scred)
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&np->n_fid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
+	    2, MB_MSYSTEM);
 	mb_put_uint16le(mbp, 0);
 	mb_put_uint32le(mbp, (uint32_t)newsize);
 	mb_put_uint16le(mbp, 0);
@@ -597,7 +601,8 @@ smbfs_smb_setftime(struct smbnode *np, struct timespec *mtime,
 	tzoff = SSTOVC(ssp)->vc_sopt.sv_tz;
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&np->n_fid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
+	    2, MB_MSYSTEM);
 	mb_put_uint32le(mbp, 0);		/* creation time */
 
 	if (atime)
@@ -642,7 +647,8 @@ smbfs_smb_setfattrNT(struct smbnode *np, u_int16_t attr, struct timespec *mtime,
 	svtz = SSTOVC(ssp)->vc_sopt.sv_tz;
 	mbp = &t2p->t2_tparam;
 	mb_init(mbp);
-	mb_put_mem(mbp, (caddr_t)&np->n_fid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
+	    2, MB_MSYSTEM);
 	mb_put_uint16le(mbp, SMB_SET_FILE_BASIC_INFO);
 	mb_put_uint32le(mbp, 0);
 	mbp = &t2p->t2_tdata;
@@ -736,7 +742,8 @@ smbfs_smb_close(struct smb_share *ssp, u_int16_t fid, struct timespec *mtime,
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&fid, sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
+	    sizeof(fid), MB_MSYSTEM);
 	if (mtime) {
 		smb_time_local2server(mtime, SSTOVC(ssp)->vc_sopt.sv_tz, &time);
 	} else
@@ -1066,7 +1073,8 @@ smbfs_findnextLM1(struct smbfs_fctx *ctx, int limit)
 	md_get_uint16le(mbp, &date);
 	md_get_uint32le(mbp, &size);
 	cp = ctx->f_name;
-	md_get_mem(mbp, cp, sizeof(ctx->f_fname), MB_MSYSTEM);
+	md_get_mem(mbp, (__cheri_tocap char * __capability)cp,
+	    sizeof(ctx->f_fname), MB_MSYSTEM);
 	cp[sizeof(ctx->f_fname) - 1] = 0;
 	cp += strlen(cp) - 1;
 	while (*cp == ' ' && cp >= ctx->f_name)
@@ -1136,13 +1144,17 @@ smbfs_smb_trans2find2(struct smbfs_fctx *ctx)
 		ctx->f_t2 = t2p;
 		mbp = &t2p->t2_tparam;
 		mb_init(mbp);
-		mb_put_mem(mbp, (caddr_t)&ctx->f_Sid, 2, MB_MSYSTEM);
+		mb_put_mem(mbp,
+		    (__cheri_tocap char * __capability)(char *)&ctx->f_Sid, 2,
+		    MB_MSYSTEM);
 		mb_put_uint16le(mbp, ctx->f_limit);
 		mb_put_uint16le(mbp, ctx->f_infolevel);
 		mb_put_uint32le(mbp, 0);		/* resume key */
 		mb_put_uint16le(mbp, flags);
 		if (ctx->f_rname)
-			mb_put_mem(mbp, ctx->f_rname, ctx->f_rnamelen + 1, MB_MSYSTEM);
+			mb_put_mem(mbp,
+			    (__cheri_tocap const char * __capability)
+			    ctx->f_rname, ctx->f_rnamelen + 1, MB_MSYSTEM);
 		else
 			mb_put_uint8(mbp, 0);	/* resume file name */
 #if 0
@@ -1213,7 +1225,8 @@ smbfs_smb_findclose2(struct smbfs_fctx *ctx)
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&ctx->f_Sid, 2, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&ctx->f_Sid,
+	    2, MB_MSYSTEM);
 	smb_rq_wend(rqp);
 	smb_rq_bstart(rqp);
 	smb_rq_bend(rqp);
@@ -1311,7 +1324,8 @@ smbfs_findnextLM2(struct smbfs_fctx *ctx, int limit)
 	} else
 		nmlen = min(size, SMB_MAXFNAMELEN);
 	cp = ctx->f_name;
-	error = md_get_mem(mbp, cp, nmlen, MB_MSYSTEM);
+	error = md_get_mem(mbp, (__cheri_tocap char * __capability)cp, nmlen,
+	    MB_MSYSTEM);
 	if (error)
 		return error;
 	if (next) {

--- a/sys/kern/subr_mchain.c
+++ b/sys/kern/subr_mchain.c
@@ -140,7 +140,9 @@ mb_put_padbyte(struct mbchain *mbp)
 
 	/* Only add padding if address is odd */
 	if ((unsigned long)dst & 1)
-		return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+		return (mb_put_mem(mbp,
+		    (__cheri_tocap char * __capability)(char *)&x, sizeof(x),
+		    MB_MSYSTEM));
 	else
 		return (0);
 }
@@ -148,57 +150,65 @@ mb_put_padbyte(struct mbchain *mbp)
 int
 mb_put_uint8(struct mbchain *mbp, uint8_t x)
 {
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint16be(struct mbchain *mbp, uint16_t x)
 {
 	x = htobe16(x);
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint16le(struct mbchain *mbp, uint16_t x)
 {
 	x = htole16(x);
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint32be(struct mbchain *mbp, uint32_t x)
 {
 	x = htobe32(x);
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint32le(struct mbchain *mbp, uint32_t x)
 {
 	x = htole32(x);
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_int64be(struct mbchain *mbp, int64_t x)
 {
 	x = htobe64(x);
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_int64le(struct mbchain *mbp, int64_t x)
 {
 	x = htole64(x);
-	return (mb_put_mem(mbp, (caddr_t)&x, sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
+	    sizeof(x), MB_MSYSTEM));
 }
 
 int
-mb_put_mem(struct mbchain *mbp, c_caddr_t source, int size, int type)
+mb_put_mem(struct mbchain *mbp, const char * __capability source, int size,
+    int type)
 {
 	struct mbuf *m;
 	caddr_t dst;
-	c_caddr_t src;
+	const char * __capability src;
 	int cplen, error, mleft, count;
 	size_t srclen, dstlen;
 
@@ -221,7 +231,9 @@ mb_put_mem(struct mbchain *mbp, c_caddr_t source, int size, int type)
 		    case MB_MCUSTOM:
 			srclen = size;
 			dstlen = mleft;
-			error = mbp->mb_copy(mbp, source, dst, &srclen, &dstlen);
+			error = mbp->mb_copy(mbp,
+			    (__cheri_fromcap const char *)source, dst, &srclen,
+			    &dstlen);
 			if (error)
 				return (error);
 			break;
@@ -230,10 +242,10 @@ mb_put_mem(struct mbchain *mbp, c_caddr_t source, int size, int type)
 				*dst++ = *src++;
 			break;
 		    case MB_MSYSTEM:
-			bcopy(source, dst, cplen);
+			bcopy((__cheri_fromcap const char *)source, dst, cplen);
 			break;
 		    case MB_MUSER:
-			error = copyin(source, dst, cplen);
+			error = copyin_c(source, dst, cplen);
 			if (error)
 				return (error);
 			break;
@@ -289,8 +301,7 @@ mb_put_uio(struct mbchain *mbp, struct uio *uiop, int size)
 		}
 		if (left > size)
 			left = size;
-		error = mb_put_mem(mbp,
-		    __DECAP_CHECK(uiop->uio_iov->iov_base, left), left, mtype);
+		error = mb_put_mem(mbp, uiop->uio_iov->iov_base, left, mtype);
 		if (error)
 			return (error);
 		uiop->uio_offset += left;
@@ -374,13 +385,15 @@ md_next_record(struct mdchain *mdp)
 int
 md_get_uint8(struct mdchain *mdp, uint8_t *x)
 {
-	return (md_get_mem(mdp, x, 1, MB_MINLINE));
+	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
+	    1, MB_MINLINE));
 }
 
 int
 md_get_uint16(struct mdchain *mdp, uint16_t *x)
 {
-	return (md_get_mem(mdp, (caddr_t)x, 2, MB_MINLINE));
+	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
+	    2, MB_MINLINE));
 }
 
 int
@@ -408,7 +421,8 @@ md_get_uint16be(struct mdchain *mdp, uint16_t *x)
 int
 md_get_uint32(struct mdchain *mdp, uint32_t *x)
 {
-	return (md_get_mem(mdp, (caddr_t)x, 4, MB_MINLINE));
+	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
+	    4, MB_MINLINE));
 }
 
 int
@@ -438,7 +452,8 @@ md_get_uint32le(struct mdchain *mdp, uint32_t *x)
 int
 md_get_int64(struct mdchain *mdp, int64_t *x)
 {
-	return (md_get_mem(mdp, (caddr_t)x, 8, MB_MINLINE));
+	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
+	    8, MB_MINLINE));
 }
 
 int
@@ -466,7 +481,7 @@ md_get_int64le(struct mdchain *mdp, int64_t *x)
 }
 
 int
-md_get_mem(struct mdchain *mdp, caddr_t target, int size, int type)
+md_get_mem(struct mdchain *mdp, char * __capability target, int size, int type)
 {
 	struct mbuf *m = mdp->md_cur;
 	int error;
@@ -494,12 +509,12 @@ md_get_mem(struct mdchain *mdp, caddr_t target, int size, int type)
 			continue;
 		switch (type) {
 		    case MB_MUSER:
-			error = copyout(s, target, count);
+			error = copyout_c(s, target, count);
 			if (error)
 				return error;
 			break;
 		    case MB_MSYSTEM:
-			bcopy(s, target, count);
+			bcopy(s, (__cheri_fromcap char *)target, count);
 			break;
 		    case MB_MINLINE:
 			while (count--)
@@ -525,7 +540,6 @@ md_get_mbuf(struct mdchain *mdp, int size, struct mbuf **ret)
 int
 md_get_uio(struct mdchain *mdp, struct uio *uiop, int size)
 {
-	char *uiocp;
 	long left;
 	int mtype, error;
 
@@ -539,10 +553,9 @@ md_get_uio(struct mdchain *mdp, struct uio *uiop, int size)
 			uiop->uio_iovcnt--;
 			continue;
 		}
-		uiocp = __DECAP_CHECK(uiop->uio_iov->iov_base, left);
 		if (left > size)
 			left = size;
-		error = md_get_mem(mdp, uiocp, left, mtype);
+		error = md_get_mem(mdp, uiop->uio_iov->iov_base, left, mtype);
 		if (error)
 			return (error);
 		uiop->uio_offset += left;

--- a/sys/netsmb/smb_dev.h
+++ b/sys/netsmb/smb_dev.h
@@ -61,9 +61,9 @@
 struct smbioc_ossn {
 	int		ioc_opt;
 	uint32_t	ioc_svlen;	/* size of ioc_server address */
-	struct sockaddr*ioc_server;
+	struct sockaddr * __kerncap ioc_server;
 	uint32_t	ioc_lolen;	/* size of ioc_local address */
-	struct sockaddr*ioc_local;
+	struct sockaddr * __kerncap ioc_local;
 	char		ioc_srvname[SMB_MAXSRVNAMELEN + 1];
 	int		ioc_timeout;
 	int		ioc_retrycount;	/* number of retries before giveup */
@@ -92,11 +92,11 @@ struct smbioc_oshare {
 struct smbioc_rq {
 	u_char		ioc_cmd;
 	u_char		ioc_twc;
-	void *		ioc_twords;
+	void * __kerncap ioc_twords;
 	u_short		ioc_tbc;
-	void *		ioc_tbytes;
+	void * __kerncap ioc_tbytes;
 	int		ioc_rpbufsz;
-	char *		ioc_rpbuf;
+	char * __kerncap ioc_rpbuf;
 	u_char		ioc_rwc;
 	u_short		ioc_rbc;
 	u_int8_t	ioc_errclass;
@@ -107,15 +107,15 @@ struct smbioc_rq {
 struct smbioc_t2rq {
 	u_int16_t	ioc_setup[3];
 	int		ioc_setupcnt;
-	char *		ioc_name;
+	char * __kerncap ioc_name;
 	u_short		ioc_tparamcnt;
-	void *		ioc_tparam;
+	void * __kerncap ioc_tparam;
 	u_short		ioc_tdatacnt;
-	void *		ioc_tdata;
+	void * __kerncap ioc_tdata;
 	u_short		ioc_rparamcnt;
-	void *		ioc_rparam;
+	void * __kerncap ioc_rparam;
 	u_short		ioc_rdatacnt;
-	void *		ioc_rdata;
+	void * __kerncap ioc_rdata;
 };
 
 struct smbioc_flags {
@@ -133,7 +133,7 @@ struct smbioc_lookup {
 
 struct smbioc_rw {
 	smbfh	ioc_fh;
-	char *	ioc_base;
+	char * __kerncap ioc_base;
 	off_t	ioc_offset;
 	int	ioc_cnt;
 };

--- a/sys/netsmb/smb_rq.c
+++ b/sys/netsmb/smb_rq.c
@@ -630,7 +630,9 @@ smb_t2_request_int(struct smb_t2rq *t2p)
 	smb_rq_bstart(rqp);
 	/* TDUNICODE */
 	if (t2p->t_name)
-		mb_put_mem(mbp, t2p->t_name, nmlen, MB_MSYSTEM);
+		mb_put_mem(mbp,
+		    (__cheri_tocap const char * __capability)t2p->t_name,
+		    nmlen, MB_MSYSTEM);
 	mb_put_uint8(mbp, 0);	/* terminating zero */
 	len = mb_fixhdr(mbp);
 	if (txpcount) {

--- a/sys/netsmb/smb_smb.c
+++ b/sys/netsmb/smb_smb.c
@@ -400,7 +400,8 @@ again:
 		mb_put_uint32le(mbp, 0);
 		smb_rq_wend(rqp);
 		smb_rq_bstart(rqp);
-		mb_put_mem(mbp, pp, plen, MB_MSYSTEM);
+		mb_put_mem(mbp, (__cheri_tocap char * __capability)pp, plen,
+		    MB_MSYSTEM);
 		smb_put_dstring(mbp, vcp, up, SMB_CS_NONE);
 	} else {
 		mb_put_uint16le(mbp, uniplen);
@@ -408,8 +409,11 @@ again:
 		mb_put_uint32le(mbp, caps);
 		smb_rq_wend(rqp);
 		smb_rq_bstart(rqp);
-		mb_put_mem(mbp, pp, plen, MB_MSYSTEM);
-		mb_put_mem(mbp, (caddr_t)unipp, uniplen, MB_MSYSTEM);
+		mb_put_mem(mbp, (__cheri_tocap char * __capability)pp, plen,
+		    MB_MSYSTEM);
+		mb_put_mem(mbp,
+		    (__cheri_tocap char * __capability)(char *)unipp, uniplen,
+		    MB_MSYSTEM);
 		smb_put_dstring(mbp, vcp, up, SMB_CS_NONE);		/* AccountName */
 		smb_put_dstring(mbp, vcp, vcp->vc_domain, SMB_CS_NONE);	/* PrimaryDomain */
 		smb_put_dstring(mbp, vcp, "FreeBSD", SMB_CS_NONE);	/* Client's OS */
@@ -561,7 +565,8 @@ again:
 	mb_put_uint16le(mbp, plen);
 	smb_rq_wend(rqp);
 	smb_rq_bstart(rqp);
-	mb_put_mem(mbp, pp, plen, MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)pp, plen,
+	    MB_MSYSTEM);
 	smb_put_dmem(mbp, vcp, "\\\\", 2, caseopt);
 	pp = vcp->vc_srvname;
 	smb_put_dmem(mbp, vcp, pp, strlen(pp), caseopt);
@@ -642,7 +647,8 @@ smb_smb_readx(struct smb_share *ssp, u_int16_t fid, int *len, int *rresid,
 	mb_put_uint8(mbp, 0xff);	/* no secondary command */
 	mb_put_uint8(mbp, 0);		/* MBZ */
 	mb_put_uint16le(mbp, 0);	/* offset to secondary */
-	mb_put_mem(mbp, (caddr_t)&fid, sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
+	    sizeof(fid), MB_MSYSTEM);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	*len = min(SSTOVC(ssp)->vc_rxmax, *len);
 	mb_put_uint16le(mbp, *len);	/* MaxCount */
@@ -722,7 +728,8 @@ smb_smb_writex(struct smb_share *ssp, u_int16_t fid, int *len, int *rresid,
 	mb_put_uint8(mbp, 0xff);	/* no secondary command */
 	mb_put_uint8(mbp, 0);		/* MBZ */
 	mb_put_uint16le(mbp, 0);	/* offset to secondary */
-	mb_put_mem(mbp, (caddr_t)&fid, sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
+	    sizeof(fid), MB_MSYSTEM);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	mb_put_uint32le(mbp, 0);	/* MBZ (timeout) */
 	mb_put_uint16le(mbp, 0);	/* !write-thru */
@@ -783,7 +790,8 @@ smb_smb_read(struct smb_share *ssp, u_int16_t fid,
 
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&fid, sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
+	    sizeof(fid), MB_MSYSTEM);
 	mb_put_uint16le(mbp, rlen);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	mb_put_uint16le(mbp, min(uio->uio_resid, 0xffff));
@@ -864,7 +872,8 @@ smb_smb_write(struct smb_share *ssp, u_int16_t fid, int *len, int *rresid,
 		return error;
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (caddr_t)&fid, sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
+	    sizeof(fid), MB_MSYSTEM);
 	mb_put_uint16le(mbp, resid);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	mb_put_uint16le(mbp, min(uio->uio_resid, 0xffff));

--- a/sys/netsmb/smb_subr.c
+++ b/sys/netsmb/smb_subr.c
@@ -110,13 +110,13 @@ smb_strdup(const char *s)
  * duplicate string from a user space.
  */
 char *
-smb_strdupin(char *s, size_t maxlen)
+smb_strdupin(char * __capability s, size_t maxlen)
 {
 	char *p;
 	int error;
 
 	p = malloc(maxlen + 1, M_SMBSTR, M_WAITOK);
-	error = copyinstr(s, p, maxlen + 1, NULL);
+	error = copyinstr_c(s, p, maxlen + 1, NULL);
 	if (error) {
 		free(p, M_SMBSTR);
 		return (NULL);
@@ -128,14 +128,14 @@ smb_strdupin(char *s, size_t maxlen)
  * duplicate memory block from a user space.
  */
 void *
-smb_memdupin(void *umem, size_t len)
+smb_memdupin(void * __capability umem, size_t len)
 {
 	char *p;
 
 	if (len > 8 * 1024)
 		return NULL;
 	p = malloc(len, M_SMBSTR, M_WAITOK);
-	if (copyin(umem, p, len) == 0)
+	if (copyin_c(umem, p, len) == 0)
 		return p;
 	free(p, M_SMBSTR);
 	return NULL;
@@ -337,13 +337,16 @@ smb_put_dmem(struct mbchain *mbp, struct smb_vc *vcp, const char *src,
 	if (size == 0)
 		return 0;
 	if (dp == NULL) {
-		return mb_put_mem(mbp, src, size, MB_MSYSTEM);
+		return mb_put_mem(mbp,
+		    (__cheri_tocap const char * __capability)src, size,
+		    MB_MSYSTEM);
 	}
 	mbp->mb_copy = smb_copy_iconv;
 	mbp->mb_udata = dp;
 	if (SMB_UNICODE_STRINGS(vcp))
 		mb_put_padbyte(mbp);
-	return mb_put_mem(mbp, src, size, MB_MCUSTOM);
+	return mb_put_mem(mbp, (__cheri_tocap const char * __capability)src,
+	    size, MB_MCUSTOM);
 }
 
 int

--- a/sys/netsmb/smb_subr.h
+++ b/sys/netsmb/smb_subr.h
@@ -103,8 +103,8 @@ void smb_makescred(struct smb_cred *scred, struct thread *td, struct ucred *cred
 int  smb_td_intr(struct thread *);
 char *smb_strdup(const char *s);
 void *smb_memdup(const void *umem, int len);
-char *smb_strdupin(char *s, size_t maxlen);
-void *smb_memdupin(void *umem, size_t len);
+char *smb_strdupin(char * __capability s, size_t maxlen);
+void *smb_memdupin(void * __capability umem, size_t len);
 void smb_strtouni(u_int16_t *dst, const char *src);
 void smb_strfree(char *s);
 void smb_memfree(void *s);

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -133,7 +133,9 @@ nb_put_name(struct mbchain *mbp, struct sockaddr_nb *snb)
 	NBDEBUG("[%s]\n", cp);
 	for (;;) {
 		seglen = (*cp) + 1;
-		error = mb_put_mem(mbp, cp, seglen, MB_MSYSTEM);
+		error = mb_put_mem(mbp,
+		    (__cheri_tocap unsigned char * __capability)cp, seglen,
+		    MB_MSYSTEM);
 		if (error)
 			return error;
 		if (seglen == 1)
@@ -268,7 +270,9 @@ nbssn_rq_request(struct nbpcb *nbp, struct thread *td)
 			error = ECONNABORTED;
 			break;
 		}
-		md_get_mem(mdp, (caddr_t)&sin.sin_addr, 4, MB_MSYSTEM);
+		md_get_mem(mdp,
+		    (__cheri_tocap char * __capability)(char *)&sin.sin_addr,
+		    4, MB_MSYSTEM);
 		md_get_uint16(mdp, &port);
 		sin.sin_port = port;
 		nbp->nbp_state = NBST_RETARGET;

--- a/sys/netsmb/smb_usr.c
+++ b/sys/netsmb/smb_usr.c
@@ -282,7 +282,7 @@ bad:
 }
 
 static int
-smb_cpdatain(struct mbchain *mbp, int len, caddr_t data)
+smb_cpdatain(struct mbchain *mbp, int len, char * __capability data)
 {
 	int error;
 

--- a/sys/sys/mchain.h
+++ b/sys/sys/mchain.h
@@ -77,7 +77,8 @@ int  mb_put_uint32be(struct mbchain *mbp, u_int32_t x);
 int  mb_put_uint32le(struct mbchain *mbp, u_int32_t x);
 int  mb_put_int64be(struct mbchain *mbp, int64_t x);
 int  mb_put_int64le(struct mbchain *mbp, int64_t x);
-int  mb_put_mem(struct mbchain *mbp, c_caddr_t source, int size, int type);
+int  mb_put_mem(struct mbchain *mbp, const char * __capability source, int size,
+	int type);
 int  mb_put_mbuf(struct mbchain *mbp, struct mbuf *m);
 int  mb_put_uio(struct mbchain *mbp, struct uio *uiop, int size);
 
@@ -96,7 +97,8 @@ int  md_get_uint32le(struct mdchain *mdp, u_int32_t *x);
 int  md_get_int64(struct mdchain *mdp, int64_t *x);
 int  md_get_int64be(struct mdchain *mdp, int64_t *x);
 int  md_get_int64le(struct mdchain *mdp, int64_t *x);
-int  md_get_mem(struct mdchain *mdp, caddr_t target, int size, int type);
+int  md_get_mem(struct mdchain *mdp, char * __capability target, int size,
+	int type);
 int  md_get_mbuf(struct mdchain *mdp, int size, struct mbuf **m);
 int  md_get_uio(struct mdchain *mdp, struct uio *uiop, int size);
 


### PR DESCRIPTION
This makes mount_smbfs work as a CheriABI binary at the cost of
breaking mips64 binaries.  I'll work 32- and 64-bit compat later.

Should fix #275 and half fixes #268.