### PR TITLE
Port cheri(abi)test to riscv

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -55,7 +55,7 @@ SUBDIR.${MK_CHERI}+=	cheri_minimal_pie_exe
 SUBDIR.${MK_CHERI}+=	cheri_pthreads
 .endif
 SUBDIR.${MK_CHERI}+=	helloworld
-.if ${MK_CXX} != "no"
+.if ${MK_CXX} != "no" && ${MACHINE} != riscv
 SUBDIR.${MK_CHERI}+=	helloworld_cxx
 .endif
 SUBDIR.${MK_CHERI}+=	helloworld_static

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -65,7 +65,6 @@ SUBDIR.${MK_LIBCHERI}+=	cheri_helloworld
 SUBDIR.${MK_LIBCHERI}+=	cheriabi_helloworld
 
 # cheritest
-.if ${MACHINE_ARCH:Mmips*}
 SUBDIR.${MK_CHERI}+=	cheriabitest
 SUBDIR.${MK_CHERI}+=	cheriabitest-dynamic
 SUBDIR.${MK_CHERI}+=	cheriabitest-dynamic-mt
@@ -74,9 +73,6 @@ SUBDIR.${MK_CHERI}+=	cheritest
 SUBDIR.${MK_CHERI}+=	cheritest-dynamic
 SUBDIR.${MK_CHERI}+=	cheritest-dynamic-mt
 SUBDIR.${MK_CHERI}+=	cheritest-mt
-.else
-.warn "TODO: port cheritest to RISCV"
-.endif
 .endif  # ${MACHINE_ABI:Mpurecap} || ${MK_COMPAT_CHERIABI} == "yes"
 
 

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -47,9 +47,13 @@ SUBDIR.${MK_LIBCHERI}+=	cheri_bench
 
 # Small cheri programs
 .if ${MACHINE_ABI:Mpurecap} || ${MK_COMPAT_CHERIABI} == "yes"
+.if ${MACHINE} == "mips"
+# link failure on riscv
 SUBDIR.${MK_CHERI}+=	cheri_minimal_dynamic_exe
 SUBDIR.${MK_CHERI}+=	cheri_minimal_pie_exe
+# mips assembly
 SUBDIR.${MK_CHERI}+=	cheri_pthreads
+.endif
 SUBDIR.${MK_CHERI}+=	helloworld
 .if ${MK_CXX} != "no"
 SUBDIR.${MK_CHERI}+=	helloworld_cxx

--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -40,6 +40,7 @@ CFLAGS.cheri_memcpy_c.S=-D__KERN_FUNC_PREFIX -D_KERNEL -DINVARIANTS
 CFLAGS+=	-DKERNEL_MEMCPY_TESTS
 .endif
 
+.if ${MACHINE} == "mips"
 .ifdef CHERI_C_TESTS
 CHERI_C_TESTS_DIR=	${SRCTOP}/contrib/subrepo-cheri-c-tests
 .if exists(${CHERI_C_TESTS_DIR}/Makefile)
@@ -62,6 +63,7 @@ SRCS+=	test_runtime.c	\
 # declared global so that the compiler emits them
 CFLAGS.${test}+=-Wno-missing-prototypes -Wno-missing-variable-declarations
 .endfor
+.endif
 .endif
 .endif
 

--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -13,7 +13,6 @@ SRCS+=	cheritest_bounds_globals.c					\
 	cheritest_kbounce.c						\
 	cheritest_longjmp.c						\
 	cheritest_registers.c						\
-	cheritest_sandbox.S						\
 	cheritest_sealcap.c						\
 	cheritest_signal.c						\
 	cheritest_string.c						\
@@ -80,6 +79,10 @@ WANT_CHERI=	pure
 LIBADD= 	z
 
 LIBADD+=	xo util
+
+.if ${MK_LIBCHERI} == "yes"
+SRCS+=	cheritest_sandbox.S
+.endif
 
 .ifdef CHERI_DYNAMIC_TESTS
 CFLAGS+=	-DCHERI_DYNAMIC_TESTS

