### PR TITLE
[UPSTREAM] Fix path to RTLD in libproc/proc_test.c

### DIFF
--- a/lib/libproc/tests/proc_test.c
+++ b/lib/libproc/tests/proc_test.c
@@ -39,14 +39,10 @@ __FBSDID("$FreeBSD$");
 #include <libelf.h>
 #include <libproc.h>
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#define	LD_ELF	"ld-cheri-elf"
-#else
-#define	LD_ELF	"ld-elf"
-#endif
+#include "../../../libexec/rtld-elf/paths.h"
 
 static const char *aout_object = "a.out";
-static const char *ldelf_object = LD_ELF".so.1";
+static const char *ldelf_object = _BASENAME_RTLD;
 static const char *target_prog_file = "target_prog";
 
 /*
@@ -203,6 +199,8 @@ ATF_TC_BODY(map_prefix_name2map, tc)
 {
 	struct proc_handle *phdl;
 	prmap_t *map1, *map2;
+	char basename_without_version[] = _BASENAME_RTLD;
+	char basename_without_suffix[] = _BASENAME_RTLD;
 
 	phdl = start_prog(tc, false);
 
@@ -210,10 +208,16 @@ ATF_TC_BODY(map_prefix_name2map, tc)
 	(void)proc_rdagent(phdl);
 
 	/* Make sure that "ld-elf" and "ld-elf.so" return the same map. */
-	map1 = proc_name2map(phdl, LD_ELF);
-	ATF_REQUIRE_MSG(map1 != NULL, "failed to look up map for '"LD_ELF"'");
-	map2 = proc_name2map(phdl, LD_ELF ".so");
-	ATF_REQUIRE_MSG(map2 != NULL, "failed to look up map for '"LD_ELF".so'");
+	ATF_REQUIRE_MSG(_BASENAME_RTLD[strlen(_BASENAME_RTLD) - 1] == '1',
+	    "Unexpected format for rtld path '" _BASENAME_RTLD "'");
+	*strchr(basename_without_suffix, '.') = '\0';
+	map1 = proc_name2map(phdl, basename_without_suffix);
+	ATF_REQUIRE_MSG(map1 != NULL, "failed to look up map for '%s'",
+	    basename_without_suffix);
+	*strrchr(basename_without_version, '.') = '\0';
+	map2 = proc_name2map(phdl, basename_without_version);
+	ATF_REQUIRE_MSG(map2 != NULL, "failed to look up map for '%s'",
+	    basename_without_version);
 	ATF_CHECK_EQ(strcmp(map1->pr_mapname, map2->pr_mapname), 0);
 
 	ATF_CHECK_EQ_MSG(proc_continue(phdl), 0, "failed to resume execution");


### PR DESCRIPTION
For a purecap world we use ld-elf.so.1, but for libcheri it should be
ld-cheri-elf.so.1. Reuse paths.h from RTLD to get the correct name.