### PR TITLE
setjmp/longjmp for RISC-V purecap.

### DIFF
--- a/lib/libc/riscv/gen/_setjmp.S
+++ b/lib/libc/riscv/gen/_setjmp.S
@@ -39,7 +39,50 @@ __FBSDID("$FreeBSD$");
 
 ENTRY(_setjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement _setjmp")
+	/* Store the magic value and stack pointer */
+	cllc	ct0, .Lmagic
+	cld	t0, (ct0)
+	csc	ct0, (0 * 16)(ca0)
+	csc	csp, (1 * 16)(ca0)
+	cincoffset ca0, ca0, (2 * 16)
+
+	/* Store the general purpose registers and ra */
+	csc	cs0, (0 * 16)(ca0)
+	csc	cs1, (1 * 16)(ca0)
+	csc	cs2, (2 * 16)(ca0)
+	csc	cs3, (3 * 16)(ca0)
+	csc	cs4, (4 * 16)(ca0)
+	csc	cs5, (5 * 16)(ca0)
+	csc	cs6, (6 * 16)(ca0)
+	csc	cs7, (7 * 16)(ca0)
+	csc	cs8, (8 * 16)(ca0)
+	csc	cs9, (9 * 16)(ca0)
+	csc	cs10, (10 * 16)(ca0)
+	csc	cs11, (11 * 16)(ca0)
+	csc	cra, (12 * 16)(ca0)
+	cspecialr ct0, ddc
+	csc	ct0, (13 * 16)(ca0)
+	cincoffset ca0, ca0, (14 * 16)
+
+#if !defined(_STANDALONE) && defined(__riscv_float_abi_double)
+	/* Store the fpe registers */
+	cfsd	fs0, (0 * 8)(ca0)
+	cfsd	fs1, (1 * 8)(ca0)
+	cfsd	fs2, (2 * 8)(ca0)
+	cfsd	fs3, (3 * 8)(ca0)
+	cfsd	fs4, (4 * 8)(ca0)
+	cfsd	fs5, (5 * 8)(ca0)
+	cfsd	fs6, (6 * 8)(ca0)
+	cfsd	fs7, (7 * 8)(ca0)
+	cfsd	fs8, (8 * 8)(ca0)
+	cfsd	fs9, (9 * 8)(ca0)
+	cfsd	fs10, (10 * 8)(ca0)
+	cfsd	fs11, (11 * 8)(ca0)
+	cincoffset ca0, ca0, (12 * 8)
+#endif
+
+	/* Return value */
+	li	a0, 0
 	cret
 #else
 	/* Store the magic value and stack pointer */
@@ -84,16 +127,62 @@ ENTRY(_setjmp)
 	/* Return value */
 	li	a0, 0
 	ret
+#endif
 	.align	3
 .Lmagic:
 	.quad	_JB_MAGIC__SETJMP
-#endif
 END(_setjmp)
 
 ENTRY(_longjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement _longjmp")
-	unimp
+	/* Check the magic value */
+	cld	t0, 0(ca0)
+	cllc	ct1, .Lmagic
+	cld	t1, (ct1)
+	bne	t0, t1, botch
+
+	/* Restore the stack pointer */
+	clc	csp, 16(ca0)
+	cincoffset ca0, ca0, (2 * 16)
+
+	/* Restore the general purpose registers and ra */
+	clc	cs0, (0 * 16)(ca0)
+	clc	cs1, (1 * 16)(ca0)
+	clc	cs2, (2 * 16)(ca0)
+	clc	cs3, (3 * 16)(ca0)
+	clc	cs4, (4 * 16)(ca0)
+	clc	cs5, (5 * 16)(ca0)
+	clc	cs6, (6 * 16)(ca0)
+	clc	cs7, (7 * 16)(ca0)
+	clc	cs8, (8 * 16)(ca0)
+	clc	cs9, (9 * 16)(ca0)
+	clc	cs10, (10 * 16)(ca0)
+	clc	cs11, (11 * 16)(ca0)
+	clc	cra, (12 * 16)(ca0)
+	clc	ct0, (13 * 16)(ca0)
+	cspecialw ddc, ct0
+	cincoffset ca0, ca0, (14 * 16)
+
+#if !defined(_STANDALONE) && defined(__riscv_float_abi_double)
+	/* Restore the fpe registers */
+	cfld	fs0, (0 * 8)(ca0)
+	cfld	fs1, (1 * 8)(ca0)
+	cfld	fs2, (2 * 8)(ca0)
+	cfld	fs3, (3 * 8)(ca0)
+	cfld	fs4, (4 * 8)(ca0)
+	cfld	fs5, (5 * 8)(ca0)
+	cfld	fs6, (6 * 8)(ca0)
+	cfld	fs7, (7 * 8)(ca0)
+	cfld	fs8, (8 * 8)(ca0)
+	cfld	fs9, (9 * 8)(ca0)
+	cfld	fs10, (10 * 8)(ca0)
+	cfld	fs11, (11 * 8)(ca0)
+	cincoffset ca0, ca0, (12 * 8)
+#endif
+
+	/* Load the return value */
+	mv	a0, a1
+	cret
 #else
 	/* Check the magic value */
 	ld	t0, 0(a0)
@@ -141,13 +230,18 @@ ENTRY(_longjmp)
 	/* Load the return value */
 	mv	a0, a1
 	ret
+#endif
 
 botch:
 #ifdef _STANDALONE
 	j	botch
+#elif defined(__CHERI_PURE_CAPABILITY__)
+	clgc	ct0, _C_LABEL(longjmperror)
+	cjalr	ct0
+	clgc	ct0, _C_LABEL(abort)
+	cjalr	ct0
 #else
 	call	_C_LABEL(longjmperror)
 	call	_C_LABEL(abort)
-#endif
 #endif
 END(_longjmp)

--- a/lib/libc/riscv/gen/setjmp.S
+++ b/lib/libc/riscv/gen/setjmp.S
@@ -39,7 +39,65 @@ __FBSDID("$FreeBSD$");
 
 ENTRY(setjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement setjmp")
+	cincoffset csp, csp, -(2 * 16)
+	csc	ca0, 0(csp)
+	csc	cra, 16(csp)
+
+	/* Store the signal mask */
+	cincoffset ca2, ca0, (_JB_SIGMASK * 8)	/* oset */
+	li	a1, 0				/* set */
+	li	a0, 1				/* SIG_BLOCK */
+	clgc	ct0, _C_LABEL(sigprocmask)
+	cjalr	ct0
+
+	clc	ca0, 0(csp)
+	clc	cra, 16(csp)
+	cincoffset csp, csp, (2 * 16)
+
+	/* Store the magic value and stack pointer */
+	cllc	ct0, .Lmagic
+	cld	t0, (ct0)
+	csc	ct0, (0 * 16)(ca0)
+	csc	csp, (1 * 16)(ca0)
+	cincoffset ca0, ca0, (2 * 16)
+
+	/* Store the general purpose registers and ra */
+	csc	cs0, (0 * 16)(ca0)
+	csc	cs1, (1 * 16)(ca0)
+	csc	cs2, (2 * 16)(ca0)
+	csc	cs3, (3 * 16)(ca0)
+	csc	cs4, (4 * 16)(ca0)
+	csc	cs5, (5 * 16)(ca0)
+	csc	cs6, (6 * 16)(ca0)
+	csc	cs7, (7 * 16)(ca0)
+	csc	cs8, (8 * 16)(ca0)
+	csc	cs9, (9 * 16)(ca0)
+	csc	cs10, (10 * 16)(ca0)
+	csc	cs11, (11 * 16)(ca0)
+	csc	cra, (12 * 16)(ca0)
+	cspecialr ct0, ddc
+	csc	ct0, (13 * 16)(ca0)
+	cincoffset ca0, ca0, (14 * 16)
+
+#ifdef __riscv_float_abi_double
+	/* Store the fpe registers */
+	cfsd	fs0, (0 * 8)(ca0)
+	cfsd	fs1, (1 * 8)(ca0)
+	cfsd	fs2, (2 * 8)(ca0)
+	cfsd	fs3, (3 * 8)(ca0)
+	cfsd	fs4, (4 * 8)(ca0)
+	cfsd	fs5, (5 * 8)(ca0)
+	cfsd	fs6, (6 * 8)(ca0)
+	cfsd	fs7, (7 * 8)(ca0)
+	cfsd	fs8, (8 * 8)(ca0)
+	cfsd	fs9, (9 * 8)(ca0)
+	cfsd	fs10, (10 * 8)(ca0)
+	cfsd	fs11, (11 * 8)(ca0)
+	cincoffset ca0, ca0, (12 * 8)
+#endif
+
+	/* Return value */
+	li	a0, 0
 	cret
 #else
 	addi	sp, sp, -(2 * 8)
@@ -98,17 +156,91 @@ ENTRY(setjmp)
 	/* Return value */
 	li	a0, 0
 	ret
+#endif
 	.align	3
 .Lmagic:
 	.quad	_JB_MAGIC_SETJMP
-#endif
 END(setjmp)
 
 ENTRY(longjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement longjmp")
-	unimp
+	/* Check the magic value */
+	cld	t0, 0(ca0)
+	cllc	ct1, .Lmagic
+	cld	t1, (ct1)
+	bne	t0, t1, botch
+
+	cincoffset csp, csp, -(3 * 16)
+	csc	ca0, (0 * 16)(csp)
+	csc	cra, (1 * 16)(csp)
+	csc	ca1, (2 * 16)(csp)
+
+	/* Restore the signal mask */
+	li	a2, 0				/* oset */
+	cincoffset ca1, ca0, (_JB_SIGMASK * 8)	/* set */
+	li	a0, 3				/* SIG_BLOCK */
+	clgc	ct0, _C_LABEL(sigprocmask)
+	cjalr	ct0
+
+	clc	ca1, (2 * 16)(csp)
+	clc	cra, (1 * 16)(csp)
+	clc	ca0, (0 * 16)(csp)
+	cincoffset csp, csp, (3 * 16)
+
+	/* Restore the stack pointer */
+	clc	csp, 16(ca0)
+	cincoffset ca0, ca0, (2 * 16)
+
+	/* Restore the general purpose registers and ra */
+	clc	cs0, (0 * 16)(ca0)
+	clc	cs1, (1 * 16)(ca0)
+	clc	cs2, (2 * 16)(ca0)
+	clc	cs3, (3 * 16)(ca0)
+	clc	cs4, (4 * 16)(ca0)
+	clc	cs5, (5 * 16)(ca0)
+	clc	cs6, (6 * 16)(ca0)
+	clc	cs7, (7 * 16)(ca0)
+	clc	cs8, (8 * 16)(ca0)
+	clc	cs9, (9 * 16)(ca0)
+	clc	cs10, (10 * 16)(ca0)
+	clc	cs11, (11 * 16)(ca0)
+	clc	cra, (12 * 16)(ca0)
+	clc	ct0, (13 * 16)(ca0)
+	cspecialw ddc, ct0
+	cincoffset ca0, ca0, (14 * 16)
+
+#ifdef __riscv_float_abi_double
+	/* Restore the fpe registers */
+	cfld	fs0, (0 * 8)(ca0)
+	cfld	fs1, (1 * 8)(ca0)
+	cfld	fs2, (2 * 8)(ca0)
+	cfld	fs3, (3 * 8)(ca0)
+	cfld	fs4, (4 * 8)(ca0)
+	cfld	fs5, (5 * 8)(ca0)
+	cfld	fs6, (6 * 8)(ca0)
+	cfld	fs7, (7 * 8)(ca0)
+	cfld	fs8, (8 * 8)(ca0)
+	cfld	fs9, (9 * 8)(ca0)
+	cfld	fs10, (10 * 8)(ca0)
+	cfld	fs11, (11 * 8)(ca0)
+	cincoffset ca0, ca0, (12 * 8)
+#endif
+
+	/* Load the return value */
+	mv	a0, a1
+	cret
+
+botch:
+	clgc	ct0, _C_LABEL(longjmperror)
+	cjalr	ct0
+	clgc	ct0, _C_LABEL(abort)
+	cjalr	ct0
 #else
+	/* Check the magic value */
+	ld	t0, 0(a0)
+	ld	t1, .Lmagic
+	bne	t0, t1, botch
+
 	addi	sp, sp, -(4 * 8)
 	sd	a0, (0 * 8)(sp)
 	sd	ra, (1 * 8)(sp)
@@ -124,11 +256,6 @@ ENTRY(longjmp)
 	ld	ra, (1 * 8)(sp)
 	ld	a0, (0 * 8)(sp)
 	addi	sp, sp, (4 * 8)
-
-	/* Check the magic value */
-	ld	t0, 0(a0)
-	ld	t1, .Lmagic
-	bne	t0, t1, botch
 
 	/* Restore the stack pointer */
 	ld	t0, 8(a0)

--- a/lib/libc/riscv/gen/sigsetjmp.S
+++ b/lib/libc/riscv/gen/sigsetjmp.S
@@ -39,8 +39,12 @@ __FBSDID("$FreeBSD$");
 
 ENTRY(sigsetjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement sigsetjmp")
-	cret
+	beqz	a1, 1f
+	clgc	ct0, _C_LABEL(setjmp)
+	cjr	ct0
+1:
+	clgc	ct0, _C_LABEL(_setjmp)
+	cjr	ct0
 #else
 	beqz	a1, 1f
 	tail	_C_LABEL(setjmp)
@@ -51,8 +55,18 @@ END(sigsetjmp)
 
 ENTRY(siglongjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
-#pragma message("TODO: RISCV-PURECAP implement siglongjmp")
-	unimp
+	/* Load the _setjmp magic */
+	cllc	ca2, .Lmagic
+	cld	a2, (ca2)
+	cld	a3, 0(ca0)
+
+	/* Check the magic */
+	beq	a2, a3, 1f
+	clgc	ct0, _C_LABEL(longjmp)
+	cjr	ct0
+1:
+	clgc	ct0, _C_LABEL(_longjmp)
+	cjr	ct0
 #else
 	/* Load the _setjmp magic */
 	ld	a2, .Lmagic
@@ -63,9 +77,9 @@ ENTRY(siglongjmp)
 	tail	_C_LABEL(longjmp)
 1:
 	tail	_C_LABEL(_longjmp)
+#endif
 
 	.align	3
 .Lmagic:
 	.quad	_JB_MAGIC__SETJMP
-#endif
 END(siglongjmp)

--- a/sys/riscv/include/setjmp.h
+++ b/sys/riscv/include/setjmp.h
@@ -40,7 +40,11 @@
 #include <sys/cdefs.h>
 
 #define	_JBLEN		63	/* sp, ra, [f]s0-11, magic val, sigmask */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	_JB_SIGMASK	44
+#else
 #define	_JB_SIGMASK	27
+#endif
 
 #ifdef	__ASSEMBLER__
 #define	_JB_MAGIC__SETJMP	0xbe87fd8a2910af00


### PR DESCRIPTION
This keeps the same size jump buffer as the hybrid ABI.  The magic
value and capability registers take up two slots instead of 1.
Floating point registers are still packed as 8-byte values.  The
signal mask is still stored after the floating point, but that is in a
different slot for purecap than hybrid.