### PR TITLE
sys/mips: Use call site for symbol name/offset when unwinding

### DIFF
--- a/sys/mips/mips/db_trace.c
+++ b/sys/mips/mips/db_trace.c
@@ -210,7 +210,7 @@ loop:
 	 * subroutine.
 	 */
 	if (!subr) {
-		va = pc - sizeof(int);
+		va = pc;
 		while (1) {
 			instr = kdbpeek((int *)va);
 
@@ -421,10 +421,15 @@ done:
 		    (uintmax_t)cause, (uintmax_t)badvaddr);
 		goto loop;
 	} else if (ra) {
-		if (pc == ra && stksize == 0)
+		/*
+		 * We subtract two instructions from ra to convert it from a return
+		 * address to a calling address, accounting for the delay slot.
+		 */
+		register_t next_pc = ra - 2 * sizeof(int);
+		if (pc == next_pc && stksize == 0)
 			db_printf("stacktrace: loop!\n");
 		else {
-			pc = ra;
+			pc = next_pc;
 			sp += stksize;
 			ra = next_ra;
 			goto loop;


### PR DESCRIPTION
Currently we use the return address, which will normally just give an
output that's off by 8 from the actual call site. However, for tail
calls, this is particularly bad, as we end up printing the symbol name
for the function that comes after the one that made the call. Instead we
should go back two instructions from the return address for the unwound
program counter.