### PR TITLE
Add support for the concept of an address-space reservation

### DIFF
--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -151,7 +151,7 @@ gen_table "vmresult"        "KERN_[A-Z_]+[[:space:]]+[0-9]+"               "vm/v
 gen_table "wait6opt"        "W[A-Z]+[[:space:]]+[0-9]+"                    "sys/wait.h"
 gen_table "seekwhence"      "SEEK_[A-Z]+[[:space:]]+[0-9]+"                "sys/unistd.h"
 gen_table "fcntlcmd"        "F_[A-Z0-9_]+[[:space:]]+[0-9]+[[:space:]]+"   "sys/fcntl.h"	"F_CANCEL|F_..LCK"
-gen_table "mmapflags"       "MAP_[A-Z_]+[[:space:]]+0x[0-9A-Fa-f]+"        "sys/mman.h"
+gen_table "mmapflags"       "MAP_[A-Z_]+[[:space:]]+0x[0-9A-Fa-f]+"        "sys/mman.h"	"MAP_UNMAPPED"
 gen_table "rtpriofuncs"     "RTP_[A-Z]+[[:space:]]+[0-9]+"                 "sys/rtprio.h"
 gen_table "msgflags"        "MSG_[A-Z]+[[:space:]]+0x[0-9]+"               "sys/socket.h"	"MSG_SOCALLBCK|MSG_MORETOCOME"
 gen_table "sigcode"         "SI_[A-Z]+[[:space:]]+0(x[0-9abcdef]+)?"       "sys/signal.h"

--- a/sys/kern/imgact_aout.c
+++ b/sys/kern/imgact_aout.c
@@ -292,7 +292,8 @@ exec_aout_imgact(struct image_params *imgp)
 		file_offset,
 		virtual_offset, text_end,
 		VM_PROT_READ | VM_PROT_EXECUTE, VM_PROT_ALL,
