### PR TITLE
Make AT_BASE untagged for static binaries

### DIFF
--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -237,8 +237,7 @@ dl_init_phdr_info(void)
 #else
 			    cheri_setbounds(cheri_setaddress(phdr_info.dlpi_phdr,
 				phdr_info.dlpi_phdr[i].p_vaddr),
-				phdr_info.dlpi_phdr[i].p_filesz);
-
+				phdr_info.dlpi_phdr[i].p_memsz);
 #endif
 		}
 	}

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -38,6 +38,7 @@ __FBSDID("$FreeBSD$");
 #ifdef __CHERI_PURE_CAPABILITY__
 #include <cheri/cheric.h>
 #endif
+#include <assert.h>
 #include <dlfcn.h>
 #include <link.h>
 #include <stdarg.h>
@@ -202,9 +203,9 @@ dl_init_phdr_info(void)
 		case AT_BASE:
 			phdr_info.dlpi_addr =
 #ifdef __CHERI_PURE_CAPABILITY__
-			    /* XXXAR: currently needs load_cap for libunwind */
-			    (uintptr_t)cheri_andperm(auxp->a_un.a_ptr,
-			        CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP);
+			    (uintptr_t)(Elf_Addr)auxp->a_un.a_ptr;
+			assert(phdr_info.dlpi_addr == 0 &&
+			    "Should be zero for static binaries");
 #else
 			    (Elf_Addr)auxp->a_un.a_ptr;
 #endif

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1374,6 +1374,7 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 	elf_auxargs->flags = 0;
 	elf_auxargs->entry = entry;
 	elf_auxargs->hdr_eflags = hdr->e_flags;
+	elf_auxargs->hdr_etype = hdr->e_type;
 
 	imgp->auxargs = elf_auxargs;
 	imgp->interpreted = 0;
@@ -1471,7 +1472,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 #ifdef __ELF_CHERI
 	/*
 	 * AT_ENTRY gives an executable capability for the whole
-	 * program and AT_PHDR a writable one.  RTLD is reponsible for
+	 * program and AT_PHDR a writable one.  RTLD is responsible for
 	 * setting bounds.
 	 */
 	AUXARGS_ENTRY_PTR(pos, AT_PHDR, cheri_setaddress(prog_cap(imgp,
@@ -1495,16 +1496,34 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 #endif
 	AUXARGS_ENTRY_PTR(pos, AT_ENTRY, entry);
 
-	/*
-	 * XXX: AT_BASE is both writable and executable to permit textrel
-	 * fixups.
-	 */
-	if (imgp->interp_end == 0)
-		exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
-		    CHERI_CAP_USER_CODE_PERMS);
-	else
-		exec_base = interp_cap(imgp, args, CHERI_CAP_USER_DATA_PERMS |
-		    CHERI_CAP_USER_CODE_PERMS);
+	if (imgp->interp_end == 0) {
+		if (args->hdr_etype != ET_DYN) {
+			/*
+			 * For statically linked (but not static-PIE, i.e.
+			 * currently only RTLD direct exec), AT_BASE should be
+			 * untagged args->base (zero) rather than a massively
+			 * out-of-bounds capability with address zero that may
+			 * or may not be tagged.
+			 */
+			exec_base = (void *__capability)(uintcap_t)args->base;
+		} else {
+			/*
+			 * For static-PIE we need AT_BASE for relocations and
+			 * therefore needs to be RWX.
+			 * TODO: should probably use AT_ENTRY/AT_PHDR instead.
+			 */
+			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
+			    CHERI_CAP_USER_CODE_PERMS);
+		}
+	} else {
+		/*
+		 * XXX: AT_BASE is both writable and executable to permit
+		 * textrel fixups.
+		 * TODO: should probably use AT_ENTRY/AT_PHDR instead.
+		 */
+		exec_base = interp_cap(imgp, args,
+		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS);
+	}
 	AUXARGS_ENTRY_PTR(pos, AT_BASE, cheri_setaddress(exec_base,
 	    args->base));
 #else

--- a/sys/sys/imgact_elf.h
+++ b/sys/sys/imgact_elf.h
@@ -66,6 +66,7 @@ typedef struct {
 	Elf_Size	flags;
 	Elf_Size	entry;
 	Elf_Word	hdr_eflags;		/* e_flags field from ehdr */
+	Elf_Word	hdr_etype;		/* e_type field from ehdr */
 } __ElfN(Auxargs);
 
 typedef struct {


### PR DESCRIPTION
In practise this was already the case since capability rpecision means that
capabilities with base 0x12... and address zero cannot be tagged. However,
becoming unrepresentable means that the bounds values are meaningless.
To avoid software from interpreting these bounds, use a NULL-derived
capability instead.

While changing dlfcn.c also change a p_filesz that should probably be p_memsz.