### PR TITLE
CHERI SMP: Install the correct caps at AP boot, too

### DIFF
--- a/sys/mips/beri/beri_mp.c
+++ b/sys/mips/beri/beri_mp.c
@@ -221,18 +221,9 @@ platform_smp_topo(void)
 void
 platform_init_ap(int cpuid)
 {
-	uint32_t status;
 	u_int clock_int_mask;
 
 	KASSERT(cpuid < MAXCPU, ("%s: invalid CPU id %d", __func__, cpuid));
-
-	/* Make sure coprocessors are enabled. */
-	status = mips_rd_status();
-	status |= (MIPS_SR_COP_0_BIT | MIPS_SR_COP_1_BIT);
-#if defined(CPU_CHERI)
-	status |= MIPS_SR_COP_2_BIT;
-#endif
-	mips_wr_status(status);
 
 #if 0
 	register_t hwrena;

--- a/sys/mips/malta/malta_mp.c
+++ b/sys/mips/malta/malta_mp.c
@@ -190,16 +190,6 @@ platform_init_ap(int cpuid)
 {
 	uint32_t clock_int_mask;
 	uint32_t ipi_intr_mask;
-#if defined(CPU_CHERI)
-	uint32_t status;
-#endif
-
-	/* Make sure capability coprocessor is enabled. */
-#if defined(CPU_CHERI)
-	status = mips_rd_status();
-	status |= MIPS_SR_COP_2_BIT;
-	mips_wr_status(status);
-#endif
 
 	/*
 	 * Clear any pending IPIs.

--- a/sys/mips/mips/locore.S
+++ b/sys/mips/mips/locore.S
@@ -151,59 +151,7 @@ VECTOR(_locore, unknown)
 	COP0_SYNC
 
 #if defined(CPU_CHERI)
-	/*
-	 * Grab the initial omnipotent capability
-	 */
-	cgetdefault	CHERI_REG_C28
-
-	/*
-	 * Create a reduced DDC.
-	 *
-	 * XXX-BD: Actually changing base/length requires changes in
-	 * linkage.
-	 */
-	cmove		CHERI_REG_C27, CHERI_REG_C28
-	REG_LI		t0, CHERI_CAP_KERN_BASE
-	csetoffset	CHERI_REG_C27, CHERI_REG_C27, t0
-	REG_LI		t0, CHERI_CAP_KERN_LENGTH
-	csetbounds	CHERI_REG_C27, CHERI_REG_C27, t0
-	REG_LI		t0, CHERI_PERMS_KERNEL_DATA
-	candperm	CHERI_REG_C27, CHERI_REG_C27, t0
-
-	/* Preserve a copy in KDC for exception handlers. */
-	csetkdc		CHERI_REG_C27
-
-	/* Install the new DDC. */
-	csetdefault	CHERI_REG_C27
-
-	/*
-	 * Create a reduced PCC.
-	 *
-	 * XXX-BD: Actually changing base/length requires changes in
-	 * linkage.
-	 */
-	cgetpcc		CHERI_REG_C27
-	REG_LI		t0, CHERI_CAP_KERN_BASE
-	csetoffset	CHERI_REG_C27, CHERI_REG_C27, t0
-	REG_LI		t0, CHERI_CAP_KERN_LENGTH
-	csetbounds	CHERI_REG_C27, CHERI_REG_C27, t0
-	REG_LI		t0, CHERI_PERMS_KERNEL_CODE
-	candperm	CHERI_REG_C27, CHERI_REG_C27, t0
-
-	/* Preserve a copy in KCC for exception handlers.  */
-
-	csetkcc		CHERI_REG_C27
-
-	/* Install the new PCC. */
-	REG_LI		t0, CHERI_CAP_KERN_BASE
-	cgetpcc		CHERI_REG_C29
-	cgetoffset	t1, CHERI_REG_C29			# 1
-	PTR_SUBU	t1, t1, t0				# 2
-	PTR_ADDIU	t1, t1, (4 * 7)				# 3
-	csetoffset	CHERI_REG_C27, CHERI_REG_C27, t1	# 4
-	cjr		CHERI_REG_C27				# 5
-	nop							# 6
-	# 7 (land here)
+	CHERI_LOCORE_ROOT_CAPS
 
 	/*
 	 * Create the parent kernel sealing capablity.

--- a/sys/mips/mips/mpboot.S
+++ b/sys/mips/mips/mpboot.S
@@ -30,6 +30,12 @@
 #include <machine/cpu.h>
 #include <machine/cpuregs.h>
 
+#if defined(CPU_CHERI)
+#include <machine/cheriasm.h>
+#include <machine/cherireg.h>
+.set cheri_sysregs_accessible	# Don't warn about uses of c27-c30
+#endif
+
 #include "assym.inc"
 
 	.text
@@ -59,9 +65,37 @@ GLOBAL(mpentry)
 
 	mtc0	zero, MIPS_COP_0_CAUSE	/* clear soft interrupts */
 
+	/* Turn on all coprocessors */
+	mfc0	t2, MIPS_COP_0_STATUS
+#if defined(CPU_BERI)
+#  if defined(CPU_CHERI)
+	li	t0, MIPS_SR_COP_0_BIT | MIPS_SR_COP_1_BIT | MIPS_SR_COP_2_BIT
+#  else
+	li	t0, MIPS_SR_COP_0_BIT | MIPS_SR_COP_1_BIT
+#  endif
+#elif defined(CPU_MALTA)
+#  if defined(CPU_CHERI)
+	li	t0, MIPS_SR_COP_0_BIT | MIPS_SR_COP_2_BIT
+#  else
+	li	t0, MIPS_SR_COP_0_BIT
+#  endif
+#else
+	li	t0, MIPS_SR_COP_0_BIT
+#endif
+	or	t0, t0, t2
+	mtc0	t0, MIPS_COP_0_STATUS
+	COP0_SYNC
+
 	li	t0, MIPS_CCA_CACHED	/* make sure kseg0 is cached */
 	mtc0	t0, MIPS_COP_0_CONFIG
 	COP0_SYNC
+
+#if defined(CPU_CHERI)
+	CHERI_LOCORE_ROOT_CAPS
+
+	cmove CHERI_REG_C27, $cnull
+	cmove CHERI_REG_C28, $cnull
+#endif
 
 	PTR_LA	t9, platform_processor_id	/* get the processor number */
 	jalr	t9


### PR DESCRIPTION
* Factor some very early boot code from locore.S to cheriasm.h and use
  it in mpboot.S too.

* Move coprocessor initialization from platform_init_ap in beri_mp.c and
  malta.c to mpboot.S.

Tests OK on CHERI BERI (DE4-multi-2) and CHERI Malta (options SMP & qemu
-smp 2).

Profuse thanks to Jonathan Woodruff, Ruslan Bukin, and Robert Watson.
I just push buttons; they figured out which ones needed to be pushed.