-		MAP_COPY_ON_WRITE | MAP_PREFAULT | MAP_VN_EXEC);
+		MAP_COPY_ON_WRITE | MAP_PREFAULT | MAP_VN_EXEC,
+		virtual_offset);
 	if (error) {
 		vm_map_unlock(map);
 		vm_object_deallocate(object);
@@ -306,7 +307,8 @@ exec_aout_imgact(struct image_params *imgp)
 			file_offset + a_out->a_text,
 			text_end, data_end,
 			VM_PROT_ALL, VM_PROT_ALL,
-			MAP_COPY_ON_WRITE | MAP_PREFAULT | MAP_VN_EXEC);
+			MAP_COPY_ON_WRITE | MAP_PREFAULT | MAP_VN_EXEC,
+			virtual_offset);
 		if (error) {
 			vm_map_unlock(map);
 			vm_object_deallocate(object);
@@ -318,7 +320,8 @@ exec_aout_imgact(struct image_params *imgp)
 	if (bss_size) {
 		error = vm_map_insert(map, NULL, 0,
 			data_end, data_end + bss_size,
-			VM_PROT_ALL, VM_PROT_ALL, 0);
+			VM_PROT_ALL, VM_PROT_ALL, 0,
+			virtual_offset);
 		if (error) {
 			vm_map_unlock(map);
 			return (error);

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1092,6 +1092,10 @@ exec_new_vmspace(struct image_params *imgp, struct sysentvec *sv)
 		map = &vmspace->vm_map;
 	}
 	map->flags |= imgp->map_flags;
+	if (SV_PROC_FLAG(p, SV_CHERI))
+		map->flags |= MAP_RESERVATIONS;
+	else
+		map->flags &= ~MAP_RESERVATIONS;
 
 #ifdef CPU_QEMU_MALTA
 	if (curthread->td_md.md_flags & MDTD_QTRACE) {

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2729,6 +2729,7 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 		kve->kve_start = entry->start;
 		kve->kve_end = entry->end;
 		kve->kve_offset += entry->offset;
+		kve->kve_reservation = entry->reservation;
 
 		if (entry->protection & VM_PROT_READ)
 			kve->kve_protection |= KVME_PROT_READ;
@@ -2749,6 +2750,10 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 			kve->kve_flags |= KVME_FLAG_GROWS_DOWN;
 		if (entry->eflags & MAP_ENTRY_USER_WIRED)
 			kve->kve_flags |= KVME_FLAG_USER_WIRED;
+		if (entry->eflags & MAP_ENTRY_GUARD)
+			kve->kve_flags |= KVME_FLAG_GUARD;
+		if (entry->eflags & MAP_ENTRY_UNMAPPED)
+			kve->kve_flags |= KVME_FLAG_UNMAPPED;
 
 		last_timestamp = map->timestamp;
 		vm_map_unlock_read(map);

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -107,6 +107,9 @@
 #ifdef __LP64__
 #define	MAP_32BIT	 0x00080000 /* map in the low 2GB of address space */
 #endif
+#ifdef _KERNEL
+#define	MAP_UNMAPPED	 0x00100000
+#endif
 
 /*
  * Request specific alignment (n == log2 of the desired alignment).

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -340,9 +340,8 @@ int	kern_mlock(struct proc *proc, struct ucred *cred, uintptr_t addr,
 	    size_t len);
 int	kern_mmap(struct thread *td, uintptr_t addr, size_t len, int prot,
 	    int flags, int fd, off_t pos);
-int	kern_mmap_req(struct thread *td, const struct mmap_req *mrp);
 int	kern_mmap_maxprot(struct proc *p, int prot);
-int	kern_mmap_req(struct thread *td, const struct mmap_req *mrp);
+int	kern_mmap_req(struct thread *td, struct mmap_req *mrp);
 int	kern_modfind(struct thread *td, const char * __capability uname);
 int	kern_modstat(struct thread *td, int modid,
 	    struct module_stat * __capability stat);

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -472,6 +472,8 @@ struct kinfo_file {
 #define	KVME_FLAG_GROWS_UP	0x00000010
 #define	KVME_FLAG_GROWS_DOWN	0x00000020
 #define	KVME_FLAG_USER_WIRED	0x00000040
+#define	KVME_FLAG_GUARD		0x00000080
+#define	KVME_FLAG_UNMAPPED	0x00000100
 
 #if defined(__amd64__)
 #define	KINFO_OVMENTRY_SIZE	1168
@@ -524,7 +526,8 @@ struct kinfo_vmentry {
 	uint16_t kve_status;			/* Status flags. */
 	uint64_t kve_vn_fsid;			/* dev_t of vnode location */
 	uint64_t kve_vn_rdev;			/* Device id if device. */
-	int	 _kve_ispare[8];		/* Space for more stuff. */
+	uint64_t kve_reservation;		/* Map reservation */
+	int	 _kve_ispare[6];		/* Space for more stuff. */
 	/* Truncated before copyout in sysctl */
 	char	 kve_path[PATH_MAX];		/* Path to VM obj, if any. */
 };

--- a/sys/vm/uma_core.c
+++ b/sys/vm/uma_core.c
@@ -2889,7 +2889,7 @@ uma_startup2(void)
 	if (bootstart != bootmem) {
 		vm_map_lock(kernel_map);
 		(void)vm_map_insert(kernel_map, NULL, 0, bootstart, bootmem,
-		    VM_PROT_RW, VM_PROT_RW, MAP_NOFAULT);
+		    VM_PROT_RW, VM_PROT_RW, MAP_NOFAULT, bootstart);
 		vm_map_unlock(kernel_map);
 	}
 

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -792,6 +792,7 @@ vm_fault_lookup(struct faultstate *fs)
 	}
 
 	MPASS((fs->entry->eflags & MAP_ENTRY_GUARD) == 0);
+	MPASS((fs->entry->eflags & MAP_ENTRY_UNMAPPED) == 0);
 
 	if (fs->wired)
 		fs->fault_type = fs->prot | (fs->fault_type & VM_PROT_COPY);

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -657,7 +657,7 @@ kmap_alloc_wait(vm_map_t map, vm_size_t size)
 		vm_map_unlock_and_wait(map, 0);
 	}
 	vm_map_insert(map, NULL, 0, addr, addr + size, VM_PROT_RW, VM_PROT_RW,
-	    MAP_ACC_CHARGED, addr);
+	    MAP_ACC_CHARGED, VM_MIN_KERNEL_ADDRESS);
 	vm_map_unlock(map);
 	return (addr);
 }
