### PR TITLE
Fix ldd to work on RISC-V.

### DIFF
--- a/usr.bin/ldd/Makefile
+++ b/usr.bin/ldd/Makefile
@@ -6,6 +6,8 @@ SRCS=		ldd.c
 SRCS+=		sods.c
 .endif
 
+LIBADD=		elf
+
 CFLAGS+=	-I${SRCTOP}/libexec/rtld-elf
 
 .include <bsd.prog.mk>

--- a/usr.bin/ldd/ldd.c
+++ b/usr.bin/ldd/ldd.c
@@ -520,22 +520,21 @@ is_executable(const char *fname, int fd, int *is_shlib, int *type,
 		 * PT_INTERP to differentiate executables from shared
 		 * libraries.
 		 */
-		if (!interp)
+		if (!interp) {
 			*is_shlib = 1;
 
-		if (!is_freebsd_elf(fname, elf, &ehdr)) {
 #if defined(__aarch64__) || defined(__riscv)
 			/*
 			 * Shared libraries on AArch64 and RISC-V have
 			 * neither a FreeBSD OSABI or a brand note.
 			 */
-			if (interp)
-#endif
-			{
+			if (!is_freebsd_elf(fname, elf, &ehdr)) {
 				elf_end(elf);
-				warnx("%s: not a FreeBSD ELF file", fname);
+				warnx("%s: not a FreeBSD ELF shared object",
+				    fname);
 				return (0);
 			}
+#endif
 		}
 		elf_end(elf);
 

--- a/usr.bin/ldd/ldd.c
+++ b/usr.bin/ldd/ldd.c
@@ -348,6 +348,7 @@ usage(void)
 	exit(1);
 }
 
+#if !defined(__aarch64__) && !defined(__riscv)
 static bool
 check_notes(const char *buf, size_t len)
 {
@@ -415,6 +416,7 @@ is_freebsd_elf(const char *fname, Elf *elf, GElf_Ehdr *ehdr)
 
 	return (false);
 }
+#endif
 
 static int
 is_executable(const char *fname, int fd, int *is_shlib, int *type,
@@ -523,7 +525,7 @@ is_executable(const char *fname, int fd, int *is_shlib, int *type,
 		if (!interp) {
 			*is_shlib = 1;
 
-#if defined(__aarch64__) || defined(__riscv)
+#if !defined(__aarch64__) && !defined(__riscv)
 			/*
 			 * Shared libraries on AArch64 and RISC-V have
 			 * neither a FreeBSD OSABI or a brand note.


### PR DESCRIPTION
- Use libelf to parse ELF data structures and remove code duplication
  for ELF32.

- Use the presence of a PT_INTERP program header to differentiate
  executables from shared libraries.  ET_DYN includes both PIEs and
  shared libraries.

- Don't require the OSABI field to be set to the FreeBSD OSABI.  Both
  AArch64 and RISC-V leave it set to "none" and instead depend on the
  ABI tag note.  For ldd, this means falling back to walking the
  sections and then walking the notes in SHT_NOTE sections to find the
  ABI tag note to verify that an ELF file is a FreeBSD ELF file.

  Note that shared libraries do not currently have the ABI tag note,
  so right now ldd assumes all shared libraries on AArch64 and RISC-V
  are FreeBSD ELF files.

- Only use the CheriABI compat path for rtld when building a
  non-purecap rtld.  This should fix the direct exec of shared
  libraries on CHERI-MIPS in a purecap world.