### PR TITLE
Remove struct iovec_native

### DIFF
--- a/sys/compat/freebsd32/freebsd32_proto.h
+++ b/sys/compat/freebsd32/freebsd32_proto.h
@@ -403,7 +403,7 @@ struct freebsd32_aio_fsync_args {
 };
 struct freebsd32_sctp_generic_sendmsg_iov_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char iov_l_[PADL_(struct iovec *)]; struct iovec * iov; char iov_r_[PADR_(struct iovec *)];
+	char iov_l_[PADL_(struct iovec32 *)]; struct iovec32 * iov; char iov_r_[PADR_(struct iovec32 *)];
 	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
 	char to_l_[PADL_(struct sockaddr *)]; struct sockaddr * to; char to_r_[PADR_(struct sockaddr *)];
 	char tolen_l_[PADL_(__socklen_t)]; __socklen_t tolen; char tolen_r_[PADR_(__socklen_t)];
@@ -412,7 +412,7 @@ struct freebsd32_sctp_generic_sendmsg_iov_args {
 };
 struct freebsd32_sctp_generic_recvmsg_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char iov_l_[PADL_(struct iovec *)]; struct iovec * iov; char iov_r_[PADR_(struct iovec *)];
+	char iov_l_[PADL_(struct iovec32 *)]; struct iovec32 * iov; char iov_r_[PADR_(struct iovec32 *)];
 	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
 	char from_l_[PADL_(struct sockaddr *)]; struct sockaddr * from; char from_r_[PADR_(struct sockaddr *)];
 	char fromlenaddr_l_[PADL_(__socklen_t *)]; __socklen_t * fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t *)];

--- a/sys/compat/freebsd32/freebsd32_proto.h
+++ b/sys/compat/freebsd32/freebsd32_proto.h
@@ -401,6 +401,24 @@ struct freebsd32_aio_fsync_args {
 	char op_l_[PADL_(int)]; int op; char op_r_[PADR_(int)];
 	char aiocbp_l_[PADL_(struct aiocb32 *)]; struct aiocb32 * aiocbp; char aiocbp_r_[PADR_(struct aiocb32 *)];
 };
+struct freebsd32_sctp_generic_sendmsg_iov_args {
+	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
+	char iov_l_[PADL_(struct iovec *)]; struct iovec * iov; char iov_r_[PADR_(struct iovec *)];
+	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
+	char to_l_[PADL_(struct sockaddr *)]; struct sockaddr * to; char to_r_[PADR_(struct sockaddr *)];
+	char tolen_l_[PADL_(__socklen_t)]; __socklen_t tolen; char tolen_r_[PADR_(__socklen_t)];
+	char sinfo_l_[PADL_(struct sctp_sndrcvinfo *)]; struct sctp_sndrcvinfo * sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo *)];
+	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
+};
+struct freebsd32_sctp_generic_recvmsg_args {
+	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
+	char iov_l_[PADL_(struct iovec *)]; struct iovec * iov; char iov_r_[PADR_(struct iovec *)];
+	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
+	char from_l_[PADL_(struct sockaddr *)]; struct sockaddr * from; char from_r_[PADR_(struct sockaddr *)];
+	char fromlenaddr_l_[PADL_(__socklen_t *)]; __socklen_t * fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t *)];
+	char sinfo_l_[PADL_(struct sctp_sndrcvinfo *)]; struct sctp_sndrcvinfo * sinfo; char sinfo_r_[PADR_(struct sctp_sndrcvinfo *)];
+	char msg_flags_l_[PADL_(int *)]; int * msg_flags; char msg_flags_r_[PADR_(int *)];
+};
 #ifdef PAD64_REQUIRED
 struct freebsd32_pread_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
