### PR TITLE
Changes to allow RISCV purecap to complete building

### DIFF
--- a/bin/cheri_minimal_dynamic_exe/main.c
+++ b/bin/cheri_minimal_dynamic_exe/main.c
@@ -37,7 +37,6 @@ void __cerror(int) __hidden;
 extern void _DYNAMIC __hidden;
 extern void __start___cap_relocs __hidden;
 extern void _CHERI_CAPABILITY_TABLE_ __hidden;
-#pragma weak _CHERI_CAPABILITY_TABLE_
 
 #define PRINT_SYMBOL(sym) simple_printf("%25s = %#p\n", #sym, &sym);
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -156,7 +156,9 @@ SUBDIR.${MK_BLUETOOTH}+=libbluetooth libsdp
 SUBDIR.${MK_BSNMP}+=	libbsnmp
 
 SUBDIR.${MK_LIBCHERI}+=	libhelloworld
-SUBDIR.${MK_CHERI}+=	libsyscalls
+.if ${MACHINE_ABI:Mpurecap} || ${MK_COMPAT_CHERIABI} != "no"
+SUBDIR+=	libsyscalls
+.endif
 
 .if ${MK_LIBCHERI} == "yes" && ${MACHINE_ARCH} != "mips"
 _libc_cheri=	libc_cheri

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -40,7 +40,6 @@ SUBDIR=	${SUBDIR_BOOTSTRAP} \
 	libbsdstat \
 	libbsm \
 	libbz2 \
-	libc_nosyscalls \
 	libcalendar \
 	libcam \
 	libcapsicum \
@@ -158,6 +157,8 @@ SUBDIR.${MK_BSNMP}+=	libbsnmp
 SUBDIR.${MK_LIBCHERI}+=	libhelloworld
 .if ${MACHINE_ABI:Mpurecap} || ${MK_COMPAT_CHERIABI} != "no"
 SUBDIR+=	libsyscalls
+# Not used yet:
+# SUBDIR+=	libc_nosyscalls
 .endif
 
 .if ${MK_LIBCHERI} == "yes" && ${MACHINE_ARCH} != "mips"

--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -62,7 +62,7 @@ static char *rcsid = "$FreeBSD$";
 #define	error_printf(...)	rtld_fdprintf(STDERR_FILENO, __VA_ARGS__)
 #elif defined(IN_LIBTHR)
 #include "thr_private.h"
-#define	error_printf(...)	_thread_printf(STDERR_FILENO, __VA_ARGS__)
+#define	error_printf(...)	_thread_fdprintf(STDERR_FILENO, __VA_ARGS__)
 #else
 #include <stdio.h>
 #define	error_printf(...)	fprintf(stderr, __VA_ARGS__)

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -65,7 +65,7 @@ static char *rcsid = "$FreeBSD$";
 #define	error_printf(...)	rtld_fdprintf(STDERR_FILENO, __VA_ARGS__)
 #elif defined(IN_LIBTHR)
 #include "thr_private.h"
-#define	error_printf(...)	_thread_printf(STDERR_FILENO, __VA_ARGS__)
+#define	error_printf(...)	_thread_fdprintf(STDERR_FILENO, __VA_ARGS__)
 #else
 #include <stdio.h>
 #define	error_printf(...)	fprintf(stderr, __VA_ARGS__)

--- a/lib/libpam/modules/modules.inc
+++ b/lib/libpam/modules/modules.inc
@@ -3,8 +3,14 @@
 .include <src.opts.mk>
 
 MODULES		 =
-MODULES		+= pam_chroot
+# A few minimal modules that can be used by tools/cheribsdbox
 MODULES		+= pam_deny
+MODULES		+= pam_nologin
+MODULES		+= pam_permit
+MODULES		+= pam_rootok
+MODULES		+= pam_self
+.if !defined(PAM_MINIMAL)
+MODULES		+= pam_chroot
 MODULES		+= pam_echo
 MODULES		+= pam_exec
 MODULES		+= pam_ftpusers
@@ -16,20 +22,17 @@ MODULES		+= pam_ksu
 .endif
 MODULES		+= pam_lastlog
 MODULES		+= pam_login_access
