### PR TITLE
Make ucontext_t use capabilities for CHERI kernels.

### DIFF
--- a/sys/compat/cheriabi/cheriabi_misc.c
+++ b/sys/compat/cheriabi/cheriabi_misc.c
@@ -411,7 +411,7 @@ cheriabi_jail_get(struct thread *td, struct cheriabi_jail_get_args *uap)
 int
 cheriabi_sigreturn(struct thread *td, struct cheriabi_sigreturn_args *uap)
 {
-	ucontext_c_t uc;
+	ucontext_t uc;
 	int error;
 
 	error = copyincap(uap->sigcntxp, &uc, sizeof(uc));
@@ -427,13 +427,13 @@ cheriabi_sigreturn(struct thread *td, struct cheriabi_sigreturn_args *uap)
 	return (EJUSTRETURN);
 }
 
-#define UCC_COPY_SIZE	offsetof(ucontext_c_t, uc_link)
+#define UCC_COPY_SIZE	offsetof(ucontext_t, uc_link)
 
 int
 cheriabi_getcontext(struct thread *td, struct cheriabi_getcontext_args *uap)
 {
 
-	ucontext_c_t uc;
+	ucontext_t uc;
 
 	if (uap->ucp == NULL)
 		return (EINVAL);
@@ -449,7 +449,7 @@ cheriabi_getcontext(struct thread *td, struct cheriabi_getcontext_args *uap)
 int
 cheriabi_setcontext(struct thread *td, struct cheriabi_setcontext_args *uap)
 {
-	ucontext_c_t uc;
+	ucontext_t uc;
 	int ret;
 
 	if (uap->ucp == NULL)
@@ -467,7 +467,7 @@ cheriabi_setcontext(struct thread *td, struct cheriabi_setcontext_args *uap)
 int
 cheriabi_swapcontext(struct thread *td, struct cheriabi_swapcontext_args *uap)
 {
-	ucontext_c_t uc;
+	ucontext_t uc;
 	int ret;
 
 	if (uap->oucp == NULL || uap->ucp == NULL)
@@ -1450,7 +1450,7 @@ cheriabi___sysctlbyname(struct thread *td,
  */
 
 struct thr_create_initthr_args_c {
-	ucontext_c_t ctx;
+	ucontext_t ctx;
 	long * __capability tid;
 };
 

--- a/sys/compat/cheriabi/cheriabi_signal.h
+++ b/sys/compat/cheriabi/cheriabi_signal.h
@@ -46,6 +46,5 @@ struct sigaltstack_c {
 	size_t		ss_size;	/* signal stack length */
 	int		ss_flags;	/* SS_DISABLE and/or SS_ONSTACK */
 };
-typedef struct sigaltstack_c cheriabi_stack_t;
 
 #endif /* _COMPAT_CHERIABI_CHERIABI_SIGNAL_H_ */

--- a/sys/compat/cheriabi/cheriabi_util.h
+++ b/sys/compat/cheriabi/cheriabi_util.h
@@ -120,8 +120,8 @@ void	cheriabi_fetch_syscall_arg(struct thread *td, void * __capability *arg,
 void * __capability	cheriabi_mmap_retcap(struct thread *td,
 	    vm_offset_t addr, const struct mmap_req *mrp);
 
-int	cheriabi_get_mcontext(struct thread *td, mcontext_c_t *mcp, int flags);
-int	cheriabi_set_mcontext(struct thread *td, mcontext_c_t *mcp);
+int	cheriabi_get_mcontext(struct thread *td, mcontext_t *mcp, int flags);
+int	cheriabi_set_mcontext(struct thread *td, mcontext_t *mcp);
 void	cheriabi_set_threadregs(struct thread *td, struct thr_param_c *param);
 
 #endif /* !_COMPAT_CHERIABI_CHERIABI_UTIL_H_ */

--- a/sys/kern/kern_context.c
+++ b/sys/kern/kern_context.c
@@ -77,7 +77,7 @@ sys_getcontext(struct thread *td, struct getcontext_args *uap)
 		PROC_LOCK(td->td_proc);
 		uc.uc_sigmask = td->td_sigmask;
 		PROC_UNLOCK(td->td_proc);
-		ret = copyout(&uc, uap->ucp, UC_COPY_SIZE);
+		ret = copyoutcap(&uc, uap->ucp, UC_COPY_SIZE);
 	}
 	return (ret);
 }
@@ -91,7 +91,7 @@ sys_setcontext(struct thread *td, struct setcontext_args *uap)
 	if (uap->ucp == NULL)
 		ret = EINVAL;
 	else {
-		ret = copyin(uap->ucp, &uc, UC_COPY_SIZE);
+		ret = copyincap(uap->ucp, &uc, UC_COPY_SIZE);
 		if (ret == 0) {
 			ret = set_mcontext(td, &uc.uc_mcontext);
 			if (ret == 0) {
@@ -117,9 +117,9 @@ sys_swapcontext(struct thread *td, struct swapcontext_args *uap)
 		PROC_LOCK(td->td_proc);
 		uc.uc_sigmask = td->td_sigmask;
 		PROC_UNLOCK(td->td_proc);
-		ret = copyout(&uc, uap->oucp, UC_COPY_SIZE);
+		ret = copyoutcap(&uc, uap->oucp, UC_COPY_SIZE);
 		if (ret == 0) {
-			ret = copyin(uap->ucp, &uc, UC_COPY_SIZE);
+			ret = copyincap(uap->ucp, &uc, UC_COPY_SIZE);
 			if (ret == 0) {
 				ret = set_mcontext(td, &uc.uc_mcontext);
 				if (ret == 0) {

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -327,7 +327,7 @@ cheriabi_set_syscall_retval(struct thread *td, int error)
 }
 
 int
-cheriabi_get_mcontext(struct thread *td, mcontext_c_t *mcp, int flags)
+cheriabi_get_mcontext(struct thread *td, mcontext_t *mcp, int flags)
 {
 	struct trapframe *tp;
 
@@ -361,7 +361,7 @@ cheriabi_get_mcontext(struct thread *td, mcontext_c_t *mcp, int flags)
 }
 
 int
-cheriabi_set_mcontext(struct thread *td, mcontext_c_t *mcp)
+cheriabi_set_mcontext(struct thread *td, mcontext_t *mcp)
 {
 	struct trapframe *tp;
 	int tag;
@@ -392,7 +392,7 @@ cheriabi_set_mcontext(struct thread *td, mcontext_c_t *mcp)
 
 /* Check that mcontext_c_t matches struct sigcontext) */
 #define	CHECK_SIGCTX_MCTX_OFFSET(mfield, sfield)	\
-    _Static_assert(offsetof(mcontext_c_t, mfield) == 	\
+    _Static_assert(offsetof(mcontext_t, mfield) == 	\
 	offsetof(struct sigcontext, sfield) -		\
 	offsetof(struct sigcontext, sc_onstack), "mcontext_c_t layout error")
 

--- a/sys/mips/include/sigframe.h
+++ b/sys/mips/include/sigframe.h
@@ -43,11 +43,7 @@ struct sigframe {
 	register_t	sf_siginfo;	/* code or pointer to sf_si */
 	register_t	sf_ucontext;	/* points to sf_uc */
 	register_t	sf_addr;	/* undocumented 4th arg */
-#if defined(_KERNEL) && __has_feature(capabilities)
-	ucontext_c_t	sf_uc;		/* = *sf_ucontext */
-#else
 	ucontext_t	sf_uc;		/* = *sf_ucontext */
-#endif
 	siginfo_t	sf_si;		/* = *sf_siginfo (SA_SIGINFO case) */
 	unsigned long	__spare__[2];
 };
@@ -86,7 +82,7 @@ struct sigframe_c {
 	register_t	sf_siginfo;	/* code or pointer to sf_si */
 	register_t	sf_ucontext;	/* points to sf_uc */
 	register_t	sf_addr;	/* undocumented 4th arg */
-	ucontext_c_t	sf_uc;		/* = *sf_ucontext */
+	ucontext_t	sf_uc;		/* = *sf_ucontext */
 	struct siginfo_c	sf_si;	/* = *sf_siginfo (SA_SIGINFO case) */
 	unsigned long	__spare__[2];
 };

--- a/sys/sys/_ucontext.h
+++ b/sys/sys/_ucontext.h
@@ -45,7 +45,7 @@ typedef struct __ucontext {
 	__sigset_t	uc_sigmask;
 	mcontext_t	uc_mcontext;
 
-	struct __ucontext *uc_link;
+	struct __ucontext * __kerncap uc_link;
 	struct __stack_t uc_stack;
 	int		uc_flags;
 	int		__spare__[4];


### PR DESCRIPTION
- mcontext_t uses the CheriABI layout on MIPS in CHERI kernels.
- ucontext_t uses __kerncap for uc_link.
- Remove mcontext_c_t and ucontext_c_t.
- get/set_mcontext() now operate on the CheriABI context in CHERI
  kernels.
- freebsd64_get/set_mcontext() convert to/from mcontext64 and mcontext_t.
  In the case of a freebsd64_set_mcontext without a CP2 block,
  mc_cheriframe is initialized from the trapframe before calling
  set_context().
- sys_sigreturn(), sys_*context() now use copyin/outcap().