### PR TITLE
Remove redundant cheri_bcopy and cheri_memcpy.

### DIFF
--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -916,14 +916,8 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 		return (NULL);
 
 	/* Copy over original contents */
-#if __has_feature(capabilities)
-	if (size >= CHERICAP_SIZE && alloc >= CHERICAP_SIZE &&
-	    ((uintptr_t)addr & (CHERICAP_SIZE-1)) == 0 &&
-	    ((uintptr_t)newaddr & (CHERICAP_SIZE-1)) == 0)
-		cheri_bcopy(addr, newaddr, min(size, alloc));
-	else
-#endif
-		bcopy(addr, newaddr, min(size, alloc));
+        bcopy(addr, newaddr, min(size, alloc));
+
 	free(addr, mtp);
 	return (newaddr);
 }

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -1298,7 +1298,7 @@ pstats_fork(struct pstats *src, struct pstats *dst)
 
 	bzero(&dst->pstat_startzero,
 	    __rangeof(struct pstats, pstat_startzero, pstat_endzero));
-	cheri_bcopy(&src->pstat_startcopy, &dst->pstat_startcopy,
+	bcopy(&src->pstat_startcopy, &dst->pstat_startcopy,
 	    __rangeof(struct pstats, pstat_startcopy, pstat_endcopy));
 }
 

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -3989,7 +3989,7 @@ sigacts_copy(struct sigacts *dest, struct sigacts *src)
 
 	KASSERT(dest->ps_refcnt == 1, ("sigacts_copy to shared dest"));
 	mtx_lock(&src->ps_mtx);
-	cheri_memcpy(dest, src, offsetof(struct sigacts, ps_refcnt));
+	memcpy(dest, src, offsetof(struct sigacts, ps_refcnt));
 	mtx_unlock(&src->ps_mtx);
 }
 

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -5392,7 +5392,7 @@ umtx_read_rb_list(struct thread *td, struct umutex *m, uintcap_t *rb_list)
 
 #ifdef COMPAT_CHERIABI
 	if (SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
-		cheri_memcpy(&m_c, m, sizeof(m_c));
+		memcpy(&m_c, m, sizeof(m_c));
 		*rb_list = m_c.m_rb_lnk;
 	} else
 #endif

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -505,7 +505,7 @@ cloneuio(struct uio *uiop)
 	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
 	*uio = *uiop;
 	uio->uio_iov = (struct iovec *)(uio + 1);
-	cheri_bcopy(uiop->uio_iov, uio->uio_iov, iovlen);
+	bcopy(uiop->uio_iov, uio->uio_iov, iovlen);
 	return (uio);
 }
 

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -3650,7 +3650,7 @@ aiocb_c_save_aiocb(struct kaiocb *kjob, const void *ujobptrp)
 	if (ujobptrp == NULL)
 		memset(&kjob->ujobptr, 0, sizeof(kjob->ujobptr));
 	else
-		cheri_memcpy(&kjob->ujobptr, ujobptrp, sizeof(__intcap_t));
+		memcpy(&kjob->ujobptr, ujobptrp, sizeof(__intcap_t));
 }
 
 static int
@@ -3661,7 +3661,7 @@ aiocb_c_store_aiocb(struct aiocb ** __capability ujobp, struct kaiocb *kjob)
 	if (kjob == NULL)
 		ujob = 0;	/* XXXBD: is this sufficent? */
 	else
-		cheri_memcpy(&ujob, &kjob->ujobptr, sizeof(__intcap_t));
+		memcpy(&ujob, &kjob->ujobptr, sizeof(__intcap_t));
 
 	return (sucap(ujobp, ujob));
 }

--- a/sys/libkern/bcopy.c
+++ b/sys/libkern/bcopy.c
@@ -50,6 +50,8 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #endif
 
+#include <cheri/cheric.h>
+
 #undef memcpy
 #undef memmove
 #undef bcopy
@@ -72,8 +74,8 @@ typedef	long	word;		/* "word" used for optimal copy speed */
  * This is the routine that actually implements
  * (the portable versions of) bcopy, memcpy, and memmove.
  */