-MODULES		+= pam_nologin
 MODULES		+= pam_opie
 MODULES		+= pam_opieaccess
 MODULES		+= pam_passwdqc
-MODULES		+= pam_permit
 .if ${MK_RADIUS_SUPPORT} != "no"
 MODULES		+= pam_radius
 .endif
 MODULES		+= pam_rhosts
-MODULES		+= pam_rootok
 MODULES		+= pam_securetty
-MODULES		+= pam_self
 .if ${MK_OPENSSH} != "no"
 MODULES		+= pam_ssh
 .endif
 MODULES		+= pam_tacplus
 MODULES		+= pam_unix
+.endif  # !defined(PAM_MINIMAL)

--- a/lib/libsimple_printf/Makefile
+++ b/lib/libsimple_printf/Makefile
@@ -10,6 +10,7 @@ SHLIB_MAJOR=    3
 
 
 SIMPLE_PRINTF_PREFIX=simple
+SIMPLE_PRINTF_CUSTOM_WRITE_SYSCALL=__simple_printf_sys_write
 SOLINKOPTS+=	-Wl,-no-undefined -Wl,-verbose
 LDFLAGS+=	-nostdlib -nodefaultlibs
 

--- a/lib/libsimple_printf/Makefile
+++ b/lib/libsimple_printf/Makefile
@@ -4,8 +4,10 @@
 MK_SSP=	no
 
 PACKAGE=lib${LIB}
-SHLIB_NAME=	libsimple_printf.so.1
+LIB=	simple_printf
 MK_CHERI_SHARED=yes
+SHLIB_MAJOR=    3
+
 
 SIMPLE_PRINTF_PREFIX=simple
 SOLINKOPTS+=	-Wl,-no-undefined -Wl,-verbose

--- a/lib/libsimple_printf/Makefile.inc
+++ b/lib/libsimple_printf/Makefile.inc
@@ -8,9 +8,15 @@ LIBSIMPLE_PRINTF_ARCH=	${MACHINE_CPUARCH}
 .endif
 
 CSTD?=		gnu11
+.ifdef SIMPLE_PRINTF_CUSTOM_WRITE_SYSCALL
+# For the standalone case (no libc), we provide our own __sys_write implementation
 .PATH: ${PRINTF_DIR}/${LIBSIMPLE_PRINTF_ARCH}
 SRCS+=	write.S
-# CFLAGS.write.S+=	-fpic -DPIC $(DEBUG)
+CFLAGS+=-DSIMPLE_PRINTF_WRITE_FUNC=${SIMPLE_PRINTF_CUSTOM_WRITE_SYSCALL}
+.else
+# Otherwise just use the default __sys_write
+CFLAGS+=-DSIMPLE_PRINTF_WRITE_FUNC=__sys_write
+.endif
 .PATH: ${PRINTF_DIR}
 SRCS+=	simple_printf.c
 

--- a/lib/libsimple_printf/mips/write.S
+++ b/lib/libsimple_printf/mips/write.S
@@ -3,11 +3,9 @@
  * We want to avoid any dependency on libc here so just do the syscall directly.
  * We also don't care about errors here to avoid any dependency on errno
  */
-
-#define WRITE_NAME __CONCAT(SIMPLE_PRINTF_PREFIX, _write)
-LEAF(WRITE_NAME)
-	.hidden _C_LABEL(WRITE_NAME)
-	PIC_PROLOGUE(WRITE_NAME);
+LEAF(SIMPLE_PRINTF_WRITE_FUNC)
+	.hidden _C_LABEL(SIMPLE_PRINTF_WRITE_FUNC)
+	PIC_PROLOGUE(SIMPLE_PRINTF_WRITE_FUNC);
 	SYSTRAP(write);
 	PIC_RETURN()
-END(WRITE_NAME)
+END(SIMPLE_PRINTF_WRITE_FUNC)

--- a/lib/libsimple_printf/riscv/write.S
+++ b/lib/libsimple_printf/riscv/write.S
@@ -4,10 +4,8 @@
  * We want to avoid any dependency on libc here so just do the syscall directly.
  * We also don't care about errors here to avoid any dependency on errno
  */
