### PR TITLE
Fix vn_rename and vn_remove to accept capabilities

### DIFF
--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -268,7 +268,7 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 
 	ASSERT(seg == UIO_SYSSPACE);
 
-	return (kern_renameat(curthread, AT_FDCWD, cheri_ptr(from,strlen(from)), AT_FDCWD, cheri_ptr(to,strlen(to)), seg));
+	return (kern_renameat(curthread, AT_FDCWD, cheri_ptr(from, strlen(from) + 1), AT_FDCWD, cheri_ptr(to, strlen(to) + 1), seg));
 }
 
 static __inline int
@@ -278,7 +278,7 @@ vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
 	ASSERT(seg == UIO_SYSSPACE);
 	ASSERT(dirflag == RMFILE);
 
-	return (kern_funlinkat(curthread, AT_FDCWD, cheri_ptr(fnamep, strlen(fnamep)), FD_NONE, seg, 0,
+	return (kern_funlinkat(curthread, AT_FDCWD, cheri_ptr(fnamep, strlen(fnamep) + 1), FD_NONE, seg, 0,
 	    0));
 }
 

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -269,8 +269,8 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 	ASSERT(seg == UIO_SYSSPACE);
 
 	return (kern_renameat(curthread, AT_FDCWD, 
-			      cheri_ptr(from, strlen(from) + 1), AT_FDCWD, 
-			      cheri_ptr(to, strlen(to) + 1), seg));
+	    cheri_ptr(from, strlen(from) + 1), AT_FDCWD, 
+	    cheri_ptr(to, strlen(to) + 1), seg));
 }
 
 static __inline int
@@ -281,8 +281,8 @@ vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
 	ASSERT(dirflag == RMFILE);
 
 	return (kern_funlinkat(curthread, AT_FDCWD, 
-			       cheri_ptr(fnamep, strlen(fnamep) + 1), FD_NONE, seg, 
-			       0, 0));
+	    cheri_ptr(fnamep, strlen(fnamep) + 1), FD_NONE, seg, 
+	    0, 0));
 }
 
 #endif	/* _KERNEL */

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -263,7 +263,7 @@ zfs_vop_close(vnode_t *vp, int flag, int count, offset_t offset, cred_t *cr)
 	zfs_vop_close((vp), (oflags), (count), (offset), (cr))
 
 static __inline int
-vn_rename(char * from, char * to, enum uio_seg seg)
+vn_rename(char *from, char *to, enum uio_seg seg)
 {
 
 	ASSERT(seg == UIO_SYSSPACE);

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -272,7 +272,7 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 }
 
 static __inline int
-vn_remove(char * fnamep, enum uio_seg seg, enum rm dirflag)
+vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
 {
 
 	ASSERT(seg == UIO_SYSSPACE);

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -268,7 +268,11 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 
 	ASSERT(seg == UIO_SYSSPACE);
 
-	return (kern_renameat(curthread, AT_FDCWD, cheri_ptr(from, strlen(from) + 1), AT_FDCWD, cheri_ptr(to, strlen(to) + 1), seg));
+	return (kern_renameat(curthread, 
+			      AT_FDCWD, 
+			      cheri_ptr(from, strlen(from) + 1), 
+			      AT_FDCWD, cheri_ptr(to, strlen(to) + 1), 
+			      seg));
 }
 
 static __inline int
@@ -278,8 +282,10 @@ vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
 	ASSERT(seg == UIO_SYSSPACE);
 	ASSERT(dirflag == RMFILE);
 
-	return (kern_funlinkat(curthread, AT_FDCWD, cheri_ptr(fnamep, strlen(fnamep) + 1), FD_NONE, seg, 0,
-	    0));
+	return (kern_funlinkat(curthread, 
+			       AT_FDCWD, 
+			       cheri_ptr(fnamep, strlen(fnamep) + 1), 
+			       FD_NONE, seg, 0, 0));
 }
 
 #endif	/* _KERNEL */

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -268,12 +268,9 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 
 	ASSERT(seg == UIO_SYSSPACE);
 
-	return (kern_renameat(curthread, 
-			      AT_FDCWD, 
-			      cheri_ptr(from, strlen(from) + 1), 
-			      AT_FDCWD, 
-			      cheri_ptr(to, strlen(to) + 1), 
-			      seg));
+	return (kern_renameat(curthread, AT_FDCWD, 
+			      cheri_ptr(from, strlen(from) + 1), AT_FDCWD, 
+			      cheri_ptr(to, strlen(to) + 1), seg));
 }
 
 static __inline int
@@ -283,10 +280,9 @@ vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
 	ASSERT(seg == UIO_SYSSPACE);
 	ASSERT(dirflag == RMFILE);
 
