### PR TITLE
Allow unrepresentable sizes in MAP_FIXED with MAP_CHERI_NOSETBOUNDS

### DIFF
--- a/lib/libcheri/libcheri_sandbox_loader.c
+++ b/lib/libcheri/libcheri_sandbox_loader.c
@@ -255,7 +255,7 @@ sandbox_object_load(struct sandbox_class *sbcp, struct sandbox_object *sbop)
 	heaplen = roundup2(sbop->sbo_heaplen, PAGE_SIZE);
 #if CHERICAP_SIZE == 16
 	heaplen_adj = length + heaplen;		/* Requested length. */
-	heaplen_adj = roundup2(heaplen_adj, (1ULL << CHERI_SEAL_ALIGN_SHIFT(heaplen_adj))); /* Aligned len. */
+	heaplen_adj = CHERI_SEALABLE_LENGTH(heaplen_adj); /* Aligned len. */
 	heaplen_adj -= (length + heaplen);	/* Calculate adjustment. */
 	heaplen += heaplen_adj;			/* Apply adjustment. */
 #endif

--- a/sys/compat/cheriabi/cheriabi_mmap.c
+++ b/sys/compat/cheriabi/cheriabi_mmap.c
@@ -228,7 +228,7 @@ cheriabi_mmap(struct thread *td, struct cheriabi_mmap_args *uap)
 		 * precisely representable.
 		 */
 		if (uap->len < PDRSIZE &&
-		    CHERI_ALIGN_SHIFT(uap->len) > PAGE_SHIFT) {
+		    CHERI_REPRESENTABLE_ALIGNMENT(uap->len) > (1UL << PAGE_SHIFT)) {
 			flags &= ~MAP_ALIGNMENT_MASK;
 			flags |= MAP_ALIGNED_CHERI;
 		}
@@ -253,8 +253,8 @@ cheriabi_mmap(struct thread *td, struct cheriabi_mmap_args *uap)
 		 * but upgrading the alignment is always safe and
 		 * we'll catch the length later.
 		 */
