### PR TITLE
kstack allocation cleanups

### DIFF
--- a/sys/mips/conf/BERI_DE4_BASE
+++ b/sys/mips/conf/BERI_DE4_BASE
@@ -11,7 +11,8 @@
 
 include "std.BERI"
 
-options	KSTACK_LARGE_PAGE	# Use a 16K page for kernel stack
+options 	KSTACK_LARGE_PAGE	# Use a 16K page for kernel stack
+options 	NO_SWAPPING
 
 options 	NFSCL			# Network Filesystem Client
 options 	NFSLOCKD		# Network Lock Manager

--- a/sys/mips/conf/BERI_SIM_BASE
+++ b/sys/mips/conf/BERI_SIM_BASE
@@ -21,3 +21,4 @@ device		altera_jtag_uart
 device		altera_sdcard
 
 options 	KSTACK_LARGE_PAGE	# Use a 16K page for kernel stack
+options 	NO_SWAPPING

--- a/sys/mips/conf/CHERI128_MALTA64
+++ b/sys/mips/conf/CHERI128_MALTA64
@@ -17,6 +17,7 @@ options 	KTRACE
 # Features required for CHERI CPU and CheriBSD support.
 #
 options 	KSTACK_LARGE_PAGE
+options 	NO_SWAPPING
 options 	TMPFS
 
 #

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -329,6 +329,16 @@ vm_kstack_palloc(vm_object_t ksobj, vm_offset_t ks, int allocflags, int pages,
 	KASSERT((ksobj != NULL), ("vm_kstack_palloc: invalid VM object"));
 	VM_OBJECT_ASSERT_WLOCKED(ksobj);
 
+#ifndef NO_SWAPPING
+	/*
+	 * Swapping adds races where some of the backing store might
+	 * be swapped out when swapping back in, but then we'd need to
+	 * make sure new pages are physically contiguous.  Without
+	 * swapping, this is only called for new kstacks for which
+	 * there should never be any existing backing store.
+	 */
+#error "KSTACK_LARGE_PAGE requires NO_SWAPPING"
+#endif
 	allocflags = (allocflags & ~VM_ALLOC_CLASS_MASK) | VM_ALLOC_NORMAL;
 
 	for (i = 0; i < pages; i++) {

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -317,8 +317,6 @@ SYSCTL_PROC(_vm, OID_AUTO, kstack_cache_size,
 
 #ifdef KSTACK_LARGE_PAGE
 
-#define	KSTACK_OBJT		OBJT_PHYS
-
 static int
 vm_kstack_palloc(vm_object_t ksobj, vm_offset_t ks, int allocflags, int pages,
     vm_page_t ma[])
@@ -394,8 +392,6 @@ retrylookup:
 
 #else /* ! KSTACK_LARGE_PAGE */
 
-#define	KSTACK_OBJT		OBJT_DEFAULT
-
 static int
 vm_kstack_palloc(vm_object_t ksobj, vm_offset_t ks, int allocflags, int pages,
     vm_page_t ma[])
@@ -417,8 +413,6 @@ vm_kstack_palloc(vm_object_t ksobj, vm_offset_t ks, int allocflags, int pages,
 #endif /* ! KSTACK_LARGE_PAGE */
 
 #else /* ! __mips__ */
-
-#define	KSTACK_OBJT		OBJT_DEFAULT
 
 static int
 vm_kstack_palloc(vm_object_t ksobj, vm_offset_t ks, int allocflags, int pages,
@@ -459,7 +453,7 @@ vm_thread_stack_create(struct domainset *ds, vm_object_t *ksobjp, int pages)
 	/*
 	 * Allocate an object for the kstack.
 	 */
-	ksobj = vm_object_allocate(KSTACK_OBJT, pages);
+	ksobj = vm_object_allocate(OBJT_DEFAULT, pages);
 
 	/*
 	 * Get a kernel virtual address for this thread's kstack.


### PR DESCRIPTION
After running into the buzzsaw of trying to rebase my earlier merge fix for the kstack issue, I decided to instead break out most of the cleanups into an earlier set of commits.  Once this is done, the merge is much simpler to resolve.  This doesn't include the actual merge as I plan to do that and push it to dev after this has landed on dev.

This should also fix #417 