### PR TITLE
Various fixes towards getting a RISC-V hybrid world building

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -3098,10 +3098,8 @@ _cddl_lib_libctf= cddl/lib/libctf
 _cddl_lib= cddl/lib
 cddl/lib/libavl__L: cddl/lib/libnvpair__L
 cddl/lib/libctf__L: lib/libz__L
-.if ${MK_LLVM_LIBUNWIND} != "no"
 # Jenkins sometimes fails to find libgcc_s when building libctf
 cddl/lib/libctf__L: lib/libgcc_s__L
-.endif
 cddl/lib/libuutil__L: cddl/lib/libnvpair__L
 cddl/lib/libzfs_core__L: cddl/lib/libnvpair__L
 .endif

--- a/contrib/atf/atf-c/check.c
+++ b/contrib/atf/atf-c/check.c
@@ -38,7 +38,6 @@
 
 #include "atf-c/check.h"
 
-#include <sys/cdefs.h>
 #include <sys/wait.h>
 
 #include <errno.h>
@@ -120,11 +119,7 @@ static
 int
 const_execvp(const char *file, const char *const *argv)
 {
-#if !__has_feature(capabilities)
-#define UNCONST(a) ((void *)(__uintptr_t)(const void *)(a))
-#else
-#define UNCONST(a) ((void *)(__uintcap_t)(const void *)(a))
-#endif
+#define UNCONST(a) ((void *)(uintptr_t)(const void *)(a))
     return execvp(file, UNCONST(argv));
 #undef UNCONST
 }

--- a/contrib/atf/atf-c/detail/process.c
+++ b/contrib/atf/atf-c/detail/process.c
@@ -37,8 +37,6 @@
 
 #include "atf-c/detail/process.h"
 
-#include <sys/cdefs.h>
-
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -566,11 +564,7 @@ static
 int
 const_execvp(const char *file, const char *const *argv)
 {
-#if !__has_feature(capabilities)
-#define UNCONST(a) ((void *)(__uintptr_t)(const void *)(a))
-#else
-#define UNCONST(a) ((void *)(__uintcap_t)(const void *)(a))
-#endif
+#define UNCONST(a) ((void *)(uintptr_t)(const void *)(a))
     return execvp(file, UNCONST(argv));
 #undef UNCONST
 }

--- a/contrib/atf/atf-c/tc.c
+++ b/contrib/atf/atf-c/tc.c
@@ -37,7 +37,6 @@
 
 #include "atf-c/tc.h"
 
