### PR TITLE
Define __LP64__ on CHERI-RISC-V

### DIFF
--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -425,6 +425,10 @@ RISCV_MARCH:=	${RISCV_MARCH}xcheri
 
 .if ${MACHINE_ARCH:Mriscv*c*}
 RISCV_ABI=	l64pc128
+# Clang no longer defines __LP64__ for Cheri purecap ABI but there are a
+# lot of files that use it to check for not 32-bit
+# XXXAR: Remove this once we have checked all the #ifdef __LP64__ uses
+CFLAGS+=	-D__LP64__=1
 .else
 RISCV_ABI=	lp64
 .endif


### PR DESCRIPTION
This is a hack due to code thinking that !defined(__LP64__) is the same
as defined(__ILP32__).  We need to audit the tree and fix these.