### PR TITLE
[RISCV-PURECAP] Implement cerror

### DIFF
--- a/lib/libc/riscv/sys/cerror.S
+++ b/lib/libc/riscv/sys/cerror.S
@@ -33,23 +33,36 @@
  */
 
 #include <machine/asm.h>
+#include "SYS.h"
 __FBSDID("$FreeBSD$");
 
+#define FRAME_SIZE	(2 * __SIZEOF_POINTER__) /* Always multiple of 16 */
+#define SPILLSLOT_RA	(0 * __SIZEOF_POINTER__)
+#define SPILLSLOT_ERRNO	(1 * __SIZEOF_POINTER__)
 ENTRY(cerror)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement cerror")
+	cincoffset	csp, csp, -FRAME_SIZE
+	csc	cra, SPILLSLOT_RA(csp)
+	csd	a0, SPILLSLOT_ERRNO(csp)	# spill new errno value
+	ASM_LOCAL_CALL(t1, __error)		# locate address of errno (in ca0)
+	cld	a1, SPILLSLOT_ERRNO(csp)	# re-load new errno value
+	csw	a1, 0(ca0)			# update errno value
+	clc	cra, SPILLSLOT_RA(csp)
+	li	a0, -1			# Set both return registers to -1 to
+	li	a1, -1			# indicate syscall failure.
+	cincoffset	csp, csp, FRAME_SIZE
 	cret
 #else
-	addi	sp, sp, -16
-	sd	a0, 0(sp)
-	sd	ra, 8(sp)
+	addi	sp, sp, -FRAME_SIZE
+	sd	a0, SPILLSLOT_ERRNO(sp)
+	sd	ra, SPILLSLOT_RA(sp)
 	call	_C_LABEL(__error)
-	ld	a1, 0(sp)
-	ld	ra, 8(sp)
+	ld	a1, SPILLSLOT_ERRNO(sp)
+	ld	ra, SPILLSLOT_RA(sp)
 	sw	a1, 0(a0)
 	li	a0, -1
 	li	a1, -1
-	addi	sp, sp, 16
+	addi	sp, sp, FRAME_SIZE
 	ret
 #endif
 END(cerror)


### PR DESCRIPTION
This change adds lots of macros to include/asm.h to avoid ifdefs inside
of cerror.S. I'm not sure if this is the best approach.