@@ -769,7 +769,7 @@ kmem_init(vm_offset_t start, vm_offset_t end)
 	addr = VM_MIN_KERNEL_ADDRESS;
 #endif
 	(void)vm_map_insert(m, NULL, 0, addr, start, VM_PROT_ALL,
-	    VM_PROT_ALL, MAP_NOFAULT, addr);
+	    VM_PROT_ALL, MAP_NOFAULT, VM_MIN_KERNEL_ADDRESS);
 	/* ... and ending with the completion of the above `insert' */
 
 #ifdef __amd64__
@@ -781,7 +781,7 @@ kmem_init(vm_offset_t start, vm_offset_t end)
 	(void)vm_map_insert(m, NULL, 0, (vm_offset_t)vm_page_array,
 	    (vm_offset_t)vm_page_array + round_2mpage(vm_page_array_size *
 	    sizeof(struct vm_page)),
-	    VM_PROT_RW, VM_PROT_RW, MAP_NOFAULT, (vm_offset_t)vm_page_array);
+	    VM_PROT_RW, VM_PROT_RW, MAP_NOFAULT, VM_MIN_KERNEL_ADDRESS);
 #endif
 	vm_map_unlock(m);
 

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -657,7 +657,7 @@ kmap_alloc_wait(vm_map_t map, vm_size_t size)
 		vm_map_unlock_and_wait(map, 0);
 	}
 	vm_map_insert(map, NULL, 0, addr, addr + size, VM_PROT_RW, VM_PROT_RW,
-	    MAP_ACC_CHARGED);
+	    MAP_ACC_CHARGED, addr);
 	vm_map_unlock(map);
 	return (addr);
 }
