### PR TITLE
Remove union semun_native, ksemun_t, and usemun_t types.

### DIFF
--- a/sys/compat/linux/linux_ipc.c
+++ b/sys/compat/linux/linux_ipc.c
@@ -544,7 +544,7 @@ linux_semctl(struct thread *td, struct linux_semctl_args *args)
 	struct l_semid64_ds linux_semid64;
 	struct l_seminfo linux_seminfo;
 	struct semid_ds semid;
-	ksemun_t semun;
+	struct semun_t semun;
 	register_t rval;
 	int cmd, error;
 

--- a/sys/sys/sem.h
+++ b/sys/sys/sem.h
@@ -48,7 +48,7 @@ struct semid_ds_old {
 
 struct semid_ds {
 	struct ipc_perm	sem_perm;	/* operation permission struct */
-	struct sem	*__sem_base;	/* pointer to first semaphore in set */
+	struct sem * __kerncap __sem_base; /* first semaphore in set */
 	unsigned short	sem_nsems;	/* number of sems in set */
 	time_t		sem_otime;	/* last operation time */
 	time_t		sem_ctime;	/* last change time */
@@ -75,40 +75,22 @@ union semun_old {
 	unsigned short	*array;		/* array for GETALL & SETALL */
 };
 #endif
-#if defined(_WANT_SEMUN) && !defined(_KERNEL)
+#if defined(_WANT_SEMUN) || defined(_KERNEL)
 /*
  * semctl's arg parameter structure
  */
 union semun {
 	int		val;		/* value for SETVAL */
-	struct		semid_ds *buf;	/* buffer for IPC_STAT & IPC_SET */
-	unsigned short	*array;		/* array for GETALL & SETALL */
+	struct semid_ds * __kerncap buf; /* buffer for IPC_STAT & IPC_SET */
+	unsigned short * __kerncap array; /* array for GETALL & SETALL */
 };
 #endif
 #if defined(_KERNEL)
-#if __has_feature(capabilities)
-/*
- * XXX: We'd like to use semun_c here, but semid_ds currently contains
- * kernel pointers for no good reason.  Because buf is copied in and
- * translated in the syscall make it not be a capability for easy of use.
- */
-union semun_kernel {
-	int			val;	/* value for SETVAL */
-	struct semid_ds		*buf;	/* buffer for IPC_STAT & IPC_SET */
-	unsigned short * __capability array;	/* array for GETALL & SETALL */
-};
-#endif
 union semun_native {
 	int		val;		/* value for SETVAL */
 	struct		semid_ds *buf;	/* buffer for IPC_STAT & IPC_SET */
 	unsigned short	*array;		/* array for GETALL & SETALL */
 };
-#if __has_feature(capabilities)
-typedef union semun_kernel	ksemun_t;
-#else
-typedef union semun_native	ksemun_t;
-#endif
-typedef union semun_native	usemun_t;
 #endif /* defined(_KERNEL) */
 
 /*

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -421,7 +421,7 @@ int	kern_sched_rr_get_interval(struct thread *td, pid_t pid,
 int	kern_sched_rr_get_interval_td(struct thread *td, struct thread *targettd,
 	    struct timespec *ts);
 int	kern_semctl(struct thread *td, int semid, int semnum, int cmd,
-	    ksemun_t *arg, register_t *rval);
+	    union semun *arg, register_t *rval);
 int	kern_sendfile(struct thread *td, int fd, int s, off_t offset,
 	    size_t nbytes, void * __capability uhdtr,
 	    off_t * __capability usbytes, int flags, int compat,


### PR DESCRIPTION
The kernel union semun and struct semid_ds now contain capabilities for
all userspace pointers.