### PR TITLE
Retire CHERI_CC and related variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,6 @@ CHERI_FLAGS=	-DDB_FROM_SRC \
 		LOCAL_DIRS="ctsrd tools/tools/atsectl" \
 		LOCAL_LIB_DIRS=ctsrd/lib \
 		LOCAL_MTREE=ctsrd/ctsrd.mtree
-.if !defined(CHERI_CC) && defined(XCC)
-CHERI_CC=	${XCC}
-.endif
 .if ${CHERI} == "128"
 CHERI_FLAGS+=	-DWITH_CHERI128
 .elif ${CHERI} == "256" || ${CHERI} == "1"

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -849,10 +849,6 @@ WMAKEENV=	${CROSSENV} \
 		PATH=${TMPPATH} \
 		SYSROOT=${WORLDTMP}
 
-.if defined(CHERI_CC)
-WMAKEENV+=	CHERI_CC=${CHERI_CC:Q} CHERI_CXX=${CHERI_CXX:Q}
-.endif
-
 # make hierarchy
 HMAKE=		PATH=${TMPPATH} ${MAKE} LOCAL_MTREE=${LOCAL_MTREE:Q}
 .if defined(NO_ROOT)
@@ -1006,8 +1002,7 @@ LIBCHERIWMAKEENV= \
 		LIBDIR=/usr/libcheri \
 		SHLIBDIR=/usr/libcheri \
 		TESTSBASE=${LIBCHERI_TESTSBASE} \
-		CC="${CHERI_CC}" \
-		LD=${CHERI_LD:U${XLD}} \
+		CC="${XCC}" CXX="${XCXX}" CPP="${XCPP}" \
 		BUILD_TOOLS_CC="env PATH=${PATH}:/usr/bin:/bin ${COMPILER_ABSOLUTE_PATH}" \
 		AS="${XAS}" AR="${XAR}" LD="${XLD}" LLVM_LINK="${XLLVM_LINK}" \
 		NM=${XNM} OBJCOPY="${XOBJCOPY}" \
@@ -1449,8 +1444,6 @@ buildcheri:
 	${_+_}cd ${.CURDIR}; ${LIBCHERIWMAKE} -f Makefile.inc1 _buildcheri_impl
 
 _buildcheri_impl:
-	@echo CHERI_CC=${CHERI_CC}, COMPILER_TYPE=${COMPILER_TYPE} \
-		COMPILER_VERSION=${COMPILER_VERSION} "COMPILER_FEATURES=${COMPILER_FEATURES}"
 .for _lib in ${_cheri_libs}
 	${_+_}@${ECHODIR} "===> ${_lib} (obj,all,install)"; \
 		cd ${.CURDIR}/${_lib} && \

--- a/share/mk/bsd.cheri.mk
+++ b/share/mk/bsd.cheri.mk
@@ -75,27 +75,6 @@ CFLAGS+=	-mstack-alignment=16
 .endif # MIPS, not hybrid (adjust stack alignment)
 
 .if ${MK_CHERI} != "no" && defined(WANT_CHERI) && ${WANT_CHERI} != "none"
-.if !defined(CHERI_CC)
-.error CHERI is enabled and request, but CHERI_CC is undefined
-.endif
-.if !exists(${CHERI_CC})
-.error CHERI_CC is defined to ${CHERI_CC} which does not exist
-.endif
-
-.if !defined(CHERI_CPP) || empty(CHERI_CPP)
-CHERI_CPP=${CHERI_CC:H}/${CHERI_CC:T:S/clang/clang-cpp/}
-.endif
-.if !exists(${CHERI_CPP})
-.error CHERI_CPP is defined to ${CHERI_CPP} which does not exist
-.endif
-
-.if !defined(CHERI_CXX) || empty(CHERI_CXX)
-CHERI_CXX=${CHERI_CC:H}/${CHERI_CC:T:S/clang/clang++/}
-.endif
-.if !exists(${CHERI_CXX})
-.error CHERI_CXX is defined to ${CHERI_CXX} which does not exist
-.endif
-
 _CHERI_COMMON_FLAGS=	-integrated-as --target=cheri-unknown-freebsd \
 			-msoft-float \
 			-cheri-uintcap=${CHERI_UINTCAP_MODE:Uoffset}
