### PR TITLE
Per-page capability-dirty tracking, take N+1

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -616,3 +616,72 @@ CHERIBSDTEST(cheribsdtest_vm_cow_write,
 	CHERIBSDTEST_CHECK_SYSCALL(close(fd));
 	cheribsdtest_success();
 }
+
+/*
+ * Store a cap to a page and check that mincore reports it CAPSTORE.
+ *
+ * Due to a shortage of bits in mincore()'s uint8_t reporting bit vector, this
+ * particular test is not able to distinguish CAPSTORE and CAPDIRTY and so is
+ * not sensitive to the vm.pmap.enter_capstore_as_capdirty sysctl.
+ *
+ * On the other hand, this test is sensitive to the vm.capstore_on_alloc sysctl:
+ * if that is asserted, our cap-capable anonymous memory will be installed
+ * CAPSTORE (and possibly even CAPDIRTY, in light of the above) whereas, if this
+ * sysctl is clear, our initial view of said memory will be !CAPSTORE.
+ */
+CHERIBSDTEST(cheribsdtest_vm_capdirty, "verify capdirty marking and mincore")
+{
+	static const size_t npg = 2;
+	size_t sz = npg * getpagesize();
+	uint8_t capstore_on_alloc;
+	size_t capstore_on_alloc_sz = sizeof(capstore_on_alloc);
+
+	void * __capability *pg0;
+	unsigned char mcv[npg] = { 0 };
+
+	CHERIBSDTEST_CHECK_SYSCALL(
+	    sysctlbyname("vm.capstore_on_alloc", &capstore_on_alloc,
+	        &capstore_on_alloc_sz, NULL, 0));
+
+	pg0 = CHERIBSDTEST_CHECK_SYSCALL(
+	    mmap(NULL, sz, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
+
+	void * __capability *pg1 = (void *)&((char *)pg0)[getpagesize()];
+
+	/*
+	 * Pages are ZFOD and so will not be CAPSTORE, or, really, anything
+	 * else, either.
+	 */
+	CHERIBSDTEST_CHECK_SYSCALL(mincore(pg0, sz, &mcv[0]));
+	CHERIBSDTEST_VERIFY2(mcv[0] == 0, "page 0 status 0");
+	CHERIBSDTEST_VERIFY2(mcv[1] == 0, "page 1 status 0");
+
+	/*
+	 * Write data to page 0, causing it to become allocated and MODIFIED.
+	 * If vm.capstore_on_alloc, then it should be CAPSTORE as well, despite
+	 * having never been the target of a capability store.
+	 */
+	*(char *)pg0 = 0x42;
+
+	CHERIBSDTEST_CHECK_SYSCALL(mincore(pg0, sz, &mcv[0]));
+	CHERIBSDTEST_VERIFY2(
+	    (mcv[0] & MINCORE_MODIFIED) != 0, "page 0 modified 1");
+	CHERIBSDTEST_VERIFY2(
+	    !(mcv[0] & MINCORE_CAPSTORE) == !capstore_on_alloc,
+	    "page 0 capstore 1");
+
+	/*
+	 * Write a capability to page 1 and check that it is MODIFIED and
+	 * CAPSTORE regardless of vm.capstore_on_alloc.
+	 */
+	*pg1 = (__cheri_tocap void * __capability)pg0;
+
+	CHERIBSDTEST_CHECK_SYSCALL(mincore(pg0, sz, &mcv[0]));
+	CHERIBSDTEST_VERIFY2(
+	    (mcv[1] & MINCORE_MODIFIED) != 0, "page 1 modified 2");
+	CHERIBSDTEST_VERIFY2(
+	    (mcv[1] & MINCORE_CAPSTORE) != 0, "page 1 capstore 2");
+
+	CHERIBSDTEST_CHECK_SYSCALL(munmap(pg0, sz));
+	cheribsdtest_success();
+}

--- a/sys/mips/include/pmap.h
+++ b/sys/mips/include/pmap.h
@@ -184,6 +184,9 @@ void *pmap_kenter_temporary(vm_paddr_t pa, int i);
 void pmap_kenter_temporary_free(vm_paddr_t pa);
 void pmap_flush_pvcache(vm_page_t m);
 int pmap_emulate_modified(pmap_t pmap, vm_offset_t va);
+#ifdef CPU_CHERI
+int pmap_emulate_capdirty(pmap_t pmap, vm_offset_t va);
+#endif
 void pmap_page_set_memattr(vm_page_t, vm_memattr_t);
 int pmap_change_attr(vm_offset_t, vm_size_t, vm_memattr_t);
 

--- a/sys/mips/include/pte.h
+++ b/sys/mips/include/pte.h
@@ -210,10 +210,10 @@ pde_page_bound(vm_pointer_t ptr)
  *
  * Upper bits of a 64 bit PTE:
  *
- *   63-62   61-----59   58 -- 56    55   54   53
- *   ---------------------------------------------
- *  |  RG  |           | PG SZ IDX | MN | W  | RO |
- *   ---------------------------------------------
+ *   63-62   61-60    59   58 -- 56    55   54   53
+ *   ------------------------------------------------
+ *  |  RG  |       | CRO | PG SZ IDX | MN | W  | RO |
+ *   ------------------------------------------------
  *
  * VM flags managed in software:
  *
@@ -240,6 +240,10 @@ pde_page_bound(vm_pointer_t ptr)
  *
  *  W:  Wired.  ???
  *
+ *  CRO: CHERI-only.  Capability read only.  Never clear PTE_SCI on this
+ *       entry, and fail attempts to store capabilities to it.  The negation
+ *       of PGA_CAPSTORE.
+ *
  *  RO: Read only.  Never set PTE_D on this page, and don't
  *      listen to requests to write to it.
  *
@@ -258,6 +262,9 @@ pde_page_bound(vm_pointer_t ptr)
 #define	PTE_PS_16M		((pt_entry_t)0x30 << TLBLO_SWBITS_SHIFT)
 #define	PTE_PS_64M		((pt_entry_t)0x38 << TLBLO_SWBITS_SHIFT)
 #define	PTE_PS_IDX_MASK		((pt_entry_t)0x38 << TLBLO_SWBITS_SHIFT)
+#if defined(CPU_CHERI)
+#define	PTE_CRO			((pt_entry_t)0x40 << TLBLO_SWBITS_SHIFT)
+#endif
 #endif
 
 #ifdef CPU_CHERI

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -1561,8 +1561,13 @@ pmap_pv_reclaim(pmap_t locked_pmap)
 				else
 					*pte = 0;
 				m = PHYS_TO_VM_PAGE(TLBLO_PTE_TO_PA(oldpte));
-				if (pte_test(&oldpte, PTE_D))
+				if (pte_test(&oldpte, PTE_D)) {
 					vm_page_dirty(m);
+#ifdef CPU_CHERI
+					if (!pte_test(&oldpte, PTE_SCI))
+						vm_page_capdirty(m);
+#endif
+				}
 				if (m->md.pv_flags & PV_TABLE_REF)
 					vm_page_aflag_set(m, PGA_REFERENCED);
 				m->md.pv_flags &= ~PV_TABLE_REF;
@@ -1860,6 +1865,10 @@ pmap_remove_pte(struct pmap *pmap, pt_entry_t *ptq, vm_offset_t va,
 			    ("%s: modified page not writable: va: %#jx, pte: %#jx",
 			    __func__, va, (uintmax_t)oldpte));
 			vm_page_dirty(m);
+#ifdef CPU_CHERI
+			if (!pte_test(&oldpte, PTE_SCI))
+				vm_page_capdirty(m);
+#endif
 		}
 		if (m->md.pv_flags & PV_TABLE_REF)
 			vm_page_aflag_set(m, PGA_REFERENCED);
@@ -2065,6 +2074,10 @@ pmap_remove_all(vm_page_t m)
 			    ("%s: modified page not writable: va: %#jx, pte: %#jx",
 			    __func__, pv->pv_va, (uintmax_t)tpte));
 			vm_page_dirty(m);
