### PR TITLE
Fix debug.kdb.enter with dtrace-enabled kernel for mips

### DIFF
--- a/sys/cddl/dev/dtrace/mips/dtrace_subr.c
+++ b/sys/cddl/dev/dtrace/mips/dtrace_subr.c
@@ -251,6 +251,9 @@ dtrace_invop_start(struct trapframe *frame)
 	int invop;
 
 	invop = dtrace_invop(TRAPF_PC(frame), frame, TRAPF_PC(frame));
+	if (invop == 0)
+		return (-1);
+
 	offs = (invop & LDSD_DATA_MASK);
 	sp = (register_t *)((uint8_t *)frame->sp + offs);
 

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -1031,7 +1031,7 @@ dofault:
 	case T_BREAK:
 #ifdef KDTRACE_HOOKS
 		if (!usermode && dtrace_invop_jump_addr != NULL &&
-			dtrace_invop_jump_addr(trapframe) == 0)
+		    dtrace_invop_jump_addr(trapframe) == 0)
 			return (trapframe->pc);
 #endif
 #ifdef DDB

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -1030,10 +1030,9 @@ dofault:
 #if defined(KDTRACE_HOOKS) || defined(DDB)
 	case T_BREAK:
 #ifdef KDTRACE_HOOKS
-		if (!usermode && dtrace_invop_jump_addr != 0) {
-			dtrace_invop_jump_addr(trapframe);
+		if (!usermode && dtrace_invop_jump_addr != NULL &&
+			dtrace_invop_jump_addr(trapframe) == 0)
 			return (trapframe->pc);
-		}
 #endif
 #ifdef DDB
 		kdb_trap(type, 0, trapframe);


### PR DESCRIPTION
As per https://reviews.freebsd.org/D24018, but for mips.
With this, KDB works when dtrace is compiled into kernel.
#397 