### PR TITLE
Trim some code from cheriabi_set_syscall_retval.

### DIFF
--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -293,32 +293,14 @@ static void
 cheriabi_set_syscall_retval(struct thread *td, int error)
 {
 	struct trapframe *locr0 = td->td_frame;
-#ifdef INVARIANTS
-	unsigned int code;
-	struct sysentvec *se;
-
-	code = locr0->v0;
-	if (code == SYS_syscall || code == SYS___syscall)
-		code = locr0->a0;
-
-	se = td->td_proc->p_sysent;
-	/*
-	 * When programs start up, they pass through the return path
-	 * (maybe via execve?).  When this happens, code is an absurd
-	 * and out of range value.
-	 */
-	if (code > se->sv_size)
-		code = 0;
-#endif
 
 	switch (error) {
 	case 0:
-		KASSERT(error != 0 ||
-		    cheri_gettag((void * __capability)td->td_retval[0]) == 0 ||
-		    code == CHERIABI_SYS_cheriabi_mmap ||
-		    code == CHERIABI_SYS_cheriabi_shmat,
+		KASSERT(cheri_gettag((void * __capability)td->td_retval[0]) == 0 ||
+		    td->td_sa.code == CHERIABI_SYS_cheriabi_mmap ||
+		    td->td_sa.code == CHERIABI_SYS_cheriabi_shmat,
 		    ("trying to return capability from integer returning "
-		    "syscall (%u)", code));
+		    "syscall (%u)", td->td_sa.code));
 
 		locr0->v0 = td->td_retval[0];
 		locr0->v1 = td->td_retval[1];


### PR DESCRIPTION
- Use td_sa to reliably read the current system call code.
  td_sa didn't exist when this code was first written, but it does
  now and simpifies this code greatly.
- Remove an always-true condition from an assertion.