### PR TITLE
Switch pointers in the default ABI to use __capability.

### DIFF
--- a/sys/compat/freebsd64/freebsd64_abort2.c
+++ b/sys/compat/freebsd64/freebsd64_abort2.c
@@ -40,7 +40,7 @@ __FBSDID("$FreeBSD$");
 int
 freebsd64_abort2(struct thread *td, struct freebsd64_abort2_args *uap)
 {
-	void *uargs[16];
+	void * __capability uargs[16];
 	void *uargsp;
 	long ptr;
 	int i, nargs;
@@ -56,7 +56,8 @@ freebsd64_abort2(struct thread *td, struct freebsd64_abort2_args *uap)
 					nargs = -1;
 					break;
 				} else
-					uargs[i] = (void *)(uintptr_t)ptr;
+					uargs[i] = __USER_CAP_UNBOUND(
+					    (void *)(uintptr_t)ptr);
 			}
 			if (nargs > 0)
 				uargsp = &uargs;

--- a/sys/dev/filemon/filemon.c
+++ b/sys/dev/filemon/filemon.c
@@ -28,6 +28,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 

--- a/sys/dev/filemon/filemon_wrapper.c
+++ b/sys/dev/filemon/filemon_wrapper.c
@@ -28,6 +28,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -147,8 +149,8 @@ filemon_event_process_exec(void *arg __unused, struct proc *p,
 }
 
 static void
-_filemon_wrapper_openat(struct thread *td, const char *upath, int flags,
-    int fd)
+_filemon_wrapper_openat(struct thread *td, const char * __capability upath,
+    int flags, int fd)
 {
 	int error;
 	struct file *fp;
@@ -261,8 +263,8 @@ copyfail:
 }
 
 static void
-_filemon_wrapper_link(struct thread *td, const char *upath1,
-    const char *upath2)
+_filemon_wrapper_link(struct thread *td, const char * __capability upath1,
+    const char * __capability upath2)
 {
 	struct filemon *filemon;
 	int error;

--- a/sys/fs/cd9660/cd9660_mount.h
+++ b/sys/fs/cd9660/cd9660_mount.h
@@ -41,12 +41,12 @@
  * Arguments to mount ISO 9660 filesystems.
  */
 struct iso_args {
-	char	*fspec;			/* block special device to mount */
+	char * __kerncap fspec;		/* block special device to mount */
 	struct	oexport_args export;	/* network export info */
 	int	flags;			/* mounting flags, see below */
 	int	ssector;		/* starting sector, 0 for 1st session */
-	char	*cs_disk;		/* disk charset for Joliet cs conversion */
-	char	*cs_local;		/* local charset for Joliet cs conversion */
+	char * __kerncap cs_disk;	/* disk charset for Joliet cs conversion */
+	char * __kerncap cs_local;	/* local charset for Joliet cs conversion */
 };
 #define	ISOFSMNT_NORRIP	0x00000001	/* disable Rock Ridge Ext.*/
 #define	ISOFSMNT_GENS	0x00000002	/* enable generation numbers */

--- a/sys/fs/cd9660/cd9660_vfsops.c
+++ b/sys/fs/cd9660/cd9660_vfsops.c
@@ -36,6 +36,8 @@
  *	@(#)cd9660_vfsops.c	8.18 (Berkeley) 5/22/95
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -98,7 +100,7 @@ static int iso_mountfs(struct vnode *devvp, struct mount *mp);
  */
 
 static int
-cd9660_cmount(struct mntarg *ma, void *data, uint64_t flags)
+cd9660_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 	struct iso_args args;
 	struct export_args exp;

--- a/sys/fs/fdescfs/fdesc_vfsops.c
+++ b/sys/fs/fdescfs/fdesc_vfsops.c
@@ -68,7 +68,7 @@ static vfs_root_t	fdesc_root;
  * Compatibility shim for old mount(2) system call.
  */
 int
-fdesc_cmount(struct mntarg *ma, void *data, uint64_t flags)
+fdesc_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 
 	return kernel_mount(ma, flags);

--- a/sys/fs/msdosfs/msdosfs_vfsops.c
+++ b/sys/fs/msdosfs/msdosfs_vfsops.c
@@ -50,6 +50,8 @@
  * October 1992
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/buf.h>
@@ -187,7 +189,7 @@ update_mp(struct mount *mp, struct thread *td)
 }
 
 static int
-msdosfs_cmount(struct mntarg *ma, void *data, uint64_t flags)
+msdosfs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 	struct msdosfs_args args;
 	struct export_args exp;

--- a/sys/fs/msdosfs/msdosfsmount.h
+++ b/sys/fs/msdosfs/msdosfsmount.h
@@ -229,7 +229,7 @@ struct msdosfs_fileno {
  *  Arguments to mount MSDOS filesystems.
  */
 struct msdosfs_args {
-	char	*fspec;		/* blocks special holding the fs to mount */
+	char * __kerncap fspec;	/* blocks special holding the fs to mount */
 	struct	oexport_args export;	/* network export information */
 	uid_t	uid;		/* uid that owns msdosfs files */
 	gid_t	gid;		/* gid that owns msdosfs files */
@@ -237,9 +237,9 @@ struct msdosfs_args {
 	int	flags;		/* see below */
 	int	unused1;	/* unused, was version number */
 	uint16_t unused2[128];	/* no longer used, was Local->Unicode table */
-	char	*cs_win;	/* Windows(Unicode) Charset */
-	char	*cs_dos;	/* DOS Charset */
-	char	*cs_local;	/* Local Charset */
+	char * __kerncap cs_win;	/* Windows(Unicode) Charset */
+	char * __kerncap cs_dos;	/* DOS Charset */
+	char * __kerncap cs_local;	/* Local Charset */
 	mode_t	dirmask;	/* dir  mask to be applied for msdosfs perms */
 };
 #endif /* MAKEFS */

--- a/sys/fs/nfs/nfs.h
+++ b/sys/fs/nfs/nfs.h
@@ -175,17 +175,17 @@ struct nfsd_addsock_args {
  * (New version supports pNFS, indicated by NFSSVC_NEWSTRUCT flag.)
  */
 struct nfsd_nfsd_args {
-	const char *principal;	/* GSS-API service principal name */
+	const char * __kerncap principal; /* GSS-API service principal name */
 	int	minthreads;	/* minimum service thread count */
 	int	maxthreads;	/* maximum service thread count */
 	int	version;	/* Allow multiple variants */
-	char	*addr;		/* pNFS DS addresses */
+	char * __kerncap addr;	/* pNFS DS addresses */
 	int	addrlen;	/* Length of addrs */
-	char	*dnshost;	/* DNS names for DS addresses */
+	char * __kerncap dnshost; /* DNS names for DS addresses */
 	int	dnshostlen;	/* Length of DNS names */
-	char	*dspath;	/* DS Mount path on MDS */
+	char * __kerncap dspath; /* DS Mount path on MDS */
 	int	dspathlen;	/* Length of DS Mount path on MDS */
-	char	*mdspath;	/* MDS mount for DS path on MDS */
+	char * __kerncap mdspath; /* MDS mount for DS path on MDS */
 	int	mdspathlen;	/* Length of MDS mount for DS path on MDS */
 	int	mirrorcnt;	/* Number of mirrors to create on DSs */
 };
@@ -200,9 +200,9 @@ struct nfsd_nfsd_args {
 
 struct nfsd_pnfsd_args {
 	int	op;		/* Which pNFSd op to perform. */
-	char	*mdspath;	/* Path of MDS file. */
-	char	*dspath;	/* Path of recovered DS mounted on dir. */
-	char	*curdspath;	/* Path of current DS mounted on dir. */
+	char * __kerncap mdspath; /* Path of MDS file. */
+	char * __kerncap dspath; /* Path of recovered DS mounted on dir. */
+	char * __kerncap curdspath; /* Path of current DS mounted on dir. */
 };
 
 #define	PNFSDOP_DELDSSERVER	1
@@ -211,7 +211,7 @@ struct nfsd_pnfsd_args {
 
 /* Old version. */
 struct nfsd_nfsd_oargs {
-	const char *principal;	/* GSS-API service principal name */
+	const char * __kerncap principal; /* GSS-API service principal name */
 	int	minthreads;	/* minimum service thread count */
 	int	maxthreads;	/* maximum service thread count */
 };
@@ -264,7 +264,7 @@ struct nfsd_clid {
 
 struct nfsd_dumplist {
 	int		ndl_size;	/* Number of elements */
-	void		*ndl_list;	/* and the list of elements */
+	void * __kerncap ndl_list;	/* and the list of elements */
 };
 
 struct nfsd_dumpclients {
@@ -284,9 +284,9 @@ struct nfsd_dumpclients {
 };
 
 struct nfsd_dumplocklist {
-	char		*ndllck_fname;	/* File Name */
+	char * __kerncap ndllck_fname;	/* File Name */
 	int		ndllck_size;	/* Number of elements */
-	void		*ndllck_list;	/* and the list of elements */
+	void * __kerncap ndllck_list;	/* and the list of elements */
 };
 
 struct nfsd_dumplocks {

--- a/sys/fs/nfs/nfs_commonport.c
+++ b/sys/fs/nfs/nfs_commonport.c
@@ -33,6 +33,8 @@
  *
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -234,11 +236,11 @@ nfsrv_object_create(struct vnode *vp, struct thread *td)
  * Look up a file name. Basically just initialize stuff and call namei().
  */
 int
-nfsrv_lookupfilename(struct nameidata *ndp, char *fname, NFSPROC_T *p)
+nfsrv_lookupfilename(struct nameidata *ndp, char * __capability fname, NFSPROC_T *p)
 {
 	int error;
 
-	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE, fname,
+	NDINIT_C(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE, fname,
 	    p);
 	error = namei(ndp);
 	if (!error) {

--- a/sys/fs/nfs/nfs_var.h
+++ b/sys/fs/nfs/nfs_var.h
@@ -393,7 +393,7 @@ void nfsd_getminorvers(struct nfsrv_descript *, u_char *, u_char **, int *,
 void nfscl_retopts(struct nfsmount *, char *, size_t);
 
 /* nfs_commonport.c */
-int nfsrv_lookupfilename(struct nameidata *, char *, NFSPROC_T *);
+int nfsrv_lookupfilename(struct nameidata *, char * __capability, NFSPROC_T *);
 void nfsrv_object_create(vnode_t, NFSPROC_T *);
 int nfsrv_mallocmget_limit(void);
 int nfsvno_v4rootexport(struct nfsrv_descript *);

--- a/sys/fs/nfsclient/nfs_clport.c
+++ b/sys/fs/nfsclient/nfs_clport.c
@@ -33,6 +33,8 @@
  *
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 

--- a/sys/fs/nfsclient/nfs_clvfsops.c
+++ b/sys/fs/nfsclient/nfs_clvfsops.c
@@ -34,6 +34,8 @@
  *	from nfs_vfsops.c	8.12 (Berkeley) 5/20/95
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -1229,11 +1231,12 @@ nfs_mount(struct mount *mp)
 			error = EINVAL;
 			goto out;
 		}
-		error = copyin((caddr_t)args.fh, (caddr_t)nfh,
+		error = copyin(__USER_CAP(args.fh, args.fhsize), nfh,
 		    args.fhsize);
 		if (error != 0)
 			goto out;
-		error = copyinstr(args.hostname, hst, MNAMELEN - 1, &hstlen);
+		error = copyinstr(__USER_CAP(args.hostname, MNAMELEN), hst,
+		    MNAMELEN - 1, &hstlen);
 		if (error != 0)
 			goto out;
 		bzero(&hst[hstlen], MNAMELEN - hstlen);
@@ -1355,7 +1358,7 @@ out:
  */
 /* ARGSUSED */
 static int
-nfs_cmount(struct mntarg *ma, void *data, uint64_t flags)
+nfs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 	int error;
 	struct nfs_args args;

--- a/sys/fs/nfsserver/nfs_nfsdkrpc.c
+++ b/sys/fs/nfsserver/nfs_nfsdkrpc.c
@@ -33,6 +33,8 @@
  *
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -33,6 +33,8 @@
  *
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -3456,37 +3458,43 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 				goto out;
 			}
 			cp[nfsdarg.addrlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.addr = cp;
+			nfsdarg.addr = (__cheri_tocap char * __capability)cp;
 			cp = malloc(nfsdarg.dnshostlen + 1, M_TEMP, M_WAITOK);
 			error = copyin(nfsdarg.dnshost, cp, nfsdarg.dnshostlen);
 			if (error != 0) {
-				free(nfsdarg.addr, M_TEMP);
+				free((__cheri_fromcap char *)nfsdarg.addr,
+				    M_TEMP);
 				free(cp, M_TEMP);
 				goto out;
 			}
 			cp[nfsdarg.dnshostlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.dnshost = cp;
+			nfsdarg.dnshost = (__cheri_tocap char * __capability)cp;
 			cp = malloc(nfsdarg.dspathlen + 1, M_TEMP, M_WAITOK);
 			error = copyin(nfsdarg.dspath, cp, nfsdarg.dspathlen);
 			if (error != 0) {
-				free(nfsdarg.addr, M_TEMP);
-				free(nfsdarg.dnshost, M_TEMP);
+				free((__cheri_fromcap char *)nfsdarg.addr,
+				    M_TEMP);
+				free((__cheri_fromcap char *)nfsdarg.dnshost,
+				    M_TEMP);
 				free(cp, M_TEMP);
 				goto out;
 			}
 			cp[nfsdarg.dspathlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.dspath = cp;
+			nfsdarg.dspath = (__cheri_tocap char * __capability)cp;
 			cp = malloc(nfsdarg.mdspathlen + 1, M_TEMP, M_WAITOK);
 			error = copyin(nfsdarg.mdspath, cp, nfsdarg.mdspathlen);
 			if (error != 0) {
-				free(nfsdarg.addr, M_TEMP);
-				free(nfsdarg.dnshost, M_TEMP);
-				free(nfsdarg.dspath, M_TEMP);
+				free((__cheri_fromcap char *)nfsdarg.addr,
+				    M_TEMP);
+				free((__cheri_fromcap char *)nfsdarg.dnshost,
+				    M_TEMP);
+				free((__cheri_fromcap char *)nfsdarg.dspath,
+				    M_TEMP);
 				free(cp, M_TEMP);
 				goto out;
 			}
 			cp[nfsdarg.mdspathlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.mdspath = cp;
+			nfsdarg.mdspath = (__cheri_tocap char * __capability)cp;
 		} else {
 			nfsdarg.addr = NULL;
 			nfsdarg.addrlen = 0;
@@ -3499,10 +3507,10 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 			nfsdarg.mirrorcnt = 1;
 		}
 		error = nfsrvd_nfsd(td, &nfsdarg);
-		free(nfsdarg.addr, M_TEMP);
-		free(nfsdarg.dnshost, M_TEMP);
-		free(nfsdarg.dspath, M_TEMP);
-		free(nfsdarg.mdspath, M_TEMP);
+		free((__cheri_fromcap char *)nfsdarg.addr, M_TEMP);
+		free((__cheri_fromcap char *)nfsdarg.dnshost, M_TEMP);
+		free((__cheri_fromcap char *)nfsdarg.dspath, M_TEMP);
+		free((__cheri_fromcap char *)nfsdarg.mdspath, M_TEMP);
 	} else if (uap->flag & NFSSVC_PNFSDS) {
 		error = copyin(uap->argp, &pnfsdarg, sizeof(pnfsdarg));
 		if (error == 0 && (pnfsdarg.op == PNFSDOP_DELDSSERVER ||

--- a/sys/fs/nfsserver/nfs_nfsdstate.c
+++ b/sys/fs/nfsserver/nfs_nfsdstate.c
@@ -7917,10 +7917,10 @@ nfsrv_createdevids(struct nfsd_nfsd_args *args, NFSPROC_T *p)
 	char *addrp, *dnshostp, *dspathp, *mdspathp;
 	int error, i;
 
-	addrp = args->addr;
-	dnshostp = args->dnshost;
-	dspathp = args->dspath;
-	mdspathp = args->mdspath;
+	addrp = (__cheri_fromcap char *)args->addr;
+	dnshostp = (__cheri_fromcap char *)args->dnshost;
+	dspathp = (__cheri_fromcap char *)args->dspath;
+	mdspathp = (__cheri_fromcap char *)args->mdspath;
 	nfsrv_maxpnfsmirror = args->mirrorcnt;
 	if (addrp == NULL || dnshostp == NULL || dspathp == NULL ||
 	    mdspathp == NULL)
@@ -7930,10 +7930,10 @@ nfsrv_createdevids(struct nfsd_nfsd_args *args, NFSPROC_T *p)
 	 * Loop around for each nul-terminated string in args->addr,
 	 * args->dnshost, args->dnspath and args->mdspath.
 	 */
-	while (addrp < (args->addr + args->addrlen) &&
-	    dnshostp < (args->dnshost + args->dnshostlen) &&
-	    dspathp < (args->dspath + args->dspathlen) &&
-	    mdspathp < (args->mdspath + args->mdspathlen)) {
+	while (addrp < ((__cheri_fromcap char *)args->addr + args->addrlen) &&
+	    dnshostp < ((__cheri_fromcap char *)args->dnshost + args->dnshostlen) &&
+	    dspathp < ((__cheri_fromcap char *)args->dspath + args->dspathlen) &&
+	    mdspathp < ((__cheri_fromcap char *)args->mdspath + args->mdspathlen)) {
 		error = nfsrv_setdsserver(dspathp, mdspathp, p, &ds);
 		if (error != 0) {
 			/* Free all DS servers. */

--- a/sys/fs/pseudofs/pseudofs.c
+++ b/sys/fs/pseudofs/pseudofs.c
@@ -390,7 +390,7 @@ pfs_mount(struct pfs_info *pi, struct mount *mp)
  * Compatibility shim for old mount(2) system call
  */
 int
-pfs_cmount(struct mntarg *ma, void *data, uint64_t flags)
+pfs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 	int error;
 

--- a/sys/fs/pseudofs/pseudofs.h
+++ b/sys/fs/pseudofs/pseudofs.h
@@ -245,7 +245,8 @@ struct pfs_node {
  * VFS interface
  */
 int		 pfs_mount	(struct pfs_info *pi, struct mount *mp);
-int		 pfs_cmount	(struct mntarg *ma, void *data, uint64_t flags);
+int		 pfs_cmount	(struct mntarg *ma, void * __capability data,
+				 uint64_t flags);
 int		 pfs_unmount	(struct mount *mp, int mntflags);
 int		 pfs_root	(struct mount *mp, int flags,
 				 struct vnode **vpp);

--- a/sys/fs/smbfs/smbfs_vfsops.c
+++ b/sys/fs/smbfs/smbfs_vfsops.c
@@ -28,6 +28,8 @@
  * $FreeBSD$
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/proc.h>
@@ -91,7 +93,7 @@ MODULE_DEPEND(smbfs, libmchain, 1, 1, 1);
 uma_zone_t smbfs_pbuf_zone;
 
 static int
-smbfs_cmount(struct mntarg *ma, void * data, uint64_t flags)
+smbfs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 	struct smbfs_args args;
 	int error;

--- a/sys/kern/Makefile
+++ b/sys/kern/Makefile
@@ -14,5 +14,5 @@ sysent: init_sysent.c syscalls.c ../sys/syscall.h ../sys/syscall.mk \
 
 init_sysent.c syscalls.c systrace_args.c ../sys/syscall.h \
 ../sys/syscall.mk ../sys/sysproto.h: makesyscalls.sh syscalls.master \
-capabilities.conf
-	sh makesyscalls.sh syscalls.master
+capabilities.conf syscalls.conf
+	sh makesyscalls.sh syscalls.master syscalls.conf

--- a/sys/kern/kern_acct.c
+++ b/sys/kern/kern_acct.c
@@ -206,7 +206,7 @@ int
 sys_acct(struct thread *td, struct acct_args *uap)
 {
 
-	return (kern_acct(td, __USER_CAP_STR(uap->path)));
+	return (kern_acct(td, uap->path));
 }
 
 int

--- a/sys/kern/kern_context.c
+++ b/sys/kern/kern_context.c
@@ -26,6 +26,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 

--- a/sys/kern/kern_cpuset.c
+++ b/sys/kern/kern_cpuset.c
@@ -1593,7 +1593,7 @@ int
 sys_cpuset(struct thread *td, struct cpuset_args *uap)
 {
 
-	return (kern_cpuset(td, __USER_CAP_OBJ(uap->setid)));
+	return (kern_cpuset(td, uap->setid));
 }
 
 int
@@ -1664,7 +1664,7 @@ sys_cpuset_getid(struct thread *td, struct cpuset_getid_args *uap)
 {
 
 	return (kern_cpuset_getid(td, uap->level, uap->which, uap->id,
-	    __USER_CAP_OBJ(uap->setid)));
+	    uap->setid));
 }
 
 int
@@ -1731,7 +1731,7 @@ sys_cpuset_getaffinity(struct thread *td, struct cpuset_getaffinity_args *uap)
 {
 
 	return (kern_cpuset_getaffinity(td, uap->level, uap->which,
-	    uap->id, uap->cpusetsize, __USER_CAP(uap->mask, uap->cpusetsize)));
+	    uap->id, uap->cpusetsize, uap->mask));
 }
 
 int
@@ -1849,7 +1849,7 @@ sys_cpuset_setaffinity(struct thread *td, struct cpuset_setaffinity_args *uap)
 {
 
 	return (kern_cpuset_setaffinity(td, uap->level, uap->which,
-	    uap->id, uap->cpusetsize, __USER_CAP(uap->mask, uap->cpusetsize)));
+	    uap->id, uap->cpusetsize, uap->mask));
 }
 
 int
@@ -1977,9 +1977,7 @@ sys_cpuset_getdomain(struct thread *td, struct cpuset_getdomain_args *uap)
 {
 
 	return (kern_cpuset_getdomain(td, uap->level, uap->which,
-	    uap->id, uap->domainsetsize,
-	    __USER_CAP(uap->mask, uap->domainsetsize),
-	    __USER_CAP_OBJ(uap->policy)));
+	    uap->id, uap->domainsetsize, uap->mask, uap->policy));
 }
 
 int
@@ -2113,8 +2111,7 @@ sys_cpuset_setdomain(struct thread *td, struct cpuset_setdomain_args *uap)
 {
 
 	return (kern_cpuset_setdomain(td, uap->level, uap->which,
-	    uap->id, uap->domainsetsize,
-	    __USER_CAP(uap->mask, uap->domainsetsize), uap->policy));
+	    uap->id, uap->domainsetsize, uap->mask, uap->policy));
 }
 
 int

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -1356,7 +1356,7 @@ ofstat(struct thread *td, struct ofstat_args *uap)
 	error = kern_fstat(td, uap->fd, &ub);
 	if (error == 0) {
 		cvtstat(&ub, &oub);
-		error = copyout(&oub, __USER_CAP_OBJ(uap->sb), sizeof(oub));
+		error = copyout(&oub, uap->sb, sizeof(oub));
 	}
 	return (error);
 }
@@ -1375,7 +1375,7 @@ freebsd11_fstat(struct thread *td, struct freebsd11_fstat_args *uap)
 		return (error);
 	error = freebsd11_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->sb), sizeof(osb));
+		error = copyout(&osb, uap->sb, sizeof(osb));
 	return (error);
 }
 #endif	/* COMPAT_FREEBSD11 */
@@ -1394,7 +1394,7 @@ int
 sys_fstat(struct thread *td, struct fstat_args *uap)
 {
 
-	return (user_fstat(td, uap->fd, __USER_CAP_OBJ(uap->sb)));
+	return (user_fstat(td, uap->fd, uap->sb));
 }
 
 int
@@ -1461,7 +1461,7 @@ freebsd11_nfstat(struct thread *td, struct freebsd11_nfstat_args *uap)
 	error = kern_fstat(td, uap->fd, &ub);
 	if (error == 0) {
 		freebsd11_cvtnstat(&ub, &nub);
-		error = copyout(&nub, __USER_CAP_OBJ(uap->sb), sizeof(nub));
+		error = copyout(&nub, uap->sb, sizeof(nub));
 	}
 	return (error);
 }

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -1016,11 +1016,11 @@ sys_kevent(struct thread *td, struct kevent_args *uap)
 	};
 	struct g_kevent_args gk_args = {
 		.fd = uap->fd,
-		.changelist = __USER_CAP_UNBOUND(uap->changelist),
+		.changelist = uap->changelist,
 		.nchanges = uap->nchanges,
-		.eventlist = __USER_CAP_UNBOUND(uap->eventlist),
+		.eventlist = uap->eventlist,
 		.nevents = uap->nevents,
-		.timeout = __USER_CAP_OBJ(uap->timeout),
+		.timeout = uap->timeout,
 	};
 
 	return (kern_kevent_generic(td, &gk_args, &k_ops, "kevent"));
@@ -1088,8 +1088,7 @@ kevent_copyout(void *arg, kkevent_t *kevp, int count)
 		ks_n[i].udata = (void *)(__cheri_addr vaddr_t)kevp[i].udata;
 		memcpy(&ks_n[i].ext[0], &kevp->ext[0], sizeof(kevp->ext));
 	}
-	error = copyout(ks_n, __USER_CAP_UNBOUND(uap->eventlist),
-	    count * sizeof(*ks_n));
+	error = copyout(ks_n, uap->eventlist, count * sizeof(*ks_n));
 #endif
 	if (error == 0)
 		uap->eventlist += count;
@@ -1115,8 +1114,7 @@ kevent_copyin(void *arg, kkevent_t *kevp, int count)
 #if !__has_feature(capabilities)
 	error = copyin(uap->changelist, kevp, count * sizeof *kevp);
 #else
-	error = copyin(__USER_CAP_UNBOUND(uap->changelist), ks_n,
-	    count * sizeof(*ks_n));
+	error = copyin(uap->changelist, ks_n, count * sizeof(*ks_n));
 	if (error != 0)
 		return (error);
 	for (i = 0; i < count; i++) {
@@ -1153,8 +1151,7 @@ kevent11_copyout(void *arg, kkevent_t *kevp, int count)
 		kev11.fflags = kevp->fflags;
 		kev11.data = kevp->data;
 		kev11.udata = (void *)(__cheri_addr vaddr_t)kevp->udata;
-		error = copyout(&kev11, __USER_CAP_OBJ(uap->eventlist),
-		    sizeof(kev11));
+		error = copyout(&kev11, uap->eventlist, sizeof(kev11));
 		if (error != 0)
 			break;
 		uap->eventlist++;
@@ -1177,8 +1174,7 @@ kevent11_copyin(void *arg, kkevent_t *kevp, int count)
 	uap = (struct freebsd11_kevent_args *)arg;
 
 	for (i = 0; i < count; i++) {
-		error = copyin(__USER_CAP_OBJ(uap->changelist), &kev11,
-		    sizeof(kev11));
+		error = copyin(uap->changelist, &kev11, sizeof(kev11));
 		if (error != 0)
 			break;
 		kevp->ident = kev11.ident;
@@ -1205,11 +1201,11 @@ freebsd11_kevent(struct thread *td, struct freebsd11_kevent_args *uap)
 	};
 	struct g_kevent_args gk_args = {
 		.fd = uap->fd,
-		.changelist = __USER_CAP_UNBOUND(uap->changelist),
+		.changelist = uap->changelist,
 		.nchanges = uap->nchanges,
-		.eventlist = __USER_CAP_UNBOUND(uap->eventlist),
+		.eventlist = uap->eventlist,
 		.nevents = uap->nevents,
-		.timeout = __USER_CAP_OBJ(uap->timeout),
+		.timeout = uap->timeout,
 	};
 
 	return (kern_kevent_generic(td, &gk_args, &k_ops, "kevent_freebsd11"));

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -217,9 +217,8 @@ sys_execve(struct thread *td, struct execve_args *uap)
 	error = pre_execve(td, &oldvmspace);
 	if (error != 0)
 		return (error);
-	error = exec_copyin_args(&args, __USER_CAP_STR(uap->fname),
-	    UIO_USERSPACE, __USER_CAP_UNBOUND(uap->argv),
-	    __USER_CAP_UNBOUND(uap->envv));
+	error = exec_copyin_args(&args, uap->fname, UIO_USERSPACE,
+	    uap->argv, uap->envv);
 	if (error == 0)
 		error = kern_execve(td, &args, NULL);
 	post_execve(td, error, oldvmspace);
@@ -244,7 +243,7 @@ sys_fexecve(struct thread *td, struct fexecve_args *uap)
 	if (error != 0)
 		return (error);
 	error = exec_copyin_args(&args, NULL, UIO_SYSSPACE,
-	    __USER_CAP_UNBOUND(uap->argv), __USER_CAP_UNBOUND(uap->envv));
+	    uap->argv, uap->envv);
 	if (error == 0) {
 		args.fd = uap->fd;
 		error = kern_execve(td, &args, NULL);
@@ -273,11 +272,10 @@ sys___mac_execve(struct thread *td, struct __mac_execve_args *uap)
 	error = pre_execve(td, &oldvmspace);
 	if (error != 0)
 		return (error);
-	error = exec_copyin_args(&args, __USER_CAP_STR(uap->fname),
-	    UIO_USERSPACE, __USER_CAP_UNBOUND(uap->argv),
-	    __USER_CAP_UNBOUND(uap->envv));
+	error = exec_copyin_args(&args, uap->fname, UIO_USERSPACE,
+	    uap->argv, uap->envv);
 	if (error == 0)
-		error = kern_execve(td, &args, __USER_CAP_OBJ(uap->mac_p));
+		error = kern_execve(td, &args, uap->mac_p);
 	post_execve(td, error, oldvmspace);
 	return (error);
 #else

--- a/sys/kern/kern_fork.c
+++ b/sys/kern/kern_fork.c
@@ -125,7 +125,7 @@ int
 sys_pdfork(struct thread *td, struct pdfork_args *uap)
 {
 
-	return (kern_pdfork(td, __USER_CAP_OBJ(uap->fdp), uap->flags));
+	return (kern_pdfork(td, uap->fdp, uap->flags));
 }
 
 int

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -236,26 +236,26 @@ sys_jail(struct thread *td, struct jail_args *uap)
 {
 	uint32_t version;
 	int error;
-	void * __capability jail = __USER_CAP_UNBOUND(uap->jailp);
 
-	error = copyin(jail, &version, sizeof(version));
+	error = copyin(uap->jailp, &version, sizeof(version));
 	if (error)
 		return (error);
 
 	switch (version) {
-	case 0: {
+	case 0:
+	{
 		struct jail_v0 j0;
 		struct in_addr ip4;
 
 		/* FreeBSD single IPv4 jails. */
-		error = copyin(jail, &j0, sizeof(struct jail_v0));
+		error = copyin(uap->jailp, &j0, sizeof(struct jail_v0));
 		if (error)
 			return (error);
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j0.ip_number);
-		return (kern_jail(td, __USER_CAP_STR(j0.path),
-		    __USER_CAP_STR(j0.hostname), NULL, &ip4, 1, NULL, 0,
-		    UIO_SYSSPACE)); }
+		return (kern_jail(td, j0.path, j0.hostname, NULL, &ip4, 1,
+		    NULL, 0, UIO_SYSSPACE));
+	}
 
 	case 1:
 		/*
@@ -264,16 +264,16 @@ sys_jail(struct thread *td, struct jail_args *uap)
 		 */
 		return (EINVAL);
 
-	case 2:	{ /* JAIL_API_VERSION */
+	case 2:	/* JAIL_API_VERSION */
+	{
 		struct jail j;
+
 		/* FreeBSD multi-IPv4/IPv6,noIP jails. */
-		error = copyin(jail, &j, sizeof(struct jail));
+		error = copyin(uap->jailp, &j, sizeof(struct jail));
 		if (error)
 			return (error);
-		return (kern_jail(td, __USER_CAP_STR(j.path),
-		    __USER_CAP_STR(j.hostname), __USER_CAP_STR(j.jailname),
-		    __USER_CAP_ARRAY(j.ip4, j.ip4s), j.ip4s,
-		    __USER_CAP_ARRAY(j.ip6, j.ip6s), j.ip6s, UIO_USERSPACE));
+		return (kern_jail(td, j.path, j.hostname, j.jailname, j.ip4,
+		    j.ip4s, j.ip6, j.ip6s, UIO_USERSPACE));
 	}
 
 	default:
@@ -447,7 +447,7 @@ int
 sys_jail_set(struct thread *td, struct jail_set_args *uap)
 {
 
-	return (user_jail_set(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (user_jail_set(td, uap->iovp,
 	    uap->iovcnt, uap->flags, (copyinuio_t *)copyinuio));
 }
 
@@ -1916,7 +1916,7 @@ int
 sys_jail_get(struct thread *td, struct jail_get_args *uap)
 {
 
-	return (user_jail_get(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (user_jail_get(td, uap->iovp,
 	    uap->iovcnt, uap->flags, (copyinuio_t *)copyinuio,
 	    (updateiov_t *)updateiov));
 }

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -1026,8 +1026,7 @@ int
 sys_ktrace(struct thread *td, struct ktrace_args *uap)
 {
 
-	return (kern_ktrace(td, __USER_CAP_STR(uap->fname), uap->ops,
-	    uap->facs, uap->pid));
+	return (kern_ktrace(td, uap->fname, uap->ops, uap->facs, uap->pid));
 }
 
 int
@@ -1177,8 +1176,7 @@ int
 sys_utrace(struct thread *td, struct utrace_args *uap)
 {
 
-	return (kern_utrace(td, __USER_CAP(uap->addr, uap->len),
-	    uap->len));
+	return (kern_utrace(td, uap->addr, uap->len));
 }
 
 int

--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -26,6 +26,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -1124,7 +1126,7 @@ int
 sys_kldload(struct thread *td, struct kldload_args *uap)
 {
 
-	return (user_kldload(td, __USER_CAP_STR(uap->file)));
+	return (user_kldload(td, uap->file));
 }
 
 int
@@ -1187,7 +1189,7 @@ int
 sys_kldfind(struct thread *td, struct kldfind_args *uap)
 {
 
-	return (kern_kldfind(td, __USER_CAP_STR(uap->file)));
+	return (kern_kldfind(td, uap->file));
 }
 
 int
@@ -1384,7 +1386,7 @@ sys_kldsym(struct thread *td, struct kldsym_args *uap)
 	    uap->cmd != KLDSYM_LOOKUP)
 		return (EINVAL);
 	error = kern_kldsym(td, uap->fileid, uap->cmd,
-	    __USER_CAP_STR(lookup.symname), &lookup.symvalue, &lookup.symsize);
+	    lookup.symname, &lookup.symvalue, &lookup.symsize);
 	if (error != 0)
 		return (error);
 	error = copyout(&lookup, uap->data, sizeof(lookup));

--- a/sys/kern/kern_loginclass.c
+++ b/sys/kern/kern_loginclass.c
@@ -189,8 +189,7 @@ int
 sys_getloginclass(struct thread *td, struct getloginclass_args *uap)
 {
 
-	return (kern_getloginclass(td, __USER_CAP(uap->namebuf, uap->namelen),
-	    uap->namelen));
+	return (kern_getloginclass(td, uap->namebuf, uap->namelen));
 }
 
 int
@@ -220,7 +219,7 @@ int
 sys_setloginclass(struct thread *td, struct setloginclass_args *uap)
 {
 
-	return (kern_setloginclass(td, __USER_CAP_STR(uap->namebuf)));
+	return (kern_setloginclass(td, uap->namebuf));
 }
 
 int

--- a/sys/kern/kern_module.c
+++ b/sys/kern/kern_module.c
@@ -373,7 +373,7 @@ int
 sys_modstat(struct thread *td, struct modstat_args *uap)
 {
 
-	return (kern_modstat(td, uap->modid, __USER_CAP_OBJ(uap->stat)));
+	return (kern_modstat(td, uap->modid, uap->stat));
 }
 
 int
@@ -431,7 +431,7 @@ int
 sys_modfind(struct thread *td, struct modfind_args *uap)
 {
 
-	return (kern_modfind(td, __USER_CAP_STR(uap->name)));
+	return (kern_modfind(td, uap->name));
 }
 
 int

--- a/sys/kern/kern_ntptime.c
+++ b/sys/kern/kern_ntptime.c
@@ -286,7 +286,7 @@ int
 sys_ntp_gettime(struct thread *td, struct ntp_gettime_args *uap)
 {	
 
-	return (kern_ntp_gettime(td, __USER_CAP_OBJ(uap->ntvp)));
+	return (kern_ntp_gettime(td, uap->ntvp));
 }
 
 int
@@ -358,13 +358,13 @@ sys_ntp_adjtime(struct thread *td, struct ntp_adjtime_args *uap)
 	struct timex ntv;
 	int error, retval;
 
-	error = copyin(__USER_CAP_OBJ(uap->tp), &ntv, sizeof(ntv));
+	error = copyin(uap->tp, &ntv, sizeof(ntv));
 	if (error)
 		return (error);
 	error = kern_ntp_adjtime(td, &ntv, &retval);
 	if (error)
 		return (error);
-	error = copyout(&ntv, __USER_CAP_OBJ(uap->tp), sizeof(ntv));
+	error = copyout(&ntv, uap->tp, sizeof(ntv));
 	if (error == 0)
 		td->td_retval[0] = retval;
 	return (error);
@@ -987,8 +987,7 @@ sys_adjtime(struct thread *td, struct adjtime_args *uap)
 	int error;
 
 	if (uap->delta) {
-		error = copyin(__USER_CAP_OBJ(uap->delta), &delta,
-		    sizeof(delta));
+		error = copyin(uap->delta, &delta, sizeof(delta));
 		if (error)
 			return (error);
 		deltap = &delta;
@@ -996,8 +995,7 @@ sys_adjtime(struct thread *td, struct adjtime_args *uap)
 		deltap = NULL;
 	error = kern_adjtime(td, deltap, &olddelta);
 	if (uap->olddelta && error == 0)
-		error = copyout(&olddelta, __USER_CAP_OBJ(uap->olddelta),
-		    sizeof(olddelta));
+		error = copyout(&olddelta, uap->olddelta, sizeof(olddelta));
 	return (error);
 }
 

--- a/sys/kern/kern_procctl.c
+++ b/sys/kern/kern_procctl.c
@@ -593,8 +593,7 @@ int
 sys_procctl(struct thread *td, struct procctl_args *uap)
 {
 
-	return (user_procctl(td, uap->idtype, uap->id, uap->com,
-	    __USER_CAP_UNBOUND(uap->data)));
+	return (user_procctl(td, uap->idtype, uap->id, uap->com, uap->data));
 }
 
 int

--- a/sys/kern/kern_prot.c
+++ b/sys/kern/kern_prot.c
@@ -289,8 +289,7 @@ int
 sys_getgroups(struct thread *td, struct getgroups_args *uap)
 {
 
-	return (kern_getgroups(td, uap->gidsetsize,
-	    __USER_CAP_ARRAY(uap->gidset, uap->gidsetsize)));
+	return (kern_getgroups(td, uap->gidsetsize, uap->gidset));
 }
 
 int
@@ -804,8 +803,7 @@ int
 sys_setgroups(struct thread *td, struct setgroups_args *uap)
 {
 
-	return (user_setgroups(td, uap->gidsetsize,
-	    __USER_CAP_ARRAY(uap->gidset, uap->gidsetsize)));
+	return (user_setgroups(td, uap->gidsetsize, uap->gidset));
 }
 
 int
@@ -1185,8 +1183,7 @@ int
 sys_getresuid(struct thread *td, struct getresuid_args *uap)
 {
 
-	return (kern_getresuid(td, __USER_CAP_OBJ(uap->ruid),
-	    __USER_CAP_OBJ(uap->euid), __USER_CAP_OBJ(uap->suid)));
+	return (kern_getresuid(td, uap->ruid, uap->euid, uap->suid));
 }
 
 int
@@ -1219,8 +1216,7 @@ int
 sys_getresgid(struct thread *td, struct getresgid_args *uap)
 {
 
-	return (kern_getresgid(td, __USER_CAP_OBJ(uap->rgid),
-	    __USER_CAP_OBJ(uap->egid), __USER_CAP_OBJ(uap->sgid)));
+	return (kern_getresgid(td, uap->rgid, uap->egid, uap->sgid));
 }
 
 int
@@ -2161,8 +2157,7 @@ int
 sys_getlogin(struct thread *td, struct getlogin_args *uap)
 {
 
-	return (kern_getlogin(td, __USER_CAP(uap->namebuf, uap->namelen),
-	    uap->namelen));
+	return (kern_getlogin(td, uap->namebuf, uap->namelen));
 }
 
 int
@@ -2197,7 +2192,7 @@ int
 sys_setlogin(struct thread *td, struct setlogin_args *uap)
 {
 
-	return (kern_setlogin(td, __USER_CAP_STR(uap->namebuf)));
+	return (kern_setlogin(td, uap->namebuf));
 }
 
 int

--- a/sys/kern/kern_resource.c
+++ b/sys/kern/kern_resource.c
@@ -290,8 +290,7 @@ int
 sys_rtprio_thread(struct thread *td, struct rtprio_thread_args *uap)
 {
 
-	return (kern_rtprio_thread(td, uap->function, uap->lwpid,
-	    __USER_CAP_OBJ(uap->rtp)));
+	return (kern_rtprio_thread(td, uap->function, uap->lwpid, uap->rtp));
 }
 
 int
@@ -381,8 +380,7 @@ int
 sys_rtprio(struct thread *td, struct rtprio_args *uap)
 {
 
-	return (kern_rtprio(td, uap->function, uap->pid,
-	    __USER_CAP_OBJ(uap->rtp)));
+	return (kern_rtprio(td, uap->function, uap->pid, uap->rtp));
 }
 
 int
@@ -612,7 +610,7 @@ sys_setrlimit(struct thread *td, struct __setrlimit_args *uap)
 	struct rlimit alim;
 	int error;
 
-	if ((error = copyin(__USER_CAP_OBJ(uap->rlp), &alim, sizeof(struct rlimit))))
+	if ((error = copyin(uap->rlp, &alim, sizeof(struct rlimit))))
 		return (error);
 	error = kern_setrlimit(td, uap->which, &alim);
 	return (error);
@@ -803,7 +801,7 @@ sys_getrlimit(struct thread *td, struct __getrlimit_args *uap)
 	if (uap->which >= RLIM_NLIMITS)
 		return (EINVAL);
 	lim_rlimit(td, uap->which, &rlim);
-	error = copyout(&rlim, __USER_CAP_OBJ(uap->rlp), sizeof(struct rlimit));
+	error = copyout(&rlim, uap->rlp, sizeof(struct rlimit));
 	return (error);
 }
 
@@ -1062,8 +1060,7 @@ sys_getrusage(struct thread *td, struct getrusage_args *uap)
 
 	error = kern_getrusage(td, uap->who, &ru);
 	if (error == 0)
-		error = copyout(&ru, __USER_CAP_OBJ(uap->rusage),
-		    sizeof(struct rusage));
+		error = copyout(&ru, uap->rusage, sizeof(struct rusage));
 	return (error);
 }
 

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1219,8 +1219,7 @@ sys_sendfile(struct thread *td, struct sendfile_args *uap)
 {
  
 	return (kern_sendfile(td, uap->fd, uap->s, uap->offset,
-	    uap->nbytes, __USER_CAP_OBJ(uap->hdtr),
-	    __USER_CAP_OBJ(uap->sbytes), uap->flags, 0,
+	    uap->nbytes, uap->hdtr, uap->sbytes, uap->flags, 0,
 	    (copyin_hdtr_t *)copyin_hdtr, (copyinuio_t *)copyinuio));
 }
 
@@ -1230,8 +1229,7 @@ freebsd4_sendfile(struct thread *td, struct freebsd4_sendfile_args *uap)
 {
 
 	return (kern_sendfile(td, uap->fd, uap->s, uap->offset,
-	    uap->nbytes, __USER_CAP_OBJ(uap->hdtr),
-	    __USER_CAP_OBJ(uap->sbytes), uap->flags, 1,
+	    uap->nbytes, uap->hdtr, uap->sbytes, uap->flags, 1,
 	    (copyin_hdtr_t *)copyin_hdtr, (copyinuio_t *)copyinuio));
 }
 #endif /* COMPAT_FREEBSD4 */

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -2171,10 +2171,8 @@ int
 sys___sysctl(struct thread *td, struct __sysctl_args *uap)
 {
 
-	return (kern_sysctl(td, __USER_CAP_ARRAY(uap->name, uap->namelen),
-	    uap->namelen, __USER_CAP_UNBOUND(uap->old),
-	    __USER_CAP_OBJ(uap->oldlenp), __USER_CAP(uap->new, uap->newlen),
-	    uap->newlen, 0));
+	return (kern_sysctl(td, uap->name, uap->namelen, uap->old,
+	    uap->oldlenp, uap->new, uap->newlen, 0));
 }
 
 int
@@ -2257,14 +2255,12 @@ sys___sysctlbyname(struct thread *td, struct __sysctlbyname_args *uap)
 	size_t rv;
 	int error;
 
-	error = kern___sysctlbyname(td, __USER_CAP(uap->name, uap->namelen),
-	    uap->namelen, __USER_CAP_UNBOUND(uap->old),
-	    __USER_CAP_OBJ(uap->oldlenp), __USER_CAP(uap->new, uap->newlen),
-	    uap->newlen, &rv, 0, 0);
+	error = kern___sysctlbyname(td, uap->name, uap->namelen, uap->old,
+	    uap->oldlenp, uap->new, uap->newlen, &rv, 0, 0);
 	if (error != 0)
 		return (error);
 	if (uap->oldlenp != NULL)
-		error = copyout(&rv, __USER_CAP_OBJ(uap->oldlenp), sizeof(rv));
+		error = copyout(&rv, uap->oldlenp, sizeof(rv));
 
 	return (error);
 }

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -3532,14 +3532,12 @@ __umtx_op_wait(struct thread *td, struct _umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		    (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_wait(td, __USER_CAP_ADDR(uap->obj), uap->val, tm_p,
-	    0, 0));
+	return (do_wait(td, uap->obj, uap->val, tm_p, 0, 0));
 }
 
 static int
@@ -3552,14 +3550,12 @@ __umtx_op_wait_uint(struct thread *td, struct _umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		    (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_wait(td, __USER_CAP_ADDR(uap->obj), uap->val, tm_p,
-	    1, 0));
+	return (do_wait(td, uap->obj, uap->val, tm_p, 1, 0));
 }
 
 static int
@@ -3572,44 +3568,41 @@ __umtx_op_wait_uint_private(struct thread *td, struct _umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		    (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_wait(td, __USER_CAP_ADDR(uap->obj), uap->val, tm_p,
-	    1, 1));
+	return (do_wait(td, uap->obj, uap->val, tm_p, 1, 1));
 }
 
 static int
 __umtx_op_wake(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (kern_umtx_wake(td, __USER_CAP(uap->obj, sizeof(struct umutex)),
-	    uap->val, 0));
+	return (kern_umtx_wake(td, uap->obj, uap->val, 0));
 }
 
-#define BATCH_SIZE	128
+#define BATCH_SIZE	(1024 / sizeof(char * __capability))
+
 static int
 __umtx_op_nwake_private(struct thread *td, struct _umtx_op_args *uap)
 {
-	char *uaddrs[BATCH_SIZE], **upp;
+	char * __capability uaddrs[BATCH_SIZE];
+	char * __capability * __capability upp;
 	int count, error, i, pos, tocopy;
 
-	upp = (char **)uap->obj;
+	upp = (char * __capability * __capability)uap->obj;
 	error = 0;
 	for (count = uap->val, pos = 0; count > 0; count -= tocopy,
 	    pos += tocopy) {
 		tocopy = MIN(count, BATCH_SIZE);
-		error = copyin(__USER_CAP_UNBOUND(upp + pos), uaddrs,
-		    tocopy * sizeof(char *));
+		error = copyincap(upp + pos, uaddrs,
+		    tocopy * sizeof(char * __capability));
 		if (error != 0)
 			break;
 		for (i = 0; i < tocopy; ++i)
-			kern_umtx_wake(td,
-			    __USER_CAP(uaddrs[i], sizeof(struct umutex)),
-			    INT_MAX, 1);
+			kern_umtx_wake(td, uaddrs[i], INT_MAX, 1);
 		maybe_yield();
 	}
 	return (error);
@@ -3619,8 +3612,7 @@ static int
 __umtx_op_wake_private(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (kern_umtx_wake(td, __USER_CAP(uap->obj, sizeof(struct umutex)),
-	    uap->val, 1));
+	return (kern_umtx_wake(td, uap->obj, uap->val, 1));
 }
 
 static int
@@ -3634,22 +3626,19 @@ __umtx_op_lock_umutex(struct thread *td, struct _umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		    (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_lock_umutex(td, __USER_CAP(uap->obj, sizeof(struct umutex)),
-	    tm_p, 0));
+	return (do_lock_umutex(td, uap->obj, tm_p, 0));
 }
 
 static int
 __umtx_op_trylock_umutex(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_lock_umutex(td, __USER_CAP(uap->obj, sizeof(struct umutex)),
-	    NULL, _UMUTEX_TRY));
+	return (do_lock_umutex(td, uap->obj, NULL, _UMUTEX_TRY));
 }
 
 static int
@@ -3663,39 +3652,33 @@ __umtx_op_wait_umutex(struct thread *td, struct _umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		    (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_lock_umutex(td, __USER_CAP(uap->obj, sizeof(struct umutex)),
-	    tm_p, _UMUTEX_WAIT));
+	return (do_lock_umutex(td, uap->obj, tm_p, _UMUTEX_WAIT));
 }
 
 static int
 __umtx_op_wake_umutex(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_wake_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex))));
+	return (do_wake_umutex(td, uap->obj));
 }
 
 static int
 __umtx_op_unlock_umutex(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_unlock_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex)), false));
+	return (do_unlock_umutex(td, uap->obj, false));
 }
 
 static int
 __umtx_op_set_ceiling(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_set_ceiling(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex)), uap->val,
-	    __USER_CAP(uap->uaddr1, sizeof(uint32_t))));
+	return (do_set_ceiling(td, uap->obj, uap->val, uap->uaddr1));
 }
 
 static int
@@ -3708,31 +3691,26 @@ __umtx_op_cv_wait(struct thread *td, struct _umtx_op_args *uap)
 	if (uap->uaddr2 == NULL)
 		ts = NULL;
 	else {
-		error = umtx_copyin_timeout(
-		    __USER_CAP(uap->uaddr2, sizeof(struct timespec)),
-		    &timeout);
+		error = umtx_copyin_timeout(uap->uaddr2, &timeout);
 		if (error != 0)
 			return (error);
 		ts = &timeout;
 	}
-	return (do_cv_wait(td, __USER_CAP(uap->obj, sizeof(struct ucond)),
-	    __USER_CAP(uap->uaddr1, sizeof(struct umutex)), ts, uap->val));
+	return (do_cv_wait(td, uap->obj, uap->uaddr1, ts, uap->val));
 }
 
 static int
 __umtx_op_cv_signal(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_cv_signal(td,
-	    __USER_CAP(uap->obj, sizeof(struct ucond))));
+	return (do_cv_signal(td, uap->obj));
 }
 
 static int
 __umtx_op_cv_broadcast(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_cv_broadcast(td,
-	    __USER_CAP(uap->obj, sizeof(struct ucond))));
+	return (do_cv_broadcast(td, uap->obj));
 }
 
 static int
@@ -3743,17 +3721,13 @@ __umtx_op_rw_rdlock(struct thread *td, struct _umtx_op_args *uap)
 
 	/* Allow a null timespec (wait forever). */
 	if (uap->uaddr2 == NULL) {
-		error = do_rw_rdlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), uap->val, 0);
+		error = do_rw_rdlock(td, uap->obj, uap->val, 0);
 	} else {
-		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		   (size_t)uap->uaddr1, &timeout);
+		error = umtx_copyin_umtx_time(uap->uaddr2,
+		   (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
-		error = do_rw_rdlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), uap->val,
-		    &timeout);
+		error = do_rw_rdlock(td, uap->obj, uap->val, &timeout);
 	}
 	return (error);
 }
@@ -3766,17 +3740,14 @@ __umtx_op_rw_wrlock(struct thread *td, struct _umtx_op_args *uap)
 
 	/* Allow a null timespec (wait forever). */
 	if (uap->uaddr2 == NULL) {
-		error = do_rw_wrlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), 0);
+		error = do_rw_wrlock(td, uap->obj, 0);
 	} else {
-		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		   (size_t)uap->uaddr1, &timeout);
+		error = umtx_copyin_umtx_time(uap->uaddr2,
+		   (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 
-		error = do_rw_wrlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), &timeout);
+		error = do_rw_wrlock(td, uap->obj, &timeout);
 	}
 	return (error);
 }
@@ -3785,8 +3756,7 @@ static int
 __umtx_op_rw_unlock(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_rw_unlock(td,
-	    __USER_CAP(uap->obj, sizeof(struct urwlock))));
+	return (do_rw_unlock(td, uap->obj));
 }
 
 #if defined(COMPAT_FREEBSD9) || defined(COMPAT_FREEBSD10)
@@ -3801,20 +3771,19 @@ __umtx_op_sem_wait(struct thread *td, struct _umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
-		    (size_t)uap->uaddr1, &timeout);
+		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_sem_wait(td, __USER_CAP_UNBOUND(uap->obj), tm_p));
+	return (do_sem_wait(td, uap->obj, tm_p));
 }
 
 static int
 __umtx_op_sem_wake(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_sem_wake(td, __USER_CAP_UNBOUND(uap->obj)));
+	return (do_sem_wake(td, uap->obj));
 }
 #endif
 
@@ -3822,8 +3791,7 @@ static int
 __umtx_op_wake2_umutex(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_wake2_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex)), uap->val));
+	return (do_wake2_umutex(td, uap->obj, uap->val));
 }
 
 static int
@@ -3838,20 +3806,18 @@ __umtx_op_sem2_wait(struct thread *td, struct _umtx_op_args *uap)
 		uasize = 0;
 		tm_p = NULL;
 	} else {
-		uasize = (size_t)uap->uaddr1;
-		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, uasize), uasize, &timeout);
+		uasize = (__cheri_addr size_t)uap->uaddr1;
+		error = umtx_copyin_umtx_time(uap->uaddr2, uasize, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	error = do_sem2_wait(td, __USER_CAP(uap->obj, sizeof(struct _usem2)),
-	    tm_p);
+	error = do_sem2_wait(td, uap->obj, tm_p);
 	if (error == EINTR && uap->uaddr2 != NULL &&
 	    (timeout._flags & UMTX_ABSTIME) == 0 &&
 	    uasize >= sizeof(struct _umtx_time) + sizeof(struct timespec)) {
 		error = copyout(&timeout._timeout,
-		    __USER_CAP_UNBOUND((struct _umtx_time *)uap->uaddr2 + 1),
+		    (struct _umtx_time * __capability)uap->uaddr2 + 1,
 		    sizeof(struct timespec));
 		if (error == 0) {
 			error = EINTR;
@@ -3865,7 +3831,7 @@ static int
 __umtx_op_sem2_wake(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (do_sem2_wake(td, __USER_CAP(uap->obj, sizeof(struct _usem2))));
+	return (do_sem2_wake(td, uap->obj));
 }
 
 #define	USHM_OBJ_UMTX(o)						\
@@ -4172,7 +4138,7 @@ static int
 __umtx_op_shm(struct thread *td, struct _umtx_op_args *uap)
 {
 
-	return (umtx_shm(td, __USER_CAP_UNBOUND(uap->uaddr1), uap->val));
+	return (umtx_shm(td, uap->uaddr1, uap->val));
 }
 
 static int
@@ -4188,22 +4154,15 @@ umtx_robust_lists(struct thread *td, struct umtx_robust_lists_params_c *rbp)
 static int
 __umtx_op_robust_lists(struct thread *td, struct _umtx_op_args *uap)
 {
-	struct umtx_robust_lists_params rb_n;
 	struct umtx_robust_lists_params_c rb;
 	int error;
 
-	if (uap->val > sizeof(rb_n))
+	if (uap->val > sizeof(rb))
 		return (EINVAL);
-	bzero(&rb_n, sizeof(rb_n));
-	error = copyin(__USER_CAP(uap->uaddr1, sizeof(rb_n)), &rb_n, uap->val);
+	bzero(&rb, sizeof(rb));
+	error = copyincap(uap->uaddr1, &rb, uap->val);
 	if (error != 0)
 		return (error);
-	rb.robust_list_offset =
-	    (intcap_t)__USER_CAP_UNBOUND((void *)rb_n.robust_list_offset);
-	rb.robust_priv_list_offset =
-	    (intcap_t)__USER_CAP_UNBOUND((void *)rb_n.robust_priv_list_offset);
-	rb.robust_inact_offset =
-	    (intcap_t)__USER_CAP_UNBOUND((void *)rb_n.robust_inact_offset);
 	return (umtx_robust_lists(td, &rb));
 }
 
@@ -4324,13 +4283,10 @@ __umtx_op_wake_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 	return (kern_umtx_wake(td, uap->obj, uap->val, 0));
 }
 
-/* BATCH_SIZE=128 consumes 1k of stack with 8 byte pointers so scale back. */
-#define	BATCH_SIZE_C \
-    (BATCH_SIZE / (sizeof(void * __capability)/sizeof(void *)))
 static int
 __umtx_op_nwake_private_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 {
-	char * __capability uaddrs[BATCH_SIZE_C];
+	char * __capability uaddrs[BATCH_SIZE];
 	char * __capability * __capability upp;
 	int count, error, i, pos, tocopy;
 
@@ -4338,7 +4294,7 @@ __umtx_op_nwake_private_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
 	error = 0;
 	for (count = uap->val, pos = 0; count > 0; count -= tocopy,
 	    pos += tocopy) {
-		tocopy = MIN(count, BATCH_SIZE_C);
+		tocopy = MIN(count, BATCH_SIZE);
 		error = copyincap(upp + pos, uaddrs,
 		    tocopy * sizeof(char * __capability));
 		if (error != 0)

--- a/sys/kern/kern_uuid.c
+++ b/sys/kern/kern_uuid.c
@@ -183,8 +183,7 @@ int
 sys_uuidgen(struct thread *td, struct uuidgen_args *uap)
 {
 
-	return (user_uuidgen(td, __USER_CAP_ARRAY(uap->store, uap->count),
-	    uap->count));
+	return (user_uuidgen(td, uap->store, uap->count));
 }
 
 int

--- a/sys/kern/p1003_1b.c
+++ b/sys/kern/p1003_1b.c
@@ -115,8 +115,7 @@ int
 sys_sched_setparam(struct thread *td, struct sched_setparam_args *uap)
 {
 
-	return (user_sched_setparam(td, uap->pid,
-	    __USER_CAP_OBJ(uap->param)));
+	return (user_sched_setparam(td, uap->pid, uap->param));
 }
 
 int
@@ -169,7 +168,7 @@ int
 sys_sched_getparam(struct thread *td, struct sched_getparam_args *uap)
 {
 
-	return (user_sched_getparam(td, uap->pid, __USER_CAP_OBJ(uap->param)));
+	return (user_sched_getparam(td, uap->pid, uap->param));
 }
 
 int
@@ -220,8 +219,7 @@ int
 sys_sched_setscheduler(struct thread *td, struct sched_setscheduler_args *uap)
 {
 
-	return (user_sched_setscheduler(td, uap->pid, uap->policy,
-	    __USER_CAP_OBJ(uap->param)));
+	return (user_sched_setscheduler(td, uap->pid, uap->policy, uap->param));
 }
 
 int
@@ -352,8 +350,7 @@ sys_sched_rr_get_interval(struct thread *td,
     struct sched_rr_get_interval_args *uap)
 {
 
-	return (user_sched_rr_get_interval(td, uap->pid,
-	    __USER_CAP_OBJ(uap->interval)));
+	return (user_sched_rr_get_interval(td, uap->pid, uap->interval));
 }
 
 int

--- a/sys/kern/subr_prof.c
+++ b/sys/kern/subr_prof.c
@@ -411,8 +411,8 @@ int
 sys_profil(struct thread *td, struct profil_args *uap)
 {
 
-	return (kern_profil(td, __USER_CAP(uap->samples, uap->size), uap->size,
-	    uap->offset, uap->scale));
+	return (kern_profil(td, uap->samples, uap->size, uap->offset,
+	    uap->scale));
 }
 
 int

--- a/sys/kern/sys_capability.c
+++ b/sys/kern/sys_capability.c
@@ -127,7 +127,7 @@ int
 sys_cap_getmode(struct thread *td, struct cap_getmode_args *uap)
 {
 
-	return (kern_cap_getmode(td, __USER_CAP_OBJ(uap->modep)));
+	return (kern_cap_getmode(td, uap->modep));
 }
 
 int
@@ -263,8 +263,7 @@ int
 sys_cap_rights_limit(struct thread *td, struct cap_rights_limit_args *uap)
 {
 
-	return (user_cap_rights_limit(td, uap->fd,
-	    __USER_CAP_UNBOUND(uap->rightsp)));
+	return (user_cap_rights_limit(td, uap->fd, uap->rightsp));
 }
 
 int
@@ -315,8 +314,7 @@ int
 sys___cap_rights_get(struct thread *td, struct __cap_rights_get_args *uap)
 {
 
-	return (kern_cap_rights_get(td, uap->version, uap->fd,
-	    __USER_CAP_UNBOUND(uap->rightsp)));
+	return (kern_cap_rights_get(td, uap->version, uap->fd, uap->rightsp));
 }
 
 int
@@ -469,8 +467,7 @@ int
 sys_cap_ioctls_limit(struct thread *td, struct cap_ioctls_limit_args *uap)
 {
 
-	return (user_cap_ioctls_limit(td, uap->fd,
-	    __USER_CAP_ARRAY(uap->cmds, uap->ncmds), uap->ncmds));
+	return (user_cap_ioctls_limit(td, uap->fd, uap->cmds, uap->ncmds));
 }
 
 int
@@ -501,8 +498,7 @@ int
 sys_cap_ioctls_get(struct thread *td, struct cap_ioctls_get_args *uap)
 {
 
-	return (kern_cap_ioctls_get(td, uap->fd,
-	    __USER_CAP_ARRAY(uap->cmds, uap->maxcmds), uap->maxcmds));
+	return (kern_cap_ioctls_get(td, uap->fd, uap->cmds, uap->maxcmds));
 }
 
 int
@@ -632,8 +628,7 @@ int
 sys_cap_fcntls_get(struct thread *td, struct cap_fcntls_get_args *uap)
 {
 
-	return (kern_cap_fcntls_get(td, uap->fd,
-	    __USER_CAP_OBJ(uap->fcntlrightsp)));
+	return (kern_cap_fcntls_get(td, uap->fd, uap->fcntlrightsp));
 }
 
 int

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -193,8 +193,7 @@ int
 sys_read(struct thread *td, struct read_args *uap)
 {
 
-	return (user_read(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
-	    uap->nbyte));
+	return (user_read(td, uap->fd, uap->buf, uap->nbyte));
 }
 
 int
@@ -229,8 +228,7 @@ int
 sys_pread(struct thread *td, struct pread_args *uap)
 {
 
-	return (kern_pread(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
-	    uap->nbyte, uap->offset));
+	return (kern_pread(td, uap->fd, uap->buf, uap->nbyte, uap->offset));
 }
 
 int
@@ -273,8 +271,8 @@ int
 sys_readv(struct thread *td, struct readv_args *uap)
 {
 
-	return (user_readv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, (copyinuio_t *)copyinuio));
+	return (user_readv(td, uap->fd, uap->iovp, uap->iovcnt,
+	    (copyinuio_t *)copyinuio));
 }
 
 int
@@ -321,8 +319,8 @@ int
 sys_preadv(struct thread *td, struct preadv_args *uap)
 {
 
-	return (user_preadv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, uap->offset, (copyinuio_t *)copyinuio));
+	return (user_preadv(td, uap->fd, uap->iovp, uap->iovcnt, uap->offset,
+	    (copyinuio_t *)copyinuio));
 }
 
 int
@@ -416,8 +414,7 @@ int
 sys_write(struct thread *td, struct write_args *uap)
 {
 
-	return (kern_write(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
-	    uap->nbyte));
+	return (kern_write(td, uap->fd, uap->buf, uap->nbyte));
 }
 
 int
@@ -455,8 +452,7 @@ int
 sys_pwrite(struct thread *td, struct pwrite_args *uap)
 {
 
-	return (kern_pwrite(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
-	    uap->nbyte, uap->offset));
+	return (kern_pwrite(td, uap->fd, uap->buf, uap->nbyte, uap->offset));
 }
 
 int
@@ -483,8 +479,7 @@ int
 freebsd6_pwrite(struct thread *td, struct freebsd6_pwrite_args *uap)
 {
 
-	return (kern_pwrite(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
-	    uap->nbyte, uap->offset));
+	return (kern_pwrite(td, uap->fd, uap->buf, uap->nbyte, uap->offset));
 }
 #endif
 
@@ -502,8 +497,8 @@ int
 sys_writev(struct thread *td, struct writev_args *uap)
 {
 
-	return (user_writev(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, (copyinuio_t *)copyinuio));
+	return (user_writev(td, uap->fd, uap->iovp, uap->iovcnt,
+	    (copyinuio_t *)copyinuio));
 }
 
 int
@@ -550,8 +545,7 @@ int
 sys_pwritev(struct thread *td, struct pwritev_args *uap)
 {
 
-	return (user_pwritev(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, uap->offset,
+	return (user_pwritev(td, uap->fd, uap->iovp, uap->iovcnt, uap->offset,
 	    (copyinuio_t *)copyinuio));
 }
 
@@ -703,16 +697,8 @@ struct ioctl_args {
 int
 sys_ioctl(struct thread *td, struct ioctl_args *uap)
 {
-	u_long com;
-	void * __capability udata;
 
-	com = uap->com;
-	if (com & IOC_VOID)
-		udata = (void * __capability)(intcap_t)uap->data;
-	else
-		udata = __USER_CAP(uap->data, IOCPARM_LEN(com));
-
-	return (user_ioctl(td, uap->fd, com, udata, &uap->data, 0));
+	return (user_ioctl(td, uap->fd, uap->com, uap->data, &uap->data, 1));
 }
 
 int
@@ -911,9 +897,8 @@ int
 sys_pselect(struct thread *td, struct pselect_args *uap)
 {
 
-	return (user_pselect(td, uap->nd, __USER_CAP_UNBOUND(uap->in),
-	    __USER_CAP_UNBOUND(uap->ou), __USER_CAP_UNBOUND(uap->ex),
-	    __USER_CAP_OBJ(uap->ts), __USER_CAP_OBJ(uap->sm)));
+	return (user_pselect(td, uap->nd, uap->in, uap->ou, uap->ex, uap->ts,
+	    uap->sm));
 }
 
 int
@@ -981,9 +966,7 @@ int
 sys_select(struct thread *td, struct select_args *uap)
 {
 
-	return (user_select(td, uap->nd, __USER_CAP_UNBOUND(uap->in),
-	    __USER_CAP_UNBOUND(uap->ou), __USER_CAP_UNBOUND(uap->ex),
-	    __USER_CAP_OBJ(uap->tv)));
+	return (user_select(td, uap->nd, uap->in, uap->ou, uap->ex, uap->tv));
 }
 
 int
@@ -1387,8 +1370,7 @@ int
 sys_poll(struct thread *td, struct poll_args *uap)
 {
 
-	return (user_poll(td, __USER_CAP_ARRAY(uap->fds, uap->nfds),
-	    uap->nfds, uap->timeout));
+	return (user_poll(td, uap->fds, uap->nfds, uap->timeout));
 }
 
 int
@@ -1514,8 +1496,7 @@ int
 sys_ppoll(struct thread *td, struct ppoll_args *uap)
 {
 
-	return (user_ppoll(td, __USER_CAP_ARRAY(uap->fds, uap->nfds),
-	    uap->nfds, __USER_CAP_OBJ(uap->ts), __USER_CAP_OBJ(uap->set)));
+	return (user_ppoll(td, uap->fds, uap->nfds, uap->ts, uap->set));
 }
 
 int

--- a/sys/kern/sys_getrandom.c
+++ b/sys/kern/sys_getrandom.c
@@ -92,6 +92,5 @@ struct getrandom_args {
 int
 sys_getrandom(struct thread *td, struct getrandom_args *uap)
 {
-	return (kern_getrandom(td, __USER_CAP(uap->buf, uap->buflen),
-	    uap->buflen, uap->flags));
+	return (kern_getrandom(td, uap->buf, uap->buflen, uap->flags));
 }

--- a/sys/kern/sys_kbounce.c
+++ b/sys/kern/sys_kbounce.c
@@ -30,6 +30,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -39,8 +41,8 @@ __FBSDID("$FreeBSD$");
 #include <sys/kbounce.h>
 
 static int
-kern_kbounce(struct thread *td, const void *src, void *dst, size_t len,
-    int flags)
+kern_kbounce(struct thread *td, const void * __capability src,
+    void * __capability dst, size_t len, int flags)
 {
 	void *bounce;
 	int error;

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -467,7 +467,7 @@ int
 sys_pipe2(struct thread *td, struct pipe2_args *uap)
 {
 
-	return (kern_pipe2(td, __USER_CAP_ARRAY(uap->fildes, 2), uap->flags));
+	return (kern_pipe2(td, uap->fildes, uap->flags));
 }
 
 int

--- a/sys/kern/sys_procdesc.c
+++ b/sys/kern/sys_procdesc.c
@@ -213,7 +213,7 @@ int
 sys_pdgetpid(struct thread *td, struct pdgetpid_args *uap)
 {
 
-	return (user_pdgetpid(td, uap->fd, __USER_CAP_OBJ(uap->pidp)));
+	return (user_pdgetpid(td, uap->fd, uap->pidp));
 }
 
 int

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -31,6 +31,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 

--- a/sys/kern/syscalls.conf
+++ b/sys/kern/syscalls.conf
@@ -1,0 +1,2 @@
+# $FreeBSD$
+ptr_qualified="* __capability "

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -32,7 +32,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 3: {
 		struct read_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->buf; /* void * */
+		uarg[1] = (intptr_t) p->buf; /* void * __capability */
 		uarg[2] = p->nbyte; /* size_t */
 		*n_args = 3;
 		break;
@@ -41,7 +41,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 4: {
 		struct write_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->buf; /* const void * */
+		uarg[1] = (intptr_t) p->buf; /* const void * __capability */
 		uarg[2] = p->nbyte; /* size_t */
 		*n_args = 3;
 		break;
@@ -49,7 +49,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* open */
 	case 5: {
 		struct open_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->flags; /* int */
 		iarg[2] = p->mode; /* mode_t */
 		*n_args = 3;
@@ -66,31 +66,31 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 7: {
 		struct wait4_args *p = params;
 		iarg[0] = p->pid; /* int */
-		uarg[1] = (intptr_t) p->status; /* int * */
+		uarg[1] = (intptr_t) p->status; /* int * __capability */
 		iarg[2] = p->options; /* int */
-		uarg[3] = (intptr_t) p->rusage; /* struct rusage * */
+		uarg[3] = (intptr_t) p->rusage; /* struct rusage * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* link */
 	case 9: {
 		struct link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
-		uarg[1] = (intptr_t) p->to; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
+		uarg[1] = (intptr_t) p->to; /* const char * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* unlink */
 	case 10: {
 		struct unlink_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* chdir */
 	case 12: {
 		struct chdir_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -104,7 +104,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* chmod */
 	case 15: {
 		struct chmod_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->mode; /* mode_t */
 		*n_args = 2;
 		break;
@@ -112,7 +112,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* chown */
 	case 16: {
 		struct chown_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->uid; /* int */
 		iarg[2] = p->gid; /* int */
 		*n_args = 3;
@@ -121,7 +121,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* break */
 	case 17: {
 		struct break_args *p = params;
-		uarg[0] = (intptr_t) p->nsize; /* char * */
+		uarg[0] = (intptr_t) p->nsize; /* char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -133,17 +133,17 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mount */
 	case 21: {
 		struct mount_args *p = params;
-		uarg[0] = (intptr_t) p->type; /* const char * */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->type; /* const char * __capability */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->flags; /* int */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* unmount */
 	case 22: {
 		struct unmount_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->flags; /* int */
 		*n_args = 2;
 		break;
@@ -170,7 +170,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct ptrace_args *p = params;
 		iarg[0] = p->req; /* int */
 		iarg[1] = p->pid; /* pid_t */
-		uarg[2] = (intptr_t) p->addr; /* char * */
+		uarg[2] = (intptr_t) p->addr; /* char * __capability */
 		iarg[3] = p->data; /* int */
 		*n_args = 4;
 		break;
@@ -179,7 +179,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 27: {
 		struct recvmsg_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->msg; /* struct msghdr_native * */
+		uarg[1] = (intptr_t) p->msg; /* struct msghdr_native * __capability */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
 		break;
@@ -188,7 +188,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 28: {
 		struct sendmsg_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->msg; /* const struct msghdr_native * */
+		uarg[1] = (intptr_t) p->msg; /* const struct msghdr_native * __capability */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
 		break;
@@ -197,11 +197,11 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 29: {
 		struct recvfrom_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->buf; /* void * */
+		uarg[1] = (intptr_t) p->buf; /* void * __capability */
 		uarg[2] = p->len; /* size_t */
 		iarg[3] = p->flags; /* int */
-		uarg[4] = (intptr_t) p->from; /* struct sockaddr * */
-		uarg[5] = (intptr_t) p->fromlenaddr; /* __socklen_t * */
+		uarg[4] = (intptr_t) p->from; /* struct sockaddr * __capability */
+		uarg[5] = (intptr_t) p->fromlenaddr; /* __socklen_t * __capability */
 		*n_args = 6;
 		break;
 	}
@@ -209,8 +209,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 30: {
 		struct accept_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->name; /* struct sockaddr * */
-		uarg[2] = (intptr_t) p->anamelen; /* __socklen_t * */
+		uarg[1] = (intptr_t) p->name; /* struct sockaddr * __capability */
+		uarg[2] = (intptr_t) p->anamelen; /* __socklen_t * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -218,8 +218,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 31: {
 		struct getpeername_args *p = params;
 		iarg[0] = p->fdes; /* int */
-		uarg[1] = (intptr_t) p->asa; /* struct sockaddr * */
-		uarg[2] = (intptr_t) p->alen; /* __socklen_t * */
+		uarg[1] = (intptr_t) p->asa; /* struct sockaddr * __capability */
+		uarg[2] = (intptr_t) p->alen; /* __socklen_t * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -227,15 +227,15 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 32: {
 		struct getsockname_args *p = params;
 		iarg[0] = p->fdes; /* int */
-		uarg[1] = (intptr_t) p->asa; /* struct sockaddr * */
-		uarg[2] = (intptr_t) p->alen; /* __socklen_t * */
+		uarg[1] = (intptr_t) p->asa; /* struct sockaddr * __capability */
+		uarg[2] = (intptr_t) p->alen; /* __socklen_t * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* access */
 	case 33: {
 		struct access_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->amode; /* int */
 		*n_args = 2;
 		break;
@@ -243,7 +243,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* chflags */
 	case 34: {
 		struct chflags_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		uarg[1] = p->flags; /* u_long */
 		*n_args = 2;
 		break;
@@ -289,7 +289,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* profil */
 	case 44: {
 		struct profil_args *p = params;
-		uarg[0] = (intptr_t) p->samples; /* char * */
+		uarg[0] = (intptr_t) p->samples; /* char * __capability */
 		uarg[1] = p->size; /* size_t */
 		uarg[2] = p->offset; /* size_t */
 		uarg[3] = p->scale; /* u_int */
@@ -299,7 +299,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* ktrace */
 	case 45: {
 		struct ktrace_args *p = params;
-		uarg[0] = (intptr_t) p->fname; /* const char * */
+		uarg[0] = (intptr_t) p->fname; /* const char * __capability */
 		iarg[1] = p->ops; /* int */
 		iarg[2] = p->facs; /* int */
 		iarg[3] = p->pid; /* int */
@@ -314,7 +314,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* getlogin */
 	case 49: {
 		struct getlogin_args *p = params;
-		uarg[0] = (intptr_t) p->namebuf; /* char * */
+		uarg[0] = (intptr_t) p->namebuf; /* char * __capability */
 		uarg[1] = p->namelen; /* u_int */
 		*n_args = 2;
 		break;
@@ -322,22 +322,22 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* setlogin */
 	case 50: {
 		struct setlogin_args *p = params;
-		uarg[0] = (intptr_t) p->namebuf; /* const char * */
+		uarg[0] = (intptr_t) p->namebuf; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* acct */
 	case 51: {
 		struct acct_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* sigaltstack */
 	case 53: {
 		struct sigaltstack_args *p = params;
-		uarg[0] = (intptr_t) p->ss; /* const struct sigaltstack_native * */
-		uarg[1] = (intptr_t) p->oss; /* struct sigaltstack_native * */
+		uarg[0] = (intptr_t) p->ss; /* const struct sigaltstack_native * __capability */
+		uarg[1] = (intptr_t) p->oss; /* struct sigaltstack_native * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -346,7 +346,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct ioctl_args *p = params;
 		iarg[0] = p->fd; /* int */
 		uarg[1] = p->com; /* u_long */
-		uarg[2] = (intptr_t) p->data; /* char * */
+		uarg[2] = (intptr_t) p->data; /* char * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -360,23 +360,23 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* revoke */
 	case 56: {
 		struct revoke_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* symlink */
 	case 57: {
 		struct symlink_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
-		uarg[1] = (intptr_t) p->link; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
+		uarg[1] = (intptr_t) p->link; /* const char * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* readlink */
 	case 58: {
 		struct readlink_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
-		uarg[1] = (intptr_t) p->buf; /* char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
+		uarg[1] = (intptr_t) p->buf; /* char * __capability */
 		uarg[2] = p->count; /* size_t */
 		*n_args = 3;
 		break;
@@ -384,9 +384,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* execve */
 	case 59: {
 		struct execve_args *p = params;
-		uarg[0] = (intptr_t) p->fname; /* const char * */
-		uarg[1] = (intptr_t) p->argv; /* char ** */
-		uarg[2] = (intptr_t) p->envv; /* char ** */
+		uarg[0] = (intptr_t) p->fname; /* const char * __capability */
+		uarg[1] = (intptr_t) p->argv; /* char * __capability * __capability */
+		uarg[2] = (intptr_t) p->envv; /* char * __capability * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -400,14 +400,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* chroot */
 	case 61: {
 		struct chroot_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* msync */
 	case 65: {
 		struct msync_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* void * */
+		uarg[0] = (intptr_t) p->addr; /* void * __capability */
 		uarg[1] = p->len; /* size_t */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -435,7 +435,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* munmap */
 	case 73: {
 		struct munmap_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* void * */
+		uarg[0] = (intptr_t) p->addr; /* void * __capability */
 		uarg[1] = p->len; /* size_t */
 		*n_args = 2;
 		break;
@@ -443,7 +443,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mprotect */
 	case 74: {
 		struct mprotect_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* const void * */
+		uarg[0] = (intptr_t) p->addr; /* const void * __capability */
 		uarg[1] = p->len; /* size_t */
 		iarg[2] = p->prot; /* int */
 		*n_args = 3;
@@ -452,7 +452,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* madvise */
 	case 75: {
 		struct madvise_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* void * */
+		uarg[0] = (intptr_t) p->addr; /* void * __capability */
 		uarg[1] = p->len; /* size_t */
 		iarg[2] = p->behav; /* int */
 		*n_args = 3;
@@ -461,9 +461,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mincore */
 	case 78: {
 		struct mincore_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* const void * */
+		uarg[0] = (intptr_t) p->addr; /* const void * __capability */
 		uarg[1] = p->len; /* size_t */
-		uarg[2] = (intptr_t) p->vec; /* char * */
+		uarg[2] = (intptr_t) p->vec; /* char * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -471,7 +471,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 79: {
 		struct getgroups_args *p = params;
 		uarg[0] = p->gidsetsize; /* u_int */
-		uarg[1] = (intptr_t) p->gidset; /* gid_t * */
+		uarg[1] = (intptr_t) p->gidset; /* gid_t * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -479,7 +479,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 80: {
 		struct setgroups_args *p = params;
 		uarg[0] = p->gidsetsize; /* u_int */
-		uarg[1] = (intptr_t) p->gidset; /* const gid_t * */
+		uarg[1] = (intptr_t) p->gidset; /* const gid_t * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -500,15 +500,15 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 83: {
 		struct setitimer_args *p = params;
 		iarg[0] = p->which; /* int */
-		uarg[1] = (intptr_t) p->itv; /* const struct itimerval * */
-		uarg[2] = (intptr_t) p->oitv; /* struct itimerval * */
+		uarg[1] = (intptr_t) p->itv; /* const struct itimerval * __capability */
+		uarg[2] = (intptr_t) p->oitv; /* struct itimerval * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* swapon */
 	case 85: {
 		struct swapon_args *p = params;
-		uarg[0] = (intptr_t) p->name; /* const char * */
+		uarg[0] = (intptr_t) p->name; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -516,7 +516,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 86: {
 		struct getitimer_args *p = params;
 		iarg[0] = p->which; /* int */
-		uarg[1] = (intptr_t) p->itv; /* struct itimerval * */
+		uarg[1] = (intptr_t) p->itv; /* struct itimerval * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -546,10 +546,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 93: {
 		struct select_args *p = params;
 		iarg[0] = p->nd; /* int */
-		uarg[1] = (intptr_t) p->in; /* fd_set * */
-		uarg[2] = (intptr_t) p->ou; /* fd_set * */
-		uarg[3] = (intptr_t) p->ex; /* fd_set * */
-		uarg[4] = (intptr_t) p->tv; /* struct timeval * */
+		uarg[1] = (intptr_t) p->in; /* fd_set * __capability */
+		uarg[2] = (intptr_t) p->ou; /* fd_set * __capability */
+		uarg[3] = (intptr_t) p->ex; /* fd_set * __capability */
+		uarg[4] = (intptr_t) p->tv; /* struct timeval * __capability */
 		*n_args = 5;
 		break;
 	}
@@ -582,7 +582,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 98: {
 		struct connect_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->name; /* const struct sockaddr * */
+		uarg[1] = (intptr_t) p->name; /* const struct sockaddr * __capability */
 		iarg[2] = p->namelen; /* __socklen_t */
 		*n_args = 3;
 		break;
@@ -599,7 +599,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 104: {
 		struct bind_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->name; /* const struct sockaddr * */
+		uarg[1] = (intptr_t) p->name; /* const struct sockaddr * __capability */
 		iarg[2] = p->namelen; /* __socklen_t */
 		*n_args = 3;
 		break;
@@ -610,7 +610,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->s; /* int */
 		iarg[1] = p->level; /* int */
 		iarg[2] = p->name; /* int */
-		uarg[3] = (intptr_t) p->val; /* const void * */
+		uarg[3] = (intptr_t) p->val; /* const void * __capability */
 		iarg[4] = p->valsize; /* __socklen_t */
 		*n_args = 5;
 		break;
@@ -626,8 +626,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* gettimeofday */
 	case 116: {
 		struct gettimeofday_args *p = params;
-		uarg[0] = (intptr_t) p->tp; /* struct timeval * */
-		uarg[1] = (intptr_t) p->tzp; /* struct timezone * */
+		uarg[0] = (intptr_t) p->tp; /* struct timeval * __capability */
+		uarg[1] = (intptr_t) p->tzp; /* struct timezone * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -635,7 +635,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 117: {
 		struct getrusage_args *p = params;
 		iarg[0] = p->who; /* int */
-		uarg[1] = (intptr_t) p->rusage; /* struct rusage * */
+		uarg[1] = (intptr_t) p->rusage; /* struct rusage * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -645,8 +645,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->s; /* int */
 		iarg[1] = p->level; /* int */
 		iarg[2] = p->name; /* int */
-		uarg[3] = (intptr_t) p->val; /* void * */
-		uarg[4] = (intptr_t) p->avalsize; /* __socklen_t * */
+		uarg[3] = (intptr_t) p->val; /* void * __capability */
+		uarg[4] = (intptr_t) p->avalsize; /* __socklen_t * __capability */
 		*n_args = 5;
 		break;
 	}
@@ -654,7 +654,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 120: {
 		struct readv_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		*n_args = 3;
 		break;
@@ -663,7 +663,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 121: {
 		struct writev_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		*n_args = 3;
 		break;
@@ -671,8 +671,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* settimeofday */
 	case 122: {
 		struct settimeofday_args *p = params;
-		uarg[0] = (intptr_t) p->tv; /* const struct timeval * */
-		uarg[1] = (intptr_t) p->tzp; /* const struct timezone * */
+		uarg[0] = (intptr_t) p->tv; /* const struct timeval * __capability */
+		uarg[1] = (intptr_t) p->tzp; /* const struct timezone * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -712,8 +712,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* rename */
 	case 128: {
 		struct rename_args *p = params;
-		uarg[0] = (intptr_t) p->from; /* const char * */
-		uarg[1] = (intptr_t) p->to; /* const char * */
+		uarg[0] = (intptr_t) p->from; /* const char * __capability */
+		uarg[1] = (intptr_t) p->to; /* const char * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -728,7 +728,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mkfifo */
 	case 132: {
 		struct mkfifo_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->mode; /* mode_t */
 		*n_args = 2;
 		break;
@@ -737,10 +737,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 133: {
 		struct sendto_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->buf; /* const void * */
+		uarg[1] = (intptr_t) p->buf; /* const void * __capability */
 		uarg[2] = p->len; /* size_t */
 		iarg[3] = p->flags; /* int */
-		uarg[4] = (intptr_t) p->to; /* const struct sockaddr * */
+		uarg[4] = (intptr_t) p->to; /* const struct sockaddr * __capability */
 		iarg[5] = p->tolen; /* __socklen_t */
 		*n_args = 6;
 		break;
@@ -759,14 +759,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->domain; /* int */
 		iarg[1] = p->type; /* int */
 		iarg[2] = p->protocol; /* int */
-		uarg[3] = (intptr_t) p->rsv; /* int * */
+		uarg[3] = (intptr_t) p->rsv; /* int * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* mkdir */
 	case 136: {
 		struct mkdir_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->mode; /* mode_t */
 		*n_args = 2;
 		break;
@@ -774,23 +774,23 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* rmdir */
 	case 137: {
 		struct rmdir_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* utimes */
 	case 138: {
 		struct utimes_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
-		uarg[1] = (intptr_t) p->tptr; /* const struct timeval * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
+		uarg[1] = (intptr_t) p->tptr; /* const struct timeval * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* adjtime */
 	case 140: {
 		struct adjtime_args *p = params;
-		uarg[0] = (intptr_t) p->delta; /* const struct timeval * */
-		uarg[1] = (intptr_t) p->olddelta; /* struct timeval * */
+		uarg[0] = (intptr_t) p->delta; /* const struct timeval * __capability */
+		uarg[1] = (intptr_t) p->olddelta; /* struct timeval * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -802,10 +802,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* quotactl */
 	case 148: {
 		struct quotactl_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->cmd; /* int */
 		iarg[2] = p->uid; /* int */
-		uarg[3] = (intptr_t) p->arg; /* void * */
+		uarg[3] = (intptr_t) p->arg; /* void * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -815,7 +815,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->debug_level; /* int */
 		iarg[1] = p->grace_period; /* int */
 		iarg[2] = p->addr_count; /* int */
-		uarg[3] = (intptr_t) p->addrs; /* char ** */
+		uarg[3] = (intptr_t) p->addrs; /* char * __capability * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -823,23 +823,23 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 155: {
 		struct nfssvc_args *p = params;
 		iarg[0] = p->flag; /* int */
-		uarg[1] = (intptr_t) p->argp; /* void * */
+		uarg[1] = (intptr_t) p->argp; /* void * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* lgetfh */
 	case 160: {
 		struct lgetfh_args *p = params;
-		uarg[0] = (intptr_t) p->fname; /* const char * */
-		uarg[1] = (intptr_t) p->fhp; /* struct fhandle * */
+		uarg[0] = (intptr_t) p->fname; /* const char * __capability */
+		uarg[1] = (intptr_t) p->fhp; /* struct fhandle * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* getfh */
 	case 161: {
 		struct getfh_args *p = params;
-		uarg[0] = (intptr_t) p->fname; /* const char * */
-		uarg[1] = (intptr_t) p->fhp; /* struct fhandle * */
+		uarg[0] = (intptr_t) p->fname; /* const char * __capability */
+		uarg[1] = (intptr_t) p->fhp; /* struct fhandle * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -847,7 +847,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 165: {
 		struct sysarch_args *p = params;
 		iarg[0] = p->op; /* int */
-		uarg[1] = (intptr_t) p->parms; /* char * */
+		uarg[1] = (intptr_t) p->parms; /* char * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -856,7 +856,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct rtprio_args *p = params;
 		iarg[0] = p->function; /* int */
 		iarg[1] = p->pid; /* pid_t */
-		uarg[2] = (intptr_t) p->rtp; /* struct rtprio * */
+		uarg[2] = (intptr_t) p->rtp; /* struct rtprio * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -903,7 +903,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* ntp_adjtime */
 	case 176: {
 		struct ntp_adjtime_args *p = params;
-		uarg[0] = (intptr_t) p->tp; /* struct timex * */
+		uarg[0] = (intptr_t) p->tp; /* struct timex * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -931,7 +931,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* pathconf */
 	case 191: {
 		struct pathconf_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->name; /* int */
 		*n_args = 2;
 		break;
@@ -948,7 +948,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 194: {
 		struct __getrlimit_args *p = params;
 		uarg[0] = p->which; /* u_int */
-		uarg[1] = (intptr_t) p->rlp; /* struct rlimit * */
+		uarg[1] = (intptr_t) p->rlp; /* struct rlimit * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -956,7 +956,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 195: {
 		struct __setrlimit_args *p = params;
 		uarg[0] = p->which; /* u_int */
-		uarg[1] = (intptr_t) p->rlp; /* struct rlimit * */
+		uarg[1] = (intptr_t) p->rlp; /* struct rlimit * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -968,11 +968,11 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* __sysctl */
 	case 202: {
 		struct __sysctl_args *p = params;
-		uarg[0] = (intptr_t) p->name; /* int * */
+		uarg[0] = (intptr_t) p->name; /* int * __capability */
 		uarg[1] = p->namelen; /* u_int */
-		uarg[2] = (intptr_t) p->old; /* void * */
-		uarg[3] = (intptr_t) p->oldlenp; /* size_t * */
-		uarg[4] = (intptr_t) p->new; /* const void * */
+		uarg[2] = (intptr_t) p->old; /* void * __capability */
+		uarg[3] = (intptr_t) p->oldlenp; /* size_t * __capability */
+		uarg[4] = (intptr_t) p->new; /* const void * __capability */
 		uarg[5] = p->newlen; /* size_t */
 		*n_args = 6;
 		break;
@@ -980,7 +980,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mlock */
 	case 203: {
 		struct mlock_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* const void * */
+		uarg[0] = (intptr_t) p->addr; /* const void * __capability */
 		uarg[1] = p->len; /* size_t */
 		*n_args = 2;
 		break;
@@ -988,7 +988,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* munlock */
 	case 204: {
 		struct munlock_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* const void * */
+		uarg[0] = (intptr_t) p->addr; /* const void * __capability */
 		uarg[1] = p->len; /* size_t */
 		*n_args = 2;
 		break;
@@ -996,7 +996,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* undelete */
 	case 205: {
 		struct undelete_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1004,7 +1004,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 206: {
 		struct futimes_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->tptr; /* const struct timeval * */
+		uarg[1] = (intptr_t) p->tptr; /* const struct timeval * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1018,7 +1018,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* poll */
 	case 209: {
 		struct poll_args *p = params;
-		uarg[0] = (intptr_t) p->fds; /* struct pollfd * */
+		uarg[0] = (intptr_t) p->fds; /* struct pollfd * __capability */
 		uarg[1] = p->nfds; /* u_int */
 		iarg[2] = p->timeout; /* int */
 		*n_args = 3;
@@ -1087,7 +1087,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 222: {
 		struct semop_args *p = params;
 		iarg[0] = p->semid; /* int */
-		uarg[1] = (intptr_t) p->sops; /* struct sembuf * */
+		uarg[1] = (intptr_t) p->sops; /* struct sembuf * __capability */
 		uarg[2] = p->nsops; /* size_t */
 		*n_args = 3;
 		break;
@@ -1104,7 +1104,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 226: {
 		struct msgsnd_args *p = params;
 		iarg[0] = p->msqid; /* int */
-		uarg[1] = (intptr_t) p->msgp; /* const void * */
+		uarg[1] = (intptr_t) p->msgp; /* const void * __capability */
 		uarg[2] = p->msgsz; /* size_t */
 		iarg[3] = p->msgflg; /* int */
 		*n_args = 4;
@@ -1114,7 +1114,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 227: {
 		struct msgrcv_args *p = params;
 		iarg[0] = p->msqid; /* int */
-		uarg[1] = (intptr_t) p->msgp; /* void * */
+		uarg[1] = (intptr_t) p->msgp; /* void * __capability */
 		uarg[2] = p->msgsz; /* size_t */
 		iarg[3] = p->msgtyp; /* long */
 		iarg[4] = p->msgflg; /* int */
@@ -1125,7 +1125,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 228: {
 		struct shmat_args *p = params;
 		iarg[0] = p->shmid; /* int */
-		uarg[1] = (intptr_t) p->shmaddr; /* const void * */
+		uarg[1] = (intptr_t) p->shmaddr; /* const void * __capability */
 		iarg[2] = p->shmflg; /* int */
 		*n_args = 3;
 		break;
@@ -1133,7 +1133,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* shmdt */
 	case 230: {
 		struct shmdt_args *p = params;
-		uarg[0] = (intptr_t) p->shmaddr; /* const void * */
+		uarg[0] = (intptr_t) p->shmaddr; /* const void * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1150,7 +1150,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 232: {
 		struct clock_gettime_args *p = params;
 		iarg[0] = p->clock_id; /* clockid_t */
-		uarg[1] = (intptr_t) p->tp; /* struct timespec * */
+		uarg[1] = (intptr_t) p->tp; /* struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1158,7 +1158,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 233: {
 		struct clock_settime_args *p = params;
 		iarg[0] = p->clock_id; /* clockid_t */
-		uarg[1] = (intptr_t) p->tp; /* const struct timespec * */
+		uarg[1] = (intptr_t) p->tp; /* const struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1166,7 +1166,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 234: {
 		struct clock_getres_args *p = params;
 		iarg[0] = p->clock_id; /* clockid_t */
-		uarg[1] = (intptr_t) p->tp; /* struct timespec * */
+		uarg[1] = (intptr_t) p->tp; /* struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1174,8 +1174,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 235: {
 		struct ktimer_create_args *p = params;
 		iarg[0] = p->clock_id; /* clockid_t */
-		uarg[1] = (intptr_t) p->evp; /* struct sigevent_native * */
-		uarg[2] = (intptr_t) p->timerid; /* int * */
+		uarg[1] = (intptr_t) p->evp; /* struct sigevent_native * __capability */
+		uarg[2] = (intptr_t) p->timerid; /* int * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1191,8 +1191,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct ktimer_settime_args *p = params;
 		iarg[0] = p->timerid; /* int */
 		iarg[1] = p->flags; /* int */
-		uarg[2] = (intptr_t) p->value; /* const struct itimerspec * */
-		uarg[3] = (intptr_t) p->ovalue; /* struct itimerspec * */
+		uarg[2] = (intptr_t) p->value; /* const struct itimerspec * __capability */
+		uarg[3] = (intptr_t) p->ovalue; /* struct itimerspec * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -1200,7 +1200,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 238: {
 		struct ktimer_gettime_args *p = params;
 		iarg[0] = p->timerid; /* int */
-		uarg[1] = (intptr_t) p->value; /* struct itimerspec * */
+		uarg[1] = (intptr_t) p->value; /* struct itimerspec * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1214,29 +1214,29 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* nanosleep */
 	case 240: {
 		struct nanosleep_args *p = params;
-		uarg[0] = (intptr_t) p->rqtp; /* const struct timespec * */
-		uarg[1] = (intptr_t) p->rmtp; /* struct timespec * */
+		uarg[0] = (intptr_t) p->rqtp; /* const struct timespec * __capability */
+		uarg[1] = (intptr_t) p->rmtp; /* struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* ffclock_getcounter */
 	case 241: {
 		struct ffclock_getcounter_args *p = params;
-		uarg[0] = (intptr_t) p->ffcount; /* ffcounter * */
+		uarg[0] = (intptr_t) p->ffcount; /* ffcounter * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* ffclock_setestimate */
 	case 242: {
 		struct ffclock_setestimate_args *p = params;
-		uarg[0] = (intptr_t) p->cest; /* struct ffclock_estimate * */
+		uarg[0] = (intptr_t) p->cest; /* struct ffclock_estimate * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* ffclock_getestimate */
 	case 243: {
 		struct ffclock_getestimate_args *p = params;
-		uarg[0] = (intptr_t) p->cest; /* struct ffclock_estimate * */
+		uarg[0] = (intptr_t) p->cest; /* struct ffclock_estimate * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1245,8 +1245,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct clock_nanosleep_args *p = params;
 		iarg[0] = p->clock_id; /* clockid_t */
 		iarg[1] = p->flags; /* int */
-		uarg[2] = (intptr_t) p->rqtp; /* const struct timespec * */
-		uarg[3] = (intptr_t) p->rmtp; /* struct timespec * */
+		uarg[2] = (intptr_t) p->rqtp; /* const struct timespec * __capability */
+		uarg[3] = (intptr_t) p->rmtp; /* struct timespec * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -1255,21 +1255,21 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct clock_getcpuclockid2_args *p = params;
 		iarg[0] = p->id; /* id_t */
 		iarg[1] = p->which; /* int */
-		uarg[2] = (intptr_t) p->clock_id; /* clockid_t * */
+		uarg[2] = (intptr_t) p->clock_id; /* clockid_t * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* ntp_gettime */
 	case 248: {
 		struct ntp_gettime_args *p = params;
-		uarg[0] = (intptr_t) p->ntvp; /* struct ntptimeval * */
+		uarg[0] = (intptr_t) p->ntvp; /* struct ntptimeval * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* minherit */
 	case 250: {
 		struct minherit_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* void * */
+		uarg[0] = (intptr_t) p->addr; /* void * __capability */
 		uarg[1] = p->len; /* size_t */
 		iarg[2] = p->inherit; /* int */
 		*n_args = 3;
@@ -1290,7 +1290,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* lchown */
 	case 254: {
 		struct lchown_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->uid; /* int */
 		iarg[2] = p->gid; /* int */
 		*n_args = 3;
@@ -1299,14 +1299,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* aio_read */
 	case 255: {
 		struct aio_read_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* aio_write */
 	case 256: {
 		struct aio_write_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1314,17 +1314,17 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 257: {
 		struct lio_listio_args *p = params;
 		iarg[0] = p->mode; /* int */
-		uarg[1] = (intptr_t) p->acb_list; /* struct aiocb_native *const * */
+		uarg[1] = (intptr_t) p->acb_list; /* struct aiocb_native * __capability const * __capability */
 		iarg[2] = p->nent; /* int */
-		uarg[3] = (intptr_t) p->sig; /* struct sigevent_native * */
+		uarg[3] = (intptr_t) p->sig; /* struct sigevent_native * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* kbounce */
 	case 258: {
 		struct kbounce_args *p = params;
-		uarg[0] = (intptr_t) p->src; /* const void * */
-		uarg[1] = (intptr_t) p->dst; /* void * */
+		uarg[0] = (intptr_t) p->src; /* const void * __capability */
+		uarg[1] = (intptr_t) p->dst; /* void * __capability */
 		uarg[2] = p->len; /* size_t */
 		iarg[3] = p->flags; /* int */
 		*n_args = 4;
@@ -1333,7 +1333,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* lchmod */
 	case 274: {
 		struct lchmod_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->mode; /* mode_t */
 		*n_args = 2;
 		break;
@@ -1341,8 +1341,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* lutimes */
 	case 276: {
 		struct lutimes_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
-		uarg[1] = (intptr_t) p->tptr; /* const struct timeval * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
+		uarg[1] = (intptr_t) p->tptr; /* const struct timeval * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1350,7 +1350,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 289: {
 		struct preadv_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		iarg[3] = p->offset; /* off_t */
 		*n_args = 4;
@@ -1360,7 +1360,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 290: {
 		struct pwritev_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		iarg[3] = p->offset; /* off_t */
 		*n_args = 4;
@@ -1369,7 +1369,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* fhopen */
 	case 298: {
 		struct fhopen_args *p = params;
-		uarg[0] = (intptr_t) p->u_fhp; /* const struct fhandle * */
+		uarg[0] = (intptr_t) p->u_fhp; /* const struct fhandle * __capability */
 		iarg[1] = p->flags; /* int */
 		*n_args = 2;
 		break;
@@ -1385,7 +1385,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 301: {
 		struct modstat_args *p = params;
 		iarg[0] = p->modid; /* int */
-		uarg[1] = (intptr_t) p->stat; /* struct module_stat * */
+		uarg[1] = (intptr_t) p->stat; /* struct module_stat * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1399,14 +1399,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* modfind */
 	case 303: {
 		struct modfind_args *p = params;
-		uarg[0] = (intptr_t) p->name; /* const char * */
+		uarg[0] = (intptr_t) p->name; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* kldload */
 	case 304: {
 		struct kldload_args *p = params;
-		uarg[0] = (intptr_t) p->file; /* const char * */
+		uarg[0] = (intptr_t) p->file; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1420,7 +1420,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* kldfind */
 	case 306: {
 		struct kldfind_args *p = params;
-		uarg[0] = (intptr_t) p->file; /* const char * */
+		uarg[0] = (intptr_t) p->file; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1435,7 +1435,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 308: {
 		struct kldstat_args *p = params;
 		iarg[0] = p->fileid; /* int */
-		uarg[1] = (intptr_t) p->stat; /* struct kld_file_stat * */
+		uarg[1] = (intptr_t) p->stat; /* struct kld_file_stat * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1474,16 +1474,16 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* aio_return */
 	case 314: {
 		struct aio_return_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* aio_suspend */
 	case 315: {
 		struct aio_suspend_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native *const * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability const * __capability */
 		iarg[1] = p->nent; /* int */
-		uarg[2] = (intptr_t) p->timeout; /* const struct timespec * */
+		uarg[2] = (intptr_t) p->timeout; /* const struct timespec * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1491,14 +1491,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 316: {
 		struct aio_cancel_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[1] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* aio_error */
 	case 317: {
 		struct aio_error_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1522,7 +1522,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* __getcwd */
 	case 326: {
 		struct __getcwd_args *p = params;
-		uarg[0] = (intptr_t) p->buf; /* char * */
+		uarg[0] = (intptr_t) p->buf; /* char * __capability */
 		uarg[1] = p->buflen; /* size_t */
 		*n_args = 2;
 		break;
@@ -1531,7 +1531,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 327: {
 		struct sched_setparam_args *p = params;
 		iarg[0] = p->pid; /* pid_t */
-		uarg[1] = (intptr_t) p->param; /* const struct sched_param * */
+		uarg[1] = (intptr_t) p->param; /* const struct sched_param * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1539,7 +1539,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 328: {
 		struct sched_getparam_args *p = params;
 		iarg[0] = p->pid; /* pid_t */
-		uarg[1] = (intptr_t) p->param; /* struct sched_param * */
+		uarg[1] = (intptr_t) p->param; /* struct sched_param * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1548,7 +1548,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct sched_setscheduler_args *p = params;
 		iarg[0] = p->pid; /* pid_t */
 		iarg[1] = p->policy; /* int */
-		uarg[2] = (intptr_t) p->param; /* const struct sched_param * */
+		uarg[2] = (intptr_t) p->param; /* const struct sched_param * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1582,14 +1582,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 334: {
 		struct sched_rr_get_interval_args *p = params;
 		iarg[0] = p->pid; /* pid_t */
-		uarg[1] = (intptr_t) p->interval; /* struct timespec * */
+		uarg[1] = (intptr_t) p->interval; /* struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* utrace */
 	case 335: {
 		struct utrace_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* const void * */
+		uarg[0] = (intptr_t) p->addr; /* const void * __capability */
 		uarg[1] = p->len; /* size_t */
 		*n_args = 2;
 		break;
@@ -1599,14 +1599,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct kldsym_args *p = params;
 		iarg[0] = p->fileid; /* int */
 		iarg[1] = p->cmd; /* int */
-		uarg[2] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->data; /* void * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* jail */
 	case 338: {
 		struct jail_args *p = params;
-		uarg[0] = (intptr_t) p->jailp; /* struct jail * */
+		uarg[0] = (intptr_t) p->jailp; /* struct jail * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1614,9 +1614,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 339: {
 		struct nnpfs_syscall_args *p = params;
 		iarg[0] = p->operation; /* int */
-		uarg[1] = (intptr_t) p->a_pathP; /* char * */
+		uarg[1] = (intptr_t) p->a_pathP; /* char * __capability */
 		iarg[2] = p->a_opcode; /* int */
-		uarg[3] = (intptr_t) p->a_paramsP; /* void * */
+		uarg[3] = (intptr_t) p->a_paramsP; /* void * __capability */
 		iarg[4] = p->a_followSymlinks; /* int */
 		*n_args = 5;
 		break;
@@ -1625,57 +1625,57 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 340: {
 		struct sigprocmask_args *p = params;
 		iarg[0] = p->how; /* int */
-		uarg[1] = (intptr_t) p->set; /* const sigset_t * */
-		uarg[2] = (intptr_t) p->oset; /* sigset_t * */
+		uarg[1] = (intptr_t) p->set; /* const sigset_t * __capability */
+		uarg[2] = (intptr_t) p->oset; /* sigset_t * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* sigsuspend */
 	case 341: {
 		struct sigsuspend_args *p = params;
-		uarg[0] = (intptr_t) p->sigmask; /* const sigset_t * */
+		uarg[0] = (intptr_t) p->sigmask; /* const sigset_t * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* sigpending */
 	case 343: {
 		struct sigpending_args *p = params;
-		uarg[0] = (intptr_t) p->set; /* sigset_t * */
+		uarg[0] = (intptr_t) p->set; /* sigset_t * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* sigtimedwait */
 	case 345: {
 		struct sigtimedwait_args *p = params;
-		uarg[0] = (intptr_t) p->set; /* const sigset_t * */
-		uarg[1] = (intptr_t) p->info; /* struct siginfo_native * */
-		uarg[2] = (intptr_t) p->timeout; /* const struct timespec * */
+		uarg[0] = (intptr_t) p->set; /* const sigset_t * __capability */
+		uarg[1] = (intptr_t) p->info; /* struct siginfo_native * __capability */
+		uarg[2] = (intptr_t) p->timeout; /* const struct timespec * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* sigwaitinfo */
 	case 346: {
 		struct sigwaitinfo_args *p = params;
-		uarg[0] = (intptr_t) p->set; /* const sigset_t * */
-		uarg[1] = (intptr_t) p->info; /* struct siginfo_native * */
+		uarg[0] = (intptr_t) p->set; /* const sigset_t * __capability */
+		uarg[1] = (intptr_t) p->info; /* struct siginfo_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* __acl_get_file */
 	case 347: {
 		struct __acl_get_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* __acl_set_file */
 	case 348: {
 		struct __acl_set_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1684,7 +1684,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct __acl_get_fd_args *p = params;
 		iarg[0] = p->filedes; /* int */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1693,14 +1693,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct __acl_set_fd_args *p = params;
 		iarg[0] = p->filedes; /* int */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* __acl_delete_file */
 	case 351: {
 		struct __acl_delete_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
 		*n_args = 2;
 		break;
@@ -1716,9 +1716,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* __acl_aclcheck_file */
 	case 353: {
 		struct __acl_aclcheck_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1727,28 +1727,28 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct __acl_aclcheck_fd_args *p = params;
 		iarg[0] = p->filedes; /* int */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* extattrctl */
 	case 355: {
 		struct extattrctl_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->cmd; /* int */
-		uarg[2] = (intptr_t) p->filename; /* const char * */
+		uarg[2] = (intptr_t) p->filename; /* const char * __capability */
 		iarg[3] = p->attrnamespace; /* int */
-		uarg[4] = (intptr_t) p->attrname; /* const char * */
+		uarg[4] = (intptr_t) p->attrname; /* const char * __capability */
 		*n_args = 5;
 		break;
 	}
 	/* extattr_set_file */
 	case 356: {
 		struct extattr_set_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		uarg[4] = p->nbytes; /* size_t */
 		*n_args = 5;
 		break;
@@ -1756,10 +1756,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* extattr_get_file */
 	case 357: {
 		struct extattr_get_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		uarg[4] = p->nbytes; /* size_t */
 		*n_args = 5;
 		break;
@@ -1767,35 +1767,35 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* extattr_delete_file */
 	case 358: {
 		struct extattr_delete_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* aio_waitcomplete */
 	case 359: {
 		struct aio_waitcomplete_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native ** */
-		uarg[1] = (intptr_t) p->timeout; /* struct timespec * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability * __capability */
+		uarg[1] = (intptr_t) p->timeout; /* struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* getresuid */
 	case 360: {
 		struct getresuid_args *p = params;
-		uarg[0] = (intptr_t) p->ruid; /* uid_t * */
-		uarg[1] = (intptr_t) p->euid; /* uid_t * */
-		uarg[2] = (intptr_t) p->suid; /* uid_t * */
+		uarg[0] = (intptr_t) p->ruid; /* uid_t * __capability */
+		uarg[1] = (intptr_t) p->euid; /* uid_t * __capability */
+		uarg[2] = (intptr_t) p->suid; /* uid_t * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* getresgid */
 	case 361: {
 		struct getresgid_args *p = params;
-		uarg[0] = (intptr_t) p->rgid; /* gid_t * */
-		uarg[1] = (intptr_t) p->egid; /* gid_t * */
-		uarg[2] = (intptr_t) p->sgid; /* gid_t * */
+		uarg[0] = (intptr_t) p->rgid; /* gid_t * __capability */
+		uarg[1] = (intptr_t) p->egid; /* gid_t * __capability */
+		uarg[2] = (intptr_t) p->sgid; /* gid_t * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1809,8 +1809,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct extattr_set_fd_args *p = params;
 		iarg[0] = p->fd; /* int */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		uarg[4] = p->nbytes; /* size_t */
 		*n_args = 5;
 		break;
@@ -1820,8 +1820,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct extattr_get_fd_args *p = params;
 		iarg[0] = p->fd; /* int */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		uarg[4] = p->nbytes; /* size_t */
 		*n_args = 5;
 		break;
@@ -1831,7 +1831,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct extattr_delete_fd_args *p = params;
 		iarg[0] = p->fd; /* int */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1845,7 +1845,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* eaccess */
 	case 376: {
 		struct eaccess_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->amode; /* int */
 		*n_args = 2;
 		break;
@@ -1866,7 +1866,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* nmount */
 	case 378: {
 		struct nmount_args *p = params;
-		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[1] = p->iovcnt; /* unsigned int */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -1875,14 +1875,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* __mac_get_proc */
 	case 384: {
 		struct __mac_get_proc_args *p = params;
-		uarg[0] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* __mac_set_proc */
 	case 385: {
 		struct __mac_set_proc_args *p = params;
-		uarg[0] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -1890,15 +1890,15 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 386: {
 		struct __mac_get_fd_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* __mac_get_file */
 	case 387: {
 		struct __mac_get_file_args *p = params;
-		uarg[0] = (intptr_t) p->path_p; /* const char * */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->path_p; /* const char * __capability */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1906,15 +1906,15 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 388: {
 		struct __mac_set_fd_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* __mac_set_file */
 	case 389: {
 		struct __mac_set_file_args *p = params;
-		uarg[0] = (intptr_t) p->path_p; /* const char * */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->path_p; /* const char * __capability */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -1922,8 +1922,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 390: {
 		struct kenv_args *p = params;
 		iarg[0] = p->what; /* int */
-		uarg[1] = (intptr_t) p->name; /* const char * */
-		uarg[2] = (intptr_t) p->value; /* char * */
+		uarg[1] = (intptr_t) p->name; /* const char * __capability */
+		uarg[2] = (intptr_t) p->value; /* char * __capability */
 		iarg[3] = p->len; /* int */
 		*n_args = 4;
 		break;
@@ -1931,7 +1931,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* lchflags */
 	case 391: {
 		struct lchflags_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		uarg[1] = p->flags; /* u_long */
 		*n_args = 2;
 		break;
@@ -1939,7 +1939,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* uuidgen */
 	case 392: {
 		struct uuidgen_args *p = params;
-		uarg[0] = (intptr_t) p->store; /* struct uuid * */
+		uarg[0] = (intptr_t) p->store; /* struct uuid * __capability */
 		iarg[1] = p->count; /* int */
 		*n_args = 2;
 		break;
@@ -1951,8 +1951,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[1] = p->s; /* int */
 		iarg[2] = p->offset; /* off_t */
 		uarg[3] = p->nbytes; /* size_t */
-		uarg[4] = (intptr_t) p->hdtr; /* struct sf_hdtr_native * */
-		uarg[5] = (intptr_t) p->sbytes; /* off_t * */
+		uarg[4] = (intptr_t) p->hdtr; /* struct sf_hdtr_native * __capability */
+		uarg[5] = (intptr_t) p->sbytes; /* off_t * __capability */
 		iarg[6] = p->flags; /* int */
 		*n_args = 7;
 		break;
@@ -1960,9 +1960,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mac_syscall */
 	case 394: {
 		struct mac_syscall_args *p = params;
-		uarg[0] = (intptr_t) p->policy; /* const char * */
+		uarg[0] = (intptr_t) p->policy; /* const char * __capability */
 		iarg[1] = p->call; /* int */
-		uarg[2] = (intptr_t) p->arg; /* void * */
+		uarg[2] = (intptr_t) p->arg; /* void * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -1997,7 +1997,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* ksem_init */
 	case 404: {
 		struct ksem_init_args *p = params;
-		uarg[0] = (intptr_t) p->idp; /* semid_t * */
+		uarg[0] = (intptr_t) p->idp; /* semid_t * __capability */
 		uarg[1] = p->value; /* unsigned int */
 		*n_args = 2;
 		break;
@@ -2005,8 +2005,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* ksem_open */
 	case 405: {
 		struct ksem_open_args *p = params;
-		uarg[0] = (intptr_t) p->idp; /* semid_t * */
-		uarg[1] = (intptr_t) p->name; /* const char * */
+		uarg[0] = (intptr_t) p->idp; /* semid_t * __capability */
+		uarg[1] = (intptr_t) p->name; /* const char * __capability */
 		iarg[2] = p->oflag; /* int */
 		iarg[3] = p->mode; /* mode_t */
 		uarg[4] = p->value; /* unsigned int */
@@ -2016,7 +2016,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* ksem_unlink */
 	case 406: {
 		struct ksem_unlink_args *p = params;
-		uarg[0] = (intptr_t) p->name; /* const char * */
+		uarg[0] = (intptr_t) p->name; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -2024,7 +2024,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 407: {
 		struct ksem_getvalue_args *p = params;
 		iarg[0] = p->id; /* semid_t */
-		uarg[1] = (intptr_t) p->val; /* int * */
+		uarg[1] = (intptr_t) p->val; /* int * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -2039,33 +2039,33 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 409: {
 		struct __mac_get_pid_args *p = params;
 		iarg[0] = p->pid; /* pid_t */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* __mac_get_link */
 	case 410: {
 		struct __mac_get_link_args *p = params;
-		uarg[0] = (intptr_t) p->path_p; /* const char * */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->path_p; /* const char * __capability */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* __mac_set_link */
 	case 411: {
 		struct __mac_set_link_args *p = params;
-		uarg[0] = (intptr_t) p->path_p; /* const char * */
-		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->path_p; /* const char * __capability */
+		uarg[1] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* extattr_set_link */
 	case 412: {
 		struct extattr_set_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		uarg[4] = p->nbytes; /* size_t */
 		*n_args = 5;
 		break;
@@ -2073,10 +2073,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* extattr_get_link */
 	case 413: {
 		struct extattr_get_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		uarg[4] = p->nbytes; /* size_t */
 		*n_args = 5;
 		break;
@@ -2084,19 +2084,19 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* extattr_delete_link */
 	case 414: {
 		struct extattr_delete_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->attrname; /* const char * */
+		uarg[2] = (intptr_t) p->attrname; /* const char * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* __mac_execve */
 	case 415: {
 		struct __mac_execve_args *p = params;
-		uarg[0] = (intptr_t) p->fname; /* const char * */
-		uarg[1] = (intptr_t) p->argv; /* char ** */
-		uarg[2] = (intptr_t) p->envv; /* char ** */
-		uarg[3] = (intptr_t) p->mac_p; /* struct mac_native * */
+		uarg[0] = (intptr_t) p->fname; /* const char * __capability */
+		uarg[1] = (intptr_t) p->argv; /* char * __capability * __capability */
+		uarg[2] = (intptr_t) p->envv; /* char * __capability * __capability */
+		uarg[3] = (intptr_t) p->mac_p; /* struct mac_native * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -2104,69 +2104,69 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 416: {
 		struct sigaction_args *p = params;
 		iarg[0] = p->sig; /* int */
-		uarg[1] = (intptr_t) p->act; /* const struct sigaction_native * */
-		uarg[2] = (intptr_t) p->oact; /* struct sigaction_native * */
+		uarg[1] = (intptr_t) p->act; /* const struct sigaction_native * __capability */
+		uarg[2] = (intptr_t) p->oact; /* struct sigaction_native * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* sigreturn */
 	case 417: {
 		struct sigreturn_args *p = params;
-		uarg[0] = (intptr_t) p->sigcntxp; /* const struct __ucontext * */
+		uarg[0] = (intptr_t) p->sigcntxp; /* const struct __ucontext * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* getcontext */
 	case 421: {
 		struct getcontext_args *p = params;
-		uarg[0] = (intptr_t) p->ucp; /* struct __ucontext * */
+		uarg[0] = (intptr_t) p->ucp; /* struct __ucontext * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* setcontext */
 	case 422: {
 		struct setcontext_args *p = params;
-		uarg[0] = (intptr_t) p->ucp; /* const struct __ucontext * */
+		uarg[0] = (intptr_t) p->ucp; /* const struct __ucontext * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* swapcontext */
 	case 423: {
 		struct swapcontext_args *p = params;
-		uarg[0] = (intptr_t) p->oucp; /* struct __ucontext * */
-		uarg[1] = (intptr_t) p->ucp; /* const struct __ucontext * */
+		uarg[0] = (intptr_t) p->oucp; /* struct __ucontext * __capability */
+		uarg[1] = (intptr_t) p->ucp; /* const struct __ucontext * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* swapoff */
 	case 424: {
 		struct swapoff_args *p = params;
-		uarg[0] = (intptr_t) p->name; /* const char * */
+		uarg[0] = (intptr_t) p->name; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* __acl_get_link */
 	case 425: {
 		struct __acl_get_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* __acl_set_link */
 	case 426: {
 		struct __acl_set_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* __acl_delete_link */
 	case 427: {
 		struct __acl_delete_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
 		*n_args = 2;
 		break;
@@ -2174,25 +2174,25 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* __acl_aclcheck_link */
 	case 428: {
 		struct __acl_aclcheck_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->type; /* acl_type_t */
-		uarg[2] = (intptr_t) p->aclp; /* struct acl * */
+		uarg[2] = (intptr_t) p->aclp; /* struct acl * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* sigwait */
 	case 429: {
 		struct sigwait_args *p = params;
-		uarg[0] = (intptr_t) p->set; /* const sigset_t * */
-		uarg[1] = (intptr_t) p->sig; /* int * */
+		uarg[0] = (intptr_t) p->set; /* const sigset_t * __capability */
+		uarg[1] = (intptr_t) p->sig; /* int * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* thr_create */
 	case 430: {
 		struct thr_create_args *p = params;
-		uarg[0] = (intptr_t) p->ctx; /* struct __ucontext * */
-		uarg[1] = (intptr_t) p->id; /* long * */
+		uarg[0] = (intptr_t) p->ctx; /* struct __ucontext * __capability */
+		uarg[1] = (intptr_t) p->id; /* long * __capability */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
 		break;
@@ -2200,14 +2200,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* thr_exit */
 	case 431: {
 		struct thr_exit_args *p = params;
-		uarg[0] = (intptr_t) p->state; /* long * */
+		uarg[0] = (intptr_t) p->state; /* long * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* thr_self */
 	case 432: {
 		struct thr_self_args *p = params;
-		uarg[0] = (intptr_t) p->id; /* long * */
+		uarg[0] = (intptr_t) p->id; /* long * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -2231,7 +2231,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct extattr_list_fd_args *p = params;
 		iarg[0] = p->fd; /* int */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->data; /* void * __capability */
 		uarg[3] = p->nbytes; /* size_t */
 		*n_args = 4;
 		break;
@@ -2239,9 +2239,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* extattr_list_file */
 	case 438: {
 		struct extattr_list_file_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->data; /* void * __capability */
 		uarg[3] = p->nbytes; /* size_t */
 		*n_args = 4;
 		break;
@@ -2249,9 +2249,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* extattr_list_link */
 	case 439: {
 		struct extattr_list_link_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->attrnamespace; /* int */
-		uarg[2] = (intptr_t) p->data; /* void * */
+		uarg[2] = (intptr_t) p->data; /* void * __capability */
 		uarg[3] = p->nbytes; /* size_t */
 		*n_args = 4;
 		break;
@@ -2260,14 +2260,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 441: {
 		struct ksem_timedwait_args *p = params;
 		iarg[0] = p->id; /* semid_t */
-		uarg[1] = (intptr_t) p->abstime; /* const struct timespec * */
+		uarg[1] = (intptr_t) p->abstime; /* const struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* thr_suspend */
 	case 442: {
 		struct thr_suspend_args *p = params;
-		uarg[0] = (intptr_t) p->timeout; /* const struct timespec * */
+		uarg[0] = (intptr_t) p->timeout; /* const struct timespec * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -2289,7 +2289,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* audit */
 	case 445: {
 		struct audit_args *p = params;
-		uarg[0] = (intptr_t) p->record; /* const void * */
+		uarg[0] = (intptr_t) p->record; /* const void * __capability */
 		uarg[1] = p->length; /* u_int */
 		*n_args = 2;
 		break;
@@ -2298,7 +2298,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 446: {
 		struct auditon_args *p = params;
 		iarg[0] = p->cmd; /* int */
-		uarg[1] = (intptr_t) p->data; /* void * */
+		uarg[1] = (intptr_t) p->data; /* void * __capability */
 		uarg[2] = p->length; /* u_int */
 		*n_args = 3;
 		break;
@@ -2306,35 +2306,35 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* getauid */
 	case 447: {
 		struct getauid_args *p = params;
-		uarg[0] = (intptr_t) p->auid; /* uid_t * */
+		uarg[0] = (intptr_t) p->auid; /* uid_t * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* setauid */
 	case 448: {
 		struct setauid_args *p = params;
-		uarg[0] = (intptr_t) p->auid; /* uid_t * */
+		uarg[0] = (intptr_t) p->auid; /* uid_t * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* getaudit */
 	case 449: {
 		struct getaudit_args *p = params;
-		uarg[0] = (intptr_t) p->auditinfo; /* struct auditinfo * */
+		uarg[0] = (intptr_t) p->auditinfo; /* struct auditinfo * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* setaudit */
 	case 450: {
 		struct setaudit_args *p = params;
-		uarg[0] = (intptr_t) p->auditinfo; /* struct auditinfo * */
+		uarg[0] = (intptr_t) p->auditinfo; /* struct auditinfo * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* getaudit_addr */
 	case 451: {
 		struct getaudit_addr_args *p = params;
-		uarg[0] = (intptr_t) p->auditinfo_addr; /* struct auditinfo_addr * */
+		uarg[0] = (intptr_t) p->auditinfo_addr; /* struct auditinfo_addr * __capability */
 		uarg[1] = p->length; /* u_int */
 		*n_args = 2;
 		break;
@@ -2342,7 +2342,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* setaudit_addr */
 	case 452: {
 		struct setaudit_addr_args *p = params;
-		uarg[0] = (intptr_t) p->auditinfo_addr; /* struct auditinfo_addr * */
+		uarg[0] = (intptr_t) p->auditinfo_addr; /* struct auditinfo_addr * __capability */
 		uarg[1] = p->length; /* u_int */
 		*n_args = 2;
 		break;
@@ -2350,25 +2350,25 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* auditctl */
 	case 453: {
 		struct auditctl_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* _umtx_op */
 	case 454: {
 		struct _umtx_op_args *p = params;
-		uarg[0] = (intptr_t) p->obj; /* void * */
+		uarg[0] = (intptr_t) p->obj; /* void * __capability */
 		iarg[1] = p->op; /* int */
 		uarg[2] = p->val; /* u_long */
-		uarg[3] = (intptr_t) p->uaddr1; /* void * */
-		uarg[4] = (intptr_t) p->uaddr2; /* void * */
+		uarg[3] = (intptr_t) p->uaddr1; /* void * __capability */
+		uarg[4] = (intptr_t) p->uaddr2; /* void * __capability */
 		*n_args = 5;
 		break;
 	}
 	/* thr_new */
 	case 455: {
 		struct thr_new_args *p = params;
-		uarg[0] = (intptr_t) p->param; /* struct thr_param * */
+		uarg[0] = (intptr_t) p->param; /* struct thr_param * __capability */
 		iarg[1] = p->param_size; /* int */
 		*n_args = 2;
 		break;
@@ -2378,17 +2378,17 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct sigqueue_args *p = params;
 		iarg[0] = p->pid; /* pid_t */
 		iarg[1] = p->signum; /* int */
-		uarg[2] = (intptr_t) p->value; /* void * */
+		uarg[2] = (intptr_t) p->value; /* void * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* kmq_open */
 	case 457: {
 		struct kmq_open_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->flags; /* int */
 		iarg[2] = p->mode; /* mode_t */
-		uarg[3] = (intptr_t) p->attr; /* const struct mq_attr * */
+		uarg[3] = (intptr_t) p->attr; /* const struct mq_attr * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -2396,8 +2396,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 458: {
 		struct kmq_setattr_args *p = params;
 		iarg[0] = p->mqd; /* int */
-		uarg[1] = (intptr_t) p->attr; /* const struct mq_attr * */
-		uarg[2] = (intptr_t) p->oattr; /* struct mq_attr * */
+		uarg[1] = (intptr_t) p->attr; /* const struct mq_attr * __capability */
+		uarg[2] = (intptr_t) p->oattr; /* struct mq_attr * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2405,10 +2405,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 459: {
 		struct kmq_timedreceive_args *p = params;
 		iarg[0] = p->mqd; /* int */
-		uarg[1] = (intptr_t) p->msg_ptr; /* char * */
+		uarg[1] = (intptr_t) p->msg_ptr; /* char * __capability */
 		uarg[2] = p->msg_len; /* size_t */
-		uarg[3] = (intptr_t) p->msg_prio; /* unsigned * */
-		uarg[4] = (intptr_t) p->abs_timeout; /* const struct timespec * */
+		uarg[3] = (intptr_t) p->msg_prio; /* unsigned * __capability */
+		uarg[4] = (intptr_t) p->abs_timeout; /* const struct timespec * __capability */
 		*n_args = 5;
 		break;
 	}
@@ -2416,10 +2416,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 460: {
 		struct kmq_timedsend_args *p = params;
 		iarg[0] = p->mqd; /* int */
-		uarg[1] = (intptr_t) p->msg_ptr; /* const char * */
+		uarg[1] = (intptr_t) p->msg_ptr; /* const char * __capability */
 		uarg[2] = p->msg_len; /* size_t */
 		uarg[3] = p->msg_prio; /* unsigned */
-		uarg[4] = (intptr_t) p->abs_timeout; /* const struct timespec * */
+		uarg[4] = (intptr_t) p->abs_timeout; /* const struct timespec * __capability */
 		*n_args = 5;
 		break;
 	}
@@ -2427,23 +2427,23 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 461: {
 		struct kmq_notify_args *p = params;
 		iarg[0] = p->mqd; /* int */
-		uarg[1] = (intptr_t) p->sigev; /* const struct sigevent_native * */
+		uarg[1] = (intptr_t) p->sigev; /* const struct sigevent_native * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* kmq_unlink */
 	case 462: {
 		struct kmq_unlink_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* abort2 */
 	case 463: {
 		struct abort2_args *p = params;
-		uarg[0] = (intptr_t) p->why; /* const char * */
+		uarg[0] = (intptr_t) p->why; /* const char * __capability */
 		iarg[1] = p->nargs; /* int */
-		uarg[2] = (intptr_t) p->args; /* void ** */
+		uarg[2] = (intptr_t) p->args; /* void * __capability * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2451,7 +2451,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 464: {
 		struct thr_set_name_args *p = params;
 		iarg[0] = p->id; /* long */
-		uarg[1] = (intptr_t) p->name; /* const char * */
+		uarg[1] = (intptr_t) p->name; /* const char * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -2459,7 +2459,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 465: {
 		struct aio_fsync_args *p = params;
 		iarg[0] = p->op; /* int */
-		uarg[1] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[1] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -2468,7 +2468,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct rtprio_thread_args *p = params;
 		iarg[0] = p->function; /* int */
 		iarg[1] = p->lwpid; /* lwpid_t */
-		uarg[2] = (intptr_t) p->rtp; /* struct rtprio * */
+		uarg[2] = (intptr_t) p->rtp; /* struct rtprio * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2484,11 +2484,11 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 472: {
 		struct sctp_generic_sendmsg_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->msg; /* void * */
+		uarg[1] = (intptr_t) p->msg; /* void * __capability */
 		iarg[2] = p->mlen; /* int */
-		uarg[3] = (intptr_t) p->to; /* const struct sockaddr * */
+		uarg[3] = (intptr_t) p->to; /* const struct sockaddr * __capability */
 		iarg[4] = p->tolen; /* __socklen_t */
-		uarg[5] = (intptr_t) p->sinfo; /* struct sctp_sndrcvinfo * */
+		uarg[5] = (intptr_t) p->sinfo; /* struct sctp_sndrcvinfo * __capability */
 		iarg[6] = p->flags; /* int */
 		*n_args = 7;
 		break;
@@ -2497,11 +2497,11 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 473: {
 		struct sctp_generic_sendmsg_iov_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->iov; /* struct iovec_native * */
+		uarg[1] = (intptr_t) p->iov; /* struct iovec_native * __capability */
 		iarg[2] = p->iovlen; /* int */
-		uarg[3] = (intptr_t) p->to; /* const struct sockaddr * */
+		uarg[3] = (intptr_t) p->to; /* const struct sockaddr * __capability */
 		iarg[4] = p->tolen; /* __socklen_t */
-		uarg[5] = (intptr_t) p->sinfo; /* struct sctp_sndrcvinfo * */
+		uarg[5] = (intptr_t) p->sinfo; /* struct sctp_sndrcvinfo * __capability */
 		iarg[6] = p->flags; /* int */
 		*n_args = 7;
 		break;
@@ -2510,12 +2510,12 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 474: {
 		struct sctp_generic_recvmsg_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->iov; /* struct iovec_native * */
+		uarg[1] = (intptr_t) p->iov; /* struct iovec_native * __capability */
 		iarg[2] = p->iovlen; /* int */
-		uarg[3] = (intptr_t) p->from; /* struct sockaddr * */
-		uarg[4] = (intptr_t) p->fromlenaddr; /* __socklen_t * */
-		uarg[5] = (intptr_t) p->sinfo; /* struct sctp_sndrcvinfo * */
-		uarg[6] = (intptr_t) p->msg_flags; /* int * */
+		uarg[3] = (intptr_t) p->from; /* struct sockaddr * __capability */
+		uarg[4] = (intptr_t) p->fromlenaddr; /* __socklen_t * __capability */
+		uarg[5] = (intptr_t) p->sinfo; /* struct sctp_sndrcvinfo * __capability */
+		uarg[6] = (intptr_t) p->msg_flags; /* int * __capability */
 		*n_args = 7;
 		break;
 	}
@@ -2523,7 +2523,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 475: {
 		struct pread_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->buf; /* void * */
+		uarg[1] = (intptr_t) p->buf; /* void * __capability */
 		uarg[2] = p->nbyte; /* size_t */
 		iarg[3] = p->offset; /* off_t */
 		*n_args = 4;
@@ -2533,7 +2533,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 476: {
 		struct pwrite_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->buf; /* const void * */
+		uarg[1] = (intptr_t) p->buf; /* const void * __capability */
 		uarg[2] = p->nbyte; /* size_t */
 		iarg[3] = p->offset; /* off_t */
 		*n_args = 4;
@@ -2542,7 +2542,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* mmap */
 	case 477: {
 		struct mmap_args *p = params;
-		uarg[0] = (intptr_t) p->addr; /* void * */
+		uarg[0] = (intptr_t) p->addr; /* void * __capability */
 		uarg[1] = p->len; /* size_t */
 		iarg[2] = p->prot; /* int */
 		iarg[3] = p->flags; /* int */
@@ -2563,7 +2563,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* truncate */
 	case 479: {
 		struct truncate_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->length; /* off_t */
 		*n_args = 2;
 		break;
@@ -2588,14 +2588,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* shm_unlink */
 	case 483: {
 		struct shm_unlink_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* cpuset */
 	case 484: {
 		struct cpuset_args *p = params;
-		uarg[0] = (intptr_t) p->setid; /* cpusetid_t * */
+		uarg[0] = (intptr_t) p->setid; /* cpusetid_t * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -2614,7 +2614,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->level; /* cpulevel_t */
 		iarg[1] = p->which; /* cpuwhich_t */
 		iarg[2] = p->id; /* id_t */
-		uarg[3] = (intptr_t) p->setid; /* cpusetid_t * */
+		uarg[3] = (intptr_t) p->setid; /* cpusetid_t * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -2625,7 +2625,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[1] = p->which; /* cpuwhich_t */
 		iarg[2] = p->id; /* id_t */
 		uarg[3] = p->cpusetsize; /* size_t */
-		uarg[4] = (intptr_t) p->mask; /* cpuset_t * */
+		uarg[4] = (intptr_t) p->mask; /* cpuset_t * __capability */
 		*n_args = 5;
 		break;
 	}
@@ -2636,7 +2636,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[1] = p->which; /* cpuwhich_t */
 		iarg[2] = p->id; /* id_t */
 		uarg[3] = p->cpusetsize; /* size_t */
-		uarg[4] = (intptr_t) p->mask; /* const cpuset_t * */
+		uarg[4] = (intptr_t) p->mask; /* const cpuset_t * __capability */
 		*n_args = 5;
 		break;
 	}
@@ -2644,7 +2644,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 489: {
 		struct faccessat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->amode; /* int */
 		iarg[3] = p->flag; /* int */
 		*n_args = 4;
@@ -2654,7 +2654,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 490: {
 		struct fchmodat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->mode; /* mode_t */
 		iarg[3] = p->flag; /* int */
 		*n_args = 4;
@@ -2664,7 +2664,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 491: {
 		struct fchownat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		uarg[2] = p->uid; /* uid_t */
 		iarg[3] = p->gid; /* gid_t */
 		iarg[4] = p->flag; /* int */
@@ -2675,8 +2675,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 492: {
 		struct fexecve_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->argv; /* char ** */
-		uarg[2] = (intptr_t) p->envv; /* char ** */
+		uarg[1] = (intptr_t) p->argv; /* char * __capability * __capability */
+		uarg[2] = (intptr_t) p->envv; /* char * __capability * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2684,8 +2684,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 494: {
 		struct futimesat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
-		uarg[2] = (intptr_t) p->times; /* const struct timeval * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
+		uarg[2] = (intptr_t) p->times; /* const struct timeval * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2693,9 +2693,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 495: {
 		struct linkat_args *p = params;
 		iarg[0] = p->fd1; /* int */
-		uarg[1] = (intptr_t) p->path1; /* const char * */
+		uarg[1] = (intptr_t) p->path1; /* const char * __capability */
 		iarg[2] = p->fd2; /* int */
-		uarg[3] = (intptr_t) p->path2; /* const char * */
+		uarg[3] = (intptr_t) p->path2; /* const char * __capability */
 		iarg[4] = p->flag; /* int */
 		*n_args = 5;
 		break;
@@ -2704,7 +2704,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 496: {
 		struct mkdirat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->mode; /* mode_t */
 		*n_args = 3;
 		break;
@@ -2713,7 +2713,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 497: {
 		struct mkfifoat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->mode; /* mode_t */
 		*n_args = 3;
 		break;
@@ -2722,7 +2722,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 499: {
 		struct openat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->flag; /* int */
 		iarg[3] = p->mode; /* mode_t */
 		*n_args = 4;
@@ -2732,8 +2732,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 500: {
 		struct readlinkat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
-		uarg[2] = (intptr_t) p->buf; /* char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
+		uarg[2] = (intptr_t) p->buf; /* char * __capability */
 		uarg[3] = p->bufsize; /* size_t */
 		*n_args = 4;
 		break;
@@ -2742,18 +2742,18 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 501: {
 		struct renameat_args *p = params;
 		iarg[0] = p->oldfd; /* int */
-		uarg[1] = (intptr_t) p->old; /* const char * */
+		uarg[1] = (intptr_t) p->old; /* const char * __capability */
 		iarg[2] = p->newfd; /* int */
-		uarg[3] = (intptr_t) p->new; /* const char * */
+		uarg[3] = (intptr_t) p->new; /* const char * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* symlinkat */
 	case 502: {
 		struct symlinkat_args *p = params;
-		uarg[0] = (intptr_t) p->path1; /* const char * */
+		uarg[0] = (intptr_t) p->path1; /* const char * __capability */
 		iarg[1] = p->fd; /* int */
-		uarg[2] = (intptr_t) p->path2; /* const char * */
+		uarg[2] = (intptr_t) p->path2; /* const char * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2761,7 +2761,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 503: {
 		struct unlinkat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->flag; /* int */
 		*n_args = 3;
 		break;
@@ -2776,14 +2776,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* gssd_syscall */
 	case 505: {
 		struct gssd_syscall_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* jail_get */
 	case 506: {
 		struct jail_get_args *p = params;
-		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[1] = p->iovcnt; /* unsigned int */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -2792,7 +2792,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* jail_set */
 	case 507: {
 		struct jail_set_args *p = params;
-		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * */
+		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
 		uarg[1] = p->iovcnt; /* unsigned int */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -2818,7 +2818,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->semid; /* int */
 		iarg[1] = p->semnum; /* int */
 		iarg[2] = p->cmd; /* int */
-		uarg[3] = (intptr_t) p->arg; /* union semun_native * */
+		uarg[3] = (intptr_t) p->arg; /* union semun_native * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -2827,7 +2827,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct msgctl_args *p = params;
 		iarg[0] = p->msqid; /* int */
 		iarg[1] = p->cmd; /* int */
-		uarg[2] = (intptr_t) p->buf; /* struct msqid_ds * */
+		uarg[2] = (intptr_t) p->buf; /* struct msqid_ds * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2836,14 +2836,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct shmctl_args *p = params;
 		iarg[0] = p->shmid; /* int */
 		iarg[1] = p->cmd; /* int */
-		uarg[2] = (intptr_t) p->buf; /* struct shmid_ds * */
+		uarg[2] = (intptr_t) p->buf; /* struct shmid_ds * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* lpathconf */
 	case 513: {
 		struct lpathconf_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->name; /* int */
 		*n_args = 2;
 		break;
@@ -2853,7 +2853,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct __cap_rights_get_args *p = params;
 		iarg[0] = p->version; /* int */
 		iarg[1] = p->fd; /* int */
-		uarg[2] = (intptr_t) p->rightsp; /* cap_rights_t * */
+		uarg[2] = (intptr_t) p->rightsp; /* cap_rights_t * __capability */
 		*n_args = 3;
 		break;
 	}
@@ -2865,14 +2865,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* cap_getmode */
 	case 517: {
 		struct cap_getmode_args *p = params;
-		uarg[0] = (intptr_t) p->modep; /* u_int * */
+		uarg[0] = (intptr_t) p->modep; /* u_int * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* pdfork */
 	case 518: {
 		struct pdfork_args *p = params;
-		uarg[0] = (intptr_t) p->fdp; /* int * */
+		uarg[0] = (intptr_t) p->fdp; /* int * __capability */
 		iarg[1] = p->flags; /* int */
 		*n_args = 2;
 		break;
@@ -2889,7 +2889,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 520: {
 		struct pdgetpid_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->pidp; /* pid_t * */
+		uarg[1] = (intptr_t) p->pidp; /* pid_t * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -2897,18 +2897,18 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 522: {
 		struct pselect_args *p = params;
 		iarg[0] = p->nd; /* int */
-		uarg[1] = (intptr_t) p->in; /* fd_set * */
-		uarg[2] = (intptr_t) p->ou; /* fd_set * */
-		uarg[3] = (intptr_t) p->ex; /* fd_set * */
-		uarg[4] = (intptr_t) p->ts; /* const struct timespec * */
-		uarg[5] = (intptr_t) p->sm; /* const sigset_t * */
+		uarg[1] = (intptr_t) p->in; /* fd_set * __capability */
+		uarg[2] = (intptr_t) p->ou; /* fd_set * __capability */
+		uarg[3] = (intptr_t) p->ex; /* fd_set * __capability */
+		uarg[4] = (intptr_t) p->ts; /* const struct timespec * __capability */
+		uarg[5] = (intptr_t) p->sm; /* const sigset_t * __capability */
 		*n_args = 6;
 		break;
 	}
 	/* getloginclass */
 	case 523: {
 		struct getloginclass_args *p = params;
-		uarg[0] = (intptr_t) p->namebuf; /* char * */
+		uarg[0] = (intptr_t) p->namebuf; /* char * __capability */
 		uarg[1] = p->namelen; /* size_t */
 		*n_args = 2;
 		break;
@@ -2916,16 +2916,16 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* setloginclass */
 	case 524: {
 		struct setloginclass_args *p = params;
-		uarg[0] = (intptr_t) p->namebuf; /* const char * */
+		uarg[0] = (intptr_t) p->namebuf; /* const char * __capability */
 		*n_args = 1;
 		break;
 	}
 	/* rctl_get_racct */
 	case 525: {
 		struct rctl_get_racct_args *p = params;
-		uarg[0] = (intptr_t) p->inbufp; /* const void * */
+		uarg[0] = (intptr_t) p->inbufp; /* const void * __capability */
 		uarg[1] = p->inbuflen; /* size_t */
-		uarg[2] = (intptr_t) p->outbufp; /* void * */
+		uarg[2] = (intptr_t) p->outbufp; /* void * __capability */
 		uarg[3] = p->outbuflen; /* size_t */
 		*n_args = 4;
 		break;
@@ -2933,9 +2933,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* rctl_get_rules */
 	case 526: {
 		struct rctl_get_rules_args *p = params;
-		uarg[0] = (intptr_t) p->inbufp; /* const void * */
+		uarg[0] = (intptr_t) p->inbufp; /* const void * __capability */
 		uarg[1] = p->inbuflen; /* size_t */
-		uarg[2] = (intptr_t) p->outbufp; /* void * */
+		uarg[2] = (intptr_t) p->outbufp; /* void * __capability */
 		uarg[3] = p->outbuflen; /* size_t */
 		*n_args = 4;
 		break;
@@ -2943,9 +2943,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* rctl_get_limits */
 	case 527: {
 		struct rctl_get_limits_args *p = params;
-		uarg[0] = (intptr_t) p->inbufp; /* const void * */
+		uarg[0] = (intptr_t) p->inbufp; /* const void * __capability */
 		uarg[1] = p->inbuflen; /* size_t */
-		uarg[2] = (intptr_t) p->outbufp; /* void * */
+		uarg[2] = (intptr_t) p->outbufp; /* void * __capability */
 		uarg[3] = p->outbuflen; /* size_t */
 		*n_args = 4;
 		break;
@@ -2953,9 +2953,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* rctl_add_rule */
 	case 528: {
 		struct rctl_add_rule_args *p = params;
-		uarg[0] = (intptr_t) p->inbufp; /* const void * */
+		uarg[0] = (intptr_t) p->inbufp; /* const void * __capability */
 		uarg[1] = p->inbuflen; /* size_t */
-		uarg[2] = (intptr_t) p->outbufp; /* void * */
+		uarg[2] = (intptr_t) p->outbufp; /* void * __capability */
 		uarg[3] = p->outbuflen; /* size_t */
 		*n_args = 4;
 		break;
@@ -2963,9 +2963,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* rctl_remove_rule */
 	case 529: {
 		struct rctl_remove_rule_args *p = params;
-		uarg[0] = (intptr_t) p->inbufp; /* const void * */
+		uarg[0] = (intptr_t) p->inbufp; /* const void * __capability */
 		uarg[1] = p->inbuflen; /* size_t */
-		uarg[2] = (intptr_t) p->outbufp; /* void * */
+		uarg[2] = (intptr_t) p->outbufp; /* void * __capability */
 		uarg[3] = p->outbuflen; /* size_t */
 		*n_args = 4;
 		break;
@@ -2994,10 +2994,10 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct wait6_args *p = params;
 		iarg[0] = p->idtype; /* idtype_t */
 		iarg[1] = p->id; /* id_t */
-		uarg[2] = (intptr_t) p->status; /* int * */
+		uarg[2] = (intptr_t) p->status; /* int * __capability */
 		iarg[3] = p->options; /* int */
-		uarg[4] = (intptr_t) p->wrusage; /* struct __wrusage * */
-		uarg[5] = (intptr_t) p->info; /* struct siginfo_native * */
+		uarg[4] = (intptr_t) p->wrusage; /* struct __wrusage * __capability */
+		uarg[5] = (intptr_t) p->info; /* struct siginfo_native * __capability */
 		*n_args = 6;
 		break;
 	}
@@ -3005,7 +3005,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 533: {
 		struct cap_rights_limit_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->rightsp; /* cap_rights_t * */
+		uarg[1] = (intptr_t) p->rightsp; /* cap_rights_t * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3013,7 +3013,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 534: {
 		struct cap_ioctls_limit_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->cmds; /* const u_long * */
+		uarg[1] = (intptr_t) p->cmds; /* const u_long * __capability */
 		uarg[2] = p->ncmds; /* size_t */
 		*n_args = 3;
 		break;
@@ -3022,7 +3022,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 535: {
 		struct cap_ioctls_get_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->cmds; /* u_long * */
+		uarg[1] = (intptr_t) p->cmds; /* u_long * __capability */
 		uarg[2] = p->maxcmds; /* size_t */
 		*n_args = 3;
 		break;
@@ -3039,7 +3039,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 537: {
 		struct cap_fcntls_get_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->fcntlrightsp; /* uint32_t * */
+		uarg[1] = (intptr_t) p->fcntlrightsp; /* uint32_t * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3048,7 +3048,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct bindat_args *p = params;
 		iarg[0] = p->fd; /* int */
 		iarg[1] = p->s; /* int */
-		uarg[2] = (intptr_t) p->name; /* const struct sockaddr * */
+		uarg[2] = (intptr_t) p->name; /* const struct sockaddr * __capability */
 		iarg[3] = p->namelen; /* __socklen_t */
 		*n_args = 4;
 		break;
@@ -3058,7 +3058,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct connectat_args *p = params;
 		iarg[0] = p->fd; /* int */
 		iarg[1] = p->s; /* int */
-		uarg[2] = (intptr_t) p->name; /* const struct sockaddr * */
+		uarg[2] = (intptr_t) p->name; /* const struct sockaddr * __capability */
 		iarg[3] = p->namelen; /* __socklen_t */
 		*n_args = 4;
 		break;
@@ -3067,7 +3067,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 540: {
 		struct chflagsat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		uarg[2] = p->flags; /* u_long */
 		iarg[3] = p->atflag; /* int */
 		*n_args = 4;
@@ -3077,8 +3077,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 541: {
 		struct accept4_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->name; /* struct sockaddr * */
-		uarg[2] = (intptr_t) p->anamelen; /* __socklen_t * */
+		uarg[1] = (intptr_t) p->name; /* struct sockaddr * __capability */
+		uarg[2] = (intptr_t) p->anamelen; /* __socklen_t * __capability */
 		iarg[3] = p->flags; /* int */
 		*n_args = 4;
 		break;
@@ -3086,7 +3086,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* pipe2 */
 	case 542: {
 		struct pipe2_args *p = params;
-		uarg[0] = (intptr_t) p->fildes; /* int * */
+		uarg[0] = (intptr_t) p->fildes; /* int * __capability */
 		iarg[1] = p->flags; /* int */
 		*n_args = 2;
 		break;
@@ -3094,7 +3094,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* aio_mlock */
 	case 543: {
 		struct aio_mlock_args *p = params;
-		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * */
+		uarg[0] = (intptr_t) p->aiocbp; /* struct aiocb_native * __capability */
 		*n_args = 1;
 		break;
 	}
@@ -3104,17 +3104,17 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[0] = p->idtype; /* idtype_t */
 		iarg[1] = p->id; /* id_t */
 		iarg[2] = p->com; /* int */
-		uarg[3] = (intptr_t) p->data; /* void * */
+		uarg[3] = (intptr_t) p->data; /* void * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* ppoll */
 	case 545: {
 		struct ppoll_args *p = params;
-		uarg[0] = (intptr_t) p->fds; /* struct pollfd * */
+		uarg[0] = (intptr_t) p->fds; /* struct pollfd * __capability */
 		uarg[1] = p->nfds; /* u_int */
-		uarg[2] = (intptr_t) p->ts; /* const struct timespec * */
-		uarg[3] = (intptr_t) p->set; /* const sigset_t * */
+		uarg[2] = (intptr_t) p->ts; /* const struct timespec * __capability */
+		uarg[3] = (intptr_t) p->set; /* const sigset_t * __capability */
 		*n_args = 4;
 		break;
 	}
@@ -3122,7 +3122,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 546: {
 		struct futimens_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->times; /* const struct timespec * */
+		uarg[1] = (intptr_t) p->times; /* const struct timespec * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3130,8 +3130,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 547: {
 		struct utimensat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
-		uarg[2] = (intptr_t) p->times; /* const struct timespec * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
+		uarg[2] = (intptr_t) p->times; /* const struct timespec * __capability */
 		iarg[3] = p->flag; /* int */
 		*n_args = 4;
 		break;
@@ -3147,7 +3147,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 551: {
 		struct fstat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->sb; /* struct stat * */
+		uarg[1] = (intptr_t) p->sb; /* struct stat * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3155,8 +3155,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 552: {
 		struct fstatat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
-		uarg[2] = (intptr_t) p->buf; /* struct stat * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
+		uarg[2] = (intptr_t) p->buf; /* struct stat * __capability */
 		iarg[3] = p->flag; /* int */
 		*n_args = 4;
 		break;
@@ -3164,8 +3164,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* fhstat */
 	case 553: {
 		struct fhstat_args *p = params;
-		uarg[0] = (intptr_t) p->u_fhp; /* const struct fhandle * */
-		uarg[1] = (intptr_t) p->sb; /* struct stat * */
+		uarg[0] = (intptr_t) p->u_fhp; /* const struct fhandle * __capability */
+		uarg[1] = (intptr_t) p->sb; /* struct stat * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3173,17 +3173,17 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 554: {
 		struct getdirentries_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->buf; /* char * */
+		uarg[1] = (intptr_t) p->buf; /* char * __capability */
 		uarg[2] = p->count; /* size_t */
-		uarg[3] = (intptr_t) p->basep; /* off_t * */
+		uarg[3] = (intptr_t) p->basep; /* off_t * __capability */
 		*n_args = 4;
 		break;
 	}
 	/* statfs */
 	case 555: {
 		struct statfs_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
-		uarg[1] = (intptr_t) p->buf; /* struct statfs * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
+		uarg[1] = (intptr_t) p->buf; /* struct statfs * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3191,14 +3191,14 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 556: {
 		struct fstatfs_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->buf; /* struct statfs * */
+		uarg[1] = (intptr_t) p->buf; /* struct statfs * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* getfsstat */
 	case 557: {
 		struct getfsstat_args *p = params;
-		uarg[0] = (intptr_t) p->buf; /* struct statfs * */
+		uarg[0] = (intptr_t) p->buf; /* struct statfs * __capability */
 		iarg[1] = p->bufsize; /* long */
 		iarg[2] = p->mode; /* int */
 		*n_args = 3;
@@ -3207,8 +3207,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* fhstatfs */
 	case 558: {
 		struct fhstatfs_args *p = params;
-		uarg[0] = (intptr_t) p->u_fhp; /* const struct fhandle * */
-		uarg[1] = (intptr_t) p->buf; /* struct statfs * */
+		uarg[0] = (intptr_t) p->u_fhp; /* const struct fhandle * __capability */
+		uarg[1] = (intptr_t) p->buf; /* struct statfs * __capability */
 		*n_args = 2;
 		break;
 	}
@@ -3216,7 +3216,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 559: {
 		struct mknodat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->mode; /* mode_t */
 		iarg[3] = p->dev; /* dev_t */
 		*n_args = 4;
@@ -3226,11 +3226,11 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 560: {
 		struct kevent_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->changelist; /* const struct kevent_native * */
+		uarg[1] = (intptr_t) p->changelist; /* const struct kevent_native * __capability */
 		iarg[2] = p->nchanges; /* int */
-		uarg[3] = (intptr_t) p->eventlist; /* struct kevent_native * */
+		uarg[3] = (intptr_t) p->eventlist; /* struct kevent_native * __capability */
 		iarg[4] = p->nevents; /* int */
-		uarg[5] = (intptr_t) p->timeout; /* const struct timespec * */
+		uarg[5] = (intptr_t) p->timeout; /* const struct timespec * __capability */
 		*n_args = 6;
 		break;
 	}
@@ -3241,8 +3241,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[1] = p->which; /* cpuwhich_t */
 		iarg[2] = p->id; /* id_t */
 		uarg[3] = p->domainsetsize; /* size_t */
-		uarg[4] = (intptr_t) p->mask; /* domainset_t * */
-		uarg[5] = (intptr_t) p->policy; /* int * */
+		uarg[4] = (intptr_t) p->mask; /* domainset_t * __capability */
+		uarg[5] = (intptr_t) p->policy; /* int * __capability */
 		*n_args = 6;
 		break;
 	}
@@ -3253,7 +3253,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[1] = p->which; /* cpuwhich_t */
 		iarg[2] = p->id; /* id_t */
 		uarg[3] = p->domainsetsize; /* size_t */
-		uarg[4] = (intptr_t) p->mask; /* domainset_t * */
+		uarg[4] = (intptr_t) p->mask; /* domainset_t * __capability */
 		iarg[5] = p->policy; /* int */
 		*n_args = 6;
 		break;
@@ -3261,7 +3261,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* getrandom */
 	case 563: {
 		struct getrandom_args *p = params;
-		uarg[0] = (intptr_t) p->buf; /* void * */
+		uarg[0] = (intptr_t) p->buf; /* void * __capability */
 		uarg[1] = p->buflen; /* size_t */
 		uarg[2] = p->flags; /* unsigned int */
 		*n_args = 3;
@@ -3271,8 +3271,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 564: {
 		struct getfhat_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->path; /* char * */
-		uarg[2] = (intptr_t) p->fhp; /* struct fhandle * */
+		uarg[1] = (intptr_t) p->path; /* char * __capability */
+		uarg[2] = (intptr_t) p->fhp; /* struct fhandle * __capability */
 		iarg[3] = p->flags; /* int */
 		*n_args = 4;
 		break;
@@ -3280,25 +3280,25 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* fhlink */
 	case 565: {
 		struct fhlink_args *p = params;
-		uarg[0] = (intptr_t) p->fhp; /* struct fhandle * */
-		uarg[1] = (intptr_t) p->to; /* const char * */
+		uarg[0] = (intptr_t) p->fhp; /* struct fhandle * __capability */
+		uarg[1] = (intptr_t) p->to; /* const char * __capability */
 		*n_args = 2;
 		break;
 	}
 	/* fhlinkat */
 	case 566: {
 		struct fhlinkat_args *p = params;
-		uarg[0] = (intptr_t) p->fhp; /* struct fhandle * */
+		uarg[0] = (intptr_t) p->fhp; /* struct fhandle * __capability */
 		iarg[1] = p->tofd; /* int */
-		uarg[2] = (intptr_t) p->to; /* const char * */
+		uarg[2] = (intptr_t) p->to; /* const char * __capability */
 		*n_args = 3;
 		break;
 	}
 	/* fhreadlink */
 	case 567: {
 		struct fhreadlink_args *p = params;
-		uarg[0] = (intptr_t) p->fhp; /* struct fhandle * */
-		uarg[1] = (intptr_t) p->buf; /* char * */
+		uarg[0] = (intptr_t) p->fhp; /* struct fhandle * __capability */
+		uarg[1] = (intptr_t) p->buf; /* char * __capability */
 		uarg[2] = p->bufsize; /* size_t */
 		*n_args = 3;
 		break;
@@ -3307,7 +3307,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 568: {
 		struct funlinkat_args *p = params;
 		iarg[0] = p->dfd; /* int */
-		uarg[1] = (intptr_t) p->path; /* const char * */
+		uarg[1] = (intptr_t) p->path; /* const char * __capability */
 		iarg[2] = p->fd; /* int */
 		iarg[3] = p->flag; /* int */
 		*n_args = 4;
@@ -3317,9 +3317,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 569: {
 		struct copy_file_range_args *p = params;
 		iarg[0] = p->infd; /* int */
-		uarg[1] = (intptr_t) p->inoffp; /* off_t * */
+		uarg[1] = (intptr_t) p->inoffp; /* off_t * __capability */
 		iarg[2] = p->outfd; /* int */
-		uarg[3] = (intptr_t) p->outoffp; /* off_t * */
+		uarg[3] = (intptr_t) p->outoffp; /* off_t * __capability */
 		uarg[4] = p->len; /* size_t */
 		uarg[5] = p->flags; /* unsigned int */
 		*n_args = 6;
@@ -3328,11 +3328,11 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* __sysctlbyname */
 	case 570: {
 		struct __sysctlbyname_args *p = params;
-		uarg[0] = (intptr_t) p->name; /* const char * */
+		uarg[0] = (intptr_t) p->name; /* const char * __capability */
 		uarg[1] = p->namelen; /* size_t */
-		uarg[2] = (intptr_t) p->old; /* void * */
-		uarg[3] = (intptr_t) p->oldlenp; /* size_t * */
-		uarg[4] = (intptr_t) p->new; /* void * */
+		uarg[2] = (intptr_t) p->old; /* void * __capability */
+		uarg[3] = (intptr_t) p->oldlenp; /* size_t * __capability */
+		uarg[4] = (intptr_t) p->new; /* void * __capability */
 		uarg[5] = p->newlen; /* size_t */
 		*n_args = 6;
 		break;
@@ -3340,19 +3340,19 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* shm_open2 */
 	case 571: {
 		struct shm_open2_args *p = params;
-		uarg[0] = (intptr_t) p->path; /* const char * */
+		uarg[0] = (intptr_t) p->path; /* const char * __capability */
 		iarg[1] = p->flags; /* int */
 		iarg[2] = p->mode; /* mode_t */
 		iarg[3] = p->shmflags; /* int */
-		uarg[4] = (intptr_t) p->name; /* const char * */
+		uarg[4] = (intptr_t) p->name; /* const char * __capability */
 		*n_args = 5;
 		break;
 	}
 	/* shm_rename */
 	case 572: {
 		struct shm_rename_args *p = params;
-		uarg[0] = (intptr_t) p->path_from; /* const char * */
-		uarg[1] = (intptr_t) p->path_to; /* const char * */
+		uarg[0] = (intptr_t) p->path_from; /* const char * __capability */
+		uarg[1] = (intptr_t) p->path_to; /* const char * __capability */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
 		break;
@@ -3390,7 +3390,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -3406,7 +3406,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -3419,7 +3419,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 5:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -3448,13 +3448,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland struct rusage *";
+			p = "userland struct rusage * __capability";
 			break;
 		default:
 			break;
@@ -3464,10 +3464,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 9:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3477,7 +3477,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 10:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3487,7 +3487,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 12:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3507,7 +3507,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 15:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "mode_t";
@@ -3520,7 +3520,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 16:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -3536,7 +3536,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 17:
 		switch(ndx) {
 		case 0:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		default:
 			break;
@@ -3549,16 +3549,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 21:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -3568,7 +3568,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 22:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -3603,7 +3603,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "pid_t";
 			break;
 		case 2:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 3:
 			p = "int";
@@ -3619,7 +3619,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct msghdr_native *";
+			p = "userland struct msghdr_native * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -3635,7 +3635,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct msghdr_native *";
+			p = "userland const struct msghdr_native * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -3651,7 +3651,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -3660,10 +3660,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 4:
-			p = "userland struct sockaddr *";
+			p = "userland struct sockaddr * __capability";
 			break;
 		case 5:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		default:
 			break;
@@ -3676,10 +3676,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct sockaddr *";
+			p = "userland struct sockaddr * __capability";
 			break;
 		case 2:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		default:
 			break;
@@ -3692,10 +3692,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct sockaddr *";
+			p = "userland struct sockaddr * __capability";
 			break;
 		case 2:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		default:
 			break;
@@ -3708,10 +3708,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct sockaddr *";
+			p = "userland struct sockaddr * __capability";
 			break;
 		case 2:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		default:
 			break;
@@ -3721,7 +3721,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 33:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -3734,7 +3734,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 34:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "u_long";
@@ -3792,7 +3792,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 44:
 		switch(ndx) {
 		case 0:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -3811,7 +3811,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 45:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -3833,7 +3833,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 49:
 		switch(ndx) {
 		case 0:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 1:
 			p = "u_int";
@@ -3846,7 +3846,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 50:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3856,7 +3856,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 51:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3866,10 +3866,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 53:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct sigaltstack_native *";
+			p = "userland const struct sigaltstack_native * __capability";
 			break;
 		case 1:
-			p = "userland struct sigaltstack_native *";
+			p = "userland struct sigaltstack_native * __capability";
 			break;
 		default:
 			break;
@@ -3885,7 +3885,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "u_long";
 			break;
 		case 2:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		default:
 			break;
@@ -3905,7 +3905,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 56:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3915,10 +3915,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 57:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3928,10 +3928,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 58:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -3944,13 +3944,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 59:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		case 2:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		default:
 			break;
@@ -3970,7 +3970,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 61:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -3980,7 +3980,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 65:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -4019,7 +4019,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 73:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -4032,7 +4032,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 74:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -4048,7 +4048,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 75:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -4064,13 +4064,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 78:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		default:
 			break;
@@ -4083,7 +4083,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "u_int";
 			break;
 		case 1:
-			p = "userland gid_t *";
+			p = "userland gid_t * __capability";
 			break;
 		default:
 			break;
@@ -4096,7 +4096,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "u_int";
 			break;
 		case 1:
-			p = "userland const gid_t *";
+			p = "userland const gid_t * __capability";
 			break;
 		default:
 			break;
@@ -4125,10 +4125,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct itimerval *";
+			p = "userland const struct itimerval * __capability";
 			break;
 		case 2:
-			p = "userland struct itimerval *";
+			p = "userland struct itimerval * __capability";
 			break;
 		default:
 			break;
@@ -4138,7 +4138,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 85:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -4151,7 +4151,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct itimerval *";
+			p = "userland struct itimerval * __capability";
 			break;
 		default:
 			break;
@@ -4196,16 +4196,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland fd_set *";
+			p = "userland fd_set * __capability";
 			break;
 		case 2:
-			p = "userland fd_set *";
+			p = "userland fd_set * __capability";
 			break;
 		case 3:
-			p = "userland fd_set *";
+			p = "userland fd_set * __capability";
 			break;
 		case 4:
-			p = "userland struct timeval *";
+			p = "userland struct timeval * __capability";
 			break;
 		default:
 			break;
@@ -4260,7 +4260,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 2:
 			p = "__socklen_t";
@@ -4289,7 +4289,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 2:
 			p = "__socklen_t";
@@ -4311,7 +4311,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 4:
 			p = "__socklen_t";
@@ -4337,10 +4337,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 116:
 		switch(ndx) {
 		case 0:
-			p = "userland struct timeval *";
+			p = "userland struct timeval * __capability";
 			break;
 		case 1:
-			p = "userland struct timezone *";
+			p = "userland struct timezone * __capability";
 			break;
 		default:
 			break;
@@ -4353,7 +4353,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct rusage *";
+			p = "userland struct rusage * __capability";
 			break;
 		default:
 			break;
@@ -4372,10 +4372,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		default:
 			break;
@@ -4388,7 +4388,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -4404,7 +4404,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -4417,10 +4417,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 122:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct timeval *";
+			p = "userland const struct timeval * __capability";
 			break;
 		case 1:
-			p = "userland const struct timezone *";
+			p = "userland const struct timezone * __capability";
 			break;
 		default:
 			break;
@@ -4485,10 +4485,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 128:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -4511,7 +4511,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 132:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "mode_t";
@@ -4527,7 +4527,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -4536,7 +4536,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 4:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 5:
 			p = "__socklen_t";
@@ -4571,7 +4571,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		default:
 			break;
@@ -4581,7 +4581,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 136:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "mode_t";
@@ -4594,7 +4594,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 137:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -4604,10 +4604,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 138:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const struct timeval *";
+			p = "userland const struct timeval * __capability";
 			break;
 		default:
 			break;
@@ -4617,10 +4617,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 140:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct timeval *";
+			p = "userland const struct timeval * __capability";
 			break;
 		case 1:
-			p = "userland struct timeval *";
+			p = "userland struct timeval * __capability";
 			break;
 		default:
 			break;
@@ -4633,7 +4633,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 148:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -4642,7 +4642,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -4661,7 +4661,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		default:
 			break;
@@ -4674,7 +4674,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -4684,10 +4684,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 160:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct fhandle *";
+			p = "userland struct fhandle * __capability";
 			break;
 		default:
 			break;
@@ -4697,10 +4697,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 161:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct fhandle *";
+			p = "userland struct fhandle * __capability";
 			break;
 		default:
 			break;
@@ -4713,7 +4713,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		default:
 			break;
@@ -4729,7 +4729,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "pid_t";
 			break;
 		case 2:
-			p = "userland struct rtprio *";
+			p = "userland struct rtprio * __capability";
 			break;
 		default:
 			break;
@@ -4815,7 +4815,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 176:
 		switch(ndx) {
 		case 0:
-			p = "userland struct timex *";
+			p = "userland struct timex * __capability";
 			break;
 		default:
 			break;
@@ -4855,7 +4855,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 191:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -4884,7 +4884,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "u_int";
 			break;
 		case 1:
-			p = "userland struct rlimit *";
+			p = "userland struct rlimit * __capability";
 			break;
 		default:
 			break;
@@ -4897,7 +4897,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "u_int";
 			break;
 		case 1:
-			p = "userland struct rlimit *";
+			p = "userland struct rlimit * __capability";
 			break;
 		default:
 			break;
@@ -4910,19 +4910,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 202:
 		switch(ndx) {
 		case 0:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		case 1:
 			p = "u_int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
-			p = "userland size_t *";
+			p = "userland size_t * __capability";
 			break;
 		case 4:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 5:
 			p = "size_t";
@@ -4935,7 +4935,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 203:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -4948,7 +4948,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 204:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -4961,7 +4961,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 205:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -4974,7 +4974,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct timeval *";
+			p = "userland const struct timeval * __capability";
 			break;
 		default:
 			break;
@@ -4994,7 +4994,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 209:
 		switch(ndx) {
 		case 0:
-			p = "userland struct pollfd *";
+			p = "userland struct pollfd * __capability";
 			break;
 		case 1:
 			p = "u_int";
@@ -5059,7 +5059,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct sembuf *";
+			p = "userland struct sembuf * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -5088,7 +5088,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -5107,7 +5107,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -5129,7 +5129,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -5142,7 +5142,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 230:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		default:
 			break;
@@ -5171,7 +5171,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "clockid_t";
 			break;
 		case 1:
-			p = "userland struct timespec *";
+			p = "userland struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5184,7 +5184,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "clockid_t";
 			break;
 		case 1:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5197,7 +5197,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "clockid_t";
 			break;
 		case 1:
-			p = "userland struct timespec *";
+			p = "userland struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5210,10 +5210,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "clockid_t";
 			break;
 		case 1:
-			p = "userland struct sigevent_native *";
+			p = "userland struct sigevent_native * __capability";
 			break;
 		case 2:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		default:
 			break;
@@ -5239,10 +5239,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const struct itimerspec *";
+			p = "userland const struct itimerspec * __capability";
 			break;
 		case 3:
-			p = "userland struct itimerspec *";
+			p = "userland struct itimerspec * __capability";
 			break;
 		default:
 			break;
@@ -5255,7 +5255,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct itimerspec *";
+			p = "userland struct itimerspec * __capability";
 			break;
 		default:
 			break;
@@ -5275,10 +5275,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 240:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		case 1:
-			p = "userland struct timespec *";
+			p = "userland struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5288,7 +5288,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 241:
 		switch(ndx) {
 		case 0:
-			p = "userland ffcounter *";
+			p = "userland ffcounter * __capability";
 			break;
 		default:
 			break;
@@ -5298,7 +5298,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 242:
 		switch(ndx) {
 		case 0:
-			p = "userland struct ffclock_estimate *";
+			p = "userland struct ffclock_estimate * __capability";
 			break;
 		default:
 			break;
@@ -5308,7 +5308,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 243:
 		switch(ndx) {
 		case 0:
-			p = "userland struct ffclock_estimate *";
+			p = "userland struct ffclock_estimate * __capability";
 			break;
 		default:
 			break;
@@ -5324,10 +5324,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		case 3:
-			p = "userland struct timespec *";
+			p = "userland struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5343,7 +5343,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland clockid_t *";
+			p = "userland clockid_t * __capability";
 			break;
 		default:
 			break;
@@ -5353,7 +5353,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 248:
 		switch(ndx) {
 		case 0:
-			p = "userland struct ntptimeval *";
+			p = "userland struct ntptimeval * __capability";
 			break;
 		default:
 			break;
@@ -5363,7 +5363,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 250:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -5392,7 +5392,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 254:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -5408,7 +5408,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 255:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -5418,7 +5418,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 256:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -5431,13 +5431,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct aiocb_native *const *";
+			p = "userland struct aiocb_native * __capability const * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland struct sigevent_native *";
+			p = "userland struct sigevent_native * __capability";
 			break;
 		default:
 			break;
@@ -5447,10 +5447,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 258:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -5466,7 +5466,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 274:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "mode_t";
@@ -5479,10 +5479,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 276:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const struct timeval *";
+			p = "userland const struct timeval * __capability";
 			break;
 		default:
 			break;
@@ -5495,7 +5495,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -5514,7 +5514,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -5530,7 +5530,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 298:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct fhandle *";
+			p = "userland const struct fhandle * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -5556,7 +5556,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct module_stat *";
+			p = "userland struct module_stat * __capability";
 			break;
 		default:
 			break;
@@ -5576,7 +5576,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 303:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -5586,7 +5586,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 304:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -5606,7 +5606,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 306:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -5629,7 +5629,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct kld_file_stat *";
+			p = "userland struct kld_file_stat * __capability";
 			break;
 		default:
 			break;
@@ -5691,7 +5691,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 314:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -5701,13 +5701,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 315:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native *const *";
+			p = "userland struct aiocb_native * __capability const * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5720,7 +5720,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -5730,7 +5730,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 317:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -5756,7 +5756,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 326:
 		switch(ndx) {
 		case 0:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -5772,7 +5772,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "pid_t";
 			break;
 		case 1:
-			p = "userland const struct sched_param *";
+			p = "userland const struct sched_param * __capability";
 			break;
 		default:
 			break;
@@ -5785,7 +5785,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "pid_t";
 			break;
 		case 1:
-			p = "userland struct sched_param *";
+			p = "userland struct sched_param * __capability";
 			break;
 		default:
 			break;
@@ -5801,7 +5801,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const struct sched_param *";
+			p = "userland const struct sched_param * __capability";
 			break;
 		default:
 			break;
@@ -5847,7 +5847,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "pid_t";
 			break;
 		case 1:
-			p = "userland struct timespec *";
+			p = "userland struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5857,7 +5857,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 335:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -5876,7 +5876,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -5886,7 +5886,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 338:
 		switch(ndx) {
 		case 0:
-			p = "userland struct jail *";
+			p = "userland struct jail * __capability";
 			break;
 		default:
 			break;
@@ -5899,13 +5899,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "int";
@@ -5921,10 +5921,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		case 2:
-			p = "userland sigset_t *";
+			p = "userland sigset_t * __capability";
 			break;
 		default:
 			break;
@@ -5934,7 +5934,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 341:
 		switch(ndx) {
 		case 0:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		default:
 			break;
@@ -5944,7 +5944,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 343:
 		switch(ndx) {
 		case 0:
-			p = "userland sigset_t *";
+			p = "userland sigset_t * __capability";
 			break;
 		default:
 			break;
@@ -5954,13 +5954,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 345:
 		switch(ndx) {
 		case 0:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		case 1:
-			p = "userland struct siginfo_native *";
+			p = "userland struct siginfo_native * __capability";
 			break;
 		case 2:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -5970,10 +5970,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 346:
 		switch(ndx) {
 		case 0:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		case 1:
-			p = "userland struct siginfo_native *";
+			p = "userland struct siginfo_native * __capability";
 			break;
 		default:
 			break;
@@ -5983,13 +5983,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 347:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -5999,13 +5999,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 348:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6021,7 +6021,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6037,7 +6037,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6047,7 +6047,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 351:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
@@ -6073,13 +6073,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 353:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6095,7 +6095,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6105,19 +6105,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 355:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
 			p = "int";
 			break;
 		case 4:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -6127,16 +6127,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 356:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -6149,16 +6149,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 357:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -6171,13 +6171,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 358:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -6187,10 +6187,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 359:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native **";
+			p = "userland struct aiocb_native * __capability * __capability";
 			break;
 		case 1:
-			p = "userland struct timespec *";
+			p = "userland struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -6200,13 +6200,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 360:
 		switch(ndx) {
 		case 0:
-			p = "userland uid_t *";
+			p = "userland uid_t * __capability";
 			break;
 		case 1:
-			p = "userland uid_t *";
+			p = "userland uid_t * __capability";
 			break;
 		case 2:
-			p = "userland uid_t *";
+			p = "userland uid_t * __capability";
 			break;
 		default:
 			break;
@@ -6216,13 +6216,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 361:
 		switch(ndx) {
 		case 0:
-			p = "userland gid_t *";
+			p = "userland gid_t * __capability";
 			break;
 		case 1:
-			p = "userland gid_t *";
+			p = "userland gid_t * __capability";
 			break;
 		case 2:
-			p = "userland gid_t *";
+			p = "userland gid_t * __capability";
 			break;
 		default:
 			break;
@@ -6241,10 +6241,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -6263,10 +6263,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -6285,7 +6285,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -6305,7 +6305,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 376:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -6346,7 +6346,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 378:
 		switch(ndx) {
 		case 0:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 1:
 			p = "unsigned int";
@@ -6362,7 +6362,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 384:
 		switch(ndx) {
 		case 0:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6372,7 +6372,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 385:
 		switch(ndx) {
 		case 0:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6385,7 +6385,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6395,10 +6395,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 387:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6411,7 +6411,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6421,10 +6421,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 389:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6437,10 +6437,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 3:
 			p = "int";
@@ -6453,7 +6453,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 391:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "u_long";
@@ -6466,7 +6466,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 392:
 		switch(ndx) {
 		case 0:
-			p = "userland struct uuid *";
+			p = "userland struct uuid * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -6491,10 +6491,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "size_t";
 			break;
 		case 4:
-			p = "userland struct sf_hdtr_native *";
+			p = "userland struct sf_hdtr_native * __capability";
 			break;
 		case 5:
-			p = "userland off_t *";
+			p = "userland off_t * __capability";
 			break;
 		case 6:
 			p = "int";
@@ -6507,13 +6507,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 394:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -6563,7 +6563,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 404:
 		switch(ndx) {
 		case 0:
-			p = "userland semid_t *";
+			p = "userland semid_t * __capability";
 			break;
 		case 1:
 			p = "unsigned int";
@@ -6576,10 +6576,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 405:
 		switch(ndx) {
 		case 0:
-			p = "userland semid_t *";
+			p = "userland semid_t * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -6598,7 +6598,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 406:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -6611,7 +6611,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "semid_t";
 			break;
 		case 1:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		default:
 			break;
@@ -6634,7 +6634,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "pid_t";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6644,10 +6644,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 410:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6657,10 +6657,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 411:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6670,16 +6670,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 412:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -6692,16 +6692,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 413:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -6714,13 +6714,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 414:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -6730,16 +6730,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 415:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		case 2:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		case 3:
-			p = "userland struct mac_native *";
+			p = "userland struct mac_native * __capability";
 			break;
 		default:
 			break;
@@ -6752,10 +6752,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct sigaction_native *";
+			p = "userland const struct sigaction_native * __capability";
 			break;
 		case 2:
-			p = "userland struct sigaction_native *";
+			p = "userland struct sigaction_native * __capability";
 			break;
 		default:
 			break;
@@ -6765,7 +6765,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 417:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct __ucontext *";
+			p = "userland const struct __ucontext * __capability";
 			break;
 		default:
 			break;
@@ -6775,7 +6775,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 421:
 		switch(ndx) {
 		case 0:
-			p = "userland struct __ucontext *";
+			p = "userland struct __ucontext * __capability";
 			break;
 		default:
 			break;
@@ -6785,7 +6785,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 422:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct __ucontext *";
+			p = "userland const struct __ucontext * __capability";
 			break;
 		default:
 			break;
@@ -6795,10 +6795,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 423:
 		switch(ndx) {
 		case 0:
-			p = "userland struct __ucontext *";
+			p = "userland struct __ucontext * __capability";
 			break;
 		case 1:
-			p = "userland const struct __ucontext *";
+			p = "userland const struct __ucontext * __capability";
 			break;
 		default:
 			break;
@@ -6808,7 +6808,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 424:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -6818,13 +6818,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 425:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6834,13 +6834,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 426:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6850,7 +6850,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 427:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
@@ -6863,13 +6863,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 428:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "acl_type_t";
 			break;
 		case 2:
-			p = "userland struct acl *";
+			p = "userland struct acl * __capability";
 			break;
 		default:
 			break;
@@ -6879,10 +6879,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 429:
 		switch(ndx) {
 		case 0:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		case 1:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		default:
 			break;
@@ -6892,10 +6892,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 430:
 		switch(ndx) {
 		case 0:
-			p = "userland struct __ucontext *";
+			p = "userland struct __ucontext * __capability";
 			break;
 		case 1:
-			p = "userland long *";
+			p = "userland long * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -6908,7 +6908,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 431:
 		switch(ndx) {
 		case 0:
-			p = "userland long *";
+			p = "userland long * __capability";
 			break;
 		default:
 			break;
@@ -6918,7 +6918,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 432:
 		switch(ndx) {
 		case 0:
-			p = "userland long *";
+			p = "userland long * __capability";
 			break;
 		default:
 			break;
@@ -6957,7 +6957,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -6970,13 +6970,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 438:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -6989,13 +6989,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 439:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -7011,7 +7011,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "semid_t";
 			break;
 		case 1:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -7021,7 +7021,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 442:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -7054,7 +7054,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 445:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "u_int";
@@ -7070,7 +7070,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -7083,7 +7083,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 447:
 		switch(ndx) {
 		case 0:
-			p = "userland uid_t *";
+			p = "userland uid_t * __capability";
 			break;
 		default:
 			break;
@@ -7093,7 +7093,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 448:
 		switch(ndx) {
 		case 0:
-			p = "userland uid_t *";
+			p = "userland uid_t * __capability";
 			break;
 		default:
 			break;
@@ -7103,7 +7103,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 449:
 		switch(ndx) {
 		case 0:
-			p = "userland struct auditinfo *";
+			p = "userland struct auditinfo * __capability";
 			break;
 		default:
 			break;
@@ -7113,7 +7113,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 450:
 		switch(ndx) {
 		case 0:
-			p = "userland struct auditinfo *";
+			p = "userland struct auditinfo * __capability";
 			break;
 		default:
 			break;
@@ -7123,7 +7123,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 451:
 		switch(ndx) {
 		case 0:
-			p = "userland struct auditinfo_addr *";
+			p = "userland struct auditinfo_addr * __capability";
 			break;
 		case 1:
 			p = "u_int";
@@ -7136,7 +7136,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 452:
 		switch(ndx) {
 		case 0:
-			p = "userland struct auditinfo_addr *";
+			p = "userland struct auditinfo_addr * __capability";
 			break;
 		case 1:
 			p = "u_int";
@@ -7149,7 +7149,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 453:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7159,7 +7159,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 454:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -7168,10 +7168,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "u_long";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 4:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -7181,7 +7181,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 455:
 		switch(ndx) {
 		case 0:
-			p = "userland struct thr_param *";
+			p = "userland struct thr_param * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -7200,7 +7200,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -7210,7 +7210,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 457:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -7219,7 +7219,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "mode_t";
 			break;
 		case 3:
-			p = "userland const struct mq_attr *";
+			p = "userland const struct mq_attr * __capability";
 			break;
 		default:
 			break;
@@ -7232,10 +7232,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct mq_attr *";
+			p = "userland const struct mq_attr * __capability";
 			break;
 		case 2:
-			p = "userland struct mq_attr *";
+			p = "userland struct mq_attr * __capability";
 			break;
 		default:
 			break;
@@ -7248,16 +7248,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 2:
 			p = "size_t";
 			break;
 		case 3:
-			p = "userland unsigned *";
+			p = "userland unsigned * __capability";
 			break;
 		case 4:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -7270,7 +7270,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -7279,7 +7279,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "unsigned";
 			break;
 		case 4:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -7292,7 +7292,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct sigevent_native *";
+			p = "userland const struct sigevent_native * __capability";
 			break;
 		default:
 			break;
@@ -7302,7 +7302,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 462:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7312,13 +7312,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 463:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland void **";
+			p = "userland void * __capability * __capability";
 			break;
 		default:
 			break;
@@ -7331,7 +7331,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "long";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7344,7 +7344,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -7360,7 +7360,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "lwpid_t";
 			break;
 		case 2:
-			p = "userland struct rtprio *";
+			p = "userland struct rtprio * __capability";
 			break;
 		default:
 			break;
@@ -7386,19 +7386,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 4:
 			p = "__socklen_t";
 			break;
 		case 5:
-			p = "userland struct sctp_sndrcvinfo *";
+			p = "userland struct sctp_sndrcvinfo * __capability";
 			break;
 		case 6:
 			p = "int";
@@ -7414,19 +7414,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 4:
 			p = "__socklen_t";
 			break;
 		case 5:
-			p = "userland struct sctp_sndrcvinfo *";
+			p = "userland struct sctp_sndrcvinfo * __capability";
 			break;
 		case 6:
 			p = "int";
@@ -7442,22 +7442,22 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland struct sockaddr *";
+			p = "userland struct sockaddr * __capability";
 			break;
 		case 4:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		case 5:
-			p = "userland struct sctp_sndrcvinfo *";
+			p = "userland struct sctp_sndrcvinfo * __capability";
 			break;
 		case 6:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		default:
 			break;
@@ -7470,7 +7470,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -7489,7 +7489,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -7505,7 +7505,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 477:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -7546,7 +7546,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 479:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "off_t";
@@ -7588,7 +7588,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 483:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7598,7 +7598,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 484:
 		switch(ndx) {
 		case 0:
-			p = "userland cpusetid_t *";
+			p = "userland cpusetid_t * __capability";
 			break;
 		default:
 			break;
@@ -7633,7 +7633,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "id_t";
 			break;
 		case 3:
-			p = "userland cpusetid_t *";
+			p = "userland cpusetid_t * __capability";
 			break;
 		default:
 			break;
@@ -7655,7 +7655,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "size_t";
 			break;
 		case 4:
-			p = "userland cpuset_t *";
+			p = "userland cpuset_t * __capability";
 			break;
 		default:
 			break;
@@ -7677,7 +7677,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "size_t";
 			break;
 		case 4:
-			p = "userland const cpuset_t *";
+			p = "userland const cpuset_t * __capability";
 			break;
 		default:
 			break;
@@ -7690,7 +7690,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -7709,7 +7709,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "mode_t";
@@ -7728,7 +7728,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "uid_t";
@@ -7750,10 +7750,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		case 2:
-			p = "userland char **";
+			p = "userland char * __capability * __capability";
 			break;
 		default:
 			break;
@@ -7766,10 +7766,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
-			p = "userland const struct timeval *";
+			p = "userland const struct timeval * __capability";
 			break;
 		default:
 			break;
@@ -7782,13 +7782,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 4:
 			p = "int";
@@ -7804,7 +7804,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "mode_t";
@@ -7820,7 +7820,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "mode_t";
@@ -7836,7 +7836,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -7855,10 +7855,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -7874,13 +7874,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7890,13 +7890,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 502:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7909,7 +7909,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -7932,7 +7932,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 505:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -7942,7 +7942,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 506:
 		switch(ndx) {
 		case 0:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 1:
 			p = "unsigned int";
@@ -7958,7 +7958,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 507:
 		switch(ndx) {
 		case 0:
-			p = "userland struct iovec_native *";
+			p = "userland struct iovec_native * __capability";
 			break;
 		case 1:
 			p = "unsigned int";
@@ -8003,7 +8003,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland union semun_native *";
+			p = "userland union semun_native * __capability";
 			break;
 		default:
 			break;
@@ -8019,7 +8019,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland struct msqid_ds *";
+			p = "userland struct msqid_ds * __capability";
 			break;
 		default:
 			break;
@@ -8035,7 +8035,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland struct shmid_ds *";
+			p = "userland struct shmid_ds * __capability";
 			break;
 		default:
 			break;
@@ -8045,7 +8045,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 513:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -8064,7 +8064,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland cap_rights_t *";
+			p = "userland cap_rights_t * __capability";
 			break;
 		default:
 			break;
@@ -8077,7 +8077,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 517:
 		switch(ndx) {
 		case 0:
-			p = "userland u_int *";
+			p = "userland u_int * __capability";
 			break;
 		default:
 			break;
@@ -8087,7 +8087,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 518:
 		switch(ndx) {
 		case 0:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -8116,7 +8116,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland pid_t *";
+			p = "userland pid_t * __capability";
 			break;
 		default:
 			break;
@@ -8129,19 +8129,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland fd_set *";
+			p = "userland fd_set * __capability";
 			break;
 		case 2:
-			p = "userland fd_set *";
+			p = "userland fd_set * __capability";
 			break;
 		case 3:
-			p = "userland fd_set *";
+			p = "userland fd_set * __capability";
 			break;
 		case 4:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		case 5:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		default:
 			break;
@@ -8151,7 +8151,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 523:
 		switch(ndx) {
 		case 0:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -8164,7 +8164,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 524:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -8174,13 +8174,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 525:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -8193,13 +8193,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 526:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -8212,13 +8212,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 527:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -8231,13 +8231,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 528:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -8250,13 +8250,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 529:
 		switch(ndx) {
 		case 0:
-			p = "userland const void *";
+			p = "userland const void * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
 			p = "size_t";
@@ -8310,16 +8310,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "id_t";
 			break;
 		case 2:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		case 3:
 			p = "int";
 			break;
 		case 4:
-			p = "userland struct __wrusage *";
+			p = "userland struct __wrusage * __capability";
 			break;
 		case 5:
-			p = "userland struct siginfo_native *";
+			p = "userland struct siginfo_native * __capability";
 			break;
 		default:
 			break;
@@ -8332,7 +8332,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland cap_rights_t *";
+			p = "userland cap_rights_t * __capability";
 			break;
 		default:
 			break;
@@ -8345,7 +8345,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const u_long *";
+			p = "userland const u_long * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -8361,7 +8361,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland u_long *";
+			p = "userland u_long * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -8390,7 +8390,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland uint32_t *";
+			p = "userland uint32_t * __capability";
 			break;
 		default:
 			break;
@@ -8406,7 +8406,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 3:
 			p = "__socklen_t";
@@ -8425,7 +8425,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "userland const struct sockaddr *";
+			p = "userland const struct sockaddr * __capability";
 			break;
 		case 3:
 			p = "__socklen_t";
@@ -8441,7 +8441,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "u_long";
@@ -8460,10 +8460,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct sockaddr *";
+			p = "userland struct sockaddr * __capability";
 			break;
 		case 2:
-			p = "userland __socklen_t *";
+			p = "userland __socklen_t * __capability";
 			break;
 		case 3:
 			p = "int";
@@ -8476,7 +8476,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 542:
 		switch(ndx) {
 		case 0:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -8489,7 +8489,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 543:
 		switch(ndx) {
 		case 0:
-			p = "userland struct aiocb_native *";
+			p = "userland struct aiocb_native * __capability";
 			break;
 		default:
 			break;
@@ -8508,7 +8508,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		default:
 			break;
@@ -8518,16 +8518,16 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 545:
 		switch(ndx) {
 		case 0:
-			p = "userland struct pollfd *";
+			p = "userland struct pollfd * __capability";
 			break;
 		case 1:
 			p = "u_int";
 			break;
 		case 2:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		case 3:
-			p = "userland const sigset_t *";
+			p = "userland const sigset_t * __capability";
 			break;
 		default:
 			break;
@@ -8540,7 +8540,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -8553,10 +8553,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		case 3:
 			p = "int";
@@ -8582,7 +8582,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct stat *";
+			p = "userland struct stat * __capability";
 			break;
 		default:
 			break;
@@ -8595,10 +8595,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
-			p = "userland struct stat *";
+			p = "userland struct stat * __capability";
 			break;
 		case 3:
 			p = "int";
@@ -8611,10 +8611,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 553:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct fhandle *";
+			p = "userland const struct fhandle * __capability";
 			break;
 		case 1:
-			p = "userland struct stat *";
+			p = "userland struct stat * __capability";
 			break;
 		default:
 			break;
@@ -8627,13 +8627,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 2:
 			p = "size_t";
 			break;
 		case 3:
-			p = "userland off_t *";
+			p = "userland off_t * __capability";
 			break;
 		default:
 			break;
@@ -8643,10 +8643,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 555:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland struct statfs *";
+			p = "userland struct statfs * __capability";
 			break;
 		default:
 			break;
@@ -8659,7 +8659,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct statfs *";
+			p = "userland struct statfs * __capability";
 			break;
 		default:
 			break;
@@ -8669,7 +8669,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 557:
 		switch(ndx) {
 		case 0:
-			p = "userland struct statfs *";
+			p = "userland struct statfs * __capability";
 			break;
 		case 1:
 			p = "long";
@@ -8685,10 +8685,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 558:
 		switch(ndx) {
 		case 0:
-			p = "userland const struct fhandle *";
+			p = "userland const struct fhandle * __capability";
 			break;
 		case 1:
-			p = "userland struct statfs *";
+			p = "userland struct statfs * __capability";
 			break;
 		default:
 			break;
@@ -8701,7 +8701,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "mode_t";
@@ -8720,19 +8720,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct kevent_native *";
+			p = "userland const struct kevent_native * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland struct kevent_native *";
+			p = "userland struct kevent_native * __capability";
 			break;
 		case 4:
 			p = "int";
 			break;
 		case 5:
-			p = "userland const struct timespec *";
+			p = "userland const struct timespec * __capability";
 			break;
 		default:
 			break;
@@ -8754,10 +8754,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "size_t";
 			break;
 		case 4:
-			p = "userland domainset_t *";
+			p = "userland domainset_t * __capability";
 			break;
 		case 5:
-			p = "userland int *";
+			p = "userland int * __capability";
 			break;
 		default:
 			break;
@@ -8779,7 +8779,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "size_t";
 			break;
 		case 4:
-			p = "userland domainset_t *";
+			p = "userland domainset_t * __capability";
 			break;
 		case 5:
 			p = "int";
@@ -8792,7 +8792,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 563:
 		switch(ndx) {
 		case 0:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 1:
 			p = "size_t";
@@ -8811,10 +8811,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 2:
-			p = "userland struct fhandle *";
+			p = "userland struct fhandle * __capability";
 			break;
 		case 3:
 			p = "int";
@@ -8827,10 +8827,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 565:
 		switch(ndx) {
 		case 0:
-			p = "userland struct fhandle *";
+			p = "userland struct fhandle * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -8840,13 +8840,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 566:
 		switch(ndx) {
 		case 0:
-			p = "userland struct fhandle *";
+			p = "userland struct fhandle * __capability";
 			break;
 		case 1:
 			p = "int";
 			break;
 		case 2:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -8856,10 +8856,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 567:
 		switch(ndx) {
 		case 0:
-			p = "userland struct fhandle *";
+			p = "userland struct fhandle * __capability";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "userland char * __capability";
 			break;
 		case 2:
 			p = "size_t";
@@ -8875,7 +8875,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -8894,13 +8894,13 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland off_t *";
+			p = "userland off_t * __capability";
 			break;
 		case 2:
 			p = "int";
 			break;
 		case 3:
-			p = "userland off_t *";
+			p = "userland off_t * __capability";
 			break;
 		case 4:
 			p = "size_t";
@@ -8916,19 +8916,19 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 570:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "size_t";
 			break;
 		case 2:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 3:
-			p = "userland size_t *";
+			p = "userland size_t * __capability";
 			break;
 		case 4:
-			p = "userland void *";
+			p = "userland void * __capability";
 			break;
 		case 5:
 			p = "size_t";
@@ -8941,7 +8941,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 571:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
 			p = "int";
@@ -8953,7 +8953,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 4:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		default:
 			break;
@@ -8963,10 +8963,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 572:
 		switch(ndx) {
 		case 0:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 1:
-			p = "userland const char *";
+			p = "userland const char * __capability";
 			break;
 		case 2:
 			p = "int";

--- a/sys/kern/sysv_sem.c
+++ b/sys/kern/sysv_sem.c
@@ -772,7 +772,7 @@ int
 sys___semctl(struct thread *td, struct __semctl_args *uap)
 {
 	struct semid_ds dsbuf;
-	usemun_t arg;
+	union semun_c arg;
 	ksemun_t semun;
 	register_t rval;
 	int error;
@@ -784,7 +784,7 @@ sys___semctl(struct thread *td, struct __semctl_args *uap)
 	case GETALL:
 	case SETVAL:
 	case SETALL:
-		error = copyin(__USER_CAP_OBJ(uap->arg), &arg, sizeof(arg));
+		error = copyincap(uap->arg, &arg, sizeof(arg));
 		if (error)
 			return (error);
 		break;
@@ -796,18 +796,14 @@ sys___semctl(struct thread *td, struct __semctl_args *uap)
 		semun.buf = &dsbuf;
 		break;
 	case IPC_SET:
-		error = copyin(__USER_CAP_OBJ(arg.buf), &dsbuf, sizeof(dsbuf));
+		error = copyin(arg.buf, &dsbuf, sizeof(dsbuf));
 		if (error)
 			return (error);
 		semun.buf = &dsbuf;
 		break;
 	case GETALL:
 	case SETALL:
-		/*
-		 * No easy way to set a better bound.  See comment in
-		 * kern_semctl().
-		 */
-		semun.array = __USER_CAP_UNBOUND(arg.array);
+		semun.array = arg.array;
 		break;
 	case SETVAL:
 		semun.val = arg.val;
@@ -822,7 +818,7 @@ sys___semctl(struct thread *td, struct __semctl_args *uap)
 	switch (uap->cmd) {
 	case SEM_STAT:
 	case IPC_STAT:
-		error = copyout(&dsbuf, __USER_CAP_OBJ(arg.buf), sizeof(dsbuf));
+		error = copyout(&dsbuf, arg.buf, sizeof(dsbuf));
 		break;
 	}
 
@@ -1312,8 +1308,7 @@ int
 sys_semop(struct thread *td, struct semop_args *uap)
 {
 
-	return (kern_semop(td, uap->semid,
-	    __USER_CAP_ARRAY(uap->sops, uap->nsops), uap->nsops));
+	return (kern_semop(td, uap->semid, uap->sops, uap->nsops));
 }
 
 static int
@@ -2043,7 +2038,7 @@ freebsd7___semctl(struct thread *td, struct freebsd7___semctl_args *uap)
 	case GETALL:
 	case SETVAL:
 	case SETALL:
-		error = copyin(__USER_CAP_OBJ(uap->arg), &arg, sizeof(arg));
+		error = copyin(uap->arg, &arg, sizeof(arg));
 		if (error)
 			return (error);
 		break;

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -413,7 +413,7 @@ int
 sys_shmdt(struct thread *td, struct shmdt_args *uap)
 {
 
-	return (kern_shmdt(td, __USER_CAP_UNBOUND(uap->shmaddr)));
+	return (kern_shmdt(td, uap->shmaddr));
 }
 
 static int
@@ -617,8 +617,7 @@ int
 sys_shmat(struct thread *td, struct shmat_args *uap)
 {
 
-	return (kern_shmat(td, uap->shmid, __USER_CAP_UNBOUND(uap->shmaddr),
-	    uap->shmflg));
+	return (kern_shmat(td, uap->shmid, uap->shmaddr, uap->shmflg));
 }
 
 static int
@@ -748,8 +747,7 @@ int
 sys_shmctl(struct thread *td, struct shmctl_args *uap)
 {
 
-	return (user_shmctl(td, uap->shmid, uap->cmd,
-	    __USER_CAP_OBJ(uap->buf)));
+	return (user_shmctl(td, uap->shmid, uap->cmd, uap->buf));
 }
 
 #ifdef COMPAT_CHERIABI

--- a/sys/kern/uipc_mqueue.c
+++ b/sys/kern/uipc_mqueue.c
@@ -2136,8 +2136,7 @@ int
 sys_kmq_open(struct thread *td, struct kmq_open_args *uap)
 {
 
-	return (user_kmq_open(td, __USER_CAP_STR(uap->path), uap->flags,
-	    uap->mode, __USER_CAP_OBJ(uap->attr)));
+	return (user_kmq_open(td, uap->path, uap->flags, uap->mode, uap->attr));
 }
 
 static int
@@ -2166,7 +2165,7 @@ int
 sys_kmq_unlink(struct thread *td, struct kmq_unlink_args *uap)
 {
 
-	return (kern_kmq_unlink(td, __USER_CAP_STR(uap->path)));
+	return (kern_kmq_unlink(td, uap->path));
 }
 
 static int
@@ -2286,8 +2285,7 @@ int
 sys_kmq_setattr(struct thread *td, struct kmq_setattr_args *uap)
 {
 
-	return (user_kmq_setattr(td, uap->mqd, __USER_CAP_OBJ(uap->attr),
-	    __USER_CAP_OBJ(uap->oattr)));
+	return (user_kmq_setattr(td, uap->mqd, uap->attr, uap->oattr));
 }
 
 static int
@@ -2316,9 +2314,8 @@ int
 sys_kmq_timedreceive(struct thread *td, struct kmq_timedreceive_args *uap)
 {
 
-	return (kern_timedreceive(td, uap->mqd, __USER_CAP(uap->msg_ptr,
-	    uap->msg_len), uap->msg_len, __USER_CAP_OBJ(uap->msg_prio),
-	    __USER_CAP_OBJ(uap->abs_timeout)));
+	return (kern_timedreceive(td, uap->mqd, uap->msg_ptr, uap->msg_len,
+	    uap->msg_prio, uap->abs_timeout));
 }
 
 static int
@@ -2355,9 +2352,8 @@ int
 sys_kmq_timedsend(struct thread *td, struct kmq_timedsend_args *uap)
 {
 
-	return (kern_kmq_timedsend(td, uap->mqd,
-	    __USER_CAP(uap->msg_ptr, uap->msg_len), uap->msg_len, uap->msg_prio,
-	    __USER_CAP_OBJ(uap->abs_timeout)));
+	return (kern_kmq_timedsend(td, uap->mqd, uap->msg_ptr, uap->msg_len,
+	    uap->msg_prio, uap->abs_timeout));
 }
 
 static int
@@ -2502,7 +2498,7 @@ sys_kmq_notify(struct thread *td, struct kmq_notify_args *uap)
 	if (uap->sigev == NULL) {
 		evp = NULL;
 	} else {
-		error = copyin(__USER_CAP_OBJ(uap->sigev), &ev_n, sizeof(ev));
+		error = copyin(uap->sigev, &ev_n, sizeof(ev));
 		if (error != 0)
 			return (error);
 		convert_sigevent(&ev_n, &ev);

--- a/sys/kern/uipc_sem.c
+++ b/sys/kern/uipc_sem.c
@@ -38,6 +38,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -122,9 +124,9 @@ static int	kern_sem_wait(struct thread *td, semid_t id, int tryflag,
 static int	ksem_access(struct ksem *ks, struct ucred *ucred);
 static struct ksem *ksem_alloc(struct ucred *ucred, mode_t mode,
 		    unsigned int value);
-static int	ksem_create(struct thread *td, const char *path,
-		    semid_t *semidp, mode_t mode, unsigned int value,
-		    int flags);
+static int	ksem_create(struct thread *td, const char * __capability path,
+		    semid_t * __capability semidp, mode_t mode,
+		    unsigned int value, int flags);
 static void	ksem_drop(struct ksem *ks);
 static int	ksem_get(struct thread *td, semid_t id, cap_rights_t *rightsp,
     struct file **fpp);
@@ -433,7 +435,8 @@ ksem_remove(char *path, Fnv32_t fnv, struct ucred *ucred)
 }
 
 static int
-ksem_create_copyout_semid(struct thread *td, semid_t *semidp, int fd)
+ksem_create_copyout_semid(struct thread *td, semid_t * __capability semidp,
+    int fd)
 {
 	semid_t semid;
 #ifdef COMPAT_FREEBSD32
@@ -460,8 +463,8 @@ ksem_create_copyout_semid(struct thread *td, semid_t *semidp, int fd)
 
 /* Other helper routines. */
 static int
-ksem_create(struct thread *td, const char * name, semid_t * semidp,
-    mode_t mode, unsigned int value, int flags)
+ksem_create(struct thread *td, const char * __capability name,
+    semid_t * __capability semidp, mode_t mode, unsigned int value, int flags)
 {
 	struct filedesc *fdp;
 	struct ksem *ks;

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -911,7 +911,7 @@ int
 freebsd12_shm_open(struct thread *td, struct freebsd12_shm_open_args *uap)
 {
 
-	return (kern_shm_open(td, __USER_CAP_STR(uap->path),
+	return (kern_shm_open(td, uap->path,
 	    uap->flags | O_CLOEXEC, uap->mode, NULL, F_SEAL_SEAL));
 }
 #endif
@@ -920,7 +920,7 @@ int
 sys_shm_unlink(struct thread *td, struct shm_unlink_args *uap)
 {
 
-	return (kern_shm_unlink(td, __USER_CAP_STR(uap->path)));
+	return (kern_shm_unlink(td, uap->path));
 }
 
 int
@@ -960,8 +960,8 @@ int
 sys_shm_rename(struct thread *td, struct shm_rename_args *uap)
 {
 
-	return (kern_shm_rename(td, __USER_CAP_STR(uap->path_from),
-	    __USER_CAP_STR(uap->path_to), uap->flags));
+	return (kern_shm_rename(td, uap->path_from,
+	    uap->path_to, uap->flags));
 }
 
 int
@@ -1516,8 +1516,8 @@ int
 sys_shm_open2(struct thread *td, struct shm_open2_args *uap)
 {
 
-	return (kern_shm_open2(td, __USER_CAP_STR(uap->path), uap->flags,
-	    uap->mode, uap->shmflags, __USER_CAP_STR(uap->name)));
+	return (kern_shm_open2(td, uap->path, uap->flags,
+	    uap->mode, uap->shmflags, uap->name));
 }
 // CHERI CHANGES START
 // {

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -166,8 +166,7 @@ int
 sys_bind(struct thread *td, struct bind_args *uap)
 {
 
-	return (user_bind(td, uap->s, __USER_CAP(uap->name, uap->namelen),
-	    uap->namelen));
+	return (user_bind(td, uap->s, uap->name, uap->namelen));
 }
 
 int
@@ -227,8 +226,7 @@ int
 sys_bindat(struct thread *td, struct bindat_args *uap)
 {
 
-	return(user_bindat(td, uap->fd, uap->s,
-	    __USER_CAP(uap->name, uap->namelen), uap->namelen));
+	return(user_bindat(td, uap->fd, uap->s, uap->name, uap->namelen));
 }
 
 int
@@ -442,8 +440,8 @@ int
 sys_accept(struct thread *td, struct accept_args *uap)
 {
 
-	return (user_accept(td, uap->s, __USER_CAP_UNBOUND(uap->name),
-	    __USER_CAP_OBJ(uap->anamelen), ACCEPT4_INHERIT));
+	return (user_accept(td, uap->s, uap->name, uap->anamelen,
+	    ACCEPT4_INHERIT));
 }
 
 int
@@ -453,8 +451,7 @@ sys_accept4(struct thread *td, struct accept4_args *uap)
 	if (uap->flags & ~(SOCK_CLOEXEC | SOCK_NONBLOCK))
 		return (EINVAL);
 
-	return (user_accept(td, uap->s, __USER_CAP_UNBOUND(uap->name),
-	    __USER_CAP_OBJ(uap->anamelen), uap->flags));
+	return (user_accept(td, uap->s, uap->name, uap->anamelen, uap->flags));
 }
 
 #ifdef COMPAT_OLDSOCK
@@ -462,8 +459,8 @@ int
 oaccept(struct thread *td, struct oaccept_args *uap)
 {
 
-	return (user_accept(td, uap->s, __USER_CAP_UNBCOUND(uap->name),
-	    __USER_CAP_OBJ(uap->anamelen), ACCEPT4_INHERIT | ACCEPT4_COMPAT));
+	return (user_accept(td, uap->s, uap->name, uap->anamelen,
+	    ACCEPT4_INHERIT | ACCEPT4_COMPAT));
 }
 #endif /* COMPAT_OLDSOCK */
 
@@ -471,8 +468,7 @@ int
 sys_connect(struct thread *td, struct connect_args *uap)
 {
 
-	return (user_connectat(td, AT_FDCWD, uap->s,
-	    __USER_CAP(uap->name, uap->namelen), uap->namelen));
+	return (user_connectat(td, AT_FDCWD, uap->s, uap->name, uap->namelen));
 }
 
 int
@@ -561,8 +557,7 @@ int
 sys_connectat(struct thread *td, struct connectat_args *uap)
 {
 
-	return (user_connectat(td, uap->fd, uap->s,
-	    __USER_CAP(uap->name, uap->namelen), uap->namelen));
+	return (user_connectat(td, uap->fd, uap->s, uap->name, uap->namelen));
 }
 
 int
@@ -660,7 +655,7 @@ sys_socketpair(struct thread *td, struct socketpair_args *uap)
 {
 
 	return (user_socketpair(td, uap->domain, uap->type, uap->protocol,
-	    __USER_CAP(uap->rsv, 2 * sizeof(int))));
+	    uap->rsv));
 }
 
 int
@@ -840,8 +835,8 @@ int
 sys_sendto(struct thread *td, struct sendto_args *uap)
 {
 
-	return (user_sendto(td, uap->s, __USER_CAP(uap->buf, uap->len),
-	    uap->len, uap->flags, __USER_CAP(uap->to, uap->tolen), uap->tolen));
+	return (user_sendto(td, uap->s, uap->buf,
+	    uap->len, uap->flags, uap->to, uap->tolen));
 }
 
 int
@@ -885,7 +880,7 @@ osend(struct thread *td, struct osend_args *uap)
 int
 osendmsg(struct thread *td, struct osendmsg_args *uap)
 {
-	kmsthdr_t msg;
+	struct msghdr msg;
 	struct omsghdr umsg;
 	struct iovec *iov;
 	int error;
@@ -917,7 +912,7 @@ sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 	struct iovec *iov;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->msg), &umsg, sizeof(umsg));
+	error = copyin(uap->msg, &umsg, sizeof(umsg));
 	if (error != 0)
 		return (error);
 	msg.msg_name = __USER_CAP(umsg.msg_name, umsg.msg_namelen);
@@ -1122,9 +1117,8 @@ int
 sys_recvfrom(struct thread *td, struct recvfrom_args *uap)
 {
 
-	return (kern_recvfrom(td, uap->s, __USER_CAP(uap->buf, uap->len),
-	    uap->len, uap->flags, __USER_CAP_UNBOUND(uap->from),
-	    __USER_CAP_OBJ(uap->fromlenaddr)));
+	return (kern_recvfrom(td, uap->s, uap->buf,
+	    uap->len, uap->flags, uap->from, uap->fromlenaddr));
 }
 
 int
@@ -1225,7 +1219,7 @@ sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 	struct iovec *iov;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->msg), &umsg, sizeof(umsg));
+	error = copyin(uap->msg, &umsg, sizeof(umsg));
 	if (error != 0)
 		return (error);
 	msg.msg_name = __USER_CAP(umsg.msg_name, umsg.msg_namelen);
@@ -1253,7 +1247,7 @@ sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 		umsg.msg_namelen = msg.msg_namelen;
 		umsg.msg_iovlen = msg.msg_iovlen;
 		umsg.msg_controllen = msg.msg_controllen;
-		error = copyout(&umsg, __USER_CAP_OBJ(uap->msg), sizeof(umsg));
+		error = copyout(&umsg, uap->msg, sizeof(umsg));
 	}
 	free(iov, M_IOV);
 	return (error);
@@ -1298,7 +1292,7 @@ sys_setsockopt(struct thread *td, struct setsockopt_args *uap)
 {
 
 	return (kern_setsockopt(td, uap->s, uap->level, uap->name,
-	    __USER_CAP(uap->val, uap->valsize), UIO_USERSPACE, uap->valsize));
+	    uap->val, UIO_USERSPACE, uap->valsize));
 }
 
 int
@@ -1347,7 +1341,7 @@ sys_getsockopt(struct thread *td, struct getsockopt_args *uap)
 {
 
 	return (user_getsockopt(td, uap->s, uap->level, uap->name,
-	    __USER_CAP_UNBOUND(uap->val), __USER_CAP_OBJ(uap->avalsize)));
+	    uap->val, uap->avalsize));
 }
 
 int
@@ -1490,8 +1484,7 @@ int
 sys_getsockname(struct thread *td, struct getsockname_args *uap)
 {
 
-	return (user_getsockname(td, uap->fdes,
-	    __USER_CAP_UNBOUND(uap->asa), __USER_CAP_OBJ(uap->alen), 0));
+	return (user_getsockname(td, uap->fdes, uap->asa, uap->alen, 0));
 }
 
 #ifdef COMPAT_OLDSOCK
@@ -1499,8 +1492,7 @@ int
 ogetsockname(struct thread *td, struct getsockname_args *uap)
 {
 
-	return (user_getsockname(td, uap->fdes,
-	    __USER_CAP_UNBOUND(uap->asa), __USER_CAP_OBJ(uap->alen), 1));
+	return (user_getsockname(td, uap->fdes, uap->asa, uap->alen, 1));
 }
 #endif /* COMPAT_OLDSOCK */
 
@@ -1582,8 +1574,7 @@ int
 sys_getpeername(struct thread *td, struct getpeername_args *uap)
 {
 
-	return (user_getpeername(td, uap->fdes, __USER_CAP_UNBOUND(uap->asa),
-	    __USER_CAP_OBJ(uap->alen), 0));
+	return (user_getpeername(td, uap->fdes, uap->asa, uap->alen, 0));
 }
 
 #ifdef COMPAT_OLDSOCK
@@ -1591,8 +1582,7 @@ int
 ogetpeername(struct thread *td, struct ogetpeername_args *uap)
 {
 
-	return (user_getpeername(td, uap->fdes, __USER_CAP_UNBOUND(uap->asa),
-	    __USER_CAP_OBJ(uap->alen), 1));
+	return (user_getpeername(td, uap->fdes, uap->asa, uap->alen, 1));
 }
 #endif /* COMPAT_OLDSOCK */
 

--- a/sys/kern/vfs_acl.c
+++ b/sys/kern/vfs_acl.c
@@ -353,8 +353,8 @@ int
 sys___acl_get_file(struct thread *td, struct __acl_get_file_args *uap)
 {
 
-	return (kern___acl_get_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), FOLLOW));
+	return (kern___acl_get_path(td, uap->path, uap->type, uap->aclp,
+	    FOLLOW));
 }
 
 /*
@@ -364,8 +364,8 @@ int
 sys___acl_get_link(struct thread *td, struct __acl_get_link_args *uap)
 {
 
-	return(kern___acl_get_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), NOFOLLOW));
+	return(kern___acl_get_path(td, uap->path, uap->type, uap->aclp,
+	    NOFOLLOW));
 }
 
 int
@@ -391,8 +391,8 @@ int
 sys___acl_set_file(struct thread *td, struct __acl_set_file_args *uap)
 {
 
-	return(kern___acl_set_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), FOLLOW));
+	return(kern___acl_set_path(td, uap->path, uap->type, uap->aclp,
+	    FOLLOW));
 }
 
 /*
@@ -402,8 +402,8 @@ int
 sys___acl_set_link(struct thread *td, struct __acl_set_link_args *uap)
 {
 
-	return(kern___acl_set_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), NOFOLLOW));
+	return(kern___acl_set_path(td, uap->path, uap->type, uap->aclp,
+	    NOFOLLOW));
 }
 
 int
@@ -429,8 +429,7 @@ int
 sys___acl_get_fd(struct thread *td, struct __acl_get_fd_args *uap)
 {
 
-	return (kern___acl_get_fd(td, uap->filedes, uap->type,
-	    __USER_CAP_OBJ(uap->aclp)));
+	return (kern___acl_get_fd(td, uap->filedes, uap->type, uap->aclp));
 }
 
 int
@@ -458,8 +457,7 @@ int
 sys___acl_set_fd(struct thread *td, struct __acl_set_fd_args *uap)
 {
 
-	return (kern___acl_set_fd(td, uap->filedes, uap->type,
-	    __USER_CAP_OBJ(uap->aclp)));
+	return (kern___acl_set_fd(td, uap->filedes, uap->type, uap->aclp));
 }
 
 int
@@ -487,8 +485,7 @@ int
 sys___acl_delete_file(struct thread *td, struct __acl_delete_file_args *uap)
 {
 
-	return (kern___acl_delete_path(td, __USER_CAP_STR(uap->path),
-	    uap->type, FOLLOW));
+	return (kern___acl_delete_path(td, uap->path, uap->type, FOLLOW));
 }
 
 /*
@@ -498,8 +495,7 @@ int
 sys___acl_delete_link(struct thread *td, struct __acl_delete_link_args *uap)
 {
 
-	return (kern___acl_delete_path(td, __USER_CAP_STR(uap->path),
-	    uap->type, NOFOLLOW));
+	return (kern___acl_delete_path(td, uap->path, uap->type, NOFOLLOW));
 }
 
 int
@@ -545,8 +541,8 @@ int
 sys___acl_aclcheck_file(struct thread *td, struct __acl_aclcheck_file_args *uap)
 {
 
-	return (kern___acl_aclcheck_path(td, __USER_CAP_STR(uap->path),
-	    uap->type, __USER_CAP_OBJ(uap->aclp), FOLLOW));
+	return (kern___acl_aclcheck_path(td, uap->path, uap->type, uap->aclp,
+	    FOLLOW));
 }
 
 /*
@@ -556,8 +552,8 @@ int
 sys___acl_aclcheck_link(struct thread *td, struct __acl_aclcheck_link_args *uap)
 {
 
-	return (kern___acl_aclcheck_path(td, __USER_CAP_STR(uap->path),
-	    uap->type, __USER_CAP_OBJ(uap->aclp), NOFOLLOW));
+	return (kern___acl_aclcheck_path(td, uap->path, uap->type, uap->aclp,
+	    NOFOLLOW));
 }
 
 int
@@ -583,8 +579,7 @@ int
 sys___acl_aclcheck_fd(struct thread *td, struct __acl_aclcheck_fd_args *uap)
 {
 
-	return (kern___acl_aclcheck_fd(td, uap->filedes, uap->type,
-	    __USER_CAP_OBJ(uap->aclp)));
+	return (kern___acl_aclcheck_fd(td, uap->filedes, uap->type, uap->aclp));
 }
 
 int

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1950,8 +1950,7 @@ int
 sys_aio_return(struct thread *td, struct aio_return_args *uap)
 {
 
-	return (kern_aio_return(td, __USER_CAP_OBJ(uap->aiocbp),
-	    &aiocb_ops));
+	return (kern_aio_return(td, uap->aiocbp, &aiocb_ops));
 }
 
 /*
@@ -2029,8 +2028,7 @@ sys_aio_suspend(struct thread *td, struct aio_suspend_args *uap)
 
 	if (uap->timeout) {
 		/* Get timespec struct. */
-		if ((error = copyin(__USER_CAP_OBJ(uap->timeout), &ts,
-		    sizeof(ts))) != 0)
+		if ((error = copyin(uap->timeout, &ts, sizeof(ts))) != 0)
 			return (error);
 		tsp = &ts;
 	} else
@@ -2038,8 +2036,7 @@ sys_aio_suspend(struct thread *td, struct aio_suspend_args *uap)
 
 	ujoblist = malloc(uap->nent * sizeof(ujoblist[0]), M_AIOS, M_WAITOK);
 	ujoblist_native = (kaiocb_t **)ujoblist;
-	error = copyin(__USER_CAP_UNBOUND(uap->aiocbp), ujoblist,
-	    uap->nent * sizeof(ujoblist[0]));
+	error = copyin(uap->aiocbp, ujoblist, uap->nent * sizeof(ujoblist[0]));
 	if (error == 0)
 		error = kern_aio_suspend(td, uap->nent, ujoblist, tsp);
 	for (i = uap->nent - 1; i >= 0; i--)
@@ -2131,8 +2128,7 @@ int
 sys_aio_cancel(struct thread *td, struct aio_cancel_args *uap)
 {
 
-	return(kern_aio_cancel(td, uap->fd, __USER_CAP_OBJ(uap->aiocbp),
-	    &aiocb_ops));
+	return(kern_aio_cancel(td, uap->fd, uap->aiocbp, &aiocb_ops));
 }
 
 /*
@@ -2190,7 +2186,8 @@ int
 sys_aio_error(struct thread *td, struct aio_error_args *uap)
 {
 
-	return (kern_aio_error(td, __USER_CAP_OBJ(uap->aiocbp), &aiocb_ops));
+	return (kern_aio_error(td, (kaiocb_t * __capability)uap->aiocbp,
+	    &aiocb_ops));
 }
 
 /* syscall - asynchronous read from a file (REALTIME) */
@@ -2200,7 +2197,7 @@ freebsd6_aio_read(struct thread *td, struct freebsd6_aio_read_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (kaiocb_t * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (kaiocb_t * __capability)uap->aiocbp,
 	    &uap->aiocbp, NULL, LIO_READ, &aiocb_ops_osigevent));
 }
 #endif
@@ -2210,7 +2207,7 @@ sys_aio_read(struct thread *td, struct aio_read_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (kaiocb_t * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (kaiocb_t * __capability)uap->aiocbp,
 	    &uap->aiocbp, NULL, LIO_READ, &aiocb_ops));
 }
 
@@ -2221,7 +2218,7 @@ freebsd6_aio_write(struct thread *td, struct freebsd6_aio_write_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (kaiocb_t * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (kaiocb_t * __capability)uap->aiocbp,
 	    &uap->aiocbp, NULL, LIO_WRITE, &aiocb_ops_osigevent));
 }
 #endif
@@ -2231,7 +2228,7 @@ sys_aio_write(struct thread *td, struct aio_write_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (kaiocb_t * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (kaiocb_t * __capability)uap->aiocbp,
 	    &uap->aiocbp, NULL, LIO_WRITE, &aiocb_ops));
 }
 
@@ -2240,7 +2237,7 @@ sys_aio_mlock(struct thread *td, struct aio_mlock_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (kaiocb_t * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (kaiocb_t * __capability)uap->aiocbp,
 	    &uap->aiocbp, NULL, LIO_MLOCK, &aiocb_ops));
 }
 
@@ -2453,7 +2450,7 @@ sys_lio_listio(struct thread *td, struct lio_listio_args *uap)
 		return (EINVAL);
 
 	if (uap->sig && (uap->mode == LIO_NOWAIT)) {
-		error = copyin(__USER_CAP_OBJ(uap->sig), &sig, sizeof(sig));
+		error = copyin(uap->sig, &sig, sizeof(sig));
 		if (error)
 			return (error);
 		sigp = &sig;
@@ -2463,8 +2460,7 @@ sys_lio_listio(struct thread *td, struct lio_listio_args *uap)
 	acb_list = malloc(sizeof(kaiocb_t * __capability) * nent, M_LIO,
 	    M_WAITOK);
 	acb_list_native = (kaiocb_t **)acb_list;
-	error = copyin(__USER_CAP_UNBOUND(uap->acb_list), acb_list,
-	    nent * sizeof(acb_list[0]));
+	error = copyin(uap->acb_list, acb_list, nent * sizeof(acb_list[0]));
 	if (error == 0) {
 		for (i = nent - 1; i >= 0; i--)
 			acb_list[i] = __USER_CAP_OBJ(acb_list_native[i]);
@@ -2598,15 +2594,15 @@ sys_aio_waitcomplete(struct thread *td, struct aio_waitcomplete_args *uap)
 
 	if (uap->timeout) {
 		/* Get timespec struct. */
-		error = copyin(__USER_CAP_OBJ(uap->timeout), &ts, sizeof(ts));
+		error = copyin(uap->timeout, &ts, sizeof(ts));
 		if (error)
 			return (error);
 		tsp = &ts;
 	} else
 		tsp = NULL;
 
-	return (kern_aio_waitcomplete(td, __USER_CAP_OBJ(uap->aiocbp), tsp,
-	    &aiocb_ops));
+	return (kern_aio_waitcomplete(td, (kaiocb_t ** __capability)uap->aiocbp,
+	    tsp, &aiocb_ops));
 }
 
 static int
@@ -2623,8 +2619,9 @@ int
 sys_aio_fsync(struct thread *td, struct aio_fsync_args *uap)
 {
 
-	return (kern_aio_fsync(td, uap->op, __USER_CAP_OBJ(uap->aiocbp),
-	    &uap->aiocbp, &aiocb_ops));
+	return (kern_aio_fsync(td, uap->op,
+	    (kaiocb_t * __capability)uap->aiocbp, &uap->aiocbp,
+	    &aiocb_ops));
 }
 
 /* kqueue attach function */

--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -2228,8 +2228,8 @@ int
 sys___getcwd(struct thread *td, struct __getcwd_args *uap)
 {
 
-	return (kern___getcwd(td, __USER_CAP(uap->buf, uap->buflen),
-	    UIO_USERSPACE, uap->buflen, MAXPATHLEN));
+	return (kern___getcwd(td, uap->buf, UIO_USERSPACE, uap->buflen,
+	    MAXPATHLEN));
 }
 
 int

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -72,9 +72,8 @@ int
 sys_extattrctl(struct thread *td, struct extattrctl_args *uap)
 {
 
-	return (kern_extattrctl(td, __USER_CAP_STR(uap->path), uap->cmd,
-	    __USER_CAP_STR(uap->filename), uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname)));
+	return (kern_extattrctl(td, uap->path, uap->cmd, uap->filename,
+	    uap->attrnamespace, uap->attrname));
 }
 
 int
@@ -235,8 +234,7 @@ sys_extattr_set_fd(struct thread *td, struct extattr_set_fd_args *uap)
 {
 
 	return (kern_extattr_set_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname), __USER_CAP(uap->data, uap->nbytes),
-	    uap->nbytes));
+	    uap->attrname, uap->data, uap->nbytes));
 }
 
 int
@@ -281,9 +279,8 @@ int
 sys_extattr_set_file(struct thread *td, struct extattr_set_file_args *uap)
 {
 
-	return (kern_extattr_set_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
+	return (kern_extattr_set_path(td, uap->path, uap->attrnamespace,
+	    uap->attrname, uap->data, uap->nbytes, FOLLOW));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -299,9 +296,8 @@ int
 sys_extattr_set_link(struct thread *td, struct extattr_set_link_args *uap)
 {
 
-	return (kern_extattr_set_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
+	return (kern_extattr_set_path(td, uap->path, uap->attrnamespace,
+	    uap->attrname, uap->data, uap->nbytes, NOFOLLOW));
 }
 
 int
@@ -416,8 +412,7 @@ sys_extattr_get_fd(struct thread *td, struct extattr_get_fd_args *uap)
 {
 
 	return (kern_extattr_get_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes));
+	    uap->attrname, uap->data, uap->nbytes));
 }
 
 int
@@ -461,9 +456,8 @@ struct extattr_get_file_args {
 int
 sys_extattr_get_file(struct thread *td, struct extattr_get_file_args *uap)
 {
-	return (kern_extattr_get_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
+	return (kern_extattr_get_path(td, uap->path, uap->attrnamespace,
+	    uap->attrname, uap->data, uap->nbytes, FOLLOW));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -478,9 +472,8 @@ struct extattr_get_link_args {
 int
 sys_extattr_get_link(struct thread *td, struct extattr_get_link_args *uap)
 {
-	return (kern_extattr_get_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
+	return (kern_extattr_get_path(td, uap->path, uap->attrnamespace,
+	    uap->attrname, uap->data, uap->nbytes, NOFOLLOW));
 }
 
 int
@@ -565,7 +558,7 @@ sys_extattr_delete_fd(struct thread *td, struct extattr_delete_fd_args *uap)
 {
 
 	return (kern_extattr_delete_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname)));
+	    uap->attrname));
 }
 
 int
@@ -606,8 +599,8 @@ int
 sys_extattr_delete_file(struct thread *td, struct extattr_delete_file_args *uap)
 {
 
-	return (kern_extattr_delete_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname), FOLLOW));
+	return (kern_extattr_delete_path(td, uap->path, uap->attrnamespace,
+	    uap->attrname, FOLLOW));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -621,8 +614,8 @@ int
 sys_extattr_delete_link(struct thread *td, struct extattr_delete_link_args *uap)
 {
 
-	return (kern_extattr_delete_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname), NOFOLLOW));
+	return (kern_extattr_delete_path(td, uap->path, uap->attrnamespace,
+	    uap->attrname, NOFOLLOW));
 }
 
 int
@@ -726,7 +719,7 @@ sys_extattr_list_fd(struct thread *td, struct extattr_list_fd_args *uap)
 {
 
 	return (kern_extattr_list_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes));
+	    uap->data, uap->nbytes));
 }
 
 int
@@ -762,9 +755,8 @@ int
 sys_extattr_list_file(struct thread *td, struct extattr_list_file_args *uap)
 {
 
-	return (kern_extattr_list_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP(uap->data, uap->nbytes),
-	    uap->nbytes, FOLLOW));
+	return (kern_extattr_list_path(td, uap->path, uap->attrnamespace,
+	    uap->data, uap->nbytes, FOLLOW));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -779,9 +771,8 @@ int
 sys_extattr_list_link(struct thread *td, struct extattr_list_link_args *uap)
 {
 
-	return (kern_extattr_list_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP(uap->data, uap->nbytes),
-	    uap->nbytes, NOFOLLOW));
+	return (kern_extattr_list_path(td, uap->path, uap->attrnamespace,
+	    uap->data, uap->nbytes, NOFOLLOW));
 }
 
 int

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -408,8 +408,8 @@ int
 sys_nmount(struct thread *td, struct nmount_args *uap)
 {
 
-	return (kern_nmount(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
-	    uap->iovcnt, uap->flags, (copyinuio_t *)copyinuio));
+	return (kern_nmount(td, uap->iovp, uap->iovcnt, uap->flags,
+	    (copyinuio_t *)copyinuio));
 }
 
 int
@@ -873,7 +873,7 @@ sys_mount(struct thread *td, struct mount_args *uap)
 	flags &= ~MNT_ROOTFS;
 
 	fstype = malloc(MFSNAMELEN, M_TEMP, M_WAITOK);
-	error = copyinstr(__USER_CAP_STR(uap->type), fstype, MFSNAMELEN, NULL);
+	error = copyinstr(uap->type, fstype, MFSNAMELEN, NULL);
 	if (error) {
 		free(fstype, M_TEMP);
 		return (error);
@@ -1311,7 +1311,7 @@ int
 sys_unmount(struct thread *td, struct unmount_args *uap)
 {
 
-	return (kern_unmount(td, __USER_CAP_STR(uap->path), uap->flags));
+	return (kern_unmount(td, uap->path, uap->flags));
 }
 
 int
@@ -2216,7 +2216,8 @@ mount_argf(struct mntarg *ma, const char *name, const char *fmt, ...)
  * Add an argument which is a userland string.
  */
 struct mntarg *
-mount_argsu(struct mntarg *ma, const char *name, const void *val, int len)
+mount_argsu(struct mntarg *ma, const char *name, const void * __capability val,
+    int len)
 {
 	struct mntaarg *maa;
 	char *tbuf;
@@ -2232,7 +2233,7 @@ mount_argsu(struct mntarg *ma, const char *name, const void *val, int len)
 	maa = malloc(sizeof *maa + len, M_MOUNT, M_WAITOK | M_ZERO);
 	SLIST_INSERT_HEAD(&ma->list, maa, next);
 	tbuf = (void *)(maa + 1);
-	ma->error = copyinstr(__USER_CAP_STR(val), tbuf, len, NULL);
+	ma->error = copyinstr(val, tbuf, len, NULL);
 	return (mount_arg(ma, name, tbuf, -1));
 }
 

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -162,8 +162,7 @@ struct quotactl_args {
 int
 sys_quotactl(struct thread *td, struct quotactl_args *uap)
 {
-	return (kern_quotactl(td, __USER_CAP_STR(uap->path),
-	    uap->cmd, uap->uid, __USER_CAP_UNBOUND(uap->arg)));
+	return (kern_quotactl(td, uap->path, uap->cmd, uap->uid, uap->arg));
 }
 
 int
@@ -291,8 +290,7 @@ int
 sys_statfs(struct thread *td, struct statfs_args *uap)
 {
 
-	return (user_statfs(td, __USER_CAP_STR(uap->path),
-	    __USER_CAP_OBJ(uap->buf)));
+	return (user_statfs(td, uap->path, uap->buf));
 }
 
 int
@@ -343,7 +341,7 @@ int
 sys_fstatfs(struct thread *td, struct fstatfs_args *uap)
 {
 
-	return (user_fstatfs(td, uap->fd, __USER_CAP_OBJ(uap->buf)));
+	return (user_fstatfs(td, uap->fd, uap->buf));
 }
 
 int
@@ -399,8 +397,7 @@ int
 sys_getfsstat(struct thread *td, struct getfsstat_args *uap)
 {
 
-	return (user_getfsstat(td, __USER_CAP(uap->buf, uap->bufsize),
-	    uap->bufsize, uap->mode));
+	return (user_getfsstat(td, uap->buf, uap->bufsize, uap->mode));
 }
 
 int
@@ -567,10 +564,10 @@ freebsd4_statfs(struct thread *td, struct freebsd4_statfs_args *uap)
 	int error;
 
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, __USER_CAP_STR(uap->path), UIO_USERSPACE, sfp);
+	error = kern_statfs(td, uap->path, UIO_USERSPACE, sfp);
 	if (error == 0) {
 		freebsd4_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -596,7 +593,7 @@ freebsd4_fstatfs(struct thread *td, struct freebsd4_fstatfs_args *uap)
 	error = kern_fstatfs(td, uap->fd, sfp);
 	if (error == 0) {
 		freebsd4_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -635,8 +632,7 @@ freebsd4_getfsstat(struct thread *td, struct freebsd4_getfsstat_args *uap)
 		sp = (__cheri_fromcap struct statfs *)buf;
 		while (count != 0 && error == 0) {
 			freebsd4_cvtstatfs(sp, &osb);
-			error = copyout(&osb, __USER_CAP_OBJ(uap->buf),
-			    sizeof(osb));
+			error = copyout(&osb, uap->buf, sizeof(osb));
 			sp++;
 			uap->buf++;
 			count--;
@@ -663,14 +659,14 @@ freebsd4_fhstatfs(struct thread *td, struct freebsd4_fhstatfs_args *uap)
 	fhandle_t fh;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
+	error = copyin(uap->u_fhp, &fh, sizeof(fhandle_t));
 	if (error != 0)
 		return (error);
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
 	error = kern_fhstatfs(td, fh, sfp);
 	if (error == 0) {
 		freebsd4_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -723,10 +719,10 @@ freebsd11_statfs(struct thread *td, struct freebsd11_statfs_args *uap)
 	int error;
 
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, __USER_CAP_STR(uap->path), UIO_USERSPACE, sfp);
+	error = kern_statfs(td, uap->path, UIO_USERSPACE, sfp);
 	if (error == 0) {
 		freebsd11_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -746,7 +742,7 @@ freebsd11_fstatfs(struct thread *td, struct freebsd11_fstatfs_args *uap)
 	error = kern_fstatfs(td, uap->fd, sfp);
 	if (error == 0) {
 		freebsd11_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -774,8 +770,7 @@ freebsd11_getfsstat(struct thread *td, struct freebsd11_getfsstat_args *uap)
 		sp = (__cheri_fromcap struct statfs *)buf;
 		while (count > 0 && error == 0) {
 			freebsd11_cvtstatfs(sp, &osb);
-			error = copyout(&osb, __USER_CAP_OBJ(uap->buf),
-			    sizeof(osb));
+			error = copyout(&osb, uap->buf, sizeof(osb));
 			sp++;
 			uap->buf++;
 			count--;
@@ -796,14 +791,14 @@ freebsd11_fhstatfs(struct thread *td, struct freebsd11_fhstatfs_args *uap)
 	fhandle_t fh;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
+	error = copyin(uap->u_fhp, &fh, sizeof(fhandle_t));
 	if (error)
 		return (error);
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
 	error = kern_fhstatfs(td, fh, sfp);
 	if (error == 0) {
 		freebsd11_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -901,7 +896,7 @@ int
 sys_chdir(struct thread *td, struct chdir_args *uap)
 {
 
-	return (kern_chdir(td, __USER_CAP_STR(uap->path), UIO_USERSPACE));
+	return (kern_chdir(td, uap->path, UIO_USERSPACE));
 }
 
 int
@@ -938,7 +933,7 @@ int
 sys_chroot(struct thread *td, struct chroot_args *uap)
 {
 
-	return (kern_chroot(td, __USER_CAP_STR(uap->path)));
+	return (kern_chroot(td, uap->path));
 }
 
 int
@@ -1047,8 +1042,8 @@ int
 sys_open(struct thread *td, struct open_args *uap)
 {
 
-	return (kern_openat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->flags, uap->mode));
+	return (kern_openat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->flags, uap->mode));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -1064,8 +1059,8 @@ sys_openat(struct thread *td, struct openat_args *uap)
 {
 
 	AUDIT_ARG_FD(uap->fd);
-	return (kern_openat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->flag, uap->mode));
+	return (kern_openat(td, uap->fd, uap->path, UIO_USERSPACE, uap->flag,
+	    uap->mode));
 }
 
 int
@@ -1241,8 +1236,8 @@ int
 sys_mknodat(struct thread *td, struct mknodat_args *uap)
 {
 
-	return (kern_mknodat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode, uap->dev));
+	return (kern_mknodat(td, uap->fd, uap->path, UIO_USERSPACE, uap->mode,
+	    uap->dev));
 }
 
 #if defined(COMPAT_FREEBSD11)
@@ -1251,8 +1246,8 @@ freebsd11_mknod(struct thread *td,
     struct freebsd11_mknod_args *uap)
 {
 
-	return (kern_mknodat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode, uap->dev));
+	return (kern_mknodat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->mode, uap->dev));
 }
 
 int
@@ -1260,8 +1255,8 @@ freebsd11_mknodat(struct thread *td,
     struct freebsd11_mknodat_args *uap)
 {
 
-	return (kern_mknodat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode, uap->dev));
+	return (kern_mknodat(td, uap->fd, uap->path, UIO_USERSPACE, uap->mode,
+	    uap->dev));
 }
 #endif /* COMPAT_FREEBSD11 */
 
@@ -1375,8 +1370,8 @@ int
 sys_mkfifo(struct thread *td, struct mkfifo_args *uap)
 {
 
-	return (kern_mkfifoat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode));
+	return (kern_mkfifoat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->mode));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -1390,8 +1385,8 @@ int
 sys_mkfifoat(struct thread *td, struct mkfifoat_args *uap)
 {
 
-	return (kern_mkfifoat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode));
+	return (kern_mkfifoat(td, uap->fd, uap->path, UIO_USERSPACE,
+	    uap->mode));
 }
 
 int
@@ -1461,8 +1456,8 @@ int
 sys_link(struct thread *td, struct link_args *uap)
 {
 
-	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    __USER_CAP_STR(uap->to), UIO_USERSPACE, FOLLOW));
+	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, uap->path, uap->to,
+	    UIO_USERSPACE, FOLLOW));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -1483,10 +1478,9 @@ sys_linkat(struct thread *td, struct linkat_args *uap)
 	if ((flag & ~(AT_SYMLINK_FOLLOW | AT_BENEATH)) != 0)
 		return (EINVAL);
 
-	return (kern_linkat(td, uap->fd1, uap->fd2, __USER_CAP_STR(uap->path1),
-	    __USER_CAP_STR(uap->path2), UIO_USERSPACE,
-	    ((flag & AT_SYMLINK_FOLLOW) ? FOLLOW : NOFOLLOW) |
-	    ((flag & AT_BENEATH) != 0 ? BENEATH : 0)));
+	return (kern_linkat(td, uap->fd1, uap->fd2, uap->path1, uap->path2,
+	    UIO_USERSPACE, ((flag & AT_SYMLINK_FOLLOW) != 0 ? FOLLOW :
+	    NOFOLLOW) | ((flag & AT_BENEATH) != 0 ? BENEATH : 0)));
 }
 
 int hardlink_check_uid = 0;
@@ -1636,8 +1630,8 @@ int
 sys_symlink(struct thread *td, struct symlink_args *uap)
 {
 
-	return (kern_symlinkat(td, __USER_CAP_STR(uap->path), AT_FDCWD,
-	    __USER_CAP_STR(uap->link), UIO_USERSPACE));
+	return (kern_symlinkat(td, uap->path, AT_FDCWD, uap->link,
+	    UIO_USERSPACE));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -1651,8 +1645,8 @@ int
 sys_symlinkat(struct thread *td, struct symlinkat_args *uap)
 {
 
-	return (kern_symlinkat(td, __USER_CAP_STR(uap->path1), uap->fd,
-	    __USER_CAP_STR(uap->path2), UIO_USERSPACE));
+	return (kern_symlinkat(td, uap->path1, uap->fd, uap->path2,
+	    UIO_USERSPACE));
 }
 
 int
@@ -1735,7 +1729,7 @@ int
 sys_undelete(struct thread *td, struct undelete_args *uap)
 {
 
-	return (kern_undelete(td, __USER_CAP_STR(uap->path), UIO_USERSPACE));
+	return (kern_undelete(td, uap->path, UIO_USERSPACE));
 }
 
 int
@@ -1789,8 +1783,8 @@ int
 sys_unlink(struct thread *td, struct unlink_args *uap)
 {
 
-	return (kern_funlinkat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    FD_NONE, UIO_USERSPACE, 0, 0));
+	return (kern_funlinkat(td, AT_FDCWD, uap->path, FD_NONE, UIO_USERSPACE,
+	    0, 0));
 }
 
 int
@@ -1818,8 +1812,8 @@ int
 sys_unlinkat(struct thread *td, struct unlinkat_args *uap)
 {
 
-	return (kern_funlinkat_ex(td, uap->fd, __USER_CAP_STR(uap->path),
-	    FD_NONE, uap->flag, UIO_USERSPACE, 0));
+	return (kern_funlinkat_ex(td, uap->fd, uap->path, FD_NONE, uap->flag,
+	    UIO_USERSPACE, 0));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -1834,8 +1828,8 @@ int
 sys_funlinkat(struct thread *td, struct funlinkat_args *uap)
 {
 
-	return (kern_funlinkat_ex(td, uap->dfd, __USER_CAP_STR(uap->path),
-	    uap->fd, uap->flag, UIO_USERSPACE, 0));
+	return (kern_funlinkat_ex(td, uap->dfd, uap->path, uap->fd, uap->flag,
+	    UIO_USERSPACE, 0));
 }
 
 int
@@ -2033,8 +2027,8 @@ int
 sys_access(struct thread *td, struct access_args *uap)
 {
 
-	return (kern_accessat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, 0, uap->amode));
+	return (kern_accessat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    0, uap->amode));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -2049,8 +2043,8 @@ int
 sys_faccessat(struct thread *td, struct faccessat_args *uap)
 {
 
-	return (kern_accessat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->flag, uap->amode));
+	return (kern_accessat(td, uap->fd, uap->path, UIO_USERSPACE, uap->flag,
+	    uap->amode));
 }
 
 int
@@ -2113,8 +2107,8 @@ int
 sys_eaccess(struct thread *td, struct eaccess_args *uap)
 {
 
-	return (kern_accessat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, AT_EACCESS, uap->amode));
+	return (kern_accessat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    AT_EACCESS, uap->amode));
 }
 
 #if defined(COMPAT_43)
@@ -2277,13 +2271,13 @@ freebsd11_stat(struct thread *td, struct freebsd11_stat_args* uap)
 	struct freebsd11_stat osb;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, &sb, NULL);
+	error = kern_statat(td, 0, AT_FDCWD, uap->path, UIO_USERSPACE, &sb,
+	    NULL);
 	if (error != 0)
 		return (error);
 	error = freebsd11_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->ub), sizeof(osb));
+		error = copyout(&osb, uap->ub, sizeof(osb));
 	return (error);
 }
 
@@ -2295,12 +2289,12 @@ freebsd11_lstat(struct thread *td, struct freebsd11_lstat_args* uap)
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE, &sb, NULL);
+	    uap->path, UIO_USERSPACE, &sb, NULL);
 	if (error != 0)
 		return (error);
 	error = freebsd11_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->ub), sizeof(osb));
+		error = copyout(&osb, uap->ub, sizeof(osb));
 	return (error);
 }
 
@@ -2312,7 +2306,7 @@ freebsd11_fhstat(struct thread *td, struct freebsd11_fhstat_args* uap)
 	struct freebsd11_stat osb;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
+	error = copyin(uap->u_fhp, &fh, sizeof(fhandle_t));
 	if (error != 0)
 		return (error);
 	error = kern_fhstat(td, fh, &sb);
@@ -2320,7 +2314,7 @@ freebsd11_fhstat(struct thread *td, struct freebsd11_fhstat_args* uap)
 		return (error);
 	error = freebsd11_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->sb), sizeof(osb));
+		error = copyout(&osb, uap->sb, sizeof(osb));
 	return (error);
 }
 
@@ -2331,13 +2325,13 @@ freebsd11_fstatat(struct thread *td, struct freebsd11_fstatat_args* uap)
 	struct freebsd11_stat osb;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, &sb, NULL);
+	error = kern_statat(td, uap->flag, uap->fd, uap->path, UIO_USERSPACE,
+	    &sb, NULL);
 	if (error != 0)
 		return (error);
 	error = freebsd11_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, uap->buf, sizeof(osb));
 	return (error);
 }
 #endif	/* COMPAT_FREEBSD11 */
@@ -2357,8 +2351,7 @@ int
 sys_fstatat(struct thread *td, struct fstatat_args *uap)
 {
 
-	return (user_fstatat(td, uap->fd, __USER_CAP_STR(uap->path), 
-	    __USER_CAP_OBJ(uap->buf), uap->flag));
+	return (user_fstatat(td, uap->fd, uap->path, uap->buf, uap->flag));
 }
 
 int
@@ -2458,12 +2451,12 @@ freebsd11_nstat(struct thread *td, struct freebsd11_nstat_args *uap)
 	struct nstat nsb;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, uap->path,
 	    UIO_USERSPACE, &sb, NULL);
 	if (error != 0)
 		return (error);
 	freebsd11_cvtnstat(&sb, &nsb);
-	return (copyout(&nsb, __USER_CAP_OBJ(uap->ub), sizeof (nsb)));
+	return (copyout(&nsb, uap->ub, sizeof (nsb)));
 }
 
 /*
@@ -2483,11 +2476,11 @@ freebsd11_nlstat(struct thread *td, struct freebsd11_nlstat_args *uap)
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE, &sb, NULL);
+	    uap->path, UIO_USERSPACE, &sb, NULL);
 	if (error != 0)
 		return (error);
 	freebsd11_cvtnstat(&sb, &nsb);
-	return (copyout(&nsb, __USER_CAP_OBJ(uap->ub), sizeof (nsb)));
+	return (copyout(&nsb, uap->ub, sizeof (nsb)));
 }
 #endif /* COMPAT_FREEBSD11 */
 
@@ -2506,7 +2499,7 @@ sys_pathconf(struct thread *td, struct pathconf_args *uap)
 	long value;
 	int error;
 
-	error = kern_pathconf(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
+	error = kern_pathconf(td, uap->path, UIO_USERSPACE,
 	    uap->name, FOLLOW, &value);
 	if (error == 0)
 		td->td_retval[0] = value;
@@ -2525,7 +2518,7 @@ sys_lpathconf(struct thread *td, struct lpathconf_args *uap)
 	long value;
 	int error;
 
-	error = kern_pathconf(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
+	error = kern_pathconf(td, uap->path, UIO_USERSPACE,
 	    uap->name, NOFOLLOW, &value);
 	if (error == 0)
 		td->td_retval[0] = value;
@@ -2564,10 +2557,8 @@ int
 sys_readlink(struct thread *td, struct readlink_args *uap)
 {
 
-	return (kern_readlinkat(td, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE,
-	    __USER_CAP(uap->buf, uap->count), UIO_USERSPACE,
-	    uap->count));
+	return (kern_readlinkat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->buf, UIO_USERSPACE, uap->count));
 }
 #ifndef _SYS_SYSPROTO_H_
 struct readlinkat_args {
@@ -2581,10 +2572,8 @@ int
 sys_readlinkat(struct thread *td, struct readlinkat_args *uap)
 {
 
-	return (kern_readlinkat(td, uap->fd,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE,
-	    __USER_CAP(uap->buf, uap->bufsize), UIO_USERSPACE,
-	    uap->bufsize));
+	return (kern_readlinkat(td, uap->fd, uap->path, UIO_USERSPACE,
+	    uap->buf, UIO_USERSPACE, uap->bufsize));
 }
 
 int
@@ -2700,8 +2689,8 @@ int
 sys_chflags(struct thread *td, struct chflags_args *uap)
 {
 
-	return (kern_chflagsat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->flags, 0));
+	return (kern_chflagsat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->flags, 0));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -2719,8 +2708,8 @@ sys_chflagsat(struct thread *td, struct chflagsat_args *uap)
 	if ((uap->atflag & ~(AT_SYMLINK_NOFOLLOW | AT_BENEATH)) != 0)
 		return (EINVAL);
 
-	return (kern_chflagsat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->flags, uap->atflag));
+	return (kern_chflagsat(td, uap->fd, uap->path, UIO_USERSPACE,
+	    uap->flags, uap->atflag));
 }
 
 /*
@@ -2736,8 +2725,8 @@ int
 sys_lchflags(struct thread *td, struct lchflags_args *uap)
 {
 
-	return (kern_chflagsat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->flags, AT_SYMLINK_NOFOLLOW));
+	return (kern_chflagsat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->flags, AT_SYMLINK_NOFOLLOW));
 }
 
 int
@@ -2829,8 +2818,8 @@ int
 sys_chmod(struct thread *td, struct chmod_args *uap)
 {
 
-	return (kern_fchmodat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode, 0));
+	return (kern_fchmodat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->mode, 0));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -2848,8 +2837,8 @@ sys_fchmodat(struct thread *td, struct fchmodat_args *uap)
 	if ((uap->flag & ~(AT_SYMLINK_NOFOLLOW | AT_BENEATH)) != 0)
 		return (EINVAL);
 
-	return (kern_fchmodat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode, uap->flag));
+	return (kern_fchmodat(td, uap->fd, uap->path, UIO_USERSPACE,
+	    uap->mode, uap->flag));
 }
 
 /*
@@ -2865,8 +2854,8 @@ int
 sys_lchmod(struct thread *td, struct lchmod_args *uap)
 {
 
-	return (kern_fchmodat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode, AT_SYMLINK_NOFOLLOW));
+	return (kern_fchmodat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->mode, AT_SYMLINK_NOFOLLOW));
 }
 
 int
@@ -2957,8 +2946,8 @@ int
 sys_chown(struct thread *td, struct chown_args *uap)
 {
 
-	return (kern_fchownat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->uid, uap->gid, 0));
+	return (kern_fchownat(td, AT_FDCWD, uap->path, UIO_USERSPACE, uap->uid,
+	    uap->gid, 0));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -2977,8 +2966,8 @@ sys_fchownat(struct thread *td, struct fchownat_args *uap)
 	if ((uap->flag & ~(AT_SYMLINK_NOFOLLOW | AT_BENEATH)) != 0)
 		return (EINVAL);
 
-	return (kern_fchownat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->uid, uap->gid, uap->flag));
+	return (kern_fchownat(td, uap->fd, uap->path, UIO_USERSPACE, uap->uid,
+	    uap->gid, uap->flag));
 }
 
 int
@@ -3016,8 +3005,8 @@ int
 sys_lchown(struct thread *td, struct lchown_args *uap)
 {
 
-	return (kern_fchownat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->uid, uap->gid, AT_SYMLINK_NOFOLLOW));
+	return (kern_fchownat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->uid, uap->gid, AT_SYMLINK_NOFOLLOW));
 }
 
 /*
@@ -3178,8 +3167,8 @@ int
 sys_utimes(struct thread *td, struct utimes_args *uap)
 {
 
-	return (kern_utimesat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->tptr), UIO_USERSPACE));
+	return (kern_utimesat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->tptr, UIO_USERSPACE));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -3193,9 +3182,8 @@ int
 sys_futimesat(struct thread *td, struct futimesat_args *uap)
 {
 
-	return (kern_utimesat(td, uap->fd,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->times), UIO_USERSPACE));
+	return (kern_utimesat(td, uap->fd, uap->path, UIO_USERSPACE,
+	    uap->times, UIO_USERSPACE));
 }
 
 int
@@ -3233,8 +3221,8 @@ int
 sys_lutimes(struct thread *td, struct lutimes_args *uap)
 {
 
-	return (kern_lutimes(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->tptr), UIO_USERSPACE));
+	return (kern_lutimes(td, uap->path, UIO_USERSPACE, uap->tptr,
+	    UIO_USERSPACE));
 }
 
 int
@@ -3270,8 +3258,7 @@ int
 sys_futimes(struct thread *td, struct futimes_args *uap)
 {
 
-	return (kern_futimes(td, uap->fd, __USER_CAP_OBJ(uap->tptr),
-	    UIO_USERSPACE));
+	return (kern_futimes(td, uap->fd, uap->tptr, UIO_USERSPACE));
 }
 
 int
@@ -3303,8 +3290,7 @@ int
 sys_futimens(struct thread *td, struct futimens_args *uap)
 {
 
-	return (kern_futimens(td, uap->fd, __USER_CAP_OBJ(uap->times),
-	    UIO_USERSPACE));
+	return (kern_futimens(td, uap->fd, uap->times, UIO_USERSPACE));
 }
 
 int
@@ -3338,9 +3324,8 @@ int
 sys_utimensat(struct thread *td, struct utimensat_args *uap)
 {
 
-	return (kern_utimensat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->times),
-	    UIO_USERSPACE, uap->flag));
+	return (kern_utimensat(td, uap->fd, uap->path, UIO_USERSPACE,
+	    uap->times, UIO_USERSPACE, uap->flag));
 }
 
 int
@@ -3390,8 +3375,7 @@ int
 sys_truncate(struct thread *td, struct truncate_args *uap)
 {
 
-	return (kern_truncate(td, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->length));
+	return (kern_truncate(td, uap->path, UIO_USERSPACE, uap->length));
 }
 
 int
@@ -3550,9 +3534,8 @@ int
 sys_rename(struct thread *td, struct rename_args *uap)
 {
 
-	return (kern_renameat(td, AT_FDCWD,
-	    __USER_CAP_STR(uap->from), AT_FDCWD,
-	    __USER_CAP_STR(uap->to), UIO_USERSPACE));
+	return (kern_renameat(td, AT_FDCWD, uap->from, AT_FDCWD,
+	    uap->to, UIO_USERSPACE));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -3567,9 +3550,8 @@ int
 sys_renameat(struct thread *td, struct renameat_args *uap)
 {
 
-	return (kern_renameat(td, uap->oldfd,
-	    __USER_CAP_STR(uap->old), uap->newfd,
-	    __USER_CAP_STR(uap->new), UIO_USERSPACE));
+	return (kern_renameat(td, uap->oldfd, uap->old, uap->newfd, uap->new,
+	    UIO_USERSPACE));
 }
 
 int
@@ -3716,8 +3698,8 @@ int
 sys_mkdir(struct thread *td, struct mkdir_args *uap)
 {
 
-	return (kern_mkdirat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode));
+	return (kern_mkdirat(td, AT_FDCWD, uap->path, UIO_USERSPACE,
+	    uap->mode));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -3731,8 +3713,7 @@ int
 sys_mkdirat(struct thread *td, struct mkdirat_args *uap)
 {
 
-	return (kern_mkdirat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, uap->mode));
+	return (kern_mkdirat(td, uap->fd, uap->path, UIO_USERSPACE, uap->mode));
 }
 
 int
@@ -3809,8 +3790,8 @@ int
 sys_rmdir(struct thread *td, struct rmdir_args *uap)
 {
 
-	return (kern_frmdirat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    FD_NONE, UIO_USERSPACE, 0));
+	return (kern_frmdirat(td, AT_FDCWD, uap->path, FD_NONE, UIO_USERSPACE,
+	    0));
 }
 
 int
@@ -4056,12 +4037,11 @@ freebsd11_getdirentries(struct thread *td,
 	long base;
 	int error;
 
-	error = freebsd11_kern_getdirentries(td, uap->fd,
-	    __USER_CAP(uap->buf, uap->count), uap->count, &base, NULL);
+	error = freebsd11_kern_getdirentries(td, uap->fd, uap->buf, uap->count,
+	    &base, NULL);
 
 	if (error == 0 && uap->basep != NULL)
-		error = copyout(&base, __USER_CAP(uap->basep, sizeof(long)),
-		    sizeof(long));
+		error = copyout(&base, uap->basep, sizeof(long));
 	return (error);
 }
 
@@ -4085,9 +4065,8 @@ int
 sys_getdirentries(struct thread *td, struct getdirentries_args *uap)
 {
 
-	return (user_getdirentries(td, uap->fd,
-	    __USER_CAP(uap->buf, uap->count), uap->count,
-	    __USER_CAP_OBJ(uap->basep)));
+	return (user_getdirentries(td, uap->fd, uap->buf, uap->count,
+	    uap->basep));
 }
 
 int
@@ -4214,8 +4193,7 @@ int
 sys_revoke(struct thread *td, struct revoke_args *uap)
 {
 
-	return (kern_revoke(td, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE));
+	return (kern_revoke(td, uap->path, UIO_USERSPACE));
 }
 
 int
@@ -4306,9 +4284,8 @@ int
 sys_lgetfh(struct thread *td, struct lgetfh_args *uap)
 {
 
-	return (kern_getfhat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->fname), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->fhp)));
+	return (kern_getfhat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD, uap->fname,
+	    UIO_USERSPACE, uap->fhp));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -4321,8 +4298,8 @@ int
 sys_getfh(struct thread *td, struct getfh_args *uap)
 {
 
-	return (kern_getfhat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->fname),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->fhp)));
+	return (kern_getfhat(td, 0, AT_FDCWD, uap->fname, UIO_USERSPACE,
+	    uap->fhp));
 }
 
 /*
@@ -4346,9 +4323,8 @@ sys_getfhat(struct thread *td, struct getfhat_args *uap)
 
 	if ((uap->flags & ~(AT_SYMLINK_NOFOLLOW | AT_BENEATH)) != 0)
 		return (EINVAL);
-	return (kern_getfhat(td, uap->flags, uap->fd,
-	    __USER_CAP_STR(uap->path), UIO_SYSSPACE,
-	    __USER_CAP_OBJ(uap->fhp)));
+	return (kern_getfhat(td, uap->flags, uap->fd, uap->path, UIO_SYSSPACE,
+	    uap->fhp));
 }
 
 int
@@ -4392,8 +4368,7 @@ int
 sys_fhlink(struct thread *td, struct fhlink_args *uap)
 {
 
-	return (kern_fhlinkat(td, AT_FDCWD, __USER_CAP_STR(uap->to),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->fhp)));
+	return (kern_fhlinkat(td, AT_FDCWD, uap->to, UIO_USERSPACE, uap->fhp));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -4407,8 +4382,7 @@ int
 sys_fhlinkat(struct thread *td, struct fhlinkat_args *uap)
 {
 
-	return (kern_fhlinkat(td, uap->tofd, __USER_CAP_STR(uap->to),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->fhp)));
+	return (kern_fhlinkat(td, uap->tofd, uap->to, UIO_USERSPACE, uap->fhp));
 }
 
 int
@@ -4450,8 +4424,7 @@ int
 sys_fhreadlink(struct thread *td, struct fhreadlink_args *uap)
 {
 	
-	return (kern_fhreadlink(td, __USER_CAP_OBJ(uap->fhp),
-	    __USER_CAP(uap->buf, uap->bufsize), uap->bufsize));
+	return (kern_fhreadlink(td, uap->fhp, uap->buf, uap->bufsize));
 }
 
 int
@@ -4499,7 +4472,7 @@ int
 sys_fhopen(struct thread *td, struct fhopen_args *uap)
 {
 
-	return (kern_fhopen(td, __USER_CAP_OBJ(uap->u_fhp), uap->flags));
+	return (kern_fhopen(td, uap->u_fhp, uap->flags));
 }
 
 int
@@ -4591,8 +4564,7 @@ int
 sys_fhstat(struct thread *td, struct fhstat_args *uap)
 {
 
-	return (user_fhstat(td, __USER_CAP_OBJ(uap->u_fhp),
-	    __USER_CAP_OBJ(uap->sb)));
+	return (user_fhstat(td, uap->u_fhp, uap->sb));
 }
 
 int
@@ -4646,8 +4618,7 @@ int
 sys_fhstatfs(struct thread *td, struct fhstatfs_args *uap)
 {
 
-	return (user_fhstatfs(td, __USER_CAP_OBJ(uap->u_fhp),
-	    __USER_CAP_OBJ(uap->buf)));
+	return (user_fhstatfs(td, uap->u_fhp, uap->buf));
 }
 
 int
@@ -5027,9 +4998,8 @@ int
 sys_copy_file_range(struct thread *td, struct copy_file_range_args *uap)
 {
 
-	return (user_copy_file_range(td, uap->infd,
-	    __USER_CAP_OBJ(uap->inoffp), uap->outfd,
-	    __USER_CAP_OBJ(uap->outoffp), uap->len, uap->flags));
+	return (user_copy_file_range(td, uap->infd, uap->inoffp, uap->outfd,
+	    uap->outoffp, uap->len, uap->flags));
 }
 
 int

--- a/sys/kgssapi/gss_impl.c
+++ b/sys/kgssapi/gss_impl.c
@@ -134,7 +134,7 @@ int
 sys_gssd_syscall(struct thread *td, struct gssd_syscall_args *uap)
 {
 
-	return (kern_gssd_syscall(td, __USER_CAP_STR(uap->path)));
+	return (kern_gssd_syscall(td, uap->path));
 }
 
 #ifdef COMPAT_CHERIABI

--- a/sys/mips/mips/pm_machdep.c
+++ b/sys/mips/mips/pm_machdep.c
@@ -37,6 +37,8 @@
  *	JNPR: pm_machdep.c,v 1.9.2.1 2007/08/16 15:59:10 girish
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -278,7 +280,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	}
 	free(cfp, M_TEMP);
 #endif
-	if (copyout(&sf, sfp, sizeof(struct sigframe)) != 0) {
+	if (copyout(&sf, __USER_CAP_OBJ(sfp), sizeof(struct sigframe)) != 0) {
 		/*
 		 * Something is wrong with the stack pointer.
 		 * ...Kill the process.

--- a/sys/nfs/nfssvc.h
+++ b/sys/nfs/nfssvc.h
@@ -77,9 +77,9 @@
 
 /* Argument structure for NFSSVC_DUMPMNTOPTS. */
 struct nfscl_dumpmntopts {
-	char	*ndmnt_fname;		/* File Name */
+	char * __kerncap ndmnt_fname;		/* File Name */
 	size_t	ndmnt_blen;		/* Size of buffer */
-	void	*ndmnt_buf;		/* and the buffer */
+	void * __kerncap ndmnt_buf;		/* and the buffer */
 };
 
 #endif /* _NFS_NFSSVC_H */

--- a/sys/nfsserver/nfs.h
+++ b/sys/nfsserver/nfs.h
@@ -106,7 +106,7 @@ struct nfsd_addsock_args {
  * Start processing requests.
  */
 struct nfsd_nfsd_args {
-	const char *principal;	/* GSS-API service principal name */
+	const char * __kerncap principal; /* GSS-API service principal name */
 	int	minthreads;	/* minimum service thread count */
 	int	maxthreads;	/* maximum service thread count */
 };

--- a/sys/nlm/nlm_prot_impl.c
+++ b/sys/nlm/nlm_prot_impl.c
@@ -27,6 +27,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include "opt_inet6.h"
 
 #include <sys/cdefs.h>
@@ -1406,7 +1408,8 @@ extern void nlm_prog_3(struct svc_req *rqstp, SVCXPRT *transp);
 extern void nlm_prog_4(struct svc_req *rqstp, SVCXPRT *transp);
 
 static int
-nlm_register_services(SVCPOOL *pool, int addr_count, char **addrs)
+nlm_register_services(SVCPOOL *pool, int addr_count,
+    char * __capability * __capability addrs)
 {
 	static rpcvers_t versions[] = {
 		NLM_SM, NLM_VERS, NLM_VERSX, NLM_VERS4
@@ -1441,10 +1444,10 @@ nlm_register_services(SVCPOOL *pool, int addr_count, char **addrs)
 			 * same transports.
 			 */
 			if (i == 0) {
-				char *up;
+				char * __capability up;
 
 				error = copyin(&addrs[2*j], &up,
-				    sizeof(char*));
+				    sizeof(up));
 				if (error)
 					goto out;
 				error = copyinstr(up, netid, sizeof(netid),
@@ -1452,7 +1455,7 @@ nlm_register_services(SVCPOOL *pool, int addr_count, char **addrs)
 				if (error)
 					goto out;
 				error = copyin(&addrs[2*j+1], &up,
-				    sizeof(char*));
+				    sizeof(up));
 				if (error)
 					goto out;
 				error = copyinstr(up, uaddr, sizeof(uaddr),
@@ -1505,7 +1508,7 @@ out:
  * by a signal.
  */
 static int
-nlm_server_main(int addr_count, char **addrs)
+nlm_server_main(int addr_count, char * __capability * __capability addrs)
 {
 	struct thread *td = curthread;
 	int error;

--- a/sys/security/audit/audit_syscalls.c
+++ b/sys/security/audit/audit_syscalls.c
@@ -74,8 +74,7 @@ int
 sys_audit(struct thread *td, struct audit_args *uap)
 {
 
-	return (kern_audit(td, __USER_CAP(uap->record, uap->length),
-	    uap->length));
+	return (kern_audit(td, uap->record, uap->length));
 }
 
 int
@@ -176,8 +175,7 @@ int
 sys_auditon(struct thread *td, struct auditon_args *uap)
 {
 
-	return (kern_auditon(td, uap->cmd, __USER_CAP(uap->data, uap->length),
-	    uap->length));
+	return (kern_auditon(td, uap->cmd, uap->data, uap->length));
 }
 
 int
@@ -615,7 +613,7 @@ int
 sys_getauid(struct thread *td, struct getauid_args *uap)
 {
 
-	return (kern_getauid(td, __USER_CAP_OBJ(uap->auid)));
+	return (kern_getauid(td, uap->auid));
 }
 
 int
@@ -637,7 +635,7 @@ int
 sys_setauid(struct thread *td, struct setauid_args *uap)
 {
 
-	return (kern_setauid(td, __USER_CAP_OBJ(uap->auid)));
+	return (kern_setauid(td, uap->auid));
 }
 
 int
@@ -684,7 +682,7 @@ int
 sys_getaudit(struct thread *td, struct getaudit_args *uap)
 {
 
-	return (kern_getaudit(td, __USER_CAP_OBJ(uap->auditinfo)));
+	return (kern_getaudit(td, uap->auditinfo));
 }
 
 int
@@ -716,7 +714,7 @@ int
 sys_setaudit(struct thread *td, struct setaudit_args *uap)
 {
 
-	return (kern_setaudit(td, __USER_CAP_OBJ(uap->auditinfo)));
+	return (kern_setaudit(td, uap->auditinfo));
 }
 
 int
@@ -766,8 +764,7 @@ int
 sys_getaudit_addr(struct thread *td, struct getaudit_addr_args *uap)
 {
 
-	return (kern_getaudit_addr(td,
-	    __USER_CAP(uap->auditinfo_addr, uap->length), uap->length));
+	return (kern_getaudit_addr(td, uap->auditinfo_addr, uap->length));
 }
 
 int
@@ -792,8 +789,7 @@ int
 sys_setaudit_addr(struct thread *td, struct setaudit_addr_args *uap)
 {
 
-	return (kern_setaudit_addr(td,
-	    __USER_CAP(uap->auditinfo_addr, uap->length), uap->length));
+	return (kern_setaudit_addr(td, uap->auditinfo_addr, uap->length));
 }
 
 int
@@ -844,7 +840,7 @@ int
 sys_auditctl(struct thread *td, struct auditctl_args *uap)
 {
 
-	return (kern_auditctl(td, __USER_CAP_STR(uap->path)));
+	return (kern_auditctl(td, uap->path));
 }
 
 int

--- a/sys/security/mac/mac_syscalls.c
+++ b/sys/security/mac/mac_syscalls.c
@@ -83,7 +83,7 @@ int
 sys___mac_get_pid(struct thread *td, struct __mac_get_pid_args *uap)
 {
 
-	return (kern_mac_get_pid(td, uap->pid, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_get_pid(td, uap->pid, uap->mac_p));
 }
 
 int
@@ -139,7 +139,7 @@ int
 sys___mac_get_proc(struct thread *td, struct __mac_get_proc_args *uap)
 {
 
-	return (kern_mac_get_proc(td, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_get_proc(td, uap->mac_p));
 }
 
 int
@@ -179,7 +179,7 @@ int
 sys___mac_set_proc(struct thread *td, struct __mac_set_proc_args *uap)
 {
 
-	return (kern_mac_set_proc(td, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_set_proc(td, uap->mac_p));
 }
 
 int
@@ -247,7 +247,7 @@ int
 sys___mac_get_fd(struct thread *td, struct __mac_get_fd_args *uap)
 {
 
-	return (kern_mac_get_fd(td, uap->fd, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_get_fd(td, uap->fd, uap->mac_p));
 }
 
 int
@@ -347,16 +347,14 @@ int
 sys___mac_get_file(struct thread *td, struct __mac_get_file_args *uap)
 {
 
-	return (kern_mac_get_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), FOLLOW));
+	return (kern_mac_get_path(td, uap->path_p, uap->mac_p, FOLLOW));
 }
 
 int
 sys___mac_get_link(struct thread *td, struct __mac_get_link_args *uap)
 {
 
-	return (kern_mac_get_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), NOFOLLOW));
+	return (kern_mac_get_path(td, uap->path_p, uap->mac_p, NOFOLLOW));
 }
 
 int
@@ -414,7 +412,7 @@ int
 sys___mac_set_fd(struct thread *td, struct __mac_set_fd_args *uap)
 {
 
-	return (kern_mac_set_fd(td, uap->fd, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_set_fd(td, uap->fd, uap->mac_p));
 }
 
 int
@@ -522,16 +520,14 @@ int
 sys___mac_set_file(struct thread *td, struct __mac_set_file_args *uap)
 {
 
-	return (kern_mac_set_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), FOLLOW));
+	return (kern_mac_set_path(td, uap->path_p, uap->mac_p, FOLLOW));
 }
 
 int
 sys___mac_set_link(struct thread *td, struct __mac_set_link_args *uap)
 {
 
-	return (kern_mac_set_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), NOFOLLOW));
+	return (kern_mac_set_path(td, uap->path_p, uap->mac_p, NOFOLLOW));
 }
 
 int
@@ -590,8 +586,7 @@ int
 sys_mac_syscall(struct thread *td, struct mac_syscall_args *uap)
 {
 
-	return (kern_mac_syscall(td, __USER_CAP_STR(uap->policy), uap->call,
-	    __USER_CAP_UNBOUND(uap->arg)));
+	return (kern_mac_syscall(td, uap->policy, uap->call, uap->arg));
 }
 
 int

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -35,21 +35,21 @@
 #ifdef _KERNEL
 struct jail_v0 {
 	u_int32_t	version;
-	char		*path;
-	char		*hostname;
+	char * __kerncap path;
+	char * __kerncap hostname;
 	u_int32_t	ip_number;
 };
 #endif
 
 struct jail {
 	uint32_t	version;
-	char		*path;
-	char		*hostname;
-	char		*jailname;
+	char * __kerncap path;
+	char * __kerncap hostname;
+	char * __kerncap jailname;
 	uint32_t	ip4s;
 	uint32_t	ip6s;
-	struct in_addr	*ip4;
-	struct in6_addr	*ip6;
+	struct in_addr * __kerncap ip4;
+	struct in6_addr	* __kerncap ip6;
 };
 #define	JAIL_API_VERSION	2
 

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -335,7 +335,7 @@ struct kld_file_stat {
 
 struct kld_sym_lookup {
     int		version;	/* set to sizeof(struct kld_sym_lookup) */
-    char	*symname;	/* Symbol name we are looking up */
+    char * __kerncap symname;	/* Symbol name we are looking up */
     u_long	symvalue;
     size_t	symsize;
 };

--- a/sys/sys/mount.h
+++ b/sys/sys/mount.h
@@ -674,7 +674,8 @@ struct mntarg;
  * implement vfs_cmount.  Hopefully a future cleanup can remove vfs_cmount and
  * mount(2) entirely.
  */
-typedef int vfs_cmount_t(struct mntarg *ma, void *data, uint64_t flags);
+typedef int vfs_cmount_t(struct mntarg *ma, void * __capability data,
+		    uint64_t flags);
 typedef int vfs_unmount_t(struct mount *mp, int mntflags);
 typedef int vfs_root_t(struct mount *mp, int flags, struct vnode **vpp);
 typedef	int vfs_quotactl_t(struct mount *mp, int cmds, uid_t uid,
@@ -875,7 +876,7 @@ int	kernel_vmount(int flags, ...);
 struct mntarg *mount_arg(struct mntarg *ma, const char *name, const void *val, int len);
 struct mntarg *mount_argb(struct mntarg *ma, int flag, const char *name);
 struct mntarg *mount_argf(struct mntarg *ma, const char *name, const char *fmt, ...);
-struct mntarg *mount_argsu(struct mntarg *ma, const char *name, const void *val, int len);
+struct mntarg *mount_argsu(struct mntarg *ma, const char *name, const void * __capability val, int len);
 void	statfs_scale_blocks(struct statfs *sf, long max_size);
 struct vfsconf *vfs_byname(const char *);
 struct vfsconf *vfs_byname_kld(const char *, struct thread *td, int *);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -90,7 +90,7 @@ int	kern___acl_set_path(struct thread *td, const char *__capability path,
 int	kern___getcwd(struct thread *td, char * __capability buf,
 	    enum uio_seg bufseg, size_t buflen, size_t path_max);
 int	kern_abort2(struct thread *td, const char * __capability why,
-            int nargs, void **uargs);
+            int nargs, void * __capability *uargs);
 int	kern_accept(struct thread *td, int s, struct sockaddr **name,
 	    socklen_t *namelen, struct file **fp);
 int	kern_accept4(struct thread *td, int s, struct sockaddr **name,

--- a/sys/sys/sysproto.h
+++ b/sys/sys/sysproto.h
@@ -54,16 +54,16 @@ struct fork_args {
 };
 struct read_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(void *)]; void * buf; char buf_r_[PADR_(void *)];
+	char buf_l_[PADL_(void * __capability)]; void * __capability buf; char buf_r_[PADR_(void * __capability)];
 	char nbyte_l_[PADL_(size_t)]; size_t nbyte; char nbyte_r_[PADR_(size_t)];
 };
 struct write_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(const void *)]; const void * buf; char buf_r_[PADR_(const void *)];
+	char buf_l_[PADL_(const void * __capability)]; const void * __capability buf; char buf_r_[PADR_(const void * __capability)];
 	char nbyte_l_[PADL_(size_t)]; size_t nbyte; char nbyte_r_[PADR_(size_t)];
 };
 struct open_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
@@ -72,46 +72,46 @@ struct close_args {
 };
 struct wait4_args {
 	char pid_l_[PADL_(int)]; int pid; char pid_r_[PADR_(int)];
-	char status_l_[PADL_(int *)]; int * status; char status_r_[PADR_(int *)];
+	char status_l_[PADL_(int * __capability)]; int * __capability status; char status_r_[PADR_(int * __capability)];
 	char options_l_[PADL_(int)]; int options; char options_r_[PADR_(int)];
-	char rusage_l_[PADL_(struct rusage *)]; struct rusage * rusage; char rusage_r_[PADR_(struct rusage *)];
+	char rusage_l_[PADL_(struct rusage * __capability)]; struct rusage * __capability rusage; char rusage_r_[PADR_(struct rusage * __capability)];
 };
 struct link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char to_l_[PADL_(const char *)]; const char * to; char to_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char to_l_[PADL_(const char * __capability)]; const char * __capability to; char to_r_[PADR_(const char * __capability)];
 };
 struct unlink_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct chdir_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct fchdir_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 };
 struct chmod_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct chown_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char uid_l_[PADL_(int)]; int uid; char uid_r_[PADR_(int)];
 	char gid_l_[PADL_(int)]; int gid; char gid_r_[PADR_(int)];
 };
 struct break_args {
-	char nsize_l_[PADL_(char *)]; char * nsize; char nsize_r_[PADR_(char *)];
+	char nsize_l_[PADL_(char * __capability)]; char * __capability nsize; char nsize_r_[PADR_(char * __capability)];
 };
 struct getpid_args {
 	register_t dummy;
 };
 struct mount_args {
-	char type_l_[PADL_(const char *)]; const char * type; char type_r_[PADR_(const char *)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char type_l_[PADL_(const char * __capability)]; const char * __capability type; char type_r_[PADR_(const char * __capability)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 };
 struct unmount_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct setuid_args {
@@ -126,48 +126,48 @@ struct geteuid_args {
 struct ptrace_args {
 	char req_l_[PADL_(int)]; int req; char req_r_[PADR_(int)];
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
-	char addr_l_[PADL_(char *)]; char * addr; char addr_r_[PADR_(char *)];
+	char addr_l_[PADL_(char * __capability)]; char * __capability addr; char addr_r_[PADR_(char * __capability)];
 	char data_l_[PADL_(int)]; int data; char data_r_[PADR_(int)];
 };
 struct recvmsg_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char msg_l_[PADL_(struct msghdr_native *)]; struct msghdr_native * msg; char msg_r_[PADR_(struct msghdr_native *)];
+	char msg_l_[PADL_(struct msghdr_native * __capability)]; struct msghdr_native * __capability msg; char msg_r_[PADR_(struct msghdr_native * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct sendmsg_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char msg_l_[PADL_(const struct msghdr_native *)]; const struct msghdr_native * msg; char msg_r_[PADR_(const struct msghdr_native *)];
+	char msg_l_[PADL_(const struct msghdr_native * __capability)]; const struct msghdr_native * __capability msg; char msg_r_[PADR_(const struct msghdr_native * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct recvfrom_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char buf_l_[PADL_(void *)]; void * buf; char buf_r_[PADR_(void *)];
+	char buf_l_[PADL_(void * __capability)]; void * __capability buf; char buf_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
-	char from_l_[PADL_(struct sockaddr *)]; struct sockaddr * from; char from_r_[PADR_(struct sockaddr *)];
-	char fromlenaddr_l_[PADL_(__socklen_t *)]; __socklen_t * fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t *)];
+	char from_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability from; char from_r_[PADR_(struct sockaddr * __capability)];
+	char fromlenaddr_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t * __capability)];
 };
 struct accept_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(struct sockaddr *)]; struct sockaddr * name; char name_r_[PADR_(struct sockaddr *)];
-	char anamelen_l_[PADL_(__socklen_t *)]; __socklen_t * anamelen; char anamelen_r_[PADR_(__socklen_t *)];
+	char name_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability name; char name_r_[PADR_(struct sockaddr * __capability)];
+	char anamelen_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability anamelen; char anamelen_r_[PADR_(__socklen_t * __capability)];
 };
 struct getpeername_args {
 	char fdes_l_[PADL_(int)]; int fdes; char fdes_r_[PADR_(int)];
-	char asa_l_[PADL_(struct sockaddr *)]; struct sockaddr * asa; char asa_r_[PADR_(struct sockaddr *)];
-	char alen_l_[PADL_(__socklen_t *)]; __socklen_t * alen; char alen_r_[PADR_(__socklen_t *)];
+	char asa_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability asa; char asa_r_[PADR_(struct sockaddr * __capability)];
+	char alen_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability alen; char alen_r_[PADR_(__socklen_t * __capability)];
 };
 struct getsockname_args {
 	char fdes_l_[PADL_(int)]; int fdes; char fdes_r_[PADR_(int)];
-	char asa_l_[PADL_(struct sockaddr *)]; struct sockaddr * asa; char asa_r_[PADR_(struct sockaddr *)];
-	char alen_l_[PADL_(__socklen_t *)]; __socklen_t * alen; char alen_r_[PADR_(__socklen_t *)];
+	char asa_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability asa; char asa_r_[PADR_(struct sockaddr * __capability)];
+	char alen_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability alen; char alen_r_[PADR_(__socklen_t * __capability)];
 };
 struct access_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char amode_l_[PADL_(int)]; int amode; char amode_r_[PADR_(int)];
 };
 struct chflags_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(u_long)]; u_long flags; char flags_r_[PADR_(u_long)];
 };
 struct fchflags_args {
@@ -194,13 +194,13 @@ struct getegid_args {
 	register_t dummy;
 };
 struct profil_args {
-	char samples_l_[PADL_(char *)]; char * samples; char samples_r_[PADR_(char *)];
+	char samples_l_[PADL_(char * __capability)]; char * __capability samples; char samples_r_[PADR_(char * __capability)];
 	char size_l_[PADL_(size_t)]; size_t size; char size_r_[PADR_(size_t)];
 	char offset_l_[PADL_(size_t)]; size_t offset; char offset_r_[PADR_(size_t)];
 	char scale_l_[PADL_(u_int)]; u_int scale; char scale_r_[PADR_(u_int)];
 };
 struct ktrace_args {
-	char fname_l_[PADL_(const char *)]; const char * fname; char fname_r_[PADR_(const char *)];
+	char fname_l_[PADL_(const char * __capability)]; const char * __capability fname; char fname_r_[PADR_(const char * __capability)];
 	char ops_l_[PADL_(int)]; int ops; char ops_r_[PADR_(int)];
 	char facs_l_[PADL_(int)]; int facs; char facs_r_[PADR_(int)];
 	char pid_l_[PADL_(int)]; int pid; char pid_r_[PADR_(int)];
@@ -209,58 +209,58 @@ struct getgid_args {
 	register_t dummy;
 };
 struct getlogin_args {
-	char namebuf_l_[PADL_(char *)]; char * namebuf; char namebuf_r_[PADR_(char *)];
+	char namebuf_l_[PADL_(char * __capability)]; char * __capability namebuf; char namebuf_r_[PADR_(char * __capability)];
 	char namelen_l_[PADL_(u_int)]; u_int namelen; char namelen_r_[PADR_(u_int)];
 };
 struct setlogin_args {
-	char namebuf_l_[PADL_(const char *)]; const char * namebuf; char namebuf_r_[PADR_(const char *)];
+	char namebuf_l_[PADL_(const char * __capability)]; const char * __capability namebuf; char namebuf_r_[PADR_(const char * __capability)];
 };
 struct acct_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct osigpending_args {
 	register_t dummy;
 };
 struct sigaltstack_args {
-	char ss_l_[PADL_(const struct sigaltstack_native *)]; const struct sigaltstack_native * ss; char ss_r_[PADR_(const struct sigaltstack_native *)];
-	char oss_l_[PADL_(struct sigaltstack_native *)]; struct sigaltstack_native * oss; char oss_r_[PADR_(struct sigaltstack_native *)];
+	char ss_l_[PADL_(const struct sigaltstack_native * __capability)]; const struct sigaltstack_native * __capability ss; char ss_r_[PADR_(const struct sigaltstack_native * __capability)];
+	char oss_l_[PADL_(struct sigaltstack_native * __capability)]; struct sigaltstack_native * __capability oss; char oss_r_[PADR_(struct sigaltstack_native * __capability)];
 };
 struct ioctl_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char com_l_[PADL_(u_long)]; u_long com; char com_r_[PADR_(u_long)];
-	char data_l_[PADL_(char *)]; char * data; char data_r_[PADR_(char *)];
+	char data_l_[PADL_(char * __capability)]; char * __capability data; char data_r_[PADR_(char * __capability)];
 };
 struct reboot_args {
 	char opt_l_[PADL_(int)]; int opt; char opt_r_[PADR_(int)];
 };
 struct revoke_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct symlink_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char link_l_[PADL_(const char *)]; const char * link; char link_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char link_l_[PADL_(const char * __capability)]; const char * __capability link; char link_r_[PADR_(const char * __capability)];
 };
 struct readlink_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char count_l_[PADL_(size_t)]; size_t count; char count_r_[PADR_(size_t)];
 };
 struct execve_args {
-	char fname_l_[PADL_(const char *)]; const char * fname; char fname_r_[PADR_(const char *)];
-	char argv_l_[PADL_(char **)]; char ** argv; char argv_r_[PADR_(char **)];
-	char envv_l_[PADL_(char **)]; char ** envv; char envv_r_[PADR_(char **)];
+	char fname_l_[PADL_(const char * __capability)]; const char * __capability fname; char fname_r_[PADR_(const char * __capability)];
+	char argv_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability argv; char argv_r_[PADR_(char * __capability * __capability)];
+	char envv_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability envv; char envv_r_[PADR_(char * __capability * __capability)];
 };
 struct umask_args {
 	char newmask_l_[PADL_(mode_t)]; mode_t newmask; char newmask_r_[PADR_(mode_t)];
 };
 struct chroot_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct ogetpagesize_args {
 	register_t dummy;
 };
 struct msync_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
@@ -274,31 +274,31 @@ struct sstk_args {
 	char incr_l_[PADL_(int)]; int incr; char incr_r_[PADR_(int)];
 };
 struct munmap_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 };
 struct mprotect_args {
-	char addr_l_[PADL_(const void *)]; const void * addr; char addr_r_[PADR_(const void *)];
+	char addr_l_[PADL_(const void * __capability)]; const void * __capability addr; char addr_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char prot_l_[PADL_(int)]; int prot; char prot_r_[PADR_(int)];
 };
 struct madvise_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char behav_l_[PADL_(int)]; int behav; char behav_r_[PADR_(int)];
 };
 struct mincore_args {
-	char addr_l_[PADL_(const void *)]; const void * addr; char addr_r_[PADR_(const void *)];
+	char addr_l_[PADL_(const void * __capability)]; const void * __capability addr; char addr_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
-	char vec_l_[PADL_(char *)]; char * vec; char vec_r_[PADR_(char *)];
+	char vec_l_[PADL_(char * __capability)]; char * __capability vec; char vec_r_[PADR_(char * __capability)];
 };
 struct getgroups_args {
 	char gidsetsize_l_[PADL_(u_int)]; u_int gidsetsize; char gidsetsize_r_[PADR_(u_int)];
-	char gidset_l_[PADL_(gid_t *)]; gid_t * gidset; char gidset_r_[PADR_(gid_t *)];
+	char gidset_l_[PADL_(gid_t * __capability)]; gid_t * __capability gidset; char gidset_r_[PADR_(gid_t * __capability)];
 };
 struct setgroups_args {
 	char gidsetsize_l_[PADL_(u_int)]; u_int gidsetsize; char gidsetsize_r_[PADR_(u_int)];
-	char gidset_l_[PADL_(const gid_t *)]; const gid_t * gidset; char gidset_r_[PADR_(const gid_t *)];
+	char gidset_l_[PADL_(const gid_t * __capability)]; const gid_t * __capability gidset; char gidset_r_[PADR_(const gid_t * __capability)];
 };
 struct getpgrp_args {
 	register_t dummy;
@@ -309,18 +309,18 @@ struct setpgid_args {
 };
 struct setitimer_args {
 	char which_l_[PADL_(int)]; int which; char which_r_[PADR_(int)];
-	char itv_l_[PADL_(const struct itimerval *)]; const struct itimerval * itv; char itv_r_[PADR_(const struct itimerval *)];
-	char oitv_l_[PADL_(struct itimerval *)]; struct itimerval * oitv; char oitv_r_[PADR_(struct itimerval *)];
+	char itv_l_[PADL_(const struct itimerval * __capability)]; const struct itimerval * __capability itv; char itv_r_[PADR_(const struct itimerval * __capability)];
+	char oitv_l_[PADL_(struct itimerval * __capability)]; struct itimerval * __capability oitv; char oitv_r_[PADR_(struct itimerval * __capability)];
 };
 struct owait_args {
 	register_t dummy;
 };
 struct swapon_args {
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 };
 struct getitimer_args {
 	char which_l_[PADL_(int)]; int which; char which_r_[PADR_(int)];
-	char itv_l_[PADL_(struct itimerval *)]; struct itimerval * itv; char itv_r_[PADR_(struct itimerval *)];
+	char itv_l_[PADL_(struct itimerval * __capability)]; struct itimerval * __capability itv; char itv_r_[PADR_(struct itimerval * __capability)];
 };
 struct getdtablesize_args {
 	register_t dummy;
@@ -336,10 +336,10 @@ struct fcntl_args {
 };
 struct select_args {
 	char nd_l_[PADL_(int)]; int nd; char nd_r_[PADR_(int)];
-	char in_l_[PADL_(fd_set *)]; fd_set * in; char in_r_[PADR_(fd_set *)];
-	char ou_l_[PADL_(fd_set *)]; fd_set * ou; char ou_r_[PADR_(fd_set *)];
-	char ex_l_[PADL_(fd_set *)]; fd_set * ex; char ex_r_[PADR_(fd_set *)];
-	char tv_l_[PADL_(struct timeval *)]; struct timeval * tv; char tv_r_[PADR_(struct timeval *)];
+	char in_l_[PADL_(fd_set * __capability)]; fd_set * __capability in; char in_r_[PADR_(fd_set * __capability)];
+	char ou_l_[PADL_(fd_set * __capability)]; fd_set * __capability ou; char ou_r_[PADR_(fd_set * __capability)];
+	char ex_l_[PADL_(fd_set * __capability)]; fd_set * __capability ex; char ex_r_[PADR_(fd_set * __capability)];
+	char tv_l_[PADL_(struct timeval * __capability)]; struct timeval * __capability tv; char tv_r_[PADR_(struct timeval * __capability)];
 };
 struct fsync_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
@@ -356,7 +356,7 @@ struct socket_args {
 };
 struct connect_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * name; char name_r_[PADR_(const struct sockaddr *)];
+	char name_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability name; char name_r_[PADR_(const struct sockaddr * __capability)];
 	char namelen_l_[PADL_(__socklen_t)]; __socklen_t namelen; char namelen_r_[PADR_(__socklen_t)];
 };
 struct getpriority_args {
@@ -365,14 +365,14 @@ struct getpriority_args {
 };
 struct bind_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * name; char name_r_[PADR_(const struct sockaddr *)];
+	char name_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability name; char name_r_[PADR_(const struct sockaddr * __capability)];
 	char namelen_l_[PADL_(__socklen_t)]; __socklen_t namelen; char namelen_r_[PADR_(__socklen_t)];
 };
 struct setsockopt_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
 	char level_l_[PADL_(int)]; int level; char level_r_[PADR_(int)];
 	char name_l_[PADL_(int)]; int name; char name_r_[PADR_(int)];
-	char val_l_[PADL_(const void *)]; const void * val; char val_r_[PADR_(const void *)];
+	char val_l_[PADL_(const void * __capability)]; const void * __capability val; char val_r_[PADR_(const void * __capability)];
 	char valsize_l_[PADL_(__socklen_t)]; __socklen_t valsize; char valsize_r_[PADR_(__socklen_t)];
 };
 struct listen_args {
@@ -380,33 +380,33 @@ struct listen_args {
 	char backlog_l_[PADL_(int)]; int backlog; char backlog_r_[PADR_(int)];
 };
 struct gettimeofday_args {
-	char tp_l_[PADL_(struct timeval *)]; struct timeval * tp; char tp_r_[PADR_(struct timeval *)];
-	char tzp_l_[PADL_(struct timezone *)]; struct timezone * tzp; char tzp_r_[PADR_(struct timezone *)];
+	char tp_l_[PADL_(struct timeval * __capability)]; struct timeval * __capability tp; char tp_r_[PADR_(struct timeval * __capability)];
+	char tzp_l_[PADL_(struct timezone * __capability)]; struct timezone * __capability tzp; char tzp_r_[PADR_(struct timezone * __capability)];
 };
 struct getrusage_args {
 	char who_l_[PADL_(int)]; int who; char who_r_[PADR_(int)];
-	char rusage_l_[PADL_(struct rusage *)]; struct rusage * rusage; char rusage_r_[PADR_(struct rusage *)];
+	char rusage_l_[PADL_(struct rusage * __capability)]; struct rusage * __capability rusage; char rusage_r_[PADR_(struct rusage * __capability)];
 };
 struct getsockopt_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
 	char level_l_[PADL_(int)]; int level; char level_r_[PADR_(int)];
 	char name_l_[PADL_(int)]; int name; char name_r_[PADR_(int)];
-	char val_l_[PADL_(void *)]; void * val; char val_r_[PADR_(void *)];
-	char avalsize_l_[PADL_(__socklen_t *)]; __socklen_t * avalsize; char avalsize_r_[PADR_(__socklen_t *)];
+	char val_l_[PADL_(void * __capability)]; void * __capability val; char val_r_[PADR_(void * __capability)];
+	char avalsize_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability avalsize; char avalsize_r_[PADR_(__socklen_t * __capability)];
 };
 struct readv_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 };
 struct writev_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 };
 struct settimeofday_args {
-	char tv_l_[PADL_(const struct timeval *)]; const struct timeval * tv; char tv_r_[PADR_(const struct timeval *)];
-	char tzp_l_[PADL_(const struct timezone *)]; const struct timezone * tzp; char tzp_r_[PADR_(const struct timezone *)];
+	char tv_l_[PADL_(const struct timeval * __capability)]; const struct timeval * __capability tv; char tv_r_[PADR_(const struct timeval * __capability)];
+	char tzp_l_[PADL_(const struct timezone * __capability)]; const struct timezone * __capability tzp; char tzp_r_[PADR_(const struct timezone * __capability)];
 };
 struct fchown_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
@@ -426,23 +426,23 @@ struct setregid_args {
 	char egid_l_[PADL_(int)]; int egid; char egid_r_[PADR_(int)];
 };
 struct rename_args {
-	char from_l_[PADL_(const char *)]; const char * from; char from_r_[PADR_(const char *)];
-	char to_l_[PADL_(const char *)]; const char * to; char to_r_[PADR_(const char *)];
+	char from_l_[PADL_(const char * __capability)]; const char * __capability from; char from_r_[PADR_(const char * __capability)];
+	char to_l_[PADL_(const char * __capability)]; const char * __capability to; char to_r_[PADR_(const char * __capability)];
 };
 struct flock_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char how_l_[PADL_(int)]; int how; char how_r_[PADR_(int)];
 };
 struct mkfifo_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct sendto_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char buf_l_[PADL_(const void *)]; const void * buf; char buf_r_[PADR_(const void *)];
+	char buf_l_[PADL_(const void * __capability)]; const void * __capability buf; char buf_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
-	char to_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * to; char to_r_[PADR_(const struct sockaddr *)];
+	char to_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability to; char to_r_[PADR_(const struct sockaddr * __capability)];
 	char tolen_l_[PADL_(__socklen_t)]; __socklen_t tolen; char tolen_r_[PADR_(__socklen_t)];
 };
 struct shutdown_args {
@@ -453,22 +453,22 @@ struct socketpair_args {
 	char domain_l_[PADL_(int)]; int domain; char domain_r_[PADR_(int)];
 	char type_l_[PADL_(int)]; int type; char type_r_[PADR_(int)];
 	char protocol_l_[PADL_(int)]; int protocol; char protocol_r_[PADR_(int)];
-	char rsv_l_[PADL_(int *)]; int * rsv; char rsv_r_[PADR_(int *)];
+	char rsv_l_[PADL_(int * __capability)]; int * __capability rsv; char rsv_r_[PADR_(int * __capability)];
 };
 struct mkdir_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct rmdir_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct utimes_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char tptr_l_[PADL_(const struct timeval *)]; const struct timeval * tptr; char tptr_r_[PADR_(const struct timeval *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char tptr_l_[PADL_(const struct timeval * __capability)]; const struct timeval * __capability tptr; char tptr_r_[PADR_(const struct timeval * __capability)];
 };
 struct adjtime_args {
-	char delta_l_[PADL_(const struct timeval *)]; const struct timeval * delta; char delta_r_[PADR_(const struct timeval *)];
-	char olddelta_l_[PADL_(struct timeval *)]; struct timeval * olddelta; char olddelta_r_[PADR_(struct timeval *)];
+	char delta_l_[PADL_(const struct timeval * __capability)]; const struct timeval * __capability delta; char delta_r_[PADR_(const struct timeval * __capability)];
+	char olddelta_l_[PADL_(struct timeval * __capability)]; struct timeval * __capability olddelta; char olddelta_r_[PADR_(struct timeval * __capability)];
 };
 struct ogethostid_args {
 	register_t dummy;
@@ -477,10 +477,10 @@ struct setsid_args {
 	register_t dummy;
 };
 struct quotactl_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
 	char uid_l_[PADL_(int)]; int uid; char uid_r_[PADR_(int)];
-	char arg_l_[PADL_(void *)]; void * arg; char arg_r_[PADR_(void *)];
+	char arg_l_[PADL_(void * __capability)]; void * __capability arg; char arg_r_[PADR_(void * __capability)];
 };
 struct oquota_args {
 	register_t dummy;
@@ -489,28 +489,28 @@ struct nlm_syscall_args {
 	char debug_level_l_[PADL_(int)]; int debug_level; char debug_level_r_[PADR_(int)];
 	char grace_period_l_[PADL_(int)]; int grace_period; char grace_period_r_[PADR_(int)];
 	char addr_count_l_[PADL_(int)]; int addr_count; char addr_count_r_[PADR_(int)];
-	char addrs_l_[PADL_(char **)]; char ** addrs; char addrs_r_[PADR_(char **)];
+	char addrs_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability addrs; char addrs_r_[PADR_(char * __capability * __capability)];
 };
 struct nfssvc_args {
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
-	char argp_l_[PADL_(void *)]; void * argp; char argp_r_[PADR_(void *)];
+	char argp_l_[PADL_(void * __capability)]; void * __capability argp; char argp_r_[PADR_(void * __capability)];
 };
 struct lgetfh_args {
-	char fname_l_[PADL_(const char *)]; const char * fname; char fname_r_[PADR_(const char *)];
-	char fhp_l_[PADL_(struct fhandle *)]; struct fhandle * fhp; char fhp_r_[PADR_(struct fhandle *)];
+	char fname_l_[PADL_(const char * __capability)]; const char * __capability fname; char fname_r_[PADR_(const char * __capability)];
+	char fhp_l_[PADL_(struct fhandle * __capability)]; struct fhandle * __capability fhp; char fhp_r_[PADR_(struct fhandle * __capability)];
 };
 struct getfh_args {
-	char fname_l_[PADL_(const char *)]; const char * fname; char fname_r_[PADR_(const char *)];
-	char fhp_l_[PADL_(struct fhandle *)]; struct fhandle * fhp; char fhp_r_[PADR_(struct fhandle *)];
+	char fname_l_[PADL_(const char * __capability)]; const char * __capability fname; char fname_r_[PADR_(const char * __capability)];
+	char fhp_l_[PADL_(struct fhandle * __capability)]; struct fhandle * __capability fhp; char fhp_r_[PADR_(struct fhandle * __capability)];
 };
 struct sysarch_args {
 	char op_l_[PADL_(int)]; int op; char op_r_[PADR_(int)];
-	char parms_l_[PADL_(char *)]; char * parms; char parms_r_[PADR_(char *)];
+	char parms_l_[PADL_(char * __capability)]; char * __capability parms; char parms_r_[PADR_(char * __capability)];
 };
 struct rtprio_args {
 	char function_l_[PADL_(int)]; int function; char function_r_[PADR_(int)];
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
-	char rtp_l_[PADL_(struct rtprio *)]; struct rtprio * rtp; char rtp_r_[PADR_(struct rtprio *)];
+	char rtp_l_[PADL_(struct rtprio * __capability)]; struct rtprio * __capability rtp; char rtp_r_[PADR_(struct rtprio * __capability)];
 };
 struct semsys_args {
 	char which_l_[PADL_(int)]; int which; char which_r_[PADR_(int)];
@@ -537,7 +537,7 @@ struct setfib_args {
 	char fibnum_l_[PADL_(int)]; int fibnum; char fibnum_r_[PADR_(int)];
 };
 struct ntp_adjtime_args {
-	char tp_l_[PADL_(struct timex *)]; struct timex * tp; char tp_r_[PADR_(struct timex *)];
+	char tp_l_[PADL_(struct timex * __capability)]; struct timex * __capability tp; char tp_r_[PADR_(struct timex * __capability)];
 };
 struct setgid_args {
 	char gid_l_[PADL_(gid_t)]; gid_t gid; char gid_r_[PADR_(gid_t)];
@@ -549,7 +549,7 @@ struct seteuid_args {
 	char euid_l_[PADL_(uid_t)]; uid_t euid; char euid_r_[PADR_(uid_t)];
 };
 struct pathconf_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char name_l_[PADL_(int)]; int name; char name_r_[PADR_(int)];
 };
 struct fpathconf_args {
@@ -558,40 +558,40 @@ struct fpathconf_args {
 };
 struct __getrlimit_args {
 	char which_l_[PADL_(u_int)]; u_int which; char which_r_[PADR_(u_int)];
-	char rlp_l_[PADL_(struct rlimit *)]; struct rlimit * rlp; char rlp_r_[PADR_(struct rlimit *)];
+	char rlp_l_[PADL_(struct rlimit * __capability)]; struct rlimit * __capability rlp; char rlp_r_[PADR_(struct rlimit * __capability)];
 };
 struct __setrlimit_args {
 	char which_l_[PADL_(u_int)]; u_int which; char which_r_[PADR_(u_int)];
-	char rlp_l_[PADL_(struct rlimit *)]; struct rlimit * rlp; char rlp_r_[PADR_(struct rlimit *)];
+	char rlp_l_[PADL_(struct rlimit * __capability)]; struct rlimit * __capability rlp; char rlp_r_[PADR_(struct rlimit * __capability)];
 };
 struct __sysctl_args {
-	char name_l_[PADL_(int *)]; int * name; char name_r_[PADR_(int *)];
+	char name_l_[PADL_(int * __capability)]; int * __capability name; char name_r_[PADR_(int * __capability)];
 	char namelen_l_[PADL_(u_int)]; u_int namelen; char namelen_r_[PADR_(u_int)];
-	char old_l_[PADL_(void *)]; void * old; char old_r_[PADR_(void *)];
-	char oldlenp_l_[PADL_(size_t *)]; size_t * oldlenp; char oldlenp_r_[PADR_(size_t *)];
-	char new_l_[PADL_(const void *)]; const void * new; char new_r_[PADR_(const void *)];
+	char old_l_[PADL_(void * __capability)]; void * __capability old; char old_r_[PADR_(void * __capability)];
+	char oldlenp_l_[PADL_(size_t * __capability)]; size_t * __capability oldlenp; char oldlenp_r_[PADR_(size_t * __capability)];
+	char new_l_[PADL_(const void * __capability)]; const void * __capability new; char new_r_[PADR_(const void * __capability)];
 	char newlen_l_[PADL_(size_t)]; size_t newlen; char newlen_r_[PADR_(size_t)];
 };
 struct mlock_args {
-	char addr_l_[PADL_(const void *)]; const void * addr; char addr_r_[PADR_(const void *)];
+	char addr_l_[PADL_(const void * __capability)]; const void * __capability addr; char addr_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 };
 struct munlock_args {
-	char addr_l_[PADL_(const void *)]; const void * addr; char addr_r_[PADR_(const void *)];
+	char addr_l_[PADL_(const void * __capability)]; const void * __capability addr; char addr_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 };
 struct undelete_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct futimes_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char tptr_l_[PADL_(const struct timeval *)]; const struct timeval * tptr; char tptr_r_[PADR_(const struct timeval *)];
+	char tptr_l_[PADL_(const struct timeval * __capability)]; const struct timeval * __capability tptr; char tptr_r_[PADR_(const struct timeval * __capability)];
 };
 struct getpgid_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
 };
 struct poll_args {
-	char fds_l_[PADL_(struct pollfd *)]; struct pollfd * fds; char fds_r_[PADR_(struct pollfd *)];
+	char fds_l_[PADL_(struct pollfd * __capability)]; struct pollfd * __capability fds; char fds_r_[PADR_(struct pollfd * __capability)];
 	char nfds_l_[PADL_(u_int)]; u_int nfds; char nfds_r_[PADR_(u_int)];
 	char timeout_l_[PADL_(int)]; int timeout; char timeout_r_[PADR_(int)];
 };
@@ -602,7 +602,7 @@ struct semget_args {
 };
 struct semop_args {
 	char semid_l_[PADL_(int)]; int semid; char semid_r_[PADR_(int)];
-	char sops_l_[PADL_(struct sembuf *)]; struct sembuf * sops; char sops_r_[PADR_(struct sembuf *)];
+	char sops_l_[PADL_(struct sembuf * __capability)]; struct sembuf * __capability sops; char sops_r_[PADR_(struct sembuf * __capability)];
 	char nsops_l_[PADL_(size_t)]; size_t nsops; char nsops_r_[PADR_(size_t)];
 };
 struct msgget_args {
@@ -611,24 +611,24 @@ struct msgget_args {
 };
 struct msgsnd_args {
 	char msqid_l_[PADL_(int)]; int msqid; char msqid_r_[PADR_(int)];
-	char msgp_l_[PADL_(const void *)]; const void * msgp; char msgp_r_[PADR_(const void *)];
+	char msgp_l_[PADL_(const void * __capability)]; const void * __capability msgp; char msgp_r_[PADR_(const void * __capability)];
 	char msgsz_l_[PADL_(size_t)]; size_t msgsz; char msgsz_r_[PADR_(size_t)];
 	char msgflg_l_[PADL_(int)]; int msgflg; char msgflg_r_[PADR_(int)];
 };
 struct msgrcv_args {
 	char msqid_l_[PADL_(int)]; int msqid; char msqid_r_[PADR_(int)];
-	char msgp_l_[PADL_(void *)]; void * msgp; char msgp_r_[PADR_(void *)];
+	char msgp_l_[PADL_(void * __capability)]; void * __capability msgp; char msgp_r_[PADR_(void * __capability)];
 	char msgsz_l_[PADL_(size_t)]; size_t msgsz; char msgsz_r_[PADR_(size_t)];
 	char msgtyp_l_[PADL_(long)]; long msgtyp; char msgtyp_r_[PADR_(long)];
 	char msgflg_l_[PADL_(int)]; int msgflg; char msgflg_r_[PADR_(int)];
 };
 struct shmat_args {
 	char shmid_l_[PADL_(int)]; int shmid; char shmid_r_[PADR_(int)];
-	char shmaddr_l_[PADL_(const void *)]; const void * shmaddr; char shmaddr_r_[PADR_(const void *)];
+	char shmaddr_l_[PADL_(const void * __capability)]; const void * __capability shmaddr; char shmaddr_r_[PADR_(const void * __capability)];
 	char shmflg_l_[PADL_(int)]; int shmflg; char shmflg_r_[PADR_(int)];
 };
 struct shmdt_args {
-	char shmaddr_l_[PADL_(const void *)]; const void * shmaddr; char shmaddr_r_[PADR_(const void *)];
+	char shmaddr_l_[PADL_(const void * __capability)]; const void * __capability shmaddr; char shmaddr_r_[PADR_(const void * __capability)];
 };
 struct shmget_args {
 	char key_l_[PADL_(key_t)]; key_t key; char key_r_[PADR_(key_t)];
@@ -637,20 +637,20 @@ struct shmget_args {
 };
 struct clock_gettime_args {
 	char clock_id_l_[PADL_(clockid_t)]; clockid_t clock_id; char clock_id_r_[PADR_(clockid_t)];
-	char tp_l_[PADL_(struct timespec *)]; struct timespec * tp; char tp_r_[PADR_(struct timespec *)];
+	char tp_l_[PADL_(struct timespec * __capability)]; struct timespec * __capability tp; char tp_r_[PADR_(struct timespec * __capability)];
 };
 struct clock_settime_args {
 	char clock_id_l_[PADL_(clockid_t)]; clockid_t clock_id; char clock_id_r_[PADR_(clockid_t)];
-	char tp_l_[PADL_(const struct timespec *)]; const struct timespec * tp; char tp_r_[PADR_(const struct timespec *)];
+	char tp_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability tp; char tp_r_[PADR_(const struct timespec * __capability)];
 };
 struct clock_getres_args {
 	char clock_id_l_[PADL_(clockid_t)]; clockid_t clock_id; char clock_id_r_[PADR_(clockid_t)];
-	char tp_l_[PADL_(struct timespec *)]; struct timespec * tp; char tp_r_[PADR_(struct timespec *)];
+	char tp_l_[PADL_(struct timespec * __capability)]; struct timespec * __capability tp; char tp_r_[PADR_(struct timespec * __capability)];
 };
 struct ktimer_create_args {
 	char clock_id_l_[PADL_(clockid_t)]; clockid_t clock_id; char clock_id_r_[PADR_(clockid_t)];
-	char evp_l_[PADL_(struct sigevent_native *)]; struct sigevent_native * evp; char evp_r_[PADR_(struct sigevent_native *)];
-	char timerid_l_[PADL_(int *)]; int * timerid; char timerid_r_[PADR_(int *)];
+	char evp_l_[PADL_(struct sigevent_native * __capability)]; struct sigevent_native * __capability evp; char evp_r_[PADR_(struct sigevent_native * __capability)];
+	char timerid_l_[PADL_(int * __capability)]; int * __capability timerid; char timerid_r_[PADR_(int * __capability)];
 };
 struct ktimer_delete_args {
 	char timerid_l_[PADL_(int)]; int timerid; char timerid_r_[PADR_(int)];
@@ -658,45 +658,45 @@ struct ktimer_delete_args {
 struct ktimer_settime_args {
 	char timerid_l_[PADL_(int)]; int timerid; char timerid_r_[PADR_(int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
-	char value_l_[PADL_(const struct itimerspec *)]; const struct itimerspec * value; char value_r_[PADR_(const struct itimerspec *)];
-	char ovalue_l_[PADL_(struct itimerspec *)]; struct itimerspec * ovalue; char ovalue_r_[PADR_(struct itimerspec *)];
+	char value_l_[PADL_(const struct itimerspec * __capability)]; const struct itimerspec * __capability value; char value_r_[PADR_(const struct itimerspec * __capability)];
+	char ovalue_l_[PADL_(struct itimerspec * __capability)]; struct itimerspec * __capability ovalue; char ovalue_r_[PADR_(struct itimerspec * __capability)];
 };
 struct ktimer_gettime_args {
 	char timerid_l_[PADL_(int)]; int timerid; char timerid_r_[PADR_(int)];
-	char value_l_[PADL_(struct itimerspec *)]; struct itimerspec * value; char value_r_[PADR_(struct itimerspec *)];
+	char value_l_[PADL_(struct itimerspec * __capability)]; struct itimerspec * __capability value; char value_r_[PADR_(struct itimerspec * __capability)];
 };
 struct ktimer_getoverrun_args {
 	char timerid_l_[PADL_(int)]; int timerid; char timerid_r_[PADR_(int)];
 };
 struct nanosleep_args {
-	char rqtp_l_[PADL_(const struct timespec *)]; const struct timespec * rqtp; char rqtp_r_[PADR_(const struct timespec *)];
-	char rmtp_l_[PADL_(struct timespec *)]; struct timespec * rmtp; char rmtp_r_[PADR_(struct timespec *)];
+	char rqtp_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability rqtp; char rqtp_r_[PADR_(const struct timespec * __capability)];
+	char rmtp_l_[PADL_(struct timespec * __capability)]; struct timespec * __capability rmtp; char rmtp_r_[PADR_(struct timespec * __capability)];
 };
 struct ffclock_getcounter_args {
-	char ffcount_l_[PADL_(ffcounter *)]; ffcounter * ffcount; char ffcount_r_[PADR_(ffcounter *)];
+	char ffcount_l_[PADL_(ffcounter * __capability)]; ffcounter * __capability ffcount; char ffcount_r_[PADR_(ffcounter * __capability)];
 };
 struct ffclock_setestimate_args {
-	char cest_l_[PADL_(struct ffclock_estimate *)]; struct ffclock_estimate * cest; char cest_r_[PADR_(struct ffclock_estimate *)];
+	char cest_l_[PADL_(struct ffclock_estimate * __capability)]; struct ffclock_estimate * __capability cest; char cest_r_[PADR_(struct ffclock_estimate * __capability)];
 };
 struct ffclock_getestimate_args {
-	char cest_l_[PADL_(struct ffclock_estimate *)]; struct ffclock_estimate * cest; char cest_r_[PADR_(struct ffclock_estimate *)];
+	char cest_l_[PADL_(struct ffclock_estimate * __capability)]; struct ffclock_estimate * __capability cest; char cest_r_[PADR_(struct ffclock_estimate * __capability)];
 };
 struct clock_nanosleep_args {
 	char clock_id_l_[PADL_(clockid_t)]; clockid_t clock_id; char clock_id_r_[PADR_(clockid_t)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
-	char rqtp_l_[PADL_(const struct timespec *)]; const struct timespec * rqtp; char rqtp_r_[PADR_(const struct timespec *)];
-	char rmtp_l_[PADL_(struct timespec *)]; struct timespec * rmtp; char rmtp_r_[PADR_(struct timespec *)];
+	char rqtp_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability rqtp; char rqtp_r_[PADR_(const struct timespec * __capability)];
+	char rmtp_l_[PADL_(struct timespec * __capability)]; struct timespec * __capability rmtp; char rmtp_r_[PADR_(struct timespec * __capability)];
 };
 struct clock_getcpuclockid2_args {
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
 	char which_l_[PADL_(int)]; int which; char which_r_[PADR_(int)];
-	char clock_id_l_[PADL_(clockid_t *)]; clockid_t * clock_id; char clock_id_r_[PADR_(clockid_t *)];
+	char clock_id_l_[PADL_(clockid_t * __capability)]; clockid_t * __capability clock_id; char clock_id_r_[PADR_(clockid_t * __capability)];
 };
 struct ntp_gettime_args {
-	char ntvp_l_[PADL_(struct ntptimeval *)]; struct ntptimeval * ntvp; char ntvp_r_[PADR_(struct ntptimeval *)];
+	char ntvp_l_[PADL_(struct ntptimeval * __capability)]; struct ntptimeval * __capability ntvp; char ntvp_r_[PADR_(struct ntptimeval * __capability)];
 };
 struct minherit_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char inherit_l_[PADL_(int)]; int inherit; char inherit_r_[PADR_(int)];
 };
@@ -707,50 +707,50 @@ struct issetugid_args {
 	register_t dummy;
 };
 struct lchown_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char uid_l_[PADL_(int)]; int uid; char uid_r_[PADR_(int)];
 	char gid_l_[PADL_(int)]; int gid; char gid_r_[PADR_(int)];
 };
 struct aio_read_args {
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct aio_write_args {
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct lio_listio_args {
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
-	char acb_list_l_[PADL_(struct aiocb_native *const *)]; struct aiocb_native *const * acb_list; char acb_list_r_[PADR_(struct aiocb_native *const *)];
+	char acb_list_l_[PADL_(struct aiocb_native * __capability const * __capability)]; struct aiocb_native * __capability const * __capability acb_list; char acb_list_r_[PADR_(struct aiocb_native * __capability const * __capability)];
 	char nent_l_[PADL_(int)]; int nent; char nent_r_[PADR_(int)];
-	char sig_l_[PADL_(struct sigevent_native *)]; struct sigevent_native * sig; char sig_r_[PADR_(struct sigevent_native *)];
+	char sig_l_[PADL_(struct sigevent_native * __capability)]; struct sigevent_native * __capability sig; char sig_r_[PADR_(struct sigevent_native * __capability)];
 };
 struct kbounce_args {
-	char src_l_[PADL_(const void *)]; const void * src; char src_r_[PADR_(const void *)];
-	char dst_l_[PADL_(void *)]; void * dst; char dst_r_[PADR_(void *)];
+	char src_l_[PADL_(const void * __capability)]; const void * __capability src; char src_r_[PADR_(const void * __capability)];
+	char dst_l_[PADL_(void * __capability)]; void * __capability dst; char dst_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct lchmod_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct lutimes_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char tptr_l_[PADL_(const struct timeval *)]; const struct timeval * tptr; char tptr_r_[PADR_(const struct timeval *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char tptr_l_[PADL_(const struct timeval * __capability)]; const struct timeval * __capability tptr; char tptr_r_[PADR_(const struct timeval * __capability)];
 };
 struct preadv_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct pwritev_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct fhopen_args {
-	char u_fhp_l_[PADL_(const struct fhandle *)]; const struct fhandle * u_fhp; char u_fhp_r_[PADR_(const struct fhandle *)];
+	char u_fhp_l_[PADL_(const struct fhandle * __capability)]; const struct fhandle * __capability u_fhp; char u_fhp_r_[PADR_(const struct fhandle * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct modnext_args {
@@ -758,29 +758,29 @@ struct modnext_args {
 };
 struct modstat_args {
 	char modid_l_[PADL_(int)]; int modid; char modid_r_[PADR_(int)];
-	char stat_l_[PADL_(struct module_stat *)]; struct module_stat * stat; char stat_r_[PADR_(struct module_stat *)];
+	char stat_l_[PADL_(struct module_stat * __capability)]; struct module_stat * __capability stat; char stat_r_[PADR_(struct module_stat * __capability)];
 };
 struct modfnext_args {
 	char modid_l_[PADL_(int)]; int modid; char modid_r_[PADR_(int)];
 };
 struct modfind_args {
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 };
 struct kldload_args {
-	char file_l_[PADL_(const char *)]; const char * file; char file_r_[PADR_(const char *)];
+	char file_l_[PADL_(const char * __capability)]; const char * __capability file; char file_r_[PADR_(const char * __capability)];
 };
 struct kldunload_args {
 	char fileid_l_[PADL_(int)]; int fileid; char fileid_r_[PADR_(int)];
 };
 struct kldfind_args {
-	char file_l_[PADL_(const char *)]; const char * file; char file_r_[PADR_(const char *)];
+	char file_l_[PADL_(const char * __capability)]; const char * __capability file; char file_r_[PADR_(const char * __capability)];
 };
 struct kldnext_args {
 	char fileid_l_[PADL_(int)]; int fileid; char fileid_r_[PADR_(int)];
 };
 struct kldstat_args {
 	char fileid_l_[PADL_(int)]; int fileid; char fileid_r_[PADR_(int)];
-	char stat_l_[PADL_(struct kld_file_stat *)]; struct kld_file_stat * stat; char stat_r_[PADR_(struct kld_file_stat *)];
+	char stat_l_[PADL_(struct kld_file_stat * __capability)]; struct kld_file_stat * __capability stat; char stat_r_[PADR_(struct kld_file_stat * __capability)];
 };
 struct kldfirstmod_args {
 	char fileid_l_[PADL_(int)]; int fileid; char fileid_r_[PADR_(int)];
@@ -799,19 +799,19 @@ struct setresgid_args {
 	char sgid_l_[PADL_(gid_t)]; gid_t sgid; char sgid_r_[PADR_(gid_t)];
 };
 struct aio_return_args {
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct aio_suspend_args {
-	char aiocbp_l_[PADL_(struct aiocb_native *const *)]; struct aiocb_native *const * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *const *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability const * __capability)]; struct aiocb_native * __capability const * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability const * __capability)];
 	char nent_l_[PADL_(int)]; int nent; char nent_r_[PADR_(int)];
-	char timeout_l_[PADL_(const struct timespec *)]; const struct timespec * timeout; char timeout_r_[PADR_(const struct timespec *)];
+	char timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability timeout; char timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct aio_cancel_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct aio_error_args {
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct yield_args {
 	register_t dummy;
@@ -823,21 +823,21 @@ struct munlockall_args {
 	register_t dummy;
 };
 struct __getcwd_args {
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char buflen_l_[PADL_(size_t)]; size_t buflen; char buflen_r_[PADR_(size_t)];
 };
 struct sched_setparam_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
-	char param_l_[PADL_(const struct sched_param *)]; const struct sched_param * param; char param_r_[PADR_(const struct sched_param *)];
+	char param_l_[PADL_(const struct sched_param * __capability)]; const struct sched_param * __capability param; char param_r_[PADR_(const struct sched_param * __capability)];
 };
 struct sched_getparam_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
-	char param_l_[PADL_(struct sched_param *)]; struct sched_param * param; char param_r_[PADR_(struct sched_param *)];
+	char param_l_[PADL_(struct sched_param * __capability)]; struct sched_param * __capability param; char param_r_[PADR_(struct sched_param * __capability)];
 };
 struct sched_setscheduler_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
 	char policy_l_[PADL_(int)]; int policy; char policy_r_[PADR_(int)];
-	char param_l_[PADL_(const struct sched_param *)]; const struct sched_param * param; char param_r_[PADR_(const struct sched_param *)];
+	char param_l_[PADL_(const struct sched_param * __capability)]; const struct sched_param * __capability param; char param_r_[PADR_(const struct sched_param * __capability)];
 };
 struct sched_getscheduler_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
@@ -853,69 +853,69 @@ struct sched_get_priority_min_args {
 };
 struct sched_rr_get_interval_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
-	char interval_l_[PADL_(struct timespec *)]; struct timespec * interval; char interval_r_[PADR_(struct timespec *)];
+	char interval_l_[PADL_(struct timespec * __capability)]; struct timespec * __capability interval; char interval_r_[PADR_(struct timespec * __capability)];
 };
 struct utrace_args {
-	char addr_l_[PADL_(const void *)]; const void * addr; char addr_r_[PADR_(const void *)];
+	char addr_l_[PADL_(const void * __capability)]; const void * __capability addr; char addr_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 };
 struct kldsym_args {
 	char fileid_l_[PADL_(int)]; int fileid; char fileid_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 };
 struct jail_args {
-	char jailp_l_[PADL_(struct jail *)]; struct jail * jailp; char jailp_r_[PADR_(struct jail *)];
+	char jailp_l_[PADL_(struct jail * __capability)]; struct jail * __capability jailp; char jailp_r_[PADR_(struct jail * __capability)];
 };
 struct nnpfs_syscall_args {
 	char operation_l_[PADL_(int)]; int operation; char operation_r_[PADR_(int)];
-	char a_pathP_l_[PADL_(char *)]; char * a_pathP; char a_pathP_r_[PADR_(char *)];
+	char a_pathP_l_[PADL_(char * __capability)]; char * __capability a_pathP; char a_pathP_r_[PADR_(char * __capability)];
 	char a_opcode_l_[PADL_(int)]; int a_opcode; char a_opcode_r_[PADR_(int)];
-	char a_paramsP_l_[PADL_(void *)]; void * a_paramsP; char a_paramsP_r_[PADR_(void *)];
+	char a_paramsP_l_[PADL_(void * __capability)]; void * __capability a_paramsP; char a_paramsP_r_[PADR_(void * __capability)];
 	char a_followSymlinks_l_[PADL_(int)]; int a_followSymlinks; char a_followSymlinks_r_[PADR_(int)];
 };
 struct sigprocmask_args {
 	char how_l_[PADL_(int)]; int how; char how_r_[PADR_(int)];
-	char set_l_[PADL_(const sigset_t *)]; const sigset_t * set; char set_r_[PADR_(const sigset_t *)];
-	char oset_l_[PADL_(sigset_t *)]; sigset_t * oset; char oset_r_[PADR_(sigset_t *)];
+	char set_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability set; char set_r_[PADR_(const sigset_t * __capability)];
+	char oset_l_[PADL_(sigset_t * __capability)]; sigset_t * __capability oset; char oset_r_[PADR_(sigset_t * __capability)];
 };
 struct sigsuspend_args {
-	char sigmask_l_[PADL_(const sigset_t *)]; const sigset_t * sigmask; char sigmask_r_[PADR_(const sigset_t *)];
+	char sigmask_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability sigmask; char sigmask_r_[PADR_(const sigset_t * __capability)];
 };
 struct sigpending_args {
-	char set_l_[PADL_(sigset_t *)]; sigset_t * set; char set_r_[PADR_(sigset_t *)];
+	char set_l_[PADL_(sigset_t * __capability)]; sigset_t * __capability set; char set_r_[PADR_(sigset_t * __capability)];
 };
 struct sigtimedwait_args {
-	char set_l_[PADL_(const sigset_t *)]; const sigset_t * set; char set_r_[PADR_(const sigset_t *)];
-	char info_l_[PADL_(struct siginfo_native *)]; struct siginfo_native * info; char info_r_[PADR_(struct siginfo_native *)];
-	char timeout_l_[PADL_(const struct timespec *)]; const struct timespec * timeout; char timeout_r_[PADR_(const struct timespec *)];
+	char set_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability set; char set_r_[PADR_(const sigset_t * __capability)];
+	char info_l_[PADL_(struct siginfo_native * __capability)]; struct siginfo_native * __capability info; char info_r_[PADR_(struct siginfo_native * __capability)];
+	char timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability timeout; char timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct sigwaitinfo_args {
-	char set_l_[PADL_(const sigset_t *)]; const sigset_t * set; char set_r_[PADR_(const sigset_t *)];
-	char info_l_[PADL_(struct siginfo_native *)]; struct siginfo_native * info; char info_r_[PADR_(struct siginfo_native *)];
+	char set_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability set; char set_r_[PADR_(const sigset_t * __capability)];
+	char info_l_[PADL_(struct siginfo_native * __capability)]; struct siginfo_native * __capability info; char info_r_[PADR_(struct siginfo_native * __capability)];
 };
 struct __acl_get_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_set_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_get_fd_args {
 	char filedes_l_[PADL_(int)]; int filedes; char filedes_r_[PADR_(int)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_set_fd_args {
 	char filedes_l_[PADL_(int)]; int filedes; char filedes_r_[PADR_(int)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_delete_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
 };
 struct __acl_delete_fd_args {
@@ -923,54 +923,54 @@ struct __acl_delete_fd_args {
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
 };
 struct __acl_aclcheck_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_aclcheck_fd_args {
 	char filedes_l_[PADL_(int)]; int filedes; char filedes_r_[PADR_(int)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct extattrctl_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char filename_l_[PADL_(const char *)]; const char * filename; char filename_r_[PADR_(const char *)];
+	char filename_l_[PADL_(const char * __capability)]; const char * __capability filename; char filename_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
 };
 struct extattr_set_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_get_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_delete_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
 };
 struct aio_waitcomplete_args {
-	char aiocbp_l_[PADL_(struct aiocb_native **)]; struct aiocb_native ** aiocbp; char aiocbp_r_[PADR_(struct aiocb_native **)];
-	char timeout_l_[PADL_(struct timespec *)]; struct timespec * timeout; char timeout_r_[PADR_(struct timespec *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability * __capability)]; struct aiocb_native * __capability * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability * __capability)];
+	char timeout_l_[PADL_(struct timespec * __capability)]; struct timespec * __capability timeout; char timeout_r_[PADR_(struct timespec * __capability)];
 };
 struct getresuid_args {
-	char ruid_l_[PADL_(uid_t *)]; uid_t * ruid; char ruid_r_[PADR_(uid_t *)];
-	char euid_l_[PADL_(uid_t *)]; uid_t * euid; char euid_r_[PADR_(uid_t *)];
-	char suid_l_[PADL_(uid_t *)]; uid_t * suid; char suid_r_[PADR_(uid_t *)];
+	char ruid_l_[PADL_(uid_t * __capability)]; uid_t * __capability ruid; char ruid_r_[PADR_(uid_t * __capability)];
+	char euid_l_[PADL_(uid_t * __capability)]; uid_t * __capability euid; char euid_r_[PADR_(uid_t * __capability)];
+	char suid_l_[PADL_(uid_t * __capability)]; uid_t * __capability suid; char suid_r_[PADR_(uid_t * __capability)];
 };
 struct getresgid_args {
-	char rgid_l_[PADL_(gid_t *)]; gid_t * rgid; char rgid_r_[PADR_(gid_t *)];
-	char egid_l_[PADL_(gid_t *)]; gid_t * egid; char egid_r_[PADR_(gid_t *)];
-	char sgid_l_[PADL_(gid_t *)]; gid_t * sgid; char sgid_r_[PADR_(gid_t *)];
+	char rgid_l_[PADL_(gid_t * __capability)]; gid_t * __capability rgid; char rgid_r_[PADR_(gid_t * __capability)];
+	char egid_l_[PADL_(gid_t * __capability)]; gid_t * __capability egid; char egid_r_[PADR_(gid_t * __capability)];
+	char sgid_l_[PADL_(gid_t * __capability)]; gid_t * __capability sgid; char sgid_r_[PADR_(gid_t * __capability)];
 };
 struct kqueue_args {
 	register_t dummy;
@@ -978,27 +978,27 @@ struct kqueue_args {
 struct extattr_set_fd_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_get_fd_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_delete_fd_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
 };
 struct __setugid_args {
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct eaccess_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char amode_l_[PADL_(int)]; int amode; char amode_r_[PADR_(int)];
 };
 struct afs3_syscall_args {
@@ -1011,44 +1011,44 @@ struct afs3_syscall_args {
 	char parm6_l_[PADL_(long)]; long parm6; char parm6_r_[PADR_(long)];
 };
 struct nmount_args {
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(unsigned int)]; unsigned int iovcnt; char iovcnt_r_[PADR_(unsigned int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct __mac_get_proc_args {
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_set_proc_args {
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_get_fd_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_get_file_args {
-	char path_p_l_[PADL_(const char *)]; const char * path_p; char path_p_r_[PADR_(const char *)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char path_p_l_[PADL_(const char * __capability)]; const char * __capability path_p; char path_p_r_[PADR_(const char * __capability)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_set_fd_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_set_file_args {
-	char path_p_l_[PADL_(const char *)]; const char * path_p; char path_p_r_[PADR_(const char *)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char path_p_l_[PADL_(const char * __capability)]; const char * __capability path_p; char path_p_r_[PADR_(const char * __capability)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct kenv_args {
 	char what_l_[PADL_(int)]; int what; char what_r_[PADR_(int)];
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
-	char value_l_[PADL_(char *)]; char * value; char value_r_[PADR_(char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
+	char value_l_[PADL_(char * __capability)]; char * __capability value; char value_r_[PADR_(char * __capability)];
 	char len_l_[PADL_(int)]; int len; char len_r_[PADR_(int)];
 };
 struct lchflags_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(u_long)]; u_long flags; char flags_r_[PADR_(u_long)];
 };
 struct uuidgen_args {
-	char store_l_[PADL_(struct uuid *)]; struct uuid * store; char store_r_[PADR_(struct uuid *)];
+	char store_l_[PADL_(struct uuid * __capability)]; struct uuid * __capability store; char store_r_[PADR_(struct uuid * __capability)];
 	char count_l_[PADL_(int)]; int count; char count_r_[PADR_(int)];
 };
 struct sendfile_args {
@@ -1056,14 +1056,14 @@ struct sendfile_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
-	char hdtr_l_[PADL_(struct sf_hdtr_native *)]; struct sf_hdtr_native * hdtr; char hdtr_r_[PADR_(struct sf_hdtr_native *)];
-	char sbytes_l_[PADL_(off_t *)]; off_t * sbytes; char sbytes_r_[PADR_(off_t *)];
+	char hdtr_l_[PADL_(struct sf_hdtr_native * __capability)]; struct sf_hdtr_native * __capability hdtr; char hdtr_r_[PADR_(struct sf_hdtr_native * __capability)];
+	char sbytes_l_[PADL_(off_t * __capability)]; off_t * __capability sbytes; char sbytes_r_[PADR_(off_t * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct mac_syscall_args {
-	char policy_l_[PADL_(const char *)]; const char * policy; char policy_r_[PADR_(const char *)];
+	char policy_l_[PADL_(const char * __capability)]; const char * __capability policy; char policy_r_[PADR_(const char * __capability)];
 	char call_l_[PADL_(int)]; int call; char call_r_[PADR_(int)];
-	char arg_l_[PADL_(void *)]; void * arg; char arg_r_[PADR_(void *)];
+	char arg_l_[PADL_(void * __capability)]; void * __capability arg; char arg_r_[PADR_(void * __capability)];
 };
 struct ksem_close_args {
 	char id_l_[PADL_(semid_t)]; semid_t id; char id_r_[PADR_(semid_t)];
@@ -1078,117 +1078,117 @@ struct ksem_trywait_args {
 	char id_l_[PADL_(semid_t)]; semid_t id; char id_r_[PADR_(semid_t)];
 };
 struct ksem_init_args {
-	char idp_l_[PADL_(semid_t *)]; semid_t * idp; char idp_r_[PADR_(semid_t *)];
+	char idp_l_[PADL_(semid_t * __capability)]; semid_t * __capability idp; char idp_r_[PADR_(semid_t * __capability)];
 	char value_l_[PADL_(unsigned int)]; unsigned int value; char value_r_[PADR_(unsigned int)];
 };
 struct ksem_open_args {
-	char idp_l_[PADL_(semid_t *)]; semid_t * idp; char idp_r_[PADR_(semid_t *)];
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char idp_l_[PADL_(semid_t * __capability)]; semid_t * __capability idp; char idp_r_[PADR_(semid_t * __capability)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 	char oflag_l_[PADL_(int)]; int oflag; char oflag_r_[PADR_(int)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 	char value_l_[PADL_(unsigned int)]; unsigned int value; char value_r_[PADR_(unsigned int)];
 };
 struct ksem_unlink_args {
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 };
 struct ksem_getvalue_args {
 	char id_l_[PADL_(semid_t)]; semid_t id; char id_r_[PADR_(semid_t)];
-	char val_l_[PADL_(int *)]; int * val; char val_r_[PADR_(int *)];
+	char val_l_[PADL_(int * __capability)]; int * __capability val; char val_r_[PADR_(int * __capability)];
 };
 struct ksem_destroy_args {
 	char id_l_[PADL_(semid_t)]; semid_t id; char id_r_[PADR_(semid_t)];
 };
 struct __mac_get_pid_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_get_link_args {
-	char path_p_l_[PADL_(const char *)]; const char * path_p; char path_p_r_[PADR_(const char *)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char path_p_l_[PADL_(const char * __capability)]; const char * __capability path_p; char path_p_r_[PADR_(const char * __capability)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct __mac_set_link_args {
-	char path_p_l_[PADL_(const char *)]; const char * path_p; char path_p_r_[PADR_(const char *)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char path_p_l_[PADL_(const char * __capability)]; const char * __capability path_p; char path_p_r_[PADR_(const char * __capability)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct extattr_set_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_get_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_delete_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char attrname_l_[PADL_(const char *)]; const char * attrname; char attrname_r_[PADR_(const char *)];
+	char attrname_l_[PADL_(const char * __capability)]; const char * __capability attrname; char attrname_r_[PADR_(const char * __capability)];
 };
 struct __mac_execve_args {
-	char fname_l_[PADL_(const char *)]; const char * fname; char fname_r_[PADR_(const char *)];
-	char argv_l_[PADL_(char **)]; char ** argv; char argv_r_[PADR_(char **)];
-	char envv_l_[PADL_(char **)]; char ** envv; char envv_r_[PADR_(char **)];
-	char mac_p_l_[PADL_(struct mac_native *)]; struct mac_native * mac_p; char mac_p_r_[PADR_(struct mac_native *)];
+	char fname_l_[PADL_(const char * __capability)]; const char * __capability fname; char fname_r_[PADR_(const char * __capability)];
+	char argv_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability argv; char argv_r_[PADR_(char * __capability * __capability)];
+	char envv_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability envv; char envv_r_[PADR_(char * __capability * __capability)];
+	char mac_p_l_[PADL_(struct mac_native * __capability)]; struct mac_native * __capability mac_p; char mac_p_r_[PADR_(struct mac_native * __capability)];
 };
 struct sigaction_args {
 	char sig_l_[PADL_(int)]; int sig; char sig_r_[PADR_(int)];
-	char act_l_[PADL_(const struct sigaction_native *)]; const struct sigaction_native * act; char act_r_[PADR_(const struct sigaction_native *)];
-	char oact_l_[PADL_(struct sigaction_native *)]; struct sigaction_native * oact; char oact_r_[PADR_(struct sigaction_native *)];
+	char act_l_[PADL_(const struct sigaction_native * __capability)]; const struct sigaction_native * __capability act; char act_r_[PADR_(const struct sigaction_native * __capability)];
+	char oact_l_[PADL_(struct sigaction_native * __capability)]; struct sigaction_native * __capability oact; char oact_r_[PADR_(struct sigaction_native * __capability)];
 };
 struct sigreturn_args {
-	char sigcntxp_l_[PADL_(const struct __ucontext *)]; const struct __ucontext * sigcntxp; char sigcntxp_r_[PADR_(const struct __ucontext *)];
+	char sigcntxp_l_[PADL_(const struct __ucontext * __capability)]; const struct __ucontext * __capability sigcntxp; char sigcntxp_r_[PADR_(const struct __ucontext * __capability)];
 };
 struct getcontext_args {
-	char ucp_l_[PADL_(struct __ucontext *)]; struct __ucontext * ucp; char ucp_r_[PADR_(struct __ucontext *)];
+	char ucp_l_[PADL_(struct __ucontext * __capability)]; struct __ucontext * __capability ucp; char ucp_r_[PADR_(struct __ucontext * __capability)];
 };
 struct setcontext_args {
-	char ucp_l_[PADL_(const struct __ucontext *)]; const struct __ucontext * ucp; char ucp_r_[PADR_(const struct __ucontext *)];
+	char ucp_l_[PADL_(const struct __ucontext * __capability)]; const struct __ucontext * __capability ucp; char ucp_r_[PADR_(const struct __ucontext * __capability)];
 };
 struct swapcontext_args {
-	char oucp_l_[PADL_(struct __ucontext *)]; struct __ucontext * oucp; char oucp_r_[PADR_(struct __ucontext *)];
-	char ucp_l_[PADL_(const struct __ucontext *)]; const struct __ucontext * ucp; char ucp_r_[PADR_(const struct __ucontext *)];
+	char oucp_l_[PADL_(struct __ucontext * __capability)]; struct __ucontext * __capability oucp; char oucp_r_[PADR_(struct __ucontext * __capability)];
+	char ucp_l_[PADL_(const struct __ucontext * __capability)]; const struct __ucontext * __capability ucp; char ucp_r_[PADR_(const struct __ucontext * __capability)];
 };
 struct swapoff_args {
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 };
 struct __acl_get_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_set_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct __acl_delete_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
 };
 struct __acl_aclcheck_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char type_l_[PADL_(acl_type_t)]; acl_type_t type; char type_r_[PADR_(acl_type_t)];
-	char aclp_l_[PADL_(struct acl *)]; struct acl * aclp; char aclp_r_[PADR_(struct acl *)];
+	char aclp_l_[PADL_(struct acl * __capability)]; struct acl * __capability aclp; char aclp_r_[PADR_(struct acl * __capability)];
 };
 struct sigwait_args {
-	char set_l_[PADL_(const sigset_t *)]; const sigset_t * set; char set_r_[PADR_(const sigset_t *)];
-	char sig_l_[PADL_(int *)]; int * sig; char sig_r_[PADR_(int *)];
+	char set_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability set; char set_r_[PADR_(const sigset_t * __capability)];
+	char sig_l_[PADL_(int * __capability)]; int * __capability sig; char sig_r_[PADR_(int * __capability)];
 };
 struct thr_create_args {
-	char ctx_l_[PADL_(struct __ucontext *)]; struct __ucontext * ctx; char ctx_r_[PADR_(struct __ucontext *)];
-	char id_l_[PADL_(long *)]; long * id; char id_r_[PADR_(long *)];
+	char ctx_l_[PADL_(struct __ucontext * __capability)]; struct __ucontext * __capability ctx; char ctx_r_[PADR_(struct __ucontext * __capability)];
+	char id_l_[PADL_(long * __capability)]; long * __capability id; char id_r_[PADR_(long * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct thr_exit_args {
-	char state_l_[PADL_(long *)]; long * state; char state_r_[PADR_(long *)];
+	char state_l_[PADL_(long * __capability)]; long * __capability state; char state_r_[PADR_(long * __capability)];
 };
 struct thr_self_args {
-	char id_l_[PADL_(long *)]; long * id; char id_r_[PADR_(long *)];
+	char id_l_[PADL_(long * __capability)]; long * __capability id; char id_r_[PADR_(long * __capability)];
 };
 struct thr_kill_args {
 	char id_l_[PADL_(long)]; long id; char id_r_[PADR_(long)];
@@ -1200,27 +1200,27 @@ struct jail_attach_args {
 struct extattr_list_fd_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_list_file_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct extattr_list_link_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char attrnamespace_l_[PADL_(int)]; int attrnamespace; char attrnamespace_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
 };
 struct ksem_timedwait_args {
 	char id_l_[PADL_(semid_t)]; semid_t id; char id_r_[PADR_(semid_t)];
-	char abstime_l_[PADL_(const struct timespec *)]; const struct timespec * abstime; char abstime_r_[PADR_(const struct timespec *)];
+	char abstime_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability abstime; char abstime_r_[PADR_(const struct timespec * __capability)];
 };
 struct thr_suspend_args {
-	char timeout_l_[PADL_(const struct timespec *)]; const struct timespec * timeout; char timeout_r_[PADR_(const struct timespec *)];
+	char timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability timeout; char timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct thr_wake_args {
 	char id_l_[PADL_(long)]; long id; char id_r_[PADR_(long)];
@@ -1230,102 +1230,102 @@ struct kldunloadf_args {
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct audit_args {
-	char record_l_[PADL_(const void *)]; const void * record; char record_r_[PADR_(const void *)];
+	char record_l_[PADL_(const void * __capability)]; const void * __capability record; char record_r_[PADR_(const void * __capability)];
 	char length_l_[PADL_(u_int)]; u_int length; char length_r_[PADR_(u_int)];
 };
 struct auditon_args {
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 	char length_l_[PADL_(u_int)]; u_int length; char length_r_[PADR_(u_int)];
 };
 struct getauid_args {
-	char auid_l_[PADL_(uid_t *)]; uid_t * auid; char auid_r_[PADR_(uid_t *)];
+	char auid_l_[PADL_(uid_t * __capability)]; uid_t * __capability auid; char auid_r_[PADR_(uid_t * __capability)];
 };
 struct setauid_args {
-	char auid_l_[PADL_(uid_t *)]; uid_t * auid; char auid_r_[PADR_(uid_t *)];
+	char auid_l_[PADL_(uid_t * __capability)]; uid_t * __capability auid; char auid_r_[PADR_(uid_t * __capability)];
 };
 struct getaudit_args {
-	char auditinfo_l_[PADL_(struct auditinfo *)]; struct auditinfo * auditinfo; char auditinfo_r_[PADR_(struct auditinfo *)];
+	char auditinfo_l_[PADL_(struct auditinfo * __capability)]; struct auditinfo * __capability auditinfo; char auditinfo_r_[PADR_(struct auditinfo * __capability)];
 };
 struct setaudit_args {
-	char auditinfo_l_[PADL_(struct auditinfo *)]; struct auditinfo * auditinfo; char auditinfo_r_[PADR_(struct auditinfo *)];
+	char auditinfo_l_[PADL_(struct auditinfo * __capability)]; struct auditinfo * __capability auditinfo; char auditinfo_r_[PADR_(struct auditinfo * __capability)];
 };
 struct getaudit_addr_args {
-	char auditinfo_addr_l_[PADL_(struct auditinfo_addr *)]; struct auditinfo_addr * auditinfo_addr; char auditinfo_addr_r_[PADR_(struct auditinfo_addr *)];
+	char auditinfo_addr_l_[PADL_(struct auditinfo_addr * __capability)]; struct auditinfo_addr * __capability auditinfo_addr; char auditinfo_addr_r_[PADR_(struct auditinfo_addr * __capability)];
 	char length_l_[PADL_(u_int)]; u_int length; char length_r_[PADR_(u_int)];
 };
 struct setaudit_addr_args {
-	char auditinfo_addr_l_[PADL_(struct auditinfo_addr *)]; struct auditinfo_addr * auditinfo_addr; char auditinfo_addr_r_[PADR_(struct auditinfo_addr *)];
+	char auditinfo_addr_l_[PADL_(struct auditinfo_addr * __capability)]; struct auditinfo_addr * __capability auditinfo_addr; char auditinfo_addr_r_[PADR_(struct auditinfo_addr * __capability)];
 	char length_l_[PADL_(u_int)]; u_int length; char length_r_[PADR_(u_int)];
 };
 struct auditctl_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct _umtx_op_args {
-	char obj_l_[PADL_(void *)]; void * obj; char obj_r_[PADR_(void *)];
+	char obj_l_[PADL_(void * __capability)]; void * __capability obj; char obj_r_[PADR_(void * __capability)];
 	char op_l_[PADL_(int)]; int op; char op_r_[PADR_(int)];
 	char val_l_[PADL_(u_long)]; u_long val; char val_r_[PADR_(u_long)];
-	char uaddr1_l_[PADL_(void *)]; void * uaddr1; char uaddr1_r_[PADR_(void *)];
-	char uaddr2_l_[PADL_(void *)]; void * uaddr2; char uaddr2_r_[PADR_(void *)];
+	char uaddr1_l_[PADL_(void * __capability)]; void * __capability uaddr1; char uaddr1_r_[PADR_(void * __capability)];
+	char uaddr2_l_[PADL_(void * __capability)]; void * __capability uaddr2; char uaddr2_r_[PADR_(void * __capability)];
 };
 struct thr_new_args {
-	char param_l_[PADL_(struct thr_param *)]; struct thr_param * param; char param_r_[PADR_(struct thr_param *)];
+	char param_l_[PADL_(struct thr_param * __capability)]; struct thr_param * __capability param; char param_r_[PADR_(struct thr_param * __capability)];
 	char param_size_l_[PADL_(int)]; int param_size; char param_size_r_[PADR_(int)];
 };
 struct sigqueue_args {
 	char pid_l_[PADL_(pid_t)]; pid_t pid; char pid_r_[PADR_(pid_t)];
 	char signum_l_[PADL_(int)]; int signum; char signum_r_[PADR_(int)];
-	char value_l_[PADL_(void *)]; void * value; char value_r_[PADR_(void *)];
+	char value_l_[PADL_(void * __capability)]; void * __capability value; char value_r_[PADR_(void * __capability)];
 };
 struct kmq_open_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
-	char attr_l_[PADL_(const struct mq_attr *)]; const struct mq_attr * attr; char attr_r_[PADR_(const struct mq_attr *)];
+	char attr_l_[PADL_(const struct mq_attr * __capability)]; const struct mq_attr * __capability attr; char attr_r_[PADR_(const struct mq_attr * __capability)];
 };
 struct kmq_setattr_args {
 	char mqd_l_[PADL_(int)]; int mqd; char mqd_r_[PADR_(int)];
-	char attr_l_[PADL_(const struct mq_attr *)]; const struct mq_attr * attr; char attr_r_[PADR_(const struct mq_attr *)];
-	char oattr_l_[PADL_(struct mq_attr *)]; struct mq_attr * oattr; char oattr_r_[PADR_(struct mq_attr *)];
+	char attr_l_[PADL_(const struct mq_attr * __capability)]; const struct mq_attr * __capability attr; char attr_r_[PADR_(const struct mq_attr * __capability)];
+	char oattr_l_[PADL_(struct mq_attr * __capability)]; struct mq_attr * __capability oattr; char oattr_r_[PADR_(struct mq_attr * __capability)];
 };
 struct kmq_timedreceive_args {
 	char mqd_l_[PADL_(int)]; int mqd; char mqd_r_[PADR_(int)];
-	char msg_ptr_l_[PADL_(char *)]; char * msg_ptr; char msg_ptr_r_[PADR_(char *)];
+	char msg_ptr_l_[PADL_(char * __capability)]; char * __capability msg_ptr; char msg_ptr_r_[PADR_(char * __capability)];
 	char msg_len_l_[PADL_(size_t)]; size_t msg_len; char msg_len_r_[PADR_(size_t)];
-	char msg_prio_l_[PADL_(unsigned *)]; unsigned * msg_prio; char msg_prio_r_[PADR_(unsigned *)];
-	char abs_timeout_l_[PADL_(const struct timespec *)]; const struct timespec * abs_timeout; char abs_timeout_r_[PADR_(const struct timespec *)];
+	char msg_prio_l_[PADL_(unsigned * __capability)]; unsigned * __capability msg_prio; char msg_prio_r_[PADR_(unsigned * __capability)];
+	char abs_timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability abs_timeout; char abs_timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct kmq_timedsend_args {
 	char mqd_l_[PADL_(int)]; int mqd; char mqd_r_[PADR_(int)];
-	char msg_ptr_l_[PADL_(const char *)]; const char * msg_ptr; char msg_ptr_r_[PADR_(const char *)];
+	char msg_ptr_l_[PADL_(const char * __capability)]; const char * __capability msg_ptr; char msg_ptr_r_[PADR_(const char * __capability)];
 	char msg_len_l_[PADL_(size_t)]; size_t msg_len; char msg_len_r_[PADR_(size_t)];
 	char msg_prio_l_[PADL_(unsigned)]; unsigned msg_prio; char msg_prio_r_[PADR_(unsigned)];
-	char abs_timeout_l_[PADL_(const struct timespec *)]; const struct timespec * abs_timeout; char abs_timeout_r_[PADR_(const struct timespec *)];
+	char abs_timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability abs_timeout; char abs_timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct kmq_notify_args {
 	char mqd_l_[PADL_(int)]; int mqd; char mqd_r_[PADR_(int)];
-	char sigev_l_[PADL_(const struct sigevent_native *)]; const struct sigevent_native * sigev; char sigev_r_[PADR_(const struct sigevent_native *)];
+	char sigev_l_[PADL_(const struct sigevent_native * __capability)]; const struct sigevent_native * __capability sigev; char sigev_r_[PADR_(const struct sigevent_native * __capability)];
 };
 struct kmq_unlink_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct abort2_args {
-	char why_l_[PADL_(const char *)]; const char * why; char why_r_[PADR_(const char *)];
+	char why_l_[PADL_(const char * __capability)]; const char * __capability why; char why_r_[PADR_(const char * __capability)];
 	char nargs_l_[PADL_(int)]; int nargs; char nargs_r_[PADR_(int)];
-	char args_l_[PADL_(void **)]; void ** args; char args_r_[PADR_(void **)];
+	char args_l_[PADL_(void * __capability * __capability)]; void * __capability * __capability args; char args_r_[PADR_(void * __capability * __capability)];
 };
 struct thr_set_name_args {
 	char id_l_[PADL_(long)]; long id; char id_r_[PADR_(long)];
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 };
 struct aio_fsync_args {
 	char op_l_[PADL_(int)]; int op; char op_r_[PADR_(int)];
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct rtprio_thread_args {
 	char function_l_[PADL_(int)]; int function; char function_r_[PADR_(int)];
 	char lwpid_l_[PADL_(lwpid_t)]; lwpid_t lwpid; char lwpid_r_[PADR_(lwpid_t)];
-	char rtp_l_[PADL_(struct rtprio *)]; struct rtprio * rtp; char rtp_r_[PADR_(struct rtprio *)];
+	char rtp_l_[PADL_(struct rtprio * __capability)]; struct rtprio * __capability rtp; char rtp_r_[PADR_(struct rtprio * __capability)];
 };
 struct sctp_peeloff_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
@@ -1333,45 +1333,45 @@ struct sctp_peeloff_args {
 };
 struct sctp_generic_sendmsg_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char msg_l_[PADL_(void *)]; void * msg; char msg_r_[PADR_(void *)];
+	char msg_l_[PADL_(void * __capability)]; void * __capability msg; char msg_r_[PADR_(void * __capability)];
 	char mlen_l_[PADL_(int)]; int mlen; char mlen_r_[PADR_(int)];
-	char to_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * to; char to_r_[PADR_(const struct sockaddr *)];
+	char to_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability to; char to_r_[PADR_(const struct sockaddr * __capability)];
 	char tolen_l_[PADL_(__socklen_t)]; __socklen_t tolen; char tolen_r_[PADR_(__socklen_t)];
-	char sinfo_l_[PADL_(struct sctp_sndrcvinfo *)]; struct sctp_sndrcvinfo * sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo *)];
+	char sinfo_l_[PADL_(struct sctp_sndrcvinfo * __capability)]; struct sctp_sndrcvinfo * __capability sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct sctp_generic_sendmsg_iov_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char iov_l_[PADL_(struct iovec_native *)]; struct iovec_native * iov; char iov_r_[PADR_(struct iovec_native *)];
+	char iov_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iov; char iov_r_[PADR_(struct iovec_native * __capability)];
 	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
-	char to_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * to; char to_r_[PADR_(const struct sockaddr *)];
+	char to_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability to; char to_r_[PADR_(const struct sockaddr * __capability)];
 	char tolen_l_[PADL_(__socklen_t)]; __socklen_t tolen; char tolen_r_[PADR_(__socklen_t)];
-	char sinfo_l_[PADL_(struct sctp_sndrcvinfo *)]; struct sctp_sndrcvinfo * sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo *)];
+	char sinfo_l_[PADL_(struct sctp_sndrcvinfo * __capability)]; struct sctp_sndrcvinfo * __capability sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct sctp_generic_recvmsg_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char iov_l_[PADL_(struct iovec_native *)]; struct iovec_native * iov; char iov_r_[PADR_(struct iovec_native *)];
+	char iov_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iov; char iov_r_[PADR_(struct iovec_native * __capability)];
 	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
-	char from_l_[PADL_(struct sockaddr *)]; struct sockaddr * from; char from_r_[PADR_(struct sockaddr *)];
-	char fromlenaddr_l_[PADL_(__socklen_t *)]; __socklen_t * fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t *)];
-	char sinfo_l_[PADL_(struct sctp_sndrcvinfo *)]; struct sctp_sndrcvinfo * sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo *)];
-	char msg_flags_l_[PADL_(int *)]; int * msg_flags; char msg_flags_r_[PADR_(int *)];
+	char from_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability from; char from_r_[PADR_(struct sockaddr * __capability)];
+	char fromlenaddr_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t * __capability)];
+	char sinfo_l_[PADL_(struct sctp_sndrcvinfo * __capability)]; struct sctp_sndrcvinfo * __capability sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo * __capability)];
+	char msg_flags_l_[PADL_(int * __capability)]; int * __capability msg_flags; char msg_flags_r_[PADR_(int * __capability)];
 };
 struct pread_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(void *)]; void * buf; char buf_r_[PADR_(void *)];
+	char buf_l_[PADL_(void * __capability)]; void * __capability buf; char buf_r_[PADR_(void * __capability)];
 	char nbyte_l_[PADL_(size_t)]; size_t nbyte; char nbyte_r_[PADR_(size_t)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct pwrite_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(const void *)]; const void * buf; char buf_r_[PADR_(const void *)];
+	char buf_l_[PADL_(const void * __capability)]; const void * __capability buf; char buf_r_[PADR_(const void * __capability)];
 	char nbyte_l_[PADL_(size_t)]; size_t nbyte; char nbyte_r_[PADR_(size_t)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct mmap_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char prot_l_[PADL_(int)]; int prot; char prot_r_[PADR_(int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
@@ -1384,7 +1384,7 @@ struct lseek_args {
 	char whence_l_[PADL_(int)]; int whence; char whence_r_[PADR_(int)];
 };
 struct truncate_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char length_l_[PADL_(off_t)]; off_t length; char length_r_[PADR_(off_t)];
 };
 struct ftruncate_args {
@@ -1397,10 +1397,10 @@ struct thr_kill2_args {
 	char sig_l_[PADL_(int)]; int sig; char sig_r_[PADR_(int)];
 };
 struct shm_unlink_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct cpuset_args {
-	char setid_l_[PADL_(cpusetid_t *)]; cpusetid_t * setid; char setid_r_[PADR_(cpusetid_t *)];
+	char setid_l_[PADL_(cpusetid_t * __capability)]; cpusetid_t * __capability setid; char setid_r_[PADR_(cpusetid_t * __capability)];
 };
 struct cpuset_setid_args {
 	char which_l_[PADL_(cpuwhich_t)]; cpuwhich_t which; char which_r_[PADR_(cpuwhich_t)];
@@ -1411,109 +1411,109 @@ struct cpuset_getid_args {
 	char level_l_[PADL_(cpulevel_t)]; cpulevel_t level; char level_r_[PADR_(cpulevel_t)];
 	char which_l_[PADL_(cpuwhich_t)]; cpuwhich_t which; char which_r_[PADR_(cpuwhich_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
-	char setid_l_[PADL_(cpusetid_t *)]; cpusetid_t * setid; char setid_r_[PADR_(cpusetid_t *)];
+	char setid_l_[PADL_(cpusetid_t * __capability)]; cpusetid_t * __capability setid; char setid_r_[PADR_(cpusetid_t * __capability)];
 };
 struct cpuset_getaffinity_args {
 	char level_l_[PADL_(cpulevel_t)]; cpulevel_t level; char level_r_[PADR_(cpulevel_t)];
 	char which_l_[PADL_(cpuwhich_t)]; cpuwhich_t which; char which_r_[PADR_(cpuwhich_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
 	char cpusetsize_l_[PADL_(size_t)]; size_t cpusetsize; char cpusetsize_r_[PADR_(size_t)];
-	char mask_l_[PADL_(cpuset_t *)]; cpuset_t * mask; char mask_r_[PADR_(cpuset_t *)];
+	char mask_l_[PADL_(cpuset_t * __capability)]; cpuset_t * __capability mask; char mask_r_[PADR_(cpuset_t * __capability)];
 };
 struct cpuset_setaffinity_args {
 	char level_l_[PADL_(cpulevel_t)]; cpulevel_t level; char level_r_[PADR_(cpulevel_t)];
 	char which_l_[PADL_(cpuwhich_t)]; cpuwhich_t which; char which_r_[PADR_(cpuwhich_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
 	char cpusetsize_l_[PADL_(size_t)]; size_t cpusetsize; char cpusetsize_r_[PADR_(size_t)];
-	char mask_l_[PADL_(const cpuset_t *)]; const cpuset_t * mask; char mask_r_[PADR_(const cpuset_t *)];
+	char mask_l_[PADL_(const cpuset_t * __capability)]; const cpuset_t * __capability mask; char mask_r_[PADR_(const cpuset_t * __capability)];
 };
 struct faccessat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char amode_l_[PADL_(int)]; int amode; char amode_r_[PADR_(int)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct fchmodat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct fchownat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char uid_l_[PADL_(uid_t)]; uid_t uid; char uid_r_[PADR_(uid_t)];
 	char gid_l_[PADL_(gid_t)]; gid_t gid; char gid_r_[PADR_(gid_t)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct fexecve_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char argv_l_[PADL_(char **)]; char ** argv; char argv_r_[PADR_(char **)];
-	char envv_l_[PADL_(char **)]; char ** envv; char envv_r_[PADR_(char **)];
+	char argv_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability argv; char argv_r_[PADR_(char * __capability * __capability)];
+	char envv_l_[PADL_(char * __capability * __capability)]; char * __capability * __capability envv; char envv_r_[PADR_(char * __capability * __capability)];
 };
 struct futimesat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char times_l_[PADL_(const struct timeval *)]; const struct timeval * times; char times_r_[PADR_(const struct timeval *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char times_l_[PADL_(const struct timeval * __capability)]; const struct timeval * __capability times; char times_r_[PADR_(const struct timeval * __capability)];
 };
 struct linkat_args {
 	char fd1_l_[PADL_(int)]; int fd1; char fd1_r_[PADR_(int)];
-	char path1_l_[PADL_(const char *)]; const char * path1; char path1_r_[PADR_(const char *)];
+	char path1_l_[PADL_(const char * __capability)]; const char * __capability path1; char path1_r_[PADR_(const char * __capability)];
 	char fd2_l_[PADL_(int)]; int fd2; char fd2_r_[PADR_(int)];
-	char path2_l_[PADL_(const char *)]; const char * path2; char path2_r_[PADR_(const char *)];
+	char path2_l_[PADL_(const char * __capability)]; const char * __capability path2; char path2_r_[PADR_(const char * __capability)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct mkdirat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct mkfifoat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct openat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };
 struct readlinkat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char bufsize_l_[PADL_(size_t)]; size_t bufsize; char bufsize_r_[PADR_(size_t)];
 };
 struct renameat_args {
 	char oldfd_l_[PADL_(int)]; int oldfd; char oldfd_r_[PADR_(int)];
-	char old_l_[PADL_(const char *)]; const char * old; char old_r_[PADR_(const char *)];
+	char old_l_[PADL_(const char * __capability)]; const char * __capability old; char old_r_[PADR_(const char * __capability)];
 	char newfd_l_[PADL_(int)]; int newfd; char newfd_r_[PADR_(int)];
-	char new_l_[PADL_(const char *)]; const char * new; char new_r_[PADR_(const char *)];
+	char new_l_[PADL_(const char * __capability)]; const char * __capability new; char new_r_[PADR_(const char * __capability)];
 };
 struct symlinkat_args {
-	char path1_l_[PADL_(const char *)]; const char * path1; char path1_r_[PADR_(const char *)];
+	char path1_l_[PADL_(const char * __capability)]; const char * __capability path1; char path1_r_[PADR_(const char * __capability)];
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path2_l_[PADL_(const char *)]; const char * path2; char path2_r_[PADR_(const char *)];
+	char path2_l_[PADL_(const char * __capability)]; const char * __capability path2; char path2_r_[PADR_(const char * __capability)];
 };
 struct unlinkat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct posix_openpt_args {
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct gssd_syscall_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct jail_get_args {
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(unsigned int)]; unsigned int iovcnt; char iovcnt_r_[PADR_(unsigned int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct jail_set_args {
-	char iovp_l_[PADL_(struct iovec_native *)]; struct iovec_native * iovp; char iovp_r_[PADR_(struct iovec_native *)];
+	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
 	char iovcnt_l_[PADL_(unsigned int)]; unsigned int iovcnt; char iovcnt_r_[PADR_(unsigned int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
@@ -1527,35 +1527,35 @@ struct __semctl_args {
 	char semid_l_[PADL_(int)]; int semid; char semid_r_[PADR_(int)];
 	char semnum_l_[PADL_(int)]; int semnum; char semnum_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char arg_l_[PADL_(union semun_native *)]; union semun_native * arg; char arg_r_[PADR_(union semun_native *)];
+	char arg_l_[PADL_(union semun_native * __capability)]; union semun_native * __capability arg; char arg_r_[PADR_(union semun_native * __capability)];
 };
 struct msgctl_args {
 	char msqid_l_[PADL_(int)]; int msqid; char msqid_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct msqid_ds *)]; struct msqid_ds * buf; char buf_r_[PADR_(struct msqid_ds *)];
+	char buf_l_[PADL_(struct msqid_ds * __capability)]; struct msqid_ds * __capability buf; char buf_r_[PADR_(struct msqid_ds * __capability)];
 };
 struct shmctl_args {
 	char shmid_l_[PADL_(int)]; int shmid; char shmid_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct shmid_ds *)]; struct shmid_ds * buf; char buf_r_[PADR_(struct shmid_ds *)];
+	char buf_l_[PADL_(struct shmid_ds * __capability)]; struct shmid_ds * __capability buf; char buf_r_[PADR_(struct shmid_ds * __capability)];
 };
 struct lpathconf_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char name_l_[PADL_(int)]; int name; char name_r_[PADR_(int)];
 };
 struct __cap_rights_get_args {
 	char version_l_[PADL_(int)]; int version; char version_r_[PADR_(int)];
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char rightsp_l_[PADL_(cap_rights_t *)]; cap_rights_t * rightsp; char rightsp_r_[PADR_(cap_rights_t *)];
+	char rightsp_l_[PADL_(cap_rights_t * __capability)]; cap_rights_t * __capability rightsp; char rightsp_r_[PADR_(cap_rights_t * __capability)];
 };
 struct cap_enter_args {
 	register_t dummy;
 };
 struct cap_getmode_args {
-	char modep_l_[PADL_(u_int *)]; u_int * modep; char modep_r_[PADR_(u_int *)];
+	char modep_l_[PADL_(u_int * __capability)]; u_int * __capability modep; char modep_r_[PADR_(u_int * __capability)];
 };
 struct pdfork_args {
-	char fdp_l_[PADL_(int *)]; int * fdp; char fdp_r_[PADR_(int *)];
+	char fdp_l_[PADL_(int * __capability)]; int * __capability fdp; char fdp_r_[PADR_(int * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct pdkill_args {
@@ -1564,51 +1564,51 @@ struct pdkill_args {
 };
 struct pdgetpid_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char pidp_l_[PADL_(pid_t *)]; pid_t * pidp; char pidp_r_[PADR_(pid_t *)];
+	char pidp_l_[PADL_(pid_t * __capability)]; pid_t * __capability pidp; char pidp_r_[PADR_(pid_t * __capability)];
 };
 struct pselect_args {
 	char nd_l_[PADL_(int)]; int nd; char nd_r_[PADR_(int)];
-	char in_l_[PADL_(fd_set *)]; fd_set * in; char in_r_[PADR_(fd_set *)];
-	char ou_l_[PADL_(fd_set *)]; fd_set * ou; char ou_r_[PADR_(fd_set *)];
-	char ex_l_[PADL_(fd_set *)]; fd_set * ex; char ex_r_[PADR_(fd_set *)];
-	char ts_l_[PADL_(const struct timespec *)]; const struct timespec * ts; char ts_r_[PADR_(const struct timespec *)];
-	char sm_l_[PADL_(const sigset_t *)]; const sigset_t * sm; char sm_r_[PADR_(const sigset_t *)];
+	char in_l_[PADL_(fd_set * __capability)]; fd_set * __capability in; char in_r_[PADR_(fd_set * __capability)];
+	char ou_l_[PADL_(fd_set * __capability)]; fd_set * __capability ou; char ou_r_[PADR_(fd_set * __capability)];
+	char ex_l_[PADL_(fd_set * __capability)]; fd_set * __capability ex; char ex_r_[PADR_(fd_set * __capability)];
+	char ts_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability ts; char ts_r_[PADR_(const struct timespec * __capability)];
+	char sm_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability sm; char sm_r_[PADR_(const sigset_t * __capability)];
 };
 struct getloginclass_args {
-	char namebuf_l_[PADL_(char *)]; char * namebuf; char namebuf_r_[PADR_(char *)];
+	char namebuf_l_[PADL_(char * __capability)]; char * __capability namebuf; char namebuf_r_[PADR_(char * __capability)];
 	char namelen_l_[PADL_(size_t)]; size_t namelen; char namelen_r_[PADR_(size_t)];
 };
 struct setloginclass_args {
-	char namebuf_l_[PADL_(const char *)]; const char * namebuf; char namebuf_r_[PADR_(const char *)];
+	char namebuf_l_[PADL_(const char * __capability)]; const char * __capability namebuf; char namebuf_r_[PADR_(const char * __capability)];
 };
 struct rctl_get_racct_args {
-	char inbufp_l_[PADL_(const void *)]; const void * inbufp; char inbufp_r_[PADR_(const void *)];
+	char inbufp_l_[PADL_(const void * __capability)]; const void * __capability inbufp; char inbufp_r_[PADR_(const void * __capability)];
 	char inbuflen_l_[PADL_(size_t)]; size_t inbuflen; char inbuflen_r_[PADR_(size_t)];
-	char outbufp_l_[PADL_(void *)]; void * outbufp; char outbufp_r_[PADR_(void *)];
+	char outbufp_l_[PADL_(void * __capability)]; void * __capability outbufp; char outbufp_r_[PADR_(void * __capability)];
 	char outbuflen_l_[PADL_(size_t)]; size_t outbuflen; char outbuflen_r_[PADR_(size_t)];
 };
 struct rctl_get_rules_args {
-	char inbufp_l_[PADL_(const void *)]; const void * inbufp; char inbufp_r_[PADR_(const void *)];
+	char inbufp_l_[PADL_(const void * __capability)]; const void * __capability inbufp; char inbufp_r_[PADR_(const void * __capability)];
 	char inbuflen_l_[PADL_(size_t)]; size_t inbuflen; char inbuflen_r_[PADR_(size_t)];
-	char outbufp_l_[PADL_(void *)]; void * outbufp; char outbufp_r_[PADR_(void *)];
+	char outbufp_l_[PADL_(void * __capability)]; void * __capability outbufp; char outbufp_r_[PADR_(void * __capability)];
 	char outbuflen_l_[PADL_(size_t)]; size_t outbuflen; char outbuflen_r_[PADR_(size_t)];
 };
 struct rctl_get_limits_args {
-	char inbufp_l_[PADL_(const void *)]; const void * inbufp; char inbufp_r_[PADR_(const void *)];
+	char inbufp_l_[PADL_(const void * __capability)]; const void * __capability inbufp; char inbufp_r_[PADR_(const void * __capability)];
 	char inbuflen_l_[PADL_(size_t)]; size_t inbuflen; char inbuflen_r_[PADR_(size_t)];
-	char outbufp_l_[PADL_(void *)]; void * outbufp; char outbufp_r_[PADR_(void *)];
+	char outbufp_l_[PADL_(void * __capability)]; void * __capability outbufp; char outbufp_r_[PADR_(void * __capability)];
 	char outbuflen_l_[PADL_(size_t)]; size_t outbuflen; char outbuflen_r_[PADR_(size_t)];
 };
 struct rctl_add_rule_args {
-	char inbufp_l_[PADL_(const void *)]; const void * inbufp; char inbufp_r_[PADR_(const void *)];
+	char inbufp_l_[PADL_(const void * __capability)]; const void * __capability inbufp; char inbufp_r_[PADR_(const void * __capability)];
 	char inbuflen_l_[PADL_(size_t)]; size_t inbuflen; char inbuflen_r_[PADR_(size_t)];
-	char outbufp_l_[PADL_(void *)]; void * outbufp; char outbufp_r_[PADR_(void *)];
+	char outbufp_l_[PADL_(void * __capability)]; void * __capability outbufp; char outbufp_r_[PADR_(void * __capability)];
 	char outbuflen_l_[PADL_(size_t)]; size_t outbuflen; char outbuflen_r_[PADR_(size_t)];
 };
 struct rctl_remove_rule_args {
-	char inbufp_l_[PADL_(const void *)]; const void * inbufp; char inbufp_r_[PADR_(const void *)];
+	char inbufp_l_[PADL_(const void * __capability)]; const void * __capability inbufp; char inbufp_r_[PADR_(const void * __capability)];
 	char inbuflen_l_[PADL_(size_t)]; size_t inbuflen; char inbuflen_r_[PADR_(size_t)];
-	char outbufp_l_[PADL_(void *)]; void * outbufp; char outbufp_r_[PADR_(void *)];
+	char outbufp_l_[PADL_(void * __capability)]; void * __capability outbufp; char outbufp_r_[PADR_(void * __capability)];
 	char outbuflen_l_[PADL_(size_t)]; size_t outbuflen; char outbuflen_r_[PADR_(size_t)];
 };
 struct posix_fallocate_args {
@@ -1625,23 +1625,23 @@ struct posix_fadvise_args {
 struct wait6_args {
 	char idtype_l_[PADL_(idtype_t)]; idtype_t idtype; char idtype_r_[PADR_(idtype_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
-	char status_l_[PADL_(int *)]; int * status; char status_r_[PADR_(int *)];
+	char status_l_[PADL_(int * __capability)]; int * __capability status; char status_r_[PADR_(int * __capability)];
 	char options_l_[PADL_(int)]; int options; char options_r_[PADR_(int)];
-	char wrusage_l_[PADL_(struct __wrusage *)]; struct __wrusage * wrusage; char wrusage_r_[PADR_(struct __wrusage *)];
-	char info_l_[PADL_(struct siginfo_native *)]; struct siginfo_native * info; char info_r_[PADR_(struct siginfo_native *)];
+	char wrusage_l_[PADL_(struct __wrusage * __capability)]; struct __wrusage * __capability wrusage; char wrusage_r_[PADR_(struct __wrusage * __capability)];
+	char info_l_[PADL_(struct siginfo_native * __capability)]; struct siginfo_native * __capability info; char info_r_[PADR_(struct siginfo_native * __capability)];
 };
 struct cap_rights_limit_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char rightsp_l_[PADL_(cap_rights_t *)]; cap_rights_t * rightsp; char rightsp_r_[PADR_(cap_rights_t *)];
+	char rightsp_l_[PADL_(cap_rights_t * __capability)]; cap_rights_t * __capability rightsp; char rightsp_r_[PADR_(cap_rights_t * __capability)];
 };
 struct cap_ioctls_limit_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char cmds_l_[PADL_(const u_long *)]; const u_long * cmds; char cmds_r_[PADR_(const u_long *)];
+	char cmds_l_[PADL_(const u_long * __capability)]; const u_long * __capability cmds; char cmds_r_[PADR_(const u_long * __capability)];
 	char ncmds_l_[PADL_(size_t)]; size_t ncmds; char ncmds_r_[PADR_(size_t)];
 };
 struct cap_ioctls_get_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char cmds_l_[PADL_(u_long *)]; u_long * cmds; char cmds_r_[PADR_(u_long *)];
+	char cmds_l_[PADL_(u_long * __capability)]; u_long * __capability cmds; char cmds_r_[PADR_(u_long * __capability)];
 	char maxcmds_l_[PADL_(size_t)]; size_t maxcmds; char maxcmds_r_[PADR_(size_t)];
 };
 struct cap_fcntls_limit_args {
@@ -1650,59 +1650,59 @@ struct cap_fcntls_limit_args {
 };
 struct cap_fcntls_get_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char fcntlrightsp_l_[PADL_(uint32_t *)]; uint32_t * fcntlrightsp; char fcntlrightsp_r_[PADR_(uint32_t *)];
+	char fcntlrightsp_l_[PADL_(uint32_t * __capability)]; uint32_t * __capability fcntlrightsp; char fcntlrightsp_r_[PADR_(uint32_t * __capability)];
 };
 struct bindat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * name; char name_r_[PADR_(const struct sockaddr *)];
+	char name_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability name; char name_r_[PADR_(const struct sockaddr * __capability)];
 	char namelen_l_[PADL_(__socklen_t)]; __socklen_t namelen; char namelen_r_[PADR_(__socklen_t)];
 };
 struct connectat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(const struct sockaddr *)]; const struct sockaddr * name; char name_r_[PADR_(const struct sockaddr *)];
+	char name_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability name; char name_r_[PADR_(const struct sockaddr * __capability)];
 	char namelen_l_[PADL_(__socklen_t)]; __socklen_t namelen; char namelen_r_[PADR_(__socklen_t)];
 };
 struct chflagsat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(u_long)]; u_long flags; char flags_r_[PADR_(u_long)];
 	char atflag_l_[PADL_(int)]; int atflag; char atflag_r_[PADR_(int)];
 };
 struct accept4_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(struct sockaddr *)]; struct sockaddr * name; char name_r_[PADR_(struct sockaddr *)];
-	char anamelen_l_[PADL_(__socklen_t *)]; __socklen_t * anamelen; char anamelen_r_[PADR_(__socklen_t *)];
+	char name_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability name; char name_r_[PADR_(struct sockaddr * __capability)];
+	char anamelen_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability anamelen; char anamelen_r_[PADR_(__socklen_t * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct pipe2_args {
-	char fildes_l_[PADL_(int *)]; int * fildes; char fildes_r_[PADR_(int *)];
+	char fildes_l_[PADL_(int * __capability)]; int * __capability fildes; char fildes_r_[PADR_(int * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct aio_mlock_args {
-	char aiocbp_l_[PADL_(struct aiocb_native *)]; struct aiocb_native * aiocbp; char aiocbp_r_[PADR_(struct aiocb_native *)];
+	char aiocbp_l_[PADL_(struct aiocb_native * __capability)]; struct aiocb_native * __capability aiocbp; char aiocbp_r_[PADR_(struct aiocb_native * __capability)];
 };
 struct procctl_args {
 	char idtype_l_[PADL_(idtype_t)]; idtype_t idtype; char idtype_r_[PADR_(idtype_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
 	char com_l_[PADL_(int)]; int com; char com_r_[PADR_(int)];
-	char data_l_[PADL_(void *)]; void * data; char data_r_[PADR_(void *)];
+	char data_l_[PADL_(void * __capability)]; void * __capability data; char data_r_[PADR_(void * __capability)];
 };
 struct ppoll_args {
-	char fds_l_[PADL_(struct pollfd *)]; struct pollfd * fds; char fds_r_[PADR_(struct pollfd *)];
+	char fds_l_[PADL_(struct pollfd * __capability)]; struct pollfd * __capability fds; char fds_r_[PADR_(struct pollfd * __capability)];
 	char nfds_l_[PADL_(u_int)]; u_int nfds; char nfds_r_[PADR_(u_int)];
-	char ts_l_[PADL_(const struct timespec *)]; const struct timespec * ts; char ts_r_[PADR_(const struct timespec *)];
-	char set_l_[PADL_(const sigset_t *)]; const sigset_t * set; char set_r_[PADR_(const sigset_t *)];
+	char ts_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability ts; char ts_r_[PADR_(const struct timespec * __capability)];
+	char set_l_[PADL_(const sigset_t * __capability)]; const sigset_t * __capability set; char set_r_[PADR_(const sigset_t * __capability)];
 };
 struct futimens_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char times_l_[PADL_(const struct timespec *)]; const struct timespec * times; char times_r_[PADR_(const struct timespec *)];
+	char times_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability times; char times_r_[PADR_(const struct timespec * __capability)];
 };
 struct utimensat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char times_l_[PADL_(const struct timespec *)]; const struct timespec * times; char times_r_[PADR_(const struct timespec *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char times_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability times; char times_r_[PADR_(const struct timespec * __capability)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct fdatasync_args {
@@ -1710,128 +1710,128 @@ struct fdatasync_args {
 };
 struct fstat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char sb_l_[PADL_(struct stat *)]; struct stat * sb; char sb_r_[PADR_(struct stat *)];
+	char sb_l_[PADL_(struct stat * __capability)]; struct stat * __capability sb; char sb_r_[PADR_(struct stat * __capability)];
 };
 struct fstatat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(struct stat *)]; struct stat * buf; char buf_r_[PADR_(struct stat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(struct stat * __capability)]; struct stat * __capability buf; char buf_r_[PADR_(struct stat * __capability)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct fhstat_args {
-	char u_fhp_l_[PADL_(const struct fhandle *)]; const struct fhandle * u_fhp; char u_fhp_r_[PADR_(const struct fhandle *)];
-	char sb_l_[PADL_(struct stat *)]; struct stat * sb; char sb_r_[PADR_(struct stat *)];
+	char u_fhp_l_[PADL_(const struct fhandle * __capability)]; const struct fhandle * __capability u_fhp; char u_fhp_r_[PADR_(const struct fhandle * __capability)];
+	char sb_l_[PADL_(struct stat * __capability)]; struct stat * __capability sb; char sb_r_[PADR_(struct stat * __capability)];
 };
 struct getdirentries_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char count_l_[PADL_(size_t)]; size_t count; char count_r_[PADR_(size_t)];
-	char basep_l_[PADL_(off_t *)]; off_t * basep; char basep_r_[PADR_(off_t *)];
+	char basep_l_[PADL_(off_t * __capability)]; off_t * __capability basep; char basep_r_[PADR_(off_t * __capability)];
 };
 struct statfs_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(struct statfs *)]; struct statfs * buf; char buf_r_[PADR_(struct statfs *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(struct statfs * __capability)]; struct statfs * __capability buf; char buf_r_[PADR_(struct statfs * __capability)];
 };
 struct fstatfs_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct statfs *)]; struct statfs * buf; char buf_r_[PADR_(struct statfs *)];
+	char buf_l_[PADL_(struct statfs * __capability)]; struct statfs * __capability buf; char buf_r_[PADR_(struct statfs * __capability)];
 };
 struct getfsstat_args {
-	char buf_l_[PADL_(struct statfs *)]; struct statfs * buf; char buf_r_[PADR_(struct statfs *)];
+	char buf_l_[PADL_(struct statfs * __capability)]; struct statfs * __capability buf; char buf_r_[PADR_(struct statfs * __capability)];
 	char bufsize_l_[PADL_(long)]; long bufsize; char bufsize_r_[PADR_(long)];
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
 };
 struct fhstatfs_args {
-	char u_fhp_l_[PADL_(const struct fhandle *)]; const struct fhandle * u_fhp; char u_fhp_r_[PADR_(const struct fhandle *)];
-	char buf_l_[PADL_(struct statfs *)]; struct statfs * buf; char buf_r_[PADR_(struct statfs *)];
+	char u_fhp_l_[PADL_(const struct fhandle * __capability)]; const struct fhandle * __capability u_fhp; char u_fhp_r_[PADR_(const struct fhandle * __capability)];
+	char buf_l_[PADL_(struct statfs * __capability)]; struct statfs * __capability buf; char buf_r_[PADR_(struct statfs * __capability)];
 };
 struct mknodat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 	char dev_l_[PADL_(dev_t)]; dev_t dev; char dev_r_[PADR_(dev_t)];
 };
 struct kevent_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char changelist_l_[PADL_(const struct kevent_native *)]; const struct kevent_native * changelist; char changelist_r_[PADR_(const struct kevent_native *)];
+	char changelist_l_[PADL_(const struct kevent_native * __capability)]; const struct kevent_native * __capability changelist; char changelist_r_[PADR_(const struct kevent_native * __capability)];
 	char nchanges_l_[PADL_(int)]; int nchanges; char nchanges_r_[PADR_(int)];
-	char eventlist_l_[PADL_(struct kevent_native *)]; struct kevent_native * eventlist; char eventlist_r_[PADR_(struct kevent_native *)];
+	char eventlist_l_[PADL_(struct kevent_native * __capability)]; struct kevent_native * __capability eventlist; char eventlist_r_[PADR_(struct kevent_native * __capability)];
 	char nevents_l_[PADL_(int)]; int nevents; char nevents_r_[PADR_(int)];
-	char timeout_l_[PADL_(const struct timespec *)]; const struct timespec * timeout; char timeout_r_[PADR_(const struct timespec *)];
+	char timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability timeout; char timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct cpuset_getdomain_args {
 	char level_l_[PADL_(cpulevel_t)]; cpulevel_t level; char level_r_[PADR_(cpulevel_t)];
 	char which_l_[PADL_(cpuwhich_t)]; cpuwhich_t which; char which_r_[PADR_(cpuwhich_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
 	char domainsetsize_l_[PADL_(size_t)]; size_t domainsetsize; char domainsetsize_r_[PADR_(size_t)];
-	char mask_l_[PADL_(domainset_t *)]; domainset_t * mask; char mask_r_[PADR_(domainset_t *)];
-	char policy_l_[PADL_(int *)]; int * policy; char policy_r_[PADR_(int *)];
+	char mask_l_[PADL_(domainset_t * __capability)]; domainset_t * __capability mask; char mask_r_[PADR_(domainset_t * __capability)];
+	char policy_l_[PADL_(int * __capability)]; int * __capability policy; char policy_r_[PADR_(int * __capability)];
 };
 struct cpuset_setdomain_args {
 	char level_l_[PADL_(cpulevel_t)]; cpulevel_t level; char level_r_[PADR_(cpulevel_t)];
 	char which_l_[PADL_(cpuwhich_t)]; cpuwhich_t which; char which_r_[PADR_(cpuwhich_t)];
 	char id_l_[PADL_(id_t)]; id_t id; char id_r_[PADR_(id_t)];
 	char domainsetsize_l_[PADL_(size_t)]; size_t domainsetsize; char domainsetsize_r_[PADR_(size_t)];
-	char mask_l_[PADL_(domainset_t *)]; domainset_t * mask; char mask_r_[PADR_(domainset_t *)];
+	char mask_l_[PADL_(domainset_t * __capability)]; domainset_t * __capability mask; char mask_r_[PADR_(domainset_t * __capability)];
 	char policy_l_[PADL_(int)]; int policy; char policy_r_[PADR_(int)];
 };
 struct getrandom_args {
-	char buf_l_[PADL_(void *)]; void * buf; char buf_r_[PADR_(void *)];
+	char buf_l_[PADL_(void * __capability)]; void * __capability buf; char buf_r_[PADR_(void * __capability)];
 	char buflen_l_[PADL_(size_t)]; size_t buflen; char buflen_r_[PADR_(size_t)];
 	char flags_l_[PADL_(unsigned int)]; unsigned int flags; char flags_r_[PADR_(unsigned int)];
 };
 struct getfhat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(char *)]; char * path; char path_r_[PADR_(char *)];
-	char fhp_l_[PADL_(struct fhandle *)]; struct fhandle * fhp; char fhp_r_[PADR_(struct fhandle *)];
+	char path_l_[PADL_(char * __capability)]; char * __capability path; char path_r_[PADR_(char * __capability)];
+	char fhp_l_[PADL_(struct fhandle * __capability)]; struct fhandle * __capability fhp; char fhp_r_[PADR_(struct fhandle * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct fhlink_args {
-	char fhp_l_[PADL_(struct fhandle *)]; struct fhandle * fhp; char fhp_r_[PADR_(struct fhandle *)];
-	char to_l_[PADL_(const char *)]; const char * to; char to_r_[PADR_(const char *)];
+	char fhp_l_[PADL_(struct fhandle * __capability)]; struct fhandle * __capability fhp; char fhp_r_[PADR_(struct fhandle * __capability)];
+	char to_l_[PADL_(const char * __capability)]; const char * __capability to; char to_r_[PADR_(const char * __capability)];
 };
 struct fhlinkat_args {
-	char fhp_l_[PADL_(struct fhandle *)]; struct fhandle * fhp; char fhp_r_[PADR_(struct fhandle *)];
+	char fhp_l_[PADL_(struct fhandle * __capability)]; struct fhandle * __capability fhp; char fhp_r_[PADR_(struct fhandle * __capability)];
 	char tofd_l_[PADL_(int)]; int tofd; char tofd_r_[PADR_(int)];
-	char to_l_[PADL_(const char *)]; const char * to; char to_r_[PADR_(const char *)];
+	char to_l_[PADL_(const char * __capability)]; const char * __capability to; char to_r_[PADR_(const char * __capability)];
 };
 struct fhreadlink_args {
-	char fhp_l_[PADL_(struct fhandle *)]; struct fhandle * fhp; char fhp_r_[PADR_(struct fhandle *)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char fhp_l_[PADL_(struct fhandle * __capability)]; struct fhandle * __capability fhp; char fhp_r_[PADR_(struct fhandle * __capability)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char bufsize_l_[PADL_(size_t)]; size_t bufsize; char bufsize_r_[PADR_(size_t)];
 };
 struct funlinkat_args {
 	char dfd_l_[PADL_(int)]; int dfd; char dfd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct copy_file_range_args {
 	char infd_l_[PADL_(int)]; int infd; char infd_r_[PADR_(int)];
-	char inoffp_l_[PADL_(off_t *)]; off_t * inoffp; char inoffp_r_[PADR_(off_t *)];
+	char inoffp_l_[PADL_(off_t * __capability)]; off_t * __capability inoffp; char inoffp_r_[PADR_(off_t * __capability)];
 	char outfd_l_[PADL_(int)]; int outfd; char outfd_r_[PADR_(int)];
-	char outoffp_l_[PADL_(off_t *)]; off_t * outoffp; char outoffp_r_[PADR_(off_t *)];
+	char outoffp_l_[PADL_(off_t * __capability)]; off_t * __capability outoffp; char outoffp_r_[PADR_(off_t * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char flags_l_[PADL_(unsigned int)]; unsigned int flags; char flags_r_[PADR_(unsigned int)];
 };
 struct __sysctlbyname_args {
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 	char namelen_l_[PADL_(size_t)]; size_t namelen; char namelen_r_[PADR_(size_t)];
-	char old_l_[PADL_(void *)]; void * old; char old_r_[PADR_(void *)];
-	char oldlenp_l_[PADL_(size_t *)]; size_t * oldlenp; char oldlenp_r_[PADR_(size_t *)];
-	char new_l_[PADL_(void *)]; void * new; char new_r_[PADR_(void *)];
+	char old_l_[PADL_(void * __capability)]; void * __capability old; char old_r_[PADR_(void * __capability)];
+	char oldlenp_l_[PADL_(size_t * __capability)]; size_t * __capability oldlenp; char oldlenp_r_[PADR_(size_t * __capability)];
+	char new_l_[PADL_(void * __capability)]; void * __capability new; char new_r_[PADR_(void * __capability)];
 	char newlen_l_[PADL_(size_t)]; size_t newlen; char newlen_r_[PADR_(size_t)];
 };
 struct shm_open2_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 	char shmflags_l_[PADL_(int)]; int shmflags; char shmflags_r_[PADR_(int)];
-	char name_l_[PADL_(const char *)]; const char * name; char name_r_[PADR_(const char *)];
+	char name_l_[PADL_(const char * __capability)]; const char * __capability name; char name_r_[PADR_(const char * __capability)];
 };
 struct shm_rename_args {
-	char path_from_l_[PADL_(const char *)]; const char * path_from; char path_from_r_[PADR_(const char *)];
-	char path_to_l_[PADL_(const char *)]; const char * path_to; char path_to_r_[PADR_(const char *)];
+	char path_from_l_[PADL_(const char * __capability)]; const char * __capability path_from; char path_from_r_[PADR_(const char * __capability)];
+	char path_to_l_[PADL_(const char * __capability)]; const char * __capability path_to; char path_to_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 int	nosys(struct thread *, struct nosys_args *);
@@ -2227,7 +2227,7 @@ int	sys_shm_rename(struct thread *, struct shm_rename_args *);
 #ifdef COMPAT_43
 
 struct ocreat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
 };
 struct olseek_args {
@@ -2236,17 +2236,17 @@ struct olseek_args {
 	char whence_l_[PADL_(int)]; int whence; char whence_r_[PADR_(int)];
 };
 struct ostat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char ub_l_[PADL_(struct ostat *)]; struct ostat * ub; char ub_r_[PADR_(struct ostat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char ub_l_[PADL_(struct ostat * __capability)]; struct ostat * __capability ub; char ub_r_[PADR_(struct ostat * __capability)];
 };
 struct olstat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char ub_l_[PADL_(struct ostat *)]; struct ostat * ub; char ub_r_[PADR_(struct ostat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char ub_l_[PADL_(struct ostat * __capability)]; struct ostat * __capability ub; char ub_r_[PADR_(struct ostat * __capability)];
 };
 struct osigaction_args {
 	char signum_l_[PADL_(int)]; int signum; char signum_r_[PADR_(int)];
-	char nsa_l_[PADL_(struct osigaction *)]; struct osigaction * nsa; char nsa_r_[PADR_(struct osigaction *)];
-	char osa_l_[PADL_(struct osigaction *)]; struct osigaction * osa; char osa_r_[PADR_(struct osigaction *)];
+	char nsa_l_[PADL_(struct osigaction * __capability)]; struct osigaction * __capability nsa; char nsa_r_[PADR_(struct osigaction * __capability)];
+	char osa_l_[PADL_(struct osigaction * __capability)]; struct osigaction * __capability osa; char osa_r_[PADR_(struct osigaction * __capability)];
 };
 struct osigprocmask_args {
 	char how_l_[PADL_(int)]; int how; char how_r_[PADR_(int)];
@@ -2254,16 +2254,16 @@ struct osigprocmask_args {
 };
 struct ofstat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char sb_l_[PADL_(struct ostat *)]; struct ostat * sb; char sb_r_[PADR_(struct ostat *)];
+	char sb_l_[PADL_(struct ostat * __capability)]; struct ostat * __capability sb; char sb_r_[PADR_(struct ostat * __capability)];
 };
 struct ogetkerninfo_args {
 	char op_l_[PADL_(int)]; int op; char op_r_[PADR_(int)];
-	char where_l_[PADL_(char *)]; char * where; char where_r_[PADR_(char *)];
-	char size_l_[PADL_(size_t *)]; size_t * size; char size_r_[PADR_(size_t *)];
+	char where_l_[PADL_(char * __capability)]; char * __capability where; char where_r_[PADR_(char * __capability)];
+	char size_l_[PADL_(size_t * __capability)]; size_t * __capability size; char size_r_[PADR_(size_t * __capability)];
 	char arg_l_[PADL_(int)]; int arg; char arg_r_[PADR_(int)];
 };
 struct ommap_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(int)]; int len; char len_r_[PADR_(int)];
 	char prot_l_[PADL_(int)]; int prot; char prot_r_[PADR_(int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
@@ -2271,37 +2271,37 @@ struct ommap_args {
 	char pos_l_[PADL_(long)]; long pos; char pos_r_[PADR_(long)];
 };
 struct ogethostname_args {
-	char hostname_l_[PADL_(char *)]; char * hostname; char hostname_r_[PADR_(char *)];
+	char hostname_l_[PADL_(char * __capability)]; char * __capability hostname; char hostname_r_[PADR_(char * __capability)];
 	char len_l_[PADL_(u_int)]; u_int len; char len_r_[PADR_(u_int)];
 };
 struct osethostname_args {
-	char hostname_l_[PADL_(char *)]; char * hostname; char hostname_r_[PADR_(char *)];
+	char hostname_l_[PADL_(char * __capability)]; char * __capability hostname; char hostname_r_[PADR_(char * __capability)];
 	char len_l_[PADL_(u_int)]; u_int len; char len_r_[PADR_(u_int)];
 };
 struct oaccept_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char name_l_[PADL_(struct sockaddr *)]; struct sockaddr * name; char name_r_[PADR_(struct sockaddr *)];
-	char anamelen_l_[PADL_(__socklen_t *)]; __socklen_t * anamelen; char anamelen_r_[PADR_(__socklen_t *)];
+	char name_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability name; char name_r_[PADR_(struct sockaddr * __capability)];
+	char anamelen_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability anamelen; char anamelen_r_[PADR_(__socklen_t * __capability)];
 };
 struct osend_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char buf_l_[PADL_(const void *)]; const void * buf; char buf_r_[PADR_(const void *)];
+	char buf_l_[PADL_(const void * __capability)]; const void * __capability buf; char buf_r_[PADR_(const void * __capability)];
 	char len_l_[PADL_(int)]; int len; char len_r_[PADR_(int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct orecv_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char buf_l_[PADL_(void *)]; void * buf; char buf_r_[PADR_(void *)];
+	char buf_l_[PADL_(void * __capability)]; void * __capability buf; char buf_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(int)]; int len; char len_r_[PADR_(int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct osigreturn_args {
-	char sigcntxp_l_[PADL_(struct osigcontext *)]; struct osigcontext * sigcntxp; char sigcntxp_r_[PADR_(struct osigcontext *)];
+	char sigcntxp_l_[PADL_(struct osigcontext * __capability)]; struct osigcontext * __capability sigcntxp; char sigcntxp_r_[PADR_(struct osigcontext * __capability)];
 };
 struct osigvec_args {
 	char signum_l_[PADL_(int)]; int signum; char signum_r_[PADR_(int)];
-	char nsv_l_[PADL_(struct sigvec *)]; struct sigvec * nsv; char nsv_r_[PADR_(struct sigvec *)];
-	char osv_l_[PADL_(struct sigvec *)]; struct sigvec * osv; char osv_r_[PADR_(struct sigvec *)];
+	char nsv_l_[PADL_(struct sigvec * __capability)]; struct sigvec * __capability nsv; char nsv_r_[PADR_(struct sigvec * __capability)];
+	char osv_l_[PADL_(struct sigvec * __capability)]; struct sigvec * __capability osv; char osv_r_[PADR_(struct sigvec * __capability)];
 };
 struct osigblock_args {
 	char mask_l_[PADL_(int)]; int mask; char mask_r_[PADR_(int)];
@@ -2313,21 +2313,21 @@ struct osigsuspend_args {
 	char mask_l_[PADL_(osigset_t)]; osigset_t mask; char mask_r_[PADR_(osigset_t)];
 };
 struct osigstack_args {
-	char nss_l_[PADL_(struct sigstack *)]; struct sigstack * nss; char nss_r_[PADR_(struct sigstack *)];
-	char oss_l_[PADL_(struct sigstack *)]; struct sigstack * oss; char oss_r_[PADR_(struct sigstack *)];
+	char nss_l_[PADL_(struct sigstack * __capability)]; struct sigstack * __capability nss; char nss_r_[PADR_(struct sigstack * __capability)];
+	char oss_l_[PADL_(struct sigstack * __capability)]; struct sigstack * __capability oss; char oss_r_[PADR_(struct sigstack * __capability)];
 };
 struct orecvmsg_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char msg_l_[PADL_(struct omsghdr *)]; struct omsghdr * msg; char msg_r_[PADR_(struct omsghdr *)];
+	char msg_l_[PADL_(struct omsghdr * __capability)]; struct omsghdr * __capability msg; char msg_r_[PADR_(struct omsghdr * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct osendmsg_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char msg_l_[PADL_(const void *)]; const void * msg; char msg_r_[PADR_(const void *)];
+	char msg_l_[PADL_(const void * __capability)]; const void * __capability msg; char msg_r_[PADR_(const void * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct otruncate_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char length_l_[PADL_(long)]; long length; char length_r_[PADR_(long)];
 };
 struct oftruncate_args {
@@ -2336,19 +2336,19 @@ struct oftruncate_args {
 };
 struct ogetpeername_args {
 	char fdes_l_[PADL_(int)]; int fdes; char fdes_r_[PADR_(int)];
-	char asa_l_[PADL_(struct sockaddr *)]; struct sockaddr * asa; char asa_r_[PADR_(struct sockaddr *)];
-	char alen_l_[PADL_(__socklen_t *)]; __socklen_t * alen; char alen_r_[PADR_(__socklen_t *)];
+	char asa_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability asa; char asa_r_[PADR_(struct sockaddr * __capability)];
+	char alen_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability alen; char alen_r_[PADR_(__socklen_t * __capability)];
 };
 struct osethostid_args {
 	char hostid_l_[PADL_(long)]; long hostid; char hostid_r_[PADR_(long)];
 };
 struct ogetrlimit_args {
 	char which_l_[PADL_(u_int)]; u_int which; char which_r_[PADR_(u_int)];
-	char rlp_l_[PADL_(struct orlimit *)]; struct orlimit * rlp; char rlp_r_[PADR_(struct orlimit *)];
+	char rlp_l_[PADL_(struct orlimit * __capability)]; struct orlimit * __capability rlp; char rlp_r_[PADR_(struct orlimit * __capability)];
 };
 struct osetrlimit_args {
 	char which_l_[PADL_(u_int)]; u_int which; char which_r_[PADR_(u_int)];
-	char rlp_l_[PADL_(struct orlimit *)]; struct orlimit * rlp; char rlp_r_[PADR_(struct orlimit *)];
+	char rlp_l_[PADL_(struct orlimit * __capability)]; struct orlimit * __capability rlp; char rlp_r_[PADR_(struct orlimit * __capability)];
 };
 struct okillpg_args {
 	char pgid_l_[PADL_(int)]; int pgid; char pgid_r_[PADR_(int)];
@@ -2356,9 +2356,9 @@ struct okillpg_args {
 };
 struct ogetdirentries_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char count_l_[PADL_(u_int)]; u_int count; char count_r_[PADR_(u_int)];
-	char basep_l_[PADL_(long *)]; long * basep; char basep_r_[PADR_(long *)];
+	char basep_l_[PADL_(long * __capability)]; long * __capability basep; char basep_r_[PADR_(long * __capability)];
 };
 int	ocreat(struct thread *, struct ocreat_args *);
 int	olseek(struct thread *, struct olseek_args *);
@@ -2404,49 +2404,49 @@ int	ogetdirentries(struct thread *, struct ogetdirentries_args *);
 #ifdef COMPAT_FREEBSD4
 
 struct freebsd4_getfsstat_args {
-	char buf_l_[PADL_(struct ostatfs *)]; struct ostatfs * buf; char buf_r_[PADR_(struct ostatfs *)];
+	char buf_l_[PADL_(struct ostatfs * __capability)]; struct ostatfs * __capability buf; char buf_r_[PADR_(struct ostatfs * __capability)];
 	char bufsize_l_[PADL_(long)]; long bufsize; char bufsize_r_[PADR_(long)];
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
 };
 struct freebsd4_statfs_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(struct ostatfs *)]; struct ostatfs * buf; char buf_r_[PADR_(struct ostatfs *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(struct ostatfs * __capability)]; struct ostatfs * __capability buf; char buf_r_[PADR_(struct ostatfs * __capability)];
 };
 struct freebsd4_fstatfs_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct ostatfs *)]; struct ostatfs * buf; char buf_r_[PADR_(struct ostatfs *)];
+	char buf_l_[PADL_(struct ostatfs * __capability)]; struct ostatfs * __capability buf; char buf_r_[PADR_(struct ostatfs * __capability)];
 };
 struct freebsd4_getdomainname_args {
-	char domainname_l_[PADL_(char *)]; char * domainname; char domainname_r_[PADR_(char *)];
+	char domainname_l_[PADL_(char * __capability)]; char * __capability domainname; char domainname_r_[PADR_(char * __capability)];
 	char len_l_[PADL_(int)]; int len; char len_r_[PADR_(int)];
 };
 struct freebsd4_setdomainname_args {
-	char domainname_l_[PADL_(char *)]; char * domainname; char domainname_r_[PADR_(char *)];
+	char domainname_l_[PADL_(char * __capability)]; char * __capability domainname; char domainname_r_[PADR_(char * __capability)];
 	char len_l_[PADL_(int)]; int len; char len_r_[PADR_(int)];
 };
 struct freebsd4_uname_args {
-	char name_l_[PADL_(struct utsname *)]; struct utsname * name; char name_r_[PADR_(struct utsname *)];
+	char name_l_[PADL_(struct utsname * __capability)]; struct utsname * __capability name; char name_r_[PADR_(struct utsname * __capability)];
 };
 struct freebsd4_fhstatfs_args {
-	char u_fhp_l_[PADL_(const struct fhandle *)]; const struct fhandle * u_fhp; char u_fhp_r_[PADR_(const struct fhandle *)];
-	char buf_l_[PADL_(struct ostatfs *)]; struct ostatfs * buf; char buf_r_[PADR_(struct ostatfs *)];
+	char u_fhp_l_[PADL_(const struct fhandle * __capability)]; const struct fhandle * __capability u_fhp; char u_fhp_r_[PADR_(const struct fhandle * __capability)];
+	char buf_l_[PADL_(struct ostatfs * __capability)]; struct ostatfs * __capability buf; char buf_r_[PADR_(struct ostatfs * __capability)];
 };
 struct freebsd4_sendfile_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
-	char hdtr_l_[PADL_(struct sf_hdtr_native *)]; struct sf_hdtr_native * hdtr; char hdtr_r_[PADR_(struct sf_hdtr_native *)];
-	char sbytes_l_[PADL_(off_t *)]; off_t * sbytes; char sbytes_r_[PADR_(off_t *)];
+	char hdtr_l_[PADL_(struct sf_hdtr_native * __capability)]; struct sf_hdtr_native * __capability hdtr; char hdtr_r_[PADR_(struct sf_hdtr_native * __capability)];
+	char sbytes_l_[PADL_(off_t * __capability)]; off_t * __capability sbytes; char sbytes_r_[PADR_(off_t * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct freebsd4_sigaction_args {
 	char sig_l_[PADL_(int)]; int sig; char sig_r_[PADR_(int)];
-	char act_l_[PADL_(const struct sigaction_native *)]; const struct sigaction_native * act; char act_r_[PADR_(const struct sigaction_native *)];
-	char oact_l_[PADL_(struct sigaction_native *)]; struct sigaction_native * oact; char oact_r_[PADR_(struct sigaction_native *)];
+	char act_l_[PADL_(const struct sigaction_native * __capability)]; const struct sigaction_native * __capability act; char act_r_[PADR_(const struct sigaction_native * __capability)];
+	char oact_l_[PADL_(struct sigaction_native * __capability)]; struct sigaction_native * __capability oact; char oact_r_[PADR_(struct sigaction_native * __capability)];
 };
 struct freebsd4_sigreturn_args {
-	char sigcntxp_l_[PADL_(const struct freebsd4_ucontext *)]; const struct freebsd4_ucontext * sigcntxp; char sigcntxp_r_[PADR_(const struct freebsd4_ucontext *)];
+	char sigcntxp_l_[PADL_(const struct freebsd4_ucontext * __capability)]; const struct freebsd4_ucontext * __capability sigcntxp; char sigcntxp_r_[PADR_(const struct freebsd4_ucontext * __capability)];
 };
 int	freebsd4_getfsstat(struct thread *, struct freebsd4_getfsstat_args *);
 int	freebsd4_statfs(struct thread *, struct freebsd4_statfs_args *);
@@ -2466,20 +2466,20 @@ int	freebsd4_sigreturn(struct thread *, struct freebsd4_sigreturn_args *);
 
 struct freebsd6_pread_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(void *)]; void * buf; char buf_r_[PADR_(void *)];
+	char buf_l_[PADL_(void * __capability)]; void * __capability buf; char buf_r_[PADR_(void * __capability)];
 	char nbyte_l_[PADL_(size_t)]; size_t nbyte; char nbyte_r_[PADR_(size_t)];
 	char pad_l_[PADL_(int)]; int pad; char pad_r_[PADR_(int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct freebsd6_pwrite_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(const void *)]; const void * buf; char buf_r_[PADR_(const void *)];
+	char buf_l_[PADL_(const void * __capability)]; const void * __capability buf; char buf_r_[PADR_(const void * __capability)];
 	char nbyte_l_[PADL_(size_t)]; size_t nbyte; char nbyte_r_[PADR_(size_t)];
 	char pad_l_[PADL_(int)]; int pad; char pad_r_[PADR_(int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct freebsd6_mmap_args {
-	char addr_l_[PADL_(void *)]; void * addr; char addr_r_[PADR_(void *)];
+	char addr_l_[PADL_(void * __capability)]; void * __capability addr; char addr_r_[PADR_(void * __capability)];
 	char len_l_[PADL_(size_t)]; size_t len; char len_r_[PADR_(size_t)];
 	char prot_l_[PADL_(int)]; int prot; char prot_r_[PADR_(int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
@@ -2494,7 +2494,7 @@ struct freebsd6_lseek_args {
 	char whence_l_[PADL_(int)]; int whence; char whence_r_[PADR_(int)];
 };
 struct freebsd6_truncate_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char pad_l_[PADL_(int)]; int pad; char pad_r_[PADR_(int)];
 	char length_l_[PADL_(off_t)]; off_t length; char length_r_[PADR_(off_t)];
 };
@@ -2504,16 +2504,16 @@ struct freebsd6_ftruncate_args {
 	char length_l_[PADL_(off_t)]; off_t length; char length_r_[PADR_(off_t)];
 };
 struct freebsd6_aio_read_args {
-	char aiocbp_l_[PADL_(struct oaiocb *)]; struct oaiocb * aiocbp; char aiocbp_r_[PADR_(struct oaiocb *)];
+	char aiocbp_l_[PADL_(struct oaiocb * __capability)]; struct oaiocb * __capability aiocbp; char aiocbp_r_[PADR_(struct oaiocb * __capability)];
 };
 struct freebsd6_aio_write_args {
-	char aiocbp_l_[PADL_(struct oaiocb *)]; struct oaiocb * aiocbp; char aiocbp_r_[PADR_(struct oaiocb *)];
+	char aiocbp_l_[PADL_(struct oaiocb * __capability)]; struct oaiocb * __capability aiocbp; char aiocbp_r_[PADR_(struct oaiocb * __capability)];
 };
 struct freebsd6_lio_listio_args {
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
-	char acb_list_l_[PADL_(struct oaiocb *const *)]; struct oaiocb *const * acb_list; char acb_list_r_[PADR_(struct oaiocb *const *)];
+	char acb_list_l_[PADL_(struct oaiocb * __capability const * __capability)]; struct oaiocb * __capability const * __capability acb_list; char acb_list_r_[PADR_(struct oaiocb * __capability const * __capability)];
 	char nent_l_[PADL_(int)]; int nent; char nent_r_[PADR_(int)];
-	char sig_l_[PADL_(struct osigevent *)]; struct osigevent * sig; char sig_r_[PADR_(struct osigevent *)];
+	char sig_l_[PADL_(struct osigevent * __capability)]; struct osigevent * __capability sig; char sig_r_[PADR_(struct osigevent * __capability)];
 };
 int	freebsd6_pread(struct thread *, struct freebsd6_pread_args *);
 int	freebsd6_pwrite(struct thread *, struct freebsd6_pwrite_args *);
@@ -2534,17 +2534,17 @@ struct freebsd7___semctl_args {
 	char semid_l_[PADL_(int)]; int semid; char semid_r_[PADR_(int)];
 	char semnum_l_[PADL_(int)]; int semnum; char semnum_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char arg_l_[PADL_(union semun_old *)]; union semun_old * arg; char arg_r_[PADR_(union semun_old *)];
+	char arg_l_[PADL_(union semun_old * __capability)]; union semun_old * __capability arg; char arg_r_[PADR_(union semun_old * __capability)];
 };
 struct freebsd7_msgctl_args {
 	char msqid_l_[PADL_(int)]; int msqid; char msqid_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct msqid_ds_old *)]; struct msqid_ds_old * buf; char buf_r_[PADR_(struct msqid_ds_old *)];
+	char buf_l_[PADL_(struct msqid_ds_old * __capability)]; struct msqid_ds_old * __capability buf; char buf_r_[PADR_(struct msqid_ds_old * __capability)];
 };
 struct freebsd7_shmctl_args {
 	char shmid_l_[PADL_(int)]; int shmid; char shmid_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct shmid_ds_old *)]; struct shmid_ds_old * buf; char buf_r_[PADR_(struct shmid_ds_old *)];
+	char buf_l_[PADL_(struct shmid_ds_old * __capability)]; struct shmid_ds_old * __capability buf; char buf_r_[PADR_(struct shmid_ds_old * __capability)];
 };
 int	freebsd7___semctl(struct thread *, struct freebsd7___semctl_args *);
 int	freebsd7_msgctl(struct thread *, struct freebsd7_msgctl_args *);
@@ -2563,7 +2563,7 @@ int	freebsd10_pipe(struct thread *, struct freebsd10_pipe_args *);
 #ifdef COMPAT_FREEBSD11
 
 struct freebsd11_mknod_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
 	char dev_l_[PADL_(uint32_t)]; uint32_t dev; char dev_r_[PADR_(uint32_t)];
 };
@@ -2571,78 +2571,78 @@ struct freebsd11_vadvise_args {
 	char anom_l_[PADL_(int)]; int anom; char anom_r_[PADR_(int)];
 };
 struct freebsd11_stat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char ub_l_[PADL_(struct freebsd11_stat *)]; struct freebsd11_stat * ub; char ub_r_[PADR_(struct freebsd11_stat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char ub_l_[PADL_(struct freebsd11_stat * __capability)]; struct freebsd11_stat * __capability ub; char ub_r_[PADR_(struct freebsd11_stat * __capability)];
 };
 struct freebsd11_fstat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char sb_l_[PADL_(struct freebsd11_stat *)]; struct freebsd11_stat * sb; char sb_r_[PADR_(struct freebsd11_stat *)];
+	char sb_l_[PADL_(struct freebsd11_stat * __capability)]; struct freebsd11_stat * __capability sb; char sb_r_[PADR_(struct freebsd11_stat * __capability)];
 };
 struct freebsd11_lstat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char ub_l_[PADL_(struct freebsd11_stat *)]; struct freebsd11_stat * ub; char ub_r_[PADR_(struct freebsd11_stat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char ub_l_[PADL_(struct freebsd11_stat * __capability)]; struct freebsd11_stat * __capability ub; char ub_r_[PADR_(struct freebsd11_stat * __capability)];
 };
 struct freebsd11_getdirentries_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char count_l_[PADL_(u_int)]; u_int count; char count_r_[PADR_(u_int)];
-	char basep_l_[PADL_(long *)]; long * basep; char basep_r_[PADR_(long *)];
+	char basep_l_[PADL_(long * __capability)]; long * __capability basep; char basep_r_[PADR_(long * __capability)];
 };
 struct freebsd11_getdents_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
+	char buf_l_[PADL_(char * __capability)]; char * __capability buf; char buf_r_[PADR_(char * __capability)];
 	char count_l_[PADL_(size_t)]; size_t count; char count_r_[PADR_(size_t)];
 };
 struct freebsd11_nstat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char ub_l_[PADL_(struct nstat *)]; struct nstat * ub; char ub_r_[PADR_(struct nstat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char ub_l_[PADL_(struct nstat * __capability)]; struct nstat * __capability ub; char ub_r_[PADR_(struct nstat * __capability)];
 };
 struct freebsd11_nfstat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char sb_l_[PADL_(struct nstat *)]; struct nstat * sb; char sb_r_[PADR_(struct nstat *)];
+	char sb_l_[PADL_(struct nstat * __capability)]; struct nstat * __capability sb; char sb_r_[PADR_(struct nstat * __capability)];
 };
 struct freebsd11_nlstat_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char ub_l_[PADL_(struct nstat *)]; struct nstat * ub; char ub_r_[PADR_(struct nstat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char ub_l_[PADL_(struct nstat * __capability)]; struct nstat * __capability ub; char ub_r_[PADR_(struct nstat * __capability)];
 };
 struct freebsd11_fhstat_args {
-	char u_fhp_l_[PADL_(const struct fhandle *)]; const struct fhandle * u_fhp; char u_fhp_r_[PADR_(const struct fhandle *)];
-	char sb_l_[PADL_(struct freebsd11_stat *)]; struct freebsd11_stat * sb; char sb_r_[PADR_(struct freebsd11_stat *)];
+	char u_fhp_l_[PADL_(const struct fhandle * __capability)]; const struct fhandle * __capability u_fhp; char u_fhp_r_[PADR_(const struct fhandle * __capability)];
+	char sb_l_[PADL_(struct freebsd11_stat * __capability)]; struct freebsd11_stat * __capability sb; char sb_r_[PADR_(struct freebsd11_stat * __capability)];
 };
 struct freebsd11_kevent_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char changelist_l_[PADL_(struct kevent_freebsd11 *)]; struct kevent_freebsd11 * changelist; char changelist_r_[PADR_(struct kevent_freebsd11 *)];
+	char changelist_l_[PADL_(struct kevent_freebsd11 * __capability)]; struct kevent_freebsd11 * __capability changelist; char changelist_r_[PADR_(struct kevent_freebsd11 * __capability)];
 	char nchanges_l_[PADL_(int)]; int nchanges; char nchanges_r_[PADR_(int)];
-	char eventlist_l_[PADL_(struct kevent_freebsd11 *)]; struct kevent_freebsd11 * eventlist; char eventlist_r_[PADR_(struct kevent_freebsd11 *)];
+	char eventlist_l_[PADL_(struct kevent_freebsd11 * __capability)]; struct kevent_freebsd11 * __capability eventlist; char eventlist_r_[PADR_(struct kevent_freebsd11 * __capability)];
 	char nevents_l_[PADL_(int)]; int nevents; char nevents_r_[PADR_(int)];
-	char timeout_l_[PADL_(const struct timespec *)]; const struct timespec * timeout; char timeout_r_[PADR_(const struct timespec *)];
+	char timeout_l_[PADL_(const struct timespec * __capability)]; const struct timespec * __capability timeout; char timeout_r_[PADR_(const struct timespec * __capability)];
 };
 struct freebsd11_getfsstat_args {
-	char buf_l_[PADL_(struct freebsd11_statfs *)]; struct freebsd11_statfs * buf; char buf_r_[PADR_(struct freebsd11_statfs *)];
+	char buf_l_[PADL_(struct freebsd11_statfs * __capability)]; struct freebsd11_statfs * __capability buf; char buf_r_[PADR_(struct freebsd11_statfs * __capability)];
 	char bufsize_l_[PADL_(long)]; long bufsize; char bufsize_r_[PADR_(long)];
 	char mode_l_[PADL_(int)]; int mode; char mode_r_[PADR_(int)];
 };
 struct freebsd11_statfs_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(struct freebsd11_statfs *)]; struct freebsd11_statfs * buf; char buf_r_[PADR_(struct freebsd11_statfs *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(struct freebsd11_statfs * __capability)]; struct freebsd11_statfs * __capability buf; char buf_r_[PADR_(struct freebsd11_statfs * __capability)];
 };
 struct freebsd11_fstatfs_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char buf_l_[PADL_(struct freebsd11_statfs *)]; struct freebsd11_statfs * buf; char buf_r_[PADR_(struct freebsd11_statfs *)];
+	char buf_l_[PADL_(struct freebsd11_statfs * __capability)]; struct freebsd11_statfs * __capability buf; char buf_r_[PADR_(struct freebsd11_statfs * __capability)];
 };
 struct freebsd11_fhstatfs_args {
-	char u_fhp_l_[PADL_(const struct fhandle *)]; const struct fhandle * u_fhp; char u_fhp_r_[PADR_(const struct fhandle *)];
-	char buf_l_[PADL_(struct freebsd11_statfs *)]; struct freebsd11_statfs * buf; char buf_r_[PADR_(struct freebsd11_statfs *)];
+	char u_fhp_l_[PADL_(const struct fhandle * __capability)]; const struct fhandle * __capability u_fhp; char u_fhp_r_[PADR_(const struct fhandle * __capability)];
+	char buf_l_[PADL_(struct freebsd11_statfs * __capability)]; struct freebsd11_statfs * __capability buf; char buf_r_[PADR_(struct freebsd11_statfs * __capability)];
 };
 struct freebsd11_fstatat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
-	char buf_l_[PADL_(struct freebsd11_stat *)]; struct freebsd11_stat * buf; char buf_r_[PADR_(struct freebsd11_stat *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
+	char buf_l_[PADL_(struct freebsd11_stat * __capability)]; struct freebsd11_stat * __capability buf; char buf_r_[PADR_(struct freebsd11_stat * __capability)];
 	char flag_l_[PADL_(int)]; int flag; char flag_r_[PADR_(int)];
 };
 struct freebsd11_mknodat_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 	char dev_l_[PADL_(uint32_t)]; uint32_t dev; char dev_r_[PADR_(uint32_t)];
 };
@@ -2671,7 +2671,7 @@ int	freebsd11_mknodat(struct thread *, struct freebsd11_mknodat_args *);
 #ifdef COMPAT_FREEBSD12
 
 struct freebsd12_shm_open_args {
-	char path_l_[PADL_(const char *)]; const char * path; char path_r_[PADR_(const char *)];
+	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 	char mode_l_[PADL_(mode_t)]; mode_t mode; char mode_r_[PADR_(mode_t)];
 };

--- a/sys/sys/thr.h
+++ b/sys/sys/thr.h
@@ -47,17 +47,17 @@ typedef __size_t	size_t;
 #define	THR_SYSTEM_SCOPE	0x0002
 
 struct thr_param {
-    void	(*start_func)(void *);	/* thread entry function. */
-    void	*arg;			/* argument for entry function. */
-    char	*stack_base;		/* stack base address. */
+    void	(* __kerncap start_func)(void *); /* thread entry function. */
+    void	* __kerncap arg;	/* argument for entry function. */
+    char	* __kerncap stack_base;	/* stack base address. */
     size_t	stack_size;		/* stack size. */
-    char	*tls_base;		/* tls base address. */
+    char	* __kerncap tls_base;	/* tls base address. */
     size_t	tls_size;		/* tls size. */
-    long	*child_tid;		/* address to store new TID. */
-    long	*parent_tid;		/* parent accesses the new TID here. */
+    long	* __kerncap child_tid;	/* address to store new TID. */
+    long	* __kerncap parent_tid;	/* parent accesses the new TID here. */
     int		flags;			/* thread flags. */
-    struct rtprio	*rtp;		/* Real-time scheduling priority */
-    void	*spare[3];		/* TODO: cpu affinity mask etc. */
+    struct rtprio * __kerncap rtp;	/* Real-time scheduling priority */
+    void	* __kerncap spare[3];	/* TODO: cpu affinity mask etc. */
 };
 
 /* 

--- a/sys/ufs/ffs/ffs_vfsops.c
+++ b/sys/ufs/ffs/ffs_vfsops.c
@@ -31,6 +31,8 @@
  *	@(#)ffs_vfsops.c	8.31 (Berkeley) 5/20/95
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -586,7 +588,7 @@ ffs_mount(struct mount *mp)
  */
 
 static int
-ffs_cmount(struct mntarg *ma, void *data, uint64_t flags)
+ffs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 {
 	struct ufs_args args;
 	struct export_args exp;

--- a/sys/ufs/ufs/ufsmount.h
+++ b/sys/ufs/ufs/ufsmount.h
@@ -39,7 +39,7 @@
  * Arguments to mount UFS-based filesystems
  */
 struct ufs_args {
-	char	*fspec;			/* block special device to mount */
+	char * __kerncap fspec;		/* block special device to mount */
 	struct	oexport_args export;	/* network export information */
 };
 

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -2353,7 +2353,7 @@ int
 sys_swapon(struct thread *td, struct swapon_args *uap)
 {
 
-	return (kern_swapon(td, __USER_CAP_STR(uap->name)));
+	return (kern_swapon(td, uap->name));
 }
 
 int
@@ -2520,7 +2520,7 @@ int
 sys_swapoff(struct thread *td, struct swapoff_args *uap)
 {
 
-	return (kern_swapoff(td, __USER_CAP_STR(uap->name)));
+	return (kern_swapoff(td, uap->name));
 }
 
 int

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -210,8 +210,8 @@ int
 sys_mmap(struct thread *td, struct mmap_args *uap)
 {
 
-	return (kern_mmap(td, (uintptr_t)uap->addr, uap->len, uap->prot,
-	    uap->flags, uap->fd, uap->pos));
+	return (kern_mmap(td, (__cheri_addr uintptr_t)uap->addr, uap->len,
+	    uap->prot, uap->flags, uap->fd, uap->pos));
 }
 
 int
@@ -671,7 +671,8 @@ int
 sys_msync(struct thread *td, struct msync_args *uap)
 {
 
-	return (kern_msync(td, (uintptr_t)uap->addr, uap->len, uap->flags));
+	return (kern_msync(td, (__cheri_addr uintptr_t)uap->addr, uap->len,
+	    uap->flags));
 }
 
 int
@@ -728,7 +729,7 @@ int
 sys_munmap(struct thread *td, struct munmap_args *uap)
 {
 
-	return (kern_munmap(td, (uintptr_t)uap->addr, uap->len));
+	return (kern_munmap(td, (__cheri_addr uintptr_t)uap->addr, uap->len));
 }
 
 int
@@ -811,7 +812,8 @@ int
 sys_mprotect(struct thread *td, struct mprotect_args *uap)
 {
 
-	return (kern_mprotect(td, (uintptr_t)uap->addr, uap->len, uap->prot));
+	return (kern_mprotect(td, (__cheri_addr uintptr_t)uap->addr, uap->len,
+	    uap->prot));
 }
 
 int
@@ -877,7 +879,7 @@ int
 sys_minherit(struct thread *td, struct minherit_args *uap)
 {
 
-	return (kern_minherit(td, (vm_offset_t)uap->addr, uap->len,
+	return (kern_minherit(td, (__cheri_addr vm_offset_t)uap->addr, uap->len,
 	    uap->inherit));
 }
 
@@ -915,7 +917,8 @@ int
 sys_madvise(struct thread *td, struct madvise_args *uap)
 {
 
-	return (kern_madvise(td, (uintptr_t)uap->addr, uap->len, uap->behav));
+	return (kern_madvise(td, (__cheri_addr uintptr_t)uap->addr, uap->len,
+	    uap->behav));
 }
 
 int
@@ -971,8 +974,8 @@ int
 sys_mincore(struct thread *td, struct mincore_args *uap)
 {
 
-	return (kern_mincore(td, (uintptr_t)uap->addr, uap->len,
-	    __USER_CAP(uap->vec, uap->len)));
+	return (kern_mincore(td, (__cheri_addr uintptr_t)uap->addr, uap->len,
+	    uap->vec));
 }
 
 int
@@ -1223,7 +1226,7 @@ sys_mlock(struct thread *td, struct mlock_args *uap)
 {
 
 	return (kern_mlock(td->td_proc, td->td_ucred,
-	    __DECONST(uintptr_t, uap->addr), uap->len));
+	    __DECONST_CAP(__cheri_addr uintptr_t, uap->addr), uap->len));
 }
 
 int
@@ -1397,7 +1400,7 @@ int
 sys_munlock(struct thread *td, struct munlock_args *uap)
 {
 
-	return (kern_munlock(td, (uintptr_t)uap->addr, uap->len));
+	return (kern_munlock(td, (__cheri_addr uintptr_t)uap->addr, uap->len));
 }
 
 int

--- a/sys/vm/vm_unix.c
+++ b/sys/vm/vm_unix.c
@@ -76,7 +76,7 @@ sys_break(struct thread *td, struct break_args *uap)
 	uintptr_t addr;
 	int error;
 
-	addr = (uintptr_t)uap->nsize;
+	addr = (__cheri_addr uintptr_t)uap->nsize;
 	error = kern_break(td, &addr);
 	if (error == 0)
 		td->td_retval[0] = addr;


### PR DESCRIPTION
This is another step towards having the default ABI be CheriABI.
Note that this is (mostly) the minimal set of changes to get the
kernel compiling again.  Not all system calls have been audited
to see if copyin/copyout need to be replaced with *cap versions
instead.

In general the changes consist of removing __USER_CAP*() for
system call arguments and using EXPLICIT_USER_ACCESS in files
with system calls that use copy*() to use the *_c versions by
default.

In some cases it seemed easier to move forward with annotating
some structures shared with userland with __kerncap