### PR TITLE
Make jenkins green again

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -2574,7 +2574,6 @@ main(int argc, char *argv[])
 	xo_close_list("test");
 	xo_close_container("testsuite");
 	xo_close_container("testsuites");
-	xo_finish();
 
 	/* print a summary which tests failed */
 	if (cheri_xfailed_tests->sl_cur != 0) {
@@ -2610,6 +2609,8 @@ main(int argc, char *argv[])
 			    tests_passed, tests_failed, tests_xfailed,
 			    expected_failures - tests_xfailed);
 	}
+	xo_finish();
+
 
 #ifdef CHERI_LIBCHERI_TESTS
 	if (!unsandboxed_tests_only)

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -2595,8 +2595,8 @@ main(int argc, char *argv[])
 	sl_free(cheri_xfailed_tests, true);
 	sl_free(cheri_xpassed_tests, true);
 	if (tests_passed + tests_failed > 1) {
-		if (expected_failures == 0)
-			xo_emit("SUMMARY: passed {d:/%d} failed %d\n",
+		if (expected_failures == 0 && tests_xfailed == 0)
+			xo_emit("SUMMARY: passed {d:/%d} failed {d:/%d}\n",
 			    tests_passed, tests_failed);
 		else if (expected_failures == tests_xfailed)
 			xo_emit("SUMMARY: passed {d:/%d} failed {d:/%d} "

--- a/bin/cheritest/cheritest_bounds_stack.c
+++ b/bin/cheritest/cheritest_bounds_stack.c
@@ -66,18 +66,35 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 {
 	size_t len, offset;
 
-	/* Confirm precise lower bound: offset of zero. */
 	offset = cheri_getoffset(c);
-	if (offset != 0)
-		cheritest_failure_errx("offset (%jd) not zero: "
-		    _CHERI_PRINTF_CAP_FMT, offset, _CHERI_PRINTF_CAP_ARG(c));
+	len = cheri_getlen(c);
+
+#ifdef __CHERI_PURE_CAPABILITY__
+	/* Confirm precise lower bound: offset of zero. */
+	CHERITEST_VERIFY2(offset == 0,
+	    "offset (%jd) not zero: " _CHERI_PRINTF_CAP_FMT, offset,
+	    _CHERI_PRINTF_CAP_ARG(c));
 
 	/* Confirm precise upper bound: length of expected size for type. */
-	len = cheri_getlen(c);
-	if (len != expected_len)
-		cheritest_failure_errx("length (%jd) not expected %jd: "
-		    _CHERI_PRINTF_CAP_FMT, len, expected_len,
-		    _CHERI_PRINTF_CAP_ARG(c));
+	CHERITEST_VERIFY2(len == expected_len,
+	    "length (%jd) not expected %jd: " _CHERI_PRINTF_CAP_FMT, len,
+	    expected_len, _CHERI_PRINTF_CAP_ARG(c));
+#else
+	/*
+	 * In hybrid mode we don't increase alignment of allocations to ensure
+	 * precise bounds, so the offset may be non-zero if the bounds were
+	 * not precisely representable. For now, simply  check that we got at
+	 * least the expected length but no more than twice that.
+	 *
+	 * See https://github.com/CTSRD-CHERI/llvm-project/issues/431
+	 */
+	CHERITEST_VERIFY2(len >= expected_len,
+	    "length (%jd) smaller than expected lower bound %jd: " _CHERI_PRINTF_CAP_FMT,
+	    len, expected_len, _CHERI_PRINTF_CAP_ARG(c));
+	CHERITEST_VERIFY2(len <= 2 * expected_len,
+	    "length (%jd) greater than expected upper bound %jd: " _CHERI_PRINTF_CAP_FMT,
+	    len, 2 * expected_len, _CHERI_PRINTF_CAP_ARG(c));
+#endif
 	cheritest_success();
 }
 

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -49,6 +49,7 @@
 #include <err.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -131,36 +132,59 @@ check_initreg_code(void * __capability c)
 {
 	uintmax_t v;
 
-	/* Base. */
-	v = cheri_getbase(c);
-	if (v != CHERI_CAP_USER_CODE_BASE)
-		cheritest_failure_errx("base %jx (expected %jx)", v,
-		    (uintmax_t)CHERI_CAP_USER_CODE_BASE);
+	CHERI_FPRINT_PTR(stderr, c);
 
-	/* Length. */
-	v = cheri_getlen(c);
-	if (v > CHERI_CAP_USER_CODE_LENGTH)
-		cheritest_failure_errx("length 0x%jx (expected <= 0x%jx)", v,
-		    CHERI_CAP_USER_CODE_LENGTH);
-
+#if defined(__CHERI_PURE_CAPABILITY__)
+	/*
+	 * Dynamically linked pure-capability code should have a program
+	 * counter that is bounded to the current DSO/executable (or function).
+	 */
+	CHERITEST_VERIFY2(cheri_getbase(c) != 0, "code base should be nonzero");
+	/*
+	 * Check that PCC ends at the end of the current DSO (or executable in
+	 * the statically linked case). Since we don't know the real value here,
+	 * just check that it is less than PCC plus a constant that should be
+	 * large enough for this binary (rounded to the next representable
+	 * length).
+	 */
+	vaddr_t upper_bound =
+	    CHERI_REPRESENTABLE_LENGTH(cheri_getaddress(c) + 0x100000);
+	CHERITEST_VERIFY2(cheri_getlength(c) < upper_bound,
+	    "code length 0x%jx should be < than 0x%jx)", cheri_getlength(c),
+	    upper_bound);
+#else
+	/*
+	 * In hybrid mode PCC should start at zero and extend to the end of the
+	 * user address space.
+	 */
+	CHERITEST_VERIFY2(cheri_getbase(c) == CHERI_CAP_USER_CODE_BASE,
+	    "code base 0x%jx (expected 0x%jx)", cheri_getbase(c),
+	    (uintmax_t)CHERI_CAP_USER_CODE_BASE);
+	CHERITEST_VERIFY2(cheri_getlength(c) == CHERI_CAP_USER_CODE_LENGTH,
+	    "code length 0x%jx should be 0x%jx", cheri_getlength(c),
+	    (uintmax_t)CHERI_CAP_USER_CODE_LENGTH);
+#endif
 	/* Offset. */
-	v = cheri_getoffset(c);
-	if (v != CHERI_CAP_USER_CODE_OFFSET)
-		cheritest_failure_errx("offset %jx (expected %jx)", v,
-		    (uintmax_t)CHERI_CAP_USER_CODE_OFFSET);
+	CHERITEST_VERIFY(cheri_getoffset(c) == 0);
 
 	/* Type -- should be (-1) for an unsealed capability. */
 	v = cheri_gettype(c);
-	if (v != 0xffffffffffffffff)
+	if (v != (uintmax_t)CHERI_OTYPE_UNSEALED)
 		cheritest_failure_errx("otype %jx (expected %jx)", v,
-		    (uintmax_t)0xffffffffffffffff);
+		    (uintmax_t)CHERI_OTYPE_UNSEALED);
+
+	/* Sealed bit. */
+	v = cheri_getsealed(c);
+	if (v != 0)
+		cheritest_failure_errx("sealed %jx (expected 0)", v);
+
+	/* Tag bit. */
+	v = cheri_gettag(c);
+	if (v != 1)
+		cheritest_failure_errx("tag %jx (expected 1)", v);
 
 	/* Permissions. */
 	v = cheri_getperm(c);
-	if (v != CHERI_CAP_USER_CODE_PERMS)
-		cheritest_failure_errx("perms %jx (expected %jx)", v,
-		    (uintmax_t)CHERI_CAP_USER_CODE_PERMS);
-
 	/*
 	 * More overt tests for permissions that should -- or should not -- be
 	 * there, regardless of consistency with the kernel headers.
@@ -204,15 +228,11 @@ check_initreg_code(void * __capability c)
 		cheritest_failure_errx("perms %jx (expected swperms %x)", v,
 		    (CHERI_PERMS_SWALL & ~CHERI_PERM_CHERIABI_VMMAP));
 
-	/* Sealed bit. */
-	v = cheri_getsealed(c);
-	if (v != 0)
-		cheritest_failure_errx("sealed %jx (expected 0)", v);
+	/* Check that the raw permission bits match the kernel header: */
+	if (v != CHERI_CAP_USER_CODE_PERMS)
+		cheritest_failure_errx("perms %jx (expected %jx)", v,
+		    (uintmax_t)CHERI_CAP_USER_CODE_PERMS);
 
-	/* Tag bit. */
-	v = cheri_gettag(c);
-	if (v != 1)
-		cheritest_failure_errx("tag %jx (expected 1)", v);
 	cheritest_success();
 }
 

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -324,6 +324,8 @@ cheritest_vm_cap_share_fd_kqueue(const struct cheri_test *ctp __unused)
 	}
 }
 
