### PR TITLE
freebsd64/cheriabi as default ioctl/sysctl fixes

### DIFF
--- a/sys/cam/scsi/scsi_enc.c
+++ b/sys/cam/scsi/scsi_enc.c
@@ -370,12 +370,12 @@ enc_ioctl(struct cdev *dev, u_long cmd, caddr_t arg_addr, int flag,
 	void *addr;
 	int error, i;
 
-#ifdef	COMPAT_CHERIABI
-	if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
-		return (ENOTTY);
-#endif
 #ifdef	COMPAT_FREEBSD32
 	if (SV_PROC_FLAG(td->td_proc, SV_ILP32))
+		return (ENOTTY);
+#endif
+#if __has_feature(capabilities) && defined (COMPAT_FREEBSD64)
+	if (!SV_PROC_FLAG(td->td_proc, SV_CHERI))
 		return (ENOTTY);
 #endif
 

--- a/sys/cam/scsi/scsi_pass.c
+++ b/sys/cam/scsi/scsi_pass.c
@@ -1862,14 +1862,14 @@ passdoioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag, struct thread 
 		union ccb **user_ccb, *ccb;
 		xpt_opcode fc;
 
-#ifdef COMPAT_CHERIABI
-		if (SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
+#ifdef COMPAT_FREEBSD32
+		if (SV_PROC_FLAG(td->td_proc, SV_ILP32)) {
 			error = ENOTTY;
 			goto bailout;
 		}
 #endif
-#ifdef COMPAT_FREEBSD32
-		if (SV_PROC_FLAG(td->td_proc, SV_ILP32)) {
+#ifdef COMPAT_FREEBSD64
+		if (!SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
 			error = ENOTTY;
 			goto bailout;
 		}
@@ -2048,14 +2048,14 @@ camioqueue_error:
 		struct pass_io_req *io_req;
 		int old_error;
 
-#ifdef COMPAT_CHERIABI
-		if (SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
+#ifdef COMPAT_FREEBSD32
+		if (SV_PROC_FLAG(td->td_proc, SV_ILP32)) {
 			error = ENOTTY;
 			goto bailout;
 		}
 #endif
-#ifdef COMPAT_FREEBSD32
-		if (SV_PROC_FLAG(td->td_proc, SV_ILP32)) {
+#ifdef COMPAT_FREEBSD64
+		if (!SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
 			error = ENOTTY;
 			goto bailout;
 		}

--- a/sys/cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c
@@ -2249,13 +2249,13 @@ fasttrap_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int fflag,
 		size_t size;
 		int ret, err;
 
-#ifdef COMPAT_CHERIABI
-		if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
-			uprobe = *(fasttrap_probe_spec_t * __capability *)arg;
+#if __has_feature(capabilities)
+		if (!SV_PROC_FLAG(td->td_proc, SV_CHERI))
+			uprobe = __USER_CAP(*(uint64_t *)arg,
+			    sizeof(fasttrap_probe_spec_t));
 		else
 #endif
-			uprobe = __USER_CAP(*(void **)arg,
-			    sizeof(fasttrap_probe_spec_t));
+			uprobe = *(fasttrap_probe_spec_t * __capability *)arg;
 		if (copyin(&uprobe->ftps_noffs, &noffs,
 		    sizeof (uprobe->ftps_noffs)))
 			return (EFAULT);

--- a/sys/compat/cheriabi/cheriabi_misc.c
+++ b/sys/compat/cheriabi/cheriabi_misc.c
@@ -1415,7 +1415,7 @@ cheriabi___sysctl(struct thread *td, struct cheriabi___sysctl_args *uap)
 {
 
 	return (kern_sysctl(td, uap->name, uap->namelen, uap->old,
-	    uap->oldlenp, uap->new, uap->newlen, SCTL_CHERIABI));
+	    uap->oldlenp, uap->new, uap->newlen, 0));
 }
 
 int

--- a/sys/compat/freebsd64/freebsd64.h
+++ b/sys/compat/freebsd64/freebsd64.h
@@ -167,6 +167,13 @@ struct kinfo_proc64 {
 	long	ki_tdflags;
 };
 
+struct kinfo_sigtramp64 {
+	uint64_t ksigtramp_start;
+	uint64_t ksigtramp_end;
+	uint64_t ksigtramp_spare[4];
+};
+
+
 struct kld_file_stat64 {
     int		version;	/* set to sizeof(struct kld_file_stat64) */
     char        name[MAXPATHLEN];

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1389,7 +1389,7 @@ freebsd64___sysctl(struct thread *td, struct freebsd64___sysctl_args *uap)
 	return (kern_sysctl(td, __USER_CAP_ARRAY(uap->name, uap->namelen),
 	    uap->namelen, __USER_CAP(uap->old, oldlen),
 	    __USER_CAP_OBJ(uap->oldlenp), __USER_CAP(uap->new, uap->newlen),
-	    uap->newlen, 0));
+	    uap->newlen, SCTL_MASK64));
 }
 
 int

--- a/sys/dev/bnxt/bnxt_hwrm.h
+++ b/sys/dev/bnxt/bnxt_hwrm.h
@@ -83,8 +83,7 @@ int bnxt_hwrm_fw_reset(struct bnxt_softc *softc, uint8_t processor,
 int bnxt_hwrm_fw_qstatus(struct bnxt_softc *softc, uint8_t type,
     uint8_t *selfreset);
 int bnxt_hwrm_nvm_write(struct bnxt_softc *softc, void * __capability data,
-    bool cpyin,
-    uint16_t type, uint16_t ordinal, uint16_t ext, uint16_t attr,
+    bool cpyin, uint16_t type, uint16_t ordinal, uint16_t ext, uint16_t attr,
     uint16_t option, uint32_t data_length, bool keep, uint32_t *item_length,
     uint16_t *index);
 int bnxt_hwrm_nvm_erase_dir_entry(struct bnxt_softc *softc, uint16_t index);

--- a/sys/dev/bnxt/bnxt_ioctl.h
+++ b/sys/dev/bnxt/bnxt_ioctl.h
@@ -68,7 +68,7 @@ struct bnxt_ioctl_hwrm_nvm_find_dir_entry {
 
 struct bnxt_ioctl_hwrm_nvm_read {
 	struct bnxt_ioctl_header hdr;
-	uint8_t * __capability data;
+	uint8_t * __kerncap data;
 	uint32_t	length;
 	uint32_t	offset;
 	uint16_t	index;
@@ -88,7 +88,7 @@ struct bnxt_ioctl_hwrm_fw_qstatus {
 
 struct bnxt_ioctl_hwrm_nvm_write {
 	struct bnxt_ioctl_header hdr;
-	uint8_t * __capability data;
+	uint8_t	* __kerncap data;
 	uint32_t	data_length;
 	uint32_t	item_length;
 	uint16_t	attr;
@@ -115,7 +115,7 @@ struct bnxt_ioctl_hwrm_nvm_get_dir_info {
 
 struct bnxt_ioctl_hwrm_nvm_get_dir_entries {
 	struct bnxt_ioctl_header hdr;
-	uint8_t * __capability data;
+	uint8_t * __kerncap data;
 	size_t		max_size;
 	uint32_t	entries;
 	uint32_t	entry_length;
@@ -139,7 +139,7 @@ struct bnxt_ioctl_hwrm_nvm_verify_update {
 
 struct bnxt_ioctl_hwrm_nvm_modify {
 	struct bnxt_ioctl_header hdr;
-	uint8_t * __capability data;
+	uint8_t * __kerncap data;
 	uint32_t	length;
 	uint32_t	offset;
 	uint16_t	index;

--- a/sys/dev/bnxt/if_bnxt.c
+++ b/sys/dev/bnxt/if_bnxt.c
@@ -1657,7 +1657,6 @@ bnxt_priv_ioctl(if_ctx_t ctx, u_long command, caddr_t data)
 	int rc = ENOTSUP;
 	struct bnxt_ioctl_data iod_storage, *iod = &iod_storage;
 
-
 	switch (command) {
 	case CASE_IOC_IFREQ(SIOCGPRIVATE_0):
 		if ((rc = priv_check(curthread, PRIV_DRIVER)) != 0)

--- a/sys/dev/evdev/uinput.c
+++ b/sys/dev/evdev/uinput.c
@@ -598,12 +598,12 @@ uinput_ioctl_sub(struct uinput_cdev_state *state, u_long cmd, caddr_t data)
 	case UI_SET_PHYS: {
 		void * __capability cap;
 
-#ifdef COMPAT_CHERIABI
-		if (SV_CURPROC_FLAG(SV_CHERI))
-			cap = *(void * __capability *)data;
+#if __has_feature(capabilities)
+		if (!SV_CURPROC_FLAG(SV_CHERI))
+			cap = __USER_CAP_STR(*(uint64_t *)data);
 		else
 #endif
-			cap = __USER_CAP_STR(*(void **)data);
+			cap = *(void * __capability *)data;
 		if (state->ucs_state == UINPUT_RUNNING)
 			return (EINVAL);
 		ret = copyinstr_c(cap, buf, sizeof(buf), NULL);
@@ -620,12 +620,12 @@ uinput_ioctl_sub(struct uinput_cdev_state *state, u_long cmd, caddr_t data)
 		void * __capability cap;
 		if (state->ucs_state == UINPUT_RUNNING)
 			return (EINVAL);
-#ifdef COMPAT_CHERIABI
-		if (SV_CURPROC_FLAG(SV_CHERI))
-			cap = *(void * __capability *)data;
+#if __has_feature(capabilities)
+		if (!SV_CURPROC_FLAG(SV_CHERI))
+			cap = __USER_CAP_STR(*(uint64_t *)data);
 		else
 #endif
-			cap = __USER_CAP_STR(*(void **)data);
+			cap = *(void * __capability *)data;
 		ret = copyinstr(cap, buf, sizeof(buf), NULL);
 		if (ret != 0)
 			return (ret);

--- a/sys/dev/isp/isp_freebsd.c
+++ b/sys/dev/isp/isp_freebsd.c
@@ -446,12 +446,12 @@ ispioctl(struct cdev *dev, u_long c, caddr_t addr, int flags, struct thread *td)
 
 	case ISP_RESCAN:
 		if (IS_FC(isp)) {
-#ifdef COMPAT_CHERIABI
-			if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
-				chan =  *(intcap_t *)addr;
+#if __has_feature(capabilities)
+			if (!SV_PROC_FLAG(td->td_proc, SV_CHERI))
+				chan = *(uint64_t *)addr;
 			else
 #endif
-				chan = *(intptr_t *)addr;
+				chan =  *(intcap_t *)addr;
 			if (chan < 0 || chan >= isp->isp_nchan) {
 				retval = -ENXIO;
 				break;
@@ -468,12 +468,12 @@ ispioctl(struct cdev *dev, u_long c, caddr_t addr, int flags, struct thread *td)
 
 	case ISP_FC_LIP:
 		if (IS_FC(isp)) {
-#ifdef COMPAT_CHERIABI
-			if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
-				chan =  *(intcap_t *)addr;
+#if __has_feature(capabilities)
+			if (!SV_PROC_FLAG(td->td_proc, SV_CHERI))
+				chan = *(uint64_t *)addr;
 			else
 #endif
-				chan = *(intptr_t *)addr;
+				chan =  *(intcap_t *)addr;
 			if (chan < 0 || chan >= isp->isp_nchan) {
 				retval = -ENXIO;
 				break;

--- a/sys/dev/kbd/kbd.c
+++ b/sys/dev/kbd/kbd.c
@@ -850,12 +850,12 @@ genkbd_commonioctl(keyboard_t *kbd, u_long cmd, caddr_t arg)
 		break;
 
 	case GIO_KEYMAP:	/* get keyboard translation table */
-#ifdef COMPAT_CHERIABI
-			if (SV_CURPROC_FLAG(SV_CHERI))
-				data = *(void * __capability *)arg;
+#ifdef __has_feature(capabilities)
+			if (!SV_CURPROC_FLAG(SV_CHERI))
+				data = __USER_CAP_UNBOUND(*(uint64_t *)arg);
 			else
 #endif
-				data = __USER_CAP_UNBOUND(*(void **)arg);
+				data = *(void * __capability *)arg;
 		error = copyout(kbd->kb_keymap, data, sizeof(keymap_t));
 		splx(s);
 		return (error);
@@ -886,12 +886,12 @@ genkbd_commonioctl(keyboard_t *kbd, u_long cmd, caddr_t arg)
 				mapp->key[i].flgs = omapp->key[i].flgs;
 			}
 		} else {
-#ifdef COMPAT_CHERIABI
-			if (SV_CURPROC_FLAG(SV_CHERI))
-				data = *(void * __capability *)arg;
+#if __has_feature(capabilities)
+			if (!SV_CURPROC_FLAG(SV_CHERI))
+				data = __USER_CAP_UNBOUND(*(uint64_t *)arg);
 			else
 #endif
-				data = __USER_CAP_UNBOUND(*(void **)arg);
+				data = *(void * __capability *)arg;
 			error = copyin(data, mapp, sizeof *mapp);
 			if (error != 0) {
 				splx(s);

--- a/sys/fs/devfs/devfs_vnops.c
+++ b/sys/fs/devfs/devfs_vnops.c
@@ -765,26 +765,27 @@ fiodgname_buf_get_ptr(void *fgnp, u_long com)
 {
 	union {
 		struct fiodgname_arg	fgn;
-#ifdef COMPAT_CHERIABI
-		struct fiodgname_arg_c	fgn_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 		struct fiodgname_arg32	fgn32;
+#endif
+#ifdef COMPAT_FREEBSD64
+		struct fiodgname_arg64	fgn64;
 #endif
 	} *fgnup;
 
 	fgnup = fgnp;
 	switch (com) {
 	case FIODGNAME:
-		return (__USER_CAP(fgnup->fgn.buf, fgnup->fgn.len));
-#ifdef COMPAT_CHERIABI
-	case FIODGNAME_C:
-		return (fgnup->fgn_c.buf);
-#endif
+		return (fgnup->fgn.buf);
 #ifdef COMPAT_FREEBSD32
 	case FIODGNAME_32:
 		return (__USER_CAP((void *)(uintptr_t)fgnup->fgn32.buf,
 		    fgnup->fgn32.len));
+#endif
+#ifdef COMPAT_FREEBSD64
+	case FIODGNAME_64:
+		return (__USER_CAP((void *)(uintptr_t)fgnup->fgn64.buf,
+		    fgnup->fgn64.len));
 #endif
 	default:
 		panic("Unhandled ioctl command %ld", com);
@@ -819,11 +820,11 @@ devfs_ioctl(struct vop_ioctl_args *ap)
 		error = 0;
 		break;
 	case FIODGNAME:
-#ifdef COMPAT_CHERIABI
-	case FIODGNAME_C:
-#endif
 #ifdef	COMPAT_FREEBSD32
 	case FIODGNAME_32:
+#endif
+#ifdef	COMPAT_FREEBSD64
+	case FIODGNAME_64:
 #endif
 		fgn = ap->a_data;
 		p = devtoname(dev);

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -2512,10 +2512,6 @@ __elfN(note_threadmd)(void *arg, struct sbuf *sb, size_t *sizep)
 	*sizep = size;
 }
 
-#ifdef KINFO_PROC_SIZE
-CTASSERT(sizeof(struct kinfo_proc) == KINFO_PROC_SIZE);
-#endif
-
 static void
 __elfN(note_procstat_proc)(void *arg, struct sbuf *sb, size_t *sizep)
 {

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -228,18 +228,6 @@ struct abs_timeout {
 	struct timespec end;
 };
 
-#ifdef COMPAT_CHERIABI
-struct umutex_c {
-	volatile __lwpid_t	m_owner;
-	__uint32_t		m_flags;
-	__uint32_t		m_ceilings[2];
-	/* XXX: 16-byte 256-bit */
-	__uintcap_t		m_rb_lnk;
-	__uint32_t		m_spare[2];
-	/* XXX: pad of 8-24 bytes */
-};
-#endif
-
 #ifdef COMPAT_FREEBSD32
 struct umutex32 {
 	volatile __lwpid_t	m_owner;	/* Owner of the mutex */
@@ -250,16 +238,24 @@ struct umutex32 {
 	__uint32_t		m_spare[2];
 };
 
+/*
+ * XXX-CHERI: Not true, but leaving the assertion intact to catch future
+ * issues
+ */
 _Static_assert(sizeof(struct umutex) == sizeof(struct umutex32), "umutex32");
 _Static_assert(__offsetof(struct umutex, m_spare[0]) ==
     __offsetof(struct umutex32, m_spare[0]), "m_spare32");
 #endif
 
-struct umtx_robust_lists_params_c {
-	uintcap_t	robust_list_offset;
-	uintcap_t	robust_priv_list_offset;
-	uintcap_t	robust_inact_offset;
+#ifdef COMPAT_FREEBSD64
+struct umutex64 {
+	volatile __lwpid_t	m_owner;	/* Owner of the mutex */
+	__uint32_t		m_flags;	/* Flags of the mutex */
+	__uint32_t		m_ceilings[2];	/* Priority protect ceiling */
+	__uint64_t		m_rb_lnk;	/* Robust linkage */
+	__uint32_t		m_spare[2];
 };
+#endif
 
 int umtx_shm_vnobj_persistent = 0;
 SYSCTL_INT(_kern_ipc, OID_AUTO, umtx_vnode_persistent, CTLFLAG_RWTUN,
@@ -4103,7 +4099,7 @@ __umtx_op_shm(struct thread *td, struct _umtx_op_args *uap)
 }
 
 static int
-umtx_robust_lists(struct thread *td, struct umtx_robust_lists_params_c *rbp)
+umtx_robust_lists(struct thread *td, struct umtx_robust_lists_params *rbp)
 {
 
 	td->td_rb_list = rbp->robust_list_offset;
@@ -4115,7 +4111,7 @@ umtx_robust_lists(struct thread *td, struct umtx_robust_lists_params_c *rbp)
 static int
 __umtx_op_robust_lists(struct thread *td, struct _umtx_op_args *uap)
 {
-	struct umtx_robust_lists_params_c rb;
+	struct umtx_robust_lists_params rb;
 	int error;
 
 	if (uap->val > sizeof(rb))
@@ -4174,358 +4170,12 @@ sys__umtx_op(struct thread *td, struct _umtx_op_args *uap)
 }
 
 #ifdef COMPAT_CHERIABI
-
-static int
-__umtx_op_unimpl_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (EOPNOTSUPP);
-}
-
-static int
-__umtx_op_wait_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time timeout, *tm_p;
-	int error;
-
-	if (uap->uaddr2 == NULL)
-		tm_p = NULL;
-	else {
-		error = umtx_copyin_umtx_time(uap->uaddr2,
-		    (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-		tm_p = &timeout;
-	}
-	return (do_wait(td, uap->obj, uap->val, tm_p, 0, 0));
-}
-
-static int
-__umtx_op_wait_uint_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time *tm_p, timeout;
-	int error;
-
-	if (uap->uaddr2 == NULL)
-		tm_p = NULL;
-	else {
-		error = umtx_copyin_umtx_time(uap->uaddr2,
-		    (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-		tm_p = &timeout;
-	}
-	return (do_wait(td, uap->obj, uap->val, tm_p, 1, 0));
-}
-
-static int
-__umtx_op_wait_uint_private_c(struct thread *td,
-    struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time *tm_p, timeout;
-	int error;
-
-	if (uap->uaddr2 == NULL)
-		tm_p = NULL;
-	else {
-		error = umtx_copyin_umtx_time(uap->uaddr2,
-		    (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-		tm_p = &timeout;
-	}
-	return (do_wait(td, uap->obj, uap->val, tm_p, 1, 1));
-}
-
-static int
-__umtx_op_wake_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (kern_umtx_wake(td, uap->obj, uap->val, 0));
-}
-
-static int
-__umtx_op_nwake_private_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	char * __capability uaddrs[BATCH_SIZE];
-	char * __capability * __capability upp;
-	int count, error, i, pos, tocopy;
-
-	upp = (char * __capability * __capability)uap->obj;
-	error = 0;
-	for (count = uap->val, pos = 0; count > 0; count -= tocopy,
-	    pos += tocopy) {
-		tocopy = MIN(count, BATCH_SIZE);
-		error = copyincap(upp + pos, uaddrs,
-		    tocopy * sizeof(char * __capability));
-		if (error != 0)
-			break;
-		for (i = 0; i < tocopy; ++i)
-			kern_umtx_wake(td, uaddrs[i], INT_MAX, 1);
-		maybe_yield();
-	}
-	return (error);
-}
-
-static int
-__umtx_op_wake_private_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (kern_umtx_wake(td, uap->obj, uap->val, 1));
-}
-
-static int
-__umtx_op_lock_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time *tm_p, timeout;
-	int error;
-
-	/* Allow a null timespec (wait forever). */
-	if (uap->uaddr2 == NULL)
-		tm_p = NULL;
-	else {
-		error = umtx_copyin_umtx_time(
-		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-		tm_p = &timeout;
-	}
-	return (do_lock_umutex(td, uap->obj, tm_p, 0));
-}
-
-static int
-__umtx_op_trylock_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_lock_umutex(td, uap->obj, NULL, _UMUTEX_TRY));
-}
-
-static int
-__umtx_op_wait_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time *tm_p, timeout;
-	int error;
-
-	/* Allow a null timespec (wait forever). */
-	if (uap->uaddr2 == NULL)
-		tm_p = NULL;
-	else {
-		error = umtx_copyin_umtx_time(uap->uaddr2,
-		    (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-		tm_p = &timeout;
-	}
-	return (do_lock_umutex(td, uap->obj, tm_p, _UMUTEX_WAIT));
-}
-
-static int
-__umtx_op_wake_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_wake_umutex(td, uap->obj));
-}
-
-static int
-__umtx_op_unlock_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_unlock_umutex(td, uap->obj, false));
-}
-
-static int
-__umtx_op_set_ceiling_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_set_ceiling(td, uap->obj, uap->val, uap->uaddr1));
-}
-
-static int
-__umtx_op_cv_wait_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct timespec *ts, timeout;
-	int error;
-
-	/* Allow a null timespec (wait forever). */
-	if (uap->uaddr2 == NULL)
-		ts = NULL;
-	else {
-		error = umtx_copyin_timeout(uap->uaddr2, &timeout);
-		if (error != 0)
-			return (error);
-		ts = &timeout;
-	}
-	return (do_cv_wait(td, uap->obj, uap->uaddr1, ts, uap->val));
-}
-
-static int
-__umtx_op_cv_signal_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_cv_signal(td, uap->obj));
-}
-
-static int
-__umtx_op_cv_broadcast_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_cv_broadcast(td, uap->obj));
-}
-
-static int
-__umtx_op_rw_rdlock_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time timeout;
-	int error;
-
-	/* Allow a null timespec (wait forever). */
-	if (uap->uaddr2 == NULL) {
-		error = do_rw_rdlock(td, uap->obj, uap->val, 0);
-	} else {
-		error = umtx_copyin_umtx_time(
-		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-		error = do_rw_rdlock(td, uap->obj, uap->val, &timeout);
-	}
-	return (error);
-}
-
-static int
-__umtx_op_rw_wrlock_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time timeout;
-	int error;
-
-	/* Allow a null timespec (wait forever). */
-	if (uap->uaddr2 == NULL) {
-		error = do_rw_wrlock(td, uap->obj, 0);
-	} else {
-		error = umtx_copyin_umtx_time(
-		    uap->uaddr2, (__cheri_addr size_t)uap->uaddr1, &timeout);
-		if (error != 0)
-			return (error);
-
-		error = do_rw_wrlock(td, uap->obj, &timeout);
-	}
-	return (error);
-}
-
-static int
-__umtx_op_rw_unlock_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_rw_unlock(td, uap->obj));
-}
-
-static int
-__umtx_op_wake2_umutex_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_wake2_umutex(td, uap->obj, uap->val));
-}
-
-static int
-__umtx_op_sem2_wait_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct _umtx_time *tm_p, timeout;
-	size_t uasize;
-	int error;
-
-	/* Allow a null timespec (wait forever). */
-	if (uap->uaddr2 == NULL) {
-		uasize = 0;
-		tm_p = NULL;
-	} else {
-		uasize = (__cheri_addr size_t)uap->uaddr1;
-		error = umtx_copyin_umtx_time(uap->uaddr2, uasize, &timeout);
-		if (error != 0)
-			return (error);
-		tm_p = &timeout;
-	}
-	error = do_sem2_wait(td, uap->obj, tm_p);
-	if (error == EINTR && uap->uaddr2 != NULL &&
-	    (timeout._flags & UMTX_ABSTIME) == 0 &&
-	    uasize >= sizeof(struct _umtx_time) + sizeof(struct timespec)) {
-		error = copyout(&timeout._timeout,
-		    (struct _umtx_time * __capability)uap->uaddr2 + 1,
-		    sizeof(struct timespec));
-		if (error == 0) {
-			error = EINTR;
-		}
-	}
-
-	return (error);
-}
-
-static int
-__umtx_op_sem2_wake_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (do_sem2_wake(td, uap->obj));
-}
-
-static int
-__umtx_op_shm_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-
-	return (umtx_shm(td, uap->uaddr1, uap->val));
-}
-
-static int
-__umtx_op_robust_lists_c(struct thread *td, struct cheriabi__umtx_op_args *uap)
-{
-	struct umtx_robust_lists_params_c rb;
-	int error;
-
-	if (uap->val > sizeof(rb))
-		return (EINVAL);
-	bzero(&rb, sizeof(rb));
-	error = copyincap(uap->uaddr1, &rb, uap->val);
-	if (error != 0)
-		return (error);
-	return (umtx_robust_lists(td, &rb));
-}
-
-typedef int (*_umtx_op_func_c)(struct thread *td,
-    struct cheriabi__umtx_op_args *uap);
-
-static const _umtx_op_func_c op_table_cheriabi[] = {
-	[UMTX_OP_RESERVED0]	= __umtx_op_unimpl_c,
-	[UMTX_OP_RESERVED1]	= __umtx_op_unimpl_c,
-	[UMTX_OP_WAIT]		= __umtx_op_wait_c,
-	[UMTX_OP_WAKE]		= __umtx_op_wake_c,
-	[UMTX_OP_MUTEX_TRYLOCK]	= __umtx_op_trylock_umutex_c,
-	[UMTX_OP_MUTEX_LOCK]	= __umtx_op_lock_umutex_c,
-	[UMTX_OP_MUTEX_UNLOCK]	= __umtx_op_unlock_umutex_c,
-	[UMTX_OP_SET_CEILING]	= __umtx_op_set_ceiling_c,
-	[UMTX_OP_CV_WAIT]	= __umtx_op_cv_wait_c,
-	[UMTX_OP_CV_SIGNAL]	= __umtx_op_cv_signal_c,
-	[UMTX_OP_CV_BROADCAST]	= __umtx_op_cv_broadcast_c,
-	[UMTX_OP_WAIT_UINT]	= __umtx_op_wait_uint_c,
-	[UMTX_OP_RW_RDLOCK]	= __umtx_op_rw_rdlock_c,
-	[UMTX_OP_RW_WRLOCK]	= __umtx_op_rw_wrlock_c,
-	[UMTX_OP_RW_UNLOCK]	= __umtx_op_rw_unlock_c,
-	[UMTX_OP_WAIT_UINT_PRIVATE] = __umtx_op_wait_uint_private_c,
-	[UMTX_OP_WAKE_PRIVATE]	= __umtx_op_wake_private_c,
-	[UMTX_OP_MUTEX_WAIT]	= __umtx_op_wait_umutex_c,
-	[UMTX_OP_MUTEX_WAKE]	= __umtx_op_wake_umutex_c,
-	[UMTX_OP_SEM_WAIT]	= __umtx_op_unimpl_c,
-	[UMTX_OP_SEM_WAKE]	= __umtx_op_unimpl_c,
-	[UMTX_OP_NWAKE_PRIVATE]	= __umtx_op_nwake_private_c,
-	[UMTX_OP_MUTEX_WAKE2]	= __umtx_op_wake2_umutex_c,
-	[UMTX_OP_SEM2_WAIT]	= __umtx_op_sem2_wait_c,
-	[UMTX_OP_SEM2_WAKE]	= __umtx_op_sem2_wake_c,
-	[UMTX_OP_SHM]		= __umtx_op_shm_c,
-	[UMTX_OP_ROBUST_LISTS]	= __umtx_op_robust_lists_c,
-};
-
 int
 cheriabi__umtx_op(struct thread *td, struct cheriabi__umtx_op_args *uap)
 {
 
-	if ((unsigned)uap->op < nitems(op_table_cheriabi)) {
-		return (*op_table_cheriabi[uap->op])(td, uap);
+	if ((unsigned)uap->op < nitems(op_table)) {
+		return (*op_table[uap->op])(td, (struct _umtx_op_args *)uap);
 	}
 	return (EINVAL);
 }
@@ -4810,7 +4460,7 @@ struct umtx_robust_lists_params_compat32 {
 static int
 __umtx_op_robust_lists_compat32(struct thread *td, struct _umtx_op_args *uap)
 {
-	struct umtx_robust_lists_params_c rb;
+	struct umtx_robust_lists_params rb;
 	struct umtx_robust_lists_params_compat32 rb32;
 	int error;
 
@@ -5212,25 +4862,30 @@ __umtx_op_shm64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 	return (umtx_shm(td, __USER_CAP_UNBOUND(uap->uaddr1), uap->val));
 }
 
+struct umtx_robust_lists_params64 {
+	uint64_t	robust_list_offset;
+	uint64_t	robust_priv_list_offset;
+	uint64_t	robust_inact_offset;
+};
+
 static int
 __umtx_op_robust_lists64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
-	struct umtx_robust_lists_params rb_n;
-	struct umtx_robust_lists_params_c rb;
+	struct umtx_robust_lists_params64 rb64;
+	struct umtx_robust_lists_params rb;
 	int error;
 
-	if (uap->val > sizeof(rb_n))
+	if (uap->val > sizeof(rb64))
 		return (EINVAL);
-	bzero(&rb_n, sizeof(rb_n));
-	error = copyin(__USER_CAP(uap->uaddr1, sizeof(rb_n)), &rb_n, uap->val);
+	error = copyin(__USER_CAP(uap->uaddr1, sizeof(rb64)), &rb64, uap->val);
 	if (error != 0)
 		return (error);
 	rb.robust_list_offset =
-	    (intcap_t)__USER_CAP_UNBOUND((void *)rb_n.robust_list_offset);
+	    (intcap_t)__USER_CAP_UNBOUND((void *)rb64.robust_list_offset);
 	rb.robust_priv_list_offset =
-	    (intcap_t)__USER_CAP_UNBOUND((void *)rb_n.robust_priv_list_offset);
+	    (intcap_t)__USER_CAP_UNBOUND((void *)rb64.robust_priv_list_offset);
 	rb.robust_inact_offset =
-	    (intcap_t)__USER_CAP_UNBOUND((void *)rb_n.robust_inact_offset);
+	    (intcap_t)__USER_CAP_UNBOUND((void *)rb64.robust_inact_offset);
 	return (umtx_robust_lists(td, &rb));
 }
 
@@ -5388,26 +5043,26 @@ umtx_read_uptr(struct thread *td, uintcap_t ptr, uintcap_t *res)
 static void
 umtx_read_rb_list(struct thread *td, struct umutex *m, uintcap_t *rb_list)
 {
-#ifdef COMPAT_CHERIABI
-	struct umutex_c m_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 	struct umutex32 m32;
 #endif
-
-#ifdef COMPAT_CHERIABI
-	if (SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
-		memcpy(&m_c, m, sizeof(m_c));
-		*rb_list = m_c.m_rb_lnk;
-	} else
+#ifdef COMPAT_FREEBSD64
+	struct umutex64 m64;
 #endif
+
 #ifdef COMPAT_FREEBSD32
 	if (SV_PROC_FLAG(td->td_proc, SV_ILP32)) {
 		memcpy(&m32, m, sizeof(m32));
 		*rb_list = (uintcap_t)__USER_CAP_UNBOUND((void *)(uintptr_t)m32.m_rb_lnk);
 	} else
 #endif
-		*rb_list = (uintcap_t)__USER_CAP_UNBOUND((void *)m->m_rb_lnk);
+#ifdef COMPAT_FREEBSD64
+	if (!SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
+		memcpy(&m64, m, sizeof(m64));
+		*rb_list = (uintcap_t)__USER_CAP_UNBOUND((void *)(uintptr_t)m64.m_rb_lnk);
+	} else
+#endif
+		*rb_list = m->m_rb_lnk;
 }
 
 static int
@@ -5415,20 +5070,20 @@ umtx_handle_rb(struct thread *td, uintcap_t rbp, uintcap_t *rb_list, bool inact)
 {
 	union {
 		struct umutex m;
-#ifdef COMPAT_CHERIABI
-		struct umutex_c m_c;
+#ifdef COMPAT_FREEBSD64
+		struct umutex64 m64;
 #endif
 	} mu;
 	int error;
 
 	KASSERT(td->td_proc == curproc, ("need current vmspace"));
-#ifdef COMPAT_CHERIABI
-	if (SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
-		error = copyincap((void * __capability)rbp, &mu.m_c,
-		    sizeof(mu.m_c));
+#ifdef COMPAT_FREEBSD64
+	if (!SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
+		error = copyin((void * __capability)rbp, &mu.m64,
+		    sizeof(mu.m64));
 	} else
 #endif
-		error = copyin((void * __capability)rbp, &mu.m, sizeof(mu.m));
+		error = copyincap((void * __capability)rbp, &mu.m, sizeof(mu.m));
 	if (error != 0)
 		return (error);
 	if (rb_list != NULL)

--- a/sys/kern/tty_pts.c
+++ b/sys/kern/tty_pts.c
@@ -285,11 +285,11 @@ ptsdev_ioctl(struct file *fp, u_long cmd, void *data,
 		tty_unlock(tp);
 		return (0);
 	case FIODGNAME:
-#ifdef COMPAT_CHERIABI
-	case FIODGNAME_C:
-#endif
 #ifdef COMPAT_FREEBSD32
 	case FIODGNAME_32:
+#endif
+#ifdef COMPAT_FREEBSD64
+	case FIODGNAME_64:
 #endif
 	{
 		struct fiodgname_arg *fgn;

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -3585,140 +3585,18 @@ freebsd64_lio_listio(struct thread *td, struct freebsd64_lio_listio_args *uap)
 #include <compat/cheriabi/cheriabi_syscall.h>
 #include <compat/cheriabi/cheriabi_util.h>
 
-static int
-aiocb_c_copyin(void * __capability ujob, struct aiocb *kjob)
-{
-
-	return (copyincap(ujob, kjob, sizeof(*kjob)));
-}
-
-static long
-aiocb_c_fetch_status(void * __capability ujob)
-{
-	struct aiocb_c * __capability ujob_c;
-
-	ujob_c = (struct aiocb_c * __capability)ujob;
-	return (fuword(&ujob_c->_aiocb_private.status));
-}
-
-static long
-aiocb_c_fetch_error(void * __capability ujob)
-{
-	struct aiocb_c * __capability ujob_c;
-
-	ujob_c = (struct aiocb_c * __capability)ujob;
-	return (fuword(&ujob_c->_aiocb_private.error));
-}
-
-static void
-aiocb_c_free_kaiocb(struct kaiocb *kjob)
-{
-
-	uma_zfree(aiocb_zone, kjob);
-}
-
-static int
-aiocb_c_store_status(void * __capability ujob, long status)
-{
-	struct aiocb_c * __capability ujob_c;
-
-	ujob_c = (struct aiocb_c * __capability)ujob;
-	return (suword(&ujob_c->_aiocb_private.status, status));
-}
-
-static int
-aiocb_c_store_error(void * __capability ujob, long error)
-{
-	struct aiocb_c * __capability ujob_c;
-
-	ujob_c = (struct aiocb_c * __capability)ujob;
-	return (suword(&ujob_c->_aiocb_private.error, error));
-}
-
-static int
-aiocb_c_store_kernelinfo(void * __capability ujob, long jobref)
-{
-
-	/* Nothing uses kernelinfo so we don't update it */
-	return (0);
-}
-
-static void
-aiocb_c_save_aiocb(struct kaiocb *kjob, const void *ujobptrp)
-{
-
-	if (ujobptrp == NULL)
-		memset(&kjob->ujobptr, 0, sizeof(kjob->ujobptr));
-	else
-		memcpy(&kjob->ujobptr, ujobptrp, sizeof(__intcap_t));
-}
-
-static int
-aiocb_c_store_aiocb(struct aiocb ** __capability ujobp, struct kaiocb *kjob)
-{
-	intcap_t ujob;
-
-	if (kjob == NULL)
-		ujob = 0;	/* XXXBD: is this sufficent? */
-	else
-		memcpy(&ujob, &kjob->ujobptr, sizeof(__intcap_t));
-
-	return (sucap(ujobp, ujob));
-}
-
-static size_t
-aiocb_c_size(void)
-{
-
-	return (sizeof(struct aiocb_c));
-}
-
-static struct aiocb_ops aiocb_c_ops = {
-	.aio_copyin = aiocb_c_copyin,
-	.fetch_status = aiocb_c_fetch_status,
-	.fetch_error = aiocb_c_fetch_error,
-	.free_kaiocb = aiocb_c_free_kaiocb,
-	.store_status = aiocb_c_store_status,
-	.store_error = aiocb_c_store_error,
-	.store_kernelinfo = aiocb_c_store_kernelinfo,
-	.save_aiocb = aiocb_c_save_aiocb,
-	.store_aiocb = aiocb_c_store_aiocb,
-	.size = aiocb_c_size,
-};
-
 int
 cheriabi_aio_return(struct thread *td, struct cheriabi_aio_return_args *uap)
 {
 
-	return (kern_aio_return(td, uap->aiocbp, &aiocb_c_ops));
+	return (kern_aio_return(td, uap->aiocbp, &aiocb_ops));
 }
 
 int
 cheriabi_aio_suspend(struct thread *td, struct cheriabi_aio_suspend_args *uap)
 {
-	struct timespec ts, *tsp;
-	struct aiocb_c * __capability *ujoblist;
-	int error;
 
-	if (uap->nent < 0 || uap->nent > max_aio_queue_per_proc)
-		return (EINVAL);
-
-	if (uap->timeout) {
-		/* Get timespec struct. */
-		if ((error = copyin(uap->timeout, &ts, sizeof(ts))) != 0)
-			return (error);
-		tsp = &ts;
-	} else
-		tsp = NULL;
-
-	ujoblist = malloc(uap->nent * sizeof(ujoblist[0]), M_AIOS, M_WAITOK);
-	error = copyincap(uap->aiocbp, ujoblist,
-	    uap->nent * sizeof(*ujoblist));
-	if (error == 0)
-		error = kern_aio_suspend(td, uap->nent,
-		    (struct aiocb * __capability *)ujoblist, tsp);
-	free(ujoblist, M_AIOS);
-	return (error);
+	return (sys_aio_suspend(td, (struct aio_suspend_args *)uap));
 }
 
 /*
@@ -3730,7 +3608,7 @@ cheriabi_aio_cancel(struct thread *td, struct cheriabi_aio_cancel_args *uap)
 {
 
 	return(kern_aio_cancel(td, uap->fd,
-	    (struct aiocb * __capability)uap->aiocbp, &aiocb_c_ops));
+	    (struct aiocb * __capability)uap->aiocbp, &aiocb_ops));
 }
 
 int
@@ -3739,7 +3617,7 @@ cheriabi_aio_error(struct thread *td, struct cheriabi_aio_error_args *uap)
 
 	return (kern_aio_error(td,
 	    (struct aiocb * __capability)uap->aiocbp,
-	    &aiocb_c_ops));
+	    &aiocb_ops));
 }
 
 int
@@ -3748,7 +3626,7 @@ cheriabi_aio_read(struct thread *td, struct cheriabi_aio_read_args *uap)
 
 	return (aio_aqueue(td,
 	    (struct aiocb * __capability)uap->aiocbp,
-	    &uap->aiocbp, NULL, LIO_READ, &aiocb_c_ops));
+	    &uap->aiocbp, NULL, LIO_READ, &aiocb_ops));
 }
 
 int
@@ -3757,7 +3635,7 @@ cheriabi_aio_write(struct thread *td, struct cheriabi_aio_write_args *uap)
 
 	return (aio_aqueue(td,
 	    (struct aiocb * __capability)uap->aiocbp,
-	    &uap->aiocbp, NULL, LIO_WRITE, &aiocb_c_ops));
+	    &uap->aiocbp, NULL, LIO_WRITE, &aiocb_ops));
 }
 
 int
@@ -3766,7 +3644,7 @@ cheriabi_aio_mlock(struct thread *td, struct cheriabi_aio_mlock_args *uap)
 
 	return (aio_aqueue(td,
 	    (struct aiocb * __capability)uap->aiocbp,
-	    &uap->aiocbp, NULL, LIO_MLOCK, &aiocb_c_ops));
+	    &uap->aiocbp, NULL, LIO_MLOCK, &aiocb_ops));
 }
 
 int
@@ -3787,7 +3665,7 @@ cheriabi_aio_waitcomplete(struct thread *td,
 
 	return (kern_aio_waitcomplete(td,
 	    (struct aiocb ** __capability)uap->aiocbp, tsp,
-	    &aiocb_c_ops));
+	    &aiocb_ops));
 }
 
 int
@@ -3796,41 +3674,14 @@ cheriabi_aio_fsync(struct thread *td, struct cheriabi_aio_fsync_args *uap)
 
 	return (kern_aio_fsync(td, uap->op,
 	    (struct aiocb * __capability)uap->aiocbp,
-	    &uap->aiocbp, &aiocb_c_ops));
+	    &uap->aiocbp, &aiocb_ops));
 }
 
 int
 cheriabi_lio_listio(struct thread *td, struct cheriabi_lio_listio_args *uap)
 {
-	struct aiocb * __capability *acb_list;
-	struct sigevent *sigp, sig;
-	int error, nent;
 
-	if ((uap->mode != LIO_NOWAIT) && (uap->mode != LIO_WAIT))
-		return (EINVAL);
-
-	nent = uap->nent;
-	if (nent < 0 || nent > max_aio_queue_per_proc)
-		return (EINVAL);
-
-	if (uap->sig && (uap->mode == LIO_NOWAIT)) {
-		error = copyincap(uap->sig, &sig, sizeof(sig));
-		if (error)
-			return (error);
-		sigp = &sig;
-	} else
-		sigp = NULL;
-	acb_list = malloc(sizeof(struct aiocb *) * nent, M_LIO, M_WAITOK);
-	error = copyincap(uap->acb_list, acb_list, nent * sizeof(*acb_list));
-	if (error) {
-		free(acb_list, M_LIO);
-		return (error);
-	}
-
-	error = kern_lio_listio(td, uap->mode, (intcap_t)(__cheri_addr vaddr_t)uap->acb_list,
-	    acb_list, nent, sigp, &aiocb_c_ops);
-	free(acb_list, M_LIO);
-	return (error);
+	return (sys_lio_listio(td, (struct lio_listio_args *)uap));
 }
 #endif /* COMPAT_CHERIABI */
 // CHERI CHANGES START

--- a/sys/libkern/iconv.c
+++ b/sys/libkern/iconv.c
@@ -403,17 +403,6 @@ iconv_add(const char *converter, const char *to, const char *from)
 	return iconv_register_cspair(to, from, dcp, NULL, &csp);
 }
 
-#ifdef COMPAT_CHERIABI
-struct iconv_add_c {
-	int	ia_version;
-	char	ia_converter[ICONV_CNVNMAXLEN];
-	char	ia_to[ICONV_CSNMAXLEN];
-	char	ia_from[ICONV_CSNMAXLEN];
-	int	ia_datalen;
-	const void * __capability ia_data;
-};
-#endif
-
 #ifdef COMPAT_FREEBSD32
 struct iconv_add32 {
 	int	ia_version;
@@ -422,6 +411,17 @@ struct iconv_add32 {
 	char	ia_from[ICONV_CSNMAXLEN];
 	int	ia_datalen;
 	uint32_t ia_data;
+};
+#endif
+
+#ifdef COMPAT_FREEBSD64
+struct iconv_add64 {
+	int	ia_version;
+	char	ia_converter[ICONV_CNVNMAXLEN];
+	char	ia_to[ICONV_CSNMAXLEN];
+	char	ia_from[ICONV_CSNMAXLEN];
+	int	ia_datalen;
+	uint64_t ia_data;
 };
 #endif
 
@@ -435,23 +435,17 @@ iconv_sysctl_add(SYSCTL_HANDLER_ARGS)
 	struct iconv_cspair *csp;
 	union {
 		struct iconv_add_in din;
-#ifdef COMPAT_CHERIABI
-		struct iconv_add_c din_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 		struct iconv_add32 din32;
+#endif
+#ifdef COMPAT_FREEBSD64
+		struct iconv_add64 din64;
 #endif
 	} du;
 	const void * __capability ia_data;
 	struct iconv_add_out dout;
 	int error;
 
-#ifdef COMPAT_CHERIABI
-	if (req->flags & SCTL_CHERIABI) {
-		error = SYSCTL_IN(req, &du.din_c, sizeof(du.din_c));
-		ia_data = du.din_c.ia_data;
-	} else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (req->flags & SCTL_MASK32) {
 		error = SYSCTL_IN(req, &du.din32, sizeof(du.din32));
@@ -459,9 +453,16 @@ iconv_sysctl_add(SYSCTL_HANDLER_ARGS)
 		    du.din32.ia_datalen);
 	} else
 #endif
+#ifdef COMPAT_FREEBSD64
+	if (req->flags & SCTL_MASK64) {
+		error = SYSCTL_IN(req, &du.din64, sizeof(du.din64));
+		ia_data = __USER_CAP((void*)(uintptr_t)du.din64.ia_data,
+		    du.din64.ia_datalen);
+	} else
+#endif
 	{
 		error = SYSCTL_IN(req, &du.din, sizeof(du.din));
-		ia_data = __USER_CAP(du.din.ia_data, du.din.ia_datalen);
+		ia_data = du.din.ia_data;
 	}
 	if (error)
 		return error;

--- a/sys/mips/include/proc.h
+++ b/sys/mips/include/proc.h
@@ -105,7 +105,12 @@ struct syscall_args {
 };
 
 #ifdef __mips_n64
+#if __has_feature(capabilities)
+#define	KINFO_PROC_SIZE 1248
+#define	KINFO_PROC64_SIZE 1088
+#else
 #define	KINFO_PROC_SIZE 1088
+#endif
 #define	KINFO_PROC32_SIZE 816
 #else
 #define	KINFO_PROC_SIZE 816

--- a/sys/mips/include/sigframe.h
+++ b/sys/mips/include/sigframe.h
@@ -74,27 +74,4 @@ struct sigframe64 {
 };
 #endif
 
-#ifdef COMPAT_CHERIABI
-#include <compat/cheriabi/cheriabi_signal.h>
-
-struct sigframe_c {
-	register_t	sf_signum;
-	register_t	sf_siginfo;	/* code or pointer to sf_si */
-	register_t	sf_ucontext;	/* points to sf_uc */
-	register_t	sf_addr;	/* undocumented 4th arg */
-	ucontext_t	sf_uc;		/* = *sf_ucontext */
-	struct siginfo_c	sf_si;	/* = *sf_siginfo (SA_SIGINFO case) */
-	unsigned long	__spare__[2];
-};
-#endif
-
 #endif /* !_MACHINE_SIGFRAME_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20181114,
-//   "target_type": "header",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/mips/include/tls.h
+++ b/sys/mips/include/tls.h
@@ -52,9 +52,6 @@
 #ifdef COMPAT_FREEBSD64
 #define TLS_TP_OFFSET64	0x7000
 #endif
-#ifdef COMPAT_CHERIABI
-#define	TLS_TP_OFFSET_C	0
-#endif
 
 #define	TLS_TCB_SIZE	(2 * sizeof(void * __kerncap))
 #ifdef COMPAT_FREEBSD32
@@ -62,9 +59,6 @@
 #endif
 #ifdef COMPAT_FREEBSD64
 #define	TLS_TCB_SIZE64	16
-#endif
-#ifdef COMPAT_CHERIABI
-#define	TLS_TCB_SIZE_C	(2 * __SIZEOF_CHERI_CAPABILITY__)
 #endif
 
 #endif	/* __MIPS_TLS_H__ */

--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -137,26 +137,6 @@ struct bpf_program_buffer {
 #define	SIZEOF_BPF_HDR(type)	\
     (offsetof(type, bh_hdrlen) + sizeof(((type *)0)->bh_hdrlen))
 
-#ifdef COMPAT_CHERIABI
-
-struct bpf_program_c {
-	u_int bf_len;
-	struct bpf_insn * __capability bf_insns;
-};
-struct bpf_dltlist_c {
-	u_int bfl_len;
-	u_int * __capability bfl_list;
-};
-
-#define	_CASE_IOC_BPF_DLTLIST_C(cmd)				\
-    _IOC_NEWTYPE((cmd), struct bpf_dltlist_c): case
-#define	_CASE_IOC_BPF_PROGRAM_C(cmd)				\
-    _IOC_NEWTYPE((cmd), struct bpf_program_c): case
-#else /* !COMPAT_CHERIABI */
-#define	_CASE_IOC_BPF_DLTLIST_C(cmd)
-#define	_CASE_IOC_BPF_PROGRAM_C(cmd)
-#endif /* !COMPAT_CHERIABI */
-
 #ifdef COMPAT_FREEBSD32
 #include <sys/mount.h>
 #include <compat/freebsd32/freebsd32.h>
@@ -198,13 +178,36 @@ struct bpf_dltlist32 {
 #define	_CASE_IOC_BPF_PROGRAM32(cmd)
 #endif /* !COMPAT_FREEBSD32 */
 
+#ifdef COMPAT_FREEBSD64
+#include <sys/mount.h>
+#include <compat/freebsd64/freebsd64.h>
+
+struct bpf_program64 {
+	u_int bf_len;
+	uint64_t bf_insns;		/* (struct bpf_insn *) */
+};
+
+struct bpf_dltlist64 {
+	u_int		bfl_len;
+	uint64_t	bfl_list;	/* (u_int *) */
+};
+
+#define	_CASE_IOC_BPF_DLTLIST64(cmd)				\
+    _IOC_NEWTYPE((cmd), struct bpf_dltlist64): case
+#define	_CASE_IOC_BPF_PROGRAM64(cmd)				\
+    _IOC_NEWTYPE((cmd), struct bpf_program64): case
+#else /* !COMPAT_FREEBSD64 */
+#define	_CASE_IOC_BPF_DLTLIST64(cmd)
+#define	_CASE_IOC_BPF_PROGRAM64(cmd)
+#endif /* !COMPAT_FREEBSD64 */
+
 #define	CASE_IOC_BPF_DLTLIST(cmd)				\
-    _CASE_IOC_BPF_DLTLIST_C(cmd)				\
     _CASE_IOC_BPF_DLTLIST32(cmd)				\
+    _CASE_IOC_BPF_DLTLIST64(cmd)				\
     (cmd)
 #define	CASE_IOC_BPF_PROGRAM(cmd)				\
-    _CASE_IOC_BPF_PROGRAM_C(cmd)				\
     _CASE_IOC_BPF_PROGRAM32(cmd)				\
+    _CASE_IOC_BPF_PROGRAM64(cmd)				\
     (cmd)
 
 #define BPF_LOCK()	   sx_xlock(&bpf_sx)
@@ -1906,27 +1909,28 @@ bf_insns_get_ptr(void *fpp)
 {
 	union {
 		struct bpf_program fp;
-#ifdef COMPAT_CHERIABI
-		struct bpf_program_c fp_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 		struct bpf_program32 fp32;
+#endif
+#ifdef COMPAT_FREEBSD64
+		struct bpf_program64 fp64;
 #endif
 	} *fpup;
 
 	fpup = fpp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (fpup->fp_c.bf_insns);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (__USER_CAP(
 		    (struct bpf_insn *)(uintptr_t)fpup->fp32.bf_insns,
 		    fpup->fp32.bf_len * sizeof(struct bpf_insn)));
 #endif
-	return (__USER_CAP(fpup->fp.bf_insns,
-	    fpup->fp.bf_len * sizeof(struct bpf_insn)));
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (__USER_CAP(
+		    (struct bpf_insn *)(uintptr_t)fpup->fp64.bf_insns,
+		    fpup->fp64.bf_len * sizeof(struct bpf_insn)));
+#endif
+	return (fpup->fp.bf_insns);
 }
 
 /*
@@ -2777,26 +2781,26 @@ bfl_list_get_ptr(void *bflp)
 {
 	union {
 		struct bpf_dltlist bfl;
-#ifdef COMPAT_CHERIABI
-		struct bpf_dltlist_c bfl_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 		struct bpf_dltlist32 bfl32;
+#endif
+#ifdef COMPAT_FREEBSD64
+		struct bpf_dltlist64 bfl64;
 #endif
 	} *bflup;
 
 	bflup = bflp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (bflup->bfl_c.bfl_list);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (__USER_CAP((u_int *)(uintptr_t)bflup->bfl32.bfl_list,
 		    bflup->bfl32.bfl_len * sizeof(u_int)));
 #endif
-	return (__USER_CAP(bflup->bfl.bfl_list,
-	    bflup->bfl.bfl_len * sizeof(u_int)));
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (__USER_CAP((u_int *)(uintptr_t)bflup->bfl64.bfl_list,
+		    bflup->bfl64.bfl_len * sizeof(u_int)));
+#endif
+	return (bflup->bfl.bfl_list);
 }
 
 /*

--- a/sys/net/bpf.h
+++ b/sys/net/bpf.h
@@ -70,7 +70,7 @@ typedef	u_int64_t bpf_u_int64;
  */
 struct bpf_program {
 	u_int bf_len;
-	struct bpf_insn *bf_insns;
+	struct bpf_insn * __kerncap bf_insns;
 };
 
 /*
@@ -378,7 +378,7 @@ struct bpf_insn {
  */
 struct bpf_dltlist {
 	u_int	bfl_len;	/* number of bfd_list array */
-	u_int	*bfl_list;	/* array of DLTs */
+	u_int * __kerncap bfl_list;	/* array of DLTs */
 };
 
 #ifdef _KERNEL

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -129,20 +129,6 @@ struct ifgroupreq_c {
 #define _CASE_IOC_IFGROUPREQ_C(cmd)
 #endif
 
-#if defined(COMPAT_FREEBSD64)
-struct ifmediareq64 {
-	char	ifm_name[IFNAMSIZ];
-	int	ifm_current;
-	int	ifm_mask;
-	int	ifm_status;
-	int	ifm_active;
-	int	ifm_count;
-	int	*ifm_ulist;
-};
-#define	SIOCGIFMEDIA64	_IOC_NEWTYPE(SIOCGIFMEDIA, struct ifmediareq64)
-#define	SIOCGIFXMEDIA64	_IOC_NEWTYPE(SIOCGIFXMEDIA, struct ifmediareq64)
-#endif
-
 #ifdef COMPAT_FREEBSD32
 struct ifreq_buffer32 {
 	uint32_t	length;		/* (size_t) */
@@ -205,6 +191,20 @@ struct ifmediareq32 {
 #else /* !COMPAT_FREEBSD32 */
 #define _CASE_IOC_IFGROUPREQ_32(cmd)
 #endif /* !COMPAT_FREEBSD32 */
+
+#ifdef COMPAT_FREEBSD64
+struct ifmediareq64 {
+	char	ifm_name[IFNAMSIZ];
+	int	ifm_current;
+	int	ifm_mask;
+	int	ifm_status;
+	int	ifm_active;
+	int	ifm_count;
+	int	*ifm_ulist;
+};
+#define	SIOCGIFMEDIA64	_IOC_NEWTYPE(SIOCGIFMEDIA, struct ifmediareq64)
+#define	SIOCGIFXMEDIA64	_IOC_NEWTYPE(SIOCGIFXMEDIA, struct ifmediareq64)
+#endif /* COMPAT_FREEBSD64 */
 
 #define CASE_IOC_IFGROUPREQ(cmd)	\
     _CASE_IOC_IFGROUPREQ_32(cmd)	\

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -113,22 +113,6 @@ __read_mostly epoch_t net_epoch_preempt;
 #include <compat/freebsd32/freebsd32.h>
 #endif
 
-#ifdef COMPAT_CHERIABI
-struct ifgroupreq_c {
-	char	ifgr_name[IFNAMSIZ];
-	u_int	ifgr_len;
-	union {
-		char		ifgru_group[IFNAMSIZ];
-		struct ifg_req * __capability ifgru_groups;
-	} ifgr_ifgru;
-};
-
-#define	_CASE_IOC_IFGROUPREQ_C(cmd)				\
-    _IOC_NEWTYPE((cmd), struct ifgroupreq_c): case
-#else
-#define _CASE_IOC_IFGROUPREQ_C(cmd)
-#endif
-
 #ifdef COMPAT_FREEBSD32
 struct ifreq_buffer32 {
 	uint32_t	length;		/* (size_t) */
@@ -161,7 +145,12 @@ struct ifreq32 {
 		u_char		ifru_vlan_pcp;
 	} ifr_ifru;
 };
+#if !__has_feature(capabilities)
 CTASSERT(sizeof(struct ifreq) == sizeof(struct ifreq32));
+#endif
+#ifdef COMPAT_FREEBSD64
+CTASSERT(sizeof(struct ifreq64) == sizeof(struct ifreq32));
+#endif
 CTASSERT(__offsetof(struct ifreq, ifr_ifru) ==
     __offsetof(struct ifreq32, ifr_ifru));
 
@@ -193,6 +182,15 @@ struct ifmediareq32 {
 #endif /* !COMPAT_FREEBSD32 */
 
 #ifdef COMPAT_FREEBSD64
+struct ifgroupreq64 {
+	char	ifgr_name[IFNAMSIZ];
+	u_int	ifgr_len;
+	union {
+		char		ifgru_group[IFNAMSIZ];
+		uint64_t	ifgru_groups;
+	} ifgr_ifgru;
+};
+
 struct ifmediareq64 {
 	char	ifm_name[IFNAMSIZ];
 	int	ifm_current;
@@ -204,30 +202,35 @@ struct ifmediareq64 {
 };
 #define	SIOCGIFMEDIA64	_IOC_NEWTYPE(SIOCGIFMEDIA, struct ifmediareq64)
 #define	SIOCGIFXMEDIA64	_IOC_NEWTYPE(SIOCGIFXMEDIA, struct ifmediareq64)
-#endif /* COMPAT_FREEBSD64 */
+
+#define	_CASE_IOC_IFGROUPREQ_64(cmd)				\
+    _IOC_NEWTYPE((cmd), struct ifgroupreq64): case
+#else /* !COMPAT_FREEBSD64 */
+#define _CASE_IOC_IFGROUPREQ_64(cmd)
+#endif /* !COMPAT_FREEBSD64 */
 
 #define CASE_IOC_IFGROUPREQ(cmd)	\
     _CASE_IOC_IFGROUPREQ_32(cmd)	\
-    _CASE_IOC_IFGROUPREQ_C(cmd)		\
+    _CASE_IOC_IFGROUPREQ_64(cmd)	\
     (cmd)
 
 union ifreq_union {
 	struct ifreq	ifr;
-#ifdef COMPAT_CHERIABI
-	struct ifreq_c	ifr_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 	struct ifreq32	ifr32;
+#endif
+#ifdef COMPAT_FREEBSD64
+	struct ifreq64	ifr64;
 #endif
 };
 
 union ifgroupreq_union {
 	struct ifgroupreq ifgr;
-#ifdef COMPAT_CHERIABI
-	struct ifgroupreq_c ifgr_c;
-#endif
 #ifdef COMPAT_FREEBSD32
 	struct ifgroupreq32 ifgr32;
+#endif
+#ifdef COMPAT_FREEBSD64
+	struct ifgroupreq64 ifgr64;
 #endif
 };
 
@@ -1646,13 +1649,13 @@ ifgr_group_get(void *ifgrp)
 	union ifgroupreq_union *ifgrup;
 
 	ifgrup = ifgrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (&ifgrup->ifgr_c.ifgr_ifgru.ifgru_group[0]);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (&ifgrup->ifgr32.ifgr_ifgru.ifgru_group[0]);
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (&ifgrup->ifgr64.ifgr_ifgru.ifgru_group[0]);
 #endif
 	return (&ifgrup->ifgr.ifgr_ifgru.ifgru_group[0]);
 }
@@ -1663,18 +1666,19 @@ ifgr_groups_get(void *ifgrp)
 	union ifgroupreq_union *ifgrup;
 
 	ifgrup = ifgrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifgrup->ifgr_c.ifgr_ifgru.ifgru_groups);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (__USER_CAP((struct ifg_req *)(uintptr_t)
 		    ifgrup->ifgr32.ifgr_ifgru.ifgru_groups,
 		    ifgrup->ifgr32.ifgr_len));
 #endif
-	return (__USER_CAP(ifgrup->ifgr.ifgr_ifgru.ifgru_groups,
-	    ifgrup->ifgr.ifgr_len));
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (__USER_CAP((struct ifg_req *)(uintptr_t)
+		    ifgrup->ifgr64.ifgr_ifgru.ifgru_groups,
+		    ifgrup->ifgr64.ifgr_len));
+#endif
+	return (ifgrup->ifgr.ifgr_ifgru.ifgru_groups);
 }
 
 /*
@@ -2469,13 +2473,13 @@ ifr__int0_get(void *ifrp)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_cap[0]);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (ifrup->ifr32.ifr_ifru.ifru_cap[0]);
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (ifrup->ifr64.ifr_ifru.ifru_cap[0]);
 #endif
 	return (ifrup->ifr.ifr_ifru.ifru_cap[0]);
 }
@@ -2486,14 +2490,14 @@ ifr__int0_set(void *ifrp, int val)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_cap[0] = val;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_cap[0] = val;
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr64.ifr_ifru.ifru_cap[0] = val;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_cap[0] = val;
@@ -2505,14 +2509,14 @@ ifr__int1_set(void *ifrp, int val)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_cap[1] = val;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_cap[1] = val;
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr64.ifr_ifru.ifru_cap[1] = val;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_cap[1] = val;
@@ -2524,13 +2528,13 @@ ifr__short0_get(void *ifrp)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_flags[0]);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (ifrup->ifr32.ifr_ifru.ifru_flags[0]);
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (ifrup->ifr64.ifr_ifru.ifru_flags[0]);
 #endif
 	return (ifrup->ifr.ifr_ifru.ifru_flags[0]);
 }
@@ -2541,14 +2545,14 @@ ifr__short0_set(void *ifrp, short val)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_flags[0] = val;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_flags[0] = val;
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr64.ifr_ifru.ifru_flags[0] = val;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_flags[0] = val;
@@ -2560,13 +2564,9 @@ ifr__short1_get(void *ifrp)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_flags[1]);
-#endif
-#ifdef COMPAT_FREEBSD32
-	if (SV_CURPROC_FLAG(SV_ILP32))
-		return (ifrup->ifr32.ifr_ifru.ifru_flags[1]);
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (ifrup->ifr64.ifr_ifru.ifru_flags[1]);
 #endif
 	return (ifrup->ifr.ifr_ifru.ifru_flags[1]);
 }
@@ -2577,14 +2577,14 @@ ifr__short1_set(void *ifrp, short val)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_flags[1] = val;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_flags[1] = val;
+	else
+#endif
+#ifdef COMPAT_FREEBSD63
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr63.ifr_ifru.ifru_flags[1] = val;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_flags[1] = val;
@@ -2596,13 +2596,13 @@ ifr__u_char_get(void *ifrp)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_vlan_pcp);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (ifrup->ifr32.ifr_ifru.ifru_vlan_pcp);
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (ifrup->ifr64.ifr_ifru.ifru_vlan_pcp);
 #endif
 	return (ifrup->ifr.ifr_ifru.ifru_vlan_pcp);
 }
@@ -2613,14 +2613,14 @@ ifr__u_char_set(void *ifrp, u_char val)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_vlan_pcp = val;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_vlan_pcp = val;
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr64.ifr_ifru.ifru_vlan_pcp = val;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_vlan_pcp = val;
@@ -2653,13 +2653,13 @@ ifr_addr_get_sa(void *ifrp)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (&ifrup->ifr_c.ifr_ifru.ifru_addr);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (&ifrup->ifr32.ifr_ifru.ifru_addr);
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (&ifrup->ifr64.ifr_ifru.ifru_addr);
 #endif
 	return (&ifrup->ifr.ifr_ifru.ifru_addr);
 }
@@ -2670,11 +2670,6 @@ ifr_buffer_get_buffer(void *data)
 	union ifreq_union *ifrup;
 
 	ifrup = data;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_buffer.buffer);
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (__USER_CAP((void *)(uintptr_t)
@@ -2682,8 +2677,14 @@ ifr_buffer_get_buffer(void *data)
 		    ifrup->ifr32.ifr_ifru.ifru_buffer.length));
 	else
 #endif
-		return (__USER_CAP(ifrup->ifr.ifr_ifru.ifru_buffer.buffer,
-		    ifrup->ifr.ifr_ifru.ifru_buffer.length));
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (__USER_CAP((void *)(uintptr_t)
+		    ifrup->ifr64.ifr_ifru.ifru_buffer.buffer,
+		    ifrup->ifr64.ifr_ifru.ifru_buffer.length));
+	else
+#endif
+		return (ifrup->ifr.ifr_ifru.ifru_buffer.buffer);
 }
 
 static void
@@ -2692,14 +2693,14 @@ ifr_buffer_set_buffer_null(void *data)
 	union ifreq_union *ifrup;
 
 	ifrup = data;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_buffer.buffer = NULL;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_buffer.buffer = 0;
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr64.ifr_ifru.ifru_buffer.buffer = 0;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_buffer.buffer = NULL;
@@ -2711,14 +2712,14 @@ ifr_buffer_get_length(void *data)
 	union ifreq_union *ifrup;
 
 	ifrup = data;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_buffer.length);
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (ifrup->ifr32.ifr_ifru.ifru_buffer.length);
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (ifrup->ifr64.ifr_ifru.ifru_buffer.length);
 	else
 #endif
 		return (ifrup->ifr.ifr_ifru.ifru_buffer.length);
@@ -2730,14 +2731,14 @@ ifr_buffer_set_length(void *data, size_t len)
 	union ifreq_union *ifrup;
 
 	ifrup = data;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		ifrup->ifr_c.ifr_ifru.ifru_buffer.length = len;
-	else
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		ifrup->ifr32.ifr_ifru.ifru_buffer.length = len;
+	else
+#endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		ifrup->ifr64.ifr_ifru.ifru_buffer.length = len;
 	else
 #endif
 		ifrup->ifr.ifr_ifru.ifru_buffer.length = len;
@@ -2757,16 +2758,17 @@ ifr_data_get_ptr(void *ifrp)
 	union ifreq_union *ifrup;
 
 	ifrup = ifrp;
-#ifdef COMPAT_CHERIABI
-	if (SV_CURPROC_FLAG(SV_CHERI))
-		return (ifrup->ifr_c.ifr_ifru.ifru_data);
-#endif
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
 		return (__USER_CAP_UNBOUND((void *)(uintptr_t)
 		    ifrup->ifr32.ifr_ifru.ifru_data));
 #endif
-		return (__USER_CAP_UNBOUND(ifrup->ifr.ifr_ifru.ifru_data));
+#ifdef COMPAT_FREEBSD64
+	if (!SV_CURPROC_FLAG(SV_CHERI))
+		return (__USER_CAP_UNBOUND((void *)(uintptr_t)
+		    ifrup->ifr64.ifr_ifru.ifru_data));
+#endif
+		return (ifrup->ifr.ifr_ifru.ifru_data);
 }
 
 u_int

--- a/sys/net/if.h
+++ b/sys/net/if.h
@@ -382,7 +382,7 @@ struct if_announcemsghdr {
  */
 struct ifreq_buffer {
 	size_t	length;
-	void	*buffer;
+	void * __kerncap buffer;
 };
 
 /*
@@ -405,7 +405,7 @@ struct	ifreq {
 		int	ifru_mtu;
 		int	ifru_phys;
 		int	ifru_media;
-		caddr_t	ifru_data;
+		char * __kerncap ifru_data;
 		int	ifru_cap[2];
 		u_int	ifru_fib;
 		u_char	ifru_vlan_pcp;
@@ -435,34 +435,6 @@ struct	ifreq {
 #define	ifr_vlan_pcp	ifr_ifru.ifru_vlan_pcp	/* VLAN priority */
 #define	ifr_lan_pcp	ifr_ifru.ifru_vlan_pcp	/* VLAN priority */
 #endif /* !defined(_KERNEL) */
-
-#if defined(_KERNEL) && __has_feature(capabilities)
-struct ifreq_buffer_c {
-	size_t			length;		/* (size_t) */
-	void * __capability	buffer;		/* (void *) */
-};
-
-struct ifreq_c {
-	char	ifr_name[IFNAMSIZ];		/* if name, e.g. "en0" */
-	union {
-		struct sockaddr	ifru_addr;
-		struct sockaddr	ifru_dstaddr;
-		struct sockaddr	ifru_broadaddr;
-		struct ifreq_buffer_c ifru_buffer;
-		short		ifru_flags[2];
-		short		ifru_index;
-		int		ifru_jid;
-		int		ifru_metric;
-		int		ifru_mtu;
-		int		ifru_phys;
-		int		ifru_media;
-		void * __capability ifru_data;
-		int		ifru_cap[2];
-		u_int		ifru_fib;
-		u_char		ifru_vlan_pcp;
-	} ifr_ifru;
-};
-#endif /* defined(_KERNEL) && __has_feature(capabilities) */
 
 #define	_SIZEOF_ADDR_IFREQ(ifr) \
 	((ifr).ifr_addr.sa_len > sizeof(struct sockaddr) ? \
@@ -556,7 +528,7 @@ struct ifgroupreq {
 	u_int	ifgr_len;
 	union {
 		char	ifgru_group[IFNAMSIZ];
-		struct	ifg_req *ifgru_groups;
+		struct ifg_req * __kerncap ifgru_groups;
 	} ifgr_ifgru;
 #ifndef _KERNEL
 #define ifgr_group	ifgr_ifgru.ifgru_group

--- a/sys/net/if_var.h
+++ b/sys/net/if_var.h
@@ -782,15 +782,47 @@ int drbr_enqueue_drv(if_t ifp, struct buf_ring *br, struct mbuf *m);
 void if_hw_tsomax_common(if_t ifp, struct ifnet_hw_tsomax *);
 int if_hw_tsomax_update(if_t ifp, struct ifnet_hw_tsomax *);
 
+#ifdef COMPAT_FREEBSD64
+struct ifreq_buffer64 {
+	uint64_t	length;		/* (size_t) */
+	uint64_t	buffer;		/* (void *) */
+};
+
+/*
+ * Interface request structure used for socket
+ * ioctl's.  All interface ioctl's must have parameter
+ * definitions which begin with ifr_name.  The
+ * remainder may be interface specific.
+ */
+struct ifreq64 {
+	char	ifr_name[IFNAMSIZ];		/* if name, e.g. "en0" */
+	union {
+		struct sockaddr	ifru_addr;
+		struct sockaddr	ifru_dstaddr;
+		struct sockaddr	ifru_broadaddr;
+		struct ifreq_buffer64 ifru_buffer;
+		short		ifru_flags[2];
+		short		ifru_index;
+		int		ifru_jid;
+		int		ifru_metric;
+		int		ifru_mtu;
+		int		ifru_phys;
+		int		ifru_media;
+		uint64_t	ifru_data;
+		int		ifru_cap[2];
+		u_int		ifru_fib;
+		u_char		ifru_vlan_pcp;
+	} ifr_ifru;
+};
+
 /* Helper macro for struct ifreq ioctls */
-#if __has_feature(capabilities)
 #define	CASE_IOC_IFREQ(cmd)					\
     (cmd):							\
-    case _IOC_NEWTYPE((cmd), struct ifreq_c)
-#else
+    case _IOC_NEWTYPE((cmd), struct ifreq64)
+#else /* !COMPAT_FREEBSD64 */
 #define	CASE_IOC_IFREQ(cmd)					\
     (cmd)
-#endif
+#endif /* !COMPAT_FREEBSD64 */
 
 /* accessors for struct ifreq */
 char *ifr_addr_get_data(void *ifrp);

--- a/sys/riscv/include/proc.h
+++ b/sys/riscv/include/proc.h
@@ -46,7 +46,12 @@ struct mdproc {
 	int dummy;
 };
 
+#if __has_feature(capabilities)
+#define	KINFO_PROC_SIZE		1568
+#define	KINFO_PROC64_SIZE	1088
+#else
 #define	KINFO_PROC_SIZE	1088
+#endif
 
 #define	MAXARGS		8
 struct syscall_args {

--- a/sys/sys/_umtx.h
+++ b/sys/sys/_umtx.h
@@ -39,7 +39,11 @@ struct umutex {
 	volatile __lwpid_t	m_owner;	/* Owner of the mutex */
 	__uint32_t		m_flags;	/* Flags of the mutex */
 	__uint32_t		m_ceilings[2];	/* Priority protect ceiling */
+#if __has_feature(capabilities) && defined(_KERNEL)
+	__uintcap_t		m_rb_lnk;	/* Robust linkage */
+#else
 	__uintptr_t		m_rb_lnk;	/* Robust linkage */
+#endif
 #ifndef __LP64__
 	__uint32_t		m_pad;
 #endif

--- a/sys/sys/filio.h
+++ b/sys/sys/filio.h
@@ -54,8 +54,8 @@
 #define	FIODTYPE	_IOR('f', 122, int)	/* get d_flags type part */
 #define	FIOGETLBA	_IOR('f', 121, int)	/* get start blk # */
 struct fiodgname_arg {
-	int	len;
-	void	*buf;
+	int		len;
+	void * __kerncap buf;
 };
 #define	FIODGNAME	_IOW('f', 120, struct fiodgname_arg) /* get dev. name */
 #define	FIONWRITE	_IOR('f', 119, int)	/* get # bytes (yet) to write */
@@ -72,20 +72,20 @@ struct fiobmap2_arg {
 #define	FIOBMAP2	_IOWR('f', 99, struct fiobmap2_arg)
 
 #ifdef _KERNEL
-#ifdef COMPAT_CHERIABI
-struct fiodgname_arg_c {
-	int		len;
-	void * __capability buf;
-};
-#define FIODGNAME_C	_IOC_NEWTYPE(FIODGNAME, struct fiodgname_arg_c)
-#endif
-
 #ifdef COMPAT_FREEBSD32
 struct fiodgname_arg32 {
 	int		len;
 	uint32_t	buf;	/* (void *) */
 };
 #define	FIODGNAME_32	_IOC_NEWTYPE(FIODGNAME, struct fiodgname_arg32)
+#endif
+
+#ifdef COMPAT_FREEBSD64
+struct fiodgname_arg64 {
+	int		len;
+	uint64_t	buf;	/* (void *) */
+};
+#define	FIODGNAME_64	_IOC_NEWTYPE(FIODGNAME, struct fiodgname_arg64)
 #endif
 
 void * __capability fiodgname_buf_get_ptr(void *fgnp, u_long com);

--- a/sys/sys/iconv.h
+++ b/sys/sys/iconv.h
@@ -77,7 +77,7 @@ struct iconv_add_in {
 	char	ia_to[ICONV_CSNMAXLEN];
 	char	ia_from[ICONV_CSNMAXLEN];
 	int	ia_datalen;
-	const void *ia_data;
+	const void * __kerncap ia_data;
 };
 
 struct iconv_add_out {

--- a/sys/sys/mdioctl.h
+++ b/sys/sys/mdioctl.h
@@ -58,14 +58,14 @@ struct md_ioctl {
 	unsigned	md_version;	/* Structure layout version */
 	unsigned	md_unit;	/* unit number */
 	enum md_types	md_type ;	/* type of disk */
-	char		*md_file;	/* pathname of file to mount */
+	char * __kerncap md_file;	/* pathname of file to mount */
 	off_t		md_mediasize;	/* size of disk in bytes */
 	unsigned	md_sectorsize;	/* sectorsize */
 	unsigned	md_options;	/* options */
 	u_int64_t	md_base;	/* base address */
 	int		md_fwheads;	/* firmware heads */
 	int		md_fwsectors;	/* firmware sectors */
-	char		*md_label;	/* label of the device */
+	char * __kerncap md_label;	/* label of the device */
 	int		md_pad[MDNPAD];	/* padding */
 };
 

--- a/sys/sys/mount.h
+++ b/sys/sys/mount.h
@@ -543,12 +543,12 @@ struct vfsconf {
 
 /* Userland version of the struct vfsconf. */
 struct xvfsconf {
-	struct	vfsops *vfc_vfsops;	/* filesystem operations vector */
+	struct vfsops * __kerncap vfc_vfsops;	/* filesystem operations vector */
 	char	vfc_name[MFSNAMELEN];	/* filesystem type name */
 	int	vfc_typenum;		/* historic filesystem type number */
 	int	vfc_refcount;		/* number mounted of this type */
 	int	vfc_flags;		/* permanent flags */
-	struct	vfsconf *vfc_next;	/* next in list */
+	struct vfsconf * __kerncap vfc_next;	/* next in list */
 };
 
 #ifndef BURN_BRIDGES

--- a/sys/sys/pciio.h
+++ b/sys/sys/pciio.h
@@ -94,10 +94,10 @@ struct pci_match_conf {
 struct pci_conf_io {
 	u_int32_t		pat_buf_len;	/* pattern buffer length */
 	u_int32_t		num_patterns;	/* number of patterns */
-	struct pci_match_conf	*patterns;	/* pattern buffer */
+	struct pci_match_conf * __kerncap patterns;	/* pattern buffer */
 	u_int32_t		match_buf_len;	/* match buffer length */
 	u_int32_t		num_matches;	/* number of matches returned */
-	struct pci_conf		*matches;	/* match buffer */
+	struct pci_conf * __kerncap matches;	/* match buffer */
 	u_int32_t		offset;		/* offset into device list */
 	u_int32_t		generation;	/* device list generation */
 	pci_getconf_status	status;		/* request status */

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -162,7 +162,9 @@ struct ctlname {
 #ifdef COMPAT_FREEBSD32
 #define	SCTL_MASK32	1	/* 32 bit emulation */
 #endif
-#define	SCTL_CHERIABI	2	/* CheriABI support */
+#if COMPAT_FREEBSD64
+#define	SCTL_MASK64	2	/* 64 bit emulation (on CHERI) */
+#endif
 #define	SCTL_PTRIN	4
 #define	SCTL_PTROUT	8
 

--- a/sys/sys/umtx.h
+++ b/sys/sys/umtx.h
@@ -117,9 +117,15 @@
 #define	UMTX_SHM_ALIVE		0x0008
 
 struct umtx_robust_lists_params {
+#if __has_feature(capabilities) && defined(_KERNEL)
+	uintcap_t	robust_list_offset;
+	uintcap_t	robust_priv_list_offset;
+	uintcap_t	robust_inact_offset;
+#else
 	uintptr_t	robust_list_offset;
 	uintptr_t	robust_priv_list_offset;
 	uintptr_t	robust_inact_offset;
+#endif
 };
 
 #ifndef _KERNEL

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -121,14 +121,14 @@
 struct kinfo_proc {
 	int	ki_structsize;		/* size of this structure */
 	int	ki_layout;		/* reserved: layout identifier */
-	struct	pargs *ki_args;		/* address of command arguments */
-	struct	proc *ki_paddr;		/* address of proc */
-	struct	user *ki_addr;		/* kernel virtual addr of u-area */
-	struct	vnode *ki_tracep;	/* pointer to trace file */
-	struct	vnode *ki_textvp;	/* pointer to executable file */
-	struct	filedesc *ki_fd;	/* pointer to open file info */
-	struct	vmspace *ki_vmspace;	/* pointer to kernel vmspace struct */
-	const void *ki_wchan;		/* sleep address */
+	struct pargs * __kerncap ki_args;	/* address of command arguments */
+	struct proc * __kerncap ki_paddr;	/* address of proc */
+	struct user * __kerncap ki_addr;	/* kernel virtual addr of u-area */
+	struct vnode * __kerncap ki_tracep;	/* pointer to trace file */
+	struct vnode * __kerncap ki_textvp;	/* pointer to executable file */
+	struct filedesc * __kerncap ki_fd;	/* pointer to open file info */
+	struct vmspace * __kerncap ki_vmspace;	/* pointer to kernel vmspace struct */
+	const void * __kerncap ki_wchan; /* sleep address */
 	pid_t	ki_pid;			/* Process identifier */
 	pid_t	ki_ppid;		/* parent process id */
 	pid_t	ki_pgid;		/* process group id */
@@ -204,16 +204,16 @@ struct kinfo_proc {
 	struct	rusage ki_rusage;	/* process rusage statistics */
 	/* XXX - most fields in ki_rusage_ch are not (yet) filled in */
 	struct	rusage ki_rusage_ch;	/* rusage of children processes */
-	struct	pcb *ki_pcb;		/* kernel virtual addr of pcb */
-	void	*ki_kstack;		/* kernel virtual addr of stack */
-	void	*ki_udata;		/* User convenience pointer */
-	struct	thread *ki_tdaddr;	/* address of thread */
+	struct pcb * __kerncap ki_pcb;	/* kernel virtual addr of pcb */
+	void * __kerncap ki_kstack;	/* kernel virtual addr of stack */
+	void * __kerncap ki_udata;	/* User convenience pointer */
+	struct thread * __kerncap ki_tdaddr;	/* address of thread */
 	/*
 	 * When adding new variables, take space for pointers from the
 	 * front of ki_spareptrs, and longs from the end of ki_sparelongs.
 	 * That way the spare room from both arrays will remain contiguous.
 	 */
-	void	*ki_spareptrs[KI_NSPARE_PTR];	/* spare room for growth */
+	void * __kerncap ki_spareptrs[KI_NSPARE_PTR];	/* spare room for growth */
 	long	ki_sparelongs[KI_NSPARE_LONG];	/* spare room for growth */
 	long	ki_sflag;		/* PS_* flags */
 	long	ki_tdflags;		/* XXXKSE kthread flag */
@@ -574,16 +574,16 @@ struct kinfo_kstack {
 };
 
 struct kinfo_sigtramp {
-	void	*ksigtramp_start;
-	void	*ksigtramp_end;
-	void	*ksigtramp_spare[4];
+	void * __kerncap ksigtramp_start;
+	void * __kerncap ksigtramp_end;
+	void * __kerncap ksigtramp_spare[4];
 };
 
 #ifdef _KERNEL
 /* Flags for kern_proc_out function. */
 #define KERN_PROC_NOTHREADS	0x1
 #define KERN_PROC_MASK32	0x2
-#define KERN_PROC_CHERIABI	0x4
+#define KERN_PROC_MASK64	0x4
 
 /* Flags for kern_proc_filedesc_out. */
 #define	KERN_FILEDESC_PACK_KINFO	0x00000001U


### PR DESCRIPTION
I've started fixing up ioctls and sysctls that need freebsd64 support and are broken without COMPAT_CHERIABI.  These all compile, but are untested. 

I've also got kinfo_proc nearly done, but need to sign off for the day.