### PR TITLE
Freebsd64 explicit user access

### DIFF
--- a/sys/compat/freebsd64/freebsd64.h
+++ b/sys/compat/freebsd64/freebsd64.h
@@ -212,4 +212,4 @@ struct iovec64 {
 	size_t	iov_len;
 };
 
-#endif /* !_COMPAT_CHERIABI_CHERIABI_H_ */
+#endif /* !_COMPAT_FREEBSD64_FREEBSD64_H_ */

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -34,6 +34,8 @@
  * SUCH DAMAGE.
  */
 
+#define EXPLICIT_USER_ACCESS 1
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -96,7 +98,7 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 	actp = (uap->act != NULL) ? &act : NULL;
 	oactp = (uap->oact != NULL) ? &oact : NULL;
 	if (actp) {
-		error = copyin(uap->act, &act64, sizeof(act64));
+		error = copyin(__USER_CAP_OBJ(uap->act), &act64, sizeof(act64));
 		if (error)
 			return (error);
 		if (is_magic_sighandler_constant(act64.sa_u))
@@ -112,7 +114,8 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 		oact64.sa_u = (__cheri_addr vaddr_t)oactp->sa_handler;
 		oact64.sa_flags = oactp->sa_flags;
 		oact64.sa_mask = oactp->sa_mask;
-		error = copyout(&oact64, uap->oact, sizeof(oact64));
+		error = copyout(&oact64, __USER_CAP_OBJ(uap->oact),
+		    sizeof(oact64));
 	}
 	return (error);
 }
