### PR TITLE
Add support for initializing stack variables on entry.

### DIFF
--- a/lib/libsimple_printf/Makefile
+++ b/lib/libsimple_printf/Makefile
@@ -2,6 +2,8 @@
 
 .include <src.opts.mk>
 MK_SSP=	no
+MK_INIT_ALL_ZERO=	no
+MK_INIT_ALL_PATTERN=	no
 
 PACKAGE=lib${LIB}
 LIB=	simple_printf

--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -24,6 +24,7 @@
 # - c++11:     supports full (or nearly full) C++11 programming environment.
 # - retpoline: supports the retpoline speculative execution vulnerability
 #              mitigation.
+# - init-all:  supports stack variable initialization.
 #
 # These variables with an X_ prefix will also be provided if XCC is set.
 #
@@ -234,7 +235,7 @@ ${X_}COMPILER_FEATURES=		c++11 c++14
 ${X_}COMPILER_FEATURES+=	c++17
 .endif
 .if ${${X_}COMPILER_TYPE} == "clang"
-${X_}COMPILER_FEATURES+=	retpoline
+${X_}COMPILER_FEATURES+=	retpoline init-all
 .endif
 
 .if ${${cc}:N${CCACHE_BIN}:[1]:M/*} && exists(${${cc}:N${CCACHE_BIN}:[1]})

--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -94,6 +94,25 @@ LDFLAGS+= -Wl,-zretpolineplt
 .endif
 .endif
 
+# Initialize stack variables on function entry
+.if ${MK_INIT_ALL_ZERO} == "yes"
+.if ${COMPILER_FEATURES:Minit-all}
+CFLAGS+= -ftrivial-auto-var-init=zero \
+    -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang
+CXXFLAGS+= -ftrivial-auto-var-init=zero \
+    -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang
+.else
+.warning InitAll (zeros) requested but not support by compiler
+.endif
+.elif ${MK_INIT_ALL_PATTERN} == "yes"
+.if ${COMPILER_FEATURES:Minit-all}
+CFLAGS+= -ftrivial-auto-var-init=pattern
+CXXFLAGS+= -ftrivial-auto-var-init=pattern
+.else
+.warning InitAll (pattern) requested but not support by compiler
+.endif
+.endif
+
 .if ${MK_DEBUG_FILES} != "no" && empty(DEBUG_FLAGS:M-g) && \
     empty(DEBUG_FLAGS:M-gdwarf*)
 CFLAGS+= ${DEBUG_FILES_CFLAGS}

--- a/share/mk/bsd.opts.mk
+++ b/share/mk/bsd.opts.mk
@@ -72,6 +72,8 @@ __DEFAULT_NO_OPTIONS = \
     BIND_NOW \
     CCACHE_BUILD \
     CTF \
+    INIT_ALL_PATTERN \
+    INIT_ALL_ZERO \
     INSTALL_AS_USER \
     PIE \
     RETPOLINE \
@@ -120,6 +122,10 @@ WITH_CHERI:=	yes
 
 .if ${__TT:Mmips*} && ${MK_CHERI} == "yes"
 MK_CLANG:=	no
+.endif
+
+.if ${MK_INIT_ALL_PATTERN} == "yes" && ${MK_INIT_ALL_ZERO} == "yes"
+.error WITH_INIT_ALL_PATTERN and WITH_INIT_ALL_ZERO are mutually exclusive.
 .endif
 
 #

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -66,6 +66,25 @@ LDFLAGS+= -Wl,-zretpolineplt
 .endif
 .endif
 
+# Initialize stack variables on function entry
+.if ${MK_INIT_ALL_ZERO} == "yes"
+.if ${COMPILER_FEATURES:Minit-all}
+CFLAGS+= -ftrivial-auto-var-init=zero \
+    -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang
+CXXFLAGS+= -ftrivial-auto-var-init=zero \
+    -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang
+.else
+.warning InitAll (zeros) requested but not support by compiler
+.endif
+.elif ${MK_INIT_ALL_PATTERN} == "yes"
+.if ${COMPILER_FEATURES:Minit-all}
+CFLAGS+= -ftrivial-auto-var-init=pattern
+CXXFLAGS+= -ftrivial-auto-var-init=pattern
+.else
+.warning InitAll (pattern) requested but not support by compiler
+.endif
+.endif
+
 # macOS linker doesn't understand the --fatal-warnings flag
 .if ${LINKER_TYPE} != "mac"
 .if defined(LD_FATAL_WARNINGS) && ${LD_FATAL_WARNINGS} == "no"

--- a/tools/build/options/WITH_INIT_ALL_PATTERN
+++ b/tools/build/options/WITH_INIT_ALL_PATTERN
@@ -1,0 +1,3 @@
+.\" $FreeBSD$
+Set to build the base system with stack variables initialized to known
+patterns on function entry.

--- a/tools/build/options/WITH_INIT_ALL_ZERO
+++ b/tools/build/options/WITH_INIT_ALL_ZERO
@@ -1,0 +1,3 @@
+.\" $FreeBSD$
+Set to build the base system with stack variables initialized to zero on
+function entry.


### PR DESCRIPTION
There are two options:
 - WITH_INITALL_ZERO: Zero all variables on the stack.
 - WITH_INITALL_PATTERN: Initialize variables with well-defined patterns.
   The exact pattern are a compiler implementation detail and vary by type.

I've used WITH_INITALL_* to matches Microsoft's InitAll feature rather
than naming them after the LLVM specific compiler flags.