### PR TITLE
Explicit copyout 3

### DIFF
--- a/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_pool.c
+++ b/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_pool.c
@@ -1311,7 +1311,11 @@ zpool_destroy(zpool_handle_t *zhp, const char *log_str)
 		return (-1);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+#ifdef __CHERI_PURE_CAPABILITY__
+	zc.zc_history = (void *)(uintptr_t)log_str;
+#else
 	zc.zc_history = (uint64_t)(uintptr_t)log_str;
+#endif
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_DESTROY, &zc) != 0) {
 		(void) snprintf(msg, sizeof (msg), dgettext(TEXT_DOMAIN,
@@ -1509,7 +1513,11 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_cookie = force;
 	zc.zc_guid = hardforce;
+#ifdef __CHERI_PURE_CAPABILITY__
+	zc.zc_history = (void *)(uintptr_t)log_str;
+#else
 	zc.zc_history = (uint64_t)(uintptr_t)log_str;
+#endif
 
 	if (zfs_ioctl(zhp->zpool_hdl, ZFS_IOC_POOL_EXPORT, &zc) != 0) {
 		switch (errno) {
@@ -3901,8 +3909,13 @@ zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
 	    &count) == 0);
 	if (count == 0)
 		return (0);
+#ifdef __CHERI_PURE_CAPABILITY__
+	if ((zc.zc_nvlist_dst = zfs_alloc(zhp->zpool_hdl,
+	    count * sizeof (zbookmark_phys_t))) == NULL)
+#else
 	if ((zc.zc_nvlist_dst = (uintptr_t)zfs_alloc(zhp->zpool_hdl,
 	    count * sizeof (zbookmark_phys_t))) == (uintptr_t)NULL)
+#endif
 		return (-1);
 	zc.zc_nvlist_dst_size = count;
 	(void) strcpy(zc.zc_name, zhp->zpool_name);
@@ -3918,7 +3931,11 @@ zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
 				    sizeof (zbookmark_phys_t));
 				if (dst == NULL)
 					return (-1);
+#ifdef __CHERI_PURE_CAPABILITY__
+				zc.zc_nvlist_dst = dst;
+#else
 				zc.zc_nvlist_dst = (uintptr_t)dst;
+#endif
 			} else {
 				return (-1);
 			}
@@ -4043,7 +4060,11 @@ get_history(zpool_handle_t *zhp, char *buf, uint64_t *off, uint64_t *len)
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	zc.zc_history = buf;
+#else
 	zc.zc_history = (uint64_t)(uintptr_t)buf;
+#endif
 	zc.zc_history_len = *len;
 	zc.zc_history_offset = *off;
 

--- a/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_sendrecv.c
+++ b/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_sendrecv.c
@@ -3528,7 +3528,11 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		return (recv_skip(hdl, infd, flags->byteswap));
 	}
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	zc.zc_nvlist_dst = prop_errbuf;
+#else
 	zc.zc_nvlist_dst = (uint64_t)(uintptr_t)prop_errbuf;
+#endif
 	zc.zc_nvlist_dst_size = sizeof (prop_errbuf);
 	zc.zc_cleanup_fd = cleanup_fd;
 	zc.zc_action_handle = *action_handlep;