--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -86,8 +86,8 @@ NEED_COMPAT=	CHERI
 .else
 .error Unknown cheritest variant ${PROG}
 .endif
-LIBADD= 	z
 
+LIBADD= 	z
 LIBADD+=	xo util
 
 .if ${MK_LIBCHERI} == "yes"

--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -74,9 +74,15 @@ CFLAGS+=	-DCHERITHREAD_TESTS
 MAN=
 
 .if ${PROG:Mcheritest*}
-NEED_CHERI=	hybrid
+.if ${MACHINE_ABI:Mpurecap}
+NEED_COMPAT=	64
+.include <bsd.compat.mk>
+.endif
 .elif ${PROG:Mcheriabitest*}
-WANT_CHERI=	pure
+.if !${MACHINE_ABI:Mpurecap}
+NEED_COMPAT=	CHERI
+.include <bsd.compat.mk>
+.endif
 .else
 .error Unknown cheritest variant ${PROG}
 .endif

--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -33,10 +33,12 @@ SRCS+=	cheritest_cheriabi_open.c
 CFLAGS+=	-DCHERIABI_TESTS
 .endif
 
+.if ${MACHINE} == mips
 .PATH: ${SRCTOP}/sys/mips/cheri
 SRCS+=	cheri_memcpy_c.S
 CFLAGS.cheri_memcpy_c.S=-D__KERN_FUNC_PREFIX -D_KERNEL -DINVARIANTS
 CFLAGS+=	-DKERNEL_MEMCPY_TESTS
+.endif
 
 .ifdef CHERI_C_TESTS
 CHERI_C_TESTS_DIR=	${SRCTOP}/contrib/subrepo-cheri-c-tests

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -46,7 +46,9 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
+#ifdef __mips__
 #include <machine/cpuregs.h>
+#endif
 #include <machine/frame.h>
 #include <machine/trap.h>
 
@@ -120,14 +122,17 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_xfail_reason = "CHERI_PERM_CHERIABI_VMMAP "
 	    "unnecessarily set in stack capability" },
 #endif
+#ifdef __mips__
 	{ .ct_name = "test_initregs_idc",
 	  .ct_desc = "Test initial value of invoked data capability",
 	  .ct_func = test_initregs_idc },
+#endif
 
 	{ .ct_name = "test_initregs_pcc",
 	  .ct_desc = "Test initial value of program-counter capability",
 	  .ct_func = test_initregs_pcc },
 
+#ifdef __mips__
 	{ .ct_name = "test_copyregs",
 	  .ct_desc = "Exercise CP2 register assignments",
 	  .ct_func = test_copyregs },
@@ -136,11 +141,13 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Print out a list of CP2 registers and values",
 	  .ct_func = test_listregs,
 	  .ct_flags = CT_FLAG_STDOUT_IGNORE },
+#endif
 
 	/*
 	 * Capability manipulation and use tests that sometimes generate
 	 * signals.
 	 */
+#ifdef __mips__
 	{ .ct_name = "test_fault_cgetcause",
 	  .ct_desc = "Ensure CGetCause is unavailable in userspace",
 	  .ct_func = test_fault_cgetcause,
@@ -174,11 +181,13 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_si_code = PROT_CHERI_PERM,
 	  .ct_mips_exccode = T_C2E,
 	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_LOAD },
+#endif
 
 	{ .ct_name = "test_nofault_perm_load",
 	  .ct_desc = "Exercise capability load permission success",
 	  .ct_func = test_nofault_perm_load },
 
+#ifdef __mips__
 	{ .ct_name = "test_fault_perm_seal",
 	  .ct_desc = "Exercise capability seal permission failure",
 	  .ct_func = test_fault_perm_seal,
@@ -198,11 +207,13 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_si_code = PROT_CHERI_PERM,
 	  .ct_mips_exccode = T_C2E,
 	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_STORE },
+#endif
 
 	{ .ct_name = "test_nofault_perm_store",
 	  .ct_desc = "Exercise capability store permission success",
 	  .ct_func = test_nofault_perm_store },
 
