### PR TITLE
Correctly initialize iovec lengths in kern_jail().

### DIFF
--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -372,7 +372,7 @@ kern_jail(struct thread *td, const char * __capability path,
 	optstr = "path";
 	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
-	error = copyinstr(path, u_path, MAXPATHLEN, NULL);
+	error = copyinstr(path, u_path, MAXPATHLEN, &tmplen);
 	if (error)
 		goto done;
 	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_path, tmplen);
@@ -381,7 +381,7 @@ kern_jail(struct thread *td, const char * __capability path,
 	optstr = "host.hostname";
 	IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 	opt.uio_iovcnt++;
-	error = copyinstr(hostname, u_hostname, MAXHOSTNAMELEN, NULL);
+	error = copyinstr(hostname, u_hostname, MAXHOSTNAMELEN, &tmplen);
 	if (error)
 		goto done;
 	IOVEC_INIT(&optiov[opt.uio_iovcnt], u_hostname, tmplen);
@@ -391,7 +391,7 @@ kern_jail(struct thread *td, const char * __capability path,
 		optstr = "name";
 		IOVEC_INIT_STR(&optiov[opt.uio_iovcnt], optstr);
 		opt.uio_iovcnt++;
-		error = copyinstr(jailname, u_name, MAXHOSTNAMELEN, NULL);
+		error = copyinstr(jailname, u_name, MAXHOSTNAMELEN, &tmplen);
 		if (error)
 			goto done;
 		IOVEC_INIT(&optiov[opt.uio_iovcnt], u_name, tmplen);


### PR DESCRIPTION
iovec objects referencing a path, a jailname and a hostname used the same
invalid length, a number of bytes allocated to store copied in strings and
addresses passed to the jail system call.

This bug resulted in invalid memory access in kern_jail_set() that is called
from kern_jail(). When not exploited, the jail system call usually returned
EINVAL or ENAMETOOLONG due to incorrectly terminated strings, according to their
invalid lengths.

Note that FreeBSD does not include this bug. It was introduced with
IOVEC_INIT*() macros in CheriBSD.