@@ -197,7 +200,7 @@ freebsd64_sigaltstack(struct thread *td,
 	int error;
 
 	if (uap->ss != NULL) {
-		error = copyin(uap->ss, &ss64, sizeof(ss64));
+		error = copyin(__USER_CAP_OBJ(uap->ss), &ss64, sizeof(ss64));
 		if (error != 0)
 			return (error);
 		ss.ss_sp = __USER_CAP_UNBOUND(ss64.ss_sp);
@@ -213,7 +216,7 @@ freebsd64_sigaltstack(struct thread *td,
 		ss64.ss_sp = (__cheri_addr uint64_t)oss.ss_sp;
 		ss64.ss_size = oss.ss_size;
 		ss64.ss_flags = oss.ss_flags;
-		error = copyout(&ss64, uap->oss, sizeof(ss64));
+		error = copyout(&ss64, __USER_CAP_OBJ(uap->oss), sizeof(ss64));
 	}
 	return (error);
 }

--- a/sys/compat/freebsd64/freebsd64_time.c
+++ b/sys/compat/freebsd64/freebsd64_time.c
@@ -32,6 +32,8 @@
  * SUCH DAMAGE.
  */
 
+#define EXPLICIT_USER_ACCESS 1
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -60,7 +62,8 @@ freebsd64_ffclock_getcounter(struct thread *td,
 	ffclock_read_counter(&ffcount);
 	if (ffcount == 0)
 		return (EAGAIN);
-	return (copyout(&ffcount, uap->ffcount, sizeof(ffcounter)));
+	return (copyout(&ffcount, __USER_CAP_OBJ(uap->ffcount),
+	    sizeof(ffcounter)));
 #else
 	return (ENOSYS);
 #endif
@@ -106,13 +109,13 @@ freebsd64_ntp_adjtime(struct thread *td, struct freebsd64_ntp_adjtime_args *uap)
 	struct timex ntv;
 	int error, retval;
 
-	error = copyin(uap->tp, &ntv, sizeof(ntv));
+	error = copyin(__USER_CAP_OBJ(uap->tp), &ntv, sizeof(ntv));
 	if (error != 0)
 		return (error);
 	error = kern_ntp_adjtime(td, &ntv, &retval);
 	if (error != 0)
 		return (error);
-	error = copyout(&ntv, uap->tp, sizeof(ntv));
+	error = copyout(&ntv, __USER_CAP_OBJ(uap->tp), sizeof(ntv));
 	if (error == 0)
 		td->td_retval[0] = retval;
 	return (error);
@@ -125,7 +128,8 @@ freebsd64_adjtime(struct thread *td, struct freebsd64_adjtime_args *uap)
 	int error;
 
 	if (uap->delta) {
-		error = copyin(uap->delta, &delta, sizeof(delta));
+		error = copyin(__USER_CAP_OBJ(uap->delta), &delta,
+		    sizeof(delta));
 		if (error != 0)
 			return (error);
 		deltap = &delta;
@@ -133,7 +137,8 @@ freebsd64_adjtime(struct thread *td, struct freebsd64_adjtime_args *uap)
 		deltap = NULL;
 	error = kern_adjtime(td, deltap, &olddelta);
 	if (uap->olddelta && error == 0)
-		error = copyout(&olddelta, uap->olddelta, sizeof(olddelta));
+		error = copyout(&olddelta, __USER_CAP_OBJ(uap->olddelta),
+		    sizeof(olddelta));
 	return (error);
 }
 
@@ -150,7 +155,8 @@ freebsd64_clock_getcpuclockid2(struct thread *td,
 
 	error = kern_clock_getcpuclockid2(td, uap->id, uap->which, &clk_id);
 	if (error == 0)
-		error = copyout(&clk_id, uap->clock_id, sizeof(clockid_t));
+		error = copyout(&clk_id, __USER_CAP_OBJ(uap->clock_id),
+		    sizeof(clockid_t));
 
 	return (error);
 }
@@ -164,7 +170,7 @@ freebsd64_clock_gettime(struct thread *td,
 
 	error = kern_clock_gettime(td, uap->clock_id, &ats);
 	if (error == 0)
-		error = copyout(&ats, uap->tp, sizeof(ats));
+		error = copyout(&ats, __USER_CAP_OBJ(uap->tp), sizeof(ats));
 
 	return (error);
 }
@@ -176,7 +182,7 @@ freebsd64_clock_settime(struct thread *td,
 	struct timespec ats;
 	int error;
 
-	error = copyin(uap->tp, &ats, sizeof(ats));
+	error = copyin(__USER_CAP_OBJ(uap->tp), &ats, sizeof(ats));
 	if (error != 0)
 		return (error);
 
@@ -195,7 +201,7 @@ freebsd64_clock_getres(struct thread *td,
 
 	error = kern_clock_getres(td, uap->clock_id, &ats);
 	if (error == 0)
-		error = copyout(&ats, uap->tp, sizeof(ats));
+		error = copyout(&ats, __USER_CAP_OBJ(uap->tp), sizeof(ats));
 	
 	return (error);
 }
@@ -245,7 +251,8 @@ freebsd64_getitimer(struct thread *td, struct freebsd64_getitimer_args *uap)
 	error = kern_getitimer(td, uap->which, &aitv);
 	if (error != 0)
 		return (error);
-	return (copyout(&aitv, uap->itv, sizeof (struct itimerval)));
+	return (copyout(&aitv, __USER_CAP_OBJ(uap->itv),
+	    sizeof(struct itimerval)));
 }
 
 int
@@ -258,16 +265,19 @@ freebsd64_setitimer(struct thread *td, struct freebsd64_setitimer_args *uap)
 		error = kern_getitimer(td, uap->which, &aitv);
 		if (error != 0)
 			return (error);
-		return (copyout(&aitv, uap->oitv, sizeof (struct itimerval)));
+		return (copyout(&aitv, __USER_CAP_OBJ(uap->oitv),
+		    sizeof(struct itimerval)));
 	}
 
-	error = copyin(uap->itv, &aitv, sizeof(struct itimerval));
+	error = copyin(__USER_CAP_OBJ(uap->itv), &aitv,
+	    sizeof(struct itimerval));
 	if (error != 0)
 		return (error);
 	error = kern_setitimer(td, uap->which, &aitv, &oitv);
 	if (error != 0 || uap->oitv == NULL)
 		return (error);
-	return (copyout(&oitv, uap->oitv, sizeof(struct itimerval)));
+	return (copyout(&oitv, __USER_CAP_OBJ(uap->oitv),
+	    sizeof(struct itimerval)));
 }
 
 int