@@ -755,6 +755,7 @@ void
 kmem_init(vm_offset_t start, vm_offset_t end)
 {
 	vm_map_t m;
+	vm_offset_t addr;
 	int domain;
 
 	m = vm_map_create(kernel_pmap, VM_MIN_KERNEL_ADDRESS, end);
@@ -762,13 +763,13 @@ kmem_init(vm_offset_t start, vm_offset_t end)
 	vm_map_lock(m);
 	/* N.B.: cannot use kgdb to debug, starting with this assignment ... */
 	kernel_map = m;
-	(void)vm_map_insert(m, NULL, 0,
 #ifdef __amd64__
-	    KERNBASE,
-#else		     
-	    VM_MIN_KERNEL_ADDRESS,
+	addr = KERNBASE;
+#else
+	addr = VM_MIN_KERNEL_ADDRESS;
 #endif
-	    start, VM_PROT_ALL, VM_PROT_ALL, MAP_NOFAULT);
+	(void)vm_map_insert(m, NULL, 0, addr, start, VM_PROT_ALL,
+	    VM_PROT_ALL, MAP_NOFAULT, addr);
 	/* ... and ending with the completion of the above `insert' */
 
 #ifdef __amd64__
@@ -780,7 +781,7 @@ kmem_init(vm_offset_t start, vm_offset_t end)
 	(void)vm_map_insert(m, NULL, 0, (vm_offset_t)vm_page_array,
 	    (vm_offset_t)vm_page_array + round_2mpage(vm_page_array_size *
 	    sizeof(struct vm_page)),
-	    VM_PROT_RW, VM_PROT_RW, MAP_NOFAULT);
+	    VM_PROT_RW, VM_PROT_RW, MAP_NOFAULT, (vm_offset_t)vm_page_array);
 #endif
 	vm_map_unlock(m);
 

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -1691,6 +1691,8 @@ vm_map_insert(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
 		protoeflags |= MAP_ENTRY_VN_EXEC;
 	if ((cow & MAP_CREATE_GUARD) != 0)
 		protoeflags |= MAP_ENTRY_GUARD;
+	if ((cow & MAP_CREATE_UNMAPPED) != 0)
+		protoeflags |= MAP_ENTRY_UNMAPPED;
 	if ((cow & MAP_CREATE_STACK_GAP_DN) != 0)
 		protoeflags |= MAP_ENTRY_STACK_GAP_DN;
 	if ((cow & MAP_CREATE_STACK_GAP_UP) != 0)
@@ -1757,7 +1759,8 @@ charged:
 			KASSERT((prev_entry->eflags & MAP_ENTRY_USER_WIRED) ==
 			    0, ("prev_entry %p has incoherent wiring",
 			    prev_entry));
-			if ((prev_entry->eflags & MAP_ENTRY_GUARD) == 0)
+			if ((prev_entry->eflags & (MAP_ENTRY_GUARD |
+			    MAP_ENTRY_UNMAPPED)) == 0)
 				map->size += end - prev_entry->end;
 			vm_map_entry_resize(map, prev_entry,
 			    end - prev_entry->end);
@@ -1814,7 +1817,7 @@ charged:
 	 * Insert the new entry into the list
 	 */
 	vm_map_entry_link(map, new_entry);
-	if ((new_entry->eflags & MAP_ENTRY_GUARD) == 0)
+	if ((new_entry->eflags & (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) == 0)
 		map->size += new_entry->end - new_entry->start;
 
 	vm_map_log("insert", new_entry);
@@ -2365,7 +2368,7 @@ vm_map_entry_charge_object(vm_map_t map, vm_map_entry_t entry)
 	KASSERT((entry->eflags & MAP_ENTRY_IS_SUB_MAP) == 0,
 	    ("map entry %p is a submap", entry));
 	if (entry->object.vm_object == NULL && !map->system_map &&
-	    (entry->eflags & MAP_ENTRY_GUARD) == 0)
+	    (entry->eflags & (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) == 0)
 		vm_map_entry_back(entry);
 	else if (entry->object.vm_object != NULL &&
 	    ((entry->eflags & MAP_ENTRY_NEEDS_COPY) == 0) &&
@@ -2707,7 +2710,8 @@ again:
 	 */
 	for (entry = first_entry; entry->start < end;
 	    entry = vm_map_entry_succ(entry)) {
-		if ((entry->eflags & MAP_ENTRY_GUARD) != 0)
+		if ((entry->eflags &
+		    (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0)
 			continue;
 		if ((entry->eflags & MAP_ENTRY_IS_SUB_MAP) != 0) {
 			vm_map_unlock(map);
@@ -2750,7 +2754,8 @@ again:
 		if (set_max ||
 		    ((new_prot & ~entry->protection) & VM_PROT_WRITE) == 0 ||
 		    ENTRY_CHARGED(entry) ||
-		    (entry->eflags & MAP_ENTRY_GUARD) != 0) {
+		    (entry->eflags &
+		    (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0) {
 			continue;
 		}
 
@@ -2808,7 +2813,8 @@ again:
 	    vm_map_try_merge_entries(map, prev_entry, entry),
 	    prev_entry = entry, entry = vm_map_entry_succ(entry)) {
 		if (rv != KERN_SUCCESS ||
-		    (entry->eflags & MAP_ENTRY_GUARD) != 0)
+		    (entry->eflags &
+		    (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0)
 			continue;
 
 		old_prot = entry->protection;
@@ -3070,7 +3076,8 @@ vm_map_inherit(vm_map_t map, vm_offset_t start, vm_offset_t end,
 	    entry->start < end;
 	    prev_entry = entry, entry = vm_map_entry_succ(entry)) {
 		vm_map_clip_end(map, entry, end);
-		if ((entry->eflags & MAP_ENTRY_GUARD) == 0 ||
+		if ((entry->eflags &
+		    (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) == 0 ||
 		    new_inheritance != VM_INHERIT_ZERO)
 			entry->inheritance = new_inheritance;
 		vm_map_try_merge_entries(map, prev_entry, entry);
@@ -3824,7 +3831,7 @@ vm_map_entry_delete(vm_map_t map, vm_map_entry_t entry)
 	vm_map_entry_unlink(map, entry, UNLINK_MERGE_NONE);
 	object = entry->object.vm_object;
 
-	if ((entry->eflags & MAP_ENTRY_GUARD) != 0) {
+	if ((entry->eflags & (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0) {
 		MPASS(entry->cred == NULL);
 		MPASS((entry->eflags & MAP_ENTRY_IS_SUB_MAP) == 0);
 		MPASS(object == NULL);
@@ -4205,7 +4212,7 @@ vmspace_map_entry_forked(const struct vmspace *vm1, struct vmspace *vm2,
 	vm_size_t entrysize;
 	vm_offset_t newend;
 
-	if ((entry->eflags & MAP_ENTRY_GUARD) != 0)
+	if ((entry->eflags & (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0)
 		return;
 	entrysize = entry->end - entry->start;
 	vm2->vm_map.size += entrysize;
@@ -4278,7 +4285,8 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 			panic("vm_map_fork: encountered a submap");
 
 		inh = old_entry->inheritance;
-		if ((old_entry->eflags & MAP_ENTRY_GUARD) != 0 &&
+		if ((old_entry->eflags &
+		    (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0 &&
 		    inh != VM_INHERIT_NONE)
 			inh = VM_INHERIT_COPY;
 
@@ -5177,6 +5185,33 @@ vm_map_pmap_KBI(vm_map_t map)
 {
 
 	return (map->pmap);
+}
+
+int
+vm_map_reservation_delete(vm_map_t map, vm_offset_t reservation)
+{
+	vm_map_entry_t	entry, next_entry;
+
+	if (!vm_map_lookup_entry(map, reservation, &entry))
+		return (KERN_FAILURE);
+
+	while (entry->reservation == reservation) {
+		next_entry = vm_map_entry_succ(entry);
+		vm_map_entry_delete(map, entry);
+	}
+	return (KERN_SUCCESS);
+}
+
+bool
+vm_map_reservation_is_unmapped(vm_map_t map, vm_offset_t reservation)
+{
+	vm_map_entry_t	entry;
+
+	if (vm_map_lookup_entry(map, reservation, &entry) &&
+	    entry->reservation == entry->start &&
+	    entry->reservation != vm_map_entry_succ(entry)->reservation)
+		return (true);
+	return (false);
 }
 
 #ifdef INVARIANTS

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -149,6 +149,7 @@ struct vm_map_entry {
 #define	MAP_ENTRY_STACK_GAP_DN		0x00020000
 #define	MAP_ENTRY_STACK_GAP_UP		0x00040000
 #define	MAP_ENTRY_HEADER		0x00080000
+#define	MAP_ENTRY_UNMAPPED		0x00100000
 
 #ifdef	_KERNEL
 static __inline u_char
@@ -364,6 +365,7 @@ long vmspace_resident_count(struct vmspace *vmspace);
 #define	MAP_CREATE_STACK_GAP_UP	0x00010000
 #define	MAP_CREATE_STACK_GAP_DN	0x00020000
 #define	MAP_VN_EXEC		0x00040000
+#define MAP_CREATE_UNMAPPED	0x00080000
 
 /*
  * vm_fault option flags
@@ -465,6 +467,8 @@ int vm_map_lookup_locked(vm_map_t *, vm_offset_t, vm_prot_t, vm_map_entry_t *, v
     vm_pindex_t *, vm_prot_t *, boolean_t *);
 void vm_map_lookup_done (vm_map_t, vm_map_entry_t);
 boolean_t vm_map_lookup_entry (vm_map_t, vm_offset_t, vm_map_entry_t *);
+bool vm_map_reservation_is_unmapped(vm_map_t, vm_offset_t);
+int vm_map_reservation_delete(vm_map_t, vm_offset_t);
 
 static inline vm_map_entry_t
 vm_map_entry_first(vm_map_t map)

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -225,6 +225,7 @@ struct vm_map {
 #define	MAP_IS_SUB_MAP		0x04	/* has parent */
 #define	MAP_ASLR		0x08	/* enabled ASLR */
 #define	MAP_ASLR_IGNSTART	0x10
+#define	MAP_RESERVATIONS	0x20	/* Don't merge reservations */
 
 #ifdef	_KERNEL
 #if defined(KLD_MODULE) && !defined(KLD_TIED)

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -103,6 +103,7 @@ struct vm_map_entry {
 	struct vm_map_entry *right;	/* right child or next entry */
 	vm_offset_t start;		/* start address */
 	vm_offset_t end;		/* end address */
+	vm_offset_t reservation;	/* VM reservation ID (lowest VA)  */
 	vm_offset_t next_read;		/* vaddr of the next sequential read */
 	vm_size_t max_free;		/* max free space in subtree */
 	union vm_map_object object;	/* object I point to */
@@ -456,7 +457,8 @@ int vm_map_fixed(vm_map_t, vm_object_t, vm_ooffset_t, vm_offset_t, vm_size_t,
 vm_offset_t vm_map_findspace(vm_map_t, vm_offset_t, vm_size_t);
 int vm_map_inherit (vm_map_t, vm_offset_t, vm_offset_t, vm_inherit_t);
 void vm_map_init(vm_map_t, pmap_t, vm_offset_t, vm_offset_t);
-int vm_map_insert (vm_map_t, vm_object_t, vm_ooffset_t, vm_offset_t, vm_offset_t, vm_prot_t, vm_prot_t, int);
+int vm_map_insert (vm_map_t, vm_object_t, vm_ooffset_t, vm_offset_t,
+    vm_offset_t, vm_prot_t, vm_prot_t, int, vm_offset_t);
 int vm_map_lookup (vm_map_t *, vm_offset_t, vm_prot_t, vm_map_entry_t *, vm_object_t *,
     vm_pindex_t *, vm_prot_t *, boolean_t *);
 int vm_map_lookup_locked(vm_map_t *, vm_offset_t, vm_prot_t, vm_map_entry_t *, vm_object_t *,

--- a/sys/vm/vm_unix.c
+++ b/sys/vm/vm_unix.c
@@ -183,7 +183,7 @@ kern_break(struct thread *td, uintptr_t *addr)
 			prot |= VM_PROT_EXECUTE;
 #endif
 		rv = vm_map_insert(map, NULL, 0, old, new, prot, VM_PROT_ALL,
-		    0);
+		    0, base);
 		if (rv == KERN_SUCCESS && (map->flags & MAP_WIREFUTURE) != 0) {
 			rv = vm_map_wire_locked(map, old, new,
 			    VM_MAP_WIRE_USER | VM_MAP_WIRE_NOHOLES);

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -194,6 +194,10 @@ Display the cpuset information for the thread.
 Display thread information for the process.
 .It Ar vm | Fl v
 Display virtual memory mappings for the process.
+.Pp
+If the
+.Fl v
+flag is passed then extra information is shown.
 .It Ar auxv | Fl x
 Display ELF auxiliary vector for the process.
 .El
@@ -598,6 +602,8 @@ process ID
 starting address of mapping
 .It END
 ending address of mapping
+.It RESERV
+starting address of the reservation this entry belongs to
 .It PRT
 protection flags
 .It RES
@@ -654,6 +660,10 @@ The following mapping flags may be displayed:
 .Bl -tag -width X -compact
 .It C
 copy-on-write
+.It G
+guard mapping
+.It u
+unmapped addresses in a reservation
 .It N
 needs copy
 .It S

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -102,7 +102,7 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_PLURAL },
 	{ "tsignal", "thread_signals", "[-n]", &procstat_threads_sigs,
 	    &cmdopt_signals, PS_CMP_PLURAL | PS_CMP_SUBSTR },
-	{ "vm", "vm", NULL, &procstat_vm, &cmdopt_none, PS_CMP_NORMAL }
+	{ "vm", "vm", NULL, &procstat_vm, &cmdopt_verbose, PS_CMP_NORMAL }
 };
 
 static void


### PR DESCRIPTION
Add an address-space reservation to each VM map entry.  Don't consolidate entries from different reservations.  When munmapping, replace unmapped space with new UNMAPPED mappings (almost, but not quite the same as guard pages).  Actually unmap the reservations only when the reservation has entirely transitioned to UNMAPPED.

Use the above functionality to allow mmapping of objects with unrepresentable sizes by padding the allocations.