### PR TITLE
QEMU MIPS MALTA SMP: set tcrestart to _locore

### DIFF
--- a/sys/mips/malta/malta_mp.c
+++ b/sys/mips/malta/malta_mp.c
@@ -244,6 +244,10 @@ platform_start_ap(int cpuid)
 	 * reg = 0x80000000;
 	 * mttc0(2, 3, reg);
 	 */
+#if defined(CPU_QEMU_MALTA)
+	extern char _locore[];
+	mttc0(2, 3, (uintptr_t)_locore);
+#endif
 
 	/* Enable thread */
 	reg = mftc0(2, 1);


### PR DESCRIPTION
The APs should jump over any "get the machine going" bootloader code
that QEMU shoves into our physical address space.  Otherwise, we end up
back in the QEMU MIPS MALTA bootloader trying to reconfigure the PCI
BARs, and that's not going to go well for anyone.  (In practice, the
first store to the BAR register triggers a data bus fault and the AP
ends up falling through to the initialization code again and faulting
again and again...)

(The curious are pointed at QEMU's hw/mips/malta.c:/write_bootloader and
the bit of code labeled "Load BAR registers as done by YAMON".)

This fixes issues observed while testing https://github.com/CTSRD-CHERI/qemu/pull/76