@@ -281,7 +291,7 @@ freebsd64_ktimer_create(struct thread *td,
 	if (uap->evp == NULL) {
 		evp = NULL;
 	} else {
-		error = copyin(uap->evp, &ev64, sizeof(ev64));
+		error = copyin(__USER_CAP_OBJ(uap->evp), &ev64, sizeof(ev64));
 		if (error != 0)
 			return (error);
 		error = convert_sigevent64(&ev64, &ev);
@@ -292,7 +302,7 @@ freebsd64_ktimer_create(struct thread *td,
 	error = kern_ktimer_create(td, uap->clock_id, evp, &id, -1);
 	if (error != 0)
 		return (error);
-	error = copyout(&id, uap->timerid, sizeof(int));
+	error = copyout(&id, __USER_CAP_OBJ(uap->timerid), sizeof(int));
 	if (error != 0)
 		kern_ktimer_delete(td, id);
 	return (error);
@@ -305,13 +315,14 @@ freebsd64_ktimer_settime(struct thread *td,
 	struct itimerspec val, oval, *ovalp;
 	int error;
 
-	error = copyin(uap->value, &val, sizeof(val));
+	error = copyin(__USER_CAP_OBJ(uap->value), &val, sizeof(val));
 	if (error != 0)
 		return (error);
 	ovalp = uap->ovalue != NULL ? &oval : NULL;
 	error = kern_ktimer_settime(td, uap->timerid, uap->flags, &val, ovalp);
 	if (error == 0 && uap->ovalue != NULL)
-		error = copyout(ovalp, uap->ovalue, sizeof(*ovalp));
+		error = copyout(ovalp, __USER_CAP_OBJ(uap->ovalue),
+		    sizeof(*ovalp));
 	return (error);
 }
 
@@ -324,6 +335,6 @@ freebsd64_ktimer_gettime(struct thread *td,
 
 	error = kern_ktimer_gettime(td, uap->timerid, &val);
 	if (error == 0)
-		error = copyout(&val, uap->value, sizeof(val));
+		error = copyout(&val, __USER_CAP_OBJ(uap->value), sizeof(val));
 	return (error);
 }

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -32,6 +32,8 @@
  * SUCH DAMAGE.
  */
 
+#define	EXPLICIT_USER_ACCESS 1
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -116,58 +118,61 @@ freebsd64_sendto(struct thread *td, struct freebsd64_sendto_args *uap)
 }
 
 static int
-freebsd64_copyinmsghdr(struct msghdr64 *msg64, struct msghdr *msg)
+freebsd64_copyinmsghdr(struct msghdr64 * __capability umsg, struct msghdr *msg,
+    struct msghdr64 *m64)
 {
-	struct msghdr64 m64;
+	struct iovec *iov;
 	int error;
 
-	error = copyin(msg64, &m64, sizeof(m64));
+	error = copyin(umsg, m64, sizeof(*m64));
 	if (error)
 		return (error);
-	msg->msg_name = __USER_CAP(m64.msg_name, m64.msg_namelen);
-	msg->msg_namelen = m64.msg_namelen;
-	msg->msg_iov = __USER_CAP_ARRAY(m64.msg_iov, m64.msg_iovlen);
-	msg->msg_iovlen = m64.msg_iovlen;
-	msg->msg_control = __USER_CAP(m64.msg_control, m64.msg_controllen);
-	msg->msg_controllen = m64.msg_controllen;
-	msg->msg_flags = m64.msg_flags;
+	msg->msg_name = __USER_CAP(m64->msg_name, m64->msg_namelen);
+	msg->msg_namelen = m64->msg_namelen;
+
+	msg->msg_iov = NULL;
+	error = freebsd64_copyiniov(
+            __USER_CAP_ARRAY((struct iovec64 *)m64->msg_iov, m64->msg_iovlen),
+	    m64->msg_iovlen, &iov, EMSGSIZE);
+	if (error)
+		return (error);
+	msg->msg_iov = (__cheri_tocap struct iovec * __capability)iov;
+	msg->msg_iovlen = m64->msg_iovlen;
+
+	msg->msg_control = __USER_CAP(m64->msg_control, m64->msg_controllen);
+	msg->msg_controllen = m64->msg_controllen;
+	msg->msg_flags = m64->msg_flags;
 	return (0);
 }
 
 /*
- * XXX-BD: arguably we should just update the lenghts and flags and leave
- * the pointers untouched.
+ * Note that we modify the lengths only, all the pointers provided by
+ * userspace are left untouched.
  */
 static int
-freebsd64_copyoutmsghdr(struct msghdr *msg, struct msghdr64 *msg64)
+freebsd64_copyoutmsghdr(struct msghdr64 *m64, struct msghdr *msg,
+    struct msghdr64 * __capability umsg)
 {
-	struct msghdr64 m64;
 	int error;
 
-	m64.msg_name = (__cheri_fromcap void *)msg->msg_name;
-	m64.msg_namelen = msg->msg_namelen;
-	/* Use value was previous restored. */
-	m64.msg_iov = (__cheri_fromcap void *)msg->msg_iov;
-	m64.msg_iovlen = msg->msg_iovlen;
-	m64.msg_control = (__cheri_fromcap void *)msg->msg_control;
-	m64.msg_controllen = msg->msg_controllen;
-	m64.msg_flags = msg->msg_flags;
-	error = copyout(&m64, msg64, sizeof(m64));
+	m64->msg_namelen = msg->msg_namelen;
+	m64->msg_iovlen = msg->msg_iovlen;
+	m64->msg_controllen = msg->msg_controllen;
+	m64->msg_flags = msg->msg_flags;
+	error = copyout(m64, umsg, sizeof(*m64));
 	return (error);
 }
 
-#define	FREEBSD64_ALIGNBYTES	(sizeof(long) - 1)
-#define FREEBSD64_ALIGN(p)	\
-    (((u_long)(p) + FREEBSD64_ALIGNBYTES) & ~FREEBSD64_ALIGNBYTES)
-#define	FREEBSD64_CMSG_SPACE(l)	\
+#define	FREEBSD64_ALIGN(p) roundup2((p), sizeof(long))
+#define	FREEBSD64_CMSG_SPACE(l)						\
     (FREEBSD64_ALIGN(sizeof(struct cmsghdr)) + FREEBSD64_ALIGN(l))
+#define	FREEBSD64_CMSG_LEN(l)				\
+    (FREEBSD64_ALIGN(sizeof(struct cmsghdr)) + (l))
+#define	FREEBSD64_CMSG_DATA(cmsg)				\
+    ((char *)(cmsg) + FREEBSD64_ALIGN(sizeof(struct cmsghdr)))
 
-/*
- * XXX-BD: does this actually need to exist?  We don't need to do time
- * conversions like on i386, but maybe alignment is an issue...
- */
 static int
-freebsd64_copy_msg_out(struct msghdr *msg, struct mbuf *control)
+freebsd64_copyout_control(struct msghdr *msg, struct mbuf *control)
 {
 	struct cmsghdr *cm;
 	void *data;
@@ -208,8 +213,7 @@ freebsd64_copy_msg_out(struct msghdr *msg, struct mbuf *control)
 				goto exit;
 			}
 			oldclen = cm->cmsg_len;
-			cm->cmsg_len = FREEBSD64_ALIGN(sizeof(struct cmsghdr)) +
-			    datalen;
+			cm->cmsg_len = FREEBSD64_CMSG_LEN(datalen);
 			error = copyout_c(cm, ctlbuf, copylen);
 			cm->cmsg_len = oldclen;
 			if (error != 0)
@@ -254,31 +258,120 @@ exit:
 	return (error);
 }
 
+static int
+freebsd64_copyin_control(struct mbuf **mp, char * __capability buf,
+    u_int buflen)
+{
+	int error;
+	struct cmsghdr *cmsg;
+	struct mbuf *m = NULL;
+	caddr_t md;
+	u_int idx, newlen, msglen, datalen;
+
+	buflen = FREEBSD64_ALIGN(buflen);
+	if (buflen > MCLBYTES)
+		return (EINVAL);
+
+	/*
+	 * Iterate over the message headers to compute the new length using
+	 * the native kernel padding.
+	 */
+	idx = 0;
+	newlen = 0;
+	while (idx < buflen) {
+		cmsg = (struct cmsghdr *)((__cheri_fromcap char *)buf + idx);
+		msglen = fuword32(__USER_CAP_OBJ(&cmsg->cmsg_len));
+		if (msglen < sizeof(struct cmsghdr) ||
+		    idx + FREEBSD64_ALIGN(msglen) > buflen)
+			return (EINVAL);
+		datalen = (char *)cmsg + msglen - FREEBSD64_CMSG_DATA(cmsg);
+		idx += FREEBSD64_CMSG_SPACE(datalen);
+		newlen += CMSG_SPACE(datalen);
+	}
+
+	if (newlen > MCLBYTES)
+		return (EINVAL);
+
+	m = m_get2(newlen, M_WAITOK, MT_CONTROL, 0);
+	m->m_len = newlen;
+
+	/* Copyin and realign the control data. */
+	md = mtod(m, caddr_t);
+	while (buflen > 0) {
+		error = copyin(buf, md, sizeof(struct cmsghdr));
+		if (error)
+			break;
+		cmsg = (struct cmsghdr *)md;
+		datalen = (__cheri_fromcap char *)buf + cmsg->cmsg_len -
+		    FREEBSD64_CMSG_DATA((__cheri_fromcap char *)buf);
+		buf += FREEBSD64_ALIGN(sizeof(struct cmsghdr));
+		md += CMSG_ALIGN(sizeof(struct cmsghdr));
+
+		/* Fix length in the message header */
+		cmsg->cmsg_len = CMSG_LEN(datalen);
+		if (datalen > 0) {
+			error = copyin(buf, md, datalen);
+			if (error)
+				break;
+			md += CMSG_ALIGN(datalen);
+			buf += FREEBSD64_ALIGN(datalen);
+		}
+		buflen -= FREEBSD64_CMSG_SPACE(datalen);
+	}
+
+	if (error)
+		m_free(m);
+	else
+		*mp = m;
+	return (error);
+}
+
 int
 freebsd64_sendmsg(struct thread *td, struct freebsd64_sendmsg_args *uap)
 {
 	struct msghdr msg;
-	struct msghdr64 m64;
-	struct iovec *iov;
+	struct msghdr64 umsg64;
+	struct mbuf *control = NULL;
+	struct sockaddr *to = NULL;
 	int error;
 
-	error = copyin(uap->msg, &m64, sizeof(m64));
-	if (error != 0)
+	error = freebsd64_copyinmsghdr(__USER_CAP_OBJ(uap->msg), &msg, &umsg64);
+	if (error)
 		return (error);
-	msg.msg_name = __USER_CAP(m64.msg_name, m64.msg_namelen);
-	msg.msg_namelen = m64.msg_namelen;
-	error = freebsd64_copyiniov(__USER_CAP_ARRAY(m64.msg_iov,
-	    m64.msg_iovlen), m64.msg_iovlen, &iov, EMSGSIZE);
-	if (error != 0)
-		return (error);
-	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
-	msg.msg_iovlen = m64.msg_iovlen;
-	msg.msg_control = __USER_CAP(m64.msg_control, m64.msg_controllen);
-	msg.msg_controllen = m64.msg_controllen;
+
+#ifdef CAPABILITY_MODE
+	if (IN_CAPABILITY_MODE(td) && (msg.msg_name != NULL))
+		return (ECAPMODE);
+#endif
+	if (msg.msg_name != NULL) {
+		error = getsockaddr(&to, msg.msg_name, msg.msg_namelen);
+		if (error)
+			goto out;
+		msg.msg_name = (__cheri_tocap struct sockaddr * __capability)to;
+	}
+
 	/* No COMPAT_OLDSOCK support, no 64-bit 43BSD binaries should exist. */
-	msg.msg_flags = m64.msg_flags;
-	error = user_sendit(td, uap->s, &msg, uap->flags);
-	free(iov, M_IOV);
+	if (msg.msg_control != NULL) {
+		if (msg.msg_controllen < sizeof(struct cmsghdr)) {
+			error = EINVAL;
+			goto out;
+		}
+
+		error = freebsd64_copyin_control(&control, msg.msg_control,
+		    msg.msg_controllen);
+		if (error)
+			goto out;
+
+		msg.msg_control = NULL;
+		msg.msg_controllen = 0;
+	}
+
+	error = kern_sendit(td, uap->s, &msg, uap->flags, control, UIO_USERSPACE);
+out:
+	if (to)
+		free(to, M_SONAME);
+	if (msg.msg_iov != NULL)
+		free((__cheri_fromcap struct iovec *)msg.msg_iov, M_IOV);
 	return (error);
 }
 
@@ -295,40 +388,29 @@ int
 freebsd64_recvmsg(struct thread *td, struct freebsd64_recvmsg_args *uap)
 {
 	struct msghdr msg;
-	struct msghdr64 m64;
-	struct iovec * __capability uiov, *iov;
+	struct msghdr64 umsg64;
 	struct mbuf *control = NULL;
 	struct mbuf **controlp;
 	int error;
+	struct msghdr64 * __capability umsg = __USER_CAP_OBJ(uap->msg);
 
-	error = copyin(uap->msg, &m64, sizeof(m64));
-	if (error != 0)
-		return (error);
-	error = freebsd64_copyinmsghdr(uap->msg, &msg);
-	if (error != 0)
-		return (error);
-	error = freebsd64_copyiniov(__USER_CAP_ARRAY(m64.msg_iov,
-	    m64.msg_iovlen), m64.msg_iovlen, &iov, EMSGSIZE);
+	error = freebsd64_copyinmsghdr(umsg, &msg, &umsg64);
 	if (error != 0)
 		return (error);
 	msg.msg_flags = uap->flags;
-	uiov = msg.msg_iov;
-	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
 
 	controlp = (msg.msg_control != NULL) ?  &control : NULL;
 	error = kern_recvit(td, uap->s, &msg, UIO_USERSPACE, controlp);
 	if (error == 0) {
-		msg.msg_iov = uiov;
-
 		if (control != NULL)
-			error = freebsd64_copy_msg_out(&msg, control);
+			error = freebsd64_copyout_control(&msg, control);
 		else
 			msg.msg_controllen = 0;
 
 		if (error == 0)
-			error = freebsd64_copyoutmsghdr(&msg, uap->msg);
+			error = freebsd64_copyoutmsghdr(&umsg64, &msg, umsg);
 	}
-	free(iov, M_IOV);
+	free((__cheri_fromcap struct iovec *)msg.msg_iov, M_IOV);
 
 	if (control != NULL) {
 		if (error != 0)

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -2942,7 +2942,7 @@ __elfN(untrans_prot)(vm_prot_t prot)
 }
 
 void
-__elfN(stackgap)(struct image_params *imgp, uintptr_t *stack_base)
+__elfN(stackgap)(struct image_params *imgp, uintcap_t *stack_base)
 {
 	uintptr_t range, rbase, gap;
 	int pct;

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1608,8 +1608,6 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	size_t ssiz;
 #endif
 	char * __capability destp, * __capability ustringp;
-	/* XXX: Temporary */
-	uintptr_t uptr, uptr_old;
 	struct ps_strings * __capability arginfo;
 	struct proc *p;
 	size_t execpath_len, len;
@@ -1731,9 +1729,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 #endif
 
 	if (imgp->sysent->sv_stackgap != NULL) {
-		uptr_old = uptr = (__cheri_addr uintptr_t)destp;
-		imgp->sysent->sv_stackgap(imgp, &uptr);
-		destp -= (uptr_old - uptr);
+		imgp->sysent->sv_stackgap(imgp, (uintcap_t *)&destp);
 	}
 
 	if (imgp->auxargs) {

--- a/sys/sys/imgact_elf.h
+++ b/sys/sys/imgact_elf.h
@@ -105,7 +105,7 @@ int	__elfN(remove_brand_entry)(Elf_Brandinfo *entry);
 int	__elfN(freebsd_fixup)(uintcap_t *, struct image_params *);
 int	__elfN(coredump)(struct thread *, struct vnode *, off_t, int);
 size_t	__elfN(populate_note)(int, void *, void *, size_t, void **);
-void	__elfN(stackgap)(struct image_params *, uintptr_t *);
+void	__elfN(stackgap)(struct image_params *, uintcap_t *);
 int	__elfN(freebsd_copyout_auxargs)(struct image_params *, uintcap_t);
 
 /* Machine specific function to dump per-thread information. */

--- a/sys/sys/sysent.h
+++ b/sys/sys/sysent.h
@@ -109,7 +109,7 @@ struct sysentvec {
 	int		(*sv_coredump)(struct thread *, struct vnode *, off_t, int);
 					/* function to dump core, or NULL */
 	int		(*sv_imgact_try)(struct image_params *);
-	void		(*sv_stackgap)(struct image_params *, uintptr_t *);
+	void		(*sv_stackgap)(struct image_params *, uintcap_t *);
 	int		(*sv_copyout_auxargs)(struct image_params *,
 			    uintcap_t);
 	int		sv_minsigstksz;	/* minimum signal stack size */


### PR DESCRIPTION
This PR makes all of freebsd64 EXPLICIT_USER_ACCESS.

Major changes are in uipc and freebsd64_copyout_strings.
- freebsd64_copyout_strings now builds a single user capability that covers the user stack, which is then split in multiple capabilities for the various things to copyout. This is consistent with the the native copyout_strings in kern_exec.c. Note that now user capabilities stored in image_params are valid. 
- uipc is changed to properly realign the control data to the kernel pointer size. This becomes necessary to support the purecap kernel. In the hybrid kernel the alignment could stay the same, however I currently align to capability size in both the hybrid and purecap variants to avoid introducing conditionals for combinations of kernel and userspace ABIs.