+extern int __sys_sigaction(int, const struct sigaction *, struct sigaction *);
+
 /*
  * We can rfork and share the sigaction table across parent and child, which
  * again allows for capability passing across address spaces.
@@ -337,8 +339,14 @@ cheritest_vm_cap_share_sigaction(const struct cheri_test *ctp __unused)
 	if (pid == -1)
 		cheritest_failure_errx("Fork failed; errno=%d", errno);
 
+	/*
+	 * Note: we call __sys_sigaction directly here, since the libthr
+	 * _thr_sigaction has a shadow list for the sigaction values
+	 * (per-process) and therefore does not read the new value installed by
+	 * the child process forked with RFSIGSHARE.
+	 */
 	if (pid == 0) {
-		void * __capability passme;
+		void *__capability passme;
 		struct sigaction sa;
 
 		bzero(&sa, sizeof(sa));
@@ -346,21 +354,32 @@ cheritest_vm_cap_share_sigaction(const struct cheri_test *ctp __unused)
 		/* This is a little abusive, but shows the point, I think */
 
 		passme = CHERITEST_CHECK_SYSCALL(mmap(0, PAGE_SIZE,
-				PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON, -1, 0));
+		    PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON, -1, 0));
 		sa.sa_handler = passme;
-		sa.sa_flags = 0;
 
