### PR TITLE
Simple compile fixes for RISC-V

### DIFF
--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -103,7 +103,9 @@ __FBSDID("$FreeBSD$");
 #include <compat/cheriabi/cheriabi_util.h>
 #endif
 
+#if __has_feature(capabilities)
 #include <cheri/cheric.h>
+#endif
 
 SDT_PROVIDER_DEFINE(proc);
 

--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -73,18 +73,12 @@ typedef	__uint64_t		uint64_t;
 #endif
 
 #ifndef _INTCAP_T_DECLARED
-#if __has_feature(capabilities)
 typedef	__intcap_t		intcap_t;
-#else
-typedef	__intptr_t		intcap_t;
-#endif
+#define	_INTCAP_T_DECLARED
 #endif
 #ifndef _UINTCAP_T_DECLARED
-#if __has_feature(capabilities)
 typedef	__uintcap_t		uintcap_t;
-#else
-typedef	__uintptr_t		uintcap_t;
-#endif
+#define	_UINTCAP_T_DECLARED
 #endif
 #ifndef _INTPTR_T_DECLARED
 typedef	__intptr_t		intptr_t;

--- a/sys/sys/_types.h
+++ b/sys/sys/_types.h
@@ -69,6 +69,10 @@ typedef	int		__cpuwhich_t;	/* which parameter for cpuset. */
 typedef	int		__cpulevel_t;	/* level parameter for cpuset. */
 typedef int		__cpusetid_t;	/* cpuset identifier. */
 typedef __int64_t	__daddr_t;	/* bwrite(3), FIOBMAP2, etc */
+#if !__has_feature(capabilities)
+typedef	__intptr_t	__intcap_t;
+typedef	__uintptr_t	__uintcap_t;
+#endif
 
 /*
  * Unusual type definitions.


### PR DESCRIPTION
These are some simple fixes to build a "plain" RISC-V kernel.  The first is to deal with a regression I just introduced in my kevent_native change.