### PR TITLE
Make possible to compile the fasttrap module into kernel

### DIFF
--- a/sys/conf/files
+++ b/sys/conf/files
@@ -334,6 +334,8 @@ compat/cheriabi/cheriabi_vfs.c		optional compat_cheriabi
 # dtrace specific
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c	optional dtrace compile-with "${DTRACE_C}" \
 							warning "kernel contains CDDL licensed DTRACE"
+cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c	optional dtrace compile-with "${FASTTRAP_C}"
+cddl/contrib/opensolaris/common/unicode/u8_textprep.c   optional dtrace compile-with "${FASTTRAP_C}"
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace_xoroshiro128_plus.c	optional dtrace compile-with "${DTRACE_C}"
 cddl/dev/dtmalloc/dtmalloc.c		optional dtmalloc        | dtraceall compile-with "${CDDL_C}"
 cddl/dev/profile/profile.c		optional dtrace_profile  | dtraceall compile-with "${CDDL_C}"

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -334,8 +334,8 @@ compat/cheriabi/cheriabi_vfs.c		optional compat_cheriabi
 # dtrace specific
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c	optional dtrace compile-with "${DTRACE_C}" \
 							warning "kernel contains CDDL licensed DTRACE"
-cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c	optional dtrace compile-with "${FASTTRAP_C}"
-cddl/contrib/opensolaris/common/unicode/u8_textprep.c   optional dtrace compile-with "${FASTTRAP_C}"
+cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c	optional dtrace_fasttrap | dtraceall compile-with "${FASTTRAP_C}"
+cddl/contrib/opensolaris/common/unicode/u8_textprep.c   optional dtrace_fasttrap | dtraceall compile-with "${FASTTRAP_C}"
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace_xoroshiro128_plus.c	optional dtrace compile-with "${DTRACE_C}"
 cddl/dev/dtmalloc/dtmalloc.c		optional dtmalloc        | dtraceall compile-with "${CDDL_C}"
 cddl/dev/profile/profile.c		optional dtrace_profile  | dtraceall compile-with "${CDDL_C}"

--- a/sys/conf/files.mips
+++ b/sys/conf/files.mips
@@ -119,6 +119,7 @@ mips/mips/mips_pic.c			optional	intrng
 cddl/compat/opensolaris/kern/opensolaris_atomic.c	optional zfs | dtrace compile-with "${CDDL_C}"
 cddl/dev/dtrace/mips/dtrace_asm.S			optional dtrace compile-with "${DTRACE_S}"
 cddl/dev/dtrace/mips/dtrace_subr.c			optional dtrace compile-with "${DTRACE_C}"
+cddl/contrib/opensolaris/uts/mips/dtrace/fasttrap_isa.c     optional dtrace compile-with "${FASTTRAP_C}"
 cddl/dev/fbt/mips/fbt_isa.c				optional dtrace_fbt | dtraceall compile-with "${FBT_C}"
 
 # Zstd

--- a/sys/conf/files.mips
+++ b/sys/conf/files.mips
@@ -119,7 +119,7 @@ mips/mips/mips_pic.c			optional	intrng
 cddl/compat/opensolaris/kern/opensolaris_atomic.c	optional zfs | dtrace compile-with "${CDDL_C}"
 cddl/dev/dtrace/mips/dtrace_asm.S			optional dtrace compile-with "${DTRACE_S}"
 cddl/dev/dtrace/mips/dtrace_subr.c			optional dtrace compile-with "${DTRACE_C}"
-cddl/contrib/opensolaris/uts/mips/dtrace/fasttrap_isa.c     optional dtrace compile-with "${FASTTRAP_C}"
+cddl/contrib/opensolaris/uts/mips/dtrace/fasttrap_isa.c     optional dtrace_fasttrap | dtraceall compile-with "${FASTTRAP_C}"
 cddl/dev/fbt/mips/fbt_isa.c				optional dtrace_fbt | dtraceall compile-with "${FBT_C}"
 
 # Zstd

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -242,6 +242,15 @@ FBT_CFLAGS+=	-I$S/cddl/dev/fbt/x86
 .endif
 FBT_C=		${CC} -c ${FBT_CFLAGS}		${WERROR} ${PROF} ${.IMPSRC}
 