+#ifdef CPU_CHERI
+			if (!pte_test(&tpte, PTE_SCI))
+				vm_page_capdirty(m);
+#endif
 		}
 
 		if (!pmap_unuse_pt(pmap, pv->pv_va, *pde))
@@ -2146,6 +2159,15 @@ pmap_protect(pmap_t pmap, vm_offset_t sva, vm_offset_t eva, vm_prot_t prot)
 					pa = TLBLO_PTE_TO_PA(pbits);
 					m = PHYS_TO_VM_PAGE(pa);
 					vm_page_dirty(m);
+
+#ifdef CPU_CHERI
+					/* Leave PTE_SCI clear, but update MI */
+					if (!pte_test(&pbits, PTE_SCI)) {
+						pa = TLBLO_PTE_TO_PA(pbits);
+						m = PHYS_TO_VM_PAGE(pa);
+						vm_page_capdirty(m);
+					}
+#endif
 				}
 				if (va == va_next)
 					va = sva;
@@ -2238,7 +2260,13 @@ pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 	origpte = *pte;
 	KASSERT(!pte_test(&origpte, PTE_D | PTE_RO | PTE_V),
 	    ("pmap_enter: modified page not writable: va: %p, pte: %#jx",
-	    (void *)(uintptr_t)va, (uintmax_t)origpte));
+	    (void *)va, (uintmax_t)origpte));
+#ifdef CPU_CHERI
+	KASSERT(
+	    !pte_test(&origpte, PTE_CRO | PTE_V) || pte_test(&origpte, PTE_SCI),
+	    ("pmap_enter: capdirty with CRO set: va: %p, pte: %#jx", (void *)va,
+		(uintmax_t)origpte));
+#endif
 	opa = TLBLO_PTE_TO_PA(origpte);
 
 	/*
@@ -2288,6 +2316,10 @@ pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 			om = PHYS_TO_VM_PAGE(opa);
 			if (pte_test(&origpte, PTE_D))
 				vm_page_dirty(om);
+#ifdef CPU_CHERI
+			if (!pte_test(&origpte, PTE_SCI))
+				vm_page_capdirty(m);
+#endif
 			if ((om->md.pv_flags & PV_TABLE_REF) != 0) {
 				om->md.pv_flags &= ~PV_TABLE_REF;
 				vm_page_aflag_set(om, PGA_REFERENCED);
@@ -2353,6 +2385,12 @@ validate:
 				if (pte_test(&origpte, PTE_MANAGED))
 					vm_page_dirty(m);
 			}
+#ifdef CPU_CHERI
+			if (!pte_test(&origpte, PTE_SCI)) {
+				if (pte_test(&origpte, PTE_MANAGED))
+					vm_page_capdirty(m);
+			}
+#endif
 			pmap_update_page(pmap, va, newpte);
 		}
 	}
@@ -2565,6 +2603,8 @@ pmap_kenter_temporary_free(vm_paddr_t pa)
  * virtual address end.  Not every virtual page between start and end
  * is mapped; only those for which a resident page exists with the
  * corresponding offset from m_start are mapped.
+ *
+ * This function has the same assumptions as pmap_enter_quick, above.
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
@@ -2729,6 +2769,12 @@ pmap_copy_page_internal(vm_page_t src, vm_page_t dst, int flags)
 	vm_pointer_t va_src, va_dst;
 	vm_paddr_t phys_src = VM_PAGE_TO_PHYS(src);
 	vm_paddr_t phys_dst = VM_PAGE_TO_PHYS(dst);
+
+#if __has_feature(capabilities)
+	if (flags & PMAP_COPY_TAGS) {
+		VM_PAGE_ASSERT_PGA_CAPMETA_COPY(src, dst);
+	}
+#endif
 
 	if (MIPS_DIRECT_MAPPABLE(phys_src) && MIPS_DIRECT_MAPPABLE(phys_dst)) {
 		/* easy case, all can be accessed via KSEG0 */
@@ -2998,6 +3044,10 @@ pmap_remove_pages(pmap_t pmap)
 				 */
 				if (pte_test(&tpte, PTE_D))
 					vm_page_dirty(m);
+#ifdef CPU_CHERI
+				if (!pte_test(&tpte, PTE_SCI))
+					vm_page_capdirty(m);
+#endif
 
 				/* Mark free */
 				PV_STAT(pv_entry_frees++);
@@ -3030,7 +3080,7 @@ pmap_remove_pages(pmap_t pmap)
  * pmap_testbit tests bits in pte's
  */
 static boolean_t
-pmap_testbit(vm_page_t m, int bit)
+pmap_testbit(vm_page_t m, pt_entry_t bit)
 {
 	pv_entry_t pv;
 	pmap_t pmap;
@@ -3111,6 +3161,11 @@ pmap_remove_write(vm_page_t m)
 			pte_clear(&pbits, PTE_D);
 			vm_page_dirty(m);
 		}
+#ifdef CPU_CHERI
+		/* Leave PTE_SCI clear, but update MI */
+		if (!pte_test(&pbits, PTE_SCI))
+			vm_page_capdirty(m);
+#endif
 		pte_set(&pbits, PTE_RO);
 		if (pbits != *pte) {
 			*pte = pbits;
@@ -3264,6 +3319,14 @@ pmap_advise(pmap_t pmap, vm_offset_t sva, vm_offset_t eva, int advice)
 					if (va == va_next)
 						va = sva;
 				}