+#ifdef __mips__
 	{ .ct_name = "test_fault_perm_unseal",
 	  .ct_desc = "Exercise capability unseal permission failure",
 	  .ct_func = test_fault_perm_unseal,
@@ -286,10 +297,12 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_si_code = PROT_CHERI_SYSREG,
 	  .ct_mips_exccode = T_C2E,
 	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+#endif
 
 	/*
 	 * Tests on the kernel-provided sealing capability (sealcap).
 	 */
+#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_sealcap_sysarch",
 	  .ct_desc = "Retrieve sealcap using sysarch(2)",
 	  .ct_func = test_sealcap_sysarch, },
@@ -301,6 +314,7 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sealcap_seal_unseal",
 	  .ct_desc = "Use sealcap to seal and unseal a capability",
 	  .ct_func = test_sealcap_seal_unseal, },
+#endif
 
 	/*
 	 * Test bounds on globals in the same file they are allocated in.
@@ -999,6 +1013,7 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "check tags are stored for /dev/zero MAP_PRIVATE pages",
 	  .ct_func = cheritest_vm_tag_dev_zero_private, },
 
+#ifdef __mips__
 	/* XXXRW: I wonder if we also need some sort of load-related test? */
 	{ .ct_name = "cheritest_vm_notag_tmpfile_shared",
 	  .ct_desc = "check tags are not stored for tmpfile() MAP_SHARED pages",
@@ -1010,6 +1025,7 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_mips_exccode = T_C2E,
 	  .ct_cp2_exccode = CHERI_EXCCODE_TLBSTORE,
 	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp, },
+#endif
 
 	{ .ct_name = "cheritest_vm_tag_tmpfile_private",
 	  .ct_desc = "check tags are stored for tmpfile() MAP_PRIVATE pages",
@@ -1624,15 +1640,19 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_string_memcpy",
 	  .ct_desc = "Test implicit capability memcpy",
 	  .ct_func = test_string_memcpy },
+#ifdef __mips__
 	{ .ct_name = "test_string_memcpy_c",
 	  .ct_desc = "Test explicit capability memcpy",
 	  .ct_func = test_string_memcpy_c },
+#endif
 	{ .ct_name = "test_string_memmove",
 	  .ct_desc = "Test implicit capability memmove",
 	  .ct_func = test_string_memmove },
+#ifdef __mips__
 	{ .ct_name = "test_string_memmove_c",
 	  .ct_desc = "Test explicit capability memmove",
 	  .ct_func = test_string_memmove_c },
