### PR TITLE
Produce uprintf() output if there is no controlling terminal

### DIFF
--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -176,8 +176,13 @@ uprintf(const char *fmt, ...)
 	int retval;
 
 	td = curthread;
-	if (TD_IS_IDLETHREAD(td))
+	if (TD_IS_IDLETHREAD(td)) {
+		/* XXXAR: for debugging early boot failures */
+		va_start(ap, fmt);
+		retval = vprintf(fmt, ap);
+		va_end(ap);
 		return (0);
+	}
 
 	sx_slock(&proctree_lock);
 	p = td->td_proc;
@@ -185,6 +190,10 @@ uprintf(const char *fmt, ...)
 	if ((p->p_flag & P_CONTROLT) == 0) {
 		PROC_UNLOCK(p);
 		sx_sunlock(&proctree_lock);
+		/* XXXAR: for debugging early boot failures */
+		va_start(ap, fmt);
+		retval = vprintf(fmt, ap);
+		va_end(ap);
 		return (0);
 	}
 	SESS_LOCK(p->p_session);


### PR DESCRIPTION
This helped me debug why /sbin/init was not being recognized by the
image activator.
I'm not sure if this is something we can upstream?