+
+				/*
+				 * Despite possibly changing PTE_D, preserve
+				 * capstore permission (PTE_CRO) and capdirty
+				 * status (PTE_SCI).  Either the page will be
+				 * laundered or will come back into service in
+				 * situ and with preserved contents.
+				 */
 			} else {
 				/*
 				 * Unless PTE_D is set, any TLB entries
@@ -3609,21 +3672,61 @@ init_pte_prot(vm_page_t m, vm_prot_t access, vm_prot_t prot)
 {
 	pt_entry_t rw;
 
-	if (!(prot & VM_PROT_WRITE))
+	if (!(prot & VM_PROT_WRITE)) {
 		rw = PTE_V | PTE_RO;
-	else if ((m->oflags & VPO_UNMANAGED) == 0) {
+#ifdef CPU_CHERI
+		rw |= PTE_CRO | PTE_SCI;
+#endif
+	} else if ((m->oflags & VPO_UNMANAGED) == 0) {
 		if ((access & VM_PROT_WRITE) != 0)
 			rw = PTE_V | PTE_D;
 		else
 			rw = PTE_V;
-	} else
+
+#ifdef CPU_CHERI
+		vm_page_astate_t mas = vm_page_astate_load(m);
+
+		KASSERT(!(mas.flags & PGA_CAPDIRTY) ||
+		    (mas.flags & PGA_CAPSTORE),
+		    ("pmap inserting CAPDIRTY w/o CAPSTORE m=%p", m));
+
+		if ((prot & VM_PROT_WRITE_CAP) != 0 &&
+		    (mas.flags & PGA_CAPSTORE) != 0) {
+			/*
+			 * The page is CAPSTORE and this mapping is
+			 * VM_PROT_WRITE_CAP.  Leave PTE_CRO clear, and if
+			 * neither the page is CAPDIRTY nor is this entry being
+			 * created in response to a cap-write, set PTE_SCI.
+			 */
+
+			if ((mas.flags & PGA_CAPDIRTY) == 0 &&
+			    (access & VM_PROT_WRITE_CAP) == 0)
+				rw |= PTE_SCI;
+		} else {
+			/*
+			 * The page is not writable OR the mapping is not
+			 * VM_PROT_WRITE_CAP OR the page is not CAPSTORE:
+			 * set both inhibits.
+			 */
+			rw |= PTE_SCI | PTE_CRO;
+		}
+#endif
+	} else {
 		/* Needn't emulate a modified bit for unmanaged pages. */
 		rw = PTE_V | PTE_D;
+
+#ifdef CPU_CHERI
+		if ((prot & VM_PROT_WRITE_CAP) == 0)
+			rw |= PTE_SCI | PTE_CRO;
+		else
+			KASSERT(vm_page_astate_load(m).flags & PGA_CAPSTORE,
+			    ("pmap_enter UNMANAGED WRITE_CAP w/o CAPSTORE"));
+#endif
+	}
+
 #ifdef CPU_CHERI
 	if ((prot & VM_PROT_READ_CAP) == 0)
 		rw |= PTE_LCI;
-	if ((prot & VM_PROT_WRITE_CAP) == 0)
-		rw |= PTE_SCI;
 #endif
 	return (rw);
 }
@@ -3710,6 +3813,46 @@ pmap_emulate_modified(pmap_t pmap, vm_offset_t va)
 
 	return (0);
 }
+
+#ifdef CPU_CHERI
+/* XREF pmap_emulate_modified */
+int
+pmap_emulate_capdirty(pmap_t pmap, vm_offset_t va)
+{
+	pt_entry_t *pte;
+
+	PMAP_LOCK(pmap);
+	pte = pmap_pte(pmap, va);
+	if (pte == NULL) {
+		PMAP_UNLOCK(pmap);
+		return (1);
+	}
+
+	if (!pte_test(pte, PTE_V) || !pte_test(pte, PTE_D)) {
+		PMAP_UNLOCK(pmap);
+		return (1);
+	}
+
+	if (!pte_test(pte, PTE_SCI)) {
+		tlb_update(pmap, va, *pte);
+		PMAP_UNLOCK(pmap);
+		return (0);
+	}
+
+	if (pte_test(pte, PTE_RO) || pte_test(pte, PTE_CRO)) {
+		PMAP_UNLOCK(pmap);
+		return (1);
+	}
+
+	if (!pte_test(pte, PTE_MANAGED))
+		panic("pmap_emulate_capdirty: unmanaged page");
+
+	pte_clear(pte, PTE_SCI);
+	tlb_update(pmap, va, *pte);
+	PMAP_UNLOCK(pmap);
+	return (0);
+}
+#endif
 
 /*
  *	Routine:	pmap_kextract

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -3489,6 +3489,10 @@ pmap_mincore(pmap_t pmap, vm_offset_t addr, vm_paddr_t *pap)
 	val = MINCORE_INCORE;
 	if (pte_test(&pte, PTE_D))
 		val |= MINCORE_MODIFIED | MINCORE_MODIFIED_OTHER;
+#ifdef CPU_CHERI
+	if (!pte_test(&pte, PTE_CRO))
+		val |= MINCORE_CAPSTORE;
+#endif
 	pa = TLBLO_PTE_TO_PA(pte);
 	if (pte_test(&pte, PTE_MANAGED)) {
 		/*

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -691,6 +691,49 @@ cpu_fetch_syscall_args(struct thread *td)
 #define __FBSDID(x)
 #include "../../kern/subr_syscall.c"
 
+#ifdef CPU_CHERI
+/*
+ * Some CHERI faults are (or may be) used transparently and don't (or may not)
+ * count as real faults.  This function returns true if it has handled the fault
+ * and no further work is to be done.  If the function returns false, it will
+ * have set *ftype to the appropriate fault code to pass to the VM subsystem for
+ * it to try hiding the fault.
+ *
+ * At the moment, there's just the one, CHERI_EXCCODE_TLBSTORE, which we hook
+ * to emulate capdirty tracking.  If the PTE for badvaddr permits transparent
+ * upgrade to capdirty, then we do so and squash the rest of the fault handling;
+ * otherwise, we indicate that this is a write fault that also needs to set a
+ * capability tag.  This logic is identical to the TLB_MOD paths through trap(),
+ * which call pmap_emulate_modified().
+ *
+ * In the future, this function will also hook capability load generation faults
+ * and call into the revoker to check all the capabilities on the target page.
+ */
+static inline bool
+c2e_fixup_fault(struct trapframe *trapframe, bool is_kernel,
+    struct vmspace *uvms, vm_prot_t *ftype)
+{
+	vm_offset_t va = trapframe->badvaddr;
+	register_t cause = trapframe->capcause;
+
+	cause &= CHERI_CAPCAUSE_EXCCODE_MASK;
+	cause >>= CHERI_CAPCAUSE_EXCCODE_SHIFT;
+
+	if (cause == CHERI_EXCCODE_TLBSTORE) {
+		*ftype = VM_PROT_WRITE | VM_PROT_WRITE_CAP;
+
+		if (KERNLAND(va)) {
+			return (is_kernel &&
+			    !pmap_emulate_capdirty(kernel_pmap, va));
+		} else {
+			pmap_t upmap = vmspace_pmap(uvms);
+			return (!pmap_emulate_capdirty(upmap, va));
+		}
+	}
+
+	return false;
+}
+#endif
 
 /*
  * Handle an exception.
@@ -1162,6 +1205,19 @@ dofault:
 		break;
 #ifdef CPU_CHERI
 	case T_C2E:
+		ftype = 0;
+
+		if (!c2e_fixup_fault(trapframe, true, p->p_vmspace, &ftype)) {
+			if (ftype != 0) {
+				if (KERNLAND(trapframe->badvaddr))
+					goto kernel_fault;
+				else
+					goto dofault;
+			}
+		} else {
+			return (trapframe->pc);
+		}
+
 		if (td->td_pcb->pcb_onfault != NULL) {
 			pc = trapf_pc_from_kernel_code_ptr(td->td_pcb->pcb_onfault);
 			td->td_pcb->pcb_onfault = NULL;
@@ -1177,6 +1233,15 @@ dofault:
 
 	case T_C2E + T_USER:
 		msg = "USER_CHERI_EXCEPTION";
+		ftype = 0;
+
+		if (!c2e_fixup_fault(trapframe, false, p->p_vmspace, &ftype)) {
+			if (ftype != 0)
+				goto dofault;
+		} else {
+			goto out;
+		}
+
 		fetch_bad_instr(trapframe);
 		if (log_user_cheri_exceptions)
 			log_c2e_exception(msg, trapframe, type);

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -2487,13 +2487,13 @@ pmap_fault_fixup(pmap_t pmap, vm_offset_t va, vm_prot_t ftype)
 	}
 
 	if ((pmap != kernel_pmap && (oldpte & PTE_U) == 0) ||
-	    (ftype == VM_PROT_WRITE && (oldpte & PTE_W) == 0) ||
+	    (((ftype & VM_PROT_WRITE) != 0) && (oldpte & PTE_W) == 0) ||
 	    (ftype == VM_PROT_EXECUTE && (oldpte & PTE_X) == 0) ||
 	    (ftype == VM_PROT_READ && (oldpte & PTE_R) == 0))
 		goto done;
 
 	bits = PTE_A;
-	if (ftype == VM_PROT_WRITE)
+	if ((ftype & VM_PROT_WRITE) != 0)
 		bits |= PTE_D;
 
 	/*

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -217,6 +217,12 @@ __FBSDID("$FreeBSD$");
 #define	VM_PAGE_TO_PV_LIST_LOCK(m)	\
 			PHYS_TO_PV_LIST_LOCK(VM_PAGE_TO_PHYS(m))
 
+#if __has_feature(capabilities)
+#define PTE_DIRTY_BITS	(PTE_D | PTE_CD)
+#else
+#define PTE_DIRTY_BITS	(PTE_D)
+#endif
+
 /* The list of all the user pmaps */
 LIST_HEAD(pmaplist, pmap);
 static struct pmaplist allpmaps = LIST_HEAD_INITIALIZER();
