### PR TITLE
makesyscalls: always use relative path for syscalls.conf

### DIFF
--- a/sys/amd64/linux/Makefile
+++ b/sys/amd64/linux/Makefile
@@ -11,5 +11,5 @@ all:
 sysent:  linux_sysent.c linux_syscall.h linux_proto.h linux_syscalls.c linux_systrace_args.c
 
 linux_sysent.c linux_syscall.h linux_proto.h linux_syscalls.c linux_systrace_args.c: \
-		../../kern/makesyscalls.sh syscalls.master syscalls.conf
-	sh ../../kern/makesyscalls.sh syscalls.master syscalls.conf
+		../../kern/makesyscalls.sh syscalls.master ./syscalls.conf
+	sh ../../kern/makesyscalls.sh syscalls.master ./syscalls.conf

--- a/sys/amd64/linux32/Makefile
+++ b/sys/amd64/linux32/Makefile
@@ -11,5 +11,5 @@ all:
 sysent:  linux32_sysent.c linux32_syscall.h linux32_proto.h linux32_syscalls.c linux32_systrace_args.c
 
 linux32_sysent.c linux32_syscall.h linux32_proto.h linux32_syscalls.c linux32_systrace_args.c: ../../kern/makesyscalls.sh \
-		syscalls.master syscalls.conf
-	sh ../../kern/makesyscalls.sh syscalls.master syscalls.conf
+		syscalls.master ./syscalls.conf
+	sh ../../kern/makesyscalls.sh syscalls.master ./syscalls.conf

--- a/sys/arm64/linux/Makefile
+++ b/sys/arm64/linux/Makefile
@@ -11,5 +11,5 @@ all:
 sysent:  linux_sysent.c linux_syscall.h linux_proto.h linux_syscalls.c linux_systrace_args.c
 
 linux_sysent.c linux_syscall.h linux_proto.h linux_syscalls.c linux_systrace_args.c: \
-		../../kern/makesyscalls.sh syscalls.master syscalls.conf
-	sh ../../kern/makesyscalls.sh syscalls.master syscalls.conf
+		../../kern/makesyscalls.sh syscalls.master ./syscalls.conf
+	sh ../../kern/makesyscalls.sh syscalls.master ./syscalls.conf

--- a/sys/compat/cheriabi/Makefile
+++ b/sys/compat/cheriabi/Makefile
@@ -11,8 +11,8 @@ all:
 sysent:  cheriabi_sysent.c cheriabi_syscall.h cheriabi_proto.h cheriabi_systrace_args.c
 
 cheriabi_sysent.c cheriabi_syscalls.c cheriabi_syscall.h cheriabi_proto.h cheriabi_systrace_args.c : \
-	    ../../kern/makesyscalls.sh ../../kern/syscalls.master syscalls.conf
-	sh ../../kern/makesyscalls.sh ../../kern/syscalls.master syscalls.conf
+	    ../../kern/makesyscalls.sh ../../kern/syscalls.master ./syscalls.conf
+	sh ../../kern/makesyscalls.sh ../../kern/syscalls.master ./syscalls.conf
 
 clean:
 	rm -f cheriabi_sysent.c cheriabi_syscalls.c cheriabi_syscall.h cheriabi_proto.h

--- a/sys/compat/cloudabi32/Makefile
+++ b/sys/compat/cloudabi32/Makefile
@@ -12,6 +12,6 @@ sysent: cloudabi32_sysent.c cloudabi32_syscall.h cloudabi32_proto.h \
 cloudabi32_sysent.c cloudabi32_syscall.h cloudabi32_proto.h \
     cloudabi32_syscalls.c cloudabi32_systrace_args.c: \
     ../../kern/makesyscalls.sh ../../contrib/cloudabi/syscalls32.master \
-    syscalls.conf
+    ./syscalls.conf
 	sh ../../kern/makesyscalls.sh ../../contrib/cloudabi/syscalls32.master \
-	    syscalls.conf
+	    ./syscalls.conf

