### PR TITLE
makefs: daddr_t may be 32 bit, even if off_t is 64

### DIFF
--- a/usr.sbin/makefs/ffs/mkfs.c
+++ b/usr.sbin/makefs/ffs/mkfs.c
@@ -776,7 +776,7 @@ ffs_rdfs(daddr_t bno, int size, void *bf, const fsinfo_t *fsopts)
 	int n;
 	off_t offset;
 
-	offset = bno * fsopts->sectorsize + fsopts->offset;
+	offset = (off_t)bno * fsopts->sectorsize + fsopts->offset;
 	if (lseek(fsopts->fd, offset, SEEK_SET) < 0)
 		err(1, "%s: seek error for sector %lld", __func__,
 		    (long long)bno);
@@ -800,7 +800,7 @@ ffs_wtfs(daddr_t bno, int size, void *bf, const fsinfo_t *fsopts)
 	int n;
 	off_t offset;
 
-	offset = bno * fsopts->sectorsize + fsopts->offset;
+	offset = (off_t)bno * fsopts->sectorsize + fsopts->offset;
 	if (lseek(fsopts->fd, offset, SEEK_SET) < 0)
 		err(1, "%s: seek error for sector %lld", __func__,
 		    (long long)bno);


### PR DESCRIPTION
Found while building on a Linux PowerPC host.  Fix by inserting a cast.

Should this go upstream?