-		if ((flags >> MAP_ALIGNMENT_SHIFT) <
-		    CHERI_ALIGN_SHIFT(uap->len)) {
+		if ((1UL << (flags >> MAP_ALIGNMENT_SHIFT)) <
+		    CHERI_REPRESENTABLE_ALIGNMENT(uap->len)) {
 			flags &= ~MAP_ALIGNMENT_MASK;
 			flags |= MAP_ALIGNED_CHERI;
 		}

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -744,7 +744,7 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	struct cheri_signal *csigp;
 	struct trapframe *frame;
 	u_long auxv, stackbase, stacklen;
-	size_t map_base, map_length, text_end, code_end;
+	size_t map_base, map_length, text_end, code_end, code_length;
 #ifdef CHERIABI_LEGACY_SUPPORT
 	size_t data_length;
 #else
@@ -782,7 +782,7 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	/*
 	 * Round the stack down as required to make it representable.
 	 */
-	stacklen = rounddown2(stacklen, 1ULL << CHERI_ALIGN_SHIFT(stacklen));
+	stacklen = rounddown2(stacklen, CHERI_REPRESENTABLE_ALIGNMENT(stacklen));
 	td->td_frame->csp = cheri_capability_build_user_data(
 	    CHERI_CAP_USER_DATA_PERMS, stackbase, stacklen, stacklen);
 
@@ -791,7 +791,7 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	CTASSERT(CHERI_CAP_USER_DATA_BASE == 0);
 	if (imgp->end_addr != 0) {
 		text_end = roundup2(imgp->end_addr,
-		    1ULL << CHERI_SEAL_ALIGN_SHIFT(imgp->end_addr));
+		    CHERI_SEALABLE_ALIGNMENT(imgp->end_addr - imgp->start_addr));
 		/*
 		 * Less confusing rounded up to a page and 256-bit
 		 * requires no other rounding.
@@ -799,19 +799,19 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 		text_end = roundup2(text_end, PAGE_SIZE);
 	} else {
 		text_end = rounddown2(stackbase,
-		    1ULL << CHERI_SEAL_ALIGN_SHIFT(stackbase));
+		    CHERI_SEALABLE_ALIGNMENT(stackbase));
 	}
 	KASSERT(text_end <= stackbase,
 	    ("text_end 0x%zx > stackbase 0x%lx", text_end, stackbase));
 
 	map_base = (text_end == stackbase) ?
 	    CHERI_CAP_USER_MMAP_BASE :
-	    roundup2(text_end, 1ULL << CHERI_ALIGN_SHIFT(stackbase - text_end));
+	    roundup2(text_end, CHERI_REPRESENTABLE_ALIGNMENT(stackbase - text_end));
 	KASSERT(map_base < stackbase,
 	    ("map_base 0x%zx >= stackbase 0x%lx", map_base, stackbase));
 	map_length = stackbase - map_base;
 	map_length = rounddown2(map_length,
-	    1ULL << CHERI_ALIGN_SHIFT(map_length));
+	    CHERI_REPRESENTABLE_ALIGNMENT(map_length));
 	/*
 	 * Use cheri_capability_build_user_rwx so mmap() can return
 	 * appropriate permissions derived from a single capability.
@@ -879,8 +879,10 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	 */
 	code_start = imgp->interp_end ? imgp->reloc_base : 0;
 	/* Ensure CHERI128 representability */
-	code_end = roundup2(code_end, 1ULL << CHERI_ALIGN_SHIFT(code_end));
-	code_start = rounddown2(code_start, 1ULL << CHERI_ALIGN_SHIFT(code_end));
+	code_length = code_end - code_start;
+	code_start = CHERI_REPRESENTABLE_BASE(code_start, code_length);
+	code_length = CHERI_REPRESENTABLE_LENGTH(code_length);
+	code_end = code_start + code_length;
 	frame->pcc = cheri_capability_build_user_code(CHERI_CAP_USER_CODE_PERMS,
 	    code_start, code_end - code_start, imgp->entry_addr - code_start);
 	/* Ensure that frame->pc is the offset of frame->pcc (needed for eret) */
@@ -913,10 +915,10 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	 */
 	if (imgp->reloc_base) {
 		vaddr_t rtld_base = imgp->reloc_base;
-		rtld_base = rounddown2(rtld_base, 1ULL << CHERI_ALIGN_SHIFT(rtld_base));
 		vaddr_t rtld_end = imgp->interp_end ? imgp->interp_end : imgp->end_addr;
 		vaddr_t rtld_len = rtld_end - rtld_base;
-		rtld_len = roundup2(rtld_len, 1ULL << CHERI_ALIGN_SHIFT(rtld_len));
+		rtld_base = CHERI_REPRESENTABLE_BASE(rtld_base, rtld_len);
+		rtld_len = CHERI_REPRESENTABLE_LENGTH(rtld_len);
 		td->td_frame->c4 = cheri_capability_build_user_data(
 		    CHERI_CAP_USER_DATA_PERMS, rtld_base, rtld_len, 0);
 	}

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -365,14 +365,14 @@ kern_mmap_req(struct thread *td, const struct mmap_req *mrp)
 	 */
 	if (align == MAP_ALIGNED_CHERI) {
 		flags &= ~MAP_ALIGNMENT_MASK;
-		if (CHERI_ALIGN_SHIFT(size) > PAGE_SHIFT) {
+		if (CHERI_REPRESENTABLE_ALIGNMENT(size) > (1UL << PAGE_SHIFT)) {
 			flags |= MAP_ALIGNED(CHERI_ALIGN_SHIFT(size));
 
 			if (size & CHERI_ALIGN_MASK(size) &&
 			    cheriabi_mmap_precise_bounds) {
 				SYSERRCAUSE("%s: MAP_ALIGNED_CHERI and size "
 				    "(0x%zx) is insufficently rounded (mask "
-				    "0x%llx)", __func__, size,
+				    "0x%lx)", __func__, size,
 				    CHERI_ALIGN_MASK(size));
 				return (ERANGE);
 			}
@@ -383,19 +383,19 @@ kern_mmap_req(struct thread *td, const struct mmap_req *mrp)
 		align = flags & MAP_ALIGNMENT_MASK;
 	} else if (align == MAP_ALIGNED_CHERI_SEAL) {
 		flags &= ~MAP_ALIGNMENT_MASK;
-		if (CHERI_SEAL_ALIGN_SHIFT(size) > PAGE_SHIFT) {
+		if (CHERI_SEALABLE_ALIGNMENT(size) > (1UL << PAGE_SHIFT)) {
 			flags |= MAP_ALIGNED(CHERI_SEAL_ALIGN_SHIFT(size));
 
-			if (size & CHERI_SEAL_ALIGN_MASK(size) &&
+			if (size != CHERI_SEALABLE_LENGTH(size) &&
 			    cheriabi_mmap_precise_bounds) {
 				SYSERRCAUSE("%s: MAP_ALIGNED_CHERI_SEAL and "
 				    "size (0x%zx) is insufficently rounded "
-				    "(mask 0x%llx)", __func__, size,
+				    "(mask 0x%lx)", __func__, size,
 				    CHERI_SEAL_ALIGN_MASK(size));
 				return (ERANGE);
 			}
 
-			if (CHERI_ALIGN_MASK(size) != 0)
+			if (CHERI_SEAL_ALIGN_MASK(size) != 0)
 				addr_mask = CHERI_SEAL_ALIGN_MASK(size);
 		}
 		align = flags & MAP_ALIGNMENT_MASK;

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -368,8 +368,8 @@ kern_mmap_req(struct thread *td, const struct mmap_req *mrp)
 		if (CHERI_REPRESENTABLE_ALIGNMENT(size) > (1UL << PAGE_SHIFT)) {
 			flags |= MAP_ALIGNED(CHERI_ALIGN_SHIFT(size));
 
-			if (size & CHERI_ALIGN_MASK(size) &&
-			    cheriabi_mmap_precise_bounds) {
+			if (size != CHERI_REPRESENTABLE_LENGTH(size) &&
+			    (cheriabi_mmap_precise_bounds || (flags & MAP_FIXED))) {
 				SYSERRCAUSE("%s: MAP_ALIGNED_CHERI and size "
 				    "(0x%zx) is insufficently rounded (mask "
 				    "0x%lx)", __func__, size,
@@ -387,7 +387,7 @@ kern_mmap_req(struct thread *td, const struct mmap_req *mrp)
 			flags |= MAP_ALIGNED(CHERI_SEAL_ALIGN_SHIFT(size));
 
 			if (size != CHERI_SEALABLE_LENGTH(size) &&
-			    cheriabi_mmap_precise_bounds) {
+			    (cheriabi_mmap_precise_bounds || (flags & MAP_FIXED))) {
 				SYSERRCAUSE("%s: MAP_ALIGNED_CHERI_SEAL and "
 				    "size (0x%zx) is insufficently rounded "
 				    "(mask 0x%lx)", __func__, size,


### PR DESCRIPTION
While touching this code I also converted the old CHERI_ALIGN_SHIFT macros to use the CRAM/CRAP compiler builtins.