@@ -2078,6 +2084,18 @@ pmap_remove_kernel_l2(pmap_t pmap, pt_entry_t *l2, vm_offset_t va)
 	    __func__, l2, oldl2));
 }
 
+static __inline void
+pmap_page_dirty(pt_entry_t entry, vm_page_t m)
+{
+	if ((entry & PTE_D) != 0)
+		vm_page_dirty(m);
+
+#if __has_feature(capabilities)
+	if ((entry & PTE_CD) != 0)
+		vm_page_capdirty(m);
+#endif
+}
+
 /*
  * pmap_remove_l2: Do the things to unmap a level 2 superpage.
  */
@@ -2114,8 +2132,7 @@ pmap_remove_l2(pmap_t pmap, pt_entry_t *l2, vm_offset_t sva,
 		eva = sva + L2_SIZE;
 		for (va = sva, m = PHYS_TO_VM_PAGE(PTE_TO_PHYS(oldl2));
 		    va < eva; va += PAGE_SIZE, m++) {
-			if ((oldl2 & PTE_D) != 0)
-				vm_page_dirty(m);
+			pmap_page_dirty(oldl2, m);
 			if ((oldl2 & PTE_A) != 0)
 				vm_page_aflag_set(m, PGA_REFERENCED);
 			if (TAILQ_EMPTY(&m->md.pv_list) &&
@@ -2162,8 +2179,7 @@ pmap_remove_l3(pmap_t pmap, pt_entry_t *l3, vm_offset_t va,
 	if (old_l3 & PTE_SW_MANAGED) {
 		phys = PTE_TO_PHYS(old_l3);
 		m = PHYS_TO_VM_PAGE(phys);
-		if ((old_l3 & PTE_D) != 0)
-			vm_page_dirty(m);
+		pmap_page_dirty(old_l3, m);
 		if (old_l3 & PTE_A)
 			vm_page_aflag_set(m, PGA_REFERENCED);
 		CHANGE_PV_LIST_LOCK_TO_VM_PAGE(lockp, m);
@@ -2341,8 +2357,7 @@ pmap_remove_all(vm_page_t m)
 		/*
 		 * Update the vm_page_t clean and reference bits.
 		 */
-		if ((l3e & PTE_D) != 0)
-			vm_page_dirty(m);
+		pmap_page_dirty(l3e, m);
 		pmap_unuse_pt(pmap, pv->pv_va, pmap_load(l2), &free);
 		TAILQ_REMOVE(&m->md.pv_list, pv, pv_next);
 		m->md.pv_gen++;
@@ -2406,12 +2421,12 @@ resume:
 			if (sva + L2_SIZE == va_next && eva >= va_next) {
 retryl2:
 				if ((prot & VM_PROT_WRITE) == 0 &&
-				    (l2e & (PTE_SW_MANAGED | PTE_D)) ==
-				    (PTE_SW_MANAGED | PTE_D)) {
+				    (l2e & PTE_SW_MANAGED) != 0 &&
+				    (l2e & PTE_DIRTY_BITS) != 0) {
 					pa = PTE_TO_PHYS(l2e);
 					m = PHYS_TO_VM_PAGE(pa);
 					for (mt = m; mt < &m[Ln_ENTRIES]; mt++)
-						vm_page_dirty(mt);
+						pmap_page_dirty(l2e, mt);
 				}
 				if (!atomic_fcmpset_long(l2, &l2e, l2e & ~mask))
 					goto retryl2;
@@ -2448,10 +2463,10 @@ retryl3:
 			if ((l3e & PTE_V) == 0)
 				continue;
 			if ((prot & VM_PROT_WRITE) == 0 &&
-			    (l3e & (PTE_SW_MANAGED | PTE_D)) ==
-			    (PTE_SW_MANAGED | PTE_D)) {
+			    (l3e & PTE_SW_MANAGED) != 0 &&
+			    (l3e & PTE_DIRTY_BITS) != 0) {
 				m = PHYS_TO_VM_PAGE(PTE_TO_PHYS(l3e));
-				vm_page_dirty(m);
+				pmap_page_dirty(l3e, m);
 			}
 			if (!atomic_fcmpset_long(l3, &l3e, l3e & ~mask))
 				goto retryl3;
@@ -2487,7 +2502,10 @@ pmap_fault_fixup(pmap_t pmap, vm_offset_t va, vm_prot_t ftype)
 	}
 
 	if ((pmap != kernel_pmap && (oldpte & PTE_U) == 0) ||
-	    (((ftype & VM_PROT_WRITE) != 0) && (oldpte & PTE_W) == 0) ||
+	    ((ftype & VM_PROT_WRITE) != 0 && (oldpte & PTE_W) == 0) ||
+#if __has_feature(capabilities)
+	    ((ftype & VM_PROT_WRITE_CAP) != 0 && (oldpte & PTE_CW) == 0) ||
+#endif
 	    (ftype == VM_PROT_EXECUTE && (oldpte & PTE_X) == 0) ||
 	    (ftype == VM_PROT_READ && (oldpte & PTE_R) == 0))
 		goto done;
@@ -2495,6 +2513,11 @@ pmap_fault_fixup(pmap_t pmap, vm_offset_t va, vm_prot_t ftype)
 	bits = PTE_A;
 	if ((ftype & VM_PROT_WRITE) != 0)
 		bits |= PTE_D;
+
+#if __has_feature(capabilities)
+	if ((ftype & VM_PROT_WRITE_CAP) != 0)
+		bits |= PTE_CD;
+#endif
 
 	/*
 	 * Spurious faults can occur if the implementation caches invalid
@@ -2685,6 +2708,38 @@ pmap_promote_l2(pmap_t pmap, pd_entry_t *l2, vm_offset_t va,
 }
 #endif
 
+#if __has_feature(capabilities)
+static __inline uint64_t
+cheri_pte_cw(vm_page_t m, vm_prot_t prot, u_int flags)
+{
+	vm_page_astate_t mas = vm_page_astate_load(m);
+
+	KASSERT((mas.flags & PGA_CAPDIRTY) == 0 ||
+	    (mas.flags & PGA_CAPSTORE) != 0,
+	    ("pmap inserting CAPDIRTY w/o CAPSTORE m=%p", m));
+
+	KASSERT((prot & VM_PROT_WRITE_CAP) == 0 ||
+	    (prot & VM_PROT_WRITE) != 0,
+	    ("pmap inserting PROT_WRITE_CAP w/o PROT_WRITE m=%p", m));
+
+	if ((prot & VM_PROT_WRITE_CAP) != 0 &&
+	    (mas.flags & PGA_CAPSTORE) != 0) {
+		/*
+		 * The page is CAPSTORE and this mapping is VM_PROT_WRITE_CAP.
+		 * Always set PTE_CW.  If the page is CAPDIRTY or this mapping
+		 * is being created in response to a cap-write, also set PTE_CD.
+		 */
+		if ((mas.flags & PGA_CAPDIRTY) != 0 ||
+		    (flags & VM_PROT_WRITE_CAP) != 0)
+			return (PTE_CW | PTE_CD);
+		else
+			return (PTE_CW);
+	}
+
+	return (0);
+}
+#endif
+
 /*
  *	Insert the given physical page (p) at
  *	the specified virtual address (v) in the
@@ -2731,8 +2786,7 @@ pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 #if __has_feature(capabilities)
 	if (prot & VM_PROT_READ_CAP)
 		new_l3 |= PTE_CR;
-	if (prot & VM_PROT_WRITE_CAP)
-		new_l3 |= PTE_CW | PTE_CD;
+	new_l3 |= cheri_pte_cw(m, prot, flags);
 #endif
 
 	new_l3 |= (pn << PTE_PPN0_S);
@@ -2892,8 +2946,7 @@ pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 			 * concurrent calls to pmap_page_test_mappings() and
 			 * pmap_ts_referenced().
 			 */
-			if ((orig_l3 & PTE_D) != 0)
-				vm_page_dirty(om);
+			pmap_page_dirty(orig_l3, om);
 			if ((orig_l3 & PTE_A) != 0)
 				vm_page_aflag_set(om, PGA_REFERENCED);
 			CHANGE_PV_LIST_LOCK_TO_PHYS(&lock, opa);
@@ -2949,9 +3002,8 @@ validate:
 		pmap_invalidate_page(pmap, va);
 		KASSERT(PTE_TO_PHYS(orig_l3) == pa,
 		    ("pmap_enter: invalid update"));
-		if ((orig_l3 & (PTE_D | PTE_SW_MANAGED)) ==
-		    (PTE_D | PTE_SW_MANAGED))
-			vm_page_dirty(m);
+		if ((orig_l3 & PTE_SW_MANAGED) != 0)
+			pmap_page_dirty(orig_l3, m);
 	} else {
 		pmap_store(l3, new_l3);
 	}
@@ -3483,6 +3535,9 @@ pmap_copy_page(vm_page_t msrc, vm_page_t mdst)
 void
 pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 {
+
+	VM_PAGE_ASSERT_PGA_CAPMETA_COPY(msrc, mdst);
+
 	vm_pointer_t src = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(msrc));
 	vm_pointer_t dst = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(mdst));
 
@@ -3803,14 +3858,15 @@ pmap_remove_pages(pmap_t pmap)
 				/*
 				 * Update the vm_page_t clean/reference bits.
 				 */
-				if ((tpte & (PTE_D | PTE_W)) ==
-				    (PTE_D | PTE_W)) {
+				if ((tpte & PTE_W) != 0 &&
+				    (tpte & PTE_DIRTY_BITS) != 0) {
 					if (superpage)
 						for (mt = m;
 						    mt < &m[Ln_ENTRIES]; mt++)
-							vm_page_dirty(mt);
+							pmap_page_dirty(tpte,
+							    mt);
 					else
-						vm_page_dirty(m);
+						pmap_page_dirty(tpte, m);
 				}
 
 				CHANGE_PV_LIST_LOCK_TO_VM_PAGE(&lock, m);
@@ -4038,8 +4094,7 @@ retry:
 			newl3 = oldl3 & ~(PTE_D | PTE_W);
 			if (!atomic_fcmpset_long(l3, &oldl3, newl3))
 				goto retry;
-			if ((oldl3 & PTE_D) != 0)
-				vm_page_dirty(m);
+			pmap_page_dirty(oldl3, m);
 			pmap_invalidate_page(pmap, pv->pv_va);
 		}
 		PMAP_UNLOCK(pmap);
@@ -4109,13 +4164,13 @@ retry:
 		va = pv->pv_va;
 		l2 = pmap_l2(pmap, va);
 		l2e = pmap_load(l2);
-		if ((l2e & (PTE_W | PTE_D)) == (PTE_W | PTE_D)) {
+		if ((l2e & PTE_W) != 0) {
 			/*
 			 * Although l2e is mapping a 2MB page, because
 			 * this function is called at a 4KB page granularity,
 			 * we only update the 4KB page under test.
 			 */
-			vm_page_dirty(m);
+			pmap_page_dirty(l2e, m);
 		}
 		if ((l2e & PTE_A) != 0) {
 			/*
@@ -4179,8 +4234,7 @@ small_mappings:
 
 		l3 = pmap_l2_to_l3(l2, pv->pv_va);
 		l3e = pmap_load(l3);
-		if ((l3e & PTE_D) != 0)
-			vm_page_dirty(m);
+		pmap_page_dirty(l3e, m);
 		if ((l3e & PTE_A) != 0) {
 			if ((l3e & PTE_SW_WIRED) == 0) {
 				/*

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -4425,6 +4425,10 @@ pmap_mincore(pmap_t pmap, vm_offset_t addr, vm_paddr_t *pap)
 			val |= MINCORE_MODIFIED | MINCORE_MODIFIED_OTHER;
 		if ((tpte & PTE_A) != 0)
 			val |= MINCORE_REFERENCED | MINCORE_REFERENCED_OTHER;
+#if __has_feature(capabilities)
+		if ((tpte & PTE_CW) != 0)
+			val |= MINCORE_CAPSTORE;
+#endif
 		managed = (tpte & PTE_SW_MANAGED) == PTE_SW_MANAGED;
 	} else {
 		managed = false;

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -345,6 +345,10 @@ page_fault_handler(struct trapframe *frame, int usermode)
 		ftype = VM_PROT_WRITE;
 	} else if (frame->tf_scause == SCAUSE_INST_PAGE_FAULT) {
 		ftype = VM_PROT_EXECUTE;
+#if __has_feature(capabilities)
+	} else if (frame->tf_scause == SCAUSE_STORE_AMO_CAP_PAGE_FAULT) {
+		ftype = VM_PROT_WRITE | VM_PROT_WRITE_CAP;
+#endif
 	} else {
 		ftype = VM_PROT_READ;
 	}
@@ -418,6 +422,9 @@ do_trap_supervisor(struct trapframe *frame)
 	case SCAUSE_STORE_PAGE_FAULT:
 	case SCAUSE_LOAD_PAGE_FAULT:
 	case SCAUSE_INST_PAGE_FAULT:
+#if __has_feature(capabilities)
+	case SCAUSE_STORE_AMO_CAP_PAGE_FAULT:
+#endif
 		page_fault_handler(frame, 0);
 		break;
 	case SCAUSE_BREAKPOINT:
@@ -440,7 +447,6 @@ do_trap_supervisor(struct trapframe *frame)
 		break;
 #if __has_feature(capabilities)
 	case SCAUSE_LOAD_CAP_PAGE_FAULT:
-	case SCAUSE_STORE_AMO_CAP_PAGE_FAULT:
 	case SCAUSE_CHERI:
 		if (curthread->td_pcb->pcb_onfault != 0) {
 			frame->tf_a[0] = EPROT;
@@ -508,6 +514,9 @@ do_trap_user(struct trapframe *frame)
 	case SCAUSE_STORE_PAGE_FAULT:
 	case SCAUSE_LOAD_PAGE_FAULT:
 	case SCAUSE_INST_PAGE_FAULT:
+#if __has_feature(capabilities)
+	case SCAUSE_STORE_AMO_CAP_PAGE_FAULT:
+#endif
 		page_fault_handler(frame, 1);
 		break;
 	case SCAUSE_ECALL_USER:
@@ -548,12 +557,6 @@ do_trap_user(struct trapframe *frame)
 		if (log_user_cheri_exceptions)
 			dump_cheri_exception(frame);
 		call_trapsignal(td, SIGSEGV, SEGV_LOADTAG,
-		    (uintcap_t)frame->tf_stval, exception, 0);
-		break;
-	case SCAUSE_STORE_AMO_CAP_PAGE_FAULT:
-		if (log_user_cheri_exceptions)
-			dump_cheri_exception(frame);
-		call_trapsignal(td, SIGSEGV, SEGV_STORETAG,
 		    (uintcap_t)frame->tf_stval, exception, 0);
 		break;
 	case SCAUSE_CHERI:

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -201,6 +201,7 @@
 #define	MINCORE_MODIFIED_OTHER	0x10 /* Page has been modified */
 #define	MINCORE_SUPER		0x60 /* Page is a "super" page */
 #define	MINCORE_PSIND(i)	(((i) << 5) & MINCORE_SUPER) /* Page size */
+#define	MINCORE_CAPSTORE	0x80 /* Page monitored for capabilities */
 
 /*
  * Anonymous object constant for shm_open().

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -2198,6 +2198,7 @@ swp_pager_meta_cheri_get_tags(vm_page_t page)
 	void * __capability *p;
 	struct swblk *sb;
 	vm_pindex_t swidx;
+	bool mark_capdirty = false;
 
 	swidx = rounddown(page->pindex, SWAP_META_PAGES);
 	scan = (void *)PHYS_TO_DMAP(VM_PAGE_TO_PHYS(page));
@@ -2207,12 +2208,20 @@ swp_pager_meta_cheri_get_tags(vm_page_t page)
 	    i < (swidx + 1) * BITS_PER_TAGS_PER_PAGE; i++) {
 		p = scan;
 		for (t = sb->swb_tags[i]; t != 0; t >>= j) {
+			mark_capdirty = true;
 			j = ffsl((long)t);
 			cheri_restore_tag(p + j - 1);
 			p += j;
 		}
 		scan += 8 * sizeof(uint64_t);
 	}
+
+	/*
+	 * Because we stored through the direct region we may have bypassed
+	 * the MMU and all its implicit capdirty tracking.
+	 */
+	if (mark_capdirty)
+		vm_page_aflag_set(page, PGA_CAPSTORE | PGA_CAPDIRTY);
 }
 
 /*

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -989,9 +989,11 @@ vm_fault_cow(struct faultstate *fs)
 		KASSERT(fs->first_object->flags & OBJ_HASCAP,
 		    ("%s: destination object %p doesn't have OBJ_HASCAP",
 		    __func__, fs->first_object));
-		if (fs->object->flags & OBJ_HASCAP)
+		if (fs->object->flags & OBJ_HASCAP) {
+			vm_page_aflag_set(fs->first_m, fs->m->a.flags &
+			    (PGA_CAPSTORE | PGA_CAPDIRTY));
 			pmap_copy_page_tags(fs->m, fs->first_m);
-		else
+		} else
 #endif
 			pmap_copy_page(fs->m, fs->first_m);
 
@@ -2071,9 +2073,12 @@ again:
 			 * Preserve tags if the source page contains tags.
 			 * See longer discussion in vm_fault_cow.
 			 */
-			if (object->flags & OBJ_HASCAP)
+			if (object->flags & OBJ_HASCAP) {
+				/* Copy across CAPSTORE|CAPDIRTY state, too */
+				vm_page_aflag_set(dst_m, src_m->a.flags &
+				    (PGA_CAPSTORE | PGA_CAPDIRTY));
 				pmap_copy_page_tags(src_m, dst_m);
-			else
+			} else
 #endif
 				pmap_copy_page(src_m, dst_m);
 			VM_OBJECT_RUNLOCK(object);

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -170,6 +170,12 @@ SYSCTL_INT(_vm, OID_AUTO, pfault_oom_wait, CTLFLAG_RWTUN,
     "Number of seconds to wait for free pages before retrying "
     "the page fault handler");
 
+static bool capstore_on_alloc = 1;
+SYSCTL_BOOL(_vm, OID_AUTO, capstore_on_alloc, CTLFLAG_RW,
+    &capstore_on_alloc, 0,
+    "Mark cap-writable pages CAPSTORE on allocation; trades revoker effort for "
+    "the expense of upgrading.");
+
 static inline void
 fault_page_release(vm_page_t *mp)
 {
@@ -598,7 +604,7 @@ vm_fault_populate(struct faultstate *fs)
 				(*fs->m_hold) = &m[i];
 				vm_page_wire(&m[i]);
 			}
-			if (fs->prot & VM_PROT_WRITE_CAP)
+			if (capstore_on_alloc && (fs->prot & VM_PROT_WRITE_CAP))
 				vm_page_aflag_set(&m[i], PGA_CAPSTORE);
 			vm_page_xunbusy(&m[i]);
 		}
@@ -1187,7 +1193,7 @@ vm_fault_allocate(struct faultstate *fs)
 	}
 	fs->oom = 0;
 
