### PR TITLE
Switch the default sysvec for purecap binaries to the native ABI.

### DIFF
--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -121,7 +121,7 @@ SYSCTL_INT(_kern, OID_AUTO, coredump_pack_vmmapinfo, CTLFLAG_RWTUN,
     &coredump_pack_vmmapinfo, 0,
     "Enable file path packing in 'procstat -v' coredump notes");
 
-int use_cheriabi = 1;
+int use_cheriabi = 0;
 SYSCTL_INT(_debug, OID_AUTO, use_cheriabi, CTLFLAG_RWTUN,
     &use_cheriabi, 0,
     "Use COMPAT_CHERIABI for purecap binaries");


### PR DESCRIPTION
Creating this PR as a bit of a testing trial balloon.