### PR TITLE
Fix string table name for DTrace when using .dynsym

### DIFF
--- a/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
+++ b/cddl/contrib/opensolaris/lib/libdtrace/common/dt_module.c
@@ -786,20 +786,8 @@ dt_module_load(dtrace_hdl_t *dtp, dt_module_t *dmp)
 	dmp->dm_ctdata.cts_entsize = 0;
 	dmp->dm_ctdata.cts_offset = 0;
 
-#ifdef __mips__
-	if (strcmp(dmp->dm_name,"kernel") == 0) {
-		dt_dprintf("LOADING .dynsym INSTEAD OF .symtab FOR MIPS! "
-		    "A lot of symbols will be missing\n");
-		dmp->dm_symtab.cts_name = ".dynsym";
-		dmp->dm_symtab.cts_type = SHT_DYNSYM;
-	} else {
-		dmp->dm_symtab.cts_name = ".symtab";
-		dmp->dm_symtab.cts_type = SHT_SYMTAB;
-	}
-#else
 	dmp->dm_symtab.cts_name = ".symtab";
 	dmp->dm_symtab.cts_type = SHT_SYMTAB;
-#endif
 	dmp->dm_symtab.cts_flags = 0;
 	dmp->dm_symtab.cts_data = NULL;
 	dmp->dm_symtab.cts_size = 0;
@@ -814,6 +802,19 @@ dt_module_load(dtrace_hdl_t *dtp, dt_module_t *dmp)
 	dmp->dm_strtab.cts_size = 0;
 	dmp->dm_strtab.cts_entsize = 0;
 	dmp->dm_strtab.cts_offset = 0;
+
+	/* TODO: remove this when we are able to load the kernel symtable */
+#ifdef __mips__
+	if (strcmp(dmp->dm_name, "kernel") == 0) {
+		dt_dprintf(
+		    "LOADING .dynsym INSTEAD OF .symtab FOR MIPS! "
+		    "A lot of symbols will be missing\n");
+		dmp->dm_symtab.cts_name = ".dynsym";
+		dmp->dm_symtab.cts_type = SHT_DYNSYM;
+		/* The string table for .dynsym is .dynstr, not .strtab. */
+		dmp->dm_strtab.cts_name = ".dynstr";
+	}
+#endif
 
 	/*
 	 * Attempt to load the module's CTF section, symbol table section, and


### PR DESCRIPTION
This follows #466 
The string table for `.dynsym` is not `.strtab`, but `.dynsym`.
Now the output of DTrace `stack()` is nicer 