--- a/sys/compat/cloudabi64/Makefile
+++ b/sys/compat/cloudabi64/Makefile
@@ -12,6 +12,6 @@ sysent: cloudabi64_sysent.c cloudabi64_syscall.h cloudabi64_proto.h \
 cloudabi64_sysent.c cloudabi64_syscall.h cloudabi64_proto.h \
     cloudabi64_syscalls.c cloudabi64_systrace_args.c: \
     ../../kern/makesyscalls.sh ../../contrib/cloudabi/syscalls64.master \
-    syscalls.conf
+    ./syscalls.conf
 	sh ../../kern/makesyscalls.sh ../../contrib/cloudabi/syscalls64.master \
-	    syscalls.conf
+	    ./syscalls.conf

--- a/sys/compat/freebsd32/Makefile
+++ b/sys/compat/freebsd32/Makefile
@@ -11,8 +11,8 @@ all:
 sysent:  freebsd32_sysent.c freebsd32_syscall.h freebsd32_proto.h freebsd32_systrace_args.c
 
 freebsd32_sysent.c freebsd32_syscalls.c freebsd32_syscall.h freebsd32_proto.h freebsd32_systrace_args.c : \
-	    ../../kern/makesyscalls.sh syscalls.master syscalls.conf ../../kern/capabilities.conf
-	sh ../../kern/makesyscalls.sh syscalls.master syscalls.conf
+	    ../../kern/makesyscalls.sh syscalls.master ./syscalls.conf ../../kern/capabilities.conf
+	sh ../../kern/makesyscalls.sh syscalls.master ./syscalls.conf
 
 clean:
 	rm -f freebsd32_sysent.c freebsd32_syscalls.c freebsd32_syscall.h freebsd32_proto.h

--- a/sys/compat/freebsd64/Makefile
+++ b/sys/compat/freebsd64/Makefile
@@ -11,8 +11,8 @@ all:
 sysent:  freebsd64_sysent.c freebsd64_syscall.h freebsd64_proto.h freebsd64_systrace_args.c
 
 freebsd64_sysent.c freebsd64_syscalls.c freebsd64_syscall.h freebsd64_proto.h freebsd64_systrace_args.c : \
-	    ../../kern/makesyscalls.sh ../../kern/syscalls.master syscalls.conf
-	sh ../../kern/makesyscalls.sh ../../kern/syscalls.master syscalls.conf
+	    ../../kern/makesyscalls.sh ../../kern/syscalls.master ./syscalls.conf
+	sh ../../kern/makesyscalls.sh ../../kern/syscalls.master ./syscalls.conf
 
 clean:
 	rm -f freebsd64_sysent.c freebsd64_syscalls.c freebsd64_syscall.h freebsd64_proto.h

--- a/sys/i386/linux/Makefile
+++ b/sys/i386/linux/Makefile
@@ -11,5 +11,5 @@ all:
 sysent:  linux_sysent.c linux_syscall.h linux_proto.h linux_syscalls.c linux_systrace_args.c
 
 linux_sysent.c linux_syscall.h linux_proto.h linux_syscalls.c linux_systrace_args.c: \
-		../../kern/makesyscalls.sh syscalls.master syscalls.conf
-	sh ../../kern/makesyscalls.sh syscalls.master syscalls.conf
+		../../kern/makesyscalls.sh syscalls.master ./syscalls.conf
+	sh ../../kern/makesyscalls.sh syscalls.master ./syscalls.conf

--- a/sys/kern/makesyscalls.sh
+++ b/sys/kern/makesyscalls.sh
@@ -69,7 +69,7 @@ case $# in
 esac
 
 if [ -n "$2" ]; then
-	. $2
+	. "$2"
 fi
 
 if [ -r $capabilities_conf ]; then


### PR DESCRIPTION
The Open Group says

> If file does not contain a \<slash\>, the shell shall use the search
> path specified by PATH to find the directory containing file.

and that's not what we want.