-
-#define WRITE_NAME __CONCAT(SIMPLE_PRINTF_PREFIX, _write)
-ENTRY(WRITE_NAME)
-	.hidden _C_LABEL(WRITE_NAME)
+ENTRY(SIMPLE_PRINTF_WRITE_FUNC)
+	.hidden _C_LABEL(SIMPLE_PRINTF_WRITE_FUNC)
 	_SYSCALL(write);
 	RETURN;
-END(WRITE_NAME)
+END(SIMPLE_PRINTF_WRITE_FUNC)

--- a/lib/libsimple_printf/simple_printf.h
+++ b/lib/libsimple_printf/simple_printf.h
@@ -47,6 +47,8 @@ int SIMPLE_PRINTF_FN(vsnprintf)(char *buf, size_t bufsize, const char *fmt,
     va_list ap) __printflike(3, 0);
 int SIMPLE_PRINTF_FN(vfdprintf)(int fd, const char *fmt, va_list ap)
     __printflike(2, 0);
+int SIMPLE_PRINTF_FN(vprintf)(const char *fmt, va_list ap)
+    __printflike(1, 0);
 int SIMPLE_PRINTF_FN(fdprintf)(int fd, const char *fmt, ...)
     __printflike(2, 3);
 int SIMPLE_PRINTF_FN(printf)(const char *fmt, ...) __printflike(1, 2);

--- a/lib/libthr/thread/Makefile.inc
+++ b/lib/libthr/thread/Makefile.inc
@@ -36,7 +36,6 @@ SRCS+= \
 	thr_mutex.c \
 	thr_mutexattr.c \
 	thr_once.c \
-	thr_printf.c \
 	thr_pshared.c \
 	thr_pspinlock.c \
 	thr_resume_np.c \
@@ -59,3 +58,7 @@ SRCS+= \
 	thr_symbols.c \
 	thr_umtx.c \
 	thr_yield.c
+
+SIMPLE_PRINTF_PREFIX=_thread
+SIMPLE_PRINTF_NO_CUSTOM_WRITE=yes
+.include "${SRCTOP}/lib/libsimple_printf/Makefile.inc"

--- a/lib/libthr/thread/thr_exit.c
+++ b/lib/libthr/thread/thr_exit.c
@@ -247,13 +247,13 @@ _thread_exitf(const char *fname, int lineno, const char *fmt, ...)
 	va_list ap;
 
 	/* Write an error message to the standard error file descriptor: */
-	_thread_printf(STDERR_FILENO, "Fatal error '");
+	_thread_fdprintf(STDERR_FILENO, "Fatal error '");
 
 	va_start(ap, fmt);
-	_thread_vprintf(STDERR_FILENO, fmt, ap);
+	_thread_vfdprintf(STDERR_FILENO, fmt, ap);
 	va_end(ap);
 
