### PR TITLE
Include SMBFS kernel modules in QEMU kernels

### DIFF
--- a/sys/riscv/conf/CHERI_QEMU_MFS_ROOT
+++ b/sys/riscv/conf/CHERI_QEMU_MFS_ROOT
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI_QEMU"
+include "std.MFS_ROOT"
+
+ident CHERI_QEMU_MFS_ROOT

--- a/sys/riscv/conf/QEMU
+++ b/sys/riscv/conf/QEMU
@@ -8,3 +8,9 @@ ident QEMU
 
 options 	HZ=100
 options 	ROOTDEVNAME=\"ufs:/dev/vtbd0\"
+
+# Access host files on QEMU
+options 	SMBFS
+options 	NETSMB			# Seems to be needed by SMBFS
+options 	LIBMCHAIN		# Also seems to be needed by SMBFS
+options 	LIBICONV		# Also seems to be needed by SMBFS

--- a/sys/riscv/conf/QEMU_MFS_ROOT
+++ b/sys/riscv/conf/QEMU_MFS_ROOT
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "QEMU"
+include "std.MFS_ROOT"
+
+ident QEMU_MFS_ROOT


### PR DESCRIPTION
This is currently needed for running tests on RISC-V