### PR TITLE
Fix mmap() after de42c1c4229a0723196bfd0fab3b130ac5b32efe

### DIFF
--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -137,6 +137,10 @@ __morepages(int n)
 		    max_pagepools * sizeof(char *), PROT_READ|PROT_WRITE,
 		    MAP_ANON, fd, 0)) == MAP_FAILED)
 			return (0);
+#ifdef __CHERI_PURE_CAPABILITY__
+		/* Check that the result is writable */
+		assert(cheri_getperm(new_pagepool_list) & CHERI_PERM_STORE);
+#endif
 		memcpy(new_pagepool_list, pagepool_list,
 		    sizeof(char *) * n_pagepools);
 		if (pagepool_list != NULL) {

--- a/sys/compat/cheriabi/cheriabi_mmap.c
+++ b/sys/compat/cheriabi/cheriabi_mmap.c
@@ -378,7 +378,7 @@ cheriabi_mmap_retcap(struct thread *td, vm_offset_t addr,
 {
 	void * __capability newcap;
 	size_t cap_base, cap_len;
-	register_t perms;
+	register_t perms, cap_prot;
 
 	/*
 	 * In the strong case (cheriabi_mmap_setbounds), return the original
@@ -400,11 +400,18 @@ cheriabi_mmap_retcap(struct thread *td, vm_offset_t addr,
 	if (cheriabi_mmap_honor_prot) {
 		perms = cheri_getperm(newcap);
 		/*
+		 * If PROT_MAX() was not passed, use the prot value to derive
+		 * capability permissions.
+		 */
+		cap_prot = PROT_MAX_EXTRACT(mrp->mr_prot);
+		if (cap_prot == 0)
+			cap_prot = PROT_EXTRACT(mrp->mr_prot);
+		/*
 		 * Set the permissions to PROT_MAX to allow a full
 		 * range of access subject to page permissions.
 		 */
 		newcap = cheri_andperm(newcap, ~PERM_RWX |
-		    cheriabi_mmap_prot2perms(PROT_MAX_EXTRACT(mrp->mr_prot)));
+		    cheriabi_mmap_prot2perms(cap_prot));
 	}
 
 	if (mrp->mr_flags & MAP_FIXED) {


### PR DESCRIPTION
After this commit we were no longer using the prot value as the default for
prot_max if no PROT_MAX() flags were passed. This resulted in all CheriABI
mmap() calls return a capability without load/store permissions and caused
crashes in tls_malloc.c.