+#endif
 
 	/* Unaligned memcpy/memmove with capabilities */
 	{ .ct_name = "test_unaligned_capability_copy_memcpy",
@@ -1687,17 +1707,23 @@ static const struct cheri_test cheri_tests[] = {
 	 * CheriABI specific tests.
 	 */
 #ifdef CHERIABI_TESTS
+#ifdef CHERI_MMAP_SETBOUNDS
 	{ .ct_name = "test_cheriabi_mmap_nospace",
 	  .ct_desc = "Test CheriABI mmap() with no space in default capability",
 	  .ct_func = test_cheriabi_mmap_nospace },
+#endif
 
+#ifdef CHERI_MMAP_GETPERM
 	{ .ct_name = "test_cheriabi_mmap_perms",
 	  .ct_desc = "Test CheriABI mmap() permissions",
 	  .ct_func = test_cheriabi_mmap_perms },
+#endif
 
+#ifdef CHERI_BASELEN_BITS
 	{ .ct_name = "test_cheriabi_mmap_unrepresentable",
 	  .ct_desc = "Test CheriABI mmap() with unrepresentable lengths",
 	  .ct_func = test_cheriabi_mmap_unrepresentable },
+#endif
 
 	{ .ct_name = "test_cheriabi_malloc_zero_size",
 	  .ct_desc = "Check that zero-sized mallocs are properly bounded",
@@ -1742,9 +1768,11 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Path with CHERI_PERM_LOAD permission missing",
 	  .ct_func = test_cheriabi_open_bad_perm, },
 
+#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_cheriabi_open_sealed",
 	  .ct_desc = "Sealed path",
 	  .ct_func = test_cheriabi_open_sealed, },
+#endif
 #endif
 #ifdef CHERI_C_TESTS
 #define	DECLARE_TEST(name, desc)			\
@@ -1849,7 +1877,9 @@ list_tests(void)
 static void
 signal_handler(int signum, siginfo_t *info, void *vuap)
 {
+#ifdef __mips__
 	struct cheri_frame *cfp;
+#endif
 	ucontext_t *uap;
 #ifdef CHERI_LIBCHERI_TESTS
 	u_int numframes;
@@ -1857,6 +1887,7 @@ signal_handler(int signum, siginfo_t *info, void *vuap)
 #endif
 
 	uap = (ucontext_t *)vuap;
+#ifdef __mips__
 	if (uap->uc_mcontext.mc_regs[0] != /* UCONTEXT_MAGIC */ 0xACEDBADE) {
 		ccsp->ccs_signum = -1;
 		fprintf(stderr, "%s: missing UCONTEXT_MAGIC\n", __func__);
@@ -1873,10 +1904,13 @@ signal_handler(int signum, siginfo_t *info, void *vuap)
 		ccsp->ccs_signum = -1;
 		_exit(EX_OSERR);
 	}
+#endif	/* __mips__ */
 	ccsp->ccs_signum = signum;
 	ccsp->ccs_si_code = info->si_code;
+#ifdef __mips__
 	ccsp->ccs_mips_cause = uap->uc_mcontext.cause;
 	ccsp->ccs_cp2_cause = cfp->cf_capcause;
+#endif
 
 #ifdef CHERI_LIBCHERI_TESTS
 	/*
@@ -1936,6 +1970,7 @@ signal_handler_clear(int sig)
 static inline void
 set_thread_tracing(void)
 {
+#ifdef CHERI_START_TRACE
 	int error, intval;
 
 	intval = 1;
@@ -1948,7 +1983,10 @@ set_thread_tracing(void)
 	 */
 	CHERI_START_TRACE;
 	if (qtrace_user_mode_only)
-		__asm__ __volatile__("li $0, 0xdeaf");
+		CHERI_START_USER_TRACE;
+#else
+	err(EX_OSERR, "%s", __func__);
+#endif
 }
 
 /* Maximum size of stdout data we will check if called for by a test. */
@@ -1965,7 +2003,9 @@ cheritest_run_test(const struct cheri_test *ctp)
 	char buffer[TEST_BUFFER_LEN];
 	const char *xfail_reason;
 	char* failure_message;
+#ifdef __mips__
 	register_t cp2_exccode, mips_exccode;
+#endif
 	ssize_t len;
 	xo_attr("classname", "%s", ctp->ct_name);
 	xo_attr("name", "%s", ctp->ct_desc);
@@ -2149,6 +2189,7 @@ cheritest_run_test(const struct cheri_test *ctp)
 		    "unwind");
 		goto fail;
 	}
+#ifdef __mips__
 	if (ctp->ct_flags & CT_FLAG_MIPS_EXCCODE) {
 		mips_exccode = (ccsp->ccs_mips_cause & MIPS_CR_EXC_CODE) >>
 		    MIPS_CR_EXC_CODE_SHIFT;
@@ -2170,6 +2211,7 @@ cheritest_run_test(const struct cheri_test *ctp)
 			goto fail;
 		}
 	}
+#endif
 
 	/*
 	 * Next, we are concerned with whether the test itself reports a

--- a/bin/cheritest/cheritest_bounds_stack.c
+++ b/bin/cheritest/cheritest_bounds_stack.c
@@ -41,7 +41,6 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
-#include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
 #include <err.h>

--- a/bin/cheritest/cheritest_cheriabi.c
+++ b/bin/cheritest/cheritest_cheriabi.c
@@ -44,7 +44,6 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
-#include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
 #include <err.h>

--- a/bin/cheritest/cheritest_cheriabi.c
+++ b/bin/cheritest/cheritest_cheriabi.c
@@ -64,6 +64,7 @@
 #define	PERM_EXEC	CHERI_PERM_EXECUTE
 #define	PERM_RWX	(PERM_READ|PERM_WRITE|PERM_EXEC)
 
+#ifdef CHERI_MMAP_SETBOUNDS
 void
 test_cheriabi_mmap_nospace(const struct cheri_test *ctp __unused)
 {
@@ -82,7 +83,9 @@ test_cheriabi_mmap_nospace(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
+#endif
 
+#ifdef CHERI_MMAP_GETPERM
 void
 test_cheriabi_mmap_perms(const struct cheri_test *ctp __unused)
 {
@@ -211,11 +214,12 @@ test_cheriabi_mmap_perms(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
+#endif	/* CHERI_MMAP_GETPERM */
 