-	if (fs->prot & VM_PROT_WRITE_CAP)
+	if (capstore_on_alloc && (fs->prot & VM_PROT_WRITE_CAP))
 		vm_page_aflag_set(fs->m, PGA_CAPSTORE);
 
 	return (KERN_NOT_RECEIVER);

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -629,7 +629,7 @@ int
 vm_fault_trap(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
     int fault_flags, int *signo, int *ucode)
 {
-	int result;
+	int result, segv_ucode;
 
 	MPASS(signo == NULL || ucode != NULL);
 #ifdef KTRACE
@@ -664,6 +664,13 @@ vm_fault_trap(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
 			*ucode = BUS_OBJERR;
 			break;
 		case KERN_PROTECTION_FAILURE:
+#if __has_feature(capabilities)
+			if ((fault_type & VM_PROT_WRITE_CAP) != 0)
+				segv_ucode = SEGV_STORETAG;
+			else
+#endif
+				segv_ucode = SEGV_ACCERR;
+
 			if (prot_fault_translation == 0) {
 				/*
 				 * Autodetect.  This check also covers
@@ -673,7 +680,7 @@ vm_fault_trap(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
 				if (SV_CURPROC_ABI() == SV_ABI_FREEBSD &&
 				    curproc->p_osrel >= P_OSREL_SIGSEGV) {
 					*signo = SIGSEGV;
-					*ucode = SEGV_ACCERR;
+					*ucode = segv_ucode;
 				} else {
 					*signo = SIGBUS;
 					*ucode = UCODE_PAGEFLT;
@@ -685,7 +692,7 @@ vm_fault_trap(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
 			} else {
 				/* Always SIGSEGV mode. */
 				*signo = SIGSEGV;
-				*ucode = SEGV_ACCERR;
+				*ucode = segv_ucode;
 			}
 			break;
 		default:

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -254,6 +254,8 @@ kmem_alloc_attr_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 			pmap_zero_page(m);
 		vm_page_valid(m);
 		VM_OBJECT_ASSERT_CAP(object, prot);
+		if (prot & VM_PROT_WRITE_CAP)
+			vm_page_aflag_set(m, PGA_CAPSTORE | PGA_CAPDIRTY);
 		pmap_enter(kernel_pmap, addr + i, m, prot,
 		    prot | PMAP_ENTER_WIRED, 0);
 	}
@@ -345,6 +347,7 @@ kmem_alloc_contig_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 			pmap_zero_page(m);
 		vm_page_valid(m);
 		VM_OBJECT_ASSERT_CAP(object, VM_PROT_RW_CAP);
+		vm_page_aflag_set(m, PGA_CAPSTORE | PGA_CAPDIRTY);
 		pmap_enter(kernel_pmap, tmp, m, VM_PROT_RW_CAP,
 		    VM_PROT_RW_CAP | PMAP_ENTER_WIRED, 0);
 		tmp += PAGE_SIZE;
@@ -544,6 +547,8 @@ retry:
 		    ("kmem_malloc: page %p is managed", m));
 		vm_page_valid(m);
 		VM_OBJECT_ASSERT_CAP(object, prot);
