### PR TITLE
Introduce a MACHINE_ABI make variable

### DIFF
--- a/bin/cheri_bench/Makefile
+++ b/bin/cheri_bench/Makefile
@@ -14,7 +14,7 @@ NO_WERROR=	YES
 
 LIBADD+= pthread
 
-.if ${MACHINE_ARCH:Mmips*c*} || ${MK_LIBCHERI} == "yes"
+.if ${MACHINE_ABI:Mpurecap} && ${MK_LIBCHERI} == "yes"
 LIBADD+=  cheri
 .ifdef CLANG_CLEARREGS
 CFLAGS+= -mllvm -cheri-use-clearregs

--- a/include/Makefile
+++ b/include/Makefile
@@ -70,7 +70,7 @@ LSUBSUBDIRS=	dev/mpt/mpilib
 LSUBSUBDIRS+=	netgraph/bluetooth/include
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*} || ${MK_CHERI} != "no"
+.if ${MACHINE_ABI:Mpurecap} || ${MK_COMPAT_CHERIABI} == "yes" || ${MK_CHERI} != "no"
 LSUBDIRS+=	compat/cheriabi
 .endif
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -187,9 +187,9 @@ SUBDIR.${MK_STATS}+=	libstats
     ${MACHINE_CPUARCH} == "arm" || ${MACHINE_CPUARCH} == "i386" || \
     ${MACHINE_CPUARCH} == "powerpc" || \
     ${MACHINE_ARCH:Mmips64*}) && \
-    ! ${MACHINE_ARCH:Mmips*c*}
+    !${MACHINE_ABI:Mpurecap}
 _libclang_rt=	libclang_rt
-.elif ! ${MACHINE_ARCH:Mmips*c*} && ${MACHINE_ARCH} != "mips" && \
+.elif !${MACHINE_ABI:Mpurecap} && ${MACHINE_ARCH} != "mips" && \
     ! ${MACHINE_ARCH:Mriscv*}
 .error "NOT BUILDING libclang_rt for ${MACHINE_ARCH}"
 .endif
@@ -265,8 +265,10 @@ SUBDIR_PARALLEL=
 SUBDIR:=	${SUBDIR:Nlibc++experimental}
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 SUBDIR+=	libmalloc_simple
+.endif
+.if ${MK_LIBCHERI} == "yes"
 SUBDIR.${MK_LIBCHERI}+=	libcheri_syscalls
 SUBDIR.${MK_LIBCHERI}+=	libcheri_support
 .endif

--- a/lib/libc/Makefile
+++ b/lib/libc/Makefile
@@ -115,8 +115,10 @@ SRCS+=	interposing_table.c
 CFLAGS+=	-DNO_SYSCALLS
 .endif
 
-.if ! ${MACHINE_ARCH:Mmips*c*}
-# stack-protector is useless when we have CHERI
+.if ${MK_SSP} != "no"
+.if ${MACHINE_ABI:Mpurecap}
+.error "stack-protector is useless when we have CHERI, MK_SSP should not be set"
+.endif
 .include "${LIBC_SRCTOP}/secure/Makefile.inc"
 .endif
 .include "${LIBC_SRCTOP}/rpc/Makefile.inc"

--- a/lib/libc/db/hash/Makefile.inc
+++ b/lib/libc/db/hash/Makefile.inc
@@ -6,7 +6,7 @@
 SRCS+=	hash.c hash_bigkey.c hash_buf.c hash_func.c hash_log2.c \
 	hash_page.c ndbm.c
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 CFLAGS.hash.c+=		-Wno-cheri-bitwise-operations
 CFLAGS.hash_buf.c+=	-Wno-cheri-bitwise-operations
 .endif

--- a/lib/libc/gen/Makefile.inc
+++ b/lib/libc/gen/Makefile.inc
@@ -4,8 +4,10 @@
 # machine-independent gen sources
 .PATH: ${LIBC_SRCTOP}/${LIBC_ARCH}/gen ${LIBC_SRCTOP}/gen ${SRCTOP}/etc
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 CFLAGS+=	-DNO_COMPAT7
+.endif
+.if ${MACHINE_ARCH:Mmips*c*}
 CFLAGS.getpwent.c=	-mxgot
 .endif
 
