### PR TITLE
sys/assym: use 8, not 16, bits when smuggling values

### DIFF
--- a/sys/kern/genassym.sh
+++ b/sys/kern/genassym.sh
@@ -12,30 +12,42 @@ work()
 {
 	${NM:='nm'} ${NMFLAGS} "$1" | ${AWK:='awk'} '
 	/ C .*sign$/ {
-		sign = substr($1, length($1) - 3, 4)
+		sign = substr($1, length($1) - 1, 2)
 		sub("^0*", "", sign)
 		if (sign != "")
 			sign = "-"
 	}
-	/ C .*w0$/ {
-		w0 = substr($1, length($1) - 3, 4)
+	/ C .*y0$/ {
+		y0 = substr($1, length($1) - 1, 2)
 	}
-	/ C .*w1$/ {
-		w1 = substr($1, length($1) - 3, 4)
+	/ C .*y1$/ {
+		y1 = substr($1, length($1) - 1, 2)
 	}
-	/ C .*w2$/ {
-		w2 = substr($1, length($1) - 3, 4)
+	/ C .*y2$/ {
+		y2 = substr($1, length($1) - 1, 2)
 	}
-	/ C .*w3$/ {
-		w3 = substr($1, length($1) - 3, 4)
-		w = w3 w2 w1 w0
+	/ C .*y3$/ {
+		y3 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y4$/ {
+		y4 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y5$/ {
+		y5 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y6$/ {
+		y6 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y7$/ {
+		y7 = substr($1, length($1) - 1, 2)
+		w = y7 y6 y5 y4 y3 y2 y1 y0
 		sub("^0*", "", w)
 		if (w == "")
 			w = "0"
 		hex = ""
 		if (w != "0")
 			hex = "0x"
-		sub("w3$", "", $3)
+		sub("y7$", "", $3)
 		# This still has minor problems representing INT_MIN, etc. 
 		# E.g.,
 		# with 32-bit 2''s complement ints, this prints -0x80000000,

--- a/sys/kern/genoffset.sh
+++ b/sys/kern/genoffset.sh
@@ -48,30 +48,42 @@ work()
 		parent = substr($3, match($3, "_parenttype_") + length("_parenttype_"))
 	}
 	/ C .*sign$/ {
-		sign = substr($1, length($1) - 3, 4)
+		sign = substr($1, length($1) - 1, 2)
 		sub("^0*", "", sign)
 		if (sign != "")
 			sign = "-"
 	}
-	/ C .*w0$/ {
-		w0 = substr($1, length($1) - 3, 4)
+	/ C .*y0$/ {
+		y0 = substr($1, length($1) - 1, 2)
 	}
-	/ C .*w1$/ {
-		w1 = substr($1, length($1) - 3, 4)
+	/ C .*y1$/ {
+		y1 = substr($1, length($1) - 1, 2)
 	}
-	/ C .*w2$/ {
-		w2 = substr($1, length($1) - 3, 4)
+	/ C .*y2$/ {
+		y2 = substr($1, length($1) - 1, 2)
 	}
-	/ C .*w3$/ {
-		w3 = substr($1, length($1) - 3, 4)
-		w = w3 w2 w1 w0
+	/ C .*y3$/ {
+		y3 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y4$/ {
+		y4 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y5$/ {
+		y5 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y6$/ {
+		y6 = substr($1, length($1) - 1, 2)
+	}
+	/ C .*y7$/ {
+		y7 = substr($1, length($1) - 1, 2)
+		w = y7 y6 y5 y4 y3 y2 y1 y0
 		sub("^0*", "", w)
 		if (w == "")
 			w = "0"
 		hex = ""
 		if (w != "0")
 			hex = "0x"
-		sub("w3$", "", $3)
+		sub("y7$", "", $3)
 		member = tolower($3)
 		# This still has minor problems representing INT_MIN, etc. 
 		# E.g.,

--- a/sys/sys/assym.h
+++ b/sys/sys/assym.h
@@ -33,16 +33,25 @@
 #ifndef _SYS_ASSYM_H_
 #define	_SYS_ASSYM_H_
 
-#define	ASSYM_BIAS		0x10000	/* avoid zero-length arrays */
+#define	ASSYM_BIAS		0x100	/* avoid zero-length arrays */
 #define	ASSYM_ABS(value)	((value) < 0 ? -((value) + 1) + 1ULL : (value))
 
-#define	ASSYM(name, value)						      \
-char name ## sign[((value) < 0 ? 1 : 0) + ASSYM_BIAS];			      \
-char name ## w0[(ASSYM_ABS(value) & 0xFFFFU) + ASSYM_BIAS];		      \
-char name ## w1[((ASSYM_ABS(value) & 0xFFFF0000UL) >> 16) + ASSYM_BIAS];      \
-char name ## w2[((ASSYM_ABS(value) & 0xFFFF00000000ULL) >> 32) + ASSYM_BIAS]; \
-char name ## w3[((ASSYM_ABS(value) & 0xFFFF000000000000ULL) >> 48) + ASSYM_BIAS]
+/*
+ * The choice of "y" is to ensure that it sorts after "sign" like the "w"
+ * that was once here, when we exported 16 bits at a time, did.  I'm so
+ * sorry you're having to think about this.
+ */
 
+#define	ASSYM(name, value)                                                        \
+char name ## sign[((value) < 0 ? 1 : 0) + ASSYM_BIAS];                            \
+char name ## y0[((ASSYM_ABS(value) & 0x00000000000000FFULL)      ) + ASSYM_BIAS]; \
+char name ## y1[((ASSYM_ABS(value) & 0x000000000000FF00ULL) >>  8) + ASSYM_BIAS]; \
+char name ## y2[((ASSYM_ABS(value) & 0x0000000000FF0000ULL) >> 16) + ASSYM_BIAS]; \
+char name ## y3[((ASSYM_ABS(value) & 0x00000000FF000000ULL) >> 24) + ASSYM_BIAS]; \
+char name ## y4[((ASSYM_ABS(value) & 0x000000FF00000000ULL) >> 32) + ASSYM_BIAS]; \
+char name ## y5[((ASSYM_ABS(value) & 0x0000FF0000000000ULL) >> 40) + ASSYM_BIAS]; \
+char name ## y6[((ASSYM_ABS(value) & 0x00FF000000000000ULL) >> 48) + ASSYM_BIAS]; \
+char name ## y7[((ASSYM_ABS(value) & 0xFF00000000000000ULL) >> 56) + ASSYM_BIAS]
 
 /* char name ## _datatype_ ## STRINGIFY(typeof(((struct parenttype *)(0x0))-> name)) [1]; */
 #ifdef OFFSET_TEST


### PR DESCRIPTION
This is a particularly... unusual dance and it breaks on CHERI.

`sys/assym.h` is used to create object files whose symbols have
structured names and associated values which encode constants available
to the C compiler, for example, the evaluation results of offsetof()
expressions.  Symbols and values can be extracted using `nm`.
`genoffset.sh` contains a pile of awk which inverts the encoding and
generates a C file which can be used to verify that the export was
successful.  `genassym.sh` contains a very similar pile of awk to
generate a #define-ful header file for use with C-preprocessing
assemblers.

The encoding that used to be used was to export 16 bits of the magnitude
of the value at a time, creating four (...{`w0`, `w1`, `w2`, `w3`})
symbols per export, as well as a symbol encoding the sign bit.  The
value of each symbol is, in particular, expressed in C as the length of
a global array.  In order to avoid zero-length arrays, an `ASSYM_BIAS`
value is used; to facilitate later (textual!) processing, this was
chosen to be `0x10000`: masking by `0xFFFF` or, equivalently, slicing
off the last four hex characters of the value suffices to recover the
component of the encoding.

Unfortunately, because the symbols' values are not their length, but
rather an *address*, compiler changes which vary global layout will
break this dance.  CHERI, for example, may pad globals so that no other
globals will occur within the most narrow representable bounds for the
object.  With today's CHERI clang (tested with
2cdaed95cde73d6fddaf5cbfc13edfb197ebfa49) and, presumably, going
forward, attempting to encode 0x158, for example, which results in an
attempt to assign the value 0x10158, instead results in 0x10180.

To work around the issue, switch to encoding byte-by-byte: construct 8
symbols, one for each byte, using an `ASSYM_BIAS` of 0x100.
Correspondingly, adjust the awk script to use two, not four, characters.
This will break if ever CHERI cannot exactly represent objects whose
sizes are in [256, 512).