### PR TITLE
Fix assertion in calloc

### DIFF
--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -498,7 +498,8 @@ arena_tdata_get_hard(tsd_t *tsd, unsigned ind) {
 
 		if (tsd_nominal(tsd) && !*arenas_tdata_bypassp) {
 			*arenas_tdata_bypassp = true;
-			arenas_tdata = (arena_tdata_t *)a0malloc(
+			arenas_tdata = BOUND_PTR((arena_tdata_t *)a0malloc(
+			    sizeof(arena_tdata_t) * narenas_tdata),
 			    sizeof(arena_tdata_t) * narenas_tdata);
 			*arenas_tdata_bypassp = false;
 		}


### PR DESCRIPTION
This both hardens malloc against off-by-one array bugs and allows the
array to be freed when it is resized.  Perviously, resizing resulted in
an assertion in unbound_ptr() due to a base != 0.