### PR TITLE
Stop using the assembly versions of memcpy on MIPS to preserve tags

### DIFF
--- a/sys/conf/files.mips
+++ b/sys/conf/files.mips
@@ -6,7 +6,6 @@
 
 # Arch dependent files
 mips/cheri/cheri.c			optional cpu_cheri
-mips/cheri/cheri_bcopy.S		optional cpu_cheri
 mips/cheri/cheri_debug.c		optional cpu_cheri
 mips/cheri/cheri_exception.c		optional cpu_cheri
 mips/cheri/cheri_ktrace.c		optional cpu_cheri ktrace
@@ -14,6 +13,7 @@ mips/cheri/cheri_memcpy_c.S		optional cpu_cheri
 mips/cheri/cheri_sealcap.c		optional cpu_cheri
 mips/cheri/cheri_signal.c		optional cpu_cheri
 mips/cheri/cheriabi_machdep.c		optional cpu_cheri compat_cheriabi
+mips/cheri/copystr_c.S			optional cpu_cheri
 mips/cheri/hybridabi_machdep.c		optional cpu_cheri
 mips/mips/autoconf.c			standard
 mips/mips/bus_space_generic.c		standard
@@ -49,7 +49,6 @@ mips/mips/stack_machdep.c		optional	ddb | stack
 mips/mips/stdatomic.c			standard \
 	compile-with "${NORMAL_C:N-Wmissing-prototypes}"
 mips/mips/support.S			standard
-mips/mips/bcopy.S			standard
 mips/mips/swtch.S			standard
 mips/mips/sys_machdep.c			standard
 mips/mips/tlb.c				standard
@@ -78,6 +77,7 @@ libkern/ucmpdi2.c			optional	mips | mipshf | mipsel | mipselhf
 libkern/ashldi3.c			standard
 libkern/ashrdi3.c			standard
 libkern/memcmp.c			standard
+libkern/bcopy.c				standard
 
 # cfe support
 dev/cfe/cfe_api.c			optional	cfe

--- a/sys/mips/cheri/copystr_c.S
+++ b/sys/mips/cheri/copystr_c.S
@@ -49,44 +49,8 @@
 .set noreorder
 
 /*
- * Implement CHERI memcpy() and bcopy() variants in assembly.
+ * XXXAR: do we really need these to be written in assembly?
  *
- * These routines attempt to handle only fully aligned access, and will throw
- * exceptions if that is not the case.  Likewise, they do not handle
- * overlapping copies, a typical requirement of bcopy() implementations.
- *
- * XXX-BD: these should probably go away in favor of capability
- * oblivious memcpy/bcopy.
- *
- * cheri_bcopy() accepts:
- * a0 - source pointer
- * a1 - destination pointer
- * a2 - length
- *
- * cheri_memcpy() has inverted source/destination pointers.
- */
-LEAF(cheri_memcpy)
-	move	v0, a0		/* Note cleverness: v0 will hold original... */
-	move	a0, a1		/* ... value of a0 for cheri_memcpy(). */
-	move	a1, v0
-
-XLEAF(cheri_bcopy)
-	beqz	a2, return	/* Return immediately if zero-length. */
-	li	v1, -CHERICAP_SIZE	/* Handle under-aligned lengths by... */
-	and	a2, a2, v1	/* .. truncating the length to capsize bytes. */
-	daddu	a2, a1, a2	/* Branch delay: put end pointer in a2. */
-loop:
-	clc	CHERI_REG_CTEMP0, a0, 0($ddc)
-	csc	CHERI_REG_CTEMP0, a1, 0($ddc)
-	daddiu	a1, a1, CHERICAP_SIZE	/* Increment destination pointer. */
-	bne	a1, a2, loop	/* Are we there yet?  If not, loop. */
-	daddiu	a0, a0, CHERICAP_SIZE	/* Branch delay: increment src ptr. */
-return:
-	jr	ra
-	nop
-END(cheri_memcpy)
-
-/*
  * Copy a string from one capabilty to another up to a maximum length.
  * Return the length by reference.
  *
@@ -96,7 +60,6 @@ END(cheri_memcpy)
  * c5 - pointer length copied (size_t)
  * a0 - maximum length
  */
-
 LEAF(copystr_c)
 	li		v0, 0	/* Hopefully we succeed */
 	beqz		a0, cstr_return_toolong /* Return if zero-length. */	

--- a/sys/mips/mips/bcopy.S
+++ b/sys/mips/mips/bcopy.S
@@ -35,6 +35,8 @@
  */
 
 
+.error "Should no longer be used"
+
 #include <machine/asm.h>
 __FBSDID("$FreeBSD$");
 


### PR DESCRIPTION
The assembly versions do not preserve tags which is starting to break the
kernel. We were crashing before because td->td_cheri_mmap_cap was becoming
detagged when fork()ing a new process (which memcpy()s the structure).

This also allows us to delete cheri_memcpy/cheri_bcopy which only handle
well-aligned sizes/pointers.