### PR TITLE
A few RISC-V build fixes

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -871,12 +871,7 @@ HMAKE+=		PATH=${TMPPATH} METALOG=${METALOG} -DNO_ROOT
 
 # cross-building -> add -target flag to clang command line
 .if ${MACHINE:Nhost:Ncommon} != "" && ${TARGET_MACHINE} != ${HOST_MACHINE} && ${X_COMPILER_TYPE} == "clang"
-.if ${TARGET_ARCH} == "amd64"
-_triple_arch=x86_64
-.else
-_triple_arch=${TARGET_ARCH}
-.endif
-CROSS_TARGET_FLAGS=-target ${_triple_arch}-unknown-freebsd${_REVISION}
+CROSS_TARGET_FLAGS=-target ${TARGET_TRIPLE}
 .endif
 
 CROSSENV+=	CC="${XCC} ${CROSS_TARGET_FLAGS} ${XCFLAGS}"\

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -185,7 +185,8 @@ SUBDIR.${MK_STATS}+=	libstats
     ${MACHINE_ARCH:Mmips64*}) && \
     ! ${MACHINE_ARCH:Mmips*c*}
 _libclang_rt=	libclang_rt
-.elif ! ${MACHINE_ARCH:Mmips*c*} && ${MACHINE_ARCH} != "mips"
+.elif ! ${MACHINE_ARCH:Mmips*c*} && ${MACHINE_ARCH} != "mips" && \
+    ! ${MACHINE_ARCH:Mriscv*}
 .error "NOT BUILDING libclang_rt for ${MACHINE_ARCH}"
 .endif
 .endif # ${COMPILER_TYPE} == "clang"

--- a/share/mk/bsd.cheri.mk
+++ b/share/mk/bsd.cheri.mk
@@ -34,7 +34,8 @@ WANT_CHERI?=	pure
 .endif
 .endif
 
-.if ! ${MACHINE_ARCH:Mmips*c*} || defined(LIBCHERI)
+.if (${MACHINE_ARCH:Mmips64*} && ! ${MACHINE_ARCH:Mmips*c*}) || \
+    defined(LIBCHERI)
 .if !${.TARGETS:Mbuild-tools} && !defined(BOOTSTRAPPING)
 .if defined(NEED_CHERI)
 .if ${MK_CHERI} == "no"

--- a/sys/dev/xilinx/if_xae.c
+++ b/sys/dev/xilinx/if_xae.c
@@ -595,7 +595,7 @@ xae_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 
 	error = 0;
 	switch (cmd) {
-	case SIOCSIFFLAGS:
+	case CASE_IOC_IFREQ(SIOCSIFFLAGS):
 		XAE_LOCK(sc);
 		if (ifp->if_flags & IFF_UP) {
 			if (ifp->if_drv_flags & IFF_DRV_RUNNING) {
@@ -613,21 +613,21 @@ xae_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 		sc->if_flags = ifp->if_flags;
 		XAE_UNLOCK(sc);
 		break;
-	case SIOCADDMULTI:
-	case SIOCDELMULTI:
+	case CASE_IOC_IFREQ(SIOCADDMULTI):
+	case CASE_IOC_IFREQ(SIOCDELMULTI):
 		if (ifp->if_drv_flags & IFF_DRV_RUNNING) {
 			XAE_LOCK(sc);
 			xae_setup_rxfilter(sc);
 			XAE_UNLOCK(sc);
 		}
 		break;
-	case SIOCSIFMEDIA:
+	case CASE_IOC_IFREQ(SIOCSIFMEDIA):
 	case SIOCGIFMEDIA:
 		mii = sc->mii_softc;
 		error = ifmedia_ioctl(ifp, ifr, &mii->mii_media, cmd);
 		break;
-	case SIOCSIFCAP:
-		mask = ifp->if_capenable ^ ifr->ifr_reqcap;
+	case CASE_IOC_IFREQ(SIOCSIFCAP):
+		mask = ifr_reqcap_get(ifr) ^ ifp->if_capenable;
 		if (mask & IFCAP_VLAN_MTU) {
 			/* No work to do except acknowledge the change took */
 			ifp->if_capenable ^= IFCAP_VLAN_MTU;


### PR DESCRIPTION
These are some CheriBSD-specific build fixes.  I haven't yet completed a full build of recent CheriBSD (and will wait to start a new test when Brooks does the next merge of this week's upstream FreeBSD changes), but I feel pretty confident that these changes will be required at least.  My other riscv branch has some other changes, but I think they may not be required either to being specific to previous use of ld.bfd instead of lld, or conflicting with some other inflight purecap native cleanups, etc.