-void *
-memcpy(void *dst0, const void *src0, size_t length)
+static void *
+_memcpy(void *dst0, const void *src0, size_t length, bool keeptags)
 {
 	char		*dst;
 	const char	*src;
@@ -116,8 +118,15 @@ memcpy(void *dst0, const void *src0, size_t length)
 		 * Copy whole words, then mop up any trailing bytes.
 		 */
 		t = length / wsize;
-		TLOOP(*(word *)dst = *(const word *)src; src += wsize;
-		    dst += wsize);
+#if __has_feature(capabilities)
+		if (!keeptags) {
+			TLOOP(*(word *)dst = (word)cheri_cleartag(
+			        (void * __capability)*(const word *)src);
+			    src += wsize; dst += wsize);
+		} else
+#endif
+			TLOOP(*(word *)dst = *(const word *)src; src += wsize;
+			    dst += wsize);
 		t = length & wmask;
 		TLOOP(*dst++ = *src++);
 	} else {
@@ -141,13 +150,26 @@ memcpy(void *dst0, const void *src0, size_t length)
 			TLOOP1(*--dst = *--src);
 		}
 		t = length / wsize;
-		TLOOP(src -= wsize; dst -= wsize;
-		    *(word *)dst = *(const word *)src);
+#if __has_feature(capabilities)
+		if (!keeptags) {
+			TLOOP(src -= wsize; dst -= wsize;
+			    *(word *)dst = (word)cheri_cleartag(
+			        (void * __capability)*(const word *)src));
+		} else
+#endif
+			TLOOP(src -= wsize; dst -= wsize;
+			    *(word *)dst = *(const word *)src);
 		t = length & wmask;
 		TLOOP(*--dst = *--src);
 	}
 done:
 	return (dst0);
+}
+
+void *
+memcpy(void *dst0, const void *src0, size_t length)
+{
+	return _memcpy(dst0, src0, length, true);
 }
 
 __strong_reference(memcpy, memmove);
@@ -156,10 +178,13 @@ void
 (bcopy)(const void *src0, void *dst0, size_t length)
 {
 
-	memcpy(dst0, src0, length);
+	_memcpy(dst0, src0, length, true);
 }
 
 #if __has_feature(capabilities)
-__strong_reference(bcopy, cheri_bcopy);
-__strong_reference(memcpy, cheri_memcpy);
+void
+bcopynocap(const void *src0, void *dst0, size_t length)
+{
+	_memcpy(dst0, src0, length, false);
+}
 #endif

--- a/sys/mips/cheri/cheri_sealcap.c
+++ b/sys/mips/cheri/cheri_sealcap.c
@@ -55,7 +55,7 @@ void
 cheri_sealcap_copy(struct proc *dst, struct proc *src)
 {
 
-	cheri_memcpy(&dst->p_md.md_cheri_sealcap, &src->p_md.md_cheri_sealcap,
+	memcpy(&dst->p_md.md_cheri_sealcap, &src->p_md.md_cheri_sealcap,
 	    sizeof(dst->p_md.md_cheri_sealcap));
 }
 

--- a/sys/mips/cheri/cheri_signal.c
+++ b/sys/mips/cheri/cheri_signal.c
@@ -54,7 +54,7 @@ void
 cheri_signal_copy(struct pcb *dst, struct pcb *src)
 {
 
-	cheri_memcpy(&dst->pcb_cherisignal, &src->pcb_cherisignal,
+	memcpy(&dst->pcb_cherisignal, &src->pcb_cherisignal,
 	    sizeof(dst->pcb_cherisignal));
 }
 

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -2659,9 +2659,12 @@ pmap_copy_page_tags(vm_page_t src, vm_page_t dst)
 
 int unmapped_buf_allowed;
 
-static void
-pmap_copy_pages_internal(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
-    vm_offset_t b_offset, int xfersize, int flags)
+/*
+ * As with pmap_copy_page(), CHERI strips tags in this case.
+ */
+void
+pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize)
 {
 	char *a_cp, *b_cp;
 	vm_page_t a_m, b_m;
@@ -2687,24 +2690,14 @@ pmap_copy_pages_internal(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 			    a_pg_offset;
 			b_cp = (char *)MIPS_PHYS_TO_DIRECT(b_phys) +
 			    b_pg_offset;
-#if __has_feature(capabilities)
-			if ((flags & PMAP_COPY_TAGS) == 0)
-				bcopynocap(a_cp, b_cp, cnt);
-			else
-#endif
-				bcopy(a_cp, b_cp, cnt);
+                        bcopynocap(a_cp, b_cp, cnt);
 			mips_dcache_wbinv_range((vm_offset_t)b_cp, cnt);
 		} else {
 			a_cp = (char *)pmap_lmem_map2(a_phys, b_phys);
 			b_cp = (char *)a_cp + PAGE_SIZE;
 			a_cp += a_pg_offset;
 			b_cp += b_pg_offset;
-#if __has_feature(capabilities)
-			if ((flags & PMAP_COPY_TAGS) == 0)
-				bcopynocap(a_cp, b_cp, cnt);
-			else
-#endif
-				bcopy(a_cp, b_cp, cnt);
+                        bcopynocap(a_cp, b_cp, cnt);
 			mips_dcache_wbinv_range((vm_offset_t)b_cp, cnt);
 			pmap_lmem_unmap();
 		}
@@ -2713,29 +2706,6 @@ pmap_copy_pages_internal(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		xfersize -= cnt;
 	}
 }
-
-/*
- * As with pmap_copy_page(), CHERI requires tagged and non-tagged versions
- * depending on the circumstances.
- */
-void
-pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
-    vm_offset_t b_offset, int xfersize)
-{
-
-	pmap_copy_pages_internal(ma, a_offset, mb, b_offset, xfersize, 0);
-}
-
-#if __has_feature(capabilities)
-void
-pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
-    vm_offset_t b_offset, int xfersize)
-{
-
-	pmap_copy_pages_internal(ma, a_offset, mb, b_offset, xfersize,
-	    PMAP_COPY_TAGS);
-}
-#endif
 
 vm_offset_t
 pmap_quick_enter_page(vm_page_t m)

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -2618,10 +2618,9 @@ pmap_copy_page_internal(vm_page_t src, vm_page_t dst, int flags)
 		    MIPS_PHYS_TO_DIRECT(phys_dst), PAGE_SIZE);
 		va_src = MIPS_PHYS_TO_DIRECT(phys_src);
 		va_dst = MIPS_PHYS_TO_DIRECT(phys_dst);
