### PR TITLE
Fix booting with 14-bit bottom precision

### DIFF
--- a/bin/cheritest/cheritest_bounds_stack.c
+++ b/bin/cheritest/cheritest_bounds_stack.c
@@ -75,13 +75,15 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 	/* Confirm precise lower bound: offset of zero. */
 	offset = cheri_getoffset(c);
 	if (offset != 0)
-		cheritest_failure_errx("offset (%jd) not zero", offset);
+		cheritest_failure_errx("offset (%jd) not zero: "
+		    _CHERI_PRINTF_CAP_FMT, offset, _CHERI_PRINTF_CAP_ARG(c));
 
 	/* Confirm precise upper bound: length of expected size for type. */
 	len = cheri_getlen(c);
 	if (len != expected_len)
-		cheritest_failure_errx("length (%jd) not expected %jd", len,
-		    expected_len);
+		cheritest_failure_errx("length (%jd) not expected %jd: "
+		    _CHERI_PRINTF_CAP_FMT, len, expected_len,
+		    _CHERI_PRINTF_CAP_ARG(c));
 	cheritest_success();
 }
 

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -203,8 +203,9 @@ _cheri_capability_build_user_rwx(uint32_t perms, vaddr_t basep, size_t length,
 	    cheri_setoffset(userspace_cap, basep), length), perms), off);
 
 	KASSERT(cheri_getlen(tmpcap) == length,
-	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx",
-	    func, line, cheri_getlen(tmpcap), length));
+	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx: "
+	    _CHERI_PRINTF_CAP_FMT, func, line, cheri_getlen(tmpcap), length,
+	    _CHERI_PRINTF_CAP_ARG(tmpcap)));
 
 	return (tmpcap);
 }

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -784,8 +784,8 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	 */
 	stacklen = rounddown2(stacklen, 1ULL << CHERI_ALIGN_SHIFT(stacklen));
 	td->td_frame->csp = cheri_capability_build_user_data(
-	    CHERI_CAP_USER_DATA_PERMS, stackbase, stacklen, 0);
-	td->td_frame->sp = stacklen;
+	    CHERI_CAP_USER_DATA_PERMS, stackbase, stacklen, stacklen);
+
 
 	/* Using addr as length means ddc base must be 0. */
 	CTASSERT(CHERI_CAP_USER_DATA_BASE == 0);
@@ -920,19 +920,6 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 		td->td_frame->c4 = cheri_capability_build_user_data(
 		    CHERI_CAP_USER_DATA_PERMS, rtld_base, rtld_len, 0);
 	}
-	/*
-	 * Restrict the stack capability to the maximum region allowed for
-	 * this process and adjust sp accordingly.
-	 *
-	 * XXXBD: 8MB should be the process stack limit.
-	 */
-	CTASSERT(CHERI_CAP_USER_DATA_BASE == 0);
-	stackbase = USRSTACK - (1024 * 1024 * 8);
-	KASSERT(stack > stackbase,
-	    ("top of stack 0x%lx is below stack base 0x%lx", stack, stackbase));
-	stacklen = stack - stackbase;
-	td->td_frame->csp = cheri_capability_build_user_data(
-	    CHERI_CAP_USER_DATA_PERMS, stackbase, stacklen, stacklen);
 
 	/*
 	 * Update privileged signal-delivery environment for actual stack.

--- a/sys/mips/include/vmparam.h
+++ b/sys/mips/include/vmparam.h
@@ -98,7 +98,11 @@
  * offset is calculated.
  */
 #define	SHAREDPAGE		(VM_MAXUSER_ADDRESS - PAGE_SIZE)
-#define	USRSTACK		SHAREDPAGE
+/*
+ * To ensure that the stack base address that is sufficiently aligned to create
+ * a bounded capability we must round down by 16 pages to get to 0x7ffbff0000.
+ */
+#define	USRSTACK		(SHAREDPAGE - (15 * PAGE_SIZE))
 #ifdef __mips_n64
 #define	FREEBSD32_SHAREDPAGE	(((vm_offset_t)0x80000000) - PAGE_SIZE)
 #define	FREEBSD32_USRSTACK	FREEBSD32_SHAREDPAGE


### PR DESCRIPTION
We need to round down the stack to 0x7ffbff0000 in order to represent a length of 0x3ff0000.

@jonwoodruff This works in QEMU, could you confirm that those values also work for the FPGA?