### PR TITLE
abort() if memcpy would strip tag bits due to unaligned destination

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1626,6 +1626,20 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Test explicit capability memmove",
 	  .ct_func = test_string_memmove_c },
 
+	/* Unaligned memcpy/memmove with capabilities */
+	{ .ct_name = "test_unaligned_capability_copy_memcpy",
+	  .ct_desc = "Check that a memcpy() of valid capabilities to an "
+		     "unaligned destination fails",
+	  .ct_func = test_unaligned_capability_copy_memcpy,
+	  .ct_flags = CT_FLAG_SIGEXIT,
+	  .ct_signum = SIGABRT },
+	{ .ct_name = "test_unaligned_capability_copy_memmove",
+	  .ct_desc = "Check that a memmove() of valid capabilities to an "
+		     "unaligned destination fails",
+	  .ct_func = test_unaligned_capability_copy_memmove,
+	  .ct_flags = CT_FLAG_SIGEXIT,
+	  .ct_signum = SIGABRT },
+
 	/*
 	 * Thread-Local Storage (TLS) tests.
 	 */
@@ -2259,10 +2273,6 @@ cheritest_run_test_name(const char *name)
 		errx(EX_USAGE, "unknown test: %s", name);
 	cheritest_run_test(&cheri_tests[i]);
 }
-
-/* For libc_memcpy and libc_memset tests: */
-extern void *cheritest_memcpy(void *dst, const void *src, size_t n);
-extern void *cheritest_memmove(void *dst, const void *src, size_t n);
 
 __noinline void *
 cheritest_memcpy(void *dst, const void *src, size_t n)

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -447,6 +447,9 @@ DECLARE_CHERI_TEST(test_string_memcpy_c);
 DECLARE_CHERI_TEST(test_string_memmove);
 DECLARE_CHERI_TEST(test_string_memmove_c);
 
+DECLARE_CHERI_TEST(test_unaligned_capability_copy_memcpy);
+DECLARE_CHERI_TEST(test_unaligned_capability_copy_memmove);
+
 /* cheritest_syscall.c */
 DECLARE_CHERI_TEST(test_sandbox_syscall);
 DECLARE_CHERI_TEST(test_sig_dfl_neq_ign);
@@ -500,6 +503,10 @@ const char	*xfail_swap_required(const char *name);
 DECLARE_CHERI_TEST(test_deflate_zeroes);
 DECLARE_CHERI_TEST(test_inflate_zeroes);
 DECLARE_CHERI_TEST(test_sandbox_inflate_zeroes);
+
+/* For libc_memcpy and libc_memset tests and the unaligned copy tests: */
+extern void *cheritest_memcpy(void *dst, const void *src, size_t n);
+extern void *cheritest_memmove(void *dst, const void *src, size_t n);
 
 #ifdef CHERI_C_TESTS
 #define	DECLARE_TEST(name, desc) \


### PR DESCRIPTION
This should help debugging tag violations due to underalinged destination
buffers such as setjmp/longjmp in csh (3dee3c077c6cfa41ef2a6d205be93b1a0350fadd).