### PR TITLE
Fix kldxref cheri-related issue

### DIFF
--- a/usr.sbin/kldxref/ef_mips.c
+++ b/usr.sbin/kldxref/ef_mips.c
@@ -54,20 +54,21 @@ ef_reloc(struct elf_file *ef, const void *reldata, int reltype, Elf_Off relbase,
 	const Elf_Rela *rela;
 	Elf_Addr addend, addr;
 	Elf_Size rtype, symidx;
+	int dest_offset;
 
 	switch (reltype) {
 	case EF_RELOC_REL:
 		rel = (const Elf_Rel *)reldata;
-		where = (Elf_Addr *)((char *)dest + relbase + rel->r_offset -
-		    dataoff);
+		dest_offset = relbase + rel->r_offset - dataoff;
+		where = (Elf_Addr *)((char *)dest + dest_offset);
 		addend = 0;
 		rtype = ELF_R_TYPE(rel->r_info);
 		symidx = ELF_R_SYM(rel->r_info);
 		break;
 	case EF_RELOC_RELA:
 		rela = (const Elf_Rela *)reldata;
-		where = (Elf_Addr *)((char *)dest + relbase + rela->r_offset -
-		    dataoff);
+		dest_offset = relbase + rel->r_offset - dataoff;
+		where = (Elf_Addr *)((char *)dest + dest_offset);
 		addend = rela->r_addend;
 		rtype = ELF_R_TYPE(rela->r_info);
 		symidx = ELF_R_SYM(rela->r_info);

--- a/usr.sbin/kldxref/ef_mips.c
+++ b/usr.sbin/kldxref/ef_mips.c
@@ -54,7 +54,7 @@ ef_reloc(struct elf_file *ef, const void *reldata, int reltype, Elf_Off relbase,
 	const Elf_Rela *rela;
 	Elf_Addr addend, addr;
 	Elf_Size rtype, symidx;
-	int dest_offset;
+	ptrdiff_t dest_offset;
 
 	switch (reltype) {
 	case EF_RELOC_REL:
@@ -67,7 +67,7 @@ ef_reloc(struct elf_file *ef, const void *reldata, int reltype, Elf_Off relbase,
 		break;
 	case EF_RELOC_RELA:
 		rela = (const Elf_Rela *)reldata;
-		dest_offset = relbase + rel->r_offset - dataoff;
+		dest_offset = relbase + rela->r_offset - dataoff;
 		where = (Elf_Addr *)((char *)dest + dest_offset);
 		addend = rela->r_addend;
 		rtype = ELF_R_TYPE(rela->r_info);


### PR DESCRIPTION
`dest` is a capability with len L. The code was advancing this pointer by (way) more than L, invalidating the TAG, and then make it step back. However, at the end the TAG was still invalid. 
After the changes, the offset is pre-computed.