### PR TITLE
build: honor some MK_* flags

### DIFF
--- a/ctsrd/lib/Makefile
+++ b/ctsrd/lib/Makefile
@@ -5,8 +5,11 @@
 SUBDIR_ORDERED=	libvuln_png
 
 SUBDIR=	${SUBDIR_ORDERED} \
-	libterasic_mtl \
-	libvuln_magic
+	libterasic_mtl
+
+.if ${MK_FILE} != "no"
+SUBDIR+= libvuln_magic
+.endif
 
 # XXX: libimagebox should be buildable without CHERI
 .if ${MK_CHERI} != "no"

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -83,7 +83,9 @@ CRUNCH_LIBS+= -lfetch
 # devinfo
 CRUNCH_LIBS+= -ldevinfo
 # usbconfig
+.if ${MK_USB} != "no"
 CRUNCH_LIBS+= -lusb
+.endif
 
 # netstat needs libkvm (which needs libelf)
 CRUNCH_LIBS+= -lkvm -lelf -lmemstat
@@ -322,8 +324,12 @@ CRUNCH_PROGS_usr.sbin+= \
 		tcpdump \
 		traceroute \
 		traceroute6 \
-		usbconfig \
 		watch
+
+.if ${MK_USB} != "no"
+CRUNCH_PROGS_usr.sbin+= \
+		usbconfig
+.endif
 
 
 # Also build mount_smb for QEMU user-mode smb shares:


### PR DESCRIPTION
libvuln_magic: only if MK_FILE

  If we aren't making file and libmagic, don't make libvuln_magic either.

cheribsdbox: honor MK_USB

  Skip crunching libusb and usbconfig if we aren't building with USB

These are necessary to fix cheribuild's cheribsd-minimal target on my
machine (verified by full clean build).