### PR TITLE
Fix some cheriabi cruft

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1637,16 +1637,12 @@ static const struct cheri_test cheri_tests[] = {
 	/* Unaligned memcpy/memmove with capabilities */
 	{ .ct_name = "test_unaligned_capability_copy_memcpy",
 	  .ct_desc = "Check that a memcpy() of valid capabilities to an "
-		     "unaligned destination fails",
-	  .ct_func = test_unaligned_capability_copy_memcpy,
-	  .ct_flags = CT_FLAG_SIGEXIT,
-	  .ct_signum = SIGABRT },
+		     "unaligned destination strips tags",
+	  .ct_func = test_unaligned_capability_copy_memcpy },
 	{ .ct_name = "test_unaligned_capability_copy_memmove",
 	  .ct_desc = "Check that a memmove() of valid capabilities to an "
-		     "unaligned destination fails",
-	  .ct_func = test_unaligned_capability_copy_memmove,
-	  .ct_flags = CT_FLAG_SIGEXIT,
-	  .ct_signum = SIGABRT },
+		     "unaligned destination strips tags",
+	  .ct_func = test_unaligned_capability_copy_memmove },
 
 	/*
 	 * Thread-Local Storage (TLS) tests.

--- a/bin/cheritest/cheritest_bounds_globals.c
+++ b/bin/cheritest/cheritest_bounds_globals.c
@@ -81,12 +81,14 @@
 	void								\
 	test_bounds_##test(const struct cheri_test *ctp __unused)	\
 	{								\
-		void * __capability allocation =				\
+		void * __capability allocation =			\
 		    (__cheri_tocap void * __capability )&test;		\
 		size_t allocation_offset = cheri_getoffset(allocation);	\
 		size_t allocation_len = cheri_getlen(allocation);	\
 		size_t pointer_offset = cheri_getoffset(test##p);	\
 		size_t pointer_len = cheri_getlen(test##p);		\
+		size_t size = sizeof(test);				\
+		size_t rounded_size = CHERI_REPRESENTABLE_LENGTH(size);	\
 									\
 		/* Global offset. */					\
 		if (allocation_offset != 0)				\
@@ -95,11 +97,11 @@
 			    allocation_offset);				\
 									\
 		/* Global length. */					\
-		if (allocation_len != sizeof(test))			\
+		if (allocation_len != rounded_size)			\
 			cheritest_failure_errx(				\
 			    "global: incorrect length (expected %ju, "	\
-			    "got %ju)", sizeof(test),			\
-			    allocation_len);				\
+			    "rounded from %ju, got %ju)", 		\
+			    rounded_size, size, allocation_len);	\
 									\
 		/* Pointer offset. */					\
 		if (pointer_offset != 0)				\
@@ -108,10 +110,11 @@
 			    pointer_offset);				\
 									\
 		/* Pointer length. */					\
-		if (pointer_len != sizeof(test))			\
+		if (pointer_len != rounded_size)			\
 			cheritest_failure_errx(				\
 			    "pointer: incorrect length (expected %ju, "	\
-			    "got %ju)", sizeof(test), pointer_len);	\
+			    "rounded from %ju, got %ju)", 		\
+			    rounded_size, size, pointer_len);		\
 		cheritest_success();					\
 	}
 
@@ -480,6 +483,7 @@ TEST_BOUNDS(extern_global_array65536);
 		size_t allocation_len = cheri_getlen(allocation);	\
 		size_t pointer_offset = cheri_getoffset(test##p);	\
 		size_t pointer_len = cheri_getlen(test##p);		\
+		size_t rounded_size = CHERI_REPRESENTABLE_LENGTH(size);	\
 									\
 		/* Global offset. */					\
 		if (allocation_offset != 0)				\
@@ -488,10 +492,11 @@ TEST_BOUNDS(extern_global_array65536);
 			    allocation_offset);				\
 									\
 		/* Global length. */					\
-		if (allocation_len != size)				\
+		if (allocation_len != rounded_size)			\
 			cheritest_failure_errx(				\
 			    "global: incorrect length (expected %ju, "	\
-			    "got %ju)", size, allocation_len);		\
+			    "rounded from %ju, got %ju)", 		\
+			    rounded_size, size, allocation_len);	\
 									\
 		/* Pointer offset. */					\
 		if (pointer_offset != 0)				\
@@ -500,10 +505,11 @@ TEST_BOUNDS(extern_global_array65536);
 			    pointer_offset);				\
 									\
 		/* Pointer length. */					\
-		if (pointer_len != size)				\
+		if (pointer_len != rounded_size)			\
 			cheritest_failure_errx(				\
 			    "pointer: incorrect length (expected %ju, "	\
-			    "got %ju)", size, pointer_len);		\
+			    "rounded from %ju, got %ju)", 		\
+			    rounded_size, size, pointer_len);		\
 		cheritest_success();					\
 	}
 

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -334,8 +334,21 @@ test_initregs_default(const struct cheri_test *ctp __unused)
  */
 #ifdef __CHERI_PURE_CAPABILITY__
 
-#define CHERI_STACK_OFFSET_MAX 0x7fffff
-#define CHERI_STACK_OFFSET_MIN 0x7fc000
+/*
+ * Following along in kern_exec.c, ...
+ *
+ * 1. We don't specify the size of the stack in the GNU_STACK program header,
+ * 2. At least on CHERI-MIPS, sv_maxssiz == NULL
+ * 3. maxssiz is set by sysctl (sys/kern/subr_param.c),
+ *    but on CHERI-MIPS defaults to 64MiB (see MAXSSIZ in
+ *    sys/mips/include/vmparam.h).
+ *
+ * So, require our stack offset to be somewhere in the first 256KiB.  That
+ * should be plenty of room for the aux vector and args and all that.
+ */
+
+#define CHERI_STACK_OFFSET_MAX 0x4000000
+#define CHERI_STACK_OFFSET_MIN 0x3fc0000
 
 void
 test_initregs_stack_user_perms(const struct cheri_test *ctp __unused)

--- a/bin/cheritest/cheritest_string.c
+++ b/bin/cheritest/cheritest_string.c
@@ -462,14 +462,17 @@ test_unaligned_capability_copy_memcpy(const struct cheri_test *ctp __unused)
 	cheritest_memcpy(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
 	/* TODO: verify the contents of the buffer? */
 
-	/* Now place a valid capability in buffer[1] and check that it causes a fault */
+	/* Even if we have a valid cap and operate misaligned, we should not fault. */
 	src_buffer[1] = (__cheri_tocap void* __capability)&strcpy;
 	CHERITEST_VERIFY(!cheri_gettag(src_buffer[0]));
 	CHERITEST_VERIFY(cheri_gettag(src_buffer[1]));
 
 	cheritest_memcpy(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
-	/* should have aborted: */
-	cheritest_failure_errx("memcpy() of an unaligned capability succeeded unexpectedly");
+	CHERITEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[0]));
+	CHERITEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[1]));
+	/* TODO: verify the contents of the buffer? */
+
+	cheritest_success();
 }
 
 void
@@ -492,14 +495,17 @@ test_unaligned_capability_copy_memmove(const struct cheri_test *ctp __unused)
 	cheritest_memmove(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
 	/* TODO: verify the contents of the buffer? */
 
-	/* Now place a valid capability in buffer[1] and check that it causes a fault */
+	/* Even if we have a valid cap and operate misaligned, we should not fault. */
 	src_buffer[1] =  (__cheri_tocap void* __capability)&strcpy;
 	CHERITEST_VERIFY(!cheri_gettag(src_buffer[0]));
 	CHERITEST_VERIFY(cheri_gettag(src_buffer[1]));
 
 	cheritest_memmove(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
-	/* should have aborted: */
-	cheritest_failure_errx("memmove() of an unaligned capability succeeded unexpectedly");
+	CHERITEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[0]));
+	CHERITEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[1]));
+	/* TODO: verify the contents of the buffer? */
+
+	cheritest_success();
 }
 
 #ifdef KERNEL_MEMCPY_TESTS


### PR DESCRIPTION
Unexpected failures:
  test_initregs_stack: stack offset 3fdcf50 (expected range 7fc000 to 7fc000)
  test_bounds_global_static_uint8_array65537: global: incorrect length (expected 65537, got 65664)
  test_bounds_global_uint8_array65537: global: incorrect length (expected 65537, got 65664)
  test_bounds_extern_global_array65537: global: incorrect length (expected 65537, got 65664)
  test_unaligned_capability_copy_memcpy: Expected child termination with signal 6
  test_unaligned_capability_copy_memmove: Expected child termination with signal 6

These are just symptoms of tests not being up to date with the world.

FIXES https://github.com/CTSRD-CHERI/cheribsd/issues/406