### PR TITLE
Fix native crossbuild

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2459,8 +2459,10 @@ _other_bootstrap_tools+=tools/build/cross-build/fake_sysctl
 _basic_bootstrap_tools+=usr.bin/mkfifo
 
 .if ${MK_BOOT} != "no"
-# xz/unxz is used by EFI
+.if !defined(CROSSBUILD_HOST)
+# xz/unxz is used by EFI (but it can only be bootstrapped on FreeBSD)
 _basic_bootstrap_tools_multilink+=usr.bin/xz xz,unxz
+.endif
 # md5 is used by boot/beri (and possibly others)
 _basic_bootstrap_tools+=sbin/md5
 .if defined(BOOTSTRAP_ALL_TOOLS)

--- a/lib/libc/tests/gen/posix_spawn/Makefile
+++ b/lib/libc/tests/gen/posix_spawn/Makefile
@@ -19,8 +19,12 @@ CLEANFILES+=	h_nonexec
 
 .include "../../Makefile.netbsd-tests"
 
+# The dd status=none option is non-standard. Only use it when this test succeeds
+# rather than require dd to be a bootstrap tool.
+DD_NOSTATUS!=(dd status=none count=0 2> /dev/null && echo status=none) || true
+DD=dd ${DD_NOSTATUS}
 h_zero:
-	dd if=/dev/zero of=h_zero bs=1k count=2 status=none
+	${DD} if=/dev/zero of=h_zero bs=1k count=2
 	chmod a+x h_zero
 
 CLEANFILES+=	h_zero

--- a/lib/libc/tests/sys/Makefile
+++ b/lib/libc/tests/sys/Makefile
@@ -97,7 +97,11 @@ truncate_test_FILESGRP= wheel
 truncate_test_FILESPACKAGE=	${PACKAGE}
 
 CLEANFILES=	truncate_test.root_owned
+# The dd status=none option is non-standard. Only use it when this test succeeds
+# rather than require dd to be a bootstrap tool.
+DD_NOSTATUS!=(dd status=none count=0 2> /dev/null && echo status=none) || true
+DD=dd ${DD_NOSTATUS}
 truncate_test.root_owned:
-	dd if=/dev/null bs=1 count=1 of=${.TARGET} status=none
+	${DD} if=/dev/null bs=1 count=1 of=${.TARGET}
 
 .include <bsd.test.mk>

--- a/lib/libpmc/Makefile
+++ b/lib/libpmc/Makefile
@@ -32,9 +32,15 @@ SUBDIR+= pmu-events
 .endif
 .endif
 
-libpmc_events.c: ${JEVENTS}
-	${JEVENTS} ${EVENT_ARCH} ${.CURDIR}/pmu-events/arch libpmc_events.c
-SRCS+= libpmc_events.c
+libpmc_events.c.tmp: ${JEVENTS} .META
+	${JEVENTS} ${EVENT_ARCH} ${.CURDIR}/pmu-events/arch ${.TARGET}
+
+libpmc_events.c: libpmc_events.c.tmp
+	if [ ! -e ${.TARGET} ] || ! cmp -s ${.TARGET} ${.TARGET}.tmp; then \
+		mv -f ${.TARGET}.tmp ${.TARGET}; \
+	fi
+CLEANFILES+=	libpmc_events.c.tmp libpmc_events.c
+SRCS+=	libpmc_events.c
 .endif
 
 WARNS?=	3

--- a/stand/defs.mk
+++ b/stand/defs.mk
@@ -233,6 +233,6 @@ ${_ILINKS}: .NOMETA
 	esac ; \
 	path=`(cd $$path && /bin/pwd)` ; \
 	${ECHO} ${.TARGET} "->" $$path ; \
-	ln -fhs $$path ${.TARGET}
+	ln -fns $$path ${.TARGET}
 .endif # !NO_OBJ
 .endif # __BOOT_DEFS_MK__

--- a/stand/efi/Makefile.inc
+++ b/stand/efi/Makefile.inc
@@ -26,7 +26,7 @@ EFI_TARGET=	efi-app-ia32
 .else
 EFI_TARGET=	binary
 .endif
-# XXX: doesn't work with llvm-objdump!
+# XXX: doesn't work with llvm-objcopy!
 OBJCOPY=${WORLDTMP}/usr/bin/objcopy
 
 # Arbitrarily set the PE/COFF header timestamps to 1 Jan 2016 00:00:00

