### PR TITLE
Freebsd64 uint64 struct pointer members.

### DIFF
--- a/sys/compat/freebsd64/freebsd64.h
+++ b/sys/compat/freebsd64/freebsd64.h
@@ -49,41 +49,41 @@
 
 struct jail64 {
 	uint32_t	version;
-	char		*path;
-	char		*hostname;
-	char		*jailname;
+	uint64_t	path;		/* char* */
+	uint64_t	hostname;	/* char* */
+	uint64_t	jailname;	/* char* */
 	uint32_t	ip4s;
 	uint32_t	ip6s;
-	struct in_addr	*ip4;
-	struct in6_addr	*ip6;
+	uint64_t	ip4;		/* struct in_addr* */
+	uint64_t	ip6;		/* struct in6_addr* */
 };
 
 struct thr_param64 {
-	void		*start_func;
-	void		*arg;
-	char		*stack_base;
+	uint64_t	start_func;	/* void* */
+	uint64_t	arg;		/* void* */
+	uint64_t	stack_base;	/* char* */
 	size_t		stack_size;
-	char		*tls_base;
+	uint64_t	tls_base;	/* char* */
 	size_t		tls_size;
-	long		*child_tid;
-	long		*parent_tid;
+	uint64_t	child_tid;	/* long* */
+	uint64_t	parent_tid;	/* long* */
 	int		flags;
-	struct rtprio	*rtp;
-	void		*ddc;
-	void		*spare[2];
+	uint64_t	rtp;		/* struct rtprio* */
+	uint64_t	ddc;		/* void* */
+	uint64_t	spare[2];	/* (void*)[2] */
 };
 
 struct kinfo_proc64 {
 	int	ki_structsize;
 	int	ki_layout;
-	void	*ki_args;		/* struct pargs */
-	void	*ki_paddr;		/* struct proc */
-	void	*ki_addr;		/* struct user */
-	void	*ki_tracep;		/* struct vnode */
-	void	*ki_textvp;		/* struct vnode */
-	void	*ki_fd;			/* struct filedesc */
-	void	*ki_vmspace;		/* struct vmspace */
-	void	*ki_wchan;		/* void */
+	uint64_t ki_args;		/* struct pargs* */
+	uint64_t ki_paddr;		/* struct proc* */
+	uint64_t ki_addr;		/* struct user* */
+	uint64_t ki_tracep;		/* struct vnode* */
+	uint64_t ki_textvp;		/* struct vnode* */
+	uint64_t ki_fd;			/* struct filedesc* */
+	uint64_t ki_vmspace;		/* struct vmspace* */
+	uint64_t ki_wchan;		/* void* */
 	pid_t	ki_pid;
 	pid_t	ki_ppid;
 	pid_t	ki_pgid;
@@ -159,11 +159,11 @@ struct kinfo_proc64 {
 	struct	rusage ki_rusage;
 	/* XXX - most fields in ki_rusage_ch are not (yet) filled in */
 	struct	rusage ki_rusage_ch;
-	void	*ki_pcb;			/* struct pcb */
-	void	*ki_kstack;		/* void	*/
-	void	*ki_udata;		/* void	*/
-	void	*ki_tdaddr;		/* struct thread  */
-	void	*ki_spareptrs[KI_NSPARE_PTR];	/* void */
+	uint64_t ki_pcb;			/* struct pcb* */
+	uint64_t ki_kstack;		/* void* */
+	uint64_t ki_udata;		/* void* */
+	uint64_t ki_tdaddr;		/* struct thread*  */
+	uint64_t ki_spareptrs[KI_NSPARE_PTR];	/* void* */
 	long	ki_sparelongs[KI_NSPARE_LONG];
 	long	ki_sflag;
 	long	ki_tdflags;
@@ -174,22 +174,22 @@ struct kld_file_stat64 {
     char        name[MAXPATHLEN];
     int		refs;
     int		id;
-    void	*address;	/* load address */
+    uint64_t	address;	/* load address (void *) */
     size_t	size;		/* size in bytes */
     char        pathname[MAXPATHLEN];
 };
 
 struct kld_sym_lookup64 {
 	int		version; /* set to sizeof(struct kld_sym_lookup64) */
-	char		*symname; /* Symbol name we are looking up */
+	uint64_t	symname; /* Symbol name we are looking up (char *) */
 	u_long		symvalue;
 	size_t		symsize;
 };
 
 struct procctl_reaper_pids64 {
-	u_int				rp_count;
-	u_int				rp_pad0[15];
-	struct procctl_reaper_pidinfo	*rp_pids;
+	u_int		rp_count;
+	u_int		rp_pad0[15];
+	uint64_t	rp_pids;	/* struct procctl_reaper_pidinfo* */
 };
 
 #include <sys/ipc.h>
@@ -210,7 +210,7 @@ struct msqid_ds64 {
 };
 
 struct iovec64 {
-	void 	*iov_base;
+	uint64_t iov_base;	/* void* */
 	size_t	iov_len;
 };
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -231,7 +231,7 @@ freebsd64_kevent_copyout(void *arg, struct kevent *kevp, int count)
 		ks64[i].flags = kevp[i].flags;
 		ks64[i].fflags = kevp[i].fflags;
 		ks64[i].data = kevp[i].data;
-		ks64[i].udata = (void *)(__cheri_addr vaddr_t)kevp[i].udata;
+		ks64[i].udata = (__cheri_addr uint64_t)kevp[i].udata;
 		memcpy(&ks64[i].ext[0], &kevp->ext[0], sizeof(kevp->ext));
 	}
 	error = copyout(ks64, uap->eventlist, count * sizeof(*ks64));

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -210,7 +210,7 @@ freebsd64_sigaltstack(struct thread *td,
 		return (error);
 	if (uap->oss != NULL) {
 		memset(&ss64, 0, sizeof(ss64));
-		ss64.ss_sp = (__cheri_fromcap void *)oss.ss_sp;
+		ss64.ss_sp = (__cheri_addr uint64_t)oss.ss_sp;
 		ss64.ss_size = oss.ss_size;
 		ss64.ss_flags = oss.ss_flags;
 		error = copyout(&ss64, uap->oss, sizeof(ss64));

--- a/sys/compat/freebsd64/freebsd64_signal.h
+++ b/sys/compat/freebsd64/freebsd64_signal.h
@@ -42,7 +42,7 @@ struct sigaction64 {
 };
 
 struct sigaltstack64 {
-	void		*ss_sp;		/* signal stack base */
+	uint64_t	ss_sp;		/* (void *) signal stack base */
 	size_t		ss_size;	/* signal stack length */
 	int		ss_flags;	/* SS_DISABLE and/or SS_ONSTACK */
 };
@@ -55,8 +55,10 @@ struct sigevent64 {
 	union {
 		__lwpid_t	_threadid;
 		struct {
-			void (*_function)(union sigval64);
-			struct pthread_attr **_attribute;
+			/* void (*_function)(union sigval64); */
+			uint64_t _function;
+			/* struct pthread_attr **_attribute; */
+			uint64_t _attribute;
 		} _sigev_thread;
 		unsigned short _kevent_flags;
 		long __spare__[8];

--- a/sys/mips/mips/freebsd64_machdep.c
+++ b/sys/mips/mips/freebsd64_machdep.c
@@ -352,7 +352,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	/* save user context */
 	bzero(&sf, sizeof(sf));
 	sf.sf_uc.uc_sigmask = *mask;
-	sf.sf_uc.uc_stack.ss_sp = (__cheri_fromcap void *)td->td_sigstk.ss_sp;
+	sf.sf_uc.uc_stack.ss_sp = (__cheri_addr uint64_t)td->td_sigstk.ss_sp;
 	sf.sf_uc.uc_stack.ss_size = td->td_sigstk.ss_size;
 	sf.sf_uc.uc_stack.ss_flags = td->td_sigstk.ss_flags;
 	sf.sf_uc.uc_mcontext.mc_onstack = (oonstack) ? 1 : 0;

--- a/sys/sys/event.h
+++ b/sys/sys/event.h
@@ -169,7 +169,7 @@ struct kevent64 {
 	unsigned short	flags;
 	unsigned int	fflags;
 	__int64_t	data;
-	void		*udata;		/* opaque user data identifier */
+	__uint64_t	udata;		/* opaque user data identifier */
 	__uint64_t	ext[4];
 };
 #endif

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -177,7 +177,7 @@ void	kassert_panic(const char *fmt, ...)  __printflike(1, 2);
  * sentinel values to work.
  */
 #define ___USER_CFROMPTR(ptr, cap)					\
-    ((ptr) == NULL ? NULL :						\
+    ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
 	__builtin_cheri_offset_set(NULL, (vaddr_t)(ptr)) :		\


### PR DESCRIPTION
This PR replaces all pointer types in compat structures with uint64_t.
A few more fixes are required to properly create pointers/capabilities from user-provided integer addresses. A few copyin/out are changed to use capabilities explicitly as this will ultimately reduce the diff between the hybrid and pure kernels. 