-	return (kern_funlinkat(curthread, 
-			       AT_FDCWD, 
-			       cheri_ptr(fnamep, strlen(fnamep) + 1), 
-			       FD_NONE, seg, 0, 0));
+	return (kern_funlinkat(curthread, AT_FDCWD, 
+			       cheri_ptr(fnamep, strlen(fnamep) + 1), FD_NONE, seg, 
+			       0, 0));
 }
 
 #endif	/* _KERNEL */

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -263,22 +263,22 @@ zfs_vop_close(vnode_t *vp, int flag, int count, offset_t offset, cred_t *cr)
 	zfs_vop_close((vp), (oflags), (count), (offset), (cr))
 
 static __inline int
-vn_rename(char *from, char *to, enum uio_seg seg)
+vn_rename(char * from, char * to, enum uio_seg seg)
 {
 
 	ASSERT(seg == UIO_SYSSPACE);
 
-	return (kern_renameat(curthread, AT_FDCWD, from, AT_FDCWD, to, seg));
+	return (kern_renameat(curthread, AT_FDCWD, cheri_ptr(from,strlen(from)), AT_FDCWD, cheri_ptr(to,strlen(to)), seg));
 }
 
 static __inline int
-vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
+vn_remove(char * fnamep, enum uio_seg seg, enum rm dirflag)
 {
 
 	ASSERT(seg == UIO_SYSSPACE);
 	ASSERT(dirflag == RMFILE);
 
-	return (kern_funlinkat(curthread, AT_FDCWD, fnamep, FD_NONE, seg, 0,
+	return (kern_funlinkat(curthread, AT_FDCWD, cheri_ptr(fnamep, strlen(fnamep)), FD_NONE, seg, 0,
 	    0));
 }
 

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -271,7 +271,8 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 	return (kern_renameat(curthread, 
 			      AT_FDCWD, 
 			      cheri_ptr(from, strlen(from) + 1), 
-			      AT_FDCWD, cheri_ptr(to, strlen(to) + 1), 
+			      AT_FDCWD, 
+			      cheri_ptr(to, strlen(to) + 1), 
 			      seg));
 }
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1401,8 +1401,9 @@ freebsd64___sysctlbyname(struct thread *td, struct
 
 	/*
 	 * Fetch the oldlen so we can bound the old capability.
-	 * This avoids a race between here and kern_sysctl's use, if the
-	 * caller increases the value at uap->oldlenp between now its later use.
+	 * While there is a race between here and kern_sysctl's use,
+	 * the caller will get what they deserve if they increase the
+	 * value at uap->oldlenp between now its later use.
 	 */
 	if (uap->oldlenp == NULL)
 		oldlen = 0;
@@ -1412,8 +1413,8 @@ freebsd64___sysctlbyname(struct thread *td, struct
 
 	error = kern___sysctlbyname(td, __USER_CAP(uap->name, uap->namelen),
 	    uap->namelen, __USER_CAP(uap->old, oldlen),
-	    &oldlen, __USER_CAP(uap->new, uap->newlen),
-	    uap->newlen, &rv, SCTL_MASK64, 1);
+	    __USER_CAP_OBJ(uap->oldlenp), __USER_CAP(uap->new, uap->newlen),
+	    uap->newlen, &rv, 0, 0);
 	if (error != 0)
 		return (error);
 	if (uap->oldlenp != NULL)

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1401,9 +1401,8 @@ freebsd64___sysctlbyname(struct thread *td, struct
 
 	/*
 	 * Fetch the oldlen so we can bound the old capability.
-	 * While there is a race between here and kern_sysctl's use,
-	 * the caller will get what they deserve if they increase the
-	 * value at uap->oldlenp between now its later use.
+	 * This avoids a race between here and kern_sysctl's use, if the
+	 * caller increases the value at uap->oldlenp between now its later use.
 	 */
 	if (uap->oldlenp == NULL)
 		oldlen = 0;
@@ -1413,8 +1412,8 @@ freebsd64___sysctlbyname(struct thread *td, struct
 
 	error = kern___sysctlbyname(td, __USER_CAP(uap->name, uap->namelen),
 	    uap->namelen, __USER_CAP(uap->old, oldlen),
-	    __USER_CAP_OBJ(uap->oldlenp), __USER_CAP(uap->new, uap->newlen),
-	    uap->newlen, &rv, 0, 0);
+	    &oldlen, __USER_CAP(uap->new, uap->newlen),
+	    uap->newlen, &rv, SCTL_MASK64, 1);
 	if (error != 0)
 		return (error);
 	if (uap->oldlenp != NULL)


### PR DESCRIPTION
Compiling DTrace, I had the error that `kern_renameat` (sys/kern/vfs_syscalls.c:3565) was called with normal pointers, while it wanted capabilities as parameters.

I changed to call sites of `vn_rename` and `vn_remove` to call them with capabilities.