### PR TITLE
Fix CTF pointer overrun (in userland)

### DIFF
--- a/cddl/contrib/opensolaris/common/ctf/ctf_lookup.c
+++ b/cddl/contrib/opensolaris/common/ctf/ctf_lookup.c
@@ -134,6 +134,8 @@ ctf_lookup_by_name(ctf_file_t *fp, const char *name)
 		for (lp = fp->ctf_lookups; lp->ctl_prefix != NULL; lp++) {
 			if (lp->ctl_prefix[0] == '\0' ||
 			    strncmp(p, lp->ctl_prefix, (size_t)(q - p)) == 0) {
+				if (p + lp->ctl_len >= end)
+					continue;
 				for (p += lp->ctl_len; isspace(*p); p++)
 					continue; /* skip prefix and next ws */
 

--- a/cddl/contrib/opensolaris/common/ctf/ctf_lookup.c
+++ b/cddl/contrib/opensolaris/common/ctf/ctf_lookup.c
@@ -133,9 +133,8 @@ ctf_lookup_by_name(ctf_file_t *fp, const char *name)
 
 		for (lp = fp->ctf_lookups; lp->ctl_prefix != NULL; lp++) {
 			if (lp->ctl_prefix[0] == '\0' ||
-			    strncmp(p, lp->ctl_prefix, (size_t)(q - p)) == 0) {
-				if (p + lp->ctl_len >= end)
-					continue;
+			    strncmp(p, lp->ctl_prefix,
+				strlen(lp->ctl_prefix)) == 0) {
 				for (p += lp->ctl_len; isspace(*p); p++)
 					continue; /* skip prefix and next ws */
 


### PR DESCRIPTION
The problem arose when `p = "s"`, and `lp->ctl_prefix = "struct"`.
`strncmp("s","struct",1)` returns 0, because it checks only the first char.
The following line was advancing `p(="s")` by 6, going over the terminator.
(the value of p can be user controlled)