### PR TITLE
Tidy the SPIKE kernel configs a bit.

### DIFF
--- a/sys/riscv/conf/CHERI_SPIKE
+++ b/sys/riscv/conf/CHERI_SPIKE
@@ -2,9 +2,5 @@
 
 include "SPIKE"
 include "std.CHERI"
-# Spike does not have a disk device so we need a MFS root
-include "std.MFS_ROOT"
 
 ident CHERI_SPIKE
-# We have to run in the 0xc0000 memory region
-makeoptions	KERNEL_LMA=0xc0200000

--- a/sys/riscv/conf/SPIKE
+++ b/sys/riscv/conf/SPIKE
@@ -1,15 +1,12 @@
 #NO_UNIVERSE
 
 include "GENERIC"
+# Spike does not have a disk device so we need a MFS root
+include "std.MFS_ROOT"
 
 ident SPIKE
 
 options 	HZ=100
-
-options 	MD_ROOT
-options 	ROOTDEVNAME=\"ufs:/dev/md0\"
-
-makeoptions 	NO_MODULES=yes
 
 options 	BREAK_TO_DEBUGGER
 options 	ALT_BREAK_TO_DEBUGGER

--- a/sys/riscv/conf/std.MFS_ROOT
+++ b/sys/riscv/conf/std.MFS_ROOT
@@ -11,3 +11,8 @@ options 	ROOTDEVNAME=\"ufs:/dev/md0\"
 nooptions	MD_ROOT_SIZE
 makeoptions	MFS_IMAGE=/you/must/set/MFS_IMAGE/on/make/cmdline.img
 
+# Don't build kernel modules
+makeoptions 	NO_MODULES=yes
+
+# Use tmpfs for /tmp and /var
+options 	TMPFS


### PR DESCRIPTION
- Move NO_MODULES to std.MFS_ROOT since it is generally true for
  kernels with an mfs root.
- Add TMPFS to std.MFS_ROOT to use the more efficient tmpfs for
  /tmp and /var to avoid double caching.
- Include std.MFS_ROOT in SPIKE and let CHERI_SPIKE inherit it from
  SPIKE.
- Use stock LMA for CHERI_SPIKE.  spike can use the "normal" OpenSBI
  LMA with BBL.