### PR TITLE
Another round of C++ exception fixes

### DIFF
--- a/lib/libgcc_eh/Makefile.inc
+++ b/lib/libgcc_eh/Makefile.inc
@@ -32,13 +32,9 @@ SRCS_EXC+=	libunwind.cpp
 SRCS+=		${SRCS_EXC}
 .for file in ${SRCS_EXC:M*.c}
 CFLAGS.${file}+=	-fno-exceptions -funwind-tables
-# Avoid tons of debug output (might speed up running GDB)
-CFLAGS.${file}+=	-DNDEBUG
 .endfor
 .for file in ${SRCS_EXC:M*.cpp}
 CXXFLAGS.${file}+=	-fno-exceptions -funwind-tables
-# Avoid tons of debug output (might speed up running GDB)
-CXXFLAGS.${file}+=	-DNDEBUG
 .endfor
 
 CFLAGS+=	-I${UNWINDINCDIR} -I${.CURDIR} -D_LIBUNWIND_IS_NATIVE_ONLY


### PR DESCRIPTION
My little test program for C++ exceptions wasn't working again today on my branch (which enables assertions by removing -DNDEBUG) and I tracked down a few bugs.  Alex, I don't mind if we push the libunwind ones into llvm first or however it's easiest.