### PR TITLE
A few kernel fixes to get closer to being able to build amd64 GENERIC

### DIFF
--- a/sys/amd64/include/fpu.h
+++ b/sys/amd64/include/fpu.h
@@ -48,6 +48,7 @@
 #ifdef _KERNEL
 
 struct fpu_kern_ctx;
+struct thread;
 
 #define	PCB_USER_FPU(pcb) (((pcb)->pcb_flags & PCB_KERNFPU) == 0)
 

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -2235,7 +2235,7 @@ freebsd4_freebsd32_sigaction(struct thread *td,
 			     struct freebsd4_freebsd32_sigaction_args *uap)
 {
 	struct sigaction32 s32;
-	struct sigaction sa, osa, *sap;
+	ksigaction_t sa, osa, *sap;
 	int error;
 
 	if (uap->act) {

--- a/sys/compat/linux/linux_errno.inc
+++ b/sys/compat/linux/linux_errno.inc
@@ -143,7 +143,9 @@ const int linux_errtbl[ELAST + 1] = {
 	-131,	/* ENOTRECOVERABLE */
 	-130,	/* EOWNERDEAD */
 	-22,	/* EINTEGRITY -> EINVAL */
+	-98	/* EPROT */
+	-99	/* ENOMETHOD */
 };
 
-_Static_assert(ELAST == 97,
+_Static_assert(ELAST == 99,
     "missing errno entries in linux_errtbl");

--- a/sys/contrib/edk2/Include/Base.h
+++ b/sys/contrib/edk2/Include/Base.h
@@ -1228,7 +1228,6 @@ typedef UINTN RETURN_STATUS;
   **/
   #define RETURN_ADDRESS(L)     ((L == 0) ? _ReturnAddress() : (VOID *) 0)
 #elif defined(__GNUC__)
-  void * __builtin_return_address (unsigned int level);
   /**
     Get the return address of the calling function.
 

--- a/sys/dev/pci/pci_user.c
+++ b/sys/dev/pci/pci_user.c
@@ -390,7 +390,7 @@ struct pci_match_conf_old32 {
 	pci_getconf_flags_old flags;	/* Matching expression */
 };
 
-struct pci_conf_io32 {
+struct pci_conf_io_old32 {
 	uint32_t	pat_buf_len;	/* pattern buffer length */
 	uint32_t	num_patterns;	/* number of patterns */
 	uint32_t	patterns;	/* pattern buffer
@@ -404,7 +404,7 @@ struct pci_conf_io32 {
 	pci_getconf_status status;	/* request status */
 };
 
-#define	PCIOCGETCONF_OLD32	_IOWR('p', 1, struct pci_conf_io32)
+#define	PCIOCGETCONF_OLD32	_IOWR('p', 1, struct pci_conf_io_old32)
 #endif	/* COMPAT_FREEBSD32 */
 
 #define	PCIOCGETCONF_OLD	_IOWR('p', 1, struct pci_conf_io)

--- a/sys/sys/signalvar.h
+++ b/sys/sys/signalvar.h
@@ -87,7 +87,7 @@ typedef struct {
 	struct osigcontext si_sc;
 	int		si_signo;
 	int		si_code;
-	union sigval	si_value;
+	ksigval_union	si_value;
 } osiginfo_t;
 
 struct osigaction {
@@ -215,7 +215,7 @@ struct osigevent {
 		int	__sigev_signo;	/* Signal number */
 		int	__sigev_notify_kqueue;
 	} __sigev_u;
-	union sigval sigev_value;	/* Signal value */
+	ksigval_union sigev_value;	/* Signal value */
 };
 #endif
 

--- a/sys/x86/include/sigframe.h
+++ b/sys/x86/include/sigframe.h
@@ -67,7 +67,11 @@ struct sigframe {
 		__sighandler_t		*sf_handler;
 	} sf_ahu;
 	ucontext_t	sf_uc;		/* = *sf_ucontext */
+#ifdef _KERNEL
+	struct siginfo_native sf_si;	/* = *sf_siginfo (SA_SIGINFO case) */
+#else
 	siginfo_t	sf_si;		/* = *sf_siginfo (SA_SIGINFO case) */
+#endif
 };
 #endif /* __amd64__ */
 


### PR DESCRIPTION
I tried running `cheribuild.py cheribsd-native` and with these changes it gets through buildworld (if I disable openmp) but there are still some issues in the kernel.