### PR TITLE
Use ld-cheri-elf.so.1 if it exists for purecap.

### DIFF
--- a/sys/mips/mips/elf_machdep.c
+++ b/sys/mips/mips/elf_machdep.c
@@ -159,11 +159,12 @@ static __ElfN(Brandinfo) freebsd_brand_info = {
 	.emul_path	= NULL,
 	.interp_path	= "/libexec/ld-elf.so.1",
 	.sysvec		= &elf_freebsd_sysvec,
-	.interp_newpath	= NULL,
 #if __has_feature(capabilities)
+	.interp_newpath	= "/libexec/ld-cheri-elf.so.1",
 	.header_supported = mips_elf_header_supported,
 	.flags		= BI_CAN_EXEC_DYN
 #else
+	.interp_newpath	= NULL,
 	.brand_note	= &__elfN(freebsd_brandnote),
 	.flags		= BI_CAN_EXEC_DYN | BI_BRAND_NOTE
 #endif


### PR DESCRIPTION
This fixes dynamic binaries in a hybrid world.