### PR TITLE
No libcheri on purecap

### DIFF
--- a/lib/libc/Makefile
+++ b/lib/libc/Makefile
@@ -20,6 +20,9 @@ LIBC_ARCH=${MACHINE_ARCH}
 .else
 LIBC_ARCH=${MACHINE_CPUARCH}
 .endif
+.if empty(LIBC_ARCH)
+.error LIBC_ARCH is empty
+.endif
 
 # All library objects contain FreeBSD revision strings by default; they may be
 # excluded as a space-saving measure.  To produce a library that does

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -433,7 +433,7 @@ __DEFAULT_NO_OPTIONS+=PIE
 # We'd really like this to be:
 #    !${MACHINE_CPU:Mcheri} || ${MACHINE_ABI:Mpurecap}
 # but that logic doesn't work in Makefile.inc1...
-.if ${__C} != "cheri" || (${__T:Mmips64*c*} || ${__C:Mriscv64*c*})
+.if ${__C} != "cheri" || (${__T:Mmips64*c*} || ${__T:Mriscv64*c*})
 BROKEN_OPTIONS+=COMPAT_CHERIABI
 .endif
 


### PR DESCRIPTION
Don't incorrectly build libcheri compatibility on riscv64c.