+#ifdef CHERI_BASELEN_BITS
 void
 test_cheriabi_mmap_unrepresentable(const struct cheri_test *ctp __unused)
 {
-#ifdef CHERI_BASELEN_BITS
 	size_t len = ((size_t)PAGE_SIZE << CHERI_BASELEN_BITS) + 1;
 	size_t expected_len;
 	void *cap;
@@ -231,11 +235,10 @@ test_cheriabi_mmap_unrepresentable(const struct cheri_test *ctp __unused)
 		    "an unexpected length (%zu vs %zu) when given an "
 		    "unrepresentable length (%zu): %#p", cheri_getlen(cap),
 		    expected_len, len, cap);
-	cheritest_success();
-#endif
 
 	cheritest_success();
 }
+#endif
 
 void
 test_cheriabi_malloc_zero_size(const struct cheri_test *ctp __unused)

--- a/bin/cheritest/cheritest_cheriabi_open.c
+++ b/bin/cheritest/cheritest_cheriabi_open.c
@@ -225,6 +225,7 @@ test_cheriabi_open_bad_perm(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
+#ifdef CHERI_GET_SEALCAP
 void
 test_cheriabi_open_sealed(const struct cheri_test *ctp __unused)
 {
@@ -252,3 +253,4 @@ test_cheriabi_open_sealed(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
+#endif

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -39,7 +39,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
 #include <cheri/cheri.h>

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -63,6 +63,7 @@
 static char array[ARRAY_LEN];
 static char sink;
 
+#ifdef __mips__
 void
 test_fault_bounds(const struct cheri_test *ctp __unused)
 {
@@ -85,6 +86,7 @@ test_fault_perm_load(const struct cheri_test *ctp __unused)
 
 	cheritest_failure_errx("access without required permissions did not fault");
 }
+#endif	/* __mips__ */
 
 void
 test_nofault_perm_load(const struct cheri_test *ctp __unused)
@@ -96,6 +98,7 @@ test_nofault_perm_load(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
+#ifdef CHERI_GET_SEALCAP
 void
 test_fault_perm_seal(const struct cheri_test *ctp __unused)
 {
@@ -116,7 +119,9 @@ test_fault_perm_seal(const struct cheri_test *ctp __unused)
 	    _CHERI_PRINTF_CAP_FMT " with bad sealcap" _CHERI_PRINTF_CAP_FMT,
 	    _CHERI_PRINTF_CAP_ARG(sealed), _CHERI_PRINTF_CAP_ARG(sealcap));
 }
+#endif
 
+#ifdef __mips__
 void
 test_fault_perm_store(const struct cheri_test *ctp __unused)
 {
@@ -124,6 +129,7 @@ test_fault_perm_store(const struct cheri_test *ctp __unused)
 
 	arrayp[0] = sink;
 }
+#endif	/* __mips__ */
 
 void
 test_nofault_perm_store(const struct cheri_test *ctp __unused)
@@ -135,6 +141,7 @@ test_nofault_perm_store(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
+#ifdef CHERI_GET_SEALCAP
 void
 test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 {
@@ -159,7 +166,9 @@ test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 	    _CHERI_PRINTF_CAP_FMT " with bad unsealcap" _CHERI_PRINTF_CAP_FMT,
 	    _CHERI_PRINTF_CAP_ARG(unsealed), _CHERI_PRINTF_CAP_ARG(sealcap));
 }
+#endif
 
+#ifdef __mips__
 void
 test_fault_tag(const struct cheri_test *ctp __unused)
 {
@@ -253,3 +262,4 @@ test_fault_read_epcc(const struct cheri_test *ctp __unused)
 
 	CHERI_CAP_PRINT(cheri_getepcc());
 }
+#endif	/* __mips__ */

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -40,7 +40,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/cpuregs.h>
 #include <machine/pte.h>
 #include <machine/vmparam.h>
 

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -57,6 +57,7 @@
 
 #include "cheritest.h"
 
+#ifdef __mips__
 void
 test_copyregs(const struct cheri_test *ctp __unused)
 {
@@ -114,6 +115,7 @@ test_listregs(const struct cheri_test *ctp __unused)
 	CHERI_PCC_PRINT();
 	cheritest_success();
 }
+#endif	/* __mips__ */
 
 /*
  * These tests assume that the compiler and run-time libraries won't muck with
@@ -454,6 +456,7 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 }
 #endif
 
+#ifdef __mips__
 void
 test_initregs_idc(const struct cheri_test *ctp __unused)
 {
@@ -495,6 +498,7 @@ test_initregs_idc(const struct cheri_test *ctp __unused)
 #endif
 	cheritest_success();
 }
+#endif
 
 void
 test_initregs_pcc(const struct cheri_test *ctp __unused)

--- a/bin/cheritest/cheritest_sealcap.c
+++ b/bin/cheritest/cheritest_sealcap.c
@@ -36,7 +36,6 @@
 
 #include <sys/types.h>
 
-#include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
 #include <cheri/cheri.h>

--- a/bin/cheritest/cheritest_sealcap.c
+++ b/bin/cheritest/cheritest_sealcap.c
@@ -45,6 +45,7 @@
 
 #include "cheritest.h"
 
+#ifdef CHERI_GET_SEALCAP
 void
 test_sealcap_sysarch(const struct cheri_test *ctp __unused)
 {
@@ -254,3 +255,4 @@ test_sealcap_seal_unseal(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
+#endif	/* CHERI_GET_SEALCAP */

--- a/bin/cheritest/cheritest_string.c
+++ b/bin/cheritest/cheritest_string.c
@@ -110,6 +110,7 @@ invalidate(struct Test *t1)
 		*x = 0xa5;
 }
 
+#ifdef __mips__
 void
 test_string_memcpy_c(const struct cheri_test *ctp __unused)
 {
@@ -211,6 +212,7 @@ test_string_memcpy_c(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
+#endif	/* __mips__ */
 
 void
 test_string_memcpy(const struct cheri_test *ctp __unused)
@@ -273,6 +275,7 @@ test_string_memcpy(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
+#ifdef __mips__
 void
 test_string_memmove_c(const struct cheri_test *ctp __unused)
 {
@@ -373,6 +376,7 @@ test_string_memmove_c(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
+#endif	/* __mips__ */
 
 void
 test_string_memmove(const struct cheri_test *ctp __unused)

--- a/bin/cheritest/cheritest_syscall.c
+++ b/bin/cheritest/cheritest_syscall.c
@@ -41,7 +41,6 @@
 #include <sys/time.h>
 #include <sys/ptrace.h>
 
-#include <machine/cpuregs.h>
 #include <machine/sysarch.h>
 
 #include <cheri/cheri.h>

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -49,7 +49,6 @@
 
 #include <sys/event.h>
 
-#include <machine/cpuregs.h>
 #include <machine/frame.h>
 #include <machine/trap.h>
 

--- a/share/mk/bsd.opts.mk
+++ b/share/mk/bsd.opts.mk
@@ -120,8 +120,6 @@ WITH_CHERI:=	yes
 
 .if ${__TT:Mmips*} && ${MK_CHERI} == "yes"
 MK_CLANG:=	no
-.else
-MK_CHERI:=	no
 .endif
 
 #


### PR DESCRIPTION
Use a large hammer and disable anything vaguely mips-specific on non-mips.  This is similar to an approach taken by @zxombie elsewhere.