+		if (prot & VM_PROT_WRITE_CAP)
+			vm_page_aflag_set(m, PGA_CAPSTORE | PGA_CAPDIRTY);
 		pmap_enter(kernel_pmap, addr + i, m, prot,
 		    prot | PMAP_ENTER_WIRED, 0);
 		if (__predict_false((prot & VM_PROT_EXECUTE) != 0))

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -1424,6 +1424,10 @@ retry:
 				    pmap_is_referenced(m) ||
 				    (m->a.flags & PGA_REFERENCED) != 0)
 					mincoreinfo |= MINCORE_REFERENCED_OTHER;
+
+				/* Expose capability tracking information */
+				if ((m->a.flags & PGA_CAPSTORE) != 0)
+					mincoreinfo |= MINCORE_CAPSTORE;
 			}
 			if (object != NULL)
 				VM_OBJECT_WUNLOCK(object);

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -5482,6 +5482,18 @@ vm_page_assert_pga_capmeta_clear(vm_page_t m, uint16_t bits)
 		VM_OBJECT_ASSERT_LOCKED(m->object);
 	}
 }
+
+/* Ensure that mdst is at least as capdirty as msrc */
+void
+vm_page_assert_pga_capmeta_copy(vm_page_t msrc, vm_page_t mdst)
+{
+	vm_page_astate_t msrca = vm_page_astate_load(msrc);
+	vm_page_astate_t mdsta = vm_page_astate_load(mdst);
+	KASSERT((mdsta.flags & msrca.flags &
+	    (PGA_CAPSTORE | PGA_CAPDIRTY))
+	    == (msrca.flags & (PGA_CAPSTORE | PGA_CAPDIRTY)),
+	    ("pmap_copy_page_internal bad capdirty metadata"));
+}
 #endif
 #endif
 

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -5466,6 +5466,23 @@ vm_page_assert_pga_writeable(vm_page_t m, uint16_t bits)
 	if (!vm_page_xbusied(m))
 		VM_OBJECT_ASSERT_BUSY(m->object);
 }