@@ -104,13 +83,13 @@ _CHERI_COMMON_FLAGS=	-integrated-as --target=cheri-unknown-freebsd \
 .if defined(__BSD_PROG_MK)
 NO_SHARED=yes
 .endif
-_CHERI_CC=		AFL_PATH=${CHERI_CC:H}/../afl/usr/local/lib/afl/ ${CHERI_CC:H}/../afl/usr/local/bin/afl-clang-fast ${_CHERI_COMMON_FLAGS}
-_CHERI_CXX=		AFL_PATH=${CHERI_CC:H}/../afl/usr/local/lib/afl/ ${CHERI_CXX:H}/../afl/usr/local/bin/afl-clang-fast++ ${_CHERI_COMMON_FLAGS}
+_CHERI_CC=		AFL_PATH=${CC:H}/../afl/usr/local/lib/afl/ ${CC:H}/../afl/usr/local/bin/afl-clang-fast ${_CHERI_COMMON_FLAGS}
+_CHERI_CXX=		AFL_PATH=${CC:H}/../afl/usr/local/lib/afl/ ${CXX:H}/../afl/usr/local/bin/afl-clang-fast++ ${_CHERI_COMMON_FLAGS}
 .else
-_CHERI_CC=		${CHERI_CC} ${_CHERI_COMMON_FLAGS}
-_CHERI_CXX=		${CHERI_CXX} ${_CHERI_COMMON_FLAGS}
+_CHERI_CC=		${CC} ${_CHERI_COMMON_FLAGS}
+_CHERI_CXX=		${CXX} ${_CHERI_COMMON_FLAGS}
 .endif
-_CHERI_CPP=		${CHERI_CPP} ${_CHERI_COMMON_FLAGS}
+_CHERI_CPP=		${CPP} ${_CHERI_COMMON_FLAGS}
 
 .if defined(CHERI_SUBOBJECT_BOUNDS)
 # Allow per-subdirectory overrides if we know that there is maximum that works
@@ -201,7 +180,6 @@ NO_SHARED=	yes
 CC:=	${_CHERI_CC}
 CXX:=   ${_CHERI_CXX}
 CPP:=	${_CHERI_CPP}
-COMPILER_TYPE=	clang
 CFLAGS+=	${_CHERI_CFLAGS}
 CXXFLAGS+=	${_CHERI_CFLAGS}
 # XXXAR: leave this for a while until everyone has updated clang to

--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -138,10 +138,6 @@ _cc_vars=CC $${_empty_var_}
 # makefiles can save a noticeable amount of time when walking the whole source
 # tree (e.g. during make includes, etc.).
 _cc_vars+=XCC X_
-# Also get version information from CHERI_CC (if it is set)
-.ifdef CHERI_CC
-_cc_vars+=CHERI_CC CHERI_
-.endif
 .endif
 
 .for cc X_ in ${_cc_vars}

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -178,8 +178,6 @@ CFLAGS		+=	-fno-strict-aliasing
 IR_CFLAGS	?=	${STATIC_CFLAGS:N-O*} ${CFLAGS:N-O*}
 PO_CFLAGS	?=	${CFLAGS}
 
-CHERI_CC	?=	/usr/local/bin/cheri-unknown-freebsd-clang
-
 # cp(1) is used to copy source files to ${.OBJDIR}, make sure it can handle
 # read-only files as non-root by passing -f.
 CP		?=	cp -f


### PR DESCRIPTION
Going forward a CHERI capable toolchain will also be able to build
and link the matching non-CHERI bits.