### PR TITLE
Fix CHERI_MALTA64

### DIFF
--- a/sys/mips/conf/CHERI_MALTA64
+++ b/sys/mips/conf/CHERI_MALTA64
@@ -19,6 +19,7 @@ options 	KTRACE
 # Features required for CHERI CPU and CheriBSD support.
 #
 options 	KSTACK_LARGE_PAGE
+options 	NO_SWAPPING
 options 	TMPFS
 
 #


### PR DESCRIPTION
Accidentally built this instead of CHERI128_MALTA64 (getting used to the RISC-V names without the "128") and tripped over this.