-#ifdef CPU_CHERI
-		if (flags & PMAP_COPY_TAGS)
-			cheri_bcopy((caddr_t)va_src, (caddr_t)va_dst,
-			    PAGE_SIZE);
+#if __has_feature(capabilities)
+		if ((flags & PMAP_COPY_TAGS) == 0)
+			bcopynocap((caddr_t)va_src, (caddr_t)va_dst, PAGE_SIZE);
 		else
 #endif
 			bcopy((caddr_t)va_src, (caddr_t)va_dst, PAGE_SIZE);
@@ -2649,7 +2648,7 @@ pmap_copy_page(vm_page_t src, vm_page_t dst)
 	pmap_copy_page_internal(src, dst, 0);
 }
 
-#ifdef CPU_CHERI
+#if __has_feature(capabilities)
 void
 pmap_copy_page_tags(vm_page_t src, vm_page_t dst)
 {
@@ -2688,9 +2687,9 @@ pmap_copy_pages_internal(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 			    a_pg_offset;
 			b_cp = (char *)MIPS_PHYS_TO_DIRECT(b_phys) +
 			    b_pg_offset;
-#ifdef CPU_CHERI
-			if (flags & PMAP_COPY_TAGS)
-				cheri_bcopy(a_cp, b_cp, cnt);
+#if __has_feature(capabilities)
+			if ((flags & PMAP_COPY_TAGS) == 0)
+				bcopynocap(a_cp, b_cp, cnt);
 			else
 #endif
 				bcopy(a_cp, b_cp, cnt);
@@ -2700,9 +2699,9 @@ pmap_copy_pages_internal(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 			b_cp = (char *)a_cp + PAGE_SIZE;
 			a_cp += a_pg_offset;
 			b_cp += b_pg_offset;
-#ifdef CPU_CHERI
-			if (flags & PMAP_COPY_TAGS)
-				cheri_bcopy(a_cp, b_cp, cnt);
+#if __has_feature(capabilities)
+			if ((flags & PMAP_COPY_TAGS) == 0)
+				bcopynocap(a_cp, b_cp, cnt);
 			else
 #endif
 				bcopy(a_cp, b_cp, cnt);
@@ -2727,7 +2726,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 	pmap_copy_pages_internal(ma, a_offset, mb, b_offset, xfersize, 0);
 }
 
-#ifdef CPU_CHERI
+#if __has_feature(capabilities)
 void
 pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
     vm_offset_t b_offset, int xfersize)

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -127,20 +127,6 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			}
 			break;
 		case UIO_SYSSPACE:
