### PR TITLE
Export capability type info objects from libcxxrt

### DIFF
--- a/lib/libcxxrt/Version.map
+++ b/lib/libcxxrt/Version.map
@@ -315,6 +315,14 @@ CXXRT_1.0 {
     __cxa_increment_exception_refcount;
     __cxa_rethrow_primary_exception;
 
+    /*
+     * HACK: also include the type_info values capabilities (U3cap) mangling
+     * Note: this is the wrong version but it seems we can't add wildcards for
+     * mangled names.
+     */
+    _ZNKSt9type_info*U3cap*;
+    _ZTIU3cap*;
+    _ZTSU3cap*;
 } CXXABI_1.3.6;
 
 


### PR DESCRIPTION
These are not in the correct version, but mangling all the names and
fixing it seems like way too much effort.
This should fix linker errors for -frtti code.

Problem was reported by @dodsonmg while compiling https://github.com/pocoproject/poco.
The linker stage fails with `error: lib/libPocoFoundation.so.71: undefined reference to typeinfo for char* cap`. We are exporting all the non-pointer ones, but are missing the pointer ones due to different mangling.