@@ -812,6 +830,8 @@ int	freebsd32_kmq_timedreceive(struct thread *, struct freebsd32_kmq_timedreceiv
 int	freebsd32_kmq_timedsend(struct thread *, struct freebsd32_kmq_timedsend_args *);
 int	freebsd32_kmq_notify(struct thread *, struct freebsd32_kmq_notify_args *);
 int	freebsd32_aio_fsync(struct thread *, struct freebsd32_aio_fsync_args *);
+int	freebsd32_sctp_generic_sendmsg_iov(struct thread *, struct freebsd32_sctp_generic_sendmsg_iov_args *);
+int	freebsd32_sctp_generic_recvmsg(struct thread *, struct freebsd32_sctp_generic_recvmsg_args *);
 #ifdef PAD64_REQUIRED
 int	freebsd32_pread(struct thread *, struct freebsd32_pread_args *);
 int	freebsd32_pwrite(struct thread *, struct freebsd32_pwrite_args *);
@@ -1404,6 +1424,8 @@ int	freebsd11_freebsd32_fstatat(struct thread *, struct freebsd11_freebsd32_fsta
 #define	FREEBSD32_SYS_AUE_freebsd32_kmq_timedsend	AUE_MQ_TIMEDSEND
 #define	FREEBSD32_SYS_AUE_freebsd32_kmq_notify	AUE_MQ_NOTIFY
 #define	FREEBSD32_SYS_AUE_freebsd32_aio_fsync	AUE_AIO_FSYNC
+#define	FREEBSD32_SYS_AUE_freebsd32_sctp_generic_sendmsg_iov	AUE_SCTP_GENERIC_SENDMSG_IOV
+#define	FREEBSD32_SYS_AUE_freebsd32_sctp_generic_recvmsg	AUE_SCTP_GENERIC_RECVMSG
 #define	FREEBSD32_SYS_AUE_freebsd32_pread	AUE_PREAD
 #define	FREEBSD32_SYS_AUE_freebsd32_pwrite	AUE_PWRITE
 #define	FREEBSD32_SYS_AUE_freebsd32_mmap	AUE_MMAP

--- a/sys/compat/freebsd32/freebsd32_syscall.h
+++ b/sys/compat/freebsd32/freebsd32_syscall.h
@@ -390,8 +390,8 @@
 #define	FREEBSD32_SYS_rtprio_thread	466
 #define	FREEBSD32_SYS_sctp_peeloff	471
 #define	FREEBSD32_SYS_sctp_generic_sendmsg	472
-#define	FREEBSD32_SYS_sctp_generic_sendmsg_iov	473
-#define	FREEBSD32_SYS_sctp_generic_recvmsg	474
+#define	FREEBSD32_SYS_freebsd32_sctp_generic_sendmsg_iov	473
+#define	FREEBSD32_SYS_freebsd32_sctp_generic_recvmsg	474
 #define	FREEBSD32_SYS_freebsd32_pread	475
 #define	FREEBSD32_SYS_freebsd32_pwrite	476
 #define	FREEBSD32_SYS_freebsd32_mmap	477

--- a/sys/compat/freebsd32/freebsd32_syscalls.c
+++ b/sys/compat/freebsd32/freebsd32_syscalls.c
@@ -482,8 +482,8 @@ const char *freebsd32_syscallnames[] = {
 	"#470",			/* 470 = __getpath_fromaddr */
 	"sctp_peeloff",			/* 471 = sctp_peeloff */
 	"sctp_generic_sendmsg",			/* 472 = sctp_generic_sendmsg */
-	"sctp_generic_sendmsg_iov",			/* 473 = sctp_generic_sendmsg_iov */
-	"sctp_generic_recvmsg",			/* 474 = sctp_generic_recvmsg */
+	"freebsd32_sctp_generic_sendmsg_iov",			/* 473 = freebsd32_sctp_generic_sendmsg_iov */
+	"freebsd32_sctp_generic_recvmsg",			/* 474 = freebsd32_sctp_generic_recvmsg */
 #ifdef PAD64_REQUIRED
 	"freebsd32_pread",			/* 475 = freebsd32_pread */
 	"freebsd32_pwrite",			/* 476 = freebsd32_pwrite */

--- a/sys/compat/freebsd32/freebsd32_sysent.c
+++ b/sys/compat/freebsd32/freebsd32_sysent.c
@@ -535,8 +535,8 @@ struct sysent freebsd32_sysent[] = {
 	{ 0, (sy_call_t *)nosys, AUE_NULL, NULL, 0, 0, 0, SY_THR_ABSENT },			/* 470 = __getpath_fromaddr */
 	{ AS(sctp_peeloff_args), (sy_call_t *)lkmressys, AUE_NULL, NULL, 0, 0, SYF_CAPENABLED, SY_THR_ABSENT },	/* 471 = sctp_peeloff */
 	{ AS(sctp_generic_sendmsg_args), (sy_call_t *)lkmressys, AUE_NULL, NULL, 0, 0, SYF_CAPENABLED, SY_THR_ABSENT },	/* 472 = sctp_generic_sendmsg */
-	{ AS(sctp_generic_sendmsg_iov_args), (sy_call_t *)lkmressys, AUE_NULL, NULL, 0, 0, SYF_CAPENABLED, SY_THR_ABSENT },	/* 473 = sctp_generic_sendmsg_iov */
-	{ AS(sctp_generic_recvmsg_args), (sy_call_t *)lkmressys, AUE_NULL, NULL, 0, 0, SYF_CAPENABLED, SY_THR_ABSENT },	/* 474 = sctp_generic_recvmsg */
+	{ AS(freebsd32_sctp_generic_sendmsg_iov_args), (sy_call_t *)lkmressys, AUE_NULL, NULL, 0, 0, SYF_CAPENABLED, SY_THR_ABSENT },	/* 473 = freebsd32_sctp_generic_sendmsg_iov */
+	{ AS(freebsd32_sctp_generic_recvmsg_args), (sy_call_t *)lkmressys, AUE_NULL, NULL, 0, 0, SYF_CAPENABLED, SY_THR_ABSENT },	/* 474 = freebsd32_sctp_generic_recvmsg */
 #ifdef PAD64_REQUIRED
 	{ AS(freebsd32_pread_args), (sy_call_t *)freebsd32_pread, AUE_PREAD, NULL, 0, 0, SYF_CAPENABLED, SY_THR_STATIC },	/* 475 = freebsd32_pread */
 	{ AS(freebsd32_pwrite_args), (sy_call_t *)freebsd32_pwrite, AUE_PWRITE, NULL, 0, 0, SYF_CAPENABLED, SY_THR_STATIC },	/* 476 = freebsd32_pwrite */

--- a/sys/compat/freebsd32/freebsd32_systrace_args.c
+++ b/sys/compat/freebsd32/freebsd32_systrace_args.c
@@ -2335,7 +2335,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 473: {
 		struct freebsd32_sctp_generic_sendmsg_iov_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->iov; /* struct iovec * */
+		uarg[1] = (intptr_t) p->iov; /* struct iovec32 * */
 		iarg[2] = p->iovlen; /* int */
 		uarg[3] = (intptr_t) p->to; /* struct sockaddr * */
 		iarg[4] = p->tolen; /* __socklen_t */
@@ -2348,7 +2348,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 474: {
 		struct freebsd32_sctp_generic_recvmsg_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->iov; /* struct iovec * */
+		uarg[1] = (intptr_t) p->iov; /* struct iovec32 * */
 		iarg[2] = p->iovlen; /* int */
 		uarg[3] = (intptr_t) p->from; /* struct sockaddr * */
 		uarg[4] = (intptr_t) p->fromlenaddr; /* __socklen_t * */
@@ -7157,7 +7157,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec *";
+			p = "userland struct iovec32 *";
 			break;
 		case 2:
 			p = "int";
@@ -7185,7 +7185,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec *";
+			p = "userland struct iovec32 *";
 			break;
 		case 2:
 			p = "int";

--- a/sys/compat/freebsd32/freebsd32_systrace_args.c
+++ b/sys/compat/freebsd32/freebsd32_systrace_args.c
@@ -2331,9 +2331,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		*n_args = 7;
 		break;
 	}
-	/* sctp_generic_sendmsg_iov */
+	/* freebsd32_sctp_generic_sendmsg_iov */
 	case 473: {
-		struct sctp_generic_sendmsg_iov_args *p = params;
+		struct freebsd32_sctp_generic_sendmsg_iov_args *p = params;
 		iarg[0] = p->sd; /* int */
 		uarg[1] = (intptr_t) p->iov; /* struct iovec * */
 		iarg[2] = p->iovlen; /* int */
@@ -2344,9 +2344,9 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		*n_args = 7;
 		break;
 	}
-	/* sctp_generic_recvmsg */
+	/* freebsd32_sctp_generic_recvmsg */
 	case 474: {
-		struct sctp_generic_recvmsg_args *p = params;
+		struct freebsd32_sctp_generic_recvmsg_args *p = params;
 		iarg[0] = p->sd; /* int */
 		uarg[1] = (intptr_t) p->iov; /* struct iovec * */
 		iarg[2] = p->iovlen; /* int */
@@ -7150,7 +7150,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
-	/* sctp_generic_sendmsg_iov */
+	/* freebsd32_sctp_generic_sendmsg_iov */
 	case 473:
 		switch(ndx) {
 		case 0:
@@ -7178,7 +7178,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
-	/* sctp_generic_recvmsg */
+	/* freebsd32_sctp_generic_recvmsg */
 	case 474:
 		switch(ndx) {
 		case 0:
@@ -10449,12 +10449,12 @@ systrace_return_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;
-	/* sctp_generic_sendmsg_iov */
+	/* freebsd32_sctp_generic_sendmsg_iov */
 	case 473:
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;
-	/* sctp_generic_recvmsg */
+	/* freebsd32_sctp_generic_recvmsg */
 	case 474:
 		if (ndx == 0 || ndx == 1)
 			p = "int";

--- a/sys/compat/freebsd32/syscalls.master
+++ b/sys/compat/freebsd32/syscalls.master
@@ -863,10 +863,10 @@
 				    int sd, void *msg, int mlen, \
 				    struct sockaddr *to, __socklen_t tolen, \
 				    struct sctp_sndrcvinfo *sinfo, int flags); }
-473	AUE_SCTP_GENERIC_SENDMSG_IOV	NOPROTO|NOSTD	{ int sctp_generic_sendmsg_iov(int sd, struct iovec *iov, int iovlen, \
+473	AUE_SCTP_GENERIC_SENDMSG_IOV	NOSTD	{ int freebsd32_sctp_generic_sendmsg_iov(int sd, struct iovec32 *iov, int iovlen, \
 				    struct sockaddr *to, __socklen_t tolen, \
 				    struct sctp_sndrcvinfo *sinfo, int flags); }
-474	AUE_SCTP_GENERIC_RECVMSG	NOPROTO|NOSTD	{ int sctp_generic_recvmsg(int sd, struct iovec *iov, int iovlen, \
+474	AUE_SCTP_GENERIC_RECVMSG	NOSTD	{ int freebsd32_sctp_generic_recvmsg(int sd, struct iovec32 *iov, int iovlen, \
 				    struct sockaddr * from, __socklen_t *fromlenaddr, \
 				    struct sctp_sndrcvinfo *sinfo, int *msg_flags); }
 #ifdef PAD64_REQUIRED

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -427,7 +427,7 @@ int
 freebsd64_copyiniov(struct iovec64 * __capability iov64, u_int iovcnt,
     struct iovec **iovp, int error)
 {
-	struct iovec_native useriov;
+	struct iovec64 useriov;
 	struct iovec *iovs;
 	size_t iovlen;
 	int i;

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -42,6 +42,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/socketvar.h>
 #include <sys/syscallsubr.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 #include <compat/freebsd64/freebsd64_util.h>
 

--- a/sys/dev/mrsas/mrsas_ioctl.h
+++ b/sys/dev/mrsas/mrsas_ioctl.h
@@ -101,7 +101,7 @@ struct mrsas_iocpacket {
 		u_int8_t raw[MEGAMFI_RAW_FRAME_SIZE];
 		struct mrsas_header hdr;
 	}	frame;
-	struct iovec_native sgl[MAX_IOCTL_SGE];
+	struct iovec sgl[MAX_IOCTL_SGE];
 };
 
 #pragma pack()

--- a/sys/dev/spibus/spigen.c
+++ b/sys/dev/spibus/spigen.c
@@ -28,6 +28,8 @@ __FBSDID("$FreeBSD$");
 #include "opt_platform.h"
 #include "opt_spi.h"
 
+#define EXPLICIT_USER_ACCESS
+
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/bus.h>

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1139,20 +1139,10 @@ out:
 }
 
 static int
-copyin_hdtr(const struct sf_hdtr_native * __capability uhdtr, struct sf_hdtr *hdtr)
+copyin_hdtr(const struct sf_hdtr * __capability uhdtr, struct sf_hdtr *hdtr)
 {
-	struct sf_hdtr_native hdtr_n;
-	int error;
 
-	error = copyin_c(uhdtr, &hdtr_n, sizeof(hdtr_n));
-	if (error != 0)
-		return (error);
-	hdtr->headers = (void * __capability)__USER_CAP_ARRAY(hdtr_n.headers, hdtr_n.hdr_cnt);
-	hdtr->hdr_cnt = hdtr_n.hdr_cnt;
-	hdtr->trailers = (void * __capability)__USER_CAP_ARRAY(hdtr_n.trailers, hdtr_n.trl_cnt);
-	hdtr->hdr_cnt = hdtr_n.trl_cnt;
-
-	return (0);
+	return (copyincap(uhdtr, hdtr, sizeof(*hdtr)));
 }
 
 int

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -263,7 +263,7 @@ freebsd6_pread(struct thread *td, struct freebsd6_pread_args *uap)
 #ifndef _SYS_SYSPROTO_H_
 struct readv_args {
 	int	fd;
-	struct	iovec_native *iovp;
+	struct	iovec *iovp;
 	u_int	iovcnt;
 };
 #endif
@@ -310,7 +310,7 @@ kern_readv(struct thread *td, int fd, struct uio *auio)
 #ifndef _SYS_SYSPROTO_H_
 struct preadv_args {
 	int	fd;
-	struct	iovec_native *iovp;
+	struct	iovec *iovp;
 	u_int	iovcnt;
 	off_t	offset;
 };
@@ -489,7 +489,7 @@ freebsd6_pwrite(struct thread *td, struct freebsd6_pwrite_args *uap)
 #ifndef _SYS_SYSPROTO_H_
 struct writev_args {
 	int	fd;
-	struct	iovec_native *iovp;
+	struct	iovec *iovp;
 	u_int	iovcnt;
 };
 #endif
@@ -536,7 +536,7 @@ kern_writev(struct thread *td, int fd, struct uio *auio)
 #ifndef _SYS_SYSPROTO_H_
 struct pwritev_args {
 	int	fd;
-	struct	iovec_native *iovp;
+	struct	iovec *iovp;
 	u_int	iovcnt;
 	off_t	offset;
 };

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -760,14 +760,14 @@
 120	AUE_READV	STD {
 		int readv(
 		    int fd,
-		    _Inout_updates_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _Inout_updates_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    u_int iovcnt
 		);
 	}
 121	AUE_WRITEV	STD {
 		int writev(
 		    int fd,
-		    _In_reads_opt_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _In_reads_opt_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    u_int iovcnt
 		);
 	}
@@ -1526,7 +1526,7 @@
 289	AUE_PREADV	STD {
 		ssize_t preadv(
 		    int fd,
-		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    u_int iovcnt,
 		    off_t offset
 		);
@@ -1534,7 +1534,7 @@
 290	AUE_PWRITEV	STD {
 		ssize_t pwritev(
 		    int fd,
-		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    u_int iovcnt,
 		    off_t offset
 		);
@@ -1991,7 +1991,7 @@
 	}
 378	AUE_NMOUNT	STD {
 		int nmount(
-		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    unsigned int iovcnt,
 		    int flags
 		);
@@ -2511,7 +2511,7 @@
 473	AUE_SCTP_GENERIC_SENDMSG_IOV	NOSTD {
 		int sctp_generic_sendmsg_iov(
 		    int sd,
-		    _In_reads_(iovlen) _Contains_long_ptr_ struct iovec_native *iov,
+		    _In_reads_(iovlen) _Contains_long_ptr_ struct iovec *iov,
 		    int iovlen,
 		    _In_reads_bytes_(tolen) const struct sockaddr *to,
 		    __socklen_t tolen,
@@ -2522,7 +2522,7 @@
 474	AUE_SCTP_GENERIC_RECVMSG	NOSTD {
 		int sctp_generic_recvmsg(
 		    int sd,
-		    _In_reads_(iovlen) _Contains_long_ptr_ struct iovec_native *iov,
+		    _In_reads_(iovlen) _Contains_long_ptr_ struct iovec *iov,
 		    int iovlen,
 		    _Out_writes_bytes_(*fromlenaddr) struct sockaddr *from,
 		    _Out_ __socklen_t *fromlenaddr,
@@ -2761,14 +2761,14 @@
 	}
 506	AUE_JAIL_GET	STD {
 		int jail_get(
-		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    unsigned int iovcnt,
 		    int flags
 		);
 	}
 507	AUE_JAIL_SET	STD {
 		int jail_set(
-		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec_native *iovp,
+		    _In_reads_(iovcnt) _Contains_long_ptr_ struct iovec *iovp,
 		    unsigned int iovcnt,
 		    int flags
 		);

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -240,14 +240,14 @@
 27	AUE_RECVMSG	STD {
 		ssize_t recvmsg(
 		    int s,
-		    _Inout_ _Contains_ptr_ struct msghdr_native *msg,
+		    _Inout_ _Contains_ptr_ struct msghdr *msg,
 		    int flags
 		);
 	}
 28	AUE_SENDMSG	STD {
 		ssize_t sendmsg(
 		    int s,
-		    _In_ _Contains_ptr_ const struct msghdr_native *msg,
+		    _In_ _Contains_ptr_ const struct msghdr *msg,
 		    int flags
 		);
 	}

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -1745,7 +1745,7 @@
 		    int s,
 		    off_t offset,
 		    size_t nbytes,
-		    _In_opt_ _Contains_ptr_ struct sf_hdtr_native *hdtr,
+		    _In_opt_ _Contains_ptr_ struct sf_hdtr *hdtr,
 		    _Out_opt_ off_t *sbytes,
 		    int flags
 		);
@@ -2061,7 +2061,7 @@
 		    int s,
 		    off_t offset,
 		    size_t nbytes,
-		    _In_opt_ _Contains_ptr_ struct sf_hdtr_native *hdtr,
+		    _In_opt_ _Contains_ptr_ struct sf_hdtr *hdtr,
 		    _Out_opt_ off_t *sbytes,
 		    int flags
 		);

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -1951,7 +1951,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[1] = p->s; /* int */
 		iarg[2] = p->offset; /* off_t */
 		uarg[3] = p->nbytes; /* size_t */
-		uarg[4] = (intptr_t) p->hdtr; /* struct sf_hdtr_native * __capability */
+		uarg[4] = (intptr_t) p->hdtr; /* struct sf_hdtr * __capability */
 		uarg[5] = (intptr_t) p->sbytes; /* off_t * __capability */
 		iarg[6] = p->flags; /* int */
 		*n_args = 7;
@@ -6491,7 +6491,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "size_t";
 			break;
 		case 4:
-			p = "userland struct sf_hdtr_native * __capability";
+			p = "userland struct sf_hdtr * __capability";
 			break;
 		case 5:
 			p = "userland off_t * __capability";

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -654,7 +654,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 120: {
 		struct readv_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		*n_args = 3;
 		break;
@@ -663,7 +663,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 121: {
 		struct writev_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		*n_args = 3;
 		break;
@@ -1350,7 +1350,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 289: {
 		struct preadv_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		iarg[3] = p->offset; /* off_t */
 		*n_args = 4;
@@ -1360,7 +1360,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 290: {
 		struct pwritev_args *p = params;
 		iarg[0] = p->fd; /* int */
-		uarg[1] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[1] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[2] = p->iovcnt; /* u_int */
 		iarg[3] = p->offset; /* off_t */
 		*n_args = 4;
@@ -1866,7 +1866,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* nmount */
 	case 378: {
 		struct nmount_args *p = params;
-		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[0] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[1] = p->iovcnt; /* unsigned int */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -2497,7 +2497,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 473: {
 		struct sctp_generic_sendmsg_iov_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->iov; /* struct iovec_native * __capability */
+		uarg[1] = (intptr_t) p->iov; /* struct iovec * __capability */
 		iarg[2] = p->iovlen; /* int */
 		uarg[3] = (intptr_t) p->to; /* const struct sockaddr * __capability */
 		iarg[4] = p->tolen; /* __socklen_t */
@@ -2510,7 +2510,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 474: {
 		struct sctp_generic_recvmsg_args *p = params;
 		iarg[0] = p->sd; /* int */
-		uarg[1] = (intptr_t) p->iov; /* struct iovec_native * __capability */
+		uarg[1] = (intptr_t) p->iov; /* struct iovec * __capability */
 		iarg[2] = p->iovlen; /* int */
 		uarg[3] = (intptr_t) p->from; /* struct sockaddr * __capability */
 		uarg[4] = (intptr_t) p->fromlenaddr; /* __socklen_t * __capability */
@@ -2783,7 +2783,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* jail_get */
 	case 506: {
 		struct jail_get_args *p = params;
-		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[0] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[1] = p->iovcnt; /* unsigned int */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -2792,7 +2792,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	/* jail_set */
 	case 507: {
 		struct jail_set_args *p = params;
-		uarg[0] = (intptr_t) p->iovp; /* struct iovec_native * __capability */
+		uarg[0] = (intptr_t) p->iovp; /* struct iovec * __capability */
 		uarg[1] = p->iovcnt; /* unsigned int */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
@@ -4388,7 +4388,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -4404,7 +4404,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -5495,7 +5495,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -5514,7 +5514,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 2:
 			p = "u_int";
@@ -6346,7 +6346,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 378:
 		switch(ndx) {
 		case 0:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 1:
 			p = "unsigned int";
@@ -7414,7 +7414,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -7442,7 +7442,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -7942,7 +7942,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 506:
 		switch(ndx) {
 		case 0:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 1:
 			p = "unsigned int";
@@ -7958,7 +7958,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 507:
 		switch(ndx) {
 		case 0:
-			p = "userland struct iovec_native * __capability";
+			p = "userland struct iovec * __capability";
 			break;
 		case 1:
 			p = "unsigned int";

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -179,7 +179,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 27: {
 		struct recvmsg_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->msg; /* struct msghdr_native * __capability */
+		uarg[1] = (intptr_t) p->msg; /* struct msghdr * __capability */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
 		break;
@@ -188,7 +188,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 28: {
 		struct sendmsg_args *p = params;
 		iarg[0] = p->s; /* int */
-		uarg[1] = (intptr_t) p->msg; /* const struct msghdr_native * __capability */
+		uarg[1] = (intptr_t) p->msg; /* const struct msghdr * __capability */
 		iarg[2] = p->flags; /* int */
 		*n_args = 3;
 		break;
@@ -3619,7 +3619,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland struct msghdr_native * __capability";
+			p = "userland struct msghdr * __capability";
 			break;
 		case 2:
 			p = "int";
@@ -3635,7 +3635,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 1:
-			p = "userland const struct msghdr_native * __capability";
+			p = "userland const struct msghdr * __capability";
 			break;
 		case 2:
 			p = "int";

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -399,7 +399,7 @@ vfs_mergeopts(struct vfsoptlist *toopts, struct vfsoptlist *oldopts)
  */
 #ifndef _SYS_SYSPROTO_H_
 struct nmount_args {
-	struct iovec_native *iovp;
+	struct iovec *iovp;
 	unsigned int iovcnt;
 	int flags;
 };

--- a/sys/netinet/sctp_syscalls.c
+++ b/sys/netinet/sctp_syscalls.c
@@ -378,7 +378,7 @@ sctp_bad2:
 #ifndef _SYS_SYSPROTO_H_
 struct sctp_generic_sendmsg_iov_args {
 	int sd;
-	struct iovec_native *iov;
+	struct iovec *iov;
 	int iovlen;
 	struct sockaddr *to;
 	__socklen_t tolen;
@@ -556,7 +556,7 @@ sctp_bad2:
 #ifndef _SYS_SYSPROTO_H_
 struct sctp_generic_recvmsg_args {
 	int sd;
-	struct iovec_native *iov;
+	struct iovec *iov;
 	int iovlen;
 	struct sockaddr *from;
 	__socklen_t *fromlenaddr;

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -46,10 +46,6 @@ struct iovec {
 	void * __kerncap	iov_base;	/* Base address. */
 	size_t			iov_len;	/* Length. */
 };
-struct iovec_native {
-	void *	iov_base;	/* Base address. */
-	size_t			iov_len;	/* Length. */
-};
 
 #if defined(_KERNEL)
 #define	IOVEC_INIT(iovp, base, len)	do {				\

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -84,6 +84,8 @@ struct iovec_native {
 #ifdef _KERNEL
 struct uio;
 
+typedef int (copyiniov_t)(const struct iovec * __capability iovp, u_int iovcnt,
+            struct iovec **iov, int error);
 typedef int (copyinuio_t)(void * __capability iovp, u_int iovcnt,
 	    struct uio **iov);
 typedef int (updateiov_t)(const struct uio *uiop, void * __capability iovp);

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -441,7 +441,7 @@ struct msghdr {
 struct msghdr64 {
 	void		*msg_name;		/* optional address */
 	socklen_t	 msg_namelen;		/* size of address */
-	struct iovec_native	*msg_iov;	/* scatter/gather array */
+	struct iovec64	*msg_iov;	/* scatter/gather array */
 	int		 msg_iovlen;		/* # elements in msg_iov */
 	void		*msg_control;		/* ancillary data, see below */
 	socklen_t	 msg_controllen;	/* ancillary data buffer len */
@@ -637,7 +637,7 @@ struct osockaddr {
 struct omsghdr {
 	char	*msg_name;		/* optional address */
 	int	msg_namelen;		/* size of address */
-	struct	iovec_native *msg_iov;		/* scatter/gather array */
+	struct	iovec *msg_iov;		/* scatter/gather array */
 	int	msg_iovlen;		/* # elements in msg_iov */
 	char	*msg_accrights;		/* access rights sent/received */
 	int	msg_accrightslen;

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -448,15 +448,6 @@ struct msghdr64 {
 	int		 msg_flags;		/* flags on received message */
 };
 #endif
-struct msghdr_native {
-	void		*msg_name;		/* optional address */
-	socklen_t	 msg_namelen;		/* size of address */
-	struct iovec_native	*msg_iov;	/* scatter/gather array */
-	int		 msg_iovlen;		/* # elements in msg_iov */
-	void		*msg_control;		/* ancillary data, see below */
-	socklen_t	 msg_controllen;	/* ancillary data buffer len */
-	int		 msg_flags;		/* flags on received message */
-};
 #endif	/* _KERNEL */
 
 #define	MSG_OOB		 0x00000001	/* process out-of-band data */
@@ -702,12 +693,6 @@ struct mmsghdr {
 	struct msghdr	msg_hdr;		/* message header */
 	ssize_t		msg_len;		/* message length */
 };
-#ifdef _KERNEL
-struct mmsghdr_native {
-	struct msghdr_native	msg_hdr;		/* message header */
-	ssize_t		msg_len;		/* message length */
-};
-#endif /* _KERNEL */
 #endif /* __BSD_VISIBLE */
 
 #ifndef	_KERNEL

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -437,11 +437,11 @@ struct msghdr {
 	int		 msg_flags;		/* flags on received message */
 };
 #ifdef _KERNEL
-#if __has_feature(capabilities)
+#ifdef COMPAT_FREEBSD64
 struct msghdr64 {
 	void		*msg_name;		/* optional address */
 	socklen_t	 msg_namelen;		/* size of address */
-	struct iovec64	*msg_iov;	/* scatter/gather array */
+	struct iovec64	*msg_iov;		/* scatter/gather array */
 	int		 msg_iovlen;		/* # elements in msg_iov */
 	void		*msg_control;		/* ancillary data, see below */
 	socklen_t	 msg_controllen;	/* ancillary data buffer len */

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -662,12 +662,6 @@ struct sf_hdtr {
 	int trl_cnt;		/* number of trailer iovec's */
 };
 #ifdef _KERNEL
-struct sf_hdtr_native {
-	struct iovec_native *headers;	/* pointer to an array of header struct iovec's */
-	int hdr_cnt;		/* number of header iovec's */
-	struct iovec_native *trailers;	/* pointer to an array of trailer struct iovec's */
-	int trl_cnt;		/* number of trailer iovec's */
-};
 typedef	int copyin_hdtr_t(const void * __capability hdtrp, struct sf_hdtr *hdtr);
 #endif /* _KERNEL */
 

--- a/sys/sys/spigenio.h
+++ b/sys/sys/spigenio.h
@@ -34,8 +34,8 @@
 #include <sys/_iovec.h>
 
 struct spigen_transfer {
-	struct iovec_native st_command; /* master to slave */
-	struct iovec_native st_data;    /* slave to master and/or master to slave */
+	struct iovec st_command; /* master to slave */
+	struct iovec st_data;    /* slave to master and/or master to slave */
 };
 
 struct spigen_transfer_mmapped {

--- a/sys/sys/sysproto.h
+++ b/sys/sys/sysproto.h
@@ -1056,7 +1056,7 @@ struct sendfile_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
-	char hdtr_l_[PADL_(struct sf_hdtr_native * __capability)]; struct sf_hdtr_native * __capability hdtr; char hdtr_r_[PADR_(struct sf_hdtr_native * __capability)];
+	char hdtr_l_[PADL_(struct sf_hdtr * __capability)]; struct sf_hdtr * __capability hdtr; char hdtr_r_[PADR_(struct sf_hdtr * __capability)];
 	char sbytes_l_[PADL_(off_t * __capability)]; off_t * __capability sbytes; char sbytes_r_[PADR_(off_t * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
@@ -2436,7 +2436,7 @@ struct freebsd4_sendfile_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 	char nbytes_l_[PADL_(size_t)]; size_t nbytes; char nbytes_r_[PADR_(size_t)];
-	char hdtr_l_[PADL_(struct sf_hdtr_native * __capability)]; struct sf_hdtr_native * __capability hdtr; char hdtr_r_[PADR_(struct sf_hdtr_native * __capability)];
+	char hdtr_l_[PADL_(struct sf_hdtr * __capability)]; struct sf_hdtr * __capability hdtr; char hdtr_r_[PADR_(struct sf_hdtr * __capability)];
 	char sbytes_l_[PADL_(off_t * __capability)]; off_t * __capability sbytes; char sbytes_r_[PADR_(off_t * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };

--- a/sys/sys/sysproto.h
+++ b/sys/sys/sysproto.h
@@ -131,12 +131,12 @@ struct ptrace_args {
 };
 struct recvmsg_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char msg_l_[PADL_(struct msghdr_native * __capability)]; struct msghdr_native * __capability msg; char msg_r_[PADR_(struct msghdr_native * __capability)];
+	char msg_l_[PADL_(struct msghdr * __capability)]; struct msghdr * __capability msg; char msg_r_[PADR_(struct msghdr * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct sendmsg_args {
 	char s_l_[PADL_(int)]; int s; char s_r_[PADR_(int)];
-	char msg_l_[PADL_(const struct msghdr_native * __capability)]; const struct msghdr_native * __capability msg; char msg_r_[PADR_(const struct msghdr_native * __capability)];
+	char msg_l_[PADL_(const struct msghdr * __capability)]; const struct msghdr * __capability msg; char msg_r_[PADR_(const struct msghdr * __capability)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct recvfrom_args {

--- a/sys/sys/sysproto.h
+++ b/sys/sys/sysproto.h
@@ -396,12 +396,12 @@ struct getsockopt_args {
 };
 struct readv_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 };
 struct writev_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 };
 struct settimeofday_args {
@@ -739,13 +739,13 @@ struct lutimes_args {
 };
 struct preadv_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
 struct pwritev_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(u_int)]; u_int iovcnt; char iovcnt_r_[PADR_(u_int)];
 	char offset_l_[PADL_(off_t)]; off_t offset; char offset_r_[PADR_(off_t)];
 };
@@ -1011,7 +1011,7 @@ struct afs3_syscall_args {
 	char parm6_l_[PADL_(long)]; long parm6; char parm6_r_[PADR_(long)];
 };
 struct nmount_args {
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(unsigned int)]; unsigned int iovcnt; char iovcnt_r_[PADR_(unsigned int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
@@ -1342,7 +1342,7 @@ struct sctp_generic_sendmsg_args {
 };
 struct sctp_generic_sendmsg_iov_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char iov_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iov; char iov_r_[PADR_(struct iovec_native * __capability)];
+	char iov_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iov; char iov_r_[PADR_(struct iovec * __capability)];
 	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
 	char to_l_[PADL_(const struct sockaddr * __capability)]; const struct sockaddr * __capability to; char to_r_[PADR_(const struct sockaddr * __capability)];
 	char tolen_l_[PADL_(__socklen_t)]; __socklen_t tolen; char tolen_r_[PADR_(__socklen_t)];
@@ -1351,7 +1351,7 @@ struct sctp_generic_sendmsg_iov_args {
 };
 struct sctp_generic_recvmsg_args {
 	char sd_l_[PADL_(int)]; int sd; char sd_r_[PADR_(int)];
-	char iov_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iov; char iov_r_[PADR_(struct iovec_native * __capability)];
+	char iov_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iov; char iov_r_[PADR_(struct iovec * __capability)];
 	char iovlen_l_[PADL_(int)]; int iovlen; char iovlen_r_[PADR_(int)];
 	char from_l_[PADL_(struct sockaddr * __capability)]; struct sockaddr * __capability from; char from_r_[PADR_(struct sockaddr * __capability)];
 	char fromlenaddr_l_[PADL_(__socklen_t * __capability)]; __socklen_t * __capability fromlenaddr; char fromlenaddr_r_[PADR_(__socklen_t * __capability)];
@@ -1508,12 +1508,12 @@ struct gssd_syscall_args {
 	char path_l_[PADL_(const char * __capability)]; const char * __capability path; char path_r_[PADR_(const char * __capability)];
 };
 struct jail_get_args {
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(unsigned int)]; unsigned int iovcnt; char iovcnt_r_[PADR_(unsigned int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };
 struct jail_set_args {
-	char iovp_l_[PADL_(struct iovec_native * __capability)]; struct iovec_native * __capability iovp; char iovp_r_[PADR_(struct iovec_native * __capability)];
+	char iovp_l_[PADL_(struct iovec * __capability)]; struct iovec * __capability iovp; char iovp_r_[PADR_(struct iovec * __capability)];
 	char iovcnt_l_[PADL_(unsigned int)]; unsigned int iovcnt; char iovcnt_r_[PADR_(unsigned int)];
 	char flags_l_[PADL_(int)]; int flags; char flags_r_[PADR_(int)];
 };

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -82,11 +82,11 @@ struct bus_dma_segment;
 struct uio *cloneuio(struct uio *uiop);
 int	copyinfrom(const void * __restrict src, void * __restrict dst,
 	    size_t len, int seg);
-int	copyiniov(const struct iovec_native * __capability iovp, u_int iovcnt,
+int	copyiniov(const struct iovec * __capability iovp, u_int iovcnt,
 	    struct iovec **iov, int error);
 int	copyinstrfrom(const void * __restrict src, void * __restrict dst,
 	    size_t len, size_t * __restrict copied, int seg);
-int	copyinuio(const struct iovec_native * __capability iovp, u_int iovcnt,
+int	copyinuio(const struct iovec * __capability iovp, u_int iovcnt,
 	    struct uio **uiop);
 int	copyout_map(struct thread *td, vm_offset_t *addr, size_t sz);
 int	copyout_unmap(struct thread *td, vm_offset_t addr, size_t sz);
@@ -102,7 +102,7 @@ int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 	    struct uio *uio);
 int	uiomove_nofault(void *cp, int n, struct uio *uio);
 int	uiomove_object(struct vm_object *obj, off_t obj_size, struct uio *uio);
-int	updateiov(const struct uio *uiop, struct iovec_native *iovp);
+int	updateiov(const struct uio *uiop, struct iovec *iovp);
 
 #else /* !_KERNEL */
 


### PR DESCRIPTION
Assorted changes to remove the use of `struct iovec_native`.  The driver changes aren't complete, but fixing up ioctls in storage drivers don't see like a good use of time right now.  I did mfi part way because I'd gotten started...