--- a/stand/efi/Makefile.inc
+++ b/stand/efi/Makefile.inc
@@ -26,6 +26,8 @@ EFI_TARGET=	efi-app-ia32
 .else
 EFI_TARGET=	binary
 .endif
+# XXX: doesn't work with llvm-objdump!
+OBJCOPY=${WORLDTMP}/usr/bin/objcopy
 
 # Arbitrarily set the PE/COFF header timestamps to 1 Jan 2016 00:00:00
 # for build reproducibility.

--- a/stand/efi/boot1/Makefile
+++ b/stand/efi/boot1/Makefile
@@ -65,7 +65,7 @@ FILES=	${BOOT1}.efi
 FILESMODE_${BOOT1}.efi=	${BINMODE}
 
 LDSCRIPT=	${EFISRC}/loader/arch/${MACHINE}/ldscript.${MACHINE}
-LDFLAGS+=	-Wl,-T${LDSCRIPT},-Bsymbolic,-znotext -shared
+LDFLAGS+=	-Wl,-T${LDSCRIPT},-Bsymbolic,-znotext -pie
 
 .if ${MACHINE_CPUARCH} == "aarch64"
 CFLAGS+=	-mgeneral-regs-only

--- a/stand/efi/loader/Makefile
+++ b/stand/efi/loader/Makefile
@@ -84,7 +84,7 @@ LINKS+=		${BINDIR}/${LOADER}.efi ${BINDIR}/loader.efi
 .endif
 
 LDSCRIPT=	${.CURDIR}/../loader/arch/${MACHINE}/ldscript.${MACHINE}
-LDFLAGS+=	-Wl,-T${LDSCRIPT},-Bsymbolic,-znotext -shared
+LDFLAGS+=	-Wl,-T${LDSCRIPT},-Bsymbolic,-znotext -pie
 
 CLEANFILES+=	loader.efi
 

--- a/stand/i386/boot2/Makefile
+++ b/stand/i386/boot2/Makefile
@@ -66,7 +66,7 @@ BOOT2SIZE=	7680
 boot2: boot2.ld
 	@set -- `ls -l ${.ALLSRC}`; x=$$((${BOOT2SIZE}-$$5)); \
 	    echo "$$x bytes available"; test $$x -ge 0
-	${DD} if=${.ALLSRC} of=${.TARGET} obs=${BOOT2SIZE} conv=osync
+	${DD} if=${.ALLSRC} of=${.TARGET} bs=${BOOT2SIZE} conv=sync
 
 boot2.ld: boot2.ldr boot2.bin ${BTXKERN}
 	btxld -v -E ${ORG2} -f bin -b ${BTXKERN} -l boot2.ldr \

--- a/stand/i386/pxeldr/Makefile
+++ b/stand/i386/pxeldr/Makefile
@@ -31,7 +31,7 @@ CLEANFILES+= ${BOOT}.tmp
 
 ${BOOT}: ${LDR} ${LOADER}
 	cat ${LDR} ${LOADER} > ${.TARGET}.tmp
-	${DD} if=${.TARGET}.tmp of=${.TARGET} obs=2k conv=osync
+	${DD} if=${.TARGET}.tmp of=${.TARGET} bs=2048 conv=sync
 	rm ${.TARGET}.tmp
 
 LDFLAGS+=${LDFLAGS_BIN}

--- a/stand/i386/zfsboot/Makefile
+++ b/stand/i386/zfsboot/Makefile
@@ -62,7 +62,7 @@ BOOT2SIZE=	262144
 zfsboot2: zfsboot.ld
 	@set -- `ls -l ${.ALLSRC}`; x=$$((${BOOT2SIZE}-$$5)); \
 	    echo "$$x bytes available"; test $$x -ge 0
-	${DD} if=${.ALLSRC} of=${.TARGET} obs=${BOOT2SIZE} conv=osync
+	${DD} if=${.ALLSRC} of=${.TARGET} bs=${BOOT2SIZE} conv=sync
 
 zfsboot.ld: zfsboot.ldr zfsboot.bin ${BTXKERN}
 	btxld -v -E ${ORG2} -f bin -b ${BTXKERN} -l zfsboot.ldr \


### PR DESCRIPTION
With these changes I am able to build an x86_64 disk image an run it on qemu-system-x86_64 on a Linux host.

I'd like to get these into CheriBSD first so that we can boot x86 in Jenkins. Once it's merged here, I'll open upstream reviews.