-#include <sys/cdefs.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
@@ -175,11 +174,7 @@ write_resfile(const int fd, const char *result, const int arg,
 
     INV(arg == -1 || reason != NULL);
 
-#if !__has_feature(capabilities)
-#define UNCONST(a) ((void *)(__uintptr_t)(const void *)(a))
-#else
-#define UNCONST(a) ((void *)(__uintcap_t)(const void *)(a))
-#endif
+#define UNCONST(a) ((void *)(uintptr_t)(const void *)(a))
     iov[count].iov_base = UNCONST(result);
     iov[count++].iov_len = strlen(result);
 

--- a/contrib/tcpdump/netdissect.h
+++ b/contrib/tcpdump/netdissect.h
@@ -143,7 +143,7 @@ typedef struct netdissect_options netdissect_options;
 
 typedef u_int (*if_printer) IF_PRINTER_ARGS;
 
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && defined(__mips__)
 #pragma pointer_interpretation capability
 #endif
 struct netdissect_options {
@@ -215,7 +215,7 @@ struct netdissect_options {
 #endif
 		     ;
 };
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && defined(__mips__)
 #pragma pointer_interpretation default
 #endif
 

--- a/contrib/tcpdump/print.h
+++ b/contrib/tcpdump/print.h
@@ -27,7 +27,10 @@
 
 #include <sys/cdefs.h>
 
-#if !__has_feature(capabilities)
+#if !__has_feature(capabilities) || !defined(__mips__)
+#ifdef __capability
+#undef __capability
+#endif
 #define	__capability
 #endif
 

--- a/contrib/tcpdump/tcpdump.c
+++ b/contrib/tcpdump/tcpdump.c
@@ -127,7 +127,7 @@ The Regents of the University of California.  All rights reserved.\n";
 
 #include "print.h"
 
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && defined(__mips__)
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 #define cheri_string(str)	cheri_ptr((str), strlen(str) + 1)

--- a/gnu/lib/Makefile
+++ b/gnu/lib/Makefile
@@ -11,14 +11,6 @@ SUBDIR.${MK_TESTS}+=	tests
 SUBDIR+=		libregex
 .endif
 
-.if ${MACHINE_ARCH:Mmips*c*}
-# Don't use csu for CheriABI
-SUBDIR:=	${SUBDIR:Ncsu}
-# We'll be using the libunwind based libgcc_eh and libgcc_eh when the time
-# comes.
-SUBDIR:=	${SUBDIR:Nlibgcc}
-.endif
-
 SUBDIR_PARALLEL=
 
 .include <bsd.subdir.mk>

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -18,7 +18,8 @@ SUBDIR_BOOTSTRAP= \
 	${_libc_cheri} \
 	${_libcheri} \
 	${_libclang_rt} \
-	${_libunwind} \
+	libgcc_eh \
+	libgcc_s \
 	${_libcplusplus} \
 	${_libcxxrt} \
 	libelf \
@@ -58,8 +59,6 @@ SUBDIR=	${SUBDIR_BOOTSTRAP} \
 	libexpat \
 	libfetch \
 	libfigpar \
-	libgcc_eh \
-	libgcc_s \
 	libgeom \
 	libifconfig \
 	libipsec \
@@ -205,13 +204,6 @@ _libclang_rt=	libclang_rt
 _libcxxrt=	libcxxrt
 _libcplusplus=	libc++
 _libcplusplus+=	libc++experimental
-.endif
-
-.if ${MK_LLVM_LIBUNWIND} != "no"
-# When building with LLVM libunwind we must build libgcc_s/libgcc_eh as part
-# of SUBDIR_BOOTSTRAP to avoid build failures due to other libraries linking
-# against -lgcc_s
-_libunwind=	libgcc_s libgcc_eh
 .endif
 
 SUBDIR.${MK_EFI}+=	libefivar

--- a/lib/libc/riscv/gen/_ctx_start.S
+++ b/lib/libc/riscv/gen/_ctx_start.S
@@ -36,7 +36,7 @@
 __FBSDID("$FreeBSD$");
 
 ENTRY(_ctx_start)
-#if !__has_feature(capabilities)
+#if !__CHERI_PURE_CAPABILITY__
 	jalr	s0		/* Call func from makecontext */
 	mv	a0, s1		/* Load ucp saved in makecontext */
 	call	_C_LABEL(ctx_done)

--- a/lib/libnetbsd/sys/cdefs.h
+++ b/lib/libnetbsd/sys/cdefs.h
@@ -77,11 +77,7 @@
  * explicit about unsigned long so that we don't have additional
  * dependencies.
  */
-#if !__has_feature(capabilities)
-#define __UNCONST(a)	((void *)(__uintptr_t)(const void *)(a))
-#else
-#define __UNCONST(a)	((void *)(__uintcap_t)(const void * __capability)(a))
-#endif
+#define __UNCONST(a)	((void *)(uintptr_t)(const void *)(a))
 
 /*
  * Return the number of elements in a statically-allocated array,

--- a/share/mk/bsd.opts.mk
+++ b/share/mk/bsd.opts.mk
@@ -110,8 +110,6 @@ MK_CLANG:=	no
 # We want to use libc++ for CHERI (even when targeting MIPS)
 MK_GNUCXX:=	no
 MK_LIBCPLUSPLUS:=yes
-# LLVM libunwind is needed for libc++
-MK_LLVM_LIBUNWIND:=	yes
 # Build cheribsdbox by default so that we have a emergency MIPS tool if the
 # CHERI world is broken
 .if !defined(WITHOUT_CHERIBSDBOX)

--- a/share/mk/bsd.opts.mk
+++ b/share/mk/bsd.opts.mk
@@ -107,8 +107,6 @@ WITH_CHERI256:=	yes
 .if ${MK_CHERI128} == "yes" || ${MK_CHERI256} == "yes"
 MK_CHERI:=	yes
 MK_CLANG:=	no
-# We want to use libc++ for CHERI (even when targeting MIPS)
-MK_LIBCPLUSPLUS:=yes
 # Build cheribsdbox by default so that we have a emergency MIPS tool if the
 # CHERI world is broken
 .if !defined(WITHOUT_CHERIBSDBOX)

--- a/share/mk/bsd.opts.mk
+++ b/share/mk/bsd.opts.mk
@@ -108,7 +108,6 @@ WITH_CHERI256:=	yes
 MK_CHERI:=	yes
 MK_CLANG:=	no
 # We want to use libc++ for CHERI (even when targeting MIPS)
-MK_GNUCXX:=	no
 MK_LIBCPLUSPLUS:=yes
 # Build cheribsdbox by default so that we have a emergency MIPS tool if the
 # CHERI world is broken

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -385,7 +385,7 @@ __DEFAULT_NO_OPTIONS+=CHERIBSDBOX
 .if ${__T:Mriscv*c*}
 # Compiler crash:
 # Skip until https://github.com/CTSRD-CHERI/llvm-project/issues/379 is fixed.
-BROKEN_OPTIONS+=LIBCPLUSPLUS GNUCXX CXX
+BROKEN_OPTIONS+=LIBCPLUSPLUS CXX
 # Crash in ZFS code. TODO: investigate
 BROKEN_OPTIONS+=CDDL
 


### PR DESCRIPTION
I have a few other hacks, but aside from tcpdump these are mostly not hacks.

Tested with `make TARGET_ARCH=riscv64 TARGET_CPUTYPE=cheri CROSS_TOOLCHAIN=cheri-clang WITHOUT_CLANG=yes WITHOUT_LLD=yes WITHOUT_LLDB=yes buildworld` where the cheri-clang toolchain sets XCC, XCXX, etc. to point to a CHERI llvm toolchain.