### PR TITLE
cheritest: xfail some more known cap sharing vectors

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -985,6 +985,14 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_xfail_reason =
 	    "Tags currently survive cross-AS aliasing of SHM_ANON objects", },
 
+#ifdef CHERIABI_TESTS
+	{ .ct_name = "cheritest_vm_cap_share_fd_kqueue",
+	  .ct_desc = "Demonstrate capability passing via shared FD table",
+	  .ct_func = cheritest_vm_cap_share_fd_kqueue,
+	  .ct_xfail_reason =
+	    "Tags currently survive cross-AS shared FD tables", },
+#endif
+
 	{ .ct_name = "cheritest_vm_tag_dev_zero_shared",
 	  .ct_desc = "check tags are stored for /dev/zero MAP_SHARED pages",
 	  .ct_func = cheritest_vm_tag_dev_zero_shared, },

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -991,6 +991,12 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_func = cheritest_vm_cap_share_fd_kqueue,
 	  .ct_xfail_reason =
 	    "Tags currently survive cross-AS shared FD tables", },
+
+	{ .ct_name = "cheritest_vm_cap_share_sigaction",
+	  .ct_desc = "Demonstrate capability passing via shared sigaction table",
+	  .ct_func = cheritest_vm_cap_share_sigaction,
+	  .ct_xfail_reason =
+	    "Tags currently survive cross-AS shared sigaction table", },
 #endif
 
 	{ .ct_name = "cheritest_vm_tag_dev_zero_shared",

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -478,6 +478,9 @@ DECLARE_CHERI_TEST(cheritest_vm_tag_shm_open_anon_shared);
 DECLARE_CHERI_TEST(cheritest_vm_tag_shm_open_anon_private);
 DECLARE_CHERI_TEST(cheritest_vm_tag_shm_open_anon_shared2x);
 DECLARE_CHERI_TEST(cheritest_vm_shm_open_anon_unix_surprise);
+#ifdef CHERIABI_TESTS
+DECLARE_CHERI_TEST(cheritest_vm_cap_share_fd_kqueue);
+#endif
 DECLARE_CHERI_TEST(cheritest_vm_tag_dev_zero_shared);
 DECLARE_CHERI_TEST(cheritest_vm_tag_dev_zero_private);
 DECLARE_CHERI_TEST(cheritest_vm_notag_tmpfile_shared);

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -480,6 +480,7 @@ DECLARE_CHERI_TEST(cheritest_vm_tag_shm_open_anon_shared2x);
 DECLARE_CHERI_TEST(cheritest_vm_shm_open_anon_unix_surprise);
 #ifdef CHERIABI_TESTS
 DECLARE_CHERI_TEST(cheritest_vm_cap_share_fd_kqueue);
+DECLARE_CHERI_TEST(cheritest_vm_cap_share_sigaction);
 #endif
 DECLARE_CHERI_TEST(cheritest_vm_tag_dev_zero_shared);
 DECLARE_CHERI_TEST(cheritest_vm_tag_dev_zero_private);

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -47,6 +47,8 @@
 #include <sys/ucontext.h>
 #include <sys/wait.h>
 
+#include <sys/event.h>
+
 #include <machine/cpuregs.h>
 #include <machine/frame.h>
 #include <machine/trap.h>
@@ -264,6 +266,69 @@ cheritest_vm_shm_open_anon_unix_surprise(const struct cheri_test *ctp __unused)
 		}
 	}
 }
