### PR TITLE
Don't build pull requests on every push to dev/master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,11 @@ properties([disableConcurrentBuilds(),
             pipelineTriggers([githubPush()])
 ])
 
+if (env.CHANGE_ID && !shouldBuildPullRequest()) {
+	echo "Not building this pull request."
+	return
+}
+
 jobs = [:]
 
 def buildImageAndRunTests(params, String suffix) {


### PR DESCRIPTION
We can still manually trigger builds or add special labels.