### PR TITLE
Fix kernel CTF problems with mips

### DIFF
--- a/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
+++ b/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
@@ -788,9 +788,8 @@ dt_module_load(dtrace_hdl_t *dtp, dt_module_t *dmp)
 
 #ifdef __mips__
 	if (strcmp(dmp->dm_name,"kernel") == 0) {
-		dt_dprintf(
-		    "LOADING .dynsym INSTEAD OF .symtab FOR MIPS! A lot of symbols will"
-		    "be missing\n");
+		dt_dprintf("LOADING .dynsym INSTEAD OF .symtab FOR MIPS! "
+		    A lot of symbols will be missing\n");
 		dmp->dm_symtab.cts_name = ".dynsym";
 		dmp->dm_symtab.cts_type = SHT_DYNSYM;
 	} else {

--- a/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
+++ b/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
@@ -786,8 +786,21 @@ dt_module_load(dtrace_hdl_t *dtp, dt_module_t *dmp)
 	dmp->dm_ctdata.cts_entsize = 0;
 	dmp->dm_ctdata.cts_offset = 0;
 
+#ifdef __mips__
+	if (strcmp(dmp->dm_name,"kernel") == 0) {
+		dt_dprintf(
+		    "LOADING .dynsym INSTEAD OF .symtab FOR MIPS! A lot of symbols will"
+		    "be missing\n");
+		dmp->dm_symtab.cts_name = ".dynsym";
+		dmp->dm_symtab.cts_type = SHT_DYNSYM;
+	} else {
+		dmp->dm_symtab.cts_name = ".symtab";
+		dmp->dm_symtab.cts_type = SHT_SYMTAB;
+	}
+#else
 	dmp->dm_symtab.cts_name = ".symtab";
 	dmp->dm_symtab.cts_type = SHT_SYMTAB;
+#endif
 	dmp->dm_symtab.cts_flags = 0;
 	dmp->dm_symtab.cts_data = NULL;
 	dmp->dm_symtab.cts_size = 0;

--- a/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
+++ b/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
@@ -789,7 +789,7 @@ dt_module_load(dtrace_hdl_t *dtp, dt_module_t *dmp)
 #ifdef __mips__
 	if (strcmp(dmp->dm_name,"kernel") == 0) {
 		dt_dprintf("LOADING .dynsym INSTEAD OF .symtab FOR MIPS! "
-		    A lot of symbols will be missing\n");
+		    "A lot of symbols will be missing\n");
 		dmp->dm_symtab.cts_name = ".dynsym";
 		dmp->dm_symtab.cts_type = SHT_DYNSYM;
 	} else {

--- a/sys/conf/kern.opts.mk
+++ b/sys/conf/kern.opts.mk
@@ -72,7 +72,7 @@ BROKEN_OPTIONS+= CDDL ZFS
 .endif
 
 .if ${MACHINE_CPUARCH} == "mips"
-BROKEN_OPTIONS+= CDDL ZFS SSP
+BROKEN_OPTIONS+= ZFS SSP
 .endif
 
 .if ${MACHINE_CPUARCH} == "powerpc" && ${MACHINE_ARCH} == "powerpc"

--- a/sys/conf/kern.post.mk
+++ b/sys/conf/kern.post.mk
@@ -187,6 +187,17 @@ gdbinit:
 .endif
 .endif
 
+CTFFLAGS_KERNEL=${CTFFLAGS}
+.if ${MACHINE_CPUARCH} == "mips"
+# For mips, the CTF section is generated from the symbols in `.dynsym`.
+# `.dymsym` only contains a subset of the `.symtab` symbols, needed for
+# dynamic linking. This flag is needed because the `.symtab` section is not
+# loaded at boot time, and its address is not available anywhere without a
+# proper bootloader.
+# The problem can be solved looking at |sys/mips/mips/elf_trampoline.c|.
+CTFFLAGS_KERNEL+=-s
+.endif
+
 ${FULLKERNEL}: ${SYSTEM_DEP} vers.o
 	@rm -f ${.TARGET}
 	@echo linking ${.TARGET}
@@ -194,9 +205,10 @@ ${FULLKERNEL}: ${SYSTEM_DEP} vers.o
 .if !empty(MD_ROOT_SIZE_CONFIGURED) && defined(MFS_IMAGE)
 	@sh ${S}/tools/embed_mfs.sh ${.TARGET} ${MFS_IMAGE}
 .endif
+
 .if ${MK_CTF} != "no"
-	@echo ${CTFMERGE} ${CTFFLAGS} -o ${.TARGET} ...
-	@${CTFMERGE} ${CTFFLAGS} -o ${.TARGET} ${SYSTEM_OBJS} vers.o
+	@echo ${CTFMERGE} ${CTFFLAGS_KERNEL} -o ${.TARGET} ...
+	@${CTFMERGE} ${CTFFLAGS_KERNEL} -o ${.TARGET} ${SYSTEM_OBJS} vers.o
 .endif
 .if !defined(DEBUG)
 	${OBJCOPY} --strip-debug ${.TARGET}

--- a/sys/conf/kern.post.mk
+++ b/sys/conf/kern.post.mk
@@ -205,7 +205,6 @@ ${FULLKERNEL}: ${SYSTEM_DEP} vers.o
 .if !empty(MD_ROOT_SIZE_CONFIGURED) && defined(MFS_IMAGE)
 	@sh ${S}/tools/embed_mfs.sh ${.TARGET} ${MFS_IMAGE}
 .endif
-
 .if ${MK_CTF} != "no"
 	@echo ${CTFMERGE} ${CTFFLAGS_KERNEL} -o ${.TARGET} ...
 	@${CTFMERGE} ${CTFFLAGS_KERNEL} -o ${.TARGET} ${SYSTEM_OBJS} vers.o


### PR DESCRIPTION
For mips, the CTF section is now generated from the symbols in `.dynsym`. `.dymsym` only contains a subset of the `.symtab` symbols, needed for dynamic linking. This flag is needed because  the kernel`.symtab` section is not loaded at boot time, and its address is not available anywhere. 
DTrace, the only consumer of those data, uses the `.dynsym` table.