### PR TITLE
DNM!: QEMU MALTA SMP: directly jump to mpentry, not locore

### DIFF
--- a/sys/mips/malta/asm_malta.S
+++ b/sys/mips/malta/asm_malta.S
@@ -68,11 +68,11 @@ END(malta_cpu_configure)
 
 /*
  * Called on APs to wait until they are told to launch.
+ *
+ * v0 should contain the result of platform_processor_id, above.
+ * Preserve s0.
  */
 LEAF(malta_ap_wait)
-	jal	platform_processor_id
-	nop
-
 	PTR_LA	t1, malta_ap_boot
 
 1:
@@ -86,7 +86,7 @@ LEAF(malta_ap_wait)
 	beqz	t0, 1b
 	nop
 
-	j	mpentry
+	jr	ra
 	nop
 END(malta_ap_wait)
 #endif

--- a/sys/mips/malta/malta_mp.c
+++ b/sys/mips/malta/malta_mp.c
@@ -239,15 +239,8 @@ platform_start_ap(int cpuid)
 
 	set_thread_context(cpuid);
 
-	/*
-	 * Hint: how to set entry point.
-	 * reg = 0x80000000;
-	 * mttc0(2, 3, reg);
-	 */
-#if defined(CPU_QEMU_MALTA)
-	extern char _locore[];
-	mttc0(2, 3, (uintptr_t)_locore);
-#endif
+	/* Jump directly to mpentry, bypassing the early locore code */
+	mttc0(2, 3, (uintptr_t)mpentry);
 
 	/* Enable thread */
 	reg = mftc0(2, 1);

--- a/sys/mips/mips/locore.S
+++ b/sys/mips/mips/locore.S
@@ -248,21 +248,6 @@ VECTOR(_locore, unknown)
 1:
 #endif
 
-#if defined(CPU_MALTA) && defined(SMP)
-	.set push
-	.set mips32r2
-	jal	malta_cpu_configure
-	nop
-	jal	platform_processor_id
-	nop
-	beqz	v0, 1f
-	nop
-	j	malta_ap_wait
-	nop
-	.set pop
-1:
-#endif
-
 	/*
 	 * Initialize stack and call machine startup.
 	 */

--- a/sys/mips/mips/mpboot.S
+++ b/sys/mips/mips/mpboot.S
@@ -97,10 +97,20 @@ GLOBAL(mpentry)
 	cmove CHERI_REG_C28, $cnull
 #endif
 
+#if defined(CPU_MALTA)
+	jal     malta_cpu_configure
+	nop
+#endif
+
 	PTR_LA	t9, platform_processor_id	/* get the processor number */
 	jalr	t9
 	nop
 	move	s0, v0
+
+#if defined(CPU_MALTA)
+	jal	malta_ap_wait
+	nop
+#endif
 
 	/*
 	 * Initialize stack and call machine startup


### PR DESCRIPTION
As suggested by @bsdjhb in https://github.com/CTSRD-CHERI/cheribsd/pull/541

I think this is the right idea, and it does seem to bring the AP online when I test with a 2-way SMP system, but something is subtly wrong and it's manifesting as the kernel blocking on waiting for CAM to finish coming online so that it can mount root.

I've gone cross-eyed trying to stare into the difference between the relevant parts of `locore.S` and `mpboot.S`, but might just be missing something.  Anyone see what I'm doing wrong?