### PR TITLE
Don't try to store cnull (c0) to sscratchc.

### DIFF
--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -125,7 +125,7 @@ __FBSDID("$FreeBSD$");
 	cspecialr ct0, sscratchc
 	csc	ct0, (TF_SP)(csp)
 .endif
-	li	t0, 0
+	cmove	ct0, cnull
 	cspecialw sscratchc, ct0
 	cspecialr ct0, sepcc
 	csc	ct0, (TF_SEPC)(csp)

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -192,7 +192,8 @@ va:
 
 	/* Ensure sscratch is zero */
 #if __has_feature(capabilities)
-	cspecialw sscratchc, cnull
+	cmove	ct0, cnull
+	cspecialw sscratchc, ct0
 #else
 	li	t0, 0
 	csrw	sscratch, t0


### PR DESCRIPTION
This instruction is nop.  Instead, mimic the existing non-CHERI code
and store a zeroed ct0 to sscratchc.