+
+#if __has_feature(capabilities)
+void
+vm_page_assert_pga_capmeta_clear(vm_page_t m, uint16_t bits)
+{
+	if ((bits & (PGA_CAPDIRTY | PGA_CAPSTORE)) == 0)
+		return;
+
+	if (vm_page_xbusied(m)) {
+		/* If it's busy at all, it's busy by us */
+		vm_page_assert_xbusied(m);
+	} else {
+		/* If it's not busy, we hold its object's lock */
+		VM_OBJECT_ASSERT_LOCKED(m->object);
+	}
+}
+#endif
 #endif
 
 #include "opt_ddb.h"

--- a/sys/vm/vm_page.h
+++ b/sys/vm/vm_page.h
@@ -805,9 +805,17 @@ void vm_page_assert_pga_writeable(vm_page_t m, uint16_t bits);
 	} while (!atomic_cmpset_int(&(m)->busy_lock, _busy_lock,	\
 	    (_busy_lock & VPB_BIT_FLAGMASK) | VPB_CURTHREAD_EXCLUSIVE)); \
 } while (0)
+#if __has_feature(capabilities)
+void vm_page_assert_pga_capmeta_clear(vm_page_t m, uint16_t bits);
+#define	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits)			\
+	vm_page_assert_pga_capmeta_clear(m, bits)
+#else
+#define	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits)	(void)0
+#endif
 #else
 #define	VM_PAGE_OBJECT_BUSY_ASSERT(m)	(void)0
 #define	VM_PAGE_ASSERT_PGA_WRITEABLE(m, bits)	(void)0
+#define	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits)	(void)0
 #define	vm_page_xbusy_claim(m)
 #endif
 
@@ -853,6 +861,8 @@ static inline void
 vm_page_aflag_clear(vm_page_t m, uint16_t bits)
 {
 	uint32_t *addr, val;
+
+	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits);
 
 	/*
 	 * Access the whole 32-bit word containing the aflags field with an

--- a/sys/vm/vm_page.h
+++ b/sys/vm/vm_page.h
@@ -433,6 +433,21 @@ extern struct mtx_padalign pa_lock[];
  * PGA_SWAP_FREE is used to defer freeing swap space to the pageout daemon
  * when the context that dirties the page does not have the object write lock
  * held.
+ *
+ * PGA_CAPSTORE indicates that the page might be holding capabilities and might
+ * be mapped as permitting capability stores (if PGA_WRITABLE is also set).  If
+ * clear, the page certainly bears no capabilities (and will not come to hold
+ * them without a trip through vm_fault).  Clearing this bit requires that the
+ * page be being freed (that is, going through the laundry) or that the system
+ * has verified the absense of capabilities and cap-store-permitting mappings in
+ * a race-free way.  For example, the paging code ensures that no stores to a
+ * page are possible and measures all capability tags as part of page-out; it is
+ * therefore in a position to dictate this bit's value on page-in.
+ *
+ * PGA_CAPDIRTY indicates that a capability was "recently" written to this page
+ * and the underlying mapping has been removed, reclaimed, or synchronized back
+ * to the MI layer.  The MD layer sets this bit happens without the page lock
+ * held, but clearing it requires synchronization, as with PGA_CAPSTORE.
  */
 #define	PGA_WRITEABLE	0x0001		/* page may be mapped writeable */
 #define	PGA_REFERENCED	0x0002		/* page has been referenced */
@@ -444,6 +459,8 @@ extern struct mtx_padalign pa_lock[];
 #define	PGA_NOSYNC	0x0080		/* do not collect for syncer */
 #define	PGA_SWAP_FREE	0x0100		/* page with swap space was dirtied */
 #define	PGA_SWAP_SPACE	0x0200		/* page has allocated swap space */
+#define	PGA_CAPSTORE 	0x4000		/* Fast-path capdirty */
+#define	PGA_CAPDIRTY	0x8000		/* page targeted by cap store */
 
 #define	PGA_QUEUE_OP_MASK	(PGA_DEQUEUE | PGA_REQUEUE | PGA_REQUEUE_HEAD)
 #define	PGA_QUEUE_STATE_MASK	(PGA_ENQUEUED | PGA_QUEUE_OP_MASK)
@@ -887,6 +904,16 @@ vm_page_dirty(vm_page_t m)
 #else
 	m->dirty = VM_PAGE_BITS_ALL;
 #endif
+}
+
+static __inline void
+vm_page_capdirty(vm_page_t m)
+{
+
+	KASSERT(vm_page_astate_load(m).flags & PGA_CAPSTORE,
+		("vm_page_capdirty w/o PGA_CAPSTORE m=%p", m));
+
+	vm_page_aflag_set(m, PGA_CAPDIRTY);
 }
 
 /*

--- a/sys/vm/vm_page.h
+++ b/sys/vm/vm_page.h
@@ -809,13 +809,19 @@ void vm_page_assert_pga_writeable(vm_page_t m, uint16_t bits);
 void vm_page_assert_pga_capmeta_clear(vm_page_t m, uint16_t bits);
 #define	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits)			\
 	vm_page_assert_pga_capmeta_clear(m, bits)
+
+void vm_page_assert_pga_capmeta_copy(vm_page_t msrc, vm_page_t mdst);
+#define	VM_PAGE_ASSERT_PGA_CAPMETA_COPY(msrc, mdst)			\
+	vm_page_assert_pga_capmeta_copy(msrc, mdst)
 #else
 #define	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits)	(void)0
+#define	VM_PAGE_ASSERT_PGA_CAPMETA_COPY(msrc, mdst)	(void)0
 #endif
 #else
 #define	VM_PAGE_OBJECT_BUSY_ASSERT(m)	(void)0
 #define	VM_PAGE_ASSERT_PGA_WRITEABLE(m, bits)	(void)0
 #define	VM_PAGE_ASSERT_PGA_CAPMETA_CLEAR(m, bits)	(void)0
+#define	VM_PAGE_ASSERT_PGA_CAPMETA_COPY(msrc, mdst)	(void)0
 #define	vm_page_xbusy_claim(m)
 #endif
 
@@ -1048,6 +1054,5 @@ vm_page_domain(vm_page_t m)
 	return (0);
 #endif
 }
-
 #endif				/* _KERNEL */
 #endif				/* !_VM_PAGE_ */


### PR DESCRIPTION
A better stab at capability dirty tracking atop `master`'s VM bits.

Among other things, this switches from the revocation-based names for the MI bits and uses a more natural (or, well, VM-themed) scheme.  While here, it obviates the `PMAP_ENTER_NOSTORETAGS` flag in favor of per-page MI bits (`VPO_FASTCAPDIRTY`).

This seems to boot both purecap and hybrid and run `cheriabitest -u -a` but I'd really enjoy some more eyes on it.