+
+#ifdef CHERIABI_TESTS
+
+/*
+ * We can fork processes with shared file descriptor tables, including
+ * shared access to a kqueue, which can hoard capabilities for us, allowing
+ * them to flow between address spaces.  It is difficult to know what to do
+ * about this case, but it seems important to acknowledge.
+ */
+void
+cheritest_vm_cap_share_fd_kqueue(const struct cheri_test *ctp __unused)
+{
+	int kq, pid;
+
+	kq = CHERITEST_CHECK_SYSCALL(kqueue());
+	pid = rfork(RFPROC);
+	if (pid == -1)
+		cheritest_failure_errx("Fork failed; errno=%d", errno);
+
+	if (pid == 0) {
+		struct kevent oke;
+		/*
+		 * Wait for receipt of the user event, and witness the
+		 * capability received from the parent.
+		 */
+		oke.udata = NULL;
+		CHERITEST_CHECK_SYSCALL(kevent(kq, NULL, 0, &oke, 1, NULL));
+		CHERITEST_VERIFY2(oke.ident == 0x2BAD, "Bad identifier from kqueue");
+		CHERITEST_VERIFY2(oke.filter == EVFILT_USER, "Bad filter from kqueue");
+
+		CHERI_FPRINT_PTR(stderr, oke.udata);
+
+		exit(cheri_gettag(oke.udata));
+	} else {
+		int res;
+		struct kevent ike;
+		void * __capability passme;
+
+		/*
+		 * Generate a capability to a new mapping to pass to the
+		 * child, who will not have this region mapped.
+		 */
+		passme = CHERITEST_CHECK_SYSCALL(mmap(0, PAGE_SIZE,
+				PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
+
+		EV_SET(&ike, 0x2BAD, EVFILT_USER, EV_ADD|EV_ONESHOT,
+			NOTE_FFNOP, 0, passme);
+		CHERITEST_CHECK_SYSCALL(kevent(kq, &ike, 1, NULL, 0, NULL));
+
+		EV_SET(&ike, 0x2BAD, EVFILT_USER, EV_KEEPUDATA,
+			NOTE_FFNOP|NOTE_TRIGGER, 0, NULL);
+		CHERITEST_CHECK_SYSCALL(kevent(kq, &ike, 1, NULL, 0, NULL));
+
+		waitpid(pid, &res, 0);
+		if (res == 0) {
+			cheritest_success();
+		} else {
+			cheritest_failure_errx("tag transfer");
+		}
+	}
+}
+
+#endif
 
 void
 cheritest_vm_tag_dev_zero_shared(const struct cheri_test *ctp __unused)

--- a/lib/libc/sys/kqueue.2
+++ b/lib/libc/sys/kqueue.2
@@ -250,6 +250,21 @@ Filters may set this flag to indicate filter-specific EOF condition.
 See
 .Sx RETURN VALUES
 below.
+.It Dv EV_KEEPUDATA
+Causes
+.Fn kevent
+to leave unchanged any
+.Fa udata
+associated with an existing event.  This allows other aspects of the
+event to be modified without requiring the caller to know the
+.Fa udata
+value presently associated.
+This is especially useful with
+.Dv NOTE_TRIGGER
+or flags like
+.Dv EV_ENABLE.
+This flag may not be used with
+.Dv EV_ADD.
 .El
 .Pp
 The predefined system filters are listed below.

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -1441,6 +1441,13 @@ kqueue_register(struct kqueue *kq, kkevent_t *kev, struct thread *td,
 		return EINVAL;
 
 	if (kev->flags & EV_ADD) {
+		/* Reject an invalid flag pair early */
+		if (kev->flags & EV_KEEPUDATA) {
+			tkn = NULL;
+			error = EINVAL;
+			goto done;
+		}
+
 		/*
 		 * Prevent waiting with locks.  Non-sleepable
 		 * allocation failures are handled in the loop, only
@@ -1629,7 +1636,8 @@ findkn:
 	kn_enter_flux(kn);
 	KQ_UNLOCK(kq);
 	knl = kn_list_lock(kn);
-	kn->kn_kevent.udata = kev->udata;
+	if ((kev->flags & EV_KEEPUDATA) == 0)
+		kn->kn_kevent.udata = kev->udata;
 	if (!fops->f_isfd && fops->f_touch != NULL) {
 		fops->f_touch(kn, kev, EVENT_REGISTER);
 	} else {

--- a/sys/sys/event.h
+++ b/sys/sys/event.h
@@ -163,6 +163,7 @@ struct kevent32_freebsd11 {
 #define EV_ENABLE	0x0004		/* enable event */
 #define EV_DISABLE	0x0008		/* disable event (not reported) */
 #define EV_FORCEONESHOT	0x0100		/* enable _ONESHOT and force trigger */
+#define EV_KEEPUDATA	0x0200		/* do not update the udata field */
 
 /* flags */
 #define EV_ONESHOT	0x0010		/* only report one occurrence */


### PR DESCRIPTION
There are some known ways to pass capabilities between separate address spaces that we probably don't want to have work.  Here are some more xfail-ing tests that will tell us when the situation improves. :)