-#ifdef CPU_CHERI
-			if (CAP_ALIGNED((vaddr_t)cp) &&
-			    CAP_ALIGNED((__cheri_addr vaddr_t)iov->iov_base) &&
-			    CAP_ALIGNED(cnt)) {
-				if (uio->uio_rw == UIO_READ)
-					cheri_bcopy(cp,
-					    (__cheri_fromcap void *)
-					    iov->iov_base, cnt);
-				else
-					cheri_bcopy(
-					    (__cheri_fromcap void *)
-					    iov->iov_base, cp, cnt);
-			} else
-#endif
 			if (uio->uio_rw == UIO_READ)
 				bcopy(cp,
 				    (__cheri_fromcap void *)iov->iov_base,

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -115,10 +115,8 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	 * of the td_frame, for us that's not needed any
 	 * longer (this copy does them both) 
 	 */
-#ifndef CPU_CHERI
 	bcopy(td1->td_pcb, pcb2, sizeof(*pcb2));
-#else
-	cheri_bcopy(td1->td_pcb, pcb2, sizeof(*pcb2));
+#ifdef CPU_CHERI
 	cheri_signal_copy(pcb2, td1->td_pcb);
 	cheri_sealcap_copy(p2, td1->td_proc);
 #endif
@@ -440,10 +438,8 @@ cpu_copy_thread(struct thread *td, struct thread *td0)
 	 * and gets copied when we copy the PCB. No separate copy
 	 * is needed.
 	 */
-#ifndef CPU_CHERI
 	bcopy(td0->td_pcb, pcb2, sizeof(*pcb2));
-#else
-	cheri_bcopy(td0->td_pcb, pcb2, sizeof(*pcb2));
+#ifdef CPU_CHERI
 	cheri_signal_copy(pcb2, td0->td_pcb);
 #endif
 

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -3452,7 +3452,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		} else {
 			b_cp = (char *)PHYS_TO_DMAP(p_b) + b_pg_offset;
 		}
-		bcopy(a_cp, b_cp, cnt);
+		bcopynocap(a_cp, b_cp, cnt);
 		a_offset += cnt;
 		b_offset += cnt;
 		xfersize -= cnt;

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -388,11 +388,11 @@ void	bcopy_c(const void * _Nonnull __capability from,
 	    void * _Nonnull __capability to, size_t len);
 void	bcopynocap_c(const void * _Nonnull __capability from,
 	    void * _Nonnull __capability to, size_t len);
-void	cheri_bcopy(const void *src, void *dst, size_t len);
+void	bcopynocap(const void *src0, void *dst0, size_t length);
 #else
 #define	bcopy_c		bcopy
 #define	bcopynocap_c	bcopy
-#define	cheri_bcopy	bcopy
+#define	bcopynocap	bcopy
 #endif
 void	bzero(void * _Nonnull buf, size_t len);
 void	explicit_bzero(void * _Nonnull, size_t);
@@ -405,10 +405,8 @@ void	* __capability memcpy_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
 void	* __capability memcpynocap_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
-void	*cheri_memcpy(void *dst, const void *src, size_t len);
 #else
 #define	memcpy_c	memcpy
-#define	cheri_memcpy	memcpy
 #endif
 void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
 #if __has_feature(capabilities)

--- a/sys/vm/pmap.h
+++ b/sys/vm/pmap.h
@@ -135,10 +135,6 @@ void		 pmap_copy_page_tags(vm_page_t, vm_page_t);
 #endif
 void		 pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset,
 		    vm_page_t mb[], vm_offset_t b_offset, int xfersize);
-#if __has_feature(capabilities)
-void		 pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset,
-		    vm_page_t mb[], vm_offset_t b_offset, int xfersize);
-#endif
 int		 pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m,
 		    vm_prot_t prot, u_int flags, int8_t psind);
 void		 pmap_enter_object(pmap_t pmap, vm_offset_t start,
@@ -189,8 +185,6 @@ void		 pmap_zero_page_area(vm_page_t, int off, int size);
  */
 #if !__has_feature(capabilities)
 #define	pmap_copy_page_tags(src, dst)	pmap_copy_page((src), (dst))
-#define	pmap_copy_pages_tags(ma, a_offset, mb, b_offset, xfersize)	\
-	    pmap_copy_pages(ma, a_offset, mb, b_offset, xfersize)
 #endif
 
 #endif /* _KERNEL */


### PR DESCRIPTION
These are replaced with the tag-preserving default bcopy and memcpy.
Instances of bcopy where tags are not meant to be preserved use
the machine-independent bcopynocap.