### PR TITLE
Don't include assert.h from cheric.h

### DIFF
--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -314,9 +314,6 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #endif
 #ifdef __check_low_ptr_bits_assignment
 #ifndef _cheri_bits_assert
-#ifndef assert
-#include <assert.h>
-#endif
 #define _cheri_bits_assert(e) assert(e)
 #endif
 #define __runtime_assert_sensible_low_bits(bits)                               \


### PR DESCRIPTION
f9e44f334302574cdccb99e837d1a527dc188fa7 causes cheric.h to be included
transitively in more places, including inside jemalloc.  The inclusion
of assert.h breaks the delicate dance done over there.  Thankfully,
simply not including it doesn't seem to otherwise break the build and
fixes the problem.