### PR TITLE
Remove [ku]iovec_t and related typedefs.

### DIFF
--- a/sys/amd64/amd64/mem.c
+++ b/sys/amd64/amd64/mem.c
@@ -238,14 +238,3 @@ memioctl(struct cdev *dev __unused, u_long cmd, caddr_t data, int flags,
 	}
 	return (error);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ],
-//   "change_comment": "",
-//   "hybrid_specific": false
-// }
-// CHERI CHANGES END

--- a/sys/amd64/amd64/mem.c
+++ b/sys/amd64/amd64/mem.c
@@ -79,7 +79,7 @@ MALLOC_DEFINE(M_MEMDESC, "memdesc", "memory range descriptors");
 int
 memrw(struct cdev *dev, struct uio *uio, int flags)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *p;
 	ssize_t orig_resid;
 	u_long v, vd;

--- a/sys/amd64/amd64/uio_machdep.c
+++ b/sys/amd64/amd64/uio_machdep.c
@@ -133,11 +133,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/amd64/amd64/uio_machdep.c
+++ b/sys/amd64/amd64/uio_machdep.c
@@ -61,7 +61,7 @@ int
 uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset, vaddr;
 	size_t cnt;

--- a/sys/amd64/linux32/linux32_machdep.c
+++ b/sys/amd64/linux32/linux32_machdep.c
@@ -148,7 +148,7 @@ int
 linux32_copyinuio(struct l_iovec32 *iovp, l_ulong iovcnt, struct uio **uiop)
 {
 	struct l_iovec32 iov32;
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct uio *uio;
 	uint32_t iovlen;
 	int error, i;
@@ -156,9 +156,9 @@ linux32_copyinuio(struct l_iovec32 *iovp, l_ulong iovcnt, struct uio **uiop)
 	*uiop = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	uio = malloc(iovlen + sizeof(*uio), M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin(&iovp[i], &iov32, sizeof(struct l_iovec32));
 		if (error) {
@@ -185,18 +185,18 @@ linux32_copyinuio(struct l_iovec32 *iovp, l_ulong iovcnt, struct uio **uiop)
 }
 
 int
-linux32_copyiniov(struct l_iovec32 *iovp32, l_ulong iovcnt, kiovec_t **iovp,
+linux32_copyiniov(struct l_iovec32 *iovp32, l_ulong iovcnt, struct iovec **iovp,
     int error)
 {
 	struct l_iovec32 iov32;
-	kiovec_t *iov;
+	struct iovec *iov;
 	uint32_t iovlen;
 	int i;
 
 	*iovp = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (error);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	iov = malloc(iovlen, M_IOV, M_WAITOK);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin(&iovp32[i], &iov32, sizeof(struct l_iovec32));

--- a/sys/amd64/linux32/linux32_machdep.c
+++ b/sys/amd64/linux32/linux32_machdep.c
@@ -782,11 +782,10 @@ DEFINE_IFUNC(, int, futex_xorl, (int, uint32_t *, int *))
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180912,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/amd64/vmm/vmm_instruction_emul.c
+++ b/sys/amd64/vmm/vmm_instruction_emul.c
@@ -756,7 +756,7 @@ emulate_movs(void *vm, int vcpuid, uint64_t gpa, struct vie *vie,
 #ifdef _KERNEL
 	struct vm_copyinfo copyinfo[2];
 #else
-	kiovec_t copyinfo[2];
+	struct iovec copyinfo[2];
 #endif
 	uint64_t dstaddr, srcaddr, dstgpa, srcgpa, val;
 	uint64_t rcx, rdi, rsi, rflags;
@@ -1429,7 +1429,7 @@ emulate_stack_op(void *vm, int vcpuid, uint64_t mmio_gpa, struct vie *vie,
 #ifdef _KERNEL
 	struct vm_copyinfo copyinfo[2];
 #else
-	kiovec_t copyinfo[2];
+	struct iovec copyinfo[2];
 #endif
 	struct seg_desc ss_desc;
 	uint64_t cr0, rflags, rsp, stack_gla, val;

--- a/sys/amd64/vmm/vmm_instruction_emul.c
+++ b/sys/amd64/vmm/vmm_instruction_emul.c
@@ -2739,12 +2739,3 @@ vmm_decode_instruction(struct vm *vm, int cpuid, uint64_t gla,
 	return (0);
 }
 #endif	/* _KERNEL */
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/arm/arm/mem.c
+++ b/sys/arm/arm/mem.c
@@ -172,12 +172,3 @@ memmmap(struct cdev *dev, vm_ooffset_t offset, vm_paddr_t *paddr,
 	}
 	return (-1);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/arm/arm/mem.c
+++ b/sys/arm/arm/mem.c
@@ -87,7 +87,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 {
 	int o;
 	u_int c = 0, v;
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error = 0;
 	vm_offset_t addr, eaddr;
 

--- a/sys/arm/arm/uio_machdep.c
+++ b/sys/arm/arm/uio_machdep.c
@@ -62,7 +62,7 @@ int
 uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset;
 	size_t cnt;

--- a/sys/arm/arm/uio_machdep.c
+++ b/sys/arm/arm/uio_machdep.c
@@ -125,11 +125,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -48,7 +48,7 @@ struct mem_range_softc mem_range_softc;
 int
 memrw(struct cdev *dev, struct uio *uio, int flags)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct vm_page m;
 	vm_page_t marr;
 	vm_offset_t off, v;

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -129,12 +129,3 @@ memmmap(struct cdev *dev, vm_ooffset_t offset, vm_paddr_t *paddr,
 	}
 	return (-1);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -59,7 +59,7 @@ int
 uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct thread *td = curthread;
-	kiovec_t iovec *iov;
+	struct iovec iovec *iov;
 	void *cp;
 	vm_offset_t page_offset, vaddr;
 	size_t cnt;

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -133,11 +133,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cam/ctl/ctl_backend_block.c
+++ b/sys/cam/ctl/ctl_backend_block.c
@@ -2897,11 +2897,10 @@ ctl_be_block_shutdown(void)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cam/ctl/ctl_backend_block.c
+++ b/sys/cam/ctl/ctl_backend_block.c
@@ -200,7 +200,7 @@ static struct ctl_be_block_softc backend_block_softc;
 struct ctl_be_block_io {
 	union ctl_io			*io;
 	struct ctl_sg_entry		sg_segs[CTLBLK_MAX_SEGS];
-	kiovec_t			xiovecs[CTLBLK_MAX_SEGS];
+	struct iovec			xiovecs[CTLBLK_MAX_SEGS];
 	int				bio_cmd;
 	int				num_segs;
 	int				num_bios_sent;
@@ -628,7 +628,7 @@ ctl_be_block_dispatch_file(struct ctl_be_block_lun *be_lun,
 	struct ctl_be_block_filedata *file_data;
 	union ctl_io *io;
 	struct uio xuio;
-	kiovec_t *xiovec;
+	struct iovec *xiovec;
 	size_t s;
 	int error, flags, i;
 
@@ -859,7 +859,7 @@ ctl_be_block_dispatch_zvol(struct ctl_be_block_lun *be_lun,
 	struct cdevsw *csw;
 	struct cdev *dev;
 	struct uio xuio;
-	kiovec_t *xiovec;
+	struct iovec *xiovec;
 	int error, flags, i, ref;
 
 	DPRINTF("entered\n");

--- a/sys/cam/ctl/ctl_ha.c
+++ b/sys/cam/ctl/ctl_ha.c
@@ -1006,11 +1006,10 @@ ctl_ha_msg_destroy(struct ctl_softc *ctl_softc)
 };
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cam/ctl/ctl_ha.c
+++ b/sys/cam/ctl/ctl_ha.c
@@ -273,7 +273,7 @@ ctl_ha_rx_thread(void *arg)
 	struct socket *so = softc->ha_so;
 	struct ha_msg_wire wire_hdr;
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	int error, flags, next;
 
 	bzero(&wire_hdr, sizeof(wire_hdr));
@@ -698,7 +698,7 @@ ctl_ha_msg_recv(ctl_ha_channel channel, void *addr, size_t len,
 {
 	struct ha_softc *softc = &ha_softc;
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	int error, flags;
 
 	if (!softc->ha_connected)

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
@@ -209,11 +209,10 @@ kobj_close_file(struct _buf *file)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
@@ -155,7 +155,7 @@ kobj_read_file_vnode(struct _buf *file, char *buf, unsigned size, unsigned off)
 	struct vnode *vp = file->ptr;
 	struct thread *td = curthread;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error;
 
 	bzero(&aiov, sizeof(aiov));

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_uio.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_uio.c
@@ -51,7 +51,7 @@
 int
 uiocopy(void *p, size_t n, enum uio_rw rw, struct uio *uio, size_t *cbytes)
 {
-	kiovec_t small_iovec[1];
+	struct iovec small_iovec[1];
 	struct uio small_uio_clone;
 	struct uio *uio_clone;
 	int error;

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_uio.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_uio.c
@@ -90,12 +90,3 @@ uioskip(uio_t *uio, size_t n)
 	uiomove(NULL, n, uio->uio_rw, uio);
 	uio->uio_segflg = segflg;
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu.c
@@ -1248,7 +1248,7 @@ dmu_xuio_fini(xuio_t *xuio)
 int
 dmu_xuio_add(xuio_t *xuio, arc_buf_t *abuf, offset_t off, size_t n)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	uio_t *uio = &xuio->xu_uio;
 	dmu_xuio_t *priv = XUIO_XUZC_PRIV(xuio);
 	int i = priv->next++;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu.c
@@ -2704,11 +2704,10 @@ dmu_fini(void)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191026,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
@@ -52,7 +52,7 @@ static int
 write_bytes(struct diffarg *da)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 
 	IOVEC_INIT_OBJ(&aiov, da->da_ddr);
 	auio.uio_iov = &aiov;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_diff.c
@@ -250,11 +250,10 @@ dmu_diff(const char *tosnap_name, const char *fromsnap_name,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_send.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_send.c
@@ -3457,11 +3457,10 @@ dmu_objset_is_receiving(objset_t *os)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_send.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/dmu_send.c
@@ -111,7 +111,7 @@ dump_bytes(dmu_sendarg_t *dsp, void *buf, int len)
 {
 	dsl_dataset_t *ds = dmu_objset_ds(dsp->dsa_os);
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 
 	/*
 	 * The code does not rely on this (len being a multiple of 8).  We keep

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
@@ -6019,11 +6019,10 @@ struct vop_vector zfs_shareops = {
 };
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
@@ -5669,7 +5669,7 @@ vop_listextattr {
 	char attrprefix[16];
 	u_char dirbuf[sizeof(struct dirent)];
 	struct dirent *dp;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio, *uio = ap->a_uio;
 	size_t *sizep = ap->a_size;
 	size_t plen;

--- a/sys/compat/cheriabi/cheriabi_misc.c
+++ b/sys/compat/cheriabi/cheriabi_misc.c
@@ -267,7 +267,7 @@ int
 cheriabi_copyinuio(struct iovec_c * __capability iovp, u_int iovcnt,
     struct uio **uiop)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct uio *uio;
 	size_t iovlen;
 	int error, i;
@@ -275,9 +275,9 @@ cheriabi_copyinuio(struct iovec_c * __capability iovp, u_int iovcnt,
 	*uiop = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	uio = malloc(iovlen + sizeof(*uio), M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 	error = copyincap(iovp, iov, iovlen);
 	if (error) {
 		free(uio, M_IOV);
@@ -301,15 +301,15 @@ cheriabi_copyinuio(struct iovec_c * __capability iovp, u_int iovcnt,
 
 int
 cheriabi_copyiniov(struct iovec_c * __capability iovp_c, u_int iovcnt,
-    kiovec_t **iovp, int error)
+    struct iovec **iovp, int error)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	u_int iovlen;
 
 	*iovp = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (error);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	iov = malloc(iovlen, M_IOV, M_WAITOK);
 	error = copyincap(iovp_c, iov, iovlen);
 	if (error) {
@@ -322,7 +322,7 @@ cheriabi_copyiniov(struct iovec_c * __capability iovp_c, u_int iovcnt,
 
 static int
 cheriabi_copyin_hdtr(const struct sf_hdtr_c * __capability uhdtr,
-    ksf_hdtr_t *hdtr)
+    struct sf_hdtr *hdtr)
 {
 
 	return(copyincap(uhdtr, hdtr, sizeof(*hdtr)));

--- a/sys/compat/cheriabi/cheriabi_misc.c
+++ b/sys/compat/cheriabi/cheriabi_misc.c
@@ -123,8 +123,8 @@ __FBSDID("$FreeBSD$");
 #include <compat/cheriabi/cheriabi_util.h>
 #if 0
 #include <compat/cheriabi/cheriabi_ipc.h>
-#include <compat/cheriabi/cheriabi_misc.h>
 #endif
+#include <compat/cheriabi/cheriabi_misc.h>
 #include <compat/cheriabi/cheriabi_signal.h>
 #include <compat/cheriabi/cheriabi_proto.h>
 #include <compat/cheriabi/cheriabi_syscall.h>
@@ -132,6 +132,13 @@ __FBSDID("$FreeBSD$");
 MALLOC_DECLARE(M_KQUEUE);
 
 FEATURE(compat_cheri_abi, "Compatible CHERI system call ABI");
+
+struct sf_hdtr_c {
+	struct iovec_c * __capability headers;	/* pointer to an array of header struct iovec's */
+	int hdr_cnt;		/* number of header iovec's */
+	struct iovec_c * __capability trailers;	/* pointer to an array of trailer struct iovec's */
+	int trl_cnt;		/* number of trailer iovec's */
+};
 
 #ifdef CHERIABI_NEEDS_UPDATE
 CTASSERT(sizeof(struct kevent32) == 20);

--- a/sys/compat/cheriabi/cheriabi_uipc.c
+++ b/sys/compat/cheriabi/cheriabi_uipc.c
@@ -37,8 +37,19 @@ __FBSDID("$FreeBSD$");
 #include <sys/socketvar.h>
 #include <sys/syscallsubr.h>
 
+#include <compat/cheriabi/cheriabi_misc.h>
 #include <compat/cheriabi/cheriabi_proto.h>
 #include <compat/cheriabi/cheriabi_util.h>
+
+struct msghdr_c {
+	void		* __capability msg_name;		/* optional address */
+	socklen_t	 msg_namelen;		/* size of address */
+	struct iovec_c	* __capability msg_iov;		/* scatter/gather array */
+	int		 msg_iovlen;		/* # elements in msg_iov */
+	void		* __capability msg_control;		/* ancillary data, see below */
+	socklen_t	 msg_controllen;	/* ancillary data buffer len */
+	int		 msg_flags;		/* flags on received message */
+};
 
 /*
  * kern_uipc.c

--- a/sys/compat/cheriabi/cheriabi_util.h
+++ b/sys/compat/cheriabi/cheriabi_util.h
@@ -106,7 +106,7 @@ int    cheriabi_syscall_helper_unregister(struct syscall_helper_data *sd);
 struct iovec_c;
 register_t *cheriabi_copyout_strings(struct image_params *imgp);
 int	cheriabi_copyiniov(struct iovec_c * __capability iovp, u_int iovcnt,
-	    kiovec_t **iov, int error);
+	    struct iovec **iov, int error);
 int	cheriabi_copyinuio(struct iovec_c * __capability iovp, u_int iovcnt,
 	    struct uio **uiop);
 

--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -379,7 +379,7 @@ int
 cloudabi_sys_file_readdir(struct thread *td,
     struct cloudabi_sys_file_readdir_args *uap)
 {
-	kiovec_t iov;
+	struct iovec iov;
 	IOVEC_INIT(&iov, uap->buf, uap->buf_len);
 	struct uio uio = {
 		.uio_iov = &iov,
@@ -415,7 +415,7 @@ cloudabi_sys_file_readdir(struct thread *td,
 	offset = uap->cookie;
 	vp = fp->f_vnode;
 	while (uio.uio_resid > 0) {
-		kiovec_t readiov;
+		struct iovec readiov;
 		IOVEC_INIT(&readiov, readbuf, MAXBSIZE);
 		struct uio readuio = {
 			.uio_iov = &readiov,

--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -771,11 +771,10 @@ cloudabi_sys_file_unlink(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20190429,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/compat/cloudabi/cloudabi_random.c
+++ b/sys/compat/cloudabi/cloudabi_random.c
@@ -51,11 +51,10 @@ cloudabi_sys_random_get(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/cloudabi/cloudabi_random.c
+++ b/sys/compat/cloudabi/cloudabi_random.c
@@ -36,7 +36,7 @@ int
 cloudabi_sys_random_get(struct thread *td,
     struct cloudabi_sys_random_get_args *uap)
 {
-	kiovec_t iov;
+	struct iovec iov;
 	IOVEC_INIT(&iov, uap->buf, uap->buf_len);
 	struct uio uio = {
 		.uio_iov = &iov,

--- a/sys/compat/cloudabi/cloudabi_sock.c
+++ b/sys/compat/cloudabi/cloudabi_sock.c
@@ -72,13 +72,13 @@ cloudabi_sys_sock_shutdown(struct thread *td,
 }
 
 int
-cloudabi_sock_recv(struct thread *td, cloudabi_fd_t fd, kiovec_t *data,
+cloudabi_sock_recv(struct thread *td, cloudabi_fd_t fd, struct iovec *data,
     size_t datalen, cloudabi_fd_t *fds, size_t fdslen,
     cloudabi_riflags_t flags, size_t *rdatalen, size_t *rfdslen,
     cloudabi_roflags_t *rflags)
 {
-	kmsghdr_t hdr = {
-		.msg_iov = (__cheri_tocap kiovec_t * __capability)data,
+	struct msghdr hdr = {
+		.msg_iov = (__cheri_tocap struct iovec * __capability)data,
 		.msg_iovlen = datalen,
 	};
 	struct mbuf *control;
@@ -145,11 +145,11 @@ cloudabi_sock_recv(struct thread *td, cloudabi_fd_t fd, kiovec_t *data,
 }
 
 int
-cloudabi_sock_send(struct thread *td, cloudabi_fd_t fd, kiovec_t *data,
+cloudabi_sock_send(struct thread *td, cloudabi_fd_t fd, struct iovec *data,
     size_t datalen, const cloudabi_fd_t *fds, size_t fdslen, size_t *rdatalen)
 {
-	kmsghdr_t hdr = {
-		.msg_iov = (__cheri_tocap kiovec_t * __capability)data,
+	struct msghdr hdr = {
+		.msg_iov = (__cheri_tocap struct iovec * __capability)data,
 		.msg_iovlen = datalen,
 	};
 	struct mbuf *control;

--- a/sys/compat/cloudabi/cloudabi_sock.c
+++ b/sys/compat/cloudabi/cloudabi_sock.c
@@ -187,11 +187,10 @@ cloudabi_sock_send(struct thread *td, cloudabi_fd_t fd, kiovec_t *data,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/cloudabi/cloudabi_util.h
+++ b/sys/compat/cloudabi/cloudabi_util.h
@@ -74,10 +74,10 @@ int cloudabi_futex_lock_wrlock(struct thread *, cloudabi_lock_t *,
     cloudabi_timestamp_t, bool);
 
 /* Socket operations. */
-int cloudabi_sock_recv(struct thread *, cloudabi_fd_t, kiovec_t *, size_t,
+int cloudabi_sock_recv(struct thread *, cloudabi_fd_t, struct iovec *, size_t,
     cloudabi_fd_t *, size_t, cloudabi_riflags_t, size_t *, size_t *,
     cloudabi_roflags_t *);
-int cloudabi_sock_send(struct thread *, cloudabi_fd_t, kiovec_t *, size_t,
+int cloudabi_sock_send(struct thread *, cloudabi_fd_t, struct iovec *, size_t,
     const cloudabi_fd_t *, size_t, size_t *);
 
 /* vDSO setup and teardown. */

--- a/sys/compat/cloudabi/cloudabi_util.h
+++ b/sys/compat/cloudabi/cloudabi_util.h
@@ -85,12 +85,3 @@ void cloudabi_vdso_init(struct sysentvec *, char *, char *);
 void cloudabi_vdso_destroy(struct sysentvec *);
 
 #endif
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/compat/cloudabi32/cloudabi32_fd.c
+++ b/sys/compat/cloudabi32/cloudabi32_fd.c
@@ -46,16 +46,16 @@ cloudabi32_copyinuio(const cloudabi32_iovec_t *iovp, size_t iovcnt,
 {
 	cloudabi32_iovec_t iovobj;
 	struct uio *uio;
-	kiovec_t *iov;
+	struct iovec *iov;
 	size_t i;
 	int error;
 
 	/* Allocate uio and iovecs. */
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	uio = malloc(sizeof(struct uio) + iovcnt * sizeof(kiovec_t),
+	uio = malloc(sizeof(struct uio) + iovcnt * sizeof(struct iovec),
 	    M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 
 	/* Initialize uio. */
 	uio->uio_iov = iov;

--- a/sys/compat/cloudabi32/cloudabi32_fd.c
+++ b/sys/compat/cloudabi32/cloudabi32_fd.c
@@ -144,11 +144,10 @@ cloudabi32_sys_fd_write(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/cloudabi32/cloudabi32_sock.c
+++ b/sys/compat/cloudabi32/cloudabi32_sock.c
@@ -48,7 +48,7 @@ cloudabi32_sys_sock_recv(struct thread *td,
 	cloudabi32_recv_in_t ri;
 	cloudabi32_recv_out_t ro = {};
 	cloudabi32_iovec_t iovobj;
-	kiovec_t *iov;
+	struct iovec *iov;
 	const cloudabi32_iovec_t *user_iov;
 	size_t i, rdatalen, rfdslen;
 	int error;
@@ -60,7 +60,7 @@ cloudabi32_sys_sock_recv(struct thread *td,
 	/* Convert iovecs to native format. */
 	if (ri.ri_data_len > UIO_MAXIOV)
 		return (EINVAL);
-	iov = mallocarray(ri.ri_data_len, sizeof(kiovec_t),
+	iov = mallocarray(ri.ri_data_len, sizeof(struct iovec),
 	    M_SOCKET, M_WAITOK);
 	user_iov = TO_PTR(ri.ri_data);
 	for (i = 0; i < ri.ri_data_len; i++) {
@@ -91,7 +91,7 @@ cloudabi32_sys_sock_send(struct thread *td,
 	cloudabi32_send_in_t si;
 	cloudabi32_send_out_t so = {};
 	cloudabi32_ciovec_t iovobj;
-	kiovec_t iovec *iov;
+	struct iovec iovec *iov;
 	const cloudabi32_ciovec_t *user_iov;
 	size_t datalen, i;
 	int error;
@@ -103,7 +103,7 @@ cloudabi32_sys_sock_send(struct thread *td,
 	/* Convert iovecs to native format. */
 	if (si.si_data_len > UIO_MAXIOV)
 		return (EINVAL);
-	iov = mallocarray(si.si_data_len, sizeof(kiovec_t),
+	iov = mallocarray(si.si_data_len, sizeof(struct iovec),
 	    M_SOCKET, M_WAITOK);
 	user_iov = TO_PTR(si.si_data);
 	for (i = 0; i < si.si_data_len; i++) {

--- a/sys/compat/cloudabi32/cloudabi32_sock.c
+++ b/sys/compat/cloudabi32/cloudabi32_sock.c
@@ -126,11 +126,10 @@ cloudabi32_sys_sock_send(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/cloudabi64/cloudabi64_fd.c
+++ b/sys/compat/cloudabi64/cloudabi64_fd.c
@@ -46,16 +46,16 @@ cloudabi64_copyinuio(const cloudabi64_iovec_t *iovp, size_t iovcnt,
 {
 	cloudabi64_iovec_t iovobj;
 	struct uio *uio;
-	kiovec_t *iov;
+	struct iovec *iov;
 	size_t i;
 	int error;
 
 	/* Allocate uio and iovecs. */
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	uio = malloc(sizeof(struct uio) + iovcnt * sizeof(kiovec_t),
+	uio = malloc(sizeof(struct uio) + iovcnt * sizeof(struct iovec),
 	    M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 
 	/* Initialize uio. */
 	uio->uio_iov = iov;

--- a/sys/compat/cloudabi64/cloudabi64_fd.c
+++ b/sys/compat/cloudabi64/cloudabi64_fd.c
@@ -144,11 +144,10 @@ cloudabi64_sys_fd_write(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/cloudabi64/cloudabi64_sock.c
+++ b/sys/compat/cloudabi64/cloudabi64_sock.c
@@ -126,11 +126,10 @@ cloudabi64_sys_sock_send(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/cloudabi64/cloudabi64_sock.c
+++ b/sys/compat/cloudabi64/cloudabi64_sock.c
@@ -48,7 +48,7 @@ cloudabi64_sys_sock_recv(struct thread *td,
 	cloudabi64_recv_in_t ri;
 	cloudabi64_recv_out_t ro = {};
 	cloudabi64_iovec_t iovobj;
-	kiovec_t *iov;
+	struct iovec *iov;
 	const cloudabi64_iovec_t *user_iov;
 	size_t i, rdatalen, rfdslen;
 	int error;
@@ -60,7 +60,7 @@ cloudabi64_sys_sock_recv(struct thread *td,
 	/* Convert iovecs to native format. */
 	if (ri.ri_data_len > UIO_MAXIOV)
 		return (EINVAL);
-	iov = mallocarray(ri.ri_data_len, sizeof(kiovec_t),
+	iov = mallocarray(ri.ri_data_len, sizeof(struct iovec),
 	    M_SOCKET, M_WAITOK);
 	user_iov = TO_PTR(ri.ri_data);
 	for (i = 0; i < ri.ri_data_len; i++) {
@@ -91,7 +91,7 @@ cloudabi64_sys_sock_send(struct thread *td,
 	cloudabi64_send_in_t si;
 	cloudabi64_send_out_t so = {};
 	cloudabi64_ciovec_t iovobj;
-	kiovec_t *iov;
+	struct iovec *iov;
 	const cloudabi64_ciovec_t *user_iov;
 	size_t datalen, i;
 	int error;
@@ -103,7 +103,7 @@ cloudabi64_sys_sock_send(struct thread *td,
 	/* Convert iovecs to native format. */
 	if (si.si_data_len > UIO_MAXIOV)
 		return (EINVAL);
-	iov = mallocarray(si.si_data_len, sizeof(kiovec_t),
+	iov = mallocarray(si.si_data_len, sizeof(struct iovec),
 	    M_SOCKET, M_WAITOK);
 	user_iov = TO_PTR(si.si_data);
 	for (i = 0; i < si.si_data_len; i++) {

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -3318,11 +3318,10 @@ freebsd32_sched_rr_get_interval(struct thread *td,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181121,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "kernel_sig_types",
 //     "integer_provenance",
 //     "user_capabilities",

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -794,7 +794,7 @@ freebsd32_copyinuio(struct iovec32 * __capability iovp, u_int iovcnt,
     struct uio **uiop)
 {
 	struct iovec32 iov32;
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct uio *uio;
 	u_int iovlen;
 	int error, i;
@@ -802,9 +802,9 @@ freebsd32_copyinuio(struct iovec32 * __capability iovp, u_int iovcnt,
 	*uiop = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin_c(&iovp[i], &iov32, sizeof(struct iovec32));
 		if (error) {
@@ -866,17 +866,17 @@ freebsd32_pwritev(struct thread *td, struct freebsd32_pwritev_args *uap)
 
 int
 freebsd32_copyiniov(struct iovec32 * __capability iovp32, u_int iovcnt,
-    kiovec_t **iovp, int error)
+    struct iovec **iovp, int error)
 {
 	struct iovec32 iov32;
-	kiovec_t *iov;
+	struct iovec *iov;
 	u_int iovlen;
 	int i;
 
 	*iovp = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (error);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	iov = malloc(iovlen, M_IOV, M_WAITOK);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin_c(&iovp32[i], &iov32, sizeof(struct iovec32));
@@ -891,7 +891,7 @@ freebsd32_copyiniov(struct iovec32 * __capability iovp32, u_int iovcnt,
 }
 
 static int
-freebsd32_copyinmsghdr(struct msghdr32 *msg32, kmsghdr_t *msg)
+freebsd32_copyinmsghdr(struct msghdr32 *msg32, struct msghdr *msg)
 {
 	struct msghdr32 m32;
 	int error;
@@ -910,7 +910,7 @@ freebsd32_copyinmsghdr(struct msghdr32 *msg32, kmsghdr_t *msg)
 }
 
 static int
-freebsd32_copyoutmsghdr(kmsghdr_t *msg, struct msghdr32 *msg32)
+freebsd32_copyoutmsghdr(struct msghdr *msg, struct msghdr32 *msg32)
 {
 	struct msghdr32 m32;
 	int error;
@@ -994,7 +994,7 @@ freebsd32_cmsg_convert(const struct cmsghdr *cm, void *data, socklen_t datalen)
 }
 
 static int
-freebsd32_copy_msg_out(kmsghdr_t *msg, struct mbuf *control)
+freebsd32_copy_msg_out(struct msghdr *msg, struct mbuf *control)
 {
 	struct cmsghdr *cm;
 	void *data;
@@ -1092,9 +1092,9 @@ freebsd32_recvmsg(td, uap)
 		int	flags;
 	} */ *uap;
 {
-	kmsghdr_t msg;
+	struct msghdr msg;
 	struct msghdr32 m32;
-	kiovec_t *uiov, *iov;
+	struct iovec *uiov, *iov;
 	struct mbuf *control = NULL;
 	struct mbuf **controlp;
 
@@ -1227,9 +1227,9 @@ int
 freebsd32_sendmsg(struct thread *td,
 		  struct freebsd32_sendmsg_args *uap)
 {
-	kmsghdr_t msg;
+	struct msghdr msg;
 	struct msghdr32 m32;
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct mbuf *control = NULL;
 	struct sockaddr *to = NULL;
 	int error;
@@ -1285,8 +1285,8 @@ int
 freebsd32_recvfrom(struct thread *td,
 		   struct freebsd32_recvfrom_args *uap)
 {
-	kmsghdr_t msg;
-	kiovec_t aiov;
+	struct msghdr msg;
+	struct iovec aiov;
 	int error;
 
 	if (uap->fromlenaddr) {
@@ -1723,7 +1723,7 @@ struct sf_hdtr32 {
 
 static int
 freebsd32_copyin_hdtr(const struct sf_hdtr32 * __capability uhdtr,
-    ksf_hdtr_t *hdtr)
+    struct sf_hdtr *hdtr)
 {
 	struct sf_hdtr32 hdtr32;
 	int error;

--- a/sys/compat/freebsd32/freebsd32_util.h
+++ b/sys/compat/freebsd32/freebsd32_util.h
@@ -121,7 +121,7 @@ struct iovec32;
 struct rusage32;
 register_t *freebsd32_copyout_strings(struct image_params *imgp);
 int	freebsd32_copyiniov(struct iovec32 * __capability iovp, u_int iovcnt,
-	    kiovec_t **iov, int error);
+	    struct iovec **iov, int error);
 void	freebsd32_rusage_out(const struct rusage *s, struct rusage32 *s32);
 
 #endif /* !_COMPAT_FREEBSD32_FREEBSD32_UTIL_H_ */

--- a/sys/compat/freebsd32/freebsd32_util.h
+++ b/sys/compat/freebsd32/freebsd32_util.h
@@ -127,10 +127,9 @@ void	freebsd32_rusage_out(const struct rusage *s, struct rusage32 *s32);
 #endif /* !_COMPAT_FREEBSD32_FREEBSD32_UTIL_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "header",
 //   "changes": [
-//     "kiovec_t",
 //     "support",
 //     "user_capabilities"
 //   ]

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -387,7 +387,7 @@ freebsd64_copyinuio(struct iovec64 * __capability iovp, u_int iovcnt,
     struct uio **uiop)
 {
 	struct iovec64 iov64;
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct uio *uio;
 	size_t iovlen;
 	int error, i;
@@ -395,9 +395,9 @@ freebsd64_copyinuio(struct iovec64 * __capability iovp, u_int iovcnt,
 	*uiop = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	uio = malloc(iovlen + sizeof(*uio), M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin_c(&iovp[i], &iov64, sizeof(iov64));
 		if (error) {
@@ -424,17 +424,17 @@ freebsd64_copyinuio(struct iovec64 * __capability iovp, u_int iovcnt,
 
 int
 freebsd64_copyiniov(struct iovec64 * __capability iov64, u_int iovcnt,
-    kiovec_t **iovp, int error)
+    struct iovec **iovp, int error)
 {
-	uiovec_t useriov;
-	kiovec_t *iovs;
+	struct iovec_native useriov;
+	struct iovec *iovs;
 	size_t iovlen;
 	int i;
 
 	*iovp = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (error);
-	iovlen = iovcnt * sizeof(kiovec_t);
+	iovlen = iovcnt * sizeof(struct iovec);
 	iovs = malloc(iovlen, M_IOV, M_WAITOK);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin_c(iov64 + i, &useriov, sizeof(useriov));
@@ -450,7 +450,7 @@ freebsd64_copyiniov(struct iovec64 * __capability iov64, u_int iovcnt,
 
 static int
 freebsd64_copyin_hdtr(const struct sf_hdtr64 * __capability uhdtr,
-    ksf_hdtr_t *hdtr)
+    struct sf_hdtr *hdtr)
 {
 	struct sf_hdtr64 hdtr64;
 	int error;

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -115,7 +115,7 @@ freebsd64_sendto(struct thread *td, struct freebsd64_sendto_args *uap)
 }
 
 static int
-freebsd64_copyinmsghdr(struct msghdr64 *msg64, kmsghdr_t *msg)
+freebsd64_copyinmsghdr(struct msghdr64 *msg64, struct msghdr *msg)
 {
 	struct msghdr64 m64;
 	int error;
@@ -138,7 +138,7 @@ freebsd64_copyinmsghdr(struct msghdr64 *msg64, kmsghdr_t *msg)
  * the pointers untouched.
  */
 static int
-freebsd64_copyoutmsghdr(kmsghdr_t *msg, struct msghdr64 *msg64)
+freebsd64_copyoutmsghdr(struct msghdr *msg, struct msghdr64 *msg64)
 {
 	struct msghdr64 m64;
 	int error;
@@ -166,7 +166,7 @@ freebsd64_copyoutmsghdr(kmsghdr_t *msg, struct msghdr64 *msg64)
  * conversions like on i386, but maybe alignment is an issue...
  */
 static int
-freebsd64_copy_msg_out(kmsghdr_t *msg, struct mbuf *control)
+freebsd64_copy_msg_out(struct msghdr *msg, struct mbuf *control)
 {
 	struct cmsghdr *cm;
 	void *data;
@@ -256,9 +256,9 @@ exit:
 int
 freebsd64_sendmsg(struct thread *td, struct freebsd64_sendmsg_args *uap)
 {
-	kmsghdr_t msg;
+	struct msghdr msg;
 	struct msghdr64 m64;
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error;
 
 	error = copyin(uap->msg, &m64, sizeof(m64));
@@ -270,7 +270,7 @@ freebsd64_sendmsg(struct thread *td, struct freebsd64_sendmsg_args *uap)
 	    m64.msg_iovlen), m64.msg_iovlen, &iov, EMSGSIZE);
 	if (error != 0)
 		return (error);
-	msg.msg_iov = (__cheri_tocap kiovec_t * __capability)iov;
+	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
 	msg.msg_iovlen = m64.msg_iovlen;
 	msg.msg_control = __USER_CAP(m64.msg_control, m64.msg_controllen);
 	msg.msg_controllen = m64.msg_controllen;
@@ -293,9 +293,9 @@ freebsd64_recvfrom(struct thread *td, struct freebsd64_recvfrom_args *uap)
 int
 freebsd64_recvmsg(struct thread *td, struct freebsd64_recvmsg_args *uap)
 {
-	kmsghdr_t msg;
+	struct msghdr msg;
 	struct msghdr64 m64;
-	kiovec_t * __capability uiov, *iov;
+	struct iovec * __capability uiov, *iov;
 	struct mbuf *control = NULL;
 	struct mbuf **controlp;
 	int error;
@@ -312,7 +312,7 @@ freebsd64_recvmsg(struct thread *td, struct freebsd64_recvmsg_args *uap)
 		return (error);
 	msg.msg_flags = uap->flags;
 	uiov = msg.msg_iov;
-	msg.msg_iov = (__cheri_tocap kiovec_t * __capability)iov;
+	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
 
 	controlp = (msg.msg_control != NULL) ?  &control : NULL;
 	error = kern_recvit(td, uap->s, &msg, UIO_USERSPACE, controlp);

--- a/sys/compat/freebsd64/freebsd64_util.h
+++ b/sys/compat/freebsd64/freebsd64_util.h
@@ -105,7 +105,7 @@ int    freebsd64_syscall_helper_unregister(struct syscall_helper_data *sd);
 struct iovec64;
 register_t *freebsd64_copyout_strings(struct image_params *imgp);
 int	freebsd64_copyiniov(struct iovec64 * __capability iovp, u_int iovcnt,
-	    kiovec_t **iov, int error);
+	    struct iovec **iov, int error);
 int	freebsd64_copyinuio(struct iovec64 * __capability iovp, u_int iovcnt,
 	    struct uio **uiop);
 

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -2302,11 +2302,10 @@ linux_mincore(struct thread *td, struct linux_mincore_args *args)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/compat/linux/linux_socket.c
+++ b/sys/compat/linux/linux_socket.c
@@ -1672,11 +1672,10 @@ linux_socketcall(struct thread *td, struct linux_socketcall_args *args)
 #endif /* __i386__ || (__amd64__ && COMPAT_LINUX32) */
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/compat/linux/linux_socket.c
+++ b/sys/compat/linux/linux_socket.c
@@ -439,7 +439,7 @@ linux_sendto_hdrincl(struct thread *td, struct linux_sendto_args *linux_args)
 
 	struct ip *packet;
 	struct msghdr msg;
-	kiovec_t aiov[1];
+	struct iovec aiov[1];
 	int error;
 
 	/* Check that the packet isn't too big or too small. */
@@ -856,7 +856,7 @@ int
 linux_sendto(struct thread *td, struct linux_sendto_args *args)
 {
 	struct msghdr msg;
-	kiovec_t aiov;
+	struct iovec aiov;
 
 	if (linux_check_hdrincl(td, args->s) == 0)
 		/* IP_HDRINCL set, tweak the packet before sending */
@@ -879,7 +879,7 @@ linux_recvfrom(struct thread *td, struct linux_recvfrom_args *args)
 	struct l_sockaddr *lsa;
 	struct sockaddr *sa;
 	struct msghdr msg;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error, fromlen;
 
 	if (PTRIN(args->fromlen) != NULL) {
@@ -933,7 +933,7 @@ linux_sendmsg_common(struct thread *td, l_int s, struct l_msghdr *msghdr,
 	struct l_cmsghdr linux_cmsg;
 	struct l_cmsghdr *ptr_cmsg;
 	struct l_msghdr linux_msg;
-	kiovec_t *iov;
+	struct iovec *iov;
 	socklen_t datalen;
 	struct sockaddr *sa;
 	struct socket *so;
@@ -1141,7 +1141,7 @@ linux_recvmsg_common(struct thread *td, l_int s, struct l_msghdr *msghdr,
 	struct l_ucred linux_ucred;
 	socklen_t datalen, maxlen, outlen;
 	struct l_msghdr linux_msg;
-	kiovec_t *iov, *uiov;
+	struct iovec *iov, *uiov;
 	struct mbuf *control = NULL;
 	struct mbuf **controlp;
 	struct timeval *ftmvl;

--- a/sys/compat/linuxkpi/common/include/linux/fs.h
+++ b/sys/compat/linuxkpi/common/include/linux/fs.h
@@ -323,12 +323,3 @@ void linux_shmem_truncate_range(vm_object_t, loff_t, loff_t);
   linux_shmem_truncate_range(__VA_ARGS__)
 
 #endif /* _LINUX_FS_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -2456,11 +2456,10 @@ SYSUNINIT(linux_compat, SI_SUB_DRIVERS, SI_ORDER_SECOND, linux_compat_uninit, NU
 CTASSERT(sizeof(unsigned long) == sizeof(uintptr_t));
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/crypto/aesni/aesni.c
+++ b/sys/crypto/aesni/aesni.c
@@ -971,12 +971,3 @@ aesni_cipher_mac(struct aesni_session *ses, struct cryptodesc *crd,
 	    (void *)res);
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/crypto/armv8/armv8_crypto.c
+++ b/sys/crypto/armv8/armv8_crypto.c
@@ -342,7 +342,7 @@ armv8_crypto_cipher_alloc(struct cryptodesc *enccrd, struct cryptop *crp,
 {
 	struct mbuf *m;
 	struct uio *uio;
-	kiovec_t *iov;
+	struct iovec *iov;
 	uint8_t *addr;
 
 	if (crp->crp_flags & CRYPTO_F_IMBUF) {

--- a/sys/crypto/armv8/armv8_crypto.c
+++ b/sys/crypto/armv8/armv8_crypto.c
@@ -470,12 +470,3 @@ static devclass_t armv8_crypto_devclass;
 
 DRIVER_MODULE(armv8crypto, nexus, armv8_crypto_driver, armv8_crypto_devclass,
     0, 0);
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/crypto/via/padlock_cipher.c
+++ b/sys/crypto/via/padlock_cipher.c
@@ -273,12 +273,3 @@ padlock_cipher_process(struct padlock_session *ses, struct cryptodesc *enccrd,
 	}
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/crypto/via/padlock_cipher.c
+++ b/sys/crypto/via/padlock_cipher.c
@@ -176,7 +176,7 @@ padlock_cipher_alloc(struct cryptodesc *enccrd, struct cryptop *crp,
 	else {
 		if (crp->crp_flags & CRYPTO_F_IOV) {
 			struct uio *uio;
-			kiovec_t *iov;
+			struct iovec *iov;
 
 			uio = (struct uio *)crp->crp_buf;
 			if (uio->uio_iovcnt != 1)

--- a/sys/dev/beri/virtio/network/if_vtbe.c
+++ b/sys/dev/beri/virtio/network/if_vtbe.c
@@ -138,10 +138,10 @@ static int pio_enable_irq(struct vtbe_softc *sc, int enable);
 static void
 vtbe_txstart_locked(struct vtbe_softc *sc)
 {
-	kiovec_t iov[DESC_COUNT];
+	struct iovec iov[DESC_COUNT];
 	struct virtio_net_hdr *vnh;
 	struct vqueue_info *vq;
-	kiovec_t *tiov;
+	struct iovec *tiov;
 	struct ifnet *ifp;
 	struct mbuf *m;
 	struct uio uio;
@@ -382,8 +382,8 @@ vq_init(struct vtbe_softc *sc)
 static void
 vtbe_proc_rx(struct vtbe_softc *sc, struct vqueue_info *vq)
 {
-	kiovec_t iov[DESC_COUNT];
-	kiovec_t *tiov;
+	struct iovec iov[DESC_COUNT];
+	struct iovec *tiov;
 	struct ifnet *ifp;
 	struct uio uio;
 	struct mbuf *m;

--- a/sys/dev/beri/virtio/network/if_vtbe.c
+++ b/sys/dev/beri/virtio/network/if_vtbe.c
@@ -651,10 +651,9 @@ DRIVER_MODULE(vtbe, simplebus, vtbe_driver, vtbe_devclass, 0, 0);
 MODULE_DEPEND(vtbe, ether, 1, 1, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "kiovec_t",
 //     "ioctl:net"
 //   ]
 // }

--- a/sys/dev/beri/virtio/virtio.c
+++ b/sys/dev/beri/virtio/virtio.c
@@ -108,7 +108,7 @@ paddr_unmap(void *phys, uint32_t size)
 
 static inline void
 _vq_record(uint32_t offs, int i, volatile struct vring_desc *vd,
-	kiovec_t *iov, int n_iov, uint16_t *flags) {
+	struct iovec *iov, int n_iov, uint16_t *flags) {
 
 	if (i >= n_iov)
 		return;
@@ -122,7 +122,7 @@ _vq_record(uint32_t offs, int i, volatile struct vring_desc *vd,
 
 int
 vq_getchain(uint32_t offs, struct vqueue_info *vq,
-	kiovec_t *iov, int n_iov, uint16_t *flags)
+	struct iovec *iov, int n_iov, uint16_t *flags)
 {
 	volatile struct vring_desc *vdir, *vindir, *vp;
 	int idx, ndesc, n_indir;
@@ -167,7 +167,7 @@ vq_getchain(uint32_t offs, struct vqueue_info *vq,
 }
 
 void
-vq_relchain(struct vqueue_info *vq, kiovec_t *iov, int n, uint32_t iolen)
+vq_relchain(struct vqueue_info *vq, struct iovec *iov, int n, uint32_t iolen)
 {
 	volatile struct vring_used_elem *vue;
 	volatile struct vring_used *vu;
@@ -244,13 +244,13 @@ setup_offset(device_t dev, uint32_t *offset)
 	return (0);
 }
 
-kiovec_t *
-getcopy(kiovec_t *iov, int n)
+struct iovec *
+getcopy(struct iovec *iov, int n)
 {
-	kiovec_t *tiov;
+	struct iovec *tiov;
 	int i;
 
-	tiov = malloc(n * sizeof(kiovec_t), M_DEVBUF, M_NOWAIT);
+	tiov = malloc(n * sizeof(struct iovec), M_DEVBUF, M_NOWAIT);
 	for (i = 0; i < n; i++) {
 		IOVEC_INIT(&tiov[i], iov[i].iov_base, iov[i].iov_len);
 	}

--- a/sys/dev/beri/virtio/virtio.c
+++ b/sys/dev/beri/virtio/virtio.c
@@ -259,11 +259,10 @@ getcopy(kiovec_t *iov, int n)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/beri/virtio/virtio.h
+++ b/sys/dev/beri/virtio/virtio.h
@@ -63,9 +63,9 @@ int vq_has_descs(struct vqueue_info *vq);
 void * paddr_map(uint32_t offset, uint32_t phys, uint32_t size);
 void paddr_unmap(void *phys, uint32_t size);
 int vq_getchain(uint32_t beri_mem_offset, struct vqueue_info *vq,
-		kiovec_t *iov, int n_iov, uint16_t *flags);
-void vq_relchain(struct vqueue_info *vq, kiovec_t *iov, int n, uint32_t iolen);
-kiovec_t * getcopy(kiovec_t *iov, int n);
+		struct iovec *iov, int n_iov, uint16_t *flags);
+void vq_relchain(struct vqueue_info *vq, struct iovec *iov, int n, uint32_t iolen);
+struct iovec * getcopy(struct iovec *iov, int n);
 
 int setup_pio(device_t dev, char *name, device_t *pio_dev);
 int setup_offset(device_t dev, uint32_t *offset);

--- a/sys/dev/beri/virtio/virtio.h
+++ b/sys/dev/beri/virtio/virtio.h
@@ -69,12 +69,3 @@ kiovec_t * getcopy(kiovec_t *iov, int n);
 
 int setup_pio(device_t dev, char *name, device_t *pio_dev);
 int setup_offset(device_t dev, uint32_t *offset);
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/beri/virtio/virtio_block.c
+++ b/sys/dev/beri/virtio/virtio_block.c
@@ -108,7 +108,7 @@ static struct resource_spec beri_spec[] = {
 };
 
 static int
-vtblk_rdwr(struct beri_vtblk_softc *sc, kiovec_t *iov,
+vtblk_rdwr(struct beri_vtblk_softc *sc, struct iovec *iov,
 	int cnt, int offset, int operation, int iolen)
 {
 	struct vnode *vp;
@@ -148,10 +148,10 @@ vtblk_rdwr(struct beri_vtblk_softc *sc, kiovec_t *iov,
 static void
 vtblk_proc(struct beri_vtblk_softc *sc, struct vqueue_info *vq)
 {
-	kiovec_t iov[VTBLK_MAXSEGS + 2];
+	struct iovec iov[VTBLK_MAXSEGS + 2];
 	uint16_t flags[VTBLK_MAXSEGS + 2];
 	struct virtio_blk_outhdr *vbh;
-	kiovec_t *tiov;
+	struct iovec *tiov;
 	uint8_t *status;
 	off_t offset;
 	int iolen;

--- a/sys/dev/beri/virtio/virtio_block.c
+++ b/sys/dev/beri/virtio/virtio_block.c
@@ -559,12 +559,3 @@ static devclass_t beri_vtblk_devclass;
 
 DRIVER_MODULE(beri_vtblk, simplebus, beri_vtblk_driver,
     beri_vtblk_devclass, 0, 0);
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/cxgbe/iw_cxgbe/cm.c
+++ b/sys/dev/cxgbe/iw_cxgbe/cm.c
@@ -2207,7 +2207,7 @@ process_mpa_request(struct c4iw_ep *ep)
 	u16 plen;
 	int flags = MSG_DONTWAIT;
 	int rc;
-	kiovec_t iov;
+	struct iovec iov;
 	struct uio uio;
 	enum c4iw_ep_state state = ep->com.state;
 

--- a/sys/dev/cxgbe/tom/t4_ddp.c
+++ b/sys/dev/cxgbe/tom/t4_ddp.c
@@ -1598,7 +1598,7 @@ sbcopy:
 	KASSERT(m == NULL || toep->ddp.active_count == 0,
 	    ("%s: sockbuf data with active DDP", __func__));
 	while (m != NULL && resid > 0) {
-		kiovec_t iov[1];
+		struct iovec iov[1];
 		struct uio uio;
 		int error;
 

--- a/sys/dev/cxgbe/tom/t4_ddp.c
+++ b/sys/dev/cxgbe/tom/t4_ddp.c
@@ -1942,11 +1942,10 @@ t4_ddp_mod_unload(void)
 #endif
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/filemon/filemon_wrapper.c
+++ b/sys/dev/filemon/filemon_wrapper.c
@@ -460,11 +460,10 @@ filemon_wrapper_deinstall(void)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191024,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/filemon/filemon_wrapper.c
+++ b/sys/dev/filemon/filemon_wrapper.c
@@ -52,7 +52,7 @@ static void
 filemon_output(struct filemon *filemon, char *msg, size_t len)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error;
 
 	if (filemon->fp == NULL)

--- a/sys/dev/firewire/firewire.c
+++ b/sys/dev/firewire/firewire.c
@@ -2384,11 +2384,10 @@ DRIVER_MODULE(firewire, fwohci, firewire_driver, firewire_devclass,
 MODULE_VERSION(firewire, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/firewire/firewirereg.h
+++ b/sys/dev/firewire/firewirereg.h
@@ -301,12 +301,3 @@ extern int firewire_phydma_enable;
 
 MALLOC_DECLARE(M_FW);
 MALLOC_DECLARE(M_FWXFER);
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/firewire/firewirereg.h
+++ b/sys/dev/firewire/firewirereg.h
@@ -254,7 +254,7 @@ struct fw_xfer {
 struct fw_rcv_buf {
 	struct firewire_comm *fc;
 	struct fw_xfer *xfer;
-	kiovec_t *vec;
+	struct iovec *vec;
 	u_int nvec;
 	uint8_t spd;
 };

--- a/sys/dev/firewire/fwohci.c
+++ b/sys/dev/firewire/fwohci.c
@@ -2977,11 +2977,10 @@ err:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20910259,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/firewire/fwohci.c
+++ b/sys/dev/firewire/fwohci.c
@@ -2734,7 +2734,7 @@ static void
 fwohci_arcv(struct fwohci_softc *sc, struct fwohci_dbch *dbch, int count)
 {
 	struct fwohcidb_tr *db_tr;
-	kiovec_t vec[2];
+	struct iovec vec[2];
 	struct fw_pkt pktbuf;
 	int nvec;
 	struct fw_pkt *fp;

--- a/sys/dev/hwpmc/hwpmc_logging.c
+++ b/sys/dev/hwpmc/hwpmc_logging.c
@@ -361,7 +361,7 @@ pmclog_loop(void *arg)
 	struct thread *td;
 	sigset_t unb;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	size_t nbytes;
 	int error;
 

--- a/sys/dev/hwpmc/hwpmc_logging.c
+++ b/sys/dev/hwpmc/hwpmc_logging.c
@@ -1296,11 +1296,10 @@ pmclog_shutdown()
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/hyperv/vmbus/vmbus_br.c
+++ b/sys/dev/hyperv/vmbus/vmbus_br.c
@@ -267,7 +267,7 @@ vmbus_txbr_copyto(const struct vmbus_txbr *tbr, uint32_t windex,
  * immediately after this channel packet.
  */
 int
-vmbus_txbr_write(struct vmbus_txbr *tbr, const kiovec_t iov[], int iovlen,
+vmbus_txbr_write(struct vmbus_txbr *tbr, const struct iovec iov[], int iovlen,
     boolean_t *need_sig)
 {
 	uint32_t old_windex, windex, total;

--- a/sys/dev/hyperv/vmbus/vmbus_br.c
+++ b/sys/dev/hyperv/vmbus/vmbus_br.c
@@ -405,12 +405,3 @@ vmbus_rxbr_read(struct vmbus_rxbr *rbr, void *data, int dlen, uint32_t skip)
 
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/hyperv/vmbus/vmbus_brvar.h
+++ b/sys/dev/hyperv/vmbus/vmbus_brvar.h
@@ -128,12 +128,3 @@ int		vmbus_txbr_write(struct vmbus_txbr *tbr,
 		    const kiovec_t iov[], int iovlen, boolean_t *need_sig);
 
 #endif  /* _VMBUS_BRVAR_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/hyperv/vmbus/vmbus_brvar.h
+++ b/sys/dev/hyperv/vmbus/vmbus_brvar.h
@@ -125,6 +125,6 @@ void		vmbus_txbr_init(struct vmbus_txbr *tbr);
 void		vmbus_txbr_deinit(struct vmbus_txbr *tbr);
 void		vmbus_txbr_setup(struct vmbus_txbr *tbr, void *buf, int blen);
 int		vmbus_txbr_write(struct vmbus_txbr *tbr,
-		    const kiovec_t iov[], int iovlen, boolean_t *need_sig);
+		    const struct iovec iov[], int iovlen, boolean_t *need_sig);
 
 #endif  /* _VMBUS_BRVAR_H_ */

--- a/sys/dev/hyperv/vmbus/vmbus_chan.c
+++ b/sys/dev/hyperv/vmbus/vmbus_chan.c
@@ -2196,11 +2196,10 @@ vmbus_chan_poll_disable(struct vmbus_channel *chan)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/hyperv/vmbus/vmbus_chan.c
+++ b/sys/dev/hyperv/vmbus/vmbus_chan.c
@@ -1019,7 +1019,7 @@ vmbus_chan_send(struct vmbus_channel *chan, uint16_t type, uint16_t flags,
 	struct vmbus_chanpkt pkt;
 	int pktlen, pad_pktlen, hlen, error;
 	uint64_t pad = 0;
-	kiovec_t iov[3];
+	struct iovec iov[3];
 	boolean_t send_evt;
 
 	hlen = sizeof(pkt);
@@ -1050,7 +1050,7 @@ vmbus_chan_send_sglist(struct vmbus_channel *chan,
 {
 	struct vmbus_chanpkt_sglist pkt;
 	int pktlen, pad_pktlen, hlen, error;
-	kiovec_t iov[4];
+	struct iovec iov[4];
 	boolean_t send_evt;
 	uint64_t pad = 0;
 
@@ -1086,7 +1086,7 @@ vmbus_chan_send_prplist(struct vmbus_channel *chan,
 {
 	struct vmbus_chanpkt_prplist pkt;
 	int pktlen, pad_pktlen, hlen, error;
-	kiovec_t iov[4];
+	struct iovec iov[4];
 	boolean_t send_evt;
 	uint64_t pad = 0;
 

--- a/sys/dev/iicbus/iic.c
+++ b/sys/dev/iicbus/iic.c
@@ -362,7 +362,7 @@ iicioctl(struct cdev *dev, u_long cmd, caddr_t data, int flags, struct thread *t
 	device_t parent, iicdev;
 	struct iiccmd *s;
 	struct uio ubuf;
-	kiovec_t uvec;
+	struct iovec uvec;
 	struct iic_cdevpriv *priv;
 	int error;
 

--- a/sys/dev/iicbus/iic.c
+++ b/sys/dev/iicbus/iic.c
@@ -502,11 +502,10 @@ MODULE_DEPEND(iic, iicbus, IICBUS_MINVER, IICBUS_PREFVER, IICBUS_MAXVER);
 MODULE_VERSION(iic, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/iscsi/icl_soft.c
+++ b/sys/dev/iscsi/icl_soft.c
@@ -1565,11 +1565,10 @@ MODULE_DEPEND(icl_soft, icl, 1, 1, 1);
 MODULE_VERSION(icl_soft, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/iscsi/icl_soft.c
+++ b/sys/dev/iscsi/icl_soft.c
@@ -175,7 +175,7 @@ icl_conn_receive(struct icl_conn *ic, size_t len)
 static int
 icl_conn_receive_buf(struct icl_conn *ic, void *buf, size_t len)
 {
-	kiovec_t iov[1];
+	struct iovec iov[1];
 	struct uio uio;
 	struct socket *so;
 	int error, flags;

--- a/sys/dev/iscsi_initiator/isc_soc.c
+++ b/sys/dev/iscsi_initiator/isc_soc.c
@@ -689,11 +689,10 @@ isc_start_receiver(isc_session_t *sp)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/iscsi_initiator/isc_soc.c
+++ b/sys/dev/iscsi_initiator/isc_soc.c
@@ -186,7 +186,7 @@ int
 isc_sendPDU(isc_session_t *sp, pduq_t *pq)
 {
      struct uio *uio = &pq->uio;
-     kiovec_t	*iv;
+     struct iovec	*iv;
      pdu_t	*pp = &pq->pdu;
      int	len, error;
 
@@ -309,7 +309,7 @@ static __inline int
 so_getbhs(isc_session_t *sp)
 {
      struct uio		*uio = &sp->uio;
-     kiovec_t		*iov = &sp->iov;
+     struct iovec		*iov = &sp->iov;
      int		error, flags;
 
      debug_called(8);
@@ -362,7 +362,7 @@ so_recv(isc_session_t *sp, pduq_t *pq)
      struct uio		*uio = &pq->uio;
      pdu_t		*pp = &pq->pdu;
      bhs_t		*bhs = &pp->ipdu.bhs;
-     kiovec_t		*iov = pq->iov;
+     struct iovec		*iov = pq->iov;
      int		error;
      u_int		len;
      u_int		max, exp;

--- a/sys/dev/iscsi_initiator/iscsivar.h
+++ b/sys/dev/iscsi_initiator/iscsivar.h
@@ -167,7 +167,7 @@ typedef struct isc_session {
      struct i_stats	stats;
      bhs_t		bhs;
      struct uio		uio;
-     kiovec_t		iov;
+     struct iovec		iov;
      /*
       | cam stuff
       */
@@ -191,7 +191,7 @@ typedef struct pduq {
      union ccb		*ccb;
 
      struct uio		uio;
-     kiovec_t		iov[5];	// XXX: careful ...
+     struct iovec		iov[5];	// XXX: careful ...
      struct mbuf	*mp;
      struct bintime	ts;
      queue_t		*pduq;		

--- a/sys/dev/iscsi_initiator/iscsivar.h
+++ b/sys/dev/iscsi_initiator/iscsivar.h
@@ -604,11 +604,10 @@ i_mbufcopy(struct mbuf *mp, caddr_t dp, int len)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "header",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/ksyms/ksyms.c
+++ b/sys/dev/ksyms/ksyms.c
@@ -520,11 +520,10 @@ DEV_MODULE(ksyms, ksyms_modevent, NULL);
 MODULE_VERSION(ksyms, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/ksyms/ksyms.c
+++ b/sys/dev/ksyms/ksyms.c
@@ -157,7 +157,7 @@ ksyms_size_calc(struct tsizes *ts)
 static int
 ksyms_emit(struct ksyms_softc *sc, void *buf, off_t off, size_t sz)
 {
-	kiovec_t iov;
+	struct iovec iov;
 	struct uio uio;
 
 	IOVEC_INIT(&iov, buf, sz);

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -886,8 +886,8 @@ mdstart_vnode(struct md_s *sc, struct bio *bp)
 {
 	int error;
 	struct uio auio;
-	kiovec_t aiov;
-	kiovec_t *piov;
+	struct iovec aiov;
+	struct iovec *piov;
 	struct mount *mp;
 	struct vnode *vp;
 	struct buf *pb;
@@ -1409,7 +1409,7 @@ mdsetcred(struct md_s *sc, struct ucred *cred)
 
 	if (sc->vnode) {
 		struct uio auio;
-		kiovec_t aiov;
+		struct iovec aiov;
 
 		tmpbuf = malloc(sc->sectorsize, M_TEMP, M_WAITOK);
 		bzero(&auio, sizeof(auio));

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -2231,12 +2231,11 @@ g_md_fini(struct g_class *mp __unused)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "ioctl:misc",
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/mfi/mfi_ioctl.h
+++ b/sys/dev/mfi/mfi_ioctl.h
@@ -193,10 +193,9 @@ struct mfi_query_disk {
 #define MFI_LINUX_SET_AEN_2	0x400c4d04
 // CHERI CHANGES START
 // {
-//   "updated": 20181121,
+//   "updated": 20191025,
 //   "target_type": "header",
 //   "changes": [
-//     "kiovec_t",
 //     "integer_provenance"
 //   ]
 // }

--- a/sys/dev/mpr/mprvar.h
+++ b/sys/dev/mpr/mprvar.h
@@ -250,7 +250,7 @@ struct mpr_command {
 	u_int				cm_length;
 	u_int				cm_out_len;
 	struct uio			cm_uio;
-	kiovec_t			cm_iovec[MPR_IOVEC_COUNT];
+	struct iovec			cm_iovec[MPR_IOVEC_COUNT];
 	u_int				cm_max_segs;
 	u_int				cm_sglsize;
 	void				*cm_sge;

--- a/sys/dev/mpr/mprvar.h
+++ b/sys/dev/mpr/mprvar.h
@@ -987,13 +987,3 @@ struct unmap_parm_list {
 #define SCSI_ASCQ_INVALID_LUN_ID                        0x09
 
 #endif
-
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/mps/mpsvar.h
+++ b/sys/dev/mps/mpsvar.h
@@ -216,7 +216,7 @@ struct mps_command {
 	u_int				cm_length;
 	u_int				cm_out_len;
 	struct uio			cm_uio;
-	kiovec_t			cm_iovec[MPS_IOVEC_COUNT];
+	struct iovec			cm_iovec[MPS_IOVEC_COUNT];
 	u_int				cm_max_segs;
 	u_int				cm_sglsize;
 	MPI2_SGE_IO_UNION		*cm_sge;

--- a/sys/dev/mps/mpsvar.h
+++ b/sys/dev/mps/mpsvar.h
@@ -862,13 +862,3 @@ SYSCTL_DECL(_hw_mps);
 #endif
 
 #endif
-
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/mrsas/mrsas_ioctl.h
+++ b/sys/dev/mrsas/mrsas_ioctl.h
@@ -126,12 +126,3 @@ struct mrsas_iocpacket32 {
 #endif					/* COMPAT_FREEBSD32 */
 
 #endif					/* MRSAS_IOCTL_H */
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/proto/proto_busdma.c
+++ b/sys/dev/proto/proto_busdma.c
@@ -506,11 +506,10 @@ proto_busdma_mmap_allowed(struct proto_busdma *busdma, vm_paddr_t physaddr)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/dev/proto/proto_busdma.c
+++ b/sys/dev/proto/proto_busdma.c
@@ -280,7 +280,7 @@ proto_busdma_md_load(struct proto_busdma *busdma, struct proto_md *md,
     struct proto_ioc_busdma *ioc, struct thread *td)
 {
 	struct proto_callback_bundle pcb;
-	kiovec_t iov;
+	struct iovec iov;
 	struct uio uio;
 	pmap_t pmap;
 	int error;

--- a/sys/dev/xen/blkback/blkback.c
+++ b/sys/dev/xen/blkback/blkback.c
@@ -499,7 +499,7 @@ struct xbb_file_data {
 	 * Only a single file based request is outstanding per-xbb instance,
 	 * so we only need one of these.
 	 */
-	kiovec_t	xiovecs[XBB_MAX_SEGMENTS_PER_REQLIST];
+	struct iovec	xiovecs[XBB_MAX_SEGMENTS_PER_REQLIST];
 #ifdef XBB_USE_BOUNCE_BUFFERS
 
 	/**
@@ -511,7 +511,7 @@ struct xbb_file_data {
 	 * bounce-out the read data.  This array serves as the temporary
 	 * storage for this saved data.
 	 */
-	kiovec_t	saved_xiovecs[XBB_MAX_SEGMENTS_PER_REQLIST];
+	struct iovec	saved_xiovecs[XBB_MAX_SEGMENTS_PER_REQLIST];
 
 	/**
 	 * \brief Array of memoized bounce buffer kva offsets used
@@ -2254,7 +2254,7 @@ xbb_dispatch_file(struct xbb_softc *xbb, struct xbb_xen_reqlist *reqlist,
 	u_int		      nseg;
 	struct uio            xuio;
 	struct xbb_sg        *xbb_sg;
-	kiovec_t         *xiovec;
+	struct iovec         *xiovec;
 #ifdef XBB_USE_BOUNCE_BUFFERS
 	void                **p_vaddr;
 	int                   saved_uio_iovcnt;

--- a/sys/dev/xen/blkback/blkback.c
+++ b/sys/dev/xen/blkback/blkback.c
@@ -3942,12 +3942,3 @@ static driver_t xbb_driver = {
 devclass_t xbb_devclass;
 
 DRIVER_MODULE(xbbd, xenbusb_back, xbb_driver, xbb_devclass, 0, 0);
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/xen/xenstore/xenstore.c
+++ b/sys/dev/xen/xenstore/xenstore.c
@@ -814,7 +814,7 @@ xs_dev_request_and_reply(struct xsd_sockmsg *msg, void **result)
  */
 static int
 xs_talkv(struct xs_transaction t, enum xsd_sockmsg_type request_type,
-    const kiovec_t *iovec, u_int num_vecs, u_int *len, void **result)
+    const struct iovec *iovec, u_int num_vecs, u_int *len, void **result)
 {
 	struct xsd_sockmsg msg;
 	void *ret = NULL;
@@ -887,7 +887,7 @@ static int
 xs_single(struct xs_transaction t, enum xsd_sockmsg_type request_type,
     const char *body, u_int *len, void **result)
 {
-	kiovec_t iovec;
+	struct iovec iovec;
 
 	IOVEC_INIT_STR(&iovec, __DECONST(void *, body));
 
@@ -907,7 +907,7 @@ xs_single(struct xs_transaction t, enum xsd_sockmsg_type request_type,
 static int
 xs_watch(const char *path, const char *token)
 {
-	kiovec_t iov[2];
+	struct iovec iov[2];
 
 	IOVEC_INIT_STR(&iov[0], __DECONST(void *, path));
 	IOVEC_INIT_STR(&iov[1], __DECONST(void *, token));
@@ -927,7 +927,7 @@ xs_watch(const char *path, const char *token)
 static int
 xs_unwatch(const char *path, const char *token)
 {
-	kiovec_t iov[2];
+	struct iovec iov[2];
 
 	IOVEC_INIT_STR(&iov[0], __DECONST(void *, path));
 	IOVEC_INIT_STR(&iov[1], __DECONST(void *, token));
@@ -1319,7 +1319,7 @@ xs_write(struct xs_transaction t, const char *dir, const char *node,
     const char *string)
 {
 	struct sbuf *path;
-	kiovec_t iovec[2];
+	struct iovec iovec[2];
 	int error;
 
 	path = xs_join(dir, node);

--- a/sys/dev/xen/xenstore/xenstore.c
+++ b/sys/dev/xen/xenstore/xenstore.c
@@ -1652,11 +1652,10 @@ xs_unlock(void)
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/cd9660/cd9660_vnops.c
+++ b/sys/fs/cd9660/cd9660_vnops.c
@@ -210,7 +210,7 @@ cd9660_getattr(ap)
 	vap->va_size	= (u_quad_t) ip->i_size;
 	if (ip->i_size == 0 && (vap->va_mode & S_IFMT) == S_IFLNK) {
 		struct vop_readlink_args rdlnk;
-		kiovec_t aiov;
+		struct iovec aiov;
 		struct uio auio;
 		char *cp;
 

--- a/sys/fs/cd9660/cd9660_vnops.c
+++ b/sys/fs/cd9660/cd9660_vnops.c
@@ -920,11 +920,10 @@ struct vop_vector cd9660_fifoops = {
 };
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/cuse/cuse.c
+++ b/sys/fs/cuse/cuse.c
@@ -855,7 +855,7 @@ cuse_proc2proc_copy(struct proc *proc_s, vm_offset_t data_s,
 	proc_cur = td->td_proc;
 
 	if (proc_cur == proc_d) {
-		kiovec_t iov;
+		struct iovec iov;
 		IOVEC_INIT(&iov, (void *)data_d, len);
 		struct uio uio = {
 			.uio_iov = &iov,
@@ -872,7 +872,7 @@ cuse_proc2proc_copy(struct proc *proc_s, vm_offset_t data_s,
 		PRELE(proc_s);
 
 	} else if (proc_cur == proc_s) {
-		kiovec_t iov;
+		struct iovec iov;
 		IOVEC_INIT(&iov, (void *)data_s, len);
 		struct uio uio = {
 			.uio_iov = &iov,

--- a/sys/fs/cuse/cuse.c
+++ b/sys/fs/cuse/cuse.c
@@ -1910,11 +1910,10 @@ cuse_client_kqfilter(struct cdev *dev, struct knote *kn)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/ext2fs/ext2_htree.c
+++ b/sys/fs/ext2fs/ext2_htree.c
@@ -412,7 +412,7 @@ static int
 ext2_htree_append_block(struct vnode *vp, char *data,
     struct componentname *cnp, uint32_t blksize)
 {
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	struct inode *dp = VTOI(vp);
 	uint64_t cursize, newsize;

--- a/sys/fs/ext2fs/ext2_htree.c
+++ b/sys/fs/ext2fs/ext2_htree.c
@@ -941,11 +941,10 @@ finish:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/ext2fs/ext2_lookup.c
+++ b/sys/fs/ext2fs/ext2_lookup.c
@@ -876,7 +876,7 @@ ext2_add_first_entry(struct vnode *dvp, struct ext2fs_direct_2 *entry,
     struct componentname *cnp)
 {
 	struct inode *dp;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	char* buf = NULL;
 	int dirblksize, error;

--- a/sys/fs/fuse/fuse_io.c
+++ b/sys/fs/fuse/fuse_io.c
@@ -1167,11 +1167,10 @@ fuse_io_invalbuf(struct vnode *vp, struct thread *td)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/fuse/fuse_io.c
+++ b/sys/fs/fuse/fuse_io.c
@@ -940,7 +940,7 @@ fuse_io_strategy(struct vnode *vp, struct buf *bp)
 	struct ucred *cred;
 	struct uio *uiop;
 	struct uio uio;
-	kiovec_t io;
+	struct iovec io;
 	off_t filesize;
 	int error = 0;
 	int fflag;

--- a/sys/fs/fuse/fuse_vnops.c
+++ b/sys/fs/fuse/fuse_vnops.c
@@ -2487,11 +2487,10 @@ fuse_vnop_vptofh(struct vop_vptofh_args *ap)
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/nfsclient/nfs_clbio.c
+++ b/sys/fs/nfsclient/nfs_clbio.c
@@ -121,7 +121,7 @@ ncl_getpages(struct vop_getpages_args *ap)
 {
 	int i, error, nextoff, size, toff, count, npages;
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	vm_offset_t kva;
 	struct buf *bp;
 	struct vnode *vp;
@@ -268,7 +268,7 @@ int
 ncl_putpages(struct vop_putpages_args *ap)
 {
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	int i, error, npages, count;
 	off_t offset;
 	int *rtvals;
@@ -739,7 +739,7 @@ nfs_directio_write(vp, uiop, cred, ioflag)
 	if (ioflag & IO_SYNC) {
 		int iomode, must_commit;
 		struct uio uio;
-		kiovec_t iov;
+		struct iovec iov;
 do_sync:
 		while (uiop->uio_resid > 0) {
 			size = MIN(uiop->uio_resid, wsize);
@@ -770,7 +770,7 @@ do_sync:
 		}
 	} else {
 		struct uio *t_uio;
-		kiovec_t *t_iov;
+		struct iovec *t_iov;
 		struct buf *bp;
 
 		/*
@@ -792,7 +792,7 @@ do_sync:
 			size = MIN(uiop->uio_iov->iov_len, size);
 			bp = uma_zalloc(ncl_pbuf_zone, M_WAITOK);
 			t_uio = malloc(sizeof(struct uio), M_NFSDIRECTIO, M_WAITOK);
-			t_iov = malloc(sizeof(kiovec_t), M_NFSDIRECTIO, M_WAITOK);
+			t_iov = malloc(sizeof(struct iovec), M_NFSDIRECTIO, M_WAITOK);
 			IOVEC_INIT(t_iov, malloc(size, M_NFSDIRECTIO, M_WAITOK),
 			    size);
 			t_uio->uio_iov = t_iov;
@@ -1585,7 +1585,7 @@ ncl_doio(struct vnode *vp, struct buf *bp, struct ucred *cr, struct thread *td,
 	struct nfsmount *nmp;
 	int error = 0, iomode, must_commit = 0;
 	struct uio uio;
-	kiovec_t io;
+	struct iovec io;
 	struct proc *p = td ? td->td_proc : NULL;
 	uint8_t	iocmd;
 

--- a/sys/fs/nfsclient/nfs_clbio.c
+++ b/sys/fs/nfsclient/nfs_clbio.c
@@ -1873,11 +1873,10 @@ ncl_meta_setsize(struct vnode *vp, struct thread *td, u_quad_t nsize)
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/nfsclient/nfs_clcomsubs.c
+++ b/sys/fs/nfsclient/nfs_clcomsubs.c
@@ -435,11 +435,10 @@ nfscl_lockderef(struct nfsv4lock *lckp)
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/fs/nfsclient/nfs_clvnops.c
+++ b/sys/fs/nfsclient/nfs_clvnops.c
@@ -468,7 +468,7 @@ nfs_access(struct vop_access_args *ap)
 		NFSLOCKNODE(np);
 		if (ap->a_cred->cr_uid == 0 && (ap->a_accmode & VREAD)
 		    && VTONFS(vp)->n_size > 0) {
-			kiovec_t aiov;
+			struct iovec aiov;
 			struct uio auio;
 			char buf[1];
 

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -495,7 +495,7 @@ nfsvno_namei(struct nfsrv_descript *nd, struct nameidata *ndp,
 {
 	struct componentname *cnp = &ndp->ni_cnd;
 	int i;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	int lockleaf = (cnp->cn_flags & LOCKLEAF) != 0, linklen;
 	int error = 0;
@@ -718,8 +718,8 @@ int
 nfsvno_readlink(struct vnode *vp, struct ucred *cred, struct thread *p,
     struct mbuf **mpp, struct mbuf **mpendp, int *lenp)
 {
-	kiovec_t iv[(NFS_MAXPATHLEN+MLEN-1)/MLEN];
-	kiovec_t *ivp = iv;
+	struct iovec iv[(NFS_MAXPATHLEN+MLEN-1)/MLEN];
+	struct iovec *ivp = iv;
 	struct uio io, *uiop = &io;
 	struct mbuf *mp, *mp2 = NULL, *mp3 = NULL;
 	int i, len, tlen, error = 0;
@@ -782,8 +782,8 @@ nfsvno_read(struct vnode *vp, off_t off, int cnt, struct ucred *cred,
 {
 	struct mbuf *m;
 	int i;
-	kiovec_t *iv;
-	kiovec_t *iv2;
+	struct iovec *iv;
+	struct iovec *iv2;
 	int error = 0, len, left, siz, tlen, ioflag = 0;
 	struct mbuf *m2 = NULL, *m3;
 	struct uio io, *uiop = &io;
@@ -817,7 +817,7 @@ nfsvno_read(struct vnode *vp, off_t off, int cnt, struct ucred *cred,
 			m3 = m;
 		m2 = m;
 	}
-	iv = malloc(i * sizeof (kiovec_t), M_TEMP, M_WAITOK);
+	iv = malloc(i * sizeof (struct iovec), M_TEMP, M_WAITOK);
 	uiop->uio_iov = iv2 = iv;
 	m = m3;
 	left = len;
@@ -876,9 +876,9 @@ int
 nfsvno_write(struct vnode *vp, off_t off, int retlen, int cnt, int *stable,
     struct mbuf *mp, char *cp, struct ucred *cred, struct thread *p)
 {
-	kiovec_t *ivp;
+	struct iovec *ivp;
 	int i, len;
-	kiovec_t *iv;
+	struct iovec *iv;
 	int ioflags, error;
 	struct uio io, *uiop = &io;
 	struct nfsheur *nh;
@@ -894,7 +894,7 @@ nfsvno_write(struct vnode *vp, off_t off, int retlen, int cnt, int *stable,
 		return (error);
 	}
 
-	ivp = malloc(cnt * sizeof (kiovec_t), M_TEMP, M_WAITOK);
+	ivp = malloc(cnt * sizeof (struct iovec), M_TEMP, M_WAITOK);
 	uiop->uio_iov = iv = ivp;
 	uiop->uio_iovcnt = cnt;
 	i = mtod(mp, caddr_t) + mp->m_len - cp;
@@ -1821,7 +1821,7 @@ nfsrvd_readdir(struct nfsrv_descript *nd, int isdgram,
 	u_int64_t off, toff, verf __unused;
 	u_long *cookies = NULL, *cookiep;
 	struct uio io;
-	kiovec_t iv;
+	struct iovec iv;
 	int is_ufs;
 	struct thread *p = curthread;
 
@@ -2071,7 +2071,7 @@ nfsrvd_readdirplus(struct nfsrv_descript *nd, int isdgram,
 	u_long *cookies = NULL, *cookiep;
 	nfsattrbit_t attrbits, rderrbits, savbits;
 	struct uio io;
-	kiovec_t iv;
+	struct iovec iv;
 	struct componentname cn;
 	int at_root, is_ufs, is_zfs, needs_unbusy, supports_nfsv4acls;
 	struct mount *mp, *new_mp;

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -5861,11 +5861,10 @@ MODULE_DEPEND(nfsd, nfssvc, 1, 1, 1);
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/smbfs/smbfs_io.c
+++ b/sys/fs/smbfs/smbfs_io.c
@@ -311,7 +311,7 @@ smbfs_doio(struct vnode *vp, struct buf *bp, struct ucred *cr, struct thread *td
 	struct smbmount *smp = VFSTOSMBFS(vp->v_mount);
 	struct smbnode *np = VTOSMB(vp);
 	struct uio *uiop;
-	kiovec_t io;
+	struct iovec io;
 	struct smb_cred *scred;
 	int error = 0;
 
@@ -424,7 +424,7 @@ smbfs_getpages(ap)
 #else
 	int i, error, nextoff, size, toff, npages, count;
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	vm_offset_t kva;
 	struct buf *bp;
 	struct vnode *vp;
@@ -564,7 +564,7 @@ smbfs_putpages(ap)
 	return error;
 #else
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	vm_offset_t kva;
 	struct buf *bp;
 	int i, npages, count;

--- a/sys/fs/smbfs/smbfs_io.c
+++ b/sys/fs/smbfs/smbfs_io.c
@@ -674,11 +674,10 @@ smbfs_vinvalbuf(struct vnode *vp, struct thread *td)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/smbfs/smbfs_vfsops.c
+++ b/sys/fs/smbfs/smbfs_vfsops.c
@@ -406,11 +406,10 @@ smbfs_statfs(struct mount *mp, struct statfs *sbp)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/udf/udf_vnops.c
+++ b/sys/fs/udf/udf_vnops.c
@@ -908,7 +908,7 @@ udf_readlink(struct vop_readlink_args *ap)
 	struct path_component *pc, *end;
 	struct vnode *vp;
 	struct uio uio;
-	kiovec_t iov[1];
+	struct iovec iov[1];
 	struct udf_node *node;
 	void *buf;
 	char *cp;

--- a/sys/fs/udf/udf_vnops.c
+++ b/sys/fs/udf/udf_vnops.c
@@ -1490,11 +1490,10 @@ udf_bmap_internal(struct udf_node *node, off_t offset, daddr_t *sector,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/unionfs/union_subr.c
+++ b/sys/fs/unionfs/union_subr.c
@@ -1276,11 +1276,10 @@ unionfs_checklowervp(struct vnode *vp, char *fil, int lno)
 #endif
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/fs/unionfs/union_subr.c
+++ b/sys/fs/unionfs/union_subr.c
@@ -986,7 +986,7 @@ unionfs_copyfile_core(struct vnode *lvp, struct vnode *uvp,
 	int		bufoffset;
 	char           *buf;
 	struct uio	uio;
-	kiovec_t	iov;
+	struct iovec	iov;
 
 	error = 0;
 	memset(&uio, 0, sizeof(uio));
@@ -1129,7 +1129,7 @@ unionfs_check_rmdir(struct vnode *vp, struct ucred *cred, struct thread *td)
 	struct dirent  *dp;
 	struct dirent  *edp;
 	struct uio	uio;
-	kiovec_t	iov;
+	struct iovec	iov;
 
 	ASSERT_VOP_ELOCKED(vp, "unionfs_check_rmdir");
 

--- a/sys/i386/i386/mem.c
+++ b/sys/i386/i386/mem.c
@@ -230,12 +230,3 @@ memioctl(struct cdev *dev __unused, u_long cmd, caddr_t data, int flags,
 	}
 	return (error);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/i386/i386/mem.c
+++ b/sys/i386/i386/mem.c
@@ -84,7 +84,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	int o;
 	u_int c = 0;
 	vm_paddr_t pa;
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error = 0;
 	vm_offset_t addr;
 

--- a/sys/i386/i386/uio_machdep.c
+++ b/sys/i386/i386/uio_machdep.c
@@ -62,7 +62,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct sf_buf *sf;
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset;
 	size_t cnt;

--- a/sys/i386/i386/uio_machdep.c
+++ b/sys/i386/i386/uio_machdep.c
@@ -127,11 +127,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_alq.c
+++ b/sys/kern/kern_alq.c
@@ -978,11 +978,10 @@ DECLARE_MODULE(alq, alq_mod, SI_SUB_LAST, SI_ORDER_ANY);
 MODULE_VERSION(alq, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_alq.c
+++ b/sys/kern/kern_alq.c
@@ -314,7 +314,7 @@ alq_doio(struct alq *alq)
 	struct vnode *vp;
 	void *write_start;
 	struct uio auio;
-	kiovec_t aiov[2];
+	struct iovec aiov[2];
 	int totlen;
 	int iov;
 	int wrapearly;

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -288,7 +288,7 @@ kern_jail(struct thread *td, const char * __capability path,
     struct in_addr * __capability ip4, size_t ip4s,
     struct in6_addr * __capability ip6, size_t ip6s, enum uio_seg ipseg)
 {
-	kiovec_t optiov[2 * (4 + nitems(pr_flag_allow)
+	struct iovec optiov[2 * (4 + nitems(pr_flag_allow)
 #ifdef INET
 			    + 1
 #endif
@@ -438,7 +438,7 @@ done:
 
 /*
  * struct jail_set_args {
- *	kiovec_t *iovp;
+ *	struct iovec *iovp;
  *	unsigned int iovcnt;
  *	int flags;
  * };
@@ -1907,7 +1907,7 @@ kern_jail_set(struct thread *td, struct uio *optuio, int flags)
 
 /*
  * struct jail_get_args {
- *	kiovec_t *iovp;
+ *	struct iovec *iovp;
  *	unsigned int iovcnt;
  *	int flags;
  * };

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -4253,11 +4253,10 @@ DB_SHOW_COMMAND(prison, db_show_prison_command)
 #endif /* DDB */
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -1444,11 +1444,10 @@ ktrcanset(struct thread *td, struct proc *targetp)
 #endif /* KTRACE */
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "support",
 //     "user_capabilities"
 //   ]

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -1306,7 +1306,7 @@ ktr_writerequest(struct thread *td, struct ktr_request *req)
 	struct proc *p;
 	struct ucred *cred;
 	struct uio auio;
-	kiovec_t aiov[3];
+	struct iovec aiov[3];
 	struct mount *mp;
 	int datalen, buflen, vrele_count;
 	int error;

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1112,7 +1112,7 @@ out:
 }
 
 static int
-copyin_hdtr(const struct sf_hdtr_native * __capability uhdtr, ksf_hdtr_t *hdtr)
+copyin_hdtr(const struct sf_hdtr_native * __capability uhdtr, struct sf_hdtr *hdtr)
 {
 	struct sf_hdtr_native hdtr_n;
 	int error;
@@ -1133,7 +1133,7 @@ kern_sendfile(struct thread *td, int fd, int s, off_t offset, size_t nbytes,
     void * __capability uhdtr, off_t * __capability usbytes, int flags,
     int compat, copyin_hdtr_t *copyin_hdtr_f, copyinuio_t *copyinuio_f)
 {
-	ksf_hdtr_t hdtr;
+	struct sf_hdtr hdtr;
 	struct uio *hdr_uio, *trl_uio;
 	struct file *fp;
 	off_t sbytes;

--- a/sys/kern/subr_bus_dma.c
+++ b/sys/kern/subr_bus_dma.c
@@ -340,7 +340,7 @@ _bus_dmamap_load_uio(bus_dma_tag_t dmat, bus_dmamap_t map, struct uio *uio,
 {
 	bus_size_t resid;
 	bus_size_t minlen;
-	kiovec_t *iov;
+	struct iovec *iov;
 	pmap_t pmap;
 	caddr_t addr;
 	int error, i;

--- a/sys/kern/subr_bus_dma.c
+++ b/sys/kern/subr_bus_dma.c
@@ -637,11 +637,10 @@ bus_dmamap_load_mem(bus_dma_tag_t dmat, bus_dmamap_t map,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/subr_mchain.c
+++ b/sys/kern/subr_mchain.c
@@ -569,11 +569,10 @@ md_get_uio(struct mdchain *mdp, struct uio *uiop, int size)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/subr_scanf.c
+++ b/sys/kern/subr_scanf.c
@@ -679,11 +679,10 @@ doswitch:
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/subr_sglist.c
+++ b/sys/kern/subr_sglist.c
@@ -613,7 +613,7 @@ sglist_append_sglist(struct sglist *sg, struct sglist *source, size_t offset,
 int
 sglist_append_uio(struct sglist *sg, struct uio *uio)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct sgsave save;
 	size_t resid, minlen;
 	pmap_t pmap;
@@ -661,7 +661,7 @@ sglist_append_uio(struct sglist *sg, struct uio *uio)
 int
 sglist_consume_uio(struct sglist *sg, struct uio *uio, size_t resid)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	size_t done;
 	pmap_t pmap;
 	int error, len;

--- a/sys/kern/subr_sglist.c
+++ b/sys/kern/subr_sglist.c
@@ -1000,11 +1000,10 @@ sglist_slice(struct sglist *original, struct sglist **slice, size_t offset,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -946,11 +946,10 @@ casuword32_c(volatile uint32_t * __capability base, uint32_t oldval,
 #endif
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -139,7 +139,7 @@ int
 physcopyin(void *src, vm_paddr_t dst, size_t len)
 {
 	vm_page_t m[PHYS_PAGE_COUNT(len)];
-	kiovec_t iov[1];
+	struct iovec iov[1];
 	struct uio uio;
 	int i;
 
@@ -159,7 +159,7 @@ int
 physcopyout(vm_paddr_t src, void *dst, size_t len)
 {
 	vm_page_t m[PHYS_PAGE_COUNT(len)];
-	kiovec_t iov[1];
+	struct iovec iov[1];
 	struct uio uio;
 	int i;
 
@@ -246,7 +246,7 @@ uiomove_nofault(void *cp, int n, struct uio *uio)
 static int
 uiomove_faultflag(void *cp, int n, struct uio *uio, int nofault)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	size_t cnt;
 	int error, newflags, save;
 
@@ -348,7 +348,7 @@ uiomove_frombuf(void *buf, int buflen, struct uio *uio)
 int
 ureadc(int c, struct uio *uio)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	char * __capability iov_base;
 
 	WITNESS_WARN(WARN_GIANTOK | WARN_SLEEPOK, NULL,
@@ -423,20 +423,20 @@ copyinstrfrom(const void * __restrict src, void * __restrict dst, size_t len,
 }
 
 int
-copyiniov(const uiovec_t * __capability iovp, u_int iovcnt, kiovec_t **iov,
+copyiniov(const struct iovec_native * __capability iovp, u_int iovcnt, struct iovec **iov,
     int error)
 {
-	uiovec_t useriov;
-	kiovec_t *iovs;
+	struct iovec_native useriov;
+	struct iovec *iovs;
 	size_t iovlen;
 	int i;
 
 	*iov = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (error);
-	iovlen = iovcnt * sizeof (kiovec_t);
+	iovlen = iovcnt * sizeof (struct iovec);
 	iovs = malloc(iovlen, M_IOV, M_WAITOK);
-	/* XXXBD: needlessly slow when uiovec_t and kiovec_t are the same */
+	/* XXXBD: needlessly slow when struct iovec_native and struct iovec are the same */
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin_c(iovp + i, &useriov, sizeof(useriov));
 		if (error) {
@@ -450,10 +450,10 @@ copyiniov(const uiovec_t * __capability iovp, u_int iovcnt, kiovec_t **iov,
 }
 
 int
-copyinuio(const uiovec_t * __capability iovp, u_int iovcnt, struct uio **uiop)
+copyinuio(const struct iovec_native * __capability iovp, u_int iovcnt, struct uio **uiop)
 {
-	uiovec_t u_iov;
-	kiovec_t *iov;
+	struct iovec_native u_iov;
+	struct iovec *iov;
 	struct uio *uio;
 	size_t iovlen;
 	int error, i;
@@ -461,9 +461,9 @@ copyinuio(const uiovec_t * __capability iovp, u_int iovcnt, struct uio **uiop)
 	*uiop = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	iovlen = iovcnt * sizeof (kiovec_t);
+	iovlen = iovcnt * sizeof (struct iovec);
 	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
-	iov = (kiovec_t *)(uio + 1);
+	iov = (struct iovec *)(uio + 1);
 	for (i = 0; i < iovcnt; i++) {
 		error = copyin_c(&iovp[i], &u_iov, sizeof(u_iov));
 		if (error) {
@@ -494,7 +494,7 @@ copyinuio(const uiovec_t * __capability iovp, u_int iovcnt, struct uio **uiop)
  * iovec.
  */
 int
-updateiov(const struct uio *uiop, uiovec_t *iovp)
+updateiov(const struct uio *uiop, struct iovec_native *iovp)
 {
 	int i, error;
 
@@ -512,10 +512,10 @@ cloneuio(struct uio *uiop)
 	struct uio *uio;
 	int iovlen;
 
-	iovlen = uiop->uio_iovcnt * sizeof (kiovec_t);
+	iovlen = uiop->uio_iovcnt * sizeof (struct iovec);
 	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
 	*uio = *uiop;
-	uio->uio_iov = (kiovec_t *)(uio + 1);
+	uio->uio_iov = (struct iovec *)(uio + 1);
 	cheri_bcopy(uiop->uio_iov, uio->uio_iov, iovlen);
 	return (uio);
 }

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -1993,11 +1993,10 @@ kern_posix_error(struct thread *td, int error)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -201,7 +201,7 @@ int
 user_read(struct thread *td, int fd, void * __capability buf, size_t nbyte)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 
 	if (nbyte > IOSIZE_MAX)
 		return (EINVAL);
@@ -238,7 +238,7 @@ kern_pread(struct thread *td, int fd, void * __capability buf, size_t nbyte,
     off_t offset)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 
 	if (nbyte > IOSIZE_MAX)
 		return (EINVAL);
@@ -425,7 +425,7 @@ kern_write(struct thread *td, int fd, const void * __capability buf,
     size_t nbyte)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error;
 
 	if (nbyte > IOSIZE_MAX)
@@ -464,7 +464,7 @@ kern_pwrite(struct thread *td, int fd, const void * __capability buf,
     size_t nbyte, off_t offset)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error;
 
 	if (nbyte > IOSIZE_MAX)

--- a/sys/kern/sys_getrandom.c
+++ b/sys/kern/sys_getrandom.c
@@ -53,7 +53,7 @@ kern_getrandom(struct thread *td, void * __capability user_buf, size_t buflen,
     unsigned int flags)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error;
 
 	if ((flags & ~GRND_VALIDFLAGS) != 0)

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -1783,11 +1783,10 @@ filt_pipenotsup(struct knote *kn, long hint)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -888,7 +888,7 @@ static void
 pipe_clone_write_buffer(struct pipe *wpipe)
 {
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	int size;
 	int pos;
 

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -1712,11 +1712,10 @@ stopevent(struct proc *p, unsigned int event, unsigned int val)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "support"
 //   ]
 // }

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -352,7 +352,7 @@ static ssize_t
 proc_iop(struct thread *td, struct proc *p, vm_offset_t va, void *buf,
     size_t len, enum uio_rw rw)
 {
-	kiovec_t iov;
+	struct iovec iov;
 	struct uio uio;
 	ssize_t slen;
 
@@ -831,7 +831,7 @@ proc_set_traced(struct proc *p, bool stop)
 int
 kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int data)
 {
-	kiovec_t iov;
+	struct iovec iov;
 	struct uio uio;
 	struct proc *curp, *p, *pp;
 	struct thread *td2 = NULL, *td3;

--- a/sys/kern/sys_socket.c
+++ b/sys/kern/sys_socket.c
@@ -822,11 +822,10 @@ soo_aio_queue(struct file *fp, struct kaiocb *job)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/sys_socket.c
+++ b/sys/kern/sys_socket.c
@@ -583,7 +583,7 @@ soaio_process_job(struct socket *so, struct sockbuf *sb, struct kaiocb *job)
 	struct thread *td;
 	struct file *fp;
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	size_t cnt, done;
 	long ru_before;
 	int error, flags;

--- a/sys/kern/uipc_mbuf.c
+++ b/sys/kern/uipc_mbuf.c
@@ -589,7 +589,7 @@ nospace:
 static void
 m_copyfromunmapped(const struct mbuf *m, int off, int len, caddr_t cp)
 {
-	kiovec_t iov;
+	struct iovec iov;
 	struct uio uio;
 	int error;
 

--- a/sys/kern/uipc_mbuf.c
+++ b/sys/kern/uipc_mbuf.c
@@ -2119,14 +2119,3 @@ SYSCTL_PROC(_kern_ipc, OID_AUTO, mbufprofile, CTLTYPE_STRING|CTLFLAG_RD,
 SYSCTL_PROC(_kern_ipc, OID_AUTO, mbufprofileclr, CTLTYPE_INT|CTLFLAG_RW,
 	    NULL, 0, mbprof_clr_handler, "I", "clear mbuf profiling statistics");
 #endif
-
-// CHERI CHANGES START
-// {
-//   "updated": 20190610,
-//   "changes": [
-//     "kiovec_t"
-//   ],
-//   "change_comment": "",
-//   "hybrid_specific": false
-// }
-// CHERI CHANGES END

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -75,7 +75,7 @@ __FBSDID("$FreeBSD$");
 #include <security/audit/audit.h>
 #include <security/mac/mac_framework.h>
 
-static int recvit(struct thread *td, int s, kmsghdr_t *mp,
+static int recvit(struct thread *td, int s, struct msghdr *mp,
     socklen_t * __capability namelenp);
 
 /*
@@ -681,7 +681,7 @@ user_socketpair(struct thread *td, int domain, int type, int protocol,
 }
 
 int
-user_sendit(struct thread *td, int s, kmsghdr_t *mp, int flags)
+user_sendit(struct thread *td, int s, struct msghdr *mp, int flags)
 {
 	struct mbuf *control;
 	struct sockaddr *to;
@@ -741,12 +741,12 @@ bad:
 }
 
 int
-kern_sendit(struct thread *td, int s, kmsghdr_t *mp, int flags,
+kern_sendit(struct thread *td, int s, struct msghdr *mp, int flags,
     struct mbuf *control, enum uio_seg segflg)
 {
 	struct file *fp;
 	struct uio auio;
-	kiovec_t * __capability iov;
+	struct iovec * __capability iov;
 	struct socket *so;
 	cap_rights_t *rights;
 #ifdef KTRACE
@@ -789,7 +789,7 @@ kern_sendit(struct thread *td, int s, kmsghdr_t *mp, int flags,
 	}
 #endif
 
-	auio.uio_iov = (__cheri_fromcap kiovec_t *)mp->msg_iov;
+	auio.uio_iov = (__cheri_fromcap struct iovec *)mp->msg_iov;
 	auio.uio_iovcnt = mp->msg_iovlen;
 	auio.uio_segflg = segflg;
 	auio.uio_rw = UIO_WRITE;
@@ -849,8 +849,8 @@ user_sendto(struct thread *td, int s, const char * __capability buf,
     size_t len, int flags, const struct sockaddr * __capability to,
     socklen_t tolen)
 {
-	kmsghdr_t msg;
-	kiovec_t aiov;
+	struct msghdr msg;
+	struct iovec aiov;
 
 	msg.msg_name = __DECONST_CAP(void * __capability, to);
 	msg.msg_namelen = tolen;
@@ -869,8 +869,8 @@ user_sendto(struct thread *td, int s, const char * __capability buf,
 int
 osend(struct thread *td, struct osend_args *uap)
 {
-	kmsghdr_t msg;
-	kiovec_t aiov;
+	struct msghdr msg;
+	struct iovec aiov;
 
 	msg.msg_name = 0;
 	msg.msg_namelen = 0;
@@ -887,7 +887,7 @@ osendmsg(struct thread *td, struct osendmsg_args *uap)
 {
 	kmsthdr_t msg;
 	struct omsghdr umsg;
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error;
 
 	error = copyin(uap->msg, &umsg, sizeof (umsg));
@@ -912,9 +912,9 @@ osendmsg(struct thread *td, struct osendmsg_args *uap)
 int
 sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 {
-	kmsghdr_t msg;
-	umsghdr_t umsg;
-	kiovec_t *iov;
+	struct msghdr msg;
+	struct msghdr_native umsg;
+	struct iovec *iov;
 	int error;
 
 	error = copyin(__USER_CAP_OBJ(uap->msg), &umsg, sizeof(umsg));
@@ -926,7 +926,7 @@ sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 	    umsg.msg_iovlen, &iov, EMSGSIZE);
 	if (error != 0)
 		return (error);
-	msg.msg_iov = (__cheri_tocap kiovec_t * __capability)iov;
+	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
 	msg.msg_iovlen = umsg.msg_iovlen;
 	msg.msg_control = __USER_CAP(umsg.msg_control, umsg.msg_controllen);
 	msg.msg_controllen = umsg.msg_controllen;
@@ -941,11 +941,11 @@ sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 }
 
 int
-kern_recvit(struct thread *td, int s, kmsghdr_t *mp, enum uio_seg fromseg,
+kern_recvit(struct thread *td, int s, struct msghdr *mp, enum uio_seg fromseg,
     struct mbuf **controlp)
 {
 	struct uio auio;
-	kiovec_t * __capability iov;
+	struct iovec * __capability iov;
 	struct mbuf *control, *m;
 	char * __capability ctlbuf;
 	struct file *fp;
@@ -975,7 +975,7 @@ kern_recvit(struct thread *td, int s, kmsghdr_t *mp, enum uio_seg fromseg,
 	}
 #endif
 
-	auio.uio_iov = (__cheri_fromcap kiovec_t *)mp->msg_iov;
+	auio.uio_iov = (__cheri_fromcap struct iovec *)mp->msg_iov;
 	auio.uio_iovcnt = mp->msg_iovlen;
 	auio.uio_segflg = UIO_USERSPACE;
 	auio.uio_rw = UIO_READ;
@@ -1098,7 +1098,7 @@ out:
 }
 
 static int
-recvit(struct thread *td, int s, kmsghdr_t *mp,
+recvit(struct thread *td, int s, struct msghdr *mp,
     socklen_t * __capability namelenp)
 {
 	int error;
@@ -1132,8 +1132,8 @@ kern_recvfrom(struct thread *td, int s, void * __capability buf, size_t len,
     int flags, struct sockaddr * __capability __restrict from,
     socklen_t * __capability __restrict fromlenaddr)
 {
-	kmsghdr_t msg;
-	kiovec_t aiov;
+	struct msghdr msg;
+	struct iovec aiov;
 	int error;
 
 	if (fromlenaddr != NULL) {
@@ -1169,8 +1169,8 @@ orecvfrom(struct thread *td, struct recvfrom_args *uap)
 int
 orecv(struct thread *td, struct orecv_args *uap)
 {
-	kmsghdr_t msg;
-	kiovec_t aiov;
+	struct msghdr msg;
+	struct iovec aiov;
 
 	msg.msg_name = 0;
 	msg.msg_namelen = 0;
@@ -1190,9 +1190,9 @@ orecv(struct thread *td, struct orecv_args *uap)
 int
 orecvmsg(struct thread *td, struct orecvmsg_args *uap)
 {
-	kmsghdr_t msg;
+	struct msghdr msg;
 	struct omsghdr umsg;
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error;
 
 	error = copyin(uap->msg, &umsg, sizeof(umsg));
@@ -1220,9 +1220,9 @@ orecvmsg(struct thread *td, struct orecvmsg_args *uap)
 int
 sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 {
-	kmsghdr_t msg;
-	umsghdr_t umsg;
-	kiovec_t *iov;
+	struct msghdr msg;
+	struct msghdr_native umsg;
+	struct iovec *iov;
 	int error;
 
 	error = copyin(__USER_CAP_OBJ(uap->msg), &umsg, sizeof(umsg));
@@ -1234,7 +1234,7 @@ sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 	    umsg.msg_iovlen, &iov, EMSGSIZE);
 	if (error != 0)
 		return (error);
-	msg.msg_iov = (__cheri_tocap kiovec_t * __capability)iov;
+	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
 	msg.msg_iovlen = umsg.msg_iovlen;
 	msg.msg_control = __USER_CAP(umsg.msg_control, umsg.msg_controllen);
 	msg.msg_controllen = umsg.msg_controllen;

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -1712,11 +1712,10 @@ m_dispose_extcontrolm(struct mbuf *m)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -3889,12 +3889,11 @@ cheriabi_lio_listio(struct thread *td, struct cheriabi_lio_listio_args *uap)
 #endif /* COMPAT_CHERIABI */
 // CHERI CHANGES START
 // {
-//   "updated": 20181203,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
 //     "kernel_sig_types",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -768,7 +768,7 @@ aio_process_rw(struct kaiocb *job)
 	kaiocb_t *cb;
 	struct file *fp;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	ssize_t cnt;
 	long msgsnd_st, msgsnd_end;
 	long msgrcv_st, msgrcv_end;

--- a/sys/kern/vfs_default.c
+++ b/sys/kern/vfs_default.c
@@ -276,7 +276,7 @@ get_next_dirent(struct vnode *vp, struct dirent **dpp, char *dirbuf,
 {
 	int error, reclen;
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	struct dirent *dp;
 
 	KASSERT(VOP_ISLOCKED(vp), ("vp %p is not locked", vp));
@@ -870,7 +870,7 @@ vop_stdallocate(struct vop_allocate_args *ap)
 	struct statfs *sfs;
 	off_t maxfilesize = 0;
 #endif
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct vattr vattr, *vap;
 	struct uio auio;
 	off_t fsize, len, cur, offset;

--- a/sys/kern/vfs_default.c
+++ b/sys/kern/vfs_default.c
@@ -1401,11 +1401,10 @@ vop_sigdefer(struct vop_vector *vop, struct vop_generic_args *a)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -179,7 +179,7 @@ extattr_set_vp(struct vnode *vp, int attrnamespace, const char *attrname,
 {
 	struct mount *mp;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	ssize_t cnt;
 	int error;
 
@@ -348,7 +348,7 @@ extattr_get_vp(struct vnode *vp, int attrnamespace, const char *attrname,
     void * __capability data, size_t nbytes, struct thread *td)
 {
 	struct uio auio, *auiop;
-	kiovec_t aiov;
+	struct iovec aiov;
 	ssize_t cnt;
 	size_t size, *sizep;
 	int error;
@@ -666,7 +666,7 @@ extattr_list_vp(struct vnode *vp, int attrnamespace, void * __capability data,
 {
 	struct uio auio, *auiop;
 	size_t size, *sizep;
-	kiovec_t aiov;
+	struct iovec aiov;
 	ssize_t cnt;
 	int error;
 

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -805,11 +805,10 @@ kern_extattr_list_path(struct thread *td, const char * __capability path,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -1498,11 +1498,10 @@ keeporig:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -311,7 +311,7 @@ namei(struct nameidata *ndp)
 	struct filedesc *fdp;	/* pointer to file descriptor state */
 	char *cp;		/* pointer into pathname argument */
 	struct vnode *dp;	/* the directory we are searching */
-	kiovec_t aiov;		/* uio for reading symbolic links */
+	struct iovec aiov;		/* uio for reading symbolic links */
 	struct componentname *cnp;
 	struct thread *td;
 	struct proc *p;

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -2326,11 +2326,10 @@ vfs_oexport_conv(const struct oexport_args *oexp, struct export_args *exp)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -2135,7 +2135,7 @@ struct mntaarg {
 
 /* The header for the mount arguments */
 struct mntarg {
-	kiovec_t *v;
+	struct iovec *v;
 	int len;
 	int error;
 	SLIST_HEAD(, mntaarg)	list;

--- a/sys/kern/vfs_subr.c
+++ b/sys/kern/vfs_subr.c
@@ -5584,7 +5584,7 @@ int
 vfs_emptydir(struct vnode *vp)
 {
 	struct uio uio;
-	kiovec_t iov;
+	struct iovec iov;
 	struct dirent *dirent, *dp, *endp;
 	int error, eof;
 

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -2620,7 +2620,7 @@ static int
 kern_readlink_vp(struct vnode *vp, char * __capability buf,
     enum uio_seg bufseg, size_t count, struct thread *td)
 {
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	int error;
 
@@ -4113,7 +4113,7 @@ kern_getdirentries(struct thread *td, int fd, char * __capability buf,
 	struct vnode *vp;
 	struct file *fp;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	off_t loff;
 	int error, eofflag;
 	off_t foffset;

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -530,7 +530,7 @@ vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base, int len, off_t offset,
     struct ucred *file_cred, ssize_t *aresid, struct thread *td)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct mount *mp;
 	struct ucred *cred;
 	void *rl_cookie;
@@ -988,7 +988,7 @@ static int
 vn_io_fault_prefault_user(const struct uio *uio)
 {
 	char * __capability base;
-	kiovec_t *iov;
+	struct iovec *iov;
 	size_t len;
 	ssize_t resid;
 	int error, i;
@@ -1039,7 +1039,7 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 {
 	vm_page_t ma[io_hold_cnt + 2];
 	struct uio *uio_clone, short_uio;
-	kiovec_t short_iovec[1];
+	struct iovec short_iovec[1];
 	vm_page_t *prev_td_ma;
 	vm_prot_t prot;
 	vm_offset_t addr, end;
@@ -1199,7 +1199,7 @@ int
 vn_io_fault_uiomove(char *data, int xfersize, struct uio *uio)
 {
 	struct uio transp_uio;
-	kiovec_t transp_iov[1];
+	struct iovec transp_iov[1];
 	struct thread *td;
 	size_t adv;
 	int error, pgadv;
@@ -1983,7 +1983,7 @@ vn_extattr_get(struct vnode *vp, int ioflg, int attrnamespace,
     const char *attrname, int *buflen, char *buf, struct thread *td)
 {
 	struct uio	auio;
-	kiovec_t	iov;
+	struct iovec	iov;
 	int	error;
 
 	IOVEC_INIT(&iov, buf, *buflen);
@@ -2023,7 +2023,7 @@ vn_extattr_set(struct vnode *vp, int ioflg, int attrnamespace,
     const char *attrname, int buflen, char *buf, struct thread *td)
 {
 	struct uio	auio;
-	kiovec_t	iov;
+	struct iovec	iov;
 	struct mount	*mp;
 	int	error;
 

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -3128,11 +3128,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20191003,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/mips/cavium/cryptocteon/cavium_crypto.c
+++ b/sys/mips/cavium/cryptocteon/cavium_crypto.c
@@ -2136,12 +2136,3 @@ octo_aes_cbc_sha1_decrypt(
 }
 
 /****************************************************************************/
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/mips/cavium/cryptocteon/cavium_crypto.c
+++ b/sys/mips/cavium/cryptocteon/cavium_crypto.c
@@ -325,7 +325,7 @@ octo_calc_hash(uint8_t auth, unsigned char *key, uint64_t *inner, uint64_t *oute
 int
 octo_des_cbc_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -384,7 +384,7 @@ octo_des_cbc_encrypt(
 int
 octo_des_cbc_decrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -444,7 +444,7 @@ octo_des_cbc_decrypt(
 int
 octo_aes_cbc_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -513,7 +513,7 @@ octo_aes_cbc_encrypt(
 int
 octo_aes_cbc_decrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -584,7 +584,7 @@ octo_aes_cbc_decrypt(
 int
 octo_null_md5_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -686,7 +686,7 @@ octo_null_md5_encrypt(
 int
 octo_null_sha1_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -791,7 +791,7 @@ octo_null_sha1_encrypt(
 int
 octo_des_cbc_md5_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -939,7 +939,7 @@ octo_des_cbc_md5_encrypt(
 int
 octo_des_cbc_md5_decrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -1090,7 +1090,7 @@ octo_des_cbc_md5_decrypt(
 int
 octo_des_cbc_sha1_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -1241,7 +1241,7 @@ octo_des_cbc_sha1_encrypt(
 int
 octo_des_cbc_sha1_decrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -1394,7 +1394,7 @@ octo_des_cbc_sha1_decrypt(
 int
 octo_aes_cbc_md5_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -1571,7 +1571,7 @@ octo_aes_cbc_md5_encrypt(
 int
 octo_aes_cbc_md5_decrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -1747,7 +1747,7 @@ octo_aes_cbc_md5_decrypt(
 int
 octo_aes_cbc_sha1_encrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)
@@ -1943,7 +1943,7 @@ octo_aes_cbc_sha1_encrypt(
 int
 octo_aes_cbc_sha1_decrypt(
     struct octo_sess *od,
-    kiovec_t *iov, size_t iovcnt, size_t iovlen,
+    struct iovec *iov, size_t iovcnt, size_t iovlen,
     int auth_off, int auth_len,
     int crypt_off, int crypt_len,
     int icv_off, uint8_t *ivp)

--- a/sys/mips/cavium/cryptocteon/cryptocteonvar.h
+++ b/sys/mips/cavium/cryptocteon/cryptocteonvar.h
@@ -34,8 +34,8 @@
 
 struct octo_sess;
 
-typedef	int octo_encrypt_t(struct octo_sess *od, kiovec_t *iov, size_t iovcnt, size_t iovlen, int auth_off, int auth_len, int crypt_off, int crypt_len, int icv_off, uint8_t *ivp);
-typedef	int octo_decrypt_t(struct octo_sess *od, kiovec_t *iov, size_t iovcnt, size_t iovlen, int auth_off, int auth_len, int crypt_off, int crypt_len, int icv_off, uint8_t *ivp);
+typedef	int octo_encrypt_t(struct octo_sess *od, struct iovec *iov, size_t iovcnt, size_t iovlen, int auth_off, int auth_len, int crypt_off, int crypt_len, int icv_off, uint8_t *ivp);
+typedef	int octo_decrypt_t(struct octo_sess *od, struct iovec *iov, size_t iovcnt, size_t iovlen, int auth_off, int auth_len, int crypt_off, int crypt_len, int icv_off, uint8_t *ivp);
 
 struct octo_sess {
 	int					 octo_encalg;
@@ -58,7 +58,7 @@ struct octo_sess {
 	uint64_t			 octo_hminner[3];
 	uint64_t			 octo_hmouter[3];
 
-	kiovec_t				octo_iov[UIO_MAXIOV];
+	struct iovec				octo_iov[UIO_MAXIOV];
 };
 
 #define	dprintf(fmt, ...)						\

--- a/sys/mips/cavium/cryptocteon/cryptocteonvar.h
+++ b/sys/mips/cavium/cryptocteon/cryptocteonvar.h
@@ -92,12 +92,3 @@ octo_decrypt_t octo_aes_cbc_md5_decrypt;
 octo_decrypt_t octo_aes_cbc_sha1_decrypt;
 
 #endif /* !_MIPS_CAVIUM_CRYPTOCTEON_CRYPTOCTEONVAR_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/mips/mips/mem.c
+++ b/sys/mips/mips/mem.c
@@ -76,7 +76,7 @@ struct mem_range_softc mem_range_softc;
 int
 memrw(struct cdev *dev, struct uio *uio, int flags)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error = 0;
 	vm_offset_t va, eva, off, v;
 	vm_prot_t prot;

--- a/sys/mips/mips/mem.c
+++ b/sys/mips/mips/mem.c
@@ -160,12 +160,3 @@ memmmap(struct cdev *dev, vm_ooffset_t offset, vm_paddr_t *paddr,
 
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -71,7 +71,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct sf_buf *sf;
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset;
 	vm_paddr_t pa;

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -169,11 +169,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181121,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "integer_provenance"
 //   ]
 // }

--- a/sys/mips/nlm/dev/sec/nlmsec.c
+++ b/sys/mips/nlm/dev/sec/nlmsec.c
@@ -790,12 +790,3 @@ errout:
 	crypto_done(crp);
 	return (err);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/mips/nlm/dev/sec/nlmsec.c
+++ b/sys/mips/nlm/dev/sec/nlmsec.c
@@ -559,11 +559,11 @@ xlp_get_nsegs(struct cryptop *crp, unsigned int *nsegs)
 		}
 	} else if (crp->crp_flags & CRYPTO_F_IOV) {
 		struct uio *uio = NULL;
-		kiovec_t *iov = NULL;
+		struct iovec *iov = NULL;
 		int iol = 0;
 
 		uio = (struct uio *)crp->crp_buf;
-		iov = (kiovec_t *)uio->uio_iov;
+		iov = (struct iovec *)uio->uio_iov;
 		iol = uio->uio_iovcnt;
 		while (iol > 0) {
 			*nsegs += NLM_CRYPTO_NUM_SEGS_REQD(iov->iov_len);

--- a/sys/mips/nlm/dev/sec/nlmseclib.c
+++ b/sys/mips/nlm/dev/sec/nlmseclib.c
@@ -307,12 +307,3 @@ nlm_get_cipher_param(struct xlp_sec_command *cmd)
 	}
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/mips/nlm/dev/sec/nlmseclib.c
+++ b/sys/mips/nlm/dev/sec/nlmseclib.c
@@ -126,11 +126,11 @@ nlm_crypto_form_srcdst_segs(struct xlp_sec_command *cmd)
 		}
 	} else if (crp->crp_flags & CRYPTO_F_IOV) {
 		struct uio *uio = NULL;
-		kiovec_t *iov = NULL;
+		struct iovec *iov = NULL;
 	        int iol = 0;
 
 		uio = (struct uio *)crp->crp_buf;
-		iov = (kiovec_t *)uio->uio_iov;
+		iov = (struct iovec *)uio->uio_iov;
 		iol = uio->uio_iovcnt;
 
 		while (iol > 0) {

--- a/sys/netinet/sctp_syscalls.c
+++ b/sys/netinet/sctp_syscalls.c
@@ -283,7 +283,7 @@ kern_sys_sctp_generic_sendmsg(struct thread *td, int sd,
 	struct uio *ktruio = NULL;
 #endif
 	struct uio auio;
-	kiovec_t iov[1];
+	struct iovec iov[1];
 	cap_rights_t rights;
 	int error = 0, len;
 
@@ -420,7 +420,7 @@ kern_sctp_generic_sendmsg_iov(struct thread *td, int sd,
 	struct uio *ktruio = NULL;
 #endif
 	struct uio auio;
-	kiovec_t *iov, *tiov;
+	struct iovec *iov, *tiov;
 	cap_rights_t rights;
 	ssize_t len;
 	int error, i;
@@ -576,7 +576,7 @@ kern_sctp_generic_recvmsg(struct thread *td, int sd, void * __capability uiov,
 #if (defined(INET) || defined(INET6)) && defined(SCTP)
 	uint8_t sockbufstore[256];
 	struct uio auio;
-	kiovec_t *iov, *tiov;
+	struct iovec *iov, *tiov;
 	struct sctp_sndrcvinfo sinfo;
 	struct socket *so;
 	struct file *fp = NULL;

--- a/sys/netinet/sctp_syscalls.c
+++ b/sys/netinet/sctp_syscalls.c
@@ -713,11 +713,10 @@ out1:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -835,7 +835,7 @@ nsmb_dev_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int flag, struct thre
 #endif
 	    {
 		struct uio auio;
-		kiovec_t iov;
+		struct iovec iov;
 	
 		if ((ssp = sdp->sd_share) == NULL) {
 			error = ENOTCONN;

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -962,12 +962,11 @@ smb_dev2share(int fd, int mode, struct smb_cred *scred,
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "ioctl:misc",
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -297,7 +297,7 @@ nbssn_recvhdr(struct nbpcb *nbp, int *lenp,
 {
 	struct socket *so = nbp->nbp_tso;
 	struct uio auio;
-	kiovec_t aio;
+	struct iovec aio;
 	u_int32_t len;
 	int error;
 

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -698,11 +698,10 @@ struct smb_tran_desc smb_tran_nbtcp_desc = {
 
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/nfs/bootp_subr.c
+++ b/sys/nfs/bootp_subr.c
@@ -587,7 +587,7 @@ bootpc_call(struct bootpc_globalcontext *gctx, struct thread *td)
 	struct sockaddr_in *sin, dst;
 	struct uio auio;
 	struct sockopt sopt;
-	kiovec_t aio;
+	struct iovec aio;
 	int error, on, rcvflg, timo, len;
 	time_t atimo;
 	time_t rtimo;

--- a/sys/nfs/bootp_subr.c
+++ b/sys/nfs/bootp_subr.c
@@ -1908,11 +1908,10 @@ out:
 SYSINIT(bootp_rootconf, SI_SUB_ROOT_CONF, SI_ORDER_FIRST, bootpc_init, NULL);
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/ofed/drivers/infiniband/ulp/sdp/sdp.h
+++ b/sys/ofed/drivers/infiniband/ulp/sdp/sdp.h
@@ -664,7 +664,7 @@ void sdp_rx_comp_full(struct sdp_sock *ssk);
 
 /* sdp_zcopy.c */
 struct kiocb;
-int sdp_sendmsg_zcopy(struct kiocb *iocb, struct socket *sk, kiovec_t *iov);
+int sdp_sendmsg_zcopy(struct kiocb *iocb, struct socket *sk, struct iovec *iov);
 int sdp_handle_srcavail(struct sdp_sock *ssk, struct sdp_srcah *srcah);
 void sdp_handle_sendsm(struct sdp_sock *ssk, u32 mseq_ack);
 void sdp_handle_rdma_read_compl(struct sdp_sock *ssk, u32 mseq_ack,

--- a/sys/ofed/drivers/infiniband/ulp/sdp/sdp.h
+++ b/sys/ofed/drivers/infiniband/ulp/sdp/sdp.h
@@ -681,12 +681,3 @@ void sdp_abort_rdma_read(struct socket *sk);
 int sdp_process_rx(struct sdp_sock *ssk);
 
 #endif
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/ofed/drivers/infiniband/ulp/sdp/sdp_zcopy.c
+++ b/sys/ofed/drivers/infiniband/ulp/sdp/sdp_zcopy.c
@@ -308,7 +308,7 @@ int sdp_post_sendsm(struct socket *sk)
 	return 0;
 }
 
-static int sdp_update_iov_used(struct socket *sk, kiovec_t *iov, int len)
+static int sdp_update_iov_used(struct socket *sk, struct iovec *iov, int len)
 {
 	sdp_dbg_data(sk, "updating consumed 0x%x bytes from iov\n", len);
 	while (len > 0) {
@@ -546,7 +546,7 @@ static int sdp_post_rdma_read(struct socket *sk, struct rx_srcavail_state *rx_sa
 	return ib_post_send(ssk->qp, &wr, &bad_wr);
 }
 
-int sdp_rdma_to_iovec(struct socket *sk, kiovec_t *iov, struct mbuf *mb,
+int sdp_rdma_to_iovec(struct socket *sk, struct iovec *iov, struct mbuf *mb,
 		unsigned long *used)
 {
 	struct sdp_sock *ssk = sdp_sk(sk);
@@ -641,7 +641,7 @@ static inline int wait_for_sndbuf(struct socket *sk, long *timeo_p)
 }
 
 static int do_sdp_sendmsg_zcopy(struct socket *sk, struct tx_srcavail_state *tx_sa,
-		kiovec_t *iov, long *timeo)
+		struct iovec *iov, long *timeo)
 {
 	struct sdp_sock *ssk = sdp_sk(sk);
 	int rc = 0;
@@ -710,7 +710,7 @@ err_alloc_fmr:
 	return rc;	
 }
 
-int sdp_sendmsg_zcopy(struct kiocb *iocb, struct socket *sk, kiovec_t *iov)
+int sdp_sendmsg_zcopy(struct kiocb *iocb, struct socket *sk, struct iovec *iov)
 {
 	struct sdp_sock *ssk = sdp_sk(sk);
 	int rc = 0;

--- a/sys/ofed/drivers/infiniband/ulp/sdp/sdp_zcopy.c
+++ b/sys/ofed/drivers/infiniband/ulp/sdp/sdp_zcopy.c
@@ -804,12 +804,3 @@ void sdp_abort_rdma_read(struct socket *sk)
 
 	ssk->rx_sa = NULL;
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/opencrypto/criov.c
+++ b/sys/opencrypto/criov.c
@@ -63,7 +63,7 @@ __FBSDID("$FreeBSD$");
 void
 cuio_copydata(struct uio* uio, int off, int len, caddr_t cp)
 {
-	kiovec_t *iov = uio->uio_iov;
+	struct iovec *iov = uio->uio_iov;
 	int iol = uio->uio_iovcnt;
 	unsigned count;
 
@@ -84,7 +84,7 @@ cuio_copydata(struct uio* uio, int off, int len, caddr_t cp)
 void
 cuio_copyback(struct uio* uio, int off, int len, c_caddr_t cp)
 {
-	kiovec_t *iov = uio->uio_iov;
+	struct iovec *iov = uio->uio_iov;
 	int iol = uio->uio_iovcnt;
 	unsigned count;
 
@@ -138,7 +138,7 @@ int
 cuio_apply(struct uio *uio, int off, int len, int (*f)(void *, void *, u_int),
     void *arg)
 {
-	kiovec_t *iov = uio->uio_iov;
+	struct iovec *iov = uio->uio_iov;
 	int iol = uio->uio_iovcnt;
 	unsigned count;
 	int rval;
@@ -200,10 +200,10 @@ crypto_apply(int flags, caddr_t buf, int off, int len,
 }
 
 int
-crypto_mbuftoiov(struct mbuf *mbuf, kiovec_t **iovptr, int *cnt,
+crypto_mbuftoiov(struct mbuf *mbuf, struct iovec **iovptr, int *cnt,
     int *allocated)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct mbuf *m, *mtmp;
 	int i, j;
 

--- a/sys/opencrypto/criov.c
+++ b/sys/opencrypto/criov.c
@@ -298,11 +298,10 @@ crypto_contiguous_subsegment(int crp_flags, void *crpbuf,
 
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/opencrypto/cryptodev.c
+++ b/sys/opencrypto/cryptodev.c
@@ -285,7 +285,7 @@ struct csession {
 struct cryptop_data {
 	struct csession *cse;
 
-	kiovec_t	iovec[1];
+	struct iovec	iovec[1];
 	struct uio	uio;
 	bool		done;
 };

--- a/sys/opencrypto/cryptodev.c
+++ b/sys/opencrypto/cryptodev.c
@@ -1571,11 +1571,10 @@ MODULE_DEPEND(cryptodev, crypto, 1, 1, 1);
 MODULE_DEPEND(cryptodev, zlib, 1, 1, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/opencrypto/cryptodev.h
+++ b/sys/opencrypto/cryptodev.h
@@ -575,12 +575,3 @@ extern void *crypto_contiguous_subsegment(int, void *, size_t, size_t);
 
 #endif /* _KERNEL */
 #endif /* _CRYPTO_CRYPTO_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/opencrypto/cryptodev.h
+++ b/sys/opencrypto/cryptodev.h
@@ -561,7 +561,7 @@ extern	int cuio_apply(struct uio *uio, int off, int len,
 	    int (*f)(void *, void *, u_int), void *arg);
 
 struct mbuf;
-extern	int crypto_mbuftoiov(struct mbuf *mbuf, kiovec_t **iovptr,
+extern	int crypto_mbuftoiov(struct mbuf *mbuf, struct iovec **iovptr,
 	    int *cnt, int *allocated);
 
 extern	void crypto_copyback(int flags, caddr_t buf, int off, int size,

--- a/sys/opencrypto/cryptosoft.c
+++ b/sys/opencrypto/cryptosoft.c
@@ -1418,11 +1418,10 @@ MODULE_VERSION(cryptosoft, 1);
 MODULE_DEPEND(cryptosoft, crypto, 1, 1, 1);
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/opencrypto/cryptosoft.c
+++ b/sys/opencrypto/cryptosoft.c
@@ -88,8 +88,8 @@ swcr_encdec(struct cryptodesc *crd, struct swcr_data *sw, caddr_t buf,
 	struct enc_xform *exf;
 	int i, j, k, blks, ind, count, ivlen;
 	struct uio *uio, uiolcl;
-	kiovec_t iovlcl[4];
-	kiovec_t *iov;
+	struct iovec iovlcl[4];
+	struct iovec *iov;
 	int iovcnt, iovalloc;
 	int error;
 

--- a/sys/opencrypto/ktls_ocf.c
+++ b/sys/opencrypto/ktls_ocf.c
@@ -52,7 +52,7 @@ struct ocf_session {
 struct ocf_operation {
 	struct ocf_session *os;
 	bool done;
-	kiovec_t iov[0];
+	struct iovec iov[0];
 };
 
 static MALLOC_DEFINE(M_KTLS_OCF, "ktls_ocf", "OCF KTLS");
@@ -85,7 +85,7 @@ ktls_ocf_callback(struct cryptop *crp)
 
 static int
 ktls_ocf_encrypt(struct ktls_session *tls, const struct tls_record_layer *hdr,
-    uint8_t *trailer, kiovec_t *iniov, kiovec_t *outiov, int iovcnt,
+    uint8_t *trailer, struct iovec *iniov, struct iovec *outiov, int iovcnt,
     uint64_t seqno, uint8_t record_type __unused)
 {
 	struct uio uio;
@@ -95,7 +95,7 @@ ktls_ocf_encrypt(struct ktls_session *tls, const struct tls_record_layer *hdr,
 	struct cryptop *crp;
 	struct ocf_session *os;
 	struct ocf_operation *oo;
-	kiovec_t *iov;
+	struct iovec *iov;
 	int i, error;
 	uint16_t tls_comp_len;
 

--- a/sys/powerpc/powerpc/mem.c
+++ b/sys/powerpc/powerpc/mem.c
@@ -318,13 +318,3 @@ memioctl(struct cdev *dev __unused, u_long cmd, caddr_t data, int flags,
 	}
 	return (error);
 }
-
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/powerpc/powerpc/mem.c
+++ b/sys/powerpc/powerpc/mem.c
@@ -91,7 +91,7 @@ struct mem_range_softc mem_range_softc = {
 int
 memrw(struct cdev *dev, struct uio *uio, int flags)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	int error = 0;
 	vm_offset_t va, eva, off, v;
 	vm_prot_t prot;

--- a/sys/powerpc/powerpc/uio_machdep.c
+++ b/sys/powerpc/powerpc/uio_machdep.c
@@ -132,11 +132,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/powerpc/powerpc/uio_machdep.c
+++ b/sys/powerpc/powerpc/uio_machdep.c
@@ -64,7 +64,7 @@ int
 uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset;
 	vm_page_t m;

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -121,13 +121,3 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 
 	return (error);
 }
-
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -50,7 +50,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 {
 	ssize_t orig_resid;
 	vm_offset_t off, v;
-	kiovec_t *iov;
+	struct iovec *iov;
 	struct vm_page m;
 	vm_page_t marr;
 	u_int cnt;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -59,7 +59,7 @@ int
 uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset, vaddr;
 	size_t cnt;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -133,11 +133,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/sparc64/sparc64/mem.c
+++ b/sys/sparc64/sparc64/mem.c
@@ -177,12 +177,3 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 		kva_free(ova, PAGE_SIZE * colors);
 	return (error);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/sparc64/sparc64/mem.c
+++ b/sys/sparc64/sparc64/mem.c
@@ -85,7 +85,7 @@ struct mem_range_softc mem_range_softc;
 int
 memrw(struct cdev *dev, struct uio *uio, int flags)
 {
-	kiovec_t *iov;
+	struct iovec *iov;
 	vm_offset_t eva;
 	vm_offset_t off;
 	vm_offset_t ova;

--- a/sys/sparc64/sparc64/uio_machdep.c
+++ b/sys/sparc64/sparc64/uio_machdep.c
@@ -140,11 +140,10 @@ out:
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/sparc64/sparc64/uio_machdep.c
+++ b/sys/sparc64/sparc64/uio_machdep.c
@@ -66,7 +66,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 {
 	struct sf_buf *sf;
 	struct thread *td = curthread;
-	kiovec_t *iov;
+	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset;
 	vm_paddr_t pa;

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -107,11 +107,10 @@ typedef int (updateiov_t)(const struct uio *uiop, void * __capability iovp);
 #endif /* !_SYS__IOVEC_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "header",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -46,12 +46,6 @@ struct iovec {
 	void * __kerncap	iov_base;	/* Base address. */
 	size_t			iov_len;	/* Length. */
 };
-#if __has_feature(capabilities)
-struct iovec_c {
-	void * __capability	iov_base;	/* Base address. */
-	size_t			iov_len;	/* Length. */
-};
-#endif
 struct iovec_native {
 	void *	iov_base;	/* Base address. */
 	size_t			iov_len;	/* Length. */

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -42,12 +42,10 @@ typedef	__size_t	size_t;
 #define	_SIZE_T_DECLARED
 #endif
 
-#ifndef _KERNEL
 struct iovec {
-	void *	iov_base;	/* Base address. */
+	void * __kerncap	iov_base;	/* Base address. */
 	size_t			iov_len;	/* Length. */
 };
-#endif
 #if __has_feature(capabilities)
 struct iovec_c {
 	void * __capability	iov_base;	/* Base address. */
@@ -58,13 +56,6 @@ struct iovec_native {
 	void *	iov_base;	/* Base address. */
 	size_t			iov_len;	/* Length. */
 };
-/* XXX: need some ifdefs */
-#if __has_feature(capabilities)
-typedef struct iovec_c		kiovec_t;
-#else
-typedef	struct iovec_native	kiovec_t;
-#endif
-typedef struct iovec_native	uiovec_t;
 
 #if defined(_KERNEL)
 #define	IOVEC_INIT(iovp, base, len)	do {				\

--- a/sys/sys/extattr.h
+++ b/sys/sys/extattr.h
@@ -103,12 +103,3 @@ __END_DECLS
 
 #endif /* !_KERNEL */
 #endif /* !_SYS_EXTATTR_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/sys/ktls.h
+++ b/sys/sys/ktls.h
@@ -145,7 +145,7 @@ struct ktls_crypto_backend {
 struct ktls_session {
 	int	(*sw_encrypt)(struct ktls_session *tls,
 	    const struct tls_record_layer *hdr, uint8_t *trailer,
-	    kiovec_t *src, kiovec_t *dst, int iovcnt,
+	    struct iovec *src, struct iovec *dst, int iovcnt,
 	    uint64_t seqno, uint8_t record_type);
 	union {
 		void *cipher;

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -438,15 +438,6 @@ struct msghdr {
 };
 #ifdef _KERNEL
 #if __has_feature(capabilities)
-struct msghdr_c {
-	void		* __capability msg_name;		/* optional address */
-	socklen_t	 msg_namelen;		/* size of address */
-	struct iovec_c	* __capability msg_iov;		/* scatter/gather array */
-	int		 msg_iovlen;		/* # elements in msg_iov */
-	void		* __capability msg_control;		/* ancillary data, see below */
-	socklen_t	 msg_controllen;	/* ancillary data buffer len */
-	int		 msg_flags;		/* flags on received message */
-};
 struct msghdr64 {
 	void		*msg_name;		/* optional address */
 	socklen_t	 msg_namelen;		/* size of address */
@@ -680,12 +671,6 @@ struct sf_hdtr {
 	int trl_cnt;		/* number of trailer iovec's */
 };
 #ifdef _KERNEL
-struct sf_hdtr_c {
-	struct iovec_c * __capability headers;	/* pointer to an array of header struct iovec's */
-	int hdr_cnt;		/* number of header iovec's */
-	struct iovec_c * __capability trailers;	/* pointer to an array of trailer struct iovec's */
-	int trl_cnt;		/* number of trailer iovec's */
-};
 struct sf_hdtr_native {
 	struct iovec_native *headers;	/* pointer to an array of header struct iovec's */
 	int hdr_cnt;		/* number of header iovec's */
@@ -718,12 +703,6 @@ struct mmsghdr {
 	ssize_t		msg_len;		/* message length */
 };
 #ifdef _KERNEL
-#if __has_feature(capabilities)
-struct mmsghdr_c {
-	struct msghdr_c	msg_hdr;		/* message header */
-	ssize_t		msg_len;		/* message length */
-};
-#endif
 struct mmsghdr_native {
 	struct msghdr_native	msg_hdr;		/* message header */
 	ssize_t		msg_len;		/* message length */

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -826,10 +826,9 @@ void so_unlock(struct socket *so);
 #endif /* !_SYS_SOCKET_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "header",
 //   "changes": [
-//     "kiovec_t",
 //     "pointer_alignment"
 //   ]
 // }

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -427,17 +427,16 @@ struct sockproto {
  * Message header for recvmsg and sendmsg calls.
  * Used value-result for recvmsg, value only for sendmsg.
  */
-#ifndef _KERNEL
 struct msghdr {
-	void		*msg_name;		/* optional address */
+	void * __kerncap msg_name;		/* optional address */
 	socklen_t	 msg_namelen;		/* size of address */
-	struct iovec	*msg_iov;		/* scatter/gather array */
+	struct iovec * __kerncap msg_iov;	/* scatter/gather array */
 	int		 msg_iovlen;		/* # elements in msg_iov */
-	void		*msg_control;		/* ancillary data, see below */
+	void * __kerncap msg_control;		/* ancillary data, see below */
 	socklen_t	 msg_controllen;	/* ancillary data buffer len */
 	int		 msg_flags;		/* flags on received message */
 };
-#else /* _KERNEL */
+#ifdef _KERNEL
 #if __has_feature(capabilities)
 struct msghdr_c {
 	void		* __capability msg_name;		/* optional address */
@@ -466,14 +465,8 @@ struct msghdr_native {
 	void		*msg_control;		/* ancillary data, see below */
 	socklen_t	 msg_controllen;	/* ancillary data buffer len */
 	int		 msg_flags;		/* flags on received message */
-}; /* _KERNEL */
-#if __has_feature(capabilities)
-typedef	struct msghdr_c		kmsghdr_t;
-#else
-typedef	struct msghdr_native	kmsghdr_t;
-#endif
-typedef	struct msghdr_native	umsghdr_t;
-#endif
+};
+#endif	/* _KERNEL */
 
 #define	MSG_OOB		 0x00000001	/* process out-of-band data */
 #define	MSG_PEEK	 0x00000002	/* peek at incoming message */
@@ -680,14 +673,13 @@ struct omsghdr {
 /*
  * sendfile(2) header/trailer struct
  */
-#ifndef _KERNEL
 struct sf_hdtr {
-	struct iovec *headers;	/* pointer to an array of header struct iovec's */
+	struct iovec * __kerncap headers;	/* header struct iovec's */
 	int hdr_cnt;		/* number of header iovec's */
-	struct iovec *trailers;	/* pointer to an array of trailer struct iovec's */
+	struct iovec * __kerncap trailers;	/* trailer struct iovec's */
 	int trl_cnt;		/* number of trailer iovec's */
 };
-#else /* _KERNEL */
+#ifdef _KERNEL
 struct sf_hdtr_c {
 	struct iovec_c * __capability headers;	/* pointer to an array of header struct iovec's */
 	int hdr_cnt;		/* number of header iovec's */
@@ -700,8 +692,7 @@ struct sf_hdtr_native {
 	struct iovec_native *trailers;	/* pointer to an array of trailer struct iovec's */
 	int trl_cnt;		/* number of trailer iovec's */
 };
-typedef	struct sf_hdtr_c	ksf_hdtr_t;
-typedef	int copyin_hdtr_t(const void * __capability hdtrp, ksf_hdtr_t *hdtr);
+typedef	int copyin_hdtr_t(const void * __capability hdtrp, struct sf_hdtr *hdtr);
 #endif /* _KERNEL */
 
 /*
@@ -722,12 +713,11 @@ typedef	int copyin_hdtr_t(const void * __capability hdtrp, ksf_hdtr_t *hdtr);
  * Sendmmsg/recvmmsg specific structure(s)
  */
 
-#ifndef _KERNEL
 struct mmsghdr {
 	struct msghdr	msg_hdr;		/* message header */
 	ssize_t		msg_len;		/* message length */
 };
-#else /* _KERNEL */
+#ifdef _KERNEL
 #if __has_feature(capabilities)
 struct mmsghdr_c {
 	struct msghdr_c	msg_hdr;		/* message header */
@@ -738,12 +728,6 @@ struct mmsghdr_native {
 	struct msghdr_native	msg_hdr;		/* message header */
 	ssize_t		msg_len;		/* message length */
 };
-#if __has_feature(capabilities)
-typedef	struct mmsghdr_c	kmmsghdr_t;
-#else
-typedef	struct mmsghdr_native	kmmsghdr_t;
-#endif
-typedef	struct mmsghdr_native	ummsghdr_t;
 #endif /* _KERNEL */
 #endif /* __BSD_VISIBLE */
 

--- a/sys/sys/spigenio.h
+++ b/sys/sys/spigenio.h
@@ -54,12 +54,3 @@ struct spigen_transfer_mmapped {
 #define SPIGENIOC_SET_SPI_MODE     _IOW(SPIGENIOC_BASE, 5, uint32_t)
 
 #endif /* !_SYS_SPIGENIO_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "header",
-//   "changes": [
-//     "kiovec_t"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -392,7 +392,7 @@ int	kern_recvfrom(struct thread *td, int s, void * __capability buf,
 	    size_t len, int flags,
 	    struct sockaddr * __capability __restrict from,
 	    socklen_t * __capability __restrict fromlenaddr);
-int	kern_recvit(struct thread *td, int s, kmsghdr_t *mp,
+int	kern_recvit(struct thread *td, int s, struct msghdr *mp,
 	    enum uio_seg fromseg, struct mbuf **controlp);
 int	kern_renameat(struct thread *td, int oldfd,
 	    const char * __capability old, int newfd,
@@ -435,7 +435,7 @@ int	kern_setloginclass(struct thread *td,
 int	kern_select(struct thread *td, int nd, fd_set * __capability fd_in,
 	    fd_set * __capability fd_ou, fd_set * __capability fd_ex,
 	    struct timeval *tvp, int abi_nfdbits);
-int	kern_sendit(struct thread *td, int s, kmsghdr_t *mp, int flags,
+int	kern_sendit(struct thread *td, int s, struct msghdr *mp, int flags,
 	    struct mbuf *control, enum uio_seg segflg);
 int	kern_setgroups(struct thread *td, u_int ngrp, gid_t *groups);
 int	kern_setitimer(struct thread *, u_int, struct itimerval *,
@@ -617,7 +617,7 @@ int	user_sched_setscheduler(struct thread *td, pid_t pid, int policy,
 int	user_select(struct thread *td, int nd, fd_set * __capability in,
 	    fd_set * __capability ou, fd_set * __capability ex,
 	    struct timeval * __capability utv);
-int	user_sendit(struct thread *td, int s, kmsghdr_t *mp, int flags);
+int	user_sendit(struct thread *td, int s, struct msghdr *mp, int flags);
 int	user_sendto(struct thread *td, int s, const char * __capability buf,
 	    size_t len, int flags, const struct sockaddr * __capability to,
 	    socklen_t tolen);

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -53,7 +53,7 @@ typedef	__off_t	off_t;
 #ifdef _KERNEL
 
 struct uio {
-	kiovec_t	*uio_iov;	/* scatter/gather list */
+	struct iovec	*uio_iov;	/* scatter/gather list */
 	int	uio_iovcnt;		/* length of scatter/gather list */
 	off_t	uio_offset;		/* offset in target object */
 	ssize_t	uio_resid;		/* remaining bytes to process */
@@ -82,11 +82,11 @@ struct bus_dma_segment;
 struct uio *cloneuio(struct uio *uiop);
 int	copyinfrom(const void * __restrict src, void * __restrict dst,
 	    size_t len, int seg);
-int	copyiniov(const uiovec_t * __capability iovp, u_int iovcnt,
-	    kiovec_t **iov, int error);
+int	copyiniov(const struct iovec_native * __capability iovp, u_int iovcnt,
+	    struct iovec **iov, int error);
 int	copyinstrfrom(const void * __restrict src, void * __restrict dst,
 	    size_t len, size_t * __restrict copied, int seg);
-int	copyinuio(const uiovec_t * __capability iovp, u_int iovcnt,
+int	copyinuio(const struct iovec_native * __capability iovp, u_int iovcnt,
 	    struct uio **uiop);
 int	copyout_map(struct thread *td, vm_offset_t *addr, size_t sz);
 int	copyout_unmap(struct thread *td, vm_offset_t addr, size_t sz);
@@ -102,7 +102,7 @@ int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 	    struct uio *uio);
 int	uiomove_nofault(void *cp, int n, struct uio *uio);
 int	uiomove_object(struct vm_object *obj, off_t obj_size, struct uio *uio);
-int	updateiov(const struct uio *uiop, uiovec_t *iovp);
+int	updateiov(const struct uio *uiop, struct iovec_native *iovp);
 
 #else /* !_KERNEL */
 

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -120,10 +120,9 @@ __END_DECLS
 #endif /* !_SYS_UIO_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "header",
 //   "changes": [
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/ufs/ffs/ffs_snapshot.c
+++ b/sys/ufs/ffs/ffs_snapshot.c
@@ -221,7 +221,7 @@ ffs_snapshot(mp, snapfile)
 	struct vattr vat;
 	struct vnode *vp, *xvp, *mvp, *devvp;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct snapdata *sn;
 	struct ufsmount *ump;
 #ifdef DIAGNOSTIC
@@ -1983,7 +1983,7 @@ ffs_snapshot_mount(mp)
 	struct vnode *lastvp;
 	struct inode *ip;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	void *snapblklist;
 	char *reason;
 	daddr_t snaplistsize;

--- a/sys/ufs/ffs/ffs_snapshot.c
+++ b/sys/ufs/ffs/ffs_snapshot.c
@@ -2720,11 +2720,10 @@ ffs_snapdata_acquire(struct vnode *devvp)
 #endif
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//   "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/ufs/ffs/ffs_vnops.c
+++ b/sys/ufs/ffs/ffs_vnops.c
@@ -1158,7 +1158,7 @@ ffs_rdextattr(u_char **p, struct vnode *vp, struct thread *td, int extra)
 	struct ufs2_dinode *dp;
 	struct fs *fs;
 	struct uio luio;
-	kiovec_t liovec;
+	struct iovec liovec;
 	u_int easize;
 	int error;
 	u_char *eae;
@@ -1255,7 +1255,7 @@ ffs_close_ea(struct vnode *vp, int commit, struct ucred *cred, struct thread *td
 {
 	struct inode *ip;
 	struct uio luio;
-	kiovec_t liovec;
+	struct iovec liovec;
 	int error;
 	struct ufs2_dinode *dp;
 

--- a/sys/ufs/ffs/ffs_vnops.c
+++ b/sys/ufs/ffs/ffs_vnops.c
@@ -1765,11 +1765,10 @@ ffs_getpages_async(struct vop_getpages_async_args *ap)
 
 // CHERI CHANGES START
 // {
-//   "updated": 20190307,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/ufs/ufs/ufs_extattr.c
+++ b/sys/ufs/ufs/ufs_extattr.c
@@ -374,7 +374,7 @@ ufs_extattr_iterate_directory(struct ufsmount *ump, struct vnode *dvp,
 	struct dirent *dp, *edp;
 	struct vnode *attr_vp;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	char *dirbuf;
 	int error, eofflag = 0;
 
@@ -595,7 +595,7 @@ ufs_extattr_enable(struct ufsmount *ump, int attrnamespace,
     const char *attrname, struct vnode *backing_vnode, struct thread *td)
 {
 	struct ufs_extattr_list_entry *attribute;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	int error = 0;
 
@@ -846,7 +846,7 @@ ufs_extattr_get(struct vnode *vp, int attrnamespace, const char *name,
 {
 	struct ufs_extattr_list_entry *attribute;
 	struct ufs_extattr_header ueh;
-	kiovec_t local_aiov;
+	struct iovec local_aiov;
 	struct uio local_aio;
 	struct mount *mp = vp->v_mount;
 	struct ufsmount *ump = VFSTOUFS(mp);
@@ -1052,7 +1052,7 @@ ufs_extattr_set(struct vnode *vp, int attrnamespace, const char *name,
 {
 	struct ufs_extattr_list_entry *attribute;
 	struct ufs_extattr_header ueh;
-	kiovec_t local_aiov;
+	struct iovec local_aiov;
 	struct uio local_aio;
 	struct mount *mp = vp->v_mount;
 	struct ufsmount *ump = VFSTOUFS(mp);
@@ -1159,7 +1159,7 @@ ufs_extattr_rm(struct vnode *vp, int attrnamespace, const char *name,
 {
 	struct ufs_extattr_list_entry *attribute;
 	struct ufs_extattr_header ueh;
-	kiovec_t local_aiov;
+	struct iovec local_aiov;
 	struct uio local_aio;
 	struct mount *mp = vp->v_mount;
 	struct ufsmount *ump = VFSTOUFS(mp);

--- a/sys/ufs/ufs/ufs_extattr.c
+++ b/sys/ufs/ufs/ufs_extattr.c
@@ -1302,11 +1302,10 @@ ufs_extattr_vnode_inactive(struct vnode *vp, struct thread *td)
 #endif /* !UFS_EXTATTR */
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/ufs/ufs/ufs_quota.c
+++ b/sys/ufs/ufs/ufs_quota.c
@@ -1238,7 +1238,7 @@ static int
 dqopen(struct vnode *vp, struct ufsmount *ump, int type)
 {
 	struct dqhdr64 dqh;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	int error;
 
@@ -1288,7 +1288,7 @@ dqget(struct vnode *vp, u_long id, struct ufsmount *ump, int type,
 	struct dquot *dq, *dq1;
 	struct dqhash *dqh;
 	struct vnode *dqvp;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	int dqvplocked, error;
 
@@ -1561,7 +1561,7 @@ dqsync(struct vnode *vp, struct dquot *dq)
 	uint8_t buf[sizeof(struct dqblk64)];
 	off_t base, recsize;
 	struct vnode *dqvp;
-	kiovec_t aiov;
+	struct iovec aiov;
 	struct uio auio;
 	int error;
 	struct mount *mp;

--- a/sys/ufs/ufs/ufs_quota.c
+++ b/sys/ufs/ufs/ufs_quota.c
@@ -1893,11 +1893,10 @@ dqb32_dqb64(const struct dqblk32 *dqb32, struct dqblk64 *dqb64)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities"
 //   ]
 // }

--- a/sys/vm/vnode_pager.c
+++ b/sys/vm/vnode_pager.c
@@ -1585,11 +1585,10 @@ vnode_pager_release_writecount(vm_object_t object, vm_offset_t start,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20191025,
 //   "target_type": "kernel",
 //   "changes": [
-//     "iovec-macros",
-//     "kiovec_t"
+//     "iovec-macros"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/vm/vnode_pager.c
+++ b/sys/vm/vnode_pager.c
@@ -648,7 +648,7 @@ static int
 vnode_pager_input_old(vm_object_t object, vm_page_t m)
 {
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	int error;
 	int size;
 	struct sf_buf *sf;
@@ -1242,7 +1242,7 @@ vnode_pager_generic_putpages(struct vnode *vp, vm_page_t *ma, int bytecount,
 	vm_page_t m;
 	vm_ooffset_t maxblksz, next_offset, poffset, prev_offset;
 	struct uio auio;
-	kiovec_t aiov;
+	struct iovec aiov;
 	off_t prev_resid, wrsz;
 	int count, error, i, maxsize, ncount, pgoff, ppscheck;
 	bool in_hole;

--- a/tools/tools/cheri-changes/cheri-changes-json.md
+++ b/tools/tools/cheri-changes/cheri-changes-json.md
@@ -18,7 +18,6 @@ comments.  The following example shows all the current annotations.
  *     "ioctl:net",
  *     "iovec-macros",
  *     "kernel_sig_types",
- *     "kiovec_t",
  *     "monotonicity",
  *     "platform",
  *     "pointer_alignment",
@@ -71,8 +70,6 @@ values are:
    `struct iovec`.  A subset of `user_capabilities`.
  * `kernel_sig_types` - (kernel) Changes to signal related types to store
    signal handlers as poineters  A subset of `user_capabilities`.
- * `kiovec_t` - (kernel) Use `kiovec_t` rather than `struct iovec`.
-   A subset of `user_capabilities`.
  * `monotonicity` - Need to retrieve a capability with greater range or
    permissions from a lesser capability.
  * `platform` - Changes related to the CHERI platform(s) that are not

--- a/tools/tools/cheri-changes/unknown-changes.jq
+++ b/tools/tools/cheri-changes/unknown-changes.jq
@@ -6,7 +6,6 @@
   "ioctl:net",
   "iovec-macros",
   "kernel_sig_types",
-  "kiovec_t",
   "monotonicity",
   "platform",
   "pointer_alignment",


### PR DESCRIPTION
This set of changes builds and boots.  It leaves the _c and _native struct variants in place with the intent that _native to away with the switch of the default ABI and _c go away with CheriABI as a compat layer.

I expect this will cause merge conflicts in forks of master, but they should resolve relatively easily if you perform the mechanical part of the change before merging.  That can be done by running:
```
git grep -l kiovec_t sys/ | xargs sed -i .bak -e 's/kiovec_t/struct iovec/g'
git grep -l uiovec_t sys/ | xargs sed -i .bak -e 's/uiovec_t/struct iovec_native/g'
git grep -l kmsghdr sys/ | xargs sed -i .bak -e 's/kmsghdr_t/struct msghdr/g'
git grep -l kmmsghdr sys/ | xargs sed -i .bak -e 's/kmmsghdr_t/struct mmsghdr/g'
git grep -l ummsghdr sys/ | xargs sed -i .bak -e 's/ummsghdr_t/struct mmsghdr_native/g'
git grep -l umsghdr sys/ | xargs sed -i .bak -e 's/umsghdr_t/struct msghdr_native/g'
git grep -l ksf_hdtr_t sys/ | xargs sed -i .bak -e 's/ksf_hdtr_t/struct sf_hdtr/g'
```
You'll then need to hand-revert the changes to typedefs in sys/sys (or just likely just do a `git checkout sys/sys`).

I've not committed directly in case timing will be bad for others.