### PR TITLE
Handle DTB aligned to less than 2MB

### DIFF
--- a/sys/riscv/include/machdep.h
+++ b/sys/riscv/include/machdep.h
@@ -42,6 +42,7 @@ struct riscv_bootparams {
 	vm_offset_t	kern_phys;	/* Kernel base (physical) addr */
 	vm_offset_t	kern_stack;
 	vm_offset_t	dtbp_virt;	/* Device tree blob virtual addr */
+	vm_offset_t	dtbp_phys;	/* Device tree blob physical addr */
 };
 
 extern vm_paddr_t physmap[PHYS_AVAIL_ENTRIES];

--- a/sys/riscv/riscv/genassym.c
+++ b/sys/riscv/riscv/genassym.c
@@ -113,6 +113,7 @@ ASSYM(RISCV_BOOTPARAMS_KERN_PHYS, offsetof(struct riscv_bootparams, kern_phys));
 ASSYM(RISCV_BOOTPARAMS_KERN_STACK, offsetof(struct riscv_bootparams,
     kern_stack));
 ASSYM(RISCV_BOOTPARAMS_DTBP_VIRT, offsetof(struct riscv_bootparams, dtbp_virt));
+ASSYM(RISCV_BOOTPARAMS_DTBP_PHYS, offsetof(struct riscv_bootparams, dtbp_phys));
 
 #ifdef CPU_QEMU_RISCV
 ASSYM(MDTD_QTRACE, MDTD_QTRACE);

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -139,6 +139,8 @@ _start:
 	lla	s1, pagetable_l2_devmap
 	mv	s2, a1
 	srli	s2, s2, PAGE_SHIFT
+	/* Mask off any bits that aren't aligned */
+	andi	s2, s2, ~((1 << (PTE_PPN1_S - PTE_PPN0_S)) - 1)
 
 	li	t0, (PTE_KERN)
 	slli	t2, s2, PTE_PPN0_S	/* << PTE_PPN0_S */
@@ -229,6 +231,10 @@ va:
 	sd	t0, RISCV_BOOTPARAMS_KERN_STACK(sp)
 
 	li	t0, (VM_EARLY_DTB_ADDRESS)
+	/* Add offset of DTB within superpage */
+	li	t1, (L2_OFFSET)
+	and	t1, a1, t1
+	add	t0, t0, t1
 	sd	t0, RISCV_BOOTPARAMS_DTBP_VIRT(sp)
 	sd	a1, RISCV_BOOTPARAMS_DTBP_PHYS(sp)
 

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -230,6 +230,7 @@ va:
 
 	li	t0, (VM_EARLY_DTB_ADDRESS)
 	sd	t0, RISCV_BOOTPARAMS_DTBP_VIRT(sp)
+	sd	a1, RISCV_BOOTPARAMS_DTBP_PHYS(sp)
 
 	mv	a0, sp
 	call	_C_LABEL(initriscv)	/* Off we go */

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -1050,7 +1050,18 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	fake_preload[i] = 0;
 	preload_metadata = (void *)fake_preload;
 
+	/* Check if bootloader clobbered part of the kernel with the DTB. */
+	KASSERT(rvbp->dtbp_phys + dtb_size < rvbp->kern_phys ||
+		rvbp->dtbp_phys > rvbp->kern_phys + (lastaddr - KERNBASE),
+	    ("FDT (%lx-%lx) and kernel (%lx-%lx) overlap", rvbp->dtbp_phys,
+		rvbp->dtbp_phys + dtb_size, rvbp->kern_phys,
+		rvbp->kern_phys + (lastaddr - KERNBASE)));
 	KASSERT(i < nitems(fake_preload), ("Too many fake_preload items"));
+
+	if (boothowto & RB_VERBOSE)
+		printf("FDT phys (%lx-%lx), kernel phys (%lx-%lx)\n",
+		    rvbp->dtbp_phys, rvbp->dtbp_phys + dtb_size,
+		    rvbp->kern_phys, rvbp->kern_phys + (lastaddr - KERNBASE));
 
 	return (lastaddr);
 }

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -1051,8 +1051,8 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	preload_metadata = (void *)fake_preload;
 
 	/* Check if bootloader clobbered part of the kernel with the DTB. */
-	KASSERT(rvbp->dtbp_phys + dtb_size < rvbp->kern_phys ||
-		rvbp->dtbp_phys > rvbp->kern_phys + (lastaddr - KERNBASE),
+	KASSERT(rvbp->dtbp_phys + dtb_size <= rvbp->kern_phys ||
+		rvbp->dtbp_phys >= rvbp->kern_phys + (lastaddr - KERNBASE),
 	    ("FDT (%lx-%lx) and kernel (%lx-%lx) overlap", rvbp->dtbp_phys,
 		rvbp->dtbp_phys + dtb_size, rvbp->kern_phys,
 		rvbp->kern_phys + (lastaddr - KERNBASE)));

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -582,8 +582,6 @@ pmap_bootstrap(vm_offset_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 	int i;
 
 	printf("pmap_bootstrap %lx %lx %lx\n", l1pt, kernstart, kernlen);
-	printf("%lx\n", l1pt);
-	printf("%lx\n", (KERNBASE >> L1_SHIFT) & Ln_ADDR_MASK);
 
 	/* Set this early so we can use the pagetable walking functions */
 	kernel_pmap_store.pm_l1 = (pd_entry_t *)l1pt;


### PR DESCRIPTION
This change also adds a KASSERT() for the case where DTB and kernel overlap.

If these changes look fine, I'll rebase on FreeBSD master and submit upstream reviews.