### PR TITLE
Enable Ptrace getregs for CheriABI

### DIFF
--- a/sys/compat/cheriabi/cheriabi_misc.c
+++ b/sys/compat/cheriabi/cheriabi_misc.c
@@ -1916,21 +1916,21 @@ cheriabi_ptrace(struct thread *td, struct cheriabi_ptrace_args *uap)
 		    offsetof(struct ptrace_io_desc_c, piod_len),
 		    sizeof(r.piod.piod_len));
 		break;
-#if 0
+
 	case PT_GETREGS:
-		error = COPYOUT(&r.reg, uap->addr, sizeof r.reg);
+		error = copyout(&r.reg, uap->addr, sizeof r.reg);
 		break;
 	case PT_GETFPREGS:
-		error = COPYOUT(&r.fpreg, uap->addr, sizeof r.fpreg);
+		error = copyout(&r.fpreg, uap->addr, sizeof r.fpreg);
 		break;
 	case PT_GETDBREGS:
-		error = COPYOUT(&r.dbreg, uap->addr, sizeof r.dbreg);
+		error = copyout(&r.dbreg, uap->addr, sizeof r.dbreg);
 		break;
+
 #if __has_feature(capabilities)
 	case PT_GETCAPREGS:
-		error = COPYOUT(&r.capreg, uap->addr, sizeof r.capreg);
+		error = copyout(&r.capreg, uap->addr, sizeof r.capreg);
 		break;
-#endif
 #endif
 	case PT_GET_EVENT_MASK:
 		/* NB: The size in uap->data is validated in kern_ptrace(). */


### PR DESCRIPTION
Those are needed for fasttrap. I don't know why they were defined out.