+# Special flags for managing the compat compiles for DTrace/fasttrap
+FASTTRAP_CFLAGS=	-DBUILDING_DTRACE -nostdinc \
+	-I$S/cddl/contrib/opensolaris/uts/${MACHINE_CPUARCH} \
+	-I$S/cddl/contrib/opensolaris/uts/common/sys \
+	-I$S/cddl/compat/opensolaris \
+	-I$S/cddl/contrib/opensolaris/uts/common \
+	-I$S ${CDDL_CFLAGS}
+FASTTRAP_C=		${CC} -c ${FASTTRAP_CFLAGS}		${WERROR} ${PROF} ${.IMPSRC}
+
 .if ${MK_CTF} != "no"
 NORMAL_CTFCONVERT=	${CTFCONVERT} ${CTFFLAGS} ${.TARGET}
 .elif ${MAKE_VERSION} >= 5201111300

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -399,8 +399,7 @@ _autofs=	autofs
 .endif
 
 .if ${MK_CDDL} != "no" || defined(ALL_MODULES)
-.if (${MACHINE_CPUARCH} != "arm" || ${MACHINE_ARCH:Marmv[67]*} != "") && \
-	${MACHINE_CPUARCH} != "mips"
+.if (${MACHINE_CPUARCH} != "arm" || ${MACHINE_ARCH:Marmv[67]*} != "")
 .if ${KERN_OPTS:MKDTRACE_HOOKS}
 SUBDIR+=	dtrace
 .endif

--- a/sys/modules/dtrace/Makefile
+++ b/sys/modules/dtrace/Makefile
@@ -16,12 +16,16 @@ SUBDIR=		dtaudit		\
 .if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
 SUBDIR+=	fasttrap fbt systrace_linux
 .endif
+
+.if ${MACHINE_CPUARCH} == "mips"
+SUBDIR+=	fasttrap
+.endif
+
 .if ${MACHINE_CPUARCH} == "amd64"
 SUBDIR+=	systrace_linux32
 .endif
 .if ${MACHINE_CPUARCH} == "amd64" || \
     ${MACHINE_CPUARCH} == "aarch64" || \
-    ${MACHINE_ARCH:Mmips64*} || \
     ${MACHINE_ARCH} == "powerpc64"
 SUBDIR+=	systrace_freebsd32
 .endif

--- a/sys/modules/dtrace/dtraceall/dtraceall.c
+++ b/sys/modules/dtrace/dtraceall/dtraceall.c
@@ -75,12 +75,12 @@ MODULE_DEPEND(dtraceall, dtnfscl, 1, 1, 1);
     defined(__powerpc__) || defined(__riscv)
 MODULE_DEPEND(dtraceall, fbt, 1, 1, 1);
 #endif
-#if defined(__amd64__) || defined(__i386__)
+#if defined(__amd64__) || defined(__i386__) || defined(__mips__)
 MODULE_DEPEND(dtraceall, fasttrap, 1, 1, 1);
 #endif
 MODULE_DEPEND(dtraceall, sdt, 1, 1, 1);
 MODULE_DEPEND(dtraceall, systrace, 1, 1, 1);
-#if defined(COMPAT_FREEBSD32)
+#if defined(COMPAT_FREEBSD32) && !defined(__mips__)
 MODULE_DEPEND(dtraceall, systrace_freebsd32, 1, 1, 1);
 #endif
 MODULE_DEPEND(dtraceall, profile, 1, 1, 1);

--- a/sys/modules/dtrace/fasttrap/Makefile
+++ b/sys/modules/dtrace/fasttrap/Makefile
@@ -19,6 +19,9 @@ CFLAGS+=	-I${SYSDIR}/cddl/contrib/opensolaris/uts/intel
 .elif ${MACHINE_CPUARCH} == "powerpc"
 CFLAGS+=	-I${SYSDIR}/cddl/contrib/opensolaris/uts/powerpc
 .PATH:		${SYSDIR}/cddl/contrib/opensolaris/uts/powerpc/dtrace
+.elif ${MACHINE_CPUARCH} == "mips"
+CFLAGS+=	-I${SYSDIR}/cddl/contrib/opensolaris/uts/mips
+.PATH:		${SYSDIR}/cddl/contrib/opensolaris/uts/mips/dtrace
 .endif
 
 .PATH:		${SYSDIR}/cddl/contrib/opensolaris/common/unicode


### PR DESCRIPTION
The necessary glue has been added to compile `fasttrap` into the kernel, and not as a dynamically loadable module (which is still possible).

Also, systrace_freebsd32 is not compiled if we are in mips. As there were too many errors.

**After this change, nothing new is compiled** (at the moment, dtrace is not compiled)