### PR TITLE
[UPSTREAM?] Set the LMA of the riscv kernel to the OpenSBI jump target

### DIFF
--- a/sys/conf/ldscript.riscv
+++ b/sys/conf/ldscript.riscv
@@ -3,11 +3,19 @@ OUTPUT_ARCH(riscv)
 ENTRY(_start)
 
 SEARCH_DIR(/usr/lib);
+
+/*
+ * Set the ELF LMA to the address that OpenSBI's fw_jump jumps to. This allows
+ * us to load the kernel with the -kernel flag in QEMU without having to embed
+ * it inside BBL or OpenSBI's fw_payload first.
+ */
+__OPENSBI_FW_JUMP_ADDR__ = 0x80200000; /* Note: 0x80400000 for RISCV32 */
+
 SECTIONS
 {
   /* Read-only sections, merged into text segment: */
   . = kernbase;
-  .text      : AT(ADDR(.text) - kernbase)
+  .text      : AT(__OPENSBI_FW_JUMP_ADDR__)
   {
     *(.text)
     *(.stub)


### PR DESCRIPTION
This allows us to boot FreeBSD RISCV on QEMU using the -kernel command line
options. When using that option, QEMU maps the kernel ELF file to the
addresses specified in the LMAs in the program headers.

Since version 4.2 QEMU ships with OpenSBI fw_jump by default so this allows
booting FreeBSD using the following command line:
qemu-system-riscv64 -bios default -kernel /.../boot/kernel/kernel -nographic -M virt

Without this change the -kernel option cannot be used since the LMAs start
at address zero and QEMU already maps a ROM to these low physical addresses.

Should I send this patch upstream? Will it break anything?