### PR TITLE
update field size for 128 bit capabilities

### DIFF
--- a/lib/libcheri/libcheri_type.c
+++ b/lib/libcheri/libcheri_type.c
@@ -50,7 +50,7 @@ __REQUIRE_CAPABILITIES
 static void * __capability libcheri_sealing_root;
 
 /* The number of bits in the type field of a capability. */
-static const int libcheri_cap_type_bits = 24;
+static const int libcheri_cap_type_bits = 18;
 
 /* The next non-system type number to allocate. */
 static _Atomic(uint64_t) libcheri_type_next = 1;


### PR DESCRIPTION
Otype field size was hard coded as 24 bits based on 256 bit capabilities.  The field size for (default) CHERI Concentrate 128 bit capabilities is 18 bits.  The existing implementation will fail if 2^18 types are requested.  See issue #408. 

This PR simply changes the hardcoded value to 18.