-		CHERITEST_CHECK_SYSCALL(sigaction(SIGUSR1, &sa, NULL));
+		CHERITEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, &sa, NULL));
+
+		/* Read it again and check that we get the same value back. */
+		CHERITEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
+		fprintf(stderr, "child value read from sigaction(): ");
+		CHERI_FPRINT_PTR(stderr, sa.sa_handler);
+		CHERITEST_CHECK_EQ_CAP(sa.sa_handler, passme);
+
 		exit(0);
 	} else {
 		struct sigaction sa;
 
 		waitpid(pid, NULL, 0);
 
-		sa.sa_handler = NULL;
-		CHERITEST_CHECK_SYSCALL(sigaction(SIGUSR1, NULL, &sa));
+		bzero(&sa, sizeof(sa));
+		sa.sa_flags = 1;
 
+		CHERITEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
+		fprintf(stderr, "parent sa read from sigaction(): ");
 		CHERI_FPRINT_PTR(stderr, sa.sa_handler);
+
+		/* Flags should be zero on read */
+		CHERITEST_CHECK_EQ_LONG(sa.sa_flags, 0);
 
 		if (cheri_gettag(sa.sa_handler)) {
 			cheritest_failure_errx("tag transfer");

--- a/libexec/rtld-cheri-elf/Makefile
+++ b/libexec/rtld-cheri-elf/Makefile
@@ -33,7 +33,7 @@ CFLAGS+=-DNO_LD_DEBUG
 # This could be optimized to use different stubs for per-file stubs but for
 # now making it opt-in is easier.
 # TODO: add a make options for this (e.g. MK_BENCHMARK_OPTIONS)?
-.ifdef RTLD_PER_FUNCTION_CAPTABLE_SUPPORT
+.if defined(RTLD_PER_FUNCTION_CAPTABLE_SUPPORT) && ${TARGET} == "mips"
 CFLAGS+=-DRTLD_SUPPORT_PER_FUNCTION_CAPTABLE=1
 .else
 CFLAGS+=-DRTLD_SUPPORT_PER_FUNCTION_CAPTABLE=0

--- a/sys/cheri/cheri_exec.c
+++ b/sys/cheri/cheri_exec.c
@@ -146,21 +146,13 @@ cheri_exec_pcc(struct image_params *imgp)
 	 * use interp_end.  If we are executing rtld directly we can
 	 * use end_addr to find the end of the rtld mapping.
 	 */
-	if (imgp->interp_end != 0)
-		code_end = imgp->interp_end;
-	else
-		code_end = imgp->end_addr;
-
-	/*
-	 * Statically linked binaries need a base 0 code capability
-	 * since otherwise crt_init_globals_will fail.
-	 *
-	 * XXXAR: TODO: is this still true??
-	 */
-	if (imgp->interp_end != 0)
+	if (imgp->interp_end != 0) {
 		code_start = imgp->reloc_base;
-	else
-		code_start = 0;
+		code_end = imgp->interp_end;
+	} else {
+		code_start = imgp->start_addr;
+		code_end = imgp->end_addr;
+	}
 
 	/* Ensure CHERI128 representability */
 	code_length = code_end - code_start;

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1481,8 +1481,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	AUXARGS_ENTRY(pos, AT_PAGESZ, args->pagesz);
 	AUXARGS_ENTRY(pos, AT_FLAGS, args->flags);
 #ifdef __ELF_CHERI
-	entry = cheri_setaddress(prog_cap(imgp,
-	    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS),
+	entry = cheri_setaddress(prog_cap(imgp, CHERI_CAP_USER_CODE_PERMS),
 	    args->entry);
 #ifdef CHERI_FLAGS_CAP_MODE
 	/*

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -925,6 +925,9 @@ __elfN(enforce_limits)(struct image_params *imgp, const Elf_Ehdr *hdr,
 	err_str = NULL;
 	text_size = data_size = total_size = text_addr = data_addr = 0;
 
+	/* Initialize start_addr so that MIN() produces something useful. */
+	imgp->start_addr = ~0UL;
+
 	for (i = 0; i < hdr->e_phnum; i++) {
 		if (phdr[i].p_type != PT_LOAD || phdr[i].p_memsz == 0)
 			continue;


### PR DESCRIPTION
With these changes all cheritests should succeed/xfail.

The result of cheritest_vm_cap_share_sigaction seems to not be consistent so XFAIL sometimes results in an XPASS.