### PR TITLE
Fix proc_regs to handle Cheri PC offset in normal registers

### DIFF
--- a/lib/libproc/proc_regs.c
+++ b/lib/libproc/proc_regs.c
@@ -97,7 +97,6 @@ proc_regget(struct proc_handle *phdl, proc_reg_t reg, unsigned long *regvalue)
 		*regvalue = regs.r_eip;
 #elif defined(__mips__)
 		*regvalue = regs.r_regs[PC];
-#endif
 #elif defined(__powerpc__)
 		*regvalue = regs.pc;
 #elif defined(__riscv)


### PR DESCRIPTION
In the normal registers gathered from `PT_GETREGS` (ptrace) the pc is only the offset.
To have the complete address we have to add the base of the PCC.

The rest of `libproc` assumes that the PC is the complete one, and not only the offset.

