### PR TITLE
Add a new 'zero_free' option.

### DIFF
--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -17,6 +17,7 @@ extern bool opt_junk_free;
 extern bool opt_utrace;
 extern bool opt_xmalloc;
 extern bool opt_zero;
+extern bool opt_zero_free;
 extern unsigned opt_narenas;
 
 /* Number of CPUs. */

--- a/contrib/jemalloc/include/jemalloc/internal/private_namespace.h
+++ b/contrib/jemalloc/include/jemalloc/internal/private_namespace.h
@@ -33,6 +33,7 @@
 #define opt_utrace JEMALLOC_N(opt_utrace)
 #define opt_xmalloc JEMALLOC_N(opt_xmalloc)
 #define opt_zero JEMALLOC_N(opt_zero)
+#define opt_zero_free JEMALLOC_N(opt_zero_free)
 #define sdallocx_default JEMALLOC_N(sdallocx_default)
 #define arena_alloc_junk_small JEMALLOC_N(arena_alloc_junk_small)
 #define arena_basic_stats_merge JEMALLOC_N(arena_basic_stats_merge)

--- a/contrib/jemalloc/include/jemalloc/internal/tcache_inlines.h
+++ b/contrib/jemalloc/include/jemalloc/internal/tcache_inlines.h
@@ -169,8 +169,12 @@ tcache_dalloc_small(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	assert(tcache_salloc(tsd_tsdn(tsd), ptr)
 	    <= SC_SMALL_MAXCLASS);
 
-	if (slow_path && config_fill && unlikely(opt_junk_free)) {
-		arena_dalloc_junk_small(ptr, &bin_infos[binind]);
+	if (slow_path && config_fill) {
+		if (unlikely(opt_junk_free)) {
+			arena_dalloc_junk_small(ptr, &bin_infos[binind]);
+		} else if (unlikely(opt_zero_free)) {
+			memset(ptr, 0, bin_infos[binind].reg_size);
+		}
 	}
 
 	bin = tcache_small_bin_get(tcache, binind);
@@ -195,8 +199,12 @@ tcache_dalloc_large(tsd_t *tsd, tcache_t *tcache, void *ptr, szind_t binind,
 	    > SC_SMALL_MAXCLASS);
 	assert(tcache_salloc(tsd_tsdn(tsd), ptr) <= tcache_maxclass);
 
-	if (slow_path && config_fill && unlikely(opt_junk_free)) {
-		large_dalloc_junk(ptr, sz_index2size(binind));
+	if (slow_path && config_fill) {
+		if (unlikely(opt_junk_free)) {
+			large_dalloc_junk(ptr, sz_index2size(binind));
+		} else if (unlikely(opt_zero_free)) {
+			memset(ptr, 0, sz_index2size(binind));
+		}
 	}
 
 	bin = tcache_large_bin_get(tcache, binind);

--- a/contrib/jemalloc/src/arena.c
+++ b/contrib/jemalloc/src/arena.c
@@ -1703,8 +1703,12 @@ arena_dalloc_bin_locked_impl(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 	arena_slab_data_t *slab_data = extent_slab_data_get(slab);
 	const bin_info_t *bin_info = &bin_infos[binind];
 
-	if (!junked && config_fill && unlikely(opt_junk_free)) {
-		arena_dalloc_junk_small(ptr, bin_info);
+	if (!junked && config_fill) {
+		if (unlikely(opt_junk_free)) {
+			arena_dalloc_junk_small(ptr, bin_info);
+		} else if (unlikely(opt_zero_free)) {
+			memset(ptr, 0, bin_info->reg_size);
+		}
 	}
 
 	arena_slab_reg_dalloc(slab, slab_data, ptr);

--- a/contrib/jemalloc/src/ctl.c
+++ b/contrib/jemalloc/src/ctl.c
@@ -107,6 +107,7 @@ CTL_PROTO(opt_stats_print)
 CTL_PROTO(opt_stats_print_opts)
 CTL_PROTO(opt_junk)
 CTL_PROTO(opt_zero)
+CTL_PROTO(opt_zero_free)
 CTL_PROTO(opt_utrace)
 CTL_PROTO(opt_xmalloc)
 CTL_PROTO(opt_tcache)
@@ -334,6 +335,7 @@ static const ctl_named_node_t opt_node[] = {
 	{NAME("stats_print_opts"),	CTL(opt_stats_print_opts)},
 	{NAME("junk"),		CTL(opt_junk)},
 	{NAME("zero"),		CTL(opt_zero)},
+	{NAME("zero_free"),	CTL(opt_zero_free)},
 	{NAME("utrace"),	CTL(opt_utrace)},
 	{NAME("xmalloc"),	CTL(opt_xmalloc)},
 	{NAME("tcache"),	CTL(opt_tcache)},
@@ -1789,6 +1791,7 @@ CTL_RO_NL_GEN(opt_stats_print, opt_stats_print, bool)
 CTL_RO_NL_GEN(opt_stats_print_opts, opt_stats_print_opts, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_junk, opt_junk, const char *)
 CTL_RO_NL_CGEN(config_fill, opt_zero, opt_zero, bool)
+CTL_RO_NL_CGEN(config_fill, opt_zero_free, opt_zero_free, bool)
 CTL_RO_NL_CGEN(config_utrace, opt_utrace, opt_utrace, bool)
 CTL_RO_NL_CGEN(config_xmalloc, opt_xmalloc, opt_xmalloc, bool)
 CTL_RO_NL_GEN(opt_tcache, opt_tcache, bool)

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -91,6 +91,7 @@ bool	opt_junk_free =
 bool	opt_utrace = false;
 bool	opt_xmalloc = false;
 bool	opt_zero = false;
+bool	opt_zero_free = false;
 unsigned	opt_narenas = 0;
 
 unsigned	ncpus;
@@ -132,7 +133,8 @@ enum {
 	flag_opt_junk_free	= (1U << 1),
 	flag_opt_zero		= (1U << 2),
 	flag_opt_utrace		= (1U << 3),
-	flag_opt_xmalloc	= (1U << 4)
+	flag_opt_xmalloc	= (1U << 4),
+	flag_opt_zero_free	= (1U << 5)
 };
 static uint8_t	malloc_slow_flags;
 
@@ -981,7 +983,8 @@ malloc_slow_flag_init(void) {
 	    | (opt_junk_free ? flag_opt_junk_free : 0)
 	    | (opt_zero ? flag_opt_zero : 0)
 	    | (opt_utrace ? flag_opt_utrace : 0)
-	    | (opt_xmalloc ? flag_opt_xmalloc : 0);
+	    | (opt_xmalloc ? flag_opt_xmalloc : 0)
+	    | (opt_zero_free ? flag_opt_zero_free : 0);
 
 	malloc_slow = (malloc_slow_flags != 0);
 }
@@ -1335,6 +1338,7 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 					CONF_CONTINUE;
 				}
 				CONF_HANDLE_BOOL(opt_zero, "zero")
+				CONF_HANDLE_BOOL(opt_zero_free, "zero_free")
 			}
 			if (config_utrace) {
 				CONF_HANDLE_BOOL(opt_utrace, "utrace")

--- a/contrib/jemalloc/src/large.c
+++ b/contrib/jemalloc/src/large.c
@@ -125,9 +125,14 @@ large_ralloc_no_move_shrink(tsdn_t *tsdn, extent_t *extent, size_t usize) {
 			return true;
 		}
 
-		if (config_fill && unlikely(opt_junk_free)) {
-			large_dalloc_maybe_junk(extent_addr_get(trail),
-			    extent_size_get(trail));
+		if (config_fill) {
+			if (unlikely(opt_junk_free)) {
+				large_dalloc_maybe_junk(extent_addr_get(trail),
+				    extent_size_get(trail));
+			} else if (unlikely(opt_zero_free)) {
+				memset(extent_addr_get(trail), 0,
+				    extent_size_get(trail));
+			}
 		}
 
 		arena_extents_dirty_dalloc(tsdn, arena, &extent_hooks, trail);


### PR DESCRIPTION
When this is set, allocations are zeroed during free().