--- a/cddl/contrib/opensolaris/lib/libzfs_core/common/libzfs_core.c
+++ b/cddl/contrib/opensolaris/lib/libzfs_core/common/libzfs_core.c
@@ -164,7 +164,11 @@ lzc_ioctl(zfs_ioc_t ioc, const char *name,
 
 	if (source != NULL) {
 		packed = fnvlist_pack(source, &size);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zc.zc_nvlist_src = packed;
+#else
 		zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
+#endif
 		zc.zc_nvlist_src_size = size;
 	}
 
@@ -176,7 +180,11 @@ lzc_ioctl(zfs_ioc_t ioc, const char *name,
 		} else {
 			zc.zc_nvlist_dst_size = MAX(size * 2, 128 * 1024);
 		}
+#ifdef __CHERI_PURE_CAPABILITY__
+		zc.zc_nvlist_dst =
+#else
 		zc.zc_nvlist_dst = (uint64_t)(uintptr_t)
+#endif
 		    malloc(zc.zc_nvlist_dst_size);
 #ifdef illumos
 		if (zc.zc_nvlist_dst == NULL) {
@@ -200,7 +208,11 @@ lzc_ioctl(zfs_ioc_t ioc, const char *name,
 		    ioc != ZFS_IOC_CHANNEL_PROGRAM) {
 			free((void *)(uintptr_t)zc.zc_nvlist_dst);
 			zc.zc_nvlist_dst_size *= 2;
+#ifdef __CHERI_PURE_CAPABILITY__
+			zc.zc_nvlist_dst =
+#else
 			zc.zc_nvlist_dst = (uint64_t)(uintptr_t)
+#endif
 			    malloc(zc.zc_nvlist_dst_size);
 #ifdef illumos
 			if (zc.zc_nvlist_dst == NULL) {
@@ -739,7 +751,11 @@ recv_impl(const char *snapname, nvlist_t *props, const char *origin,
 	if (props != NULL) {
 		/* zc_nvlist_src is props to set */
 		packed = fnvlist_pack(props, &size);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zc.zc_nvlist_src = packed;
+#else
 		zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
+#endif
 		zc.zc_nvlist_src_size = size;
 	}
 

--- a/sys/cddl/contrib/opensolaris/common/zfs/zfs_ioctl_compat.c
+++ b/sys/cddl/contrib/opensolaris/common/zfs/zfs_ioctl_compat.c
@@ -26,6 +26,8 @@
  * Use is subject to license terms.
  */
 
+#define EXPLICIT_USER_ACCESS
+
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/cred.h>
@@ -41,6 +43,17 @@ static int zfs_version_ioctl = ZFS_IOCVER_CURRENT;
 SYSCTL_DECL(_vfs_zfs_version);
 SYSCTL_INT(_vfs_zfs_version, OID_AUTO, ioctl, CTLFLAG_RD, &zfs_version_ioctl,
     0, "ZFS_IOCTL_VERSION");
+
+#ifdef _KERNEL
+#define	__PTR_COMPAT_TO_NATIVE(addr, len)	__USER_CAP(addr, len)
+#define	__PTR_NATIVE_TO_COMPAT(ptr)		((__cheri_addr vaddr_t)(ptr))
+#elif defined(__CHERI_PURE_CAPABILITY__)
+#define	__PTR_COMPAT_TO_NATIVE(addr, len)	((void *)(uintptr_t)(addr))
+#define	__PTR_NATIVE_TO_COMPAT(ptr)		((__cheri_addr vaddr_t)(ptr))
+#else
+#define	__PTR_COMPAT_TO_NATIVE(addr, len)	(addr)
+#define	__PTR_NATIVE_TO_COMPAT(ptr)		(ptr)
+#endif
 
 /*
  * FreeBSD zfs_cmd compatibility with older binaries
@@ -66,15 +79,16 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_string, inlanes_c->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zc->field = inlanes_c->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(inlanes_c->field, inlanes_c->len)
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history, zc_history_len);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -99,6 +113,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_RESUME:
@@ -109,15 +124,16 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_string, resume_c->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zc->field = resume_c->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(resume_c->field, resume_c->len)
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history, zc_history_len);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -159,6 +175,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_EDBP:
@@ -169,15 +186,16 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_string, edbp_c->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zc->field = edbp_c->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(edbp_c->field, edbp_c->len)
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history, zc_history_len);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -219,6 +237,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_ZCMD:
@@ -229,15 +248,16 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_string, zcmd_c->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zc->field = zcmd_c->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(zcmd_c->field, zcmd_c->len)
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history, zc_history_len);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -282,6 +302,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 
 		break;
 
@@ -293,17 +314,18 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_string, zcdm_c->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zc->field = zcdm_c->field
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(zcdm_c->field, zcdm_c->len)
 		zc->zc_guid = zcdm_c->zc_guid;
-		zc->zc_nvlist_conf = zcdm_c->zc_nvlist_conf;
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		zc->zc_nvlist_conf_size = zcdm_c->zc_nvlist_conf_size;
-		zc->zc_nvlist_src = zcdm_c->zc_nvlist_src;
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		zc->zc_nvlist_src_size = zcdm_c->zc_nvlist_src_size;
-		zc->zc_nvlist_dst = zcdm_c->zc_nvlist_dst;
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		zc->zc_nvlist_dst_size = zcdm_c->zc_nvlist_dst_size;
 		zc->zc_cookie = zcdm_c->zc_cookie;
 		zc->zc_objset_type = zcdm_c->zc_objset_type;
 		zc->zc_perm_action = zcdm_c->zc_perm_action;
-		zc->zc_history = zcdm_c->zc_history;
+		PTR_COPY(zc_history, zc_history_len);
 		zc->zc_history_len = zcdm_c->zc_history_len;
 		zc->zc_history_offset = zcdm_c->zc_history_offset;
 		zc->zc_obj = zcdm_c->zc_obj;
@@ -344,6 +366,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		/* we always assume zc_nvlist_dst_filled is true */
 		zc->zc_nvlist_dst_filled = B_TRUE;
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_V28:
@@ -353,17 +376,20 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_name, zc28_c->zc_name, MAXPATHLEN);
 		strlcpy(zc->zc_value, zc28_c->zc_value, MAXPATHLEN * 2);
 		strlcpy(zc->zc_string, zc28_c->zc_string, MAXPATHLEN);
+
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(zc28_c->field, zc28_c->len)
+
 		zc->zc_guid = zc28_c->zc_guid;
-		zc->zc_nvlist_conf = zc28_c->zc_nvlist_conf;
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		zc->zc_nvlist_conf_size = zc28_c->zc_nvlist_conf_size;
-		zc->zc_nvlist_src = zc28_c->zc_nvlist_src;
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		zc->zc_nvlist_src_size = zc28_c->zc_nvlist_src_size;
-		zc->zc_nvlist_dst = zc28_c->zc_nvlist_dst;
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		zc->zc_nvlist_dst_size = zc28_c->zc_nvlist_dst_size;
 		zc->zc_cookie = zc28_c->zc_cookie;
 		zc->zc_objset_type = zc28_c->zc_objset_type;
 		zc->zc_perm_action = zc28_c->zc_perm_action;
-		zc->zc_history = zc28_c->zc_history;
+		PTR_COPY(zc_history, zc_history_len);
 		zc->zc_history_len = zc28_c->zc_history_len;
 		zc->zc_history_offset = zc28_c->zc_history_offset;
 		zc->zc_obj = zc28_c->zc_obj;
@@ -415,6 +441,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		zc->zc_inject_record.zi_nlanes = 1;
 		zc->zc_inject_record.zi_cmd = ZINJECT_UNINITIALIZED;
 		zc->zc_inject_record.zi_pad = 0;
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_V15:
@@ -424,17 +451,20 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		strlcpy(zc->zc_name, zc_c->zc_name, MAXPATHLEN);
 		strlcpy(zc->zc_value, zc_c->zc_value, MAXPATHLEN);
 		strlcpy(zc->zc_string, zc_c->zc_string, MAXPATHLEN);
+
+#define PTR_COPY(field, len) zc->field = __PTR_COMPAT_TO_NATIVE(zc_c->field, zc_c->len)
+
 		zc->zc_guid = zc_c->zc_guid;
-		zc->zc_nvlist_conf = zc_c->zc_nvlist_conf;
+		PTR_COPY(zc_nvlist_conf, zc_nvlist_conf_size);
 		zc->zc_nvlist_conf_size = zc_c->zc_nvlist_conf_size;
-		zc->zc_nvlist_src = zc_c->zc_nvlist_src;
+		PTR_COPY(zc_nvlist_src, zc_nvlist_src_size);
 		zc->zc_nvlist_src_size = zc_c->zc_nvlist_src_size;
-		zc->zc_nvlist_dst = zc_c->zc_nvlist_dst;
+		PTR_COPY(zc_nvlist_dst, zc_nvlist_dst_size);
 		zc->zc_nvlist_dst_size = zc_c->zc_nvlist_dst_size;
 		zc->zc_cookie = zc_c->zc_cookie;
 		zc->zc_objset_type = zc_c->zc_objset_type;
 		zc->zc_perm_action = zc_c->zc_perm_action;
-		zc->zc_history = zc_c->zc_history;
+		PTR_COPY(zc_history, zc_history_len);
 		zc->zc_history_len = zc_c->zc_history_len;
 		zc->zc_history_offset = zc_c->zc_history_offset;
 		zc->zc_obj = zc_c->zc_obj;
@@ -464,6 +494,7 @@ zfs_cmd_compat_get(zfs_cmd_t *zc, caddr_t addr, const int cflag)
 		    zc_c->zc_inject_record.zi_freq;
 		zc->zc_inject_record.zi_failfast =
 		    zc_c->zc_inject_record.zi_failfast;
+#undef PTR_COPY
 		break;
 	}
 }
@@ -488,15 +519,16 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(inlanes_c->zc_string, zc->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) inlanes_c->field = zc->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field) inlanes_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
+		PTR_COPY(zc_nvlist_src);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -520,6 +552,7 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_RESUME:
@@ -529,15 +562,16 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(resume_c->zc_string, zc->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) resume_c->field = zc->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field) resume_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
+		PTR_COPY(zc_nvlist_src);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -577,6 +611,7 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_EDBP:
@@ -586,15 +621,16 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(edbp_c->zc_string, zc->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) edbp_c->field = zc->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field) edbp_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
+		PTR_COPY(zc_nvlist_src);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -634,6 +670,7 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_ZCMD:
@@ -644,15 +681,16 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(zcmd_c->zc_string, zc->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zcmd_c->field = zc->field
-		FIELD_COPY(zc_nvlist_src);
+#define PTR_COPY(field) zcmd_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
+		PTR_COPY(zc_nvlist_src);
 		FIELD_COPY(zc_nvlist_src_size);
-		FIELD_COPY(zc_nvlist_dst);
+		PTR_COPY(zc_nvlist_dst);
 		FIELD_COPY(zc_nvlist_dst_size);
 		FIELD_COPY(zc_nvlist_dst_filled);
 		FIELD_COPY(zc_pad2);
-		FIELD_COPY(zc_history);
+		PTR_COPY(zc_history);
 		FIELD_COPY(zc_guid);
-		FIELD_COPY(zc_nvlist_conf);
+		PTR_COPY(zc_nvlist_conf);
 		FIELD_COPY(zc_nvlist_conf_size);
 		FIELD_COPY(zc_cookie);
 		FIELD_COPY(zc_objset_type);
@@ -695,6 +733,7 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		FIELD_COPY(zc_createtxg);
 		FIELD_COPY(zc_stat);
 #undef FIELD_COPY
+#undef PTR_COPY
 
 		break;
 
@@ -706,17 +745,18 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(zcdm_c->zc_string, zc->zc_string, MAXPATHLEN);
 
 #define FIELD_COPY(field) zcdm_c->field = zc->field
+#define PTR_COPY(field) zcdm_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
 		zcdm_c->zc_guid = zc->zc_guid;
-		zcdm_c->zc_nvlist_conf = zc->zc_nvlist_conf;
+		PTR_COPY(zc_nvlist_conf);
 		zcdm_c->zc_nvlist_conf_size = zc->zc_nvlist_conf_size;
-		zcdm_c->zc_nvlist_src = zc->zc_nvlist_src;
+		PTR_COPY(zc_nvlist_src);
 		zcdm_c->zc_nvlist_src_size = zc->zc_nvlist_src_size;
-		zcdm_c->zc_nvlist_dst = zc->zc_nvlist_dst;
+		PTR_COPY(zc_nvlist_dst);
 		zcdm_c->zc_nvlist_dst_size = zc->zc_nvlist_dst_size;
 		zcdm_c->zc_cookie = zc->zc_cookie;
 		zcdm_c->zc_objset_type = zc->zc_objset_type;
 		zcdm_c->zc_perm_action = zc->zc_perm_action;
-		zcdm_c->zc_history = zc->zc_history;
+		PTR_COPY(zc_history);
 		zcdm_c->zc_history_len = zc->zc_history_len;
 		zcdm_c->zc_history_offset = zc->zc_history_offset;
 		zcdm_c->zc_obj = zc->zc_obj;
@@ -752,6 +792,7 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		FIELD_COPY(zc_inject_record.zi_cmd);
 		FIELD_COPY(zc_inject_record.zi_pad);
 #undef FIELD_COPY
+#undef PTR_COPY
 #ifndef _KERNEL
 		if (request == ZFS_IOC_RECV)
 			strlcpy(zcdm_c->zc_top_ds,
@@ -766,17 +807,19 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(zc28_c->zc_name, zc->zc_name, MAXPATHLEN);
 		strlcpy(zc28_c->zc_value, zc->zc_value, MAXPATHLEN * 2);
 		strlcpy(zc28_c->zc_string, zc->zc_string, MAXPATHLEN);
+
+#define PTR_COPY(field) zc28_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
 		zc28_c->zc_guid = zc->zc_guid;
-		zc28_c->zc_nvlist_conf = zc->zc_nvlist_conf;
+		PTR_COPY(zc_nvlist_conf);
 		zc28_c->zc_nvlist_conf_size = zc->zc_nvlist_conf_size;
-		zc28_c->zc_nvlist_src = zc->zc_nvlist_src;
+		PTR_COPY(zc_nvlist_src);
 		zc28_c->zc_nvlist_src_size = zc->zc_nvlist_src_size;
-		zc28_c->zc_nvlist_dst = zc->zc_nvlist_dst;
+		PTR_COPY(zc_nvlist_dst);
 		zc28_c->zc_nvlist_dst_size = zc->zc_nvlist_dst_size;
 		zc28_c->zc_cookie = zc->zc_cookie;
 		zc28_c->zc_objset_type = zc->zc_objset_type;
 		zc28_c->zc_perm_action = zc->zc_perm_action;
-		zc28_c->zc_history = zc->zc_history;
+		PTR_COPY(zc_history);
 		zc28_c->zc_history_len = zc->zc_history_len;
 		zc28_c->zc_history_offset = zc->zc_history_offset;
 		zc28_c->zc_obj = zc->zc_obj;
@@ -829,6 +872,7 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		    zc->zc_inject_record.zi_duration;
 		zc28_c->zc_inject_record.zi_timer =
 		    zc->zc_inject_record.zi_timer;
+#undef PTR_COPY
 		break;
 
 	case ZFS_CMD_COMPAT_V15:
@@ -838,17 +882,19 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		strlcpy(zc_c->zc_name, zc->zc_name, MAXPATHLEN);
 		strlcpy(zc_c->zc_value, zc->zc_value, MAXPATHLEN);
 		strlcpy(zc_c->zc_string, zc->zc_string, MAXPATHLEN);
+
+#define PTR_COPY(field) zc_c->field = __PTR_NATIVE_TO_COMPAT(zc->field)
 		zc_c->zc_guid = zc->zc_guid;
-		zc_c->zc_nvlist_conf = zc->zc_nvlist_conf;
+		PTR_COPY(zc_nvlist_conf);
 		zc_c->zc_nvlist_conf_size = zc->zc_nvlist_conf_size;
-		zc_c->zc_nvlist_src = zc->zc_nvlist_src;
+		PTR_COPY(zc_nvlist_src);
 		zc_c->zc_nvlist_src_size = zc->zc_nvlist_src_size;
-		zc_c->zc_nvlist_dst = zc->zc_nvlist_dst;
+		PTR_COPY(zc_nvlist_dst);
 		zc_c->zc_nvlist_dst_size = zc->zc_nvlist_dst_size;
 		zc_c->zc_cookie = zc->zc_cookie;
 		zc_c->zc_objset_type = zc->zc_objset_type;
 		zc_c->zc_perm_action = zc->zc_perm_action;
-		zc_c->zc_history = zc->zc_history;
+		PTR_COPY(zc_history);
 		zc_c->zc_history_len = zc->zc_history_len;
 		zc_c->zc_history_offset = zc->zc_history_offset;
 		zc_c->zc_obj = zc->zc_obj;
@@ -878,14 +924,21 @@ zfs_cmd_compat_put(zfs_cmd_t *zc, caddr_t addr, const int request,
 		    zc->zc_inject_record.zi_freq;
 		zc_c->zc_inject_record.zi_failfast =
 		    zc->zc_inject_record.zi_failfast;
+#undef PTR_COPY
 
 		break;
 	}
 }
 
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+static int
+zfs_ioctl_compat_get_nvlist(void * __capability nvl, size_t size, int iflag,
+    nvlist_t **nvp)
+#else
 static int
 zfs_ioctl_compat_get_nvlist(uint64_t nvl, size_t size, int iflag,
     nvlist_t **nvp)
+#endif
 {
 	char *packed;
 	int error;
@@ -899,7 +952,7 @@ zfs_ioctl_compat_get_nvlist(uint64_t nvl, size_t size, int iflag,
 
 #ifdef _KERNEL
 	packed = kmem_alloc(size, KM_SLEEP);
-	if ((error = ddi_copyin((void *)(uintptr_t)nvl, packed, size,
+	if ((error = ddi_copyin(nvl, packed, size,
 	    iflag)) != 0) {
 		kmem_free(packed, size);
 		return (error);
@@ -936,7 +989,7 @@ zfs_ioctl_compat_put_nvlist(zfs_cmd_t *zc, nvlist_t *nvl)
 	    KM_SLEEP) == 0);
 
 	if (ddi_copyout(packed,
-	    (void *)(uintptr_t)zc->zc_nvlist_dst, size, zc->zc_iflags) != 0)
+	    zc->zc_nvlist_dst, size, zc->zc_iflags) != 0)
 		error = EFAULT;
 	kmem_free(packed, size);
 #else
@@ -1069,31 +1122,51 @@ zcmd_ioctl_compat(int fd, int request, zfs_cmd_t *zc, const int cflag)
 	switch (cflag) {
 	case ZFS_CMD_COMPAT_NONE:
 		ncmd = _IOWR('Z', request, struct zfs_iocparm);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zp.zfs_cmd = zc;
+#else
 		zp.zfs_cmd = (uint64_t)zc;
+#endif
 		zp.zfs_cmd_size = sizeof(zfs_cmd_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_CURRENT;
 		return (ioctl(fd, ncmd, &zp));
 	case ZFS_CMD_COMPAT_INLANES:
 		ncmd = _IOWR('Z', request, struct zfs_iocparm);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zp.zfs_cmd = zc;
+#else
 		zp.zfs_cmd = (uint64_t)zc;
+#endif
 		zp.zfs_cmd_size = sizeof(zfs_cmd_inlanes_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_INLANES;
 		return (ioctl(fd, ncmd, &zp));
 	case ZFS_CMD_COMPAT_RESUME:
 		ncmd = _IOWR('Z', request, struct zfs_iocparm);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zp.zfs_cmd = zc;
+#else
 		zp.zfs_cmd = (uint64_t)zc;
+#endif
 		zp.zfs_cmd_size = sizeof(zfs_cmd_resume_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_RESUME;
 		return (ioctl(fd, ncmd, &zp));
 	case ZFS_CMD_COMPAT_EDBP:
 		ncmd = _IOWR('Z', request, struct zfs_iocparm);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zp.zfs_cmd = zc;
+#else
 		zp.zfs_cmd = (uint64_t)zc;
+#endif
 		zp.zfs_cmd_size = sizeof(zfs_cmd_edbp_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_EDBP;
 		return (ioctl(fd, ncmd, &zp));
 	case ZFS_CMD_COMPAT_ZCMD:
 		ncmd = _IOWR('Z', request, struct zfs_iocparm);
+#ifdef __CHERI_PURE_CAPABILITY__
+		zp.zfs_cmd = zc;
+#else
 		zp.zfs_cmd = (uint64_t)zc;
+#endif
 		zp.zfs_cmd_size = sizeof(zfs_cmd_zcmd_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_ZCMD;
 		return (ioctl(fd, ncmd, &zp));

--- a/sys/cddl/contrib/opensolaris/common/zfs/zfs_ioctl_compat.h
+++ b/sys/cddl/contrib/opensolaris/common/zfs/zfs_ioctl_compat.h
@@ -75,7 +75,11 @@ extern "C" {
 
 typedef struct zfs_iocparm {
 	uint32_t	zfs_ioctl_version;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability zfs_cmd;
+#else
 	uint64_t	zfs_cmd;
+#endif
 	uint64_t	zfs_cmd_size;
 } zfs_iocparm_t;
 

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/spa_errlog.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/spa_errlog.c
@@ -48,6 +48,8 @@
  * this list and displaying it to the user.
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/dmu_tx.h>
 #include <sys/spa.h>
 #include <sys/spa_impl.h>
@@ -161,7 +163,7 @@ spa_get_errlog_size(spa_t *spa)
 
 #ifdef _KERNEL
 static int
-process_error_log(spa_t *spa, uint64_t obj, void *addr, size_t *count)
+process_error_log(spa_t *spa, uint64_t obj, void * __capability addr, size_t *count)
 {
 	zap_cursor_t zc;
 	zap_attribute_t za;
@@ -181,7 +183,7 @@ process_error_log(spa_t *spa, uint64_t obj, void *addr, size_t *count)
 
 		name_to_bookmark(za.za_name, &zb);
 
-		if (copyout(&zb, (char *)addr +
+		if (copyout(&zb, (char * __capability)addr +
 		    (*count - 1) * sizeof (zbookmark_phys_t),
 		    sizeof (zbookmark_phys_t)) != 0) {
 			zap_cursor_fini(&zc);
@@ -197,7 +199,7 @@ process_error_log(spa_t *spa, uint64_t obj, void *addr, size_t *count)
 }
 
 static int
-process_error_list(avl_tree_t *list, void *addr, size_t *count)
+process_error_list(avl_tree_t *list, void * __capability addr, size_t *count)
 {
 	spa_error_entry_t *se;
 
@@ -206,7 +208,7 @@ process_error_list(avl_tree_t *list, void *addr, size_t *count)
 		if (*count == 0)
 			return (SET_ERROR(ENOMEM));
 
-		if (copyout(&se->se_bookmark, (char *)addr +
+		if (copyout(&se->se_bookmark, (char * __capability)addr +
 		    (*count - 1) * sizeof (zbookmark_phys_t),
 		    sizeof (zbookmark_phys_t)) != 0)
 			return (SET_ERROR(EFAULT));
@@ -230,7 +232,7 @@ process_error_list(avl_tree_t *list, void *addr, size_t *count)
  * the error list lock when we are finished.
  */
 int
-spa_get_errlog(spa_t *spa, void *uaddr, size_t *count)
+spa_get_errlog(spa_t *spa, void * __capability uaddr, size_t *count)
 {
 	int ret = 0;
 

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/sys/spa.h
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/sys/spa.h
@@ -918,7 +918,7 @@ extern void zfs_post_remove(spa_t *spa, vdev_t *vd);
 extern void zfs_post_state_change(spa_t *spa, vdev_t *vd);
 extern void zfs_post_autoreplace(spa_t *spa, vdev_t *vd);
 extern uint64_t spa_get_errlog_size(spa_t *spa);
-extern int spa_get_errlog(spa_t *spa, void *uaddr, size_t *count);
+extern int spa_get_errlog(spa_t *spa, void * __capability uaddr, size_t *count);
 extern void spa_errlog_rotate(spa_t *spa);
 extern void spa_errlog_drain(spa_t *spa);
 extern void spa_errlog_sync(spa_t *spa, uint64_t txg);

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/sys/zfs_ioctl.h
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/sys/zfs_ioctl.h
@@ -359,9 +359,17 @@ typedef enum zfs_case {
  */
 typedef struct zfs_cmd {
 	char		zc_name[MAXPATHLEN];	/* name of pool or dataset */
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability zc_nvlist_src;
+#else
 	uint64_t	zc_nvlist_src;		/* really (char *) */
+#endif
 	uint64_t	zc_nvlist_src_size;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability zc_nvlist_dst;
+#else
 	uint64_t	zc_nvlist_dst;		/* really (char *) */
+#endif
 	uint64_t	zc_nvlist_dst_size;
 	boolean_t	zc_nvlist_dst_filled;	/* put an nvlist in dst? */
 	int		zc_pad2;
@@ -370,11 +378,19 @@ typedef struct zfs_cmd {
 	 * The following members are for legacy ioctls which haven't been
 	 * converted to the new method.
 	 */
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability zc_history;
+#else
 	uint64_t	zc_history;		/* really (char *) */
+#endif
 	char		zc_value[MAXPATHLEN * 2];
 	char		zc_string[MAXNAMELEN];
 	uint64_t	zc_guid;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability zc_nvlist_conf;
+#else
 	uint64_t	zc_nvlist_conf;		/* really (char *) */
+#endif
 	uint64_t	zc_nvlist_conf_size;
 	uint64_t	zc_cookie;
 	uint64_t	zc_objset_type;

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_ioctl.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_ioctl.c
@@ -137,6 +137,8 @@
  *         distinguish between the operation failing, and
  *         deserialization failing.
  */
+#define EXPLICIT_USER_ACCESS
+
 #ifdef __FreeBSD__
 #include "opt_kstack_pages.h"
 #endif
@@ -262,7 +264,7 @@ static int zfs_check_clearable(char *dataset, nvlist_t *props,
 static int zfs_fill_zplprops_root(uint64_t, nvlist_t *, nvlist_t *,
     boolean_t *);
 int zfs_set_prop_nvlist(const char *, zprop_source_t, nvlist_t *, nvlist_t *);
-static int get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp);
+static int get_nvlist(void * __capability nvl, uint64_t size, int iflag, nvlist_t **nvp);
  
 static void zfsdev_close(void *data);
 
@@ -319,7 +321,7 @@ history_str_get(zfs_cmd_t *zc)
 		return (NULL);
 
 	buf = kmem_alloc(HIS_MAX_RECORD_LEN, KM_SLEEP);
-	if (copyinstr((void *)(uintptr_t)zc->zc_history,
+	if (copyinstr(zc->zc_history,
 	    buf, HIS_MAX_RECORD_LEN, NULL) != 0) {
 		history_str_free(buf);
 		return (NULL);
@@ -1362,7 +1364,7 @@ zfs_secpolicy_tmp_snapshot(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  * Returns the nvlist as specified by the user in the zfs_cmd_t.
  */
 static int
-get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
+get_nvlist(void * __capability nvl, uint64_t size, int iflag, nvlist_t **nvp)
 {
 	char *packed;
 	int error;
@@ -1376,7 +1378,7 @@ get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
 
 	packed = kmem_alloc(size, KM_SLEEP);
 
-	if ((error = ddi_copyin((void *)(uintptr_t)nvl, packed, size,
+	if ((error = ddi_copyin(nvl, packed, size,
 	    iflag)) != 0) {
 		kmem_free(packed, size);
 		return (SET_ERROR(EFAULT));
@@ -1453,7 +1455,7 @@ put_nvlist(zfs_cmd_t *zc, nvlist_t *nvl)
 		error = 0;
 	} else {
 		packed = fnvlist_pack(nvl, &size);
-		if (ddi_copyout(packed, (void *)(uintptr_t)zc->zc_nvlist_dst,
+		if (ddi_copyout(packed, zc->zc_nvlist_dst,
 		    size, zc->zc_iflags) != 0)
 			error = SET_ERROR(EFAULT);
 		fnvlist_pack_free(packed, size);
@@ -1866,7 +1868,7 @@ zfs_ioc_pool_get_history(zfs_cmd_t *zc)
 	if ((error = spa_history_get(spa, &zc->zc_history_offset,
 	    &zc->zc_history_len, hist_buf)) == 0) {
 		error = ddi_copyout(hist_buf,
-		    (void *)(uintptr_t)zc->zc_history,
+		    zc->zc_history,
 		    zc->zc_history_len, zc->zc_iflags);
 	}
 
@@ -5079,7 +5081,7 @@ zfs_ioc_error_log(zfs_cmd_t *zc)
 	if ((error = spa_open(zc->zc_name, &spa, FTAG)) != 0)
 		return (error);
 
-	error = spa_get_errlog(spa, (void *)(uintptr_t)zc->zc_nvlist_dst,
+	error = spa_get_errlog(spa, zc->zc_nvlist_dst,
 	    &count);
 	if (error == 0)
 		zc->zc_nvlist_dst_size = count;
@@ -5327,7 +5329,7 @@ zfs_ioc_userspace_many(zfs_cmd_t *zc)
 
 	if (error == 0) {
 		error = ddi_copyout(buf,
-		    (void *)(uintptr_t)zc->zc_nvlist_dst,
+		    zc->zc_nvlist_dst,
 		    zc->zc_nvlist_dst_size, zc->zc_iflags);
 	}
 	kmem_free(buf, bufsize);
@@ -6804,15 +6806,15 @@ zfsdev_ioctl(struct cdev *dev, u_long zcmd, caddr_t arg, int flag,
 			compat_zc = kmem_zalloc(sizeof(zfs_cmd_t), KM_SLEEP);
 			bzero(compat_zc, sizeof(zfs_cmd_t));
 
-			error = ddi_copyin((void *)(uintptr_t)zc_iocparm->zfs_cmd,
+			error = ddi_copyin(zc_iocparm->zfs_cmd,
 			    compat_zc, zc_iocparm->zfs_cmd_size, flag);
 			if (error != 0) {
 				error = SET_ERROR(EFAULT);
 				goto out;
 			}
 		} else {
-			error = ddi_copyin((void *)(uintptr_t)zc_iocparm->zfs_cmd,
-			    zc, zc_iocparm->zfs_cmd_size, flag);
+			error = copyincap(zc_iocparm->zfs_cmd,
+			    zc, zc_iocparm->zfs_cmd_size);
 			if (error != 0) {
 				error = SET_ERROR(EFAULT);
 				goto out;
@@ -6981,7 +6983,7 @@ out:
 
 			zfs_cmd_compat_put(zc, compat_zc, vecnum, cflag);
 			rc = ddi_copyout(compat_zc,
-			    (void *)(uintptr_t)zc_iocparm->zfs_cmd,
+			    zc_iocparm->zfs_cmd,
 			    zc_iocparm->zfs_cmd_size, flag);
 			if (error == 0 && rc != 0)
 				error = SET_ERROR(EFAULT);
@@ -6992,8 +6994,8 @@ out:
 	} else {
 		ASSERT(newioc);
 
-		rc = ddi_copyout(zc, (void *)(uintptr_t)zc_iocparm->zfs_cmd,
-		    sizeof (zfs_cmd_t), flag);
+		rc = copyoutcap(zc, zc_iocparm->zfs_cmd,
+		    sizeof (zfs_cmd_t));
 		if (error == 0 && rc != 0)
 			error = SET_ERROR(EFAULT);
 	}

--- a/sys/dev/cxgb/cxgb_ioctl.h
+++ b/sys/dev/cxgb/cxgb_ioctl.h
@@ -97,7 +97,7 @@ struct ch_mem_range {
 	uint32_t addr;
 	uint32_t len;
 	uint32_t version;
-	uint8_t  *buf;
+	uint8_t * __kerncap buf;
 };
 
 enum { MEM_CM, MEM_PMRX, MEM_PMTX };   /* ch_mem_range.mem_id values */
@@ -177,7 +177,7 @@ struct ch_trace {
 struct ch_ifconf_regs {
 	uint32_t  version;
 	uint32_t  len; /* bytes */
-	uint8_t   *data;
+	uint8_t * __kerncap data;
 };
 
 struct ch_mii_data {
@@ -191,7 +191,7 @@ struct ch_eeprom {
 	uint32_t magic;
 	uint32_t offset;
 	uint32_t len;
-	uint8_t  *data;
+	uint8_t * __kerncap data;
 };
 
 #define LA_BUFSIZE	(2 * 1024)
@@ -199,7 +199,7 @@ struct ch_up_la {
 	uint32_t stopped;
 	uint32_t idx;
 	uint32_t bufsize;
-	uint32_t *data;
+	uint32_t * __kerncap data;
 };
 
 struct t3_ioq_entry {
@@ -216,7 +216,7 @@ struct ch_up_ioqs {
 	uint32_t ioq_rx_status;
 	uint32_t ioq_tx_status;
 	uint32_t bufsize;
-	struct t3_ioq_entry *data;
+	struct t3_ioq_entry * __kerncap data;
 };
 
 struct ch_filter_tuple {

--- a/sys/dev/cxgb/cxgb_main.c
+++ b/sys/dev/cxgb/cxgb_main.c
@@ -28,6 +28,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ***************************************************************************/
 
+#define EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -2830,7 +2832,7 @@ cxgb_extension_ioctl(struct cdev *dev, unsigned long cmd, caddr_t data,
 	case CHELSIO_GET_MEM: {
 		struct ch_mem_range *t = (struct ch_mem_range *)data;
 		struct mc7 *mem;
-		uint8_t *useraddr;
+		uint8_t * __capability useraddr;
 		u64 buf[32];
 
 		/*
@@ -2865,7 +2867,7 @@ cxgb_extension_ioctl(struct cdev *dev, unsigned long cmd, caddr_t data,
 		 * Read 256 bytes at a time as len can be large and we don't
 		 * want to use huge intermediate buffers.
 		 */
-		useraddr = (uint8_t *)t->buf; 
+		useraddr = (uint8_t * __capability)t->buf; 
 		while (len) {
 			unsigned int chunk = min(len, sizeof(buf));
 

--- a/sys/dev/mpr/mpr_ioctl.h
+++ b/sys/dev/mpr/mpr_ioctl.h
@@ -86,7 +86,7 @@
 struct mpr_cfg_page_req {	
 	MPI2_CONFIG_PAGE_HEADER header;
 	uint32_t page_address;
-	void	*buf;
+	void * __kerncap buf;
 	int	len;
 	uint16_t ioc_status;
 };
@@ -94,7 +94,7 @@ struct mpr_cfg_page_req {
 struct mpr_ext_cfg_page_req {
 	MPI2_CONFIG_EXTENDED_PAGE_HEADER header;
 	uint32_t page_address;
-	void	*buf;
+	void * __kerncap buf;
 	int	len;
 	uint16_t ioc_status;
 };
@@ -105,7 +105,7 @@ struct mpr_raid_action {
 	uint8_t volume_id;
 	uint8_t phys_disk_num;
 	uint32_t action_data_word;
-	void *buf;
+	void * __kerncap buf;
 	int len;
 	uint32_t volume_status;
 	uint32_t action_data[4];
@@ -115,11 +115,11 @@ struct mpr_raid_action {
 };
 
 struct mpr_usr_command {
-	void *req;
+	void * __kerncap req;
 	uint32_t req_len;
-	void *rpl;
+	void * __kerncap rpl;
 	uint32_t rpl_len;
-	void *buf;
+	void * __kerncap buf;
 	int len;
 	uint32_t flags;
 };
@@ -173,7 +173,11 @@ typedef struct mpr_adapter_data
 
 typedef struct mpr_update_flash
 {
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrBuffer;
+#else
 	uint64_t	PtrBuffer;
+#endif
 	uint32_t	ImageChecksum;
 	uint32_t	ImageOffset;
 	uint32_t	ImageSize;
@@ -188,14 +192,24 @@ typedef struct mpr_update_flash
 
 typedef struct mpr_pass_thru
 {
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrRequest;
+	void * __capability PtrReply;
+	void * __capability PtrData;
+#else
 	uint64_t	PtrRequest;
 	uint64_t	PtrReply;
 	uint64_t	PtrData;
+#endif
 	uint32_t	RequestSize;
 	uint32_t	ReplySize;
 	uint32_t	DataSize;
 	uint32_t	DataDirection;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrDataOut;
+#else
 	uint64_t	PtrDataOut;
+#endif
 	uint32_t	DataOutSize;
 	uint32_t	Timeout;
 } mpr_pass_thru_t;
@@ -232,7 +246,11 @@ typedef struct mpr_event_entry
 typedef struct mpr_event_report
 {
 	uint32_t	Size;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrEvents;
+#else
 	uint64_t	PtrEvents;
+#endif
 } mpr_event_report_t;
 
 
@@ -250,7 +268,11 @@ typedef struct mpr_diag_action
 {
 	uint32_t	Action;
 	uint32_t	Length;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrDiagAction;
+#else
 	uint64_t	PtrDiagAction;
+#endif
 	uint32_t	ReturnCode;
 } mpr_diag_action_t;
 
@@ -327,7 +349,11 @@ typedef struct mpr_diag_read_buffer
 	uint32_t	StartingOffset;
 	uint32_t	BytesToRead;
 	uint32_t	UniqueId;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrDataBuffer;
+#else
 	uint64_t	PtrDataBuffer;
+#endif
 } mpr_diag_read_buffer_t;
 
 /*

--- a/sys/dev/mpr/mpr_user.c
+++ b/sys/dev/mpr/mpr_user.c
@@ -61,6 +61,8 @@
  * $FreeBSD$
  */
 
+#define	EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -162,12 +164,12 @@ static int mpr_diag_unregister(struct mpr_softc *sc,
 static int mpr_diag_query(struct mpr_softc *sc, mpr_fw_diag_query_t *diag_query,
     uint32_t *return_code);
 static int mpr_diag_read_buffer(struct mpr_softc *sc,
-    mpr_diag_read_buffer_t *diag_read_buffer, uint8_t *ioctl_buf,
+    mpr_diag_read_buffer_t *diag_read_buffer, uint8_t * __capability ioctl_buf,
     uint32_t *return_code);
 static int mpr_diag_release(struct mpr_softc *sc,
     mpr_fw_diag_release_t *diag_release, uint32_t *return_code);
 static int mpr_do_diag_action(struct mpr_softc *sc, uint32_t action,
-    uint8_t *diag_action, uint32_t length, uint32_t *return_code);
+    uint8_t * __capability diag_action, uint32_t length, uint32_t *return_code);
 static int mpr_user_diag_action(struct mpr_softc *sc, mpr_diag_action_t *data);
 static void mpr_user_event_query(struct mpr_softc *sc, mpr_event_query_t *data);
 static void mpr_user_event_enable(struct mpr_softc *sc,
@@ -787,8 +789,8 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 		goto RetFreeUnlocked;
 	}
 
-	mpr_dprint(sc, MPR_USER, "%s: req 0x%jx %d  rpl 0x%jx %d "
-	    "data in 0x%jx %d data out 0x%jx %d data dir %d\n", __func__,
+	mpr_dprint(sc, MPR_USER, "%s: req %p %d  rpl %p %d "
+	    "data in %p %d data out %p %d data dir %d\n", __func__,
 	    data->PtrRequest, data->RequestSize, data->PtrReply,
 	    data->ReplySize, data->PtrData, data->DataSize,
 	    data->PtrDataOut, data->DataOutSize, data->DataDirection);
@@ -797,7 +799,7 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 	 * copy in the header so we know what we're dealing with before we
 	 * commit to allocating a command for it.
 	 */
-	err = copyin(PTRIN(data->PtrRequest), &tmphdr, data->RequestSize);
+	err = copyin(data->PtrRequest, &tmphdr, data->RequestSize);
 	if (err != 0)
 		goto RetFreeUnlocked;
 
@@ -862,7 +864,7 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 				    __func__, data->ReplySize, sz);
 			}
 			mpr_unlock(sc);
-			copyout(cm->cm_reply, PTRIN(data->PtrReply),
+			copyout(cm->cm_reply, data->PtrReply,
 			    data->ReplySize);
 			mpr_lock(sc);
 		}
@@ -908,12 +910,12 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 		cm->cm_flags = MPR_CM_FLAGS_DATAIN;
 		if (data->DataOutSize) {
 			cm->cm_flags |= MPR_CM_FLAGS_DATAOUT;
-			err = copyin(PTRIN(data->PtrDataOut),
+			err = copyin(data->PtrDataOut,
 			    cm->cm_data, data->DataOutSize);
 		} else if (data->DataDirection ==
 		    MPR_PASS_THRU_DIRECTION_WRITE) {
 			cm->cm_flags = MPR_CM_FLAGS_DATAOUT;
-			err = copyin(PTRIN(data->PtrData),
+			err = copyin(data->PtrData,
 			    cm->cm_data, data->DataSize);
 		}
 		if (err != 0)
@@ -1067,7 +1069,7 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 		if (cm->cm_flags & MPR_CM_FLAGS_DATAIN) {
 			mpr_unlock(sc);
 			err = copyout(cm->cm_data,
-			    PTRIN(data->PtrData), data->DataSize);
+			    data->PtrData, data->DataSize);
 			mpr_lock(sc);
 			if (err != 0)
 				mpr_dprint(sc, MPR_FAULT, "%s: failed to copy "
@@ -1088,7 +1090,7 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 			    data->ReplySize, sz);
 		}
 		mpr_unlock(sc);
-		copyout(cm->cm_reply, PTRIN(data->PtrReply), data->ReplySize);
+		copyout(cm->cm_reply, data->PtrReply, data->ReplySize);
 		mpr_lock(sc);
 
 		if ((function == MPI2_FUNCTION_SCSI_IO_REQUEST) ||
@@ -1100,8 +1102,8 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 				    SenseCount)), sizeof(struct
 				    scsi_sense_data));
 				mpr_unlock(sc);
-				copyout(cm->cm_sense, (PTRIN(data->PtrReply +
-				    sizeof(MPI2_SCSI_IO_REPLY))), sense_len);
+				copyout(cm->cm_sense, (char * __capability)data->PtrReply +
+				    sizeof(MPI2_SCSI_IO_REPLY), sense_len);
 				mpr_lock(sc);
 			}
 		}
@@ -1135,8 +1137,8 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 			    NVME_ERROR_RESPONSE_SIZE);
 			mpr_unlock(sc);
 			copyout(cm->cm_sense,
-			    (PTRIN(data->PtrReply +
-			    sizeof(MPI2_SCSI_IO_REPLY))), sz);
+			    (char * __capability)data->PtrReply +
+			    sizeof(MPI2_SCSI_IO_REPLY), sz);
 			mpr_lock(sc);
 		}
 	}
@@ -1767,7 +1769,7 @@ mpr_diag_query(struct mpr_softc *sc, mpr_fw_diag_query_t *diag_query,
 
 static int
 mpr_diag_read_buffer(struct mpr_softc *sc,
-    mpr_diag_read_buffer_t *diag_read_buffer, uint8_t *ioctl_buf,
+    mpr_diag_read_buffer_t *diag_read_buffer, uint8_t * __capability ioctl_buf,
     uint32_t *return_code)
 {
 	mpr_fw_diagnostic_buffer_t	*pBuffer;
@@ -1876,7 +1878,7 @@ mpr_diag_release(struct mpr_softc *sc, mpr_fw_diag_release_t *diag_release,
 }
 
 static int
-mpr_do_diag_action(struct mpr_softc *sc, uint32_t action, uint8_t *diag_action,
+mpr_do_diag_action(struct mpr_softc *sc, uint32_t action, uint8_t * __capability diag_action,
     uint32_t length, uint32_t *return_code)
 {
 	mpr_fw_diag_register_t		diag_register;
@@ -1947,7 +1949,7 @@ mpr_do_diag_action(struct mpr_softc *sc, uint32_t action, uint8_t *diag_action,
 				break;
 			}
 			status = mpr_diag_read_buffer(sc, &diag_read_buffer,
-			    PTRIN(diag_read_buffer.PtrDataBuffer),
+			    diag_read_buffer.PtrDataBuffer,
 			    return_code);
 			if (status == MPR_DIAG_SUCCESS) {
 				if (copyout(&diag_read_buffer, diag_action,
@@ -2010,7 +2012,7 @@ mpr_user_diag_action(struct mpr_softc *sc, mpr_diag_action_t *data)
 	    data->Action == MPR_FW_DIAG_TYPE_READ_BUFFER ||
 	    data->Action == MPR_FW_DIAG_TYPE_RELEASE) {
 		status = mpr_do_diag_action(sc, data->Action,
-		    PTRIN(data->PtrDiagAction), data->Length,
+		    data->PtrDiagAction, data->Length,
 		    &data->ReturnCode);
 	} else
 		status = EINVAL;
@@ -2073,7 +2075,7 @@ mpr_user_event_report(struct mpr_softc *sc, mpr_event_report_t *data)
 	if ((size >= sizeof(sc->recorded_events)) && (status == 0)) {
 		mpr_unlock(sc);
 		if (copyout((void *)sc->recorded_events,
-		    PTRIN(data->PtrEvents), size) != 0)
+		    data->PtrEvents, size) != 0)
 			status = EFAULT;
 		mpr_lock(sc);
 	} else {

--- a/sys/dev/mps/mps_ioctl.h
+++ b/sys/dev/mps/mps_ioctl.h
@@ -87,7 +87,7 @@
 struct mps_cfg_page_req {	
 	MPI2_CONFIG_PAGE_HEADER header;
 	uint32_t page_address;
-	void	*buf;
+	void * __kerncap buf;
 	int	len;
 	uint16_t ioc_status;
 };
@@ -95,7 +95,7 @@ struct mps_cfg_page_req {
 struct mps_ext_cfg_page_req {
 	MPI2_CONFIG_EXTENDED_PAGE_HEADER header;
 	uint32_t page_address;
-	void	*buf;
+	void * __kerncap buf;
 	int	len;
 	uint16_t ioc_status;
 };
@@ -106,7 +106,7 @@ struct mps_raid_action {
 	uint8_t volume_id;
 	uint8_t phys_disk_num;
 	uint32_t action_data_word;
-	void *buf;
+	void * __kerncap buf;
 	int len;
 	uint32_t volume_status;
 	uint32_t action_data[4];
@@ -116,11 +116,11 @@ struct mps_raid_action {
 };
 
 struct mps_usr_command {
-	void *req;
+	void * __kerncap req;
 	uint32_t req_len;
-	void *rpl;
+	void * __kerncap rpl;
 	uint32_t rpl_len;
-	void *buf;
+	void * __kerncap buf;
 	int len;
 	uint32_t flags;
 };
@@ -174,7 +174,11 @@ typedef struct mps_adapter_data
 
 typedef struct mps_update_flash
 {
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrBuffer;
+#else
 	uint64_t	PtrBuffer;
+#endif
 	uint32_t	ImageChecksum;
 	uint32_t	ImageOffset;
 	uint32_t	ImageSize;
@@ -189,14 +193,24 @@ typedef struct mps_update_flash
 
 typedef struct mps_pass_thru
 {
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrRequest;
+	void * __capability PtrReply;
+	void * __capability PtrData;
+#else
 	uint64_t	PtrRequest;
 	uint64_t	PtrReply;
 	uint64_t	PtrData;
+#endif
 	uint32_t	RequestSize;
 	uint32_t	ReplySize;
 	uint32_t	DataSize;
 	uint32_t	DataDirection;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrDataOut;
+#else
 	uint64_t	PtrDataOut;
+#endif
 	uint32_t	DataOutSize;
 	uint32_t	Timeout;
 } mps_pass_thru_t;
@@ -233,7 +247,11 @@ typedef struct mps_event_entry
 typedef struct mps_event_report
 {
 	uint32_t	Size;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrEvents;
+#else
 	uint64_t	PtrEvents;
+#endif
 } mps_event_report_t;
 
 
@@ -251,7 +269,11 @@ typedef struct mps_diag_action
 {
 	uint32_t	Action;
 	uint32_t	Length;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrDiagAction;
+#else
 	uint64_t	PtrDiagAction;
+#endif
 	uint32_t	ReturnCode;
 } mps_diag_action_t;
 
@@ -328,7 +350,11 @@ typedef struct mps_diag_read_buffer
 	uint32_t	StartingOffset;
 	uint32_t	BytesToRead;
 	uint32_t	UniqueId;
+#if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
+	void * __capability PtrDataBuffer;
+#else
 	uint64_t	PtrDataBuffer;
+#endif
 } mps_diag_read_buffer_t;
 
 /*

--- a/sys/dev/mps/mps_user.c
+++ b/sys/dev/mps/mps_user.c
@@ -62,6 +62,8 @@
  * $FreeBSD$
  */
 
+#define EXPLICIT_USER_ACCESS
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -164,12 +166,12 @@ static int mps_diag_unregister(struct mps_softc *sc,
 static int mps_diag_query(struct mps_softc *sc, mps_fw_diag_query_t *diag_query,
     uint32_t *return_code);
 static int mps_diag_read_buffer(struct mps_softc *sc,
-    mps_diag_read_buffer_t *diag_read_buffer, uint8_t *ioctl_buf,
+    mps_diag_read_buffer_t *diag_read_buffer, uint8_t * __capability ioctl_buf,
     uint32_t *return_code);
 static int mps_diag_release(struct mps_softc *sc,
     mps_fw_diag_release_t *diag_release, uint32_t *return_code);
 static int mps_do_diag_action(struct mps_softc *sc, uint32_t action,
-    uint8_t *diag_action, uint32_t length, uint32_t *return_code);
+    uint8_t * __capability diag_action, uint32_t length, uint32_t *return_code);
 static int mps_user_diag_action(struct mps_softc *sc, mps_diag_action_t *data);
 static void mps_user_event_query(struct mps_softc *sc, mps_event_query_t *data);
 static void mps_user_event_enable(struct mps_softc *sc,
@@ -798,8 +800,8 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 		goto RetFreeUnlocked;
 	}
 
-	mps_dprint(sc, MPS_USER, "%s: req 0x%jx %d  rpl 0x%jx %d "
-	    "data in 0x%jx %d data out 0x%jx %d data dir %d\n", __func__,
+	mps_dprint(sc, MPS_USER, "%s: req %p %d  rpl %p %d "
+	    "data in %p %d data out %p %d data dir %d\n", __func__,
 	    data->PtrRequest, data->RequestSize, data->PtrReply,
 	    data->ReplySize, data->PtrData, data->DataSize,
 	    data->PtrDataOut, data->DataOutSize, data->DataDirection);
@@ -808,7 +810,7 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 	 * copy in the header so we know what we're dealing with before we
 	 * commit to allocating a command for it.
 	 */
-	err = copyin(PTRIN(data->PtrRequest), &tmphdr, data->RequestSize);
+	err = copyin(data->PtrRequest, &tmphdr, data->RequestSize);
 	if (err != 0)
 		goto RetFreeUnlocked;
 
@@ -873,7 +875,7 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 				    __func__, data->ReplySize, sz);
 			}
 			mps_unlock(sc);
-			copyout(cm->cm_reply, PTRIN(data->PtrReply),
+			copyout(cm->cm_reply, data->PtrReply,
 			    data->ReplySize);
 			mps_lock(sc);
 		}
@@ -919,12 +921,12 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 		cm->cm_flags = MPS_CM_FLAGS_DATAIN;
 		if (data->DataOutSize) {
 			cm->cm_flags |= MPS_CM_FLAGS_DATAOUT;
-			err = copyin(PTRIN(data->PtrDataOut),
+			err = copyin(data->PtrDataOut,
 			    cm->cm_data, data->DataOutSize);
 		} else if (data->DataDirection ==
 		    MPS_PASS_THRU_DIRECTION_WRITE) {
 			cm->cm_flags = MPS_CM_FLAGS_DATAOUT;
-			err = copyin(PTRIN(data->PtrData),
+			err = copyin(data->PtrData,
 			    cm->cm_data, data->DataSize);
 		}
 		if (err != 0)
@@ -1007,7 +1009,7 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 		if (cm->cm_flags & MPS_CM_FLAGS_DATAIN) {
 			mps_unlock(sc);
 			err = copyout(cm->cm_data,
-			    PTRIN(data->PtrData), data->DataSize);
+			    data->PtrData, data->DataSize);
 			mps_lock(sc);
 			if (err != 0)
 				mps_dprint(sc, MPS_FAULT, "%s: failed to copy "
@@ -1028,7 +1030,7 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 			    data->ReplySize, sz);
 		}
 		mps_unlock(sc);
-		copyout(cm->cm_reply, PTRIN(data->PtrReply), data->ReplySize);
+		copyout(cm->cm_reply, data->PtrReply, data->ReplySize);
 		mps_lock(sc);
 
 		if ((function == MPI2_FUNCTION_SCSI_IO_REQUEST) ||
@@ -1040,8 +1042,8 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 				    SenseCount)), sizeof(struct
 				    scsi_sense_data));
 				mps_unlock(sc);
-				copyout(cm->cm_sense, (PTRIN(data->PtrReply +
-				    sizeof(MPI2_SCSI_IO_REPLY))), sense_len);
+				copyout(cm->cm_sense, (char * __capability)data->PtrReply +
+				    sizeof(MPI2_SCSI_IO_REPLY), sense_len);
 				mps_lock(sc);
 			}
 		}
@@ -1675,7 +1677,7 @@ mps_diag_query(struct mps_softc *sc, mps_fw_diag_query_t *diag_query,
 
 static int
 mps_diag_read_buffer(struct mps_softc *sc,
-    mps_diag_read_buffer_t *diag_read_buffer, uint8_t *ioctl_buf,
+    mps_diag_read_buffer_t *diag_read_buffer, uint8_t * __capability ioctl_buf,
     uint32_t *return_code)
 {
 	mps_fw_diagnostic_buffer_t	*pBuffer;
@@ -1784,7 +1786,7 @@ mps_diag_release(struct mps_softc *sc, mps_fw_diag_release_t *diag_release,
 }
 
 static int
-mps_do_diag_action(struct mps_softc *sc, uint32_t action, uint8_t *diag_action,
+mps_do_diag_action(struct mps_softc *sc, uint32_t action, uint8_t * __capability diag_action,
     uint32_t length, uint32_t *return_code)
 {
 	mps_fw_diag_register_t		diag_register;
@@ -1855,7 +1857,7 @@ mps_do_diag_action(struct mps_softc *sc, uint32_t action, uint8_t *diag_action,
 				break;
 			}
 			status = mps_diag_read_buffer(sc, &diag_read_buffer,
-			    PTRIN(diag_read_buffer.PtrDataBuffer),
+			    diag_read_buffer.PtrDataBuffer,
 			    return_code);
 			if (status == MPS_DIAG_SUCCESS) {
 				if (copyout(&diag_read_buffer, diag_action,
@@ -1918,7 +1920,7 @@ mps_user_diag_action(struct mps_softc *sc, mps_diag_action_t *data)
 	    data->Action == MPS_FW_DIAG_TYPE_READ_BUFFER ||
 	    data->Action == MPS_FW_DIAG_TYPE_RELEASE) {
 		status = mps_do_diag_action(sc, data->Action,
-		    PTRIN(data->PtrDiagAction), data->Length,
+		    data->PtrDiagAction, data->Length,
 		    &data->ReturnCode);
 	} else
 		status = EINVAL;
@@ -1981,7 +1983,7 @@ mps_user_event_report(struct mps_softc *sc, mps_event_report_t *data)
 	if ((size >= sizeof(sc->recorded_events)) && (status == 0)) {
 		mps_unlock(sc);
 		if (copyout((void *)sc->recorded_events,
-		    PTRIN(data->PtrEvents), size) != 0)
+		    data->PtrEvents, size) != 0)
 			status = EFAULT;
 		mps_lock(sc);
 	} else {

--- a/sys/dev/ofw/openfirmio.c
+++ b/sys/dev/ofw/openfirmio.c
@@ -46,6 +46,8 @@ __FBSDID("$FreeBSD$");
  *
  */
 
+#define EXPLICIT_USER_ACCESS
+
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/conf.h>
@@ -74,7 +76,7 @@ static struct cdevsw openfirm_cdevsw = {
 static phandle_t lastnode;	/* speed hack */
 
 static int openfirm_checkid(phandle_t, phandle_t);
-static int openfirm_getstr(int, const char *, char **);
+static int openfirm_getstr(int, const char * __capability, char **);
 
 /*
  * Verify target ID is valid (exists in the OPENPROM tree), as
@@ -92,7 +94,7 @@ openfirm_checkid(phandle_t sid, phandle_t tid)
 }
 
 static int
-openfirm_getstr(int len, const char *user, char **cpp)
+openfirm_getstr(int len, const char * __capability user, char **cpp)
 {
 	int error;
 	char *cp;

--- a/sys/dev/ofw/openfirmio.h
+++ b/sys/dev/ofw/openfirmio.h
@@ -47,9 +47,9 @@
 struct ofiocdesc {
 	phandle_t	of_nodeid;	/* passed or returned node id */
 	int		of_namelen;	/* length of of_name */
-	const char	*of_name;	/* pointer to field name */
+	const char * __kerncap of_name;	/* pointer to field name */
 	int		of_buflen;	/* length of of_buf (value-result) */
-	char		*of_buf;	/* pointer to field value */
+	char *__kerncap	of_buf;		/* pointer to field value */
 };
 
 #define	OFIOC_BASE	'O'


### PR DESCRIPTION
A third round of changes for drivers not included in MIPS builds but included in RISC-V builds.  mpr, mps, and ZFS all have the anti-pattern of assuming that uint64_t can hold any pointer to avoid having to deal with compat32 shims.