### PR TITLE
Make sure we clear MIPS user TLS pointer on exec.

### DIFF
--- a/sys/mips/mips/pm_machdep.c
+++ b/sys/mips/mips/pm_machdep.c
@@ -766,6 +766,7 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 	    PCPU_SET(fpcurthread, (struct thread *)0);
 	td->td_md.md_ss_addr = 0;
 
+	td->td_md.md_tls = NULL;
 #ifdef COMPAT_FREEBSD32
 	if (SV_PROC_FLAG(td->td_proc, SV_ILP32))
 		td->td_md.md_tls_tcb_offset = TLS_TP_OFFSET32 + TLS_TCB_SIZE32;


### PR DESCRIPTION
It seems that the `md_tls` field was never cleared in `exec_setregs`. This results in weirdness if the old TLS pointer (capability) is retained.