### PR TITLE
Add cheribsd.kernel_startup_benchmark kernel variable

### DIFF
--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -721,15 +721,13 @@ start_init(void *dummy)
 	}
 	free_init_path = tmp_init_path = strdup(init_path, M_TEMP);
 
-#define TEST_KERNEL_STARTUP_VAR "cheribsd.kernel_startup_benchmark"
-	if (kern_getenv(TEST_KERNEL_STARTUP_VAR)) {
-		printf("Shutting down for benchmarking (%s is set)\n",
-		    TEST_KERNEL_STARTUP_VAR);
+	if (kern_getenv("cheribsd.kernel_startup_benchmark")) {
+		printf("Shutting down for benchmarking"
+		    " (cheribsd.kernel_startup_benchmark is set)\n");
 		poweroff_delay = 0; /* Don't sleep before poweroff. */
 		kern_reboot(RB_HALT | RB_POWEROFF | RB_NOSYNC | RB_VERBOSE);
 		panic("Did not power off");
 	}
-#undef TEST_KERNEL_STARTUP_VAR
 
 	while ((path = strsep(&tmp_init_path, ":")) != NULL) {
 		if (bootverbose)

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -720,7 +720,17 @@ start_init(void *dummy)
 		freeenv(var);
 	}
 	free_init_path = tmp_init_path = strdup(init_path, M_TEMP);
-	
+
+#define TEST_KERNEL_STARTUP_VAR "cheribsd.kernel_startup_benchmark"
+	if (kern_getenv(TEST_KERNEL_STARTUP_VAR)) {
+		printf("Shutting down for benchmarking (%s is set)\n",
+		    TEST_KERNEL_STARTUP_VAR);
+		poweroff_delay = 0; /* Don't sleep before poweroff. */
+		kern_reboot(RB_HALT | RB_POWEROFF | RB_NOSYNC | RB_VERBOSE);
+		panic("Did not power off");
+	}
+#undef TEST_KERNEL_STARTUP_VAR
+
 	while ((path = strsep(&tmp_init_path, ":")) != NULL) {
 		if (bootverbose)
 			printf("start_init: trying %s\n", path);

--- a/sys/kern/kern_shutdown.c
+++ b/sys/kern/kern_shutdown.c
@@ -941,7 +941,7 @@ vpanic(const char *fmt, va_list ap)
 #ifndef POWEROFF_DELAY
 # define POWEROFF_DELAY 5000
 #endif
-static int poweroff_delay = POWEROFF_DELAY;
+int poweroff_delay = POWEROFF_DELAY;
 
 SYSCTL_INT(_kern_shutdown, OID_AUTO, poweroff_delay, CTLFLAG_RW,
     &poweroff_delay, 0, "Delay before poweroff to write disk caches (msec)");

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -61,6 +61,7 @@ __NULLABILITY_PRAGMA_PUSH
 extern int cold;		/* nonzero if we are doing a cold boot */
 extern int suspend_blocked;	/* block suspend due to pending shutdown */
 extern int rebooting;		/* kern_reboot() has been called. */
+extern int poweroff_delay;	/* Delay (in msec) before poweroff. */
 extern const char *panicstr;	/* panic message */
 extern bool panicked;
 #define	KERNEL_PANICKED()	__predict_false(panicked)


### PR DESCRIPTION
When this variable is set, we shutdown the kernel inside start_init. This
is very useful to benchmark e.g. QEMU performance improvements.
To make this useful, it overwrites poweroff_delay to avoid sleeping for 1-2
seconds on shutdown.

Usage:
$CHERI_SDK/bin/qemu-system-cheri128 -M malta -kernel $KERNEL -m 2048 -nographic -append "cheribsd.kernel_startup_benchmark=1"