### PR TITLE
Truss freebsd64

### DIFF
--- a/lib/libsysdecode/errno.c
+++ b/lib/libsysdecode/errno.c
@@ -128,6 +128,7 @@ sysdecode_abi_to_freebsd_errno(enum sysdecode_abi abi, int error)
 	switch (abi) {
 	case SYSDECODE_ABI_FREEBSD:
 	case SYSDECODE_ABI_FREEBSD32:
+	case SYSDECODE_ABI_FREEBSD64:
 		return (error);
 #if defined(__aarch64__) || defined(__amd64__) || defined(__i386__)
 	case SYSDECODE_ABI_LINUX:

--- a/lib/libsysdecode/syscallnames.c
+++ b/lib/libsysdecode/syscallnames.c
@@ -48,6 +48,11 @@ static
 #include <compat/freebsd32/freebsd32_syscalls.c>
 #endif
 
+#if __has_feature(capabilities)
+static
+#include <compat/freebsd64/freebsd64_syscalls.c>
+#endif
+
 #if defined(__aarch64__) || defined(__amd64__) || defined(__i386__)
 static
 #ifdef __aarch64__
@@ -82,6 +87,12 @@ sysdecode_syscallname(enum sysdecode_abi abi, unsigned int code)
 	case SYSDECODE_ABI_FREEBSD32:
 		if (code < nitems(freebsd32_syscallnames))
 			return (freebsd32_syscallnames[code]);
+		break;
+#endif
+#if __has_feature(capabilities)
+	case SYSDECODE_ABI_FREEBSD64:
+		if (code < nitems(freebsd64_syscallnames))
+			return (freebsd64_syscallnames[code]);
 		break;
 #endif
 #if defined(__aarch64__) || defined(__amd64__) || defined(__i386__)

--- a/lib/libsysdecode/sysdecode.3
+++ b/lib/libsysdecode/sysdecode.3
@@ -54,6 +54,9 @@ Supported on all platforms.
 .It Li SYSDECODE_ABI_FREEBSD32
 32-bit FreeBSD binaries.
 Supported on amd64 and powerpc64.
+.It Li SYSDECODE_ABI_FREEBSD64
+64-bit FreeBSD binaries.
+Supported on mips64c128 and riscv64c.
 .It Li SYSDECODE_ABI_LINUX
 Linux binaries of the same platform.
 Supported on amd64, i386, and arm64.

--- a/lib/libsysdecode/sysdecode.h
+++ b/lib/libsysdecode/sysdecode.h
@@ -35,7 +35,13 @@ enum sysdecode_abi {
 	SYSDECODE_ABI_LINUX,
 	SYSDECODE_ABI_LINUX32,
 	SYSDECODE_ABI_CLOUDABI64,
-	SYSDECODE_ABI_CLOUDABI32
+	SYSDECODE_ABI_CLOUDABI32,
+
+	/*
+	 * XXX: 100 is to avoid ABI issues in CheriBSD, would use next
+	 * value when merged upstream.
+	 */
+	SYSDECODE_ABI_FREEBSD64 = 100,
 };
 
 int	sysdecode_abi_to_freebsd_errno(enum sysdecode_abi _abi, int _error);

--- a/usr.bin/kdump/kdump.c
+++ b/usr.bin/kdump/kdump.c
@@ -727,16 +727,10 @@ dumpheader(struct ktr_header *kth, u_int sv_flags)
 		else
 			arch = "00";
 
-		if (sv_flags & SV_CHERI) {
-			/* XXX: Can't determine capability size from sv_flags */
-#if MIPS_SZCAP == 32
-			cap = "C256";
-#else
-			cap = "C128";
-#endif
-		}
-			else
-				cap = "";
+		if (sv_flags & SV_CHERI)
+			cap = "C";
+		else
+			cap = "";
 
 		printf("%s%s%s  ", abi, arch, cap);
 	}

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -103,6 +103,15 @@ static struct procabi freebsd32 = {
 };
 #endif
 
+#ifdef __CHERI_PURE_CAPABILITY__
+static struct procabi freebsd64 = {
+	"FreeBSD64",
+	SYSDECODE_ABI_FREEBSD64,
+	STAILQ_HEAD_INITIALIZER(freebsd64.extra_syscalls),
+	{ NULL }
+};
+#endif
+
 static struct procabi linux = {
 	"Linux",
 	SYSDECODE_ABI_LINUX,
@@ -122,14 +131,23 @@ static struct procabi linux32 = {
 static struct procabi_table abis[] = {
 	{ "CloudABI ELF32", &cloudabi32 },
 	{ "CloudABI ELF64", &cloudabi64 },
-#ifdef __LP64__
+#ifdef __CHERI_PURE_CAPABILITY__
+	{ "FreeBSD ELF64C", &freebsd },
+#elif defined(__LP64__)
+	/* This permits hybrid truss to trace CheriABI. */
+	{ "FreeBSD ELF64C", &freebsd },
 	{ "FreeBSD ELF64", &freebsd },
-	{ "FreeBSD ELF32", &freebsd32 },
 #else
 	{ "FreeBSD ELF32", &freebsd },
 #endif
 #if defined(__powerpc64__)
 	{ "FreeBSD ELF64 V2", &freebsd },
+#endif
+#ifdef __CHERI_PURE_CAPABILITY__
+	{ "FreeBSD ELF64", &freebsd64 },
+#endif
+#ifdef __LP64__
+	{ "FreeBSD ELF32", &freebsd32 },
 #endif
 #if defined(__amd64__)
 	{ "FreeBSD a.out", &freebsd32 },
@@ -144,13 +162,9 @@ static struct procabi_table abis[] = {
 	{ "Linux ELF", &linux },
 #endif
 	/*
-	 * XXX: Temporary hack for CheriABI.  If CheriABI were going
-	 * to stay around longer we might add a sysdecode enum, etc.
-	 *
-	 * Eventually we will have to handle freebsd64 though.
+	 * XXX: Temporary hack for COMPAT_CHERIABI.
 	 */
 	{ "CheriABI ELF64", &freebsd },
-	{ "FreeBSD ELF64C", &freebsd },
 };
 
 /*


### PR DESCRIPTION
This was originally to fix purecap truss on RISC-V since we weren't defining `__LP64__`.  This is still the "right" solution for truss I think (at least in the current world order where we don't use `__SIZEOF_POINTER__` upstream).