-	_thread_printf(STDERR_FILENO, "' at line %d in file %s (errno = %d)\n",
+	_thread_fdprintf(STDERR_FILENO, "' at line %d in file %s (errno = %d)\n",
 	    lineno, fname, errno);
 
 	abort();
@@ -312,7 +312,7 @@ _pthread_exit_mask(void *status, sigset_t *mask)
 		if (curthread->unwind_disabled) {
 			if (message_printed == 0) {
 				message_printed = 1;
-				_thread_printf(2, "Warning: old _pthread_cleanup_push was called, "
+				_thread_fdprintf(STDERR_FILENO, "Warning: old _pthread_cleanup_push was called, "
 				  	"stack unwinding is disabled.\n");
 			}
 			goto cleanup;

--- a/lib/libthr/thread/thr_list.c
+++ b/lib/libthr/thread/thr_list.c
@@ -130,7 +130,7 @@ _thr_gc(struct pthread *curthread)
 #ifdef ISSUE301_HAS_BEEN_FIXED
 		_thr_free(curthread, td);
 #else
-		_thread_printf(STDERR_FILENO,
+		_thread_fdprintf(STDERR_FILENO,
 		    "Not freeing %p to work around "
 		    "https://github.com/CTSRD-CHERI/cheribsd/issues/301\n", td);
 #endif

--- a/lib/libthr/thread/thr_printf.c
+++ b/lib/libthr/thread/thr_printf.c
@@ -64,7 +64,7 @@ static void	pstr(int fd, const char *s);
  *	%p	-> unsigned int (base 16)
  */
 void
-_thread_printf(int fd, const char *fmt, ...)
+_thread_fdprintf(int fd, const char *fmt, ...)
 {
 	va_list	ap;
 
@@ -74,7 +74,7 @@ _thread_printf(int fd, const char *fmt, ...)
 }
 
 void
-_thread_vprintf(int fd, const char *fmt, va_list ap)
+_thread_vfdprintf(int fd, const char *fmt, va_list ap)
 {
 	static const char digits[16] = "0123456789abcdef";
 	/* XXX_AR: we should print capabilities not vaddr_t -> increase size */
@@ -171,3 +171,4 @@ pstr(int fd, const char *s)
 	__sys_write(fd, s, strlen(s));
 }
 
+#error "Should no longer be used"

--- a/lib/libthr/thread/thr_private.h
+++ b/lib/libthr/thread/thr_private.h
@@ -93,7 +93,7 @@ extern struct pthread	*_thr_initial __hidden;
 #include "pthread_md.h"
 #include "thr_umtx.h"
 #include "thread_db.h"
-
+#include "simple_printf.h"
 #ifdef _PTHREAD_FORCED_UNWIND
 #define _BSD_SOURCE
 #include <unwind.h>
@@ -112,8 +112,8 @@ TAILQ_HEAD(mutex_queue, pthread_mutex);
 #define PANIC(args...)		_thread_exitf(__FILE__, __LINE__, ##args)
 
 /* Output debug messages like this: */
-#define stdout_debug(args...)	_thread_printf(STDOUT_FILENO, ##args)
-#define stderr_debug(args...)	_thread_printf(STDERR_FILENO, ##args)
+#define stdout_debug(args...)	_thread_fdprintf(STDOUT_FILENO, ##args)
+#define stderr_debug(args...)	_thread_fdprintf(STDERR_FILENO, ##args)
 
 #ifdef _PTHREADS_INVARIANTS
 #define THR_ASSERT(cond, msg) do {	\
@@ -823,8 +823,6 @@ void	_thr_stack_free(struct pthread_attr *) __hidden;
 void	_thr_free(struct pthread *, struct pthread *) __hidden;
 void	_thr_gc(struct pthread *) __hidden;
 void    _thread_cleanupspecific(void) __hidden;
-void	_thread_printf(int, const char *, ...) __hidden __printflike(2, 3);
-void	_thread_vprintf(int, const char *, va_list) __hidden;
 void	_thr_spinlock_init(void) __hidden;
 void	_thr_cancel_enter(struct pthread *) __hidden;
 void	_thr_cancel_enter2(struct pthread *, int) __hidden;

--- a/libexec/tftpd/tftp-file.c
+++ b/libexec/tftpd/tftp-file.c
@@ -229,7 +229,7 @@ seek_file(off_t offset)
 }
 
 int
-read_init(int fd, FILE *f, const char *mode)
+tftp_read_init(int fd, FILE *f, const char *mode)
 {
 
 	convert_to_net(NULL, 0, 1);
@@ -248,7 +248,7 @@ read_init(int fd, FILE *f, const char *mode)
 }
 
 size_t
-read_file(char *buffer, int count)
+tftp_read_file(char *buffer, int count)
 {
 
 	if (convert == 0)
@@ -258,7 +258,7 @@ read_file(char *buffer, int count)
 }
 
 int
-read_close(void)
+tftp_read_close(void)
 {
 
 	if (fclose(file) != 0) {

--- a/libexec/tftpd/tftp-file.h
+++ b/libexec/tftpd/tftp-file.h
@@ -32,9 +32,9 @@ int	write_init(int fd, FILE *f, const char *mode);
 size_t	write_file(char *buffer, int count);
 int	write_close(void);
 
-int	read_init(int fd, FILE *f, const char *mode);
-size_t	read_file(char *buffer, int count);
-int	read_close(void);
+int	tftp_read_init(int fd, FILE *f, const char *mode);
+size_t	tftp_read_file(char *buffer, int count);
+int	tftp_read_close(void);
 
 int	seek_file(off_t offset);
 off_t	tell_file(void);

--- a/libexec/tftpd/tftp-transfer.c
+++ b/libexec/tftpd/tftp-transfer.c
@@ -81,7 +81,7 @@ read_block:
 
 		window[windowblock].offset = tell_file();
 		window[windowblock].block = *block;
-		size = read_file(sendbuffer, segsize);
+		size = tftp_read_file(sendbuffer, segsize);
 		if (size < 0) {
 			tftp_log(LOG_ERR, "read_file returned %d", size);
 			send_error(peer, errno + 100);
@@ -343,7 +343,7 @@ tftp_receive(int peer, uint16_t *block, struct tftp_stats *ts,
 					retry = 0;
 					continue;
 				}
-						
+
 				tftp_log(LOG_WARNING,
 				    "Expected DATA block %d, got block %d",
 				    *block, rp->th_block);

--- a/libexec/tftpd/tftpd.c
+++ b/libexec/tftpd/tftpd.c
@@ -812,10 +812,10 @@ tftp_xmitfile(int peer, const char *mode)
 	if (debug&DEBUG_SIMPLE)
 		tftp_log(LOG_DEBUG, "Transmitting file");
 
-	read_init(0, file, mode);
+	tftp_read_init(0, file, mode);
 	block = 1;
 	tftp_send(peer, &block, &ts);
-	read_close();
+	tftp_read_close();
 	if (debug&DEBUG_SIMPLE)
 		tftp_log(LOG_INFO, "Sent %jd bytes in %jd seconds",
 		    (intmax_t)ts.amount, (intmax_t)time(NULL) - now);

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -37,6 +37,11 @@ CTFFLAGS+= -g
 PROG=	${PROG_CXX}
 .endif
 
+.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_ARCH:Mriscv*} && !defined(NO_SHARED)
+.info "Building ${PROG} statically since we don't have purecap RTLD yet"
+NO_SHARED:=yes
+.endif
+
 .if !empty(LDFLAGS:M-Wl,*--oformat,*) || !empty(LDFLAGS:M-static)
 MK_DEBUG_FILES=	no
 .endif

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -394,6 +394,9 @@ BROKEN_OPTIONS+=SVN SVNLITE
 
 # libcheri has not been ported to RISCV
 BROKEN_OPTIONS+=LIBCHERI
+
+# No RTLD yet
+BROKEN_OPTIONS+=CASPER DYNAMICROOT
 .endif
 
 # EFI doesn't exist on mips, powerpc or riscv.

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -24,6 +24,17 @@ CRUNCH_BUILDOPTS+=	-DWITHOUT_TESTS MK_TESTS=no -D_CRUNCHGEN
 CRUNCH_BUILDOPTS+=	-DWITHOUT_CASPER MK_CASPER=no
 # Try to reduce size by avoiding locale support
 CRUNCH_BUILDOPTS+=	-DWITHOUT_LOCALES MK_LOCALES=no
+# Disable kerberos support
+CRUNCH_BUILDOPTS+=	MK_KERBEROS=no MK_KERBEROS_SUPPORT=no MK_GSSAPI=no
+# Smaller PAM:
+CRUNCH_BUILDOPTS+=	MK_RADIUS_SUPPORT=no
+# Smaller SSH
+CRUNCH_BUILDOPTS+=	MK_LDNS_UTILS=no MK_LDNS=no
+# Avoid redundant libs
+CRUNCH_BUILDOPTS+=	MK_PROFILE=no
+# Avoid dependency on audit
+CRUNCH_BUILDOPTS+=	MK_AUDIT=no
+
 
 
 # Do not do hardlinks as part of the install since we want to be able to install
@@ -81,9 +92,6 @@ CRUNCH_SHLIBS+=	-pthread
 
 # ktrace:
 CRUNCH_LIBS+=	-lsysdecode
-
-# login/su (could theoretically use static_libpam but that will probably not work)
-CRUNCH_SHLIBS+= -lpam -lbsm
 
 # needed by ifconfig
 CRUNCH_LIBS+=	-l80211
@@ -385,14 +393,6 @@ CRUNCH_PROGS_secure/usr.sbin+=	sshd
 # TODO: should we link libssh static and use ${LIBSSH}?
 CRUNCH_SHLIBS+=	-lpam -lutil
 
-# Build ssh deps static?
-CRUNCH_LIBS+=	${LIBSSH}
-.if ${MK_LDNS} != "no"
-# needed by LIBSSH
-CRUNCH_LIBS+=	${LIBLDNS}
-.endif
-
-
 CRUNCH_SRCDIRS+= secure/usr.bin
 CRUNCH_PROGS_secure/usr.bin+=	scp sftp ssh ssh-keygen
 
@@ -482,6 +482,31 @@ check_crunchgen:
 	    echo "Should not be using crunchgen from /usr/bin!"; false; \
 	fi
 all: check_crunchgen
+
+.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_ARCH:Mriscv*}
+# No RTLD yet!
+NO_SHARED=yes
+.endif
+
+
+
+.if defined(NO_RTLD) || defined(NO_SHARED)
+# Force empty shlibs if we are building without RTLD/NO_SHARED
+# See top_makefile_rules(FILE *outmk) in crunchgen.c
+CRUNCH_LIBS:=${CRUNCH_LIBS} ${CRUNCH_SHLIBS} -Wl,--verbose -v
+# CRUNCH_SHLIBS:=-Bstatic
+CRUNCH_SHLIBS:=
+.undef CRUNCH_SHLIBS
+# TODO: CRUNCH_BUILDOPTS+=-DNO_SHARED
+.endif
+
+# Build PAM with only minimal modules support
+CRUNCH_CUSTOM_LIBS+=lib/libpam
+CRUNCH_BUILDOPTS_lib/libpam+=-DPAM_MINIMAL
+# Also build a version of libssh without optional deps
+CRUNCH_CUSTOM_LIBS+=secure/lib/libssh
+CRUNCH_BUILDOPTS_secure/lib/libssh+="SSHDIR=${SRCTOP}/crypto/openssh"
+CRUNCH_LIBS+=-lprivatessh
 
 # the crunchgen build environment
 .include <bsd.crunchgen.mk>

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -278,7 +278,7 @@ CRUNCH_ALIAS_hexdump=	hd od
 CRUNCH_ALIAS_w=	uptime
 CRUNCH_PROGS_usr.bin+=su
 
-.if ${MK_CHERI} != "no"
+.if ${MACHINE_ARCH:Mmips*} && ${MK_CHERI} != "no"
 CRUNCH_PROGS_usr.bin+=	qtrace
 .endif
 .if ${MACHINE_ARCH:Mmips64*}

--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -202,8 +202,12 @@ SUBDIR.${MK_ATM}+=	atm
 SUBDIR.${MK_BLUETOOTH}+=	bluetooth
 SUBDIR.${MK_BSD_CPIO}+=	cpio
 SUBDIR.${MK_CALENDAR}+=	calendar
-SUBDIR.${MK_CHERI}+=	capsize \
-			qtrace
+SUBDIR.${MK_CHERI}+=	capsize
+# Tracing currently only implemented for MIPS
+.if ${MACHINE_ARCH:Mmips*}
+SUBDIR.${MK_CHERI}+=	qtrace
+.endif
+
 SUBDIR.${MK_CLANG}+=	clang
 SUBDIR.${MK_DIALOG}+=	dpv
 SUBDIR.${MK_EE}+=	ee

--- a/usr.bin/tftp/tftp.c
+++ b/usr.bin/tftp/tftp.c
@@ -152,15 +152,15 @@ xmitfile(int peer, char *port, int fd, char *name, char *mode)
 		parse_options(peer, rp->th_stuff, n + 2);
 	}
 
-	if (read_init(fd, NULL, mode) < 0) {
-		warn("read_init()");
+	if (tftp_read_init(fd, NULL, mode) < 0) {
+		warn("tftp_read_init()");
 		return;
 	}
 
 	block = 1;
 	tftp_send(peer, &block, &tftp_stats);
 
-	read_close();
+	tftp_read_close();
 	if (tftp_stats.amount > 0)
 		printstats("Sent", verbose, &tftp_stats);
 


### PR DESCRIPTION
I think many of these changes can be applied now, but I'm not sure about the bsd.compat.mk/bsd.prog.mk changes. There is probably a better solution for those.