### PR TITLE
Sane libedit key bindings

### DIFF
--- a/bin/sh/histedit.c
+++ b/bin/sh/histedit.c
@@ -137,20 +137,15 @@ bad:
 			INTON;
 		}
 		if (el) {
-			char* editor = NULL;
-
 			if (Vflag)
 				el_set(el, EL_EDITOR, "vi");
 			else if (Eflag)
 				el_set(el, EL_EDITOR, "emacs");
-			el_get(el, EL_EDITOR, &editor);
 			/*
 			 * Set CTRL+R to history search for compatibility with
 			 * other operating systems' default shells.
 			 */
-			if (strcmp(editor, "emacs") == 0)
-				el_set(el, EL_BIND, "^R", "em-inc-search-prev",
-				    NULL);
+			el_set(el, EL_BIND, "^R", "em-inc-search-prev", NULL);
 			el_set(el, EL_BIND, "^I", "sh-complete", NULL);
 			el_source(el, NULL);
 		}

--- a/bin/sh/histedit.c
+++ b/bin/sh/histedit.c
@@ -137,10 +137,20 @@ bad:
 			INTON;
 		}
 		if (el) {
+			char* editor = NULL;
+
 			if (Vflag)
 				el_set(el, EL_EDITOR, "vi");
 			else if (Eflag)
 				el_set(el, EL_EDITOR, "emacs");
+			el_get(el, EL_EDITOR, &editor);
+			/*
+			 * Set CTRL+R to history search for compatibility with
+			 * other operating systems' default shells.
+			 */
+			if (strcmp(editor, "emacs") == 0)
+				el_set(el, EL_BIND, "^R", "em-inc-search-prev",
+				    NULL);
 			el_set(el, EL_BIND, "^I", "sh-complete", NULL);
 			el_source(el, NULL);
 		}

--- a/lib/libedit/map.c
+++ b/lib/libedit/map.c
@@ -1024,31 +1024,37 @@ map_init_meta(EditLine *el)
 private void
 set_expected_default_key_bindings(EditLine *e)
 {
+#define DO_BIND(keys, action) do { \
+    const Char* argv[] = { STR("bind"), STR(keys), STR(action), NULL}; \
+    map_bind(e, 3, argv); \
+} while(0)
 	/*
 	 * Allow the use of Home/End keys.
 	 */
-	el_set(e, EL_BIND, "\\e[1~", "ed-move-to-beg", NULL);
-	el_set(e, EL_BIND, "\\e[4~", "ed-move-to-end", NULL);
-	el_set(e, EL_BIND, "\\e[7~", "ed-move-to-beg", NULL);
-	el_set(e, EL_BIND, "\\e[8~", "ed-move-to-end", NULL);
-	el_set(e, EL_BIND, "\\e[H", "ed-move-to-beg", NULL);
-	el_set(e, EL_BIND, "\\e[F", "ed-move-to-end", NULL);
+	DO_BIND("\\e[1~", "ed-move-to-beg");
+	DO_BIND("\\e[4~", "ed-move-to-end");
+	DO_BIND("\\e[7~", "ed-move-to-beg");
+	DO_BIND("\\e[8~", "ed-move-to-end");
+	DO_BIND("\\e[H", "ed-move-to-beg");
+	DO_BIND("\\e[F", "ed-move-to-end");
 
 	/*
 	 * Allow the use of the Delete/Insert keys.
 	 */
-	el_set(e, EL_BIND, "\\e[3~", "ed-delete-next-char", NULL);
-	el_set(e, EL_BIND, "\\e[2~", "ed-quoted-insert", NULL);
+	DO_BIND("\\e[3~", "ed-delete-next-char");
+	DO_BIND("\\e[2~", "ed-quoted-insert");
 
 	/*
 	 * Ctrl-left-arrow and Ctrl-right-arrow for word moving.
 	 */
-	el_set(e, EL_BIND, "\\e[1;5C", "em-next-word", NULL);
-	el_set(e, EL_BIND, "\\e[1;5D", "ed-prev-word", NULL);
-	el_set(e, EL_BIND, "\\e[5C", "em-next-word", NULL);
-	el_set(e, EL_BIND, "\\e[5D", "ed-prev-word", NULL);
-	el_set(e, EL_BIND, "\\e\\e[C", "em-next-word", NULL);
-	el_set(e, EL_BIND, "\\e\\e[D", "ed-prev-word", NULL);
+	DO_BIND("\\e[1;5C", "em-next-word");
+	DO_BIND("\\e[1;5D", "ed-prev-word");
+	DO_BIND("\\e[5C", "em-next-word");
+	DO_BIND("\\e[5D", "ed-prev-word");
+	DO_BIND("\\e\\e[C", "em-next-word");
+	DO_BIND("\\e\\e[D", "ed-prev-word");
+
+#undef DO_BIND
 }
 
 /* map_init_vi():

--- a/lib/libedit/map.c
+++ b/lib/libedit/map.c
@@ -1017,6 +1017,39 @@ map_init_meta(EditLine *el)
 	map[(int) buf[0]] = ED_SEQUENCE_LEAD_IN;
 }
 
+/* set_expected_default_key_bindings():
+ *	Ensure that most key sequences sent by terminal emulator (such as
+ * 	Home/End/Delete/Insert) work by default e.g. in /bin/sh.
+ */
+private void
+set_expected_default_key_bindings(EditLine *e)
+{
+	/*
+	 * Allow the use of Home/End keys.
+	 */
+	el_set(e, EL_BIND, "\\e[1~", "ed-move-to-beg", NULL);
+	el_set(e, EL_BIND, "\\e[4~", "ed-move-to-end", NULL);
+	el_set(e, EL_BIND, "\\e[7~", "ed-move-to-beg", NULL);
+	el_set(e, EL_BIND, "\\e[8~", "ed-move-to-end", NULL);
+	el_set(e, EL_BIND, "\\e[H", "ed-move-to-beg", NULL);
+	el_set(e, EL_BIND, "\\e[F", "ed-move-to-end", NULL);
+
+	/*
+	 * Allow the use of the Delete/Insert keys.
+	 */
+	el_set(e, EL_BIND, "\\e[3~", "ed-delete-next-char", NULL);
+	el_set(e, EL_BIND, "\\e[2~", "ed-quoted-insert", NULL);
+
+	/*
+	 * Ctrl-left-arrow and Ctrl-right-arrow for word moving.
+	 */
+	el_set(e, EL_BIND, "\\e[1;5C", "em-next-word", NULL);
+	el_set(e, EL_BIND, "\\e[1;5D", "ed-prev-word", NULL);
+	el_set(e, EL_BIND, "\\e[5C", "em-next-word", NULL);
+	el_set(e, EL_BIND, "\\e[5D", "ed-prev-word", NULL);
+	el_set(e, EL_BIND, "\\e\\e[C", "em-next-word", NULL);
+	el_set(e, EL_BIND, "\\e\\e[D", "ed-prev-word", NULL);
+}
 
 /* map_init_vi():
  *	Initialize the vi bindings
@@ -1045,6 +1078,7 @@ map_init_vi(EditLine *el)
 
 	tty_bind_char(el, 1);
 	terminal_bind_arrow(el);
+	set_expected_default_key_bindings(el);
 }
 
 
@@ -1079,6 +1113,7 @@ map_init_emacs(EditLine *el)
 
 	tty_bind_char(el, 1);
 	terminal_bind_arrow(el);
+	set_expected_default_key_bindings(el);
 }
 
 

--- a/lib/libedit/readline.c
+++ b/lib/libedit/readline.c
@@ -368,32 +368,6 @@ rl_initialize(void)
 	 */
 	el_set(e, EL_BIND, "^R", "em-inc-search-prev", NULL);
 
-	/*
-	 * Allow the use of Home/End keys.
-	 */
-	el_set(e, EL_BIND, "\\e[1~", "ed-move-to-beg", NULL);
-	el_set(e, EL_BIND, "\\e[4~", "ed-move-to-end", NULL);
-	el_set(e, EL_BIND, "\\e[7~", "ed-move-to-beg", NULL);
-	el_set(e, EL_BIND, "\\e[8~", "ed-move-to-end", NULL);
-	el_set(e, EL_BIND, "\\e[H", "ed-move-to-beg", NULL);
-	el_set(e, EL_BIND, "\\e[F", "ed-move-to-end", NULL);
-
-	/*
-	 * Allow the use of the Delete/Insert keys.
-	 */
-	el_set(e, EL_BIND, "\\e[3~", "ed-delete-next-char", NULL);
-	el_set(e, EL_BIND, "\\e[2~", "ed-quoted-insert", NULL);
-
-	/*
-	 * Ctrl-left-arrow and Ctrl-right-arrow for word moving.
-	 */
-	el_set(e, EL_BIND, "\\e[1;5C", "em-next-word", NULL);
-	el_set(e, EL_BIND, "\\e[1;5D", "ed-prev-word", NULL);
-	el_set(e, EL_BIND, "\\e[5C", "em-next-word", NULL);
-	el_set(e, EL_BIND, "\\e[5D", "ed-prev-word", NULL);
-	el_set(e, EL_BIND, "\\e\\e[C", "em-next-word", NULL);
-	el_set(e, EL_BIND, "\\e\\e[D", "ed-prev-word", NULL);
-
 	/* read settings from configuration file */
 	el_source(e, NULL);
 


### PR DESCRIPTION
Now /bin/sh is no longer as annoying to use and it should also make delete
work in gdb.
Previously these key bindings only worked for the readline API but not
when using libedit. I believe it makes sense to always support common
bindings that users expect from other operatings systems default shells.

I don't use the vi mode so I'm not sure if the bindings make sense there or
if they should only be set for emacs mode.

I'll try to upstream this as well but for now I really want it in cheribsd.