### PR TITLE
[UPSTREAM?] Allow building custom libs in bsd.crunchgen.mk

### DIFF
--- a/lib/libpam/modules/modules.inc
+++ b/lib/libpam/modules/modules.inc
@@ -3,8 +3,14 @@
 .include <src.opts.mk>
 
 MODULES		 =
-MODULES		+= pam_chroot
+# A few minimal modules that can be used by tools/cheribsdbox
 MODULES		+= pam_deny
+MODULES		+= pam_nologin
+MODULES		+= pam_permit
+MODULES		+= pam_rootok
+MODULES		+= pam_self
+.if !defined(PAM_MINIMAL)
+MODULES		+= pam_chroot
 MODULES		+= pam_echo
 MODULES		+= pam_exec
 MODULES		+= pam_ftpusers
@@ -16,20 +22,17 @@ MODULES		+= pam_ksu
 .endif
 MODULES		+= pam_lastlog
 MODULES		+= pam_login_access
-MODULES		+= pam_nologin
 MODULES		+= pam_opie
 MODULES		+= pam_opieaccess
 MODULES		+= pam_passwdqc
-MODULES		+= pam_permit
 .if ${MK_RADIUS_SUPPORT} != "no"
 MODULES		+= pam_radius
 .endif
 MODULES		+= pam_rhosts
-MODULES		+= pam_rootok
 MODULES		+= pam_securetty
-MODULES		+= pam_self
 .if ${MK_OPENSSH} != "no"
 MODULES		+= pam_ssh
 .endif
 MODULES		+= pam_tacplus
 MODULES		+= pam_unix
+.endif  # !defined(PAM_MINIMAL)

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -24,6 +24,17 @@ CRUNCH_BUILDOPTS+=	-DWITHOUT_TESTS MK_TESTS=no -D_CRUNCHGEN
 CRUNCH_BUILDOPTS+=	-DWITHOUT_CASPER MK_CASPER=no
 # Try to reduce size by avoiding locale support
 CRUNCH_BUILDOPTS+=	-DWITHOUT_LOCALES MK_LOCALES=no
+# Disable kerberos support
+CRUNCH_BUILDOPTS+=	MK_KERBEROS=no MK_KERBEROS_SUPPORT=no MK_GSSAPI=no
+# Smaller PAM:
+CRUNCH_BUILDOPTS+=	MK_RADIUS_SUPPORT=no
+# Smaller SSH
+CRUNCH_BUILDOPTS+=	MK_LDNS_UTILS=no MK_LDNS=no
+# Avoid redundant libs
+CRUNCH_BUILDOPTS+=	MK_PROFILE=no
+# Avoid dependency on audit
+CRUNCH_BUILDOPTS+=	MK_AUDIT=no
+
 
 
 # Do not do hardlinks as part of the install since we want to be able to install
@@ -81,9 +92,6 @@ CRUNCH_SHLIBS+=	-pthread
 
 # ktrace:
 CRUNCH_LIBS+=	-lsysdecode
-
-# login/su (could theoretically use static_libpam but that will probably not work)
-CRUNCH_SHLIBS+= -lpam -lbsm
 
 # needed by ifconfig
 CRUNCH_LIBS+=	-l80211
@@ -385,14 +393,6 @@ CRUNCH_PROGS_secure/usr.sbin+=	sshd
 # TODO: should we link libssh static and use ${LIBSSH}?
 CRUNCH_SHLIBS+=	-lpam -lutil
 
-# Build ssh deps static?
-CRUNCH_LIBS+=	${LIBSSH}
-.if ${MK_LDNS} != "no"
-# needed by LIBSSH
-CRUNCH_LIBS+=	${LIBLDNS}
-.endif
-
-
 CRUNCH_SRCDIRS+= secure/usr.bin
 CRUNCH_PROGS_secure/usr.bin+=	scp sftp ssh ssh-keygen
 
@@ -482,6 +482,27 @@ check_crunchgen:
 	    echo "Should not be using crunchgen from /usr/bin!"; false; \
 	fi
 all: check_crunchgen
+
+.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_ARCH:Mriscv*}
+# No RTLD yet!
+NO_SHARED=yes
+.endif
+
+.if defined(NO_RTLD) || defined(NO_SHARED)
+# Force empty shlibs if we are building without RTLD/NO_SHARED
+# See top_makefile_rules(FILE *outmk) in crunchgen.c
+CRUNCH_LIBS:=${CRUNCH_LIBS} ${CRUNCH_SHLIBS} -Wl,--verbose -v
+.undef CRUNCH_SHLIBS
+# TODO: CRUNCH_BUILDOPTS+=-DNO_SHARED
+.endif
+
+# Build PAM with only minimal modules support
+CRUNCH_CUSTOM_LIBS+=lib/libpam
+CRUNCH_BUILDOPTS_lib/libpam+=-DPAM_MINIMAL
+# Also build a version of libssh without optional deps
+CRUNCH_CUSTOM_LIBS+=secure/lib/libssh
+CRUNCH_BUILDOPTS_secure/lib/libssh+="SSHDIR=${SRCTOP}/crypto/openssh"
+CRUNCH_LIBS+=-lprivatessh
 
 # the crunchgen build environment
 .include <bsd.crunchgen.mk>


### PR DESCRIPTION
Use this to build libpam and libssh without kerberos support. This reduces
the size of cheribsdbox and means we don't need to add as many .so files to
the minimal disk image.