### PR TITLE
Add freed pointer sanity checks.

### DIFF
--- a/contrib/jemalloc/doc/jemalloc.3
+++ b/contrib/jemalloc/doc/jemalloc.3
@@ -857,13 +857,6 @@ for related details)\&. This option is disabled by default unless discarding vir
 causes issues on 32\-bit Linux as well, retaining virtual memory for 32\-bit Linux is disabled by default due to the practical possibility of address space exhaustion\&.
 .RE
 .PP
-config\&.cheri_setbounds (\fBbool\fR) r\-
-.RS 4
-Set bounds on allocations\&. This is enabled by default unless jemalloc is compiled with
-\fB\JEMALLOC_NO_PTR_BOUNDS\fR
-defined\&. This option is available only on CHERI systems in pure-capability mode.
-.RE
-.PP
 opt\&.dss (\fBconst char *\fR) r\-
 .RS 4
 dss (\fBsbrk\fR(2)) allocation precedence as related to

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_preamble.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_preamble.h
@@ -62,14 +62,6 @@ static const bool config_debug =
 #endif
     ;
 
-static const bool config_cheri_setbounds =
-#if defined(JEMALLOC_NO_PTR_BOUNDS)
-    false
-#else
-    true
-#endif
-    ;
-
 static const bool have_dss =
 #ifdef JEMALLOC_DSS
     true

--- a/contrib/jemalloc/src/ctl.c
+++ b/contrib/jemalloc/src/ctl.c
@@ -79,9 +79,6 @@ CTL_PROTO(thread_allocatedp)
 CTL_PROTO(thread_deallocated)
 CTL_PROTO(thread_deallocatedp)
 CTL_PROTO(config_cache_oblivious)
-#ifdef __CHERI_PURE_CAPABILITY__
-CTL_PROTO(config_cheri_setbounds)
-#endif
 CTL_PROTO(config_debug)
 CTL_PROTO(config_fill)
 CTL_PROTO(config_lazy_lock)
@@ -280,9 +277,6 @@ static const ctl_named_node_t	thread_node[] = {
 
 static const ctl_named_node_t	config_node[] = {
 	{NAME("cache_oblivious"), CTL(config_cache_oblivious)},
-#ifdef __CHERI_PURE_CAPABILITY__
-	{NAME("cheri_setbounds"), CTL(config_cheri_setbounds)},
-#endif
 	{NAME("debug"),		CTL(config_debug)},
 	{NAME("fill"),		CTL(config_fill)},
 	{NAME("lazy_lock"),	CTL(config_lazy_lock)},
@@ -1655,9 +1649,6 @@ label_return:
 /******************************************************************************/
 
 CTL_RO_CONFIG_GEN(config_cache_oblivious, bool)
-#ifdef __CHERI_PURE_CAPABILITY__
-CTL_RO_CONFIG_GEN(config_cheri_setbounds, bool)
-#endif
 CTL_RO_CONFIG_GEN(config_debug, bool)
 CTL_RO_CONFIG_GEN(config_fill, bool)
 CTL_RO_CONFIG_GEN(config_lazy_lock, bool)

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -207,11 +207,10 @@ typedef struct {
 #define	BOUND_PTR(ptr, size)	(ptr)
 #define	ROUND_SIZE(size)		(size)
 #else
-#define	BOUND_PTR(ptr, size)	\
-    ((config_cheri_setbounds && ptr != NULL) ? \
-    cheri_andperm(cheri_setbounds((ptr), (size)), \
-	CHERI_PERMS_USERSPACE_DATA & ~CHERI_PERM_CHERIABI_VMMAP) : \
-    (ptr))
+#define	BOUND_PTR(ptr, size)						\
+    (ptr == NULL) ? NULL :						\
+    cheri_andperm(cheri_setbounds((ptr), (size)),			\
+	CHERI_PERMS_USERSPACE_DATA & ~CHERI_PERM_CHERIABI_VMMAP)
 #define roundup2(x, y)	(((x)+((y)-1))&(~((y)-1)))
 
 /*
@@ -3195,7 +3194,7 @@ je_malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *ptr) {
 			ret = isalloc(tsdn, ptr);
 		}
 #ifdef __CHERI_PURE_CAPABILITY__
-		if (config_cheri_setbounds && ret != 0) {
+		if (ret != 0) {
 			ret = MIN(ret, cheri_getlen(ptr));
 		}
 #endif


### PR DESCRIPTION
Require that the pointer be tagged (see #393) and that it's offset be zero
(see #342).  For an adversary who can't (or doesn't) adjust pointer bounds,
it sufficent to prevent forged or mis-bounded pointers from being returned
by later mallocs.