### PR TITLE
[UPSTREAM] Fix openpam_static_modules

### DIFF
--- a/contrib/openpam/include/security/openpam.h
+++ b/contrib/openpam/include/security/openpam.h
@@ -378,7 +378,7 @@ struct pam_module {
 			[PAM_SM_CHAUTHTOK] = _PAM_SM_CHAUTHTOK		\
 		},							\
 	};								\
-	DATA_SET(_openpam_static_modules, _pam_module)
+	DATA_SET(openpam_static_modules, _pam_module)
 #else
 /* normal case */
 # define PAM_EXTERN


### PR DESCRIPTION
The PAM_MODULE_ENTRY() was incorrectly adding an additional underscore to
the section that contains all modules. This resulted in them being placed
in set__openpam_static_modules

relevant output of objdump -h -t before:
17 set__openpam_static_modules 00000160 00000000004ee5b0 DATA
0000000000000000  w      *UND*	0000000000000000 __start_set_openpam_static_modules
0000000000000000  w      *UND*	0000000000000000 __stop_set_openpam_static_modules
after:
17 set_openpam_static_modules 00000160 00000000004ee5b0 DATA
00000000004ee5b0 g       set_openpam_static_modules	0000000000000000 .protected __start_set_openpam_static_modules
00000000004ee710 g       set_openpam_static_modules	0000000000000000 .protected __stop_set_openpam_static_modules