@@ -162,8 +164,7 @@ SRCS+=	__getosreldate.c \
 	waitpid.c \
 	waitid.c \
 	wordexp.c
-.if ${MK_SYMVER} == yes && \
-    ! ${MACHINE_ARCH:Mmips*c*}
+.if ${MK_SYMVER} == yes && !${MACHINE_ABI:Mpurecap}
 SRCS+=	devname-compat11.c \
 	fts-compat.c \
 	fts-compat11.c \

--- a/lib/libc/mips/gen/Makefile.inc
+++ b/lib/libc/mips/gen/Makefile.inc
@@ -10,7 +10,7 @@ SRCS+=	_ctx_start.S _set_tp.c makecontext.c \
 	signalcontext.c sigsetjmp.S \
 	trivial-getcontextx.c
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 SRCS+=	_setjmp_c.S setjmp_c.S
 .else
 SRCS+=	_setjmp.S setjmp.S

--- a/lib/libc/mips/string/Makefile.inc
+++ b/lib/libc/mips/string/Makefile.inc
@@ -4,7 +4,7 @@ MDSRCS+= \
 	ffs.S \
 	strlen.S
 
-.if ! ${MACHINE_ARCH:Mmips*c*}
+.if ! ${MACHINE_ABI:Mpurecap}
 MDSRCS+= \
 	bcmp.S \
 	bzero.S \
@@ -14,7 +14,7 @@ MDSRCS+= \
 	strrchr.S
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*} || ${MK_CHERI} == "yes"
+.if ${MACHINE_ABI:Mpurecap} || ${MK_CHERI} == "yes"
 CHERI_MDSRCS=	\
 		memcpy_c.c \
 		memmove_c.c \
@@ -26,7 +26,7 @@ CHERI_MISRCS=	\
 
 MDSRCS+=	${CHERI_MDSRCS}
 
-.if ! ${MACHINE_ARCH:Mmips*c*}
+.if ! ${MACHINE_ABI:Mpurecap}
 .if ${MK_CHERI128} == "yes"
 _CHERIBITS=128
 .else

--- a/lib/libc/sys/Makefile.inc
+++ b/lib/libc/sys/Makefile.inc
@@ -6,11 +6,11 @@
 
 # Include the generated makefile containing the *complete* list
 # of syscall names in MIASM.
-.if ! ${MACHINE_ARCH:Mmips*c*}
-.include "${SRCTOP}/sys/sys/syscall.mk"
-.else
+.if ${MACHINE_ABI:Mpurecap}
 .include "${SRCTOP}/sys/compat/cheriabi/cheriabi_syscall.mk"
 MIASM:=	${MIASM:S/^cheriabi_//}
+.else
+.include "${SRCTOP}/sys/sys/syscall.mk"
 .endif
 
 # Include machine dependent definitions.
@@ -40,7 +40,7 @@ SRCS+=	\
 
 SRCS+= getdents.c lstat.c mknod.c stat.c
 
-.if (!${MACHINE_ARCH:Mmips*c*} && !${MACHINE_ARCH:Mriscv*c*})
+.if !${MACHINE_ABI:Mpurecap}
 SRCS+= brk.c
 .endif
 SRCS+= pipe.c
@@ -95,7 +95,8 @@ NOASM+=	sigaction.o
 INTERPOSED+= sigaction
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
+# Var-args calling convention different for purecap
 NO_UNDERSCORE=	fcntl ioctl open
 .for _nu in ${NO_UNDERSCORE}
 INTERPOSED:=	${INTERPOSED:N${_nu}}

--- a/lib/libc/tests/sys/Makefile
+++ b/lib/libc/tests/sys/Makefile
@@ -5,7 +5,7 @@ PACKAGE=			tests
 .include <bsd.own.mk>
 
 .if ${MACHINE_CPUARCH} != "aarch64" && ${MACHINE_CPUARCH} != "riscv" && \
-    ! ${MACHINE_ARCH:Mmips*c*}
+    !${MACHINE_ABI:Mpurecap}
 ATF_TESTS_C+=			brk_test
 .endif
 ATF_TESTS_C+=			queue_test

--- a/lib/libcheri/Makefile
+++ b/lib/libcheri/Makefile
@@ -19,7 +19,7 @@ SRCS=	libcheri_ccall.c		\
 	libcheri_sandbox_loader.c	\
 	libcheri_sandbox_methods.c
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 SRCS+=	libcheri_invoke_cabi.S		\
 	libcheri_classes_cabi.S
 .else
@@ -64,7 +64,7 @@ NEED_CHERI=	hybrid
 .endif
 
 CLEANFILES=	libcheri_ccall_trampoline.o
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 CLEANFILES+=	libcheri_invoke_cabi.o		\
 		libcheri_classes_cabi.o
 .else

--- a/lib/libgcc_eh/Makefile.inc
+++ b/lib/libgcc_eh/Makefile.inc
@@ -8,7 +8,7 @@ _USE_CHERI_LIBUNWIND=0
 .if ${MK_CHERI} != "no"
 WANT_CHERI?=	hybrid
 _USE_CHERI_LIBUNWIND=1
-.elif (${MACHINE_ARCH:Mmips*} || ${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
+.elif (${MACHINE_ARCH:Mmips*} || ${MACHINE_ABI:Mpurecap})
 _USE_CHERI_LIBUNWIND=1
 .endif
 

--- a/lib/libsysdecode/Makefile
+++ b/lib/libsysdecode/Makefile
@@ -125,7 +125,7 @@ CFLAGS.gcc.ioctl.c+= -Wno-redundant-decls
 
 CFLAGS.gcc+=	${CFLAGS.gcc.${.IMPSRC}}
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 # Work around packed struct in cissio.h
 CFLAGS.ioctl.c+=	-Wno-error-cheri-capability-misuse
 .endif

--- a/lib/libthr/Makefile
+++ b/lib/libthr/Makefile
@@ -23,7 +23,7 @@ CFLAGS+=-I${SRCTOP}/include
 CFLAGS+=-I${.CURDIR}/arch/${MACHINE_CPUARCH}/include
 CFLAGS+=-I${.CURDIR}/sys
 CFLAGS+=-I${SRCTOP}/libexec/rtld-elf
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 CFLAGS+=-I${SRCTOP}/libexec/rtld-cheri-elf/${MACHINE_CPUARCH}
 .else
 CFLAGS+=-I${SRCTOP}/libexec/rtld-elf/${MACHINE_CPUARCH}
@@ -56,7 +56,7 @@ CFLAGS+=-D_PTHREADS_INVARIANTS
 PRECIOUSLIB=
 
 .PATH: ${.CURDIR}/arch/${MACHINE_CPUARCH}/${MACHINE_CPUARCH}
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 .PATH: ${SRCTOP}/lib/libmalloc_simple
 .else
 .PATH: ${SRCTOP}/libexec/rtld-elf
@@ -67,7 +67,7 @@ PRECIOUSLIB=
 .endif
 .include "${.CURDIR}/sys/Makefile.inc"
 .include "${.CURDIR}/thread/Makefile.inc"
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 SRCS+=	malloc.c heap.c
 CFLAGS.malloc.c+=	-DIN_LIBTHR
 CFLAGS.heap.c+=	-DIN_LIBTHR

--- a/libexec/Makefile
+++ b/libexec/Makefile
@@ -44,7 +44,7 @@ _blacklistd-helper+=	blacklistd-helper
 SUBDIR+=	bootpd
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*} || ${MK_CHERI} != "no"
+.if !defined(NO_PIC) && !defined(NO_RTLD) && (${MACHINE_ABI:Mpurecap} || ${MK_CHERI} != "no")
 SUBDIR+=	rtld-cheri-elf rtld-cheri-elf-debug
 .endif
 
@@ -81,7 +81,7 @@ _pppoed=	pppoed
 _tftp-proxy=	tftp-proxy
 .endif
 
-.if !defined(NO_PIC) && !defined(NO_RTLD) && !${MACHINE_ARCH:Mmips*c*}
+.if !defined(NO_PIC) && !defined(NO_RTLD) && !${MACHINE_ABI:Mpurecap}
 _rtld-elf=	rtld-elf rtld-elf-debug
 SUBDIR.${MK_LIB32}+=	rtld-elf32
 .endif

--- a/libexec/rtld-cheri-elf-debug/Makefile
+++ b/libexec/rtld-cheri-elf-debug/Makefile
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 PROG=ld-elf-debug.so.1
 .else
 PROG=ld-cheri-elf-debug.so.1

--- a/libexec/rtld-cheri-elf/Makefile
+++ b/libexec/rtld-cheri-elf/Makefile
@@ -39,12 +39,12 @@ CFLAGS+=-DRTLD_SUPPORT_PER_FUNCTION_CAPTABLE=1
 CFLAGS+=-DRTLD_SUPPORT_PER_FUNCTION_CAPTABLE=0
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*}
+.if ${MACHINE_ABI:Mpurecap}
 PROG?=		ld-elf.so.1
 .else
 PROG?=		ld-cheri-elf.so.1
 .endif
-.if ${MACHINE_ARCH:Mmips*c*} && ${PROG} == ld-elf.so.1
+.if ${MACHINE_ABI:Mpurecap} && ${PROG} == ld-elf.so.1
 LINKS=		${BINDIR}/ld-elf.so.1 ${BINDIR}/ld-cheri-elf.so.1
 .endif
 SRCS=		rtld_start.S reloc.c rtld.c heap.c malloc.c cheri_reloc.c

--- a/libexec/rtld-cheri-elf/tests/abi-mismatch/Makefile
+++ b/libexec/rtld-cheri-elf/tests/abi-mismatch/Makefile
@@ -2,7 +2,7 @@
 
 TESTSDIR=	${TESTSBASE}/libexec/rtld-cheri-elf/abi-mismatch
 
-.if !${MACHINE_ARCH:Mmips*c*}
+.if !${MACHINE_ABI:Mpurecap}
 # Disable when building a pure-cap world as we don't support
 # bsd.cheri.mk hacks there.  Alternative workaround needed.
 SUBDIR+=	basic_nocheri_lib basic_hybrid_lib basic_purecap_lib
@@ -15,7 +15,7 @@ SUBDIR+=	wrong_size_purecap_lib wrong_size_hybrid_lib
 #CFLAGS.option-domain-search_test+=	-I${.CURDIR:H}
 #LIBADD.option-domain-search_test=	util
 
-.if !${MACHINE_ARCH:Mmips*c*}
+.if !${MACHINE_ABI:Mpurecap}
 TESTS_SUBDIRS+=	dlopen-hybrid
 .endif
 TESTS_SUBDIRS+=	dlopen-purecap

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -16,6 +16,15 @@ unix		?=	We run FreeBSD, not UNIX.
 __TO_CPUARCH=C/mips(n32|64)?(el)?(hf)?(c(128|256))?/mips/:C/arm(v[67])?(eb)?/arm/:C/powerpc(64|spe)/powerpc/:C/riscv64(sf)?c?/riscv/
 MACHINE_CPUARCH=${MACHINE_ARCH:${__TO_CPUARCH}}
 .endif
+.if (${MACHINE_ARCH:Mmips*} && !${MACHINE_ARCH:Mmips*hf*}) || ${MACHINE_ARCH:Mriscv*sf*}
+MACHINE_ABI+=	soft-float
+.else
+MACHINE_ABI+=	hard-float
+.endif
+.if (${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
+MACHINE_ABI+=	purecap
+.endif
+
 
 __DEFAULT_YES_OPTIONS+= \
 	UNIFIED_OBJDIR


### PR DESCRIPTION
This allows us to use ${MACHINE_ABI:Mpurecap} instead of
(${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*}).
I also added a hard-float vs soft-float value to this variable but that
is not currently used.