### PR TITLE
Change td_retval[] to an array of syscallarg_t and retire td_retcap.

### DIFF
--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -1220,19 +1220,6 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 		if (psr->sr_error == 0) {
 			psr->sr_retval[0] = td2->td_retval[0];
 			psr->sr_retval[1] = td2->td_retval[1];
-#if __has_feature(capabilities)
-			/* XXX: Gross hack. */
-			if (SV_PROC_FLAG(td2->td_proc, SV_CHERI)) {
-				switch (td2->td_sa.code) {
-				case SYS_mmap:
-				case SYS_shmat:
-					psr->sr_retval[0] =
-					    (uintcap_t)td2->td_retcap;
-					psr->sr_retval[1] = 0;
-					break;
-				}
-			}
-#endif
 		}
 #if __has_feature(capabilities)
 		if (wrap64)

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -586,7 +586,8 @@ kern_shmat_locked(struct thread *td, int shmid,
 			    CHERI_REPRESENTABLE_LENGTH(shmseg->u.shm_segsz));
 		}
 		/* XXX: set perms */
-		td->td_retcap = __DECONST_CAP(void * __capability, shmaddr);
+		td->td_retval[0] = (uintcap_t)__DECONST_CAP(void * __capability,
+		    shmaddr);
 	} else
 #endif
 		td->td_retval[0] = attach_va;

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -287,7 +287,6 @@ cheriabi_fetch_syscall_args(struct thread *td)
 
 	td->td_retval[0] = 0;
 	td->td_retval[1] = locr0->v1;
-	td->td_retcap = locr0->c3;
 
 	return (error);
 }
@@ -317,7 +316,7 @@ cheriabi_set_syscall_retval(struct thread *td, int error)
 	switch (error) {
 	case 0:
 		KASSERT(error != 0 ||
-		    td->td_retcap == locr0->c3 || td->td_retcap == NULL ||
+		    cheri_gettag((void * __capability)td->td_retval[0]) == 0 ||
 		    code == CHERIABI_SYS_cheriabi_mmap ||
 		    code == CHERIABI_SYS_cheriabi_shmat,
 		    ("trying to return capability from integer returning "
@@ -325,7 +324,7 @@ cheriabi_set_syscall_retval(struct thread *td, int error)
 
 		locr0->v0 = td->td_retval[0];
 		locr0->v1 = td->td_retval[1];
-		locr0->c3 = td->td_retcap;
+		locr0->c3 = (void * __capability)td->td_retval[0];
 		locr0->a3 = 0;
 		break;
 
@@ -737,14 +736,6 @@ cheriabi_exec_setregs(struct thread *td, struct image_params *imgp, u_long stack
 	/* const bool is_rtld_direct_exec = imgp->reloc_base == imgp->start_addr; */
 
 	bzero((caddr_t)td->td_frame, sizeof(struct trapframe));
-	/*
-	 * Ensure we don't have an old retcap value laying around.  In
-	 * principle we won't ever return it wrongly, but better safe
-	 * then sorry.
-	 *
-	 * XXXBD: This doesn't feel like the right place to do this...
-	 */
-	td->td_retcap = NULL;
 
 	KASSERT(stack % sizeof(void * __capability) == 0,
 	    ("CheriABI stack pointer not properly aligned"));

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -657,9 +657,6 @@ cpu_fetch_syscall_args(struct thread *td)
 	if (error == 0) {
 		td->td_retval[0] = 0;
 		td->td_retval[1] = locr0->v1;
-#ifdef CPU_CHERI
-		td->td_retcap = locr0->c3;
-#endif
 	}
 
 	return (error);

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -310,9 +310,6 @@ struct thread {
 	int		td_errno;	/* (k) Error from last syscall. */
 	size_t		td_vslock_sz;	/* (k) amount of vslock-ed space */
 	struct kcov_info *td_kcov_info;	/* (*) Kernel code coverage data */
-#if __has_feature(capabilities)
-	void * __capability	td_retcap; /* (k) Syscall cap return . */
-#endif
 #define	td_endzero td_sigmask
 
 /* Copied during fork1() or create_thread(). */
@@ -345,8 +342,12 @@ struct thread {
 		TDS_RUNNING
 	} td_state;			/* (t) thread state */
 	union {
-		register_t	tdu_retval[2];
+		syscallarg_t	tdu_retval[2];
+#if __has_feature(capabilities)
+#define	tdu_off tdu_retval[0]
+#else
 		off_t		tdu_off;
+#endif
 	} td_uretoff;			/* (k) Syscall aux returns. */
 #define td_retval	td_uretoff.tdu_retval
 	u_int		td_cowgen;	/* (k) Generation of COW pointers. */

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -579,11 +579,11 @@ kern_mmap_req(struct thread *td, const struct mmap_req *mrp)
 	if (error == 0) {
 #ifdef COMPAT_CHERIABI
 		if (SV_CURPROC_FLAG(SV_CHERI))
-			td->td_retcap = cheriabi_mmap_retcap(td,
+			td->td_retval[0] = (uintcap_t)cheriabi_mmap_retcap(td,
 			    addr + pageoff,  mrp);
-		/* Unconditionaly return the VA in td_retval[0] for ktrace */
+		else
 #endif
-		td->td_retval[0] = (register_t) (addr + pageoff);
+			td->td_retval[0] = (syscallarg_t)(addr + pageoff);
 	}
 done:
 	if (fp)


### PR DESCRIPTION
$c3 on MIPS is not call-safe, so it's ok if it gets overwritten with the
scalar value for syscalls returning integers.  v0 and c3 now always both
hold the first return value on return from all system calls.  This removes
the need for a hack in PT_SC_GET_RET.  tdu_retoff requires somewhat special
handling as the simple union case does not work for MIPS.