### PR TITLE
First cut at changes to the mbuf allocator to place bounds on m_pages.

### DIFF
--- a/sys/dev/netmap/netmap_freebsd.c
+++ b/sys/dev/netmap/netmap_freebsd.c
@@ -69,6 +69,8 @@
 #include <netinet/in.h>		/* in6_cksum_pseudo() */
 #include <machine/in_cksum.h>  /* in_pseudo(), in_cksum_hdr() */
 
+#include <cheri/cheric.h>
+
 #include <net/netmap.h>
 #include <dev/netmap/netmap_kern.h>
 #include <net/netmap_virt.h>
@@ -440,7 +442,7 @@ nm_os_generic_xmit_frame(struct nm_os_gen_arg *a)
 #else  /* __FreeBSD_version >= 1100000 */
 	/* New FreeBSD versions. Link the external storage to
 	 * the netmap buffer, so that no copy is necessary. */
-	m->m_ext.ext_buf = m->m_data = a->addr;
+	m->m_ext.ext_buf = m->m_data = cheri_csetbounds(a->addr, len);
 	m->m_ext.ext_size = len;
 #endif /* __FreeBSD_version >= 1100000 */
 

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -82,6 +82,7 @@
 #endif
 
 #if defined(__FreeBSD__)
+#include <cheri/cheric.h>
 #include <sys/selinfo.h>
 
 #define likely(x)	__builtin_expect((long)!!(x), 1L)
@@ -2308,6 +2309,7 @@ static int
 void_mbuf_dtor(struct mbuf *m, void *arg1, void *arg2)
 {
 	/* restore original mbuf */
+	/* XXXRW: CHERI -- what length to pass to cheri_csetbounds() here? */
 	m->m_ext.ext_buf = m->m_data = m->m_ext.ext_arg1;
 	m->m_ext.ext_arg1 = NULL;
 	m->m_ext.ext_type = EXT_PACKET;

--- a/sys/kern/kern_mbuf.c
+++ b/sys/kern/kern_mbuf.c
@@ -60,6 +60,8 @@ __FBSDID("$FreeBSD$");
 #include <vm/uma.h>
 #include <vm/uma_dbg.h>
 
+#include <cheri/cheric.h>
+
 /*
  * In FreeBSD, Mbufs and Mbuf Clusters are allocated from UMA
  * Zones.
@@ -717,7 +719,7 @@ mb_ctor_clust(void *mem, int size, void *arg, int how)
 #endif
 	m = (struct mbuf *)arg;
 	if (m != NULL) {
-		m->m_ext.ext_buf = (char *)mem;
+		m->m_ext.ext_buf = cheri_csetbounds((char *)mem, size);
 		m->m_data = m->m_ext.ext_buf;
 		m->m_flags |= M_EXT;
 		m->m_ext.ext_free = NULL;
@@ -1132,7 +1134,7 @@ m_extadd(struct mbuf *mb, char *buf, u_int size, m_ext_free_t freef,
 	KASSERT(type != EXT_CLUSTER, ("%s: EXT_CLUSTER not allowed", __func__));
 
 	mb->m_flags |= (M_EXT | flags);
-	mb->m_ext.ext_buf = buf;
+	mb->m_ext.ext_buf = cheri_csetbounds(buf, size);
 	mb->m_data = mb->m_ext.ext_buf;
 	mb->m_ext.ext_size = size;
 	mb->m_ext.ext_free = freef;

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -60,6 +60,8 @@ __FBSDID("$FreeBSD$");
 #include <vm/vm_object.h>
 #include <vm/vm_pager.h>
 
+#include <cheri/cheric.h>
+
 #define	EXT_FLAG_SYNC		EXT_FLAG_VENDOR1
 #define	EXT_FLAG_NOCACHE	EXT_FLAG_VENDOR2
 
@@ -792,7 +794,8 @@ retry_space:
 			}
 
 			m0 = m_get(M_WAITOK, MT_DATA);
-			m0->m_ext.ext_buf = (char *)sf_buf_kva(sf);
+			m0->m_ext.ext_buf = cheri_csetbounds(
+			    (char *)sf_buf_kva(sf), PAGE_SIZE);
 			m0->m_ext.ext_size = PAGE_SIZE;
 			m0->m_ext.ext_arg1 = sf;
 			m0->m_ext.ext_type = EXT_SFBUF;

--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -45,6 +45,7 @@
 #ifdef WITNESS
 #include <sys/lock.h>
 #endif
+#include <cheri/cheric.h>
 #endif
 
 #ifdef _KERNEL
@@ -690,7 +691,7 @@ m_extaddref(struct mbuf *m, char *buf, u_int size, u_int *ref_cnt,
 
 	atomic_add_int(ref_cnt, 1);
 	m->m_flags |= M_EXT;
-	m->m_ext.ext_buf = buf;
+	m->m_ext.ext_buf = cheri_csetbounds(buf, size);
 	m->m_ext.ext_cnt = ref_cnt;
 	m->m_data = m->m_ext.ext_buf;
 	m->m_ext.ext_size = size;
@@ -742,7 +743,7 @@ m_init(struct mbuf *m, int how, short type, int flags)
 
 	m->m_next = NULL;
 	m->m_nextpkt = NULL;
-	m->m_data = m->m_dat;
+	m->m_data = cheri_csetbounds(m->m_dat, MLEN);
 	m->m_len = 0;
 	m->m_flags = flags;
 	m->m_type = type;
@@ -824,7 +825,7 @@ m_cljset(struct mbuf *m, void *cl, int type)
 		break;
 	}
 
-	m->m_data = m->m_ext.ext_buf = cl;
+	m->m_data = m->m_ext.ext_buf = cheri_csetbounds(cl, size);
 	m->m_ext.ext_free = m->m_ext.ext_arg1 = m->m_ext.ext_arg2 = NULL;
 	m->m_ext.ext_size = size;
 	m->m_ext.ext_type = type;


### PR DESCRIPTION
Use bounds derived from m_dat/m_pktdat (which should ideally be subobject
bounds set automatically by the compiler), pages coming from VM, clusters,
etc.  In one case, relating to netmap, more plumbing is required to find a
suitable bound dynamically.  The kernel boots, and simple loopback pings
and TCP over IPv4 appear to work.