### PR TITLE
RISC-V exception cheritests

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1005,7 +1005,12 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_STORETAG,
 	  .ct_si_trapno = TRAPNO_CHERI,
-	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp, },
+#ifdef __riscv
+	  .ct_xfail_reason = "CHERI-RISC-V doesn't implement CHERI PTE bits",
+#else
+	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp,
+#endif
+	},
 
 	{ .ct_name = "cheritest_vm_tag_tmpfile_private",
 	  .ct_desc = "check tags are stored for tmpfile() MAP_PRIVATE pages",

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -46,10 +46,10 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
-#ifdef __mips__
-#include <machine/cpuregs.h>
-#endif
 #include <machine/frame.h>
+#ifdef __riscv
+#include <machine/riscvreg.h>
+#endif
 #include <machine/trap.h>
 
 #ifdef CHERI_LIBCHERI_TESTS
@@ -105,6 +105,14 @@
 #define	PROT_CHERI_LOCALRET		0
 #endif /* SIGPROT */
 
+#ifdef __mips__
+#define	TRAPNO_CHERI	(T_C2E)
+#elif defined(__riscv)
+#define	TRAPNO_CHERI	(EXCP_CHERI)
+#else
+#error "Unsupported architecture"
+#endif
+
 static const struct cheri_test cheri_tests[] = {
 	/*
 	 * Exercise CHERI functions without an expectation of a signal.
@@ -151,12 +159,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_fault_cgetcause",
 	  .ct_desc = "Ensure CGetCause is unavailable in userspace",
 	  .ct_func = test_fault_cgetcause,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_SYSREG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+	  .ct_si_trapno = TRAPNO_CHERI },
+#endif
 
 	{ .ct_name = "test_nofault_cfromptr",
 	  .ct_desc = "Exercise CFromPtr success",
@@ -165,84 +172,71 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_fault_bounds",
 	  .ct_desc = "Exercise capability bounds check failure",
 	  .ct_func = test_fault_bounds,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_BOUNDS,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_LENGTH },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_perm_load",
 	  .ct_desc = "Exercise capability load permission failure",
 	  .ct_func = test_fault_perm_load,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_LOAD },
-#endif
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_nofault_perm_load",
 	  .ct_desc = "Exercise capability load permission success",
 	  .ct_func = test_nofault_perm_load },
 
-#ifdef __mips__
+#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_fault_perm_seal",
 	  .ct_desc = "Exercise capability seal permission failure",
 	  .ct_func = test_fault_perm_seal,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_SEAL },
+	  .ct_si_trapno = TRAPNO_CHERI },
+#endif
 
 	{ .ct_name = "test_fault_perm_store",
 	  .ct_desc = "Exercise capability store permission failure",
 	  .ct_func = test_fault_perm_store,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_STORE },
-#endif
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_nofault_perm_store",
 	  .ct_desc = "Exercise capability store permission success",
 	  .ct_func = test_nofault_perm_store },
 
-#ifdef __mips__
+#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_fault_perm_unseal",
 	  .ct_desc = "Exercise capability unseal permission failure",
 	  .ct_func = test_fault_perm_unseal,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_UNSEAL },
+	  .ct_si_trapno = TRAPNO_CHERI },
+#endif
 
 	{ .ct_name = "test_fault_tag",
 	  .ct_desc = "Store via untagged capability",
 	  .ct_func = test_fault_tag,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_TAG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_TAG },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
+#ifdef __mips__
 	{ .ct_name = "test_fault_ccheck_user_fail",
 	  .ct_desc = "Exercise CCheckPerm failure",
 	  .ct_func = test_fault_ccheck_user_fail,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_USER },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_nofault_ccheck_user_pass",
 	  .ct_desc = "Exercise CCheckPerm success",
@@ -251,52 +245,42 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_fault_read_kr1c",
 	  .ct_desc = "Ensure KR1C is unavailable in userspace",
 	  .ct_func = test_fault_read_kr1c,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_SYSREG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_read_kr2c",
 	  .ct_desc = "Ensure KR2C is unavailable in userspace",
 	  .ct_func = test_fault_read_kr2c,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_SYSREG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_read_kcc",
 	  .ct_desc = "Ensure KCC is unavailable in userspace",
 	  .ct_func = test_fault_read_kcc,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_SYSREG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_read_kdc",
 	  .ct_desc = "Ensure KDC is unavailable in userspace",
 	  .ct_func = test_fault_read_kdc,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_SYSREG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_read_epcc",
 	  .ct_desc = "Ensure EPCC is unavailable in userspace",
 	  .ct_func = test_fault_read_epcc,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_SYSREG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SYSTEM_REGS },
+	  .ct_si_trapno = TRAPNO_CHERI },
 #endif
 
 	/*
@@ -1013,19 +997,15 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "check tags are stored for /dev/zero MAP_PRIVATE pages",
 	  .ct_func = cheritest_vm_tag_dev_zero_private, },
 
-#ifdef __mips__
 	/* XXXRW: I wonder if we also need some sort of load-related test? */
 	{ .ct_name = "cheritest_vm_notag_tmpfile_shared",
 	  .ct_desc = "check tags are not stored for tmpfile() MAP_SHARED pages",
 	  .ct_func = cheritest_vm_notag_tmpfile_shared,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-	    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_STORETAG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_TLBSTORE,
+	  .ct_si_trapno = TRAPNO_CHERI,
 	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp, },
-#endif
 
 	{ .ct_name = "cheritest_vm_tag_tmpfile_private",
 	  .ct_desc = "check tags are stored for tmpfile() MAP_PRIVATE pages",
@@ -1058,12 +1038,10 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_fault_creturn",
 	  .ct_desc = "Exercise trusted stack underflow",
 	  .ct_func = test_fault_creturn,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_UNDERFLOW,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_RETURN },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_nofault_ccall_creturn",
 	  .ct_desc = "Exercise CCall/CReturn",
@@ -1084,72 +1062,58 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_fault_ccall_code_untagged",
 	  .ct_desc = "Invoke CCall with untagged code capability",
 	  .ct_func = test_fault_ccall_code_untagged,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_TAG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_TAG },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_ccall_data_untagged",
 	  .ct_desc = "Invoke CCall with an untagged data capability",
 	  .ct_func = test_fault_ccall_data_untagged,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_TAG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_TAG },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_ccall_code_unsealed",
 	  .ct_desc = "Invoke CCall with an unsealed code capability",
 	  .ct_func = test_fault_ccall_code_unsealed,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_UNSEALED,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SEAL },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_ccall_data_unsealed",
 	  .ct_desc = "Invoke CCall with an unsealed data capability",
 	  .ct_func = test_fault_ccall_data_unsealed,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_UNSEALED,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_SEAL },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_ccall_typemismatch",
 	  .ct_desc = "Invoke CCall with code/data type mismatch",
 	  .ct_func = test_fault_ccall_typemismatch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_TYPE,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_TYPE },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_ccall_code_noexecute",
 	  .ct_desc = "Invoke CCall with a non-executable code capability",
 	  .ct_func = test_fault_ccall_code_noexecute,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_EXECUTE },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_fault_ccall_data_execute",
 	  .ct_desc = "Invoke CCall with an executable data capability",
 	  .ct_func = test_fault_ccall_data_execute,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_EXECUTE },
+	  .ct_si_trapno = TRAPNO_CHERI },
 #endif
 #endif
 
@@ -1199,13 +1163,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_cp2_bound_catch",
 	  .ct_desc = "Exercise sandboxed CP2 bounds-check failure; caught",
 	  .ct_func = test_sandbox_cp2_bound_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_BOUNDS,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_LENGTH },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_sandbox_cp2_bound_nocatch",
 	  .ct_desc = "Exercise sandboxed CP2 bounds-check failure; uncaught",
@@ -1223,13 +1185,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_cp2_perm_load_catch",
 	  .ct_desc = "Exercise sandboxed CP2 load-perm-check failure; caught",
 	  .ct_func = test_sandbox_cp2_perm_load_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_LOAD },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_sandbox_cp2_perm_load_nocatch",
 	  .ct_desc = "Exercise sandboxed CP2 load-perm-check failure; uncaught",
@@ -1240,13 +1200,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_cp2_perm_store_catch",
 	  .ct_desc = "Exercise sandboxed CP2 store-perm-check failure; caught",
 	  .ct_func = test_sandbox_cp2_perm_store_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_STORE },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_sandbox_cp2_perm_store_nocatch",
 	  .ct_desc = "Exercise sandboxed CP2 store-perm-check failure; uncaught",
@@ -1257,13 +1215,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_cp2_tag_catch",
 	  .ct_desc = "Exercise sandboxed CP2 tag-check failure; caught",
 	  .ct_func = test_sandbox_cp2_tag_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_TAG,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_TAG },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_sandbox_cp2_tag_nocatch",
 	  .ct_desc = "Exercise sandboxed CP2 tag-check failure; uncaught",
@@ -1274,13 +1230,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_cp2_seal_catch",
 	  .ct_desc = "Exercise sandboxed CP2 seal failure; caught",
 	  .ct_func = test_sandbox_cp2_seal_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_PERM_SEAL },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_sandbox_cp2_seal_nocatch",
 	  .ct_desc = "Exercise sandboxed CP2 seal failure; uncaught",
@@ -1291,30 +1245,30 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_divzero_catch",
 	  .ct_desc = "Exercise sandboxed divide-by-zero exception; caught",
 	  .ct_func = test_sandbox_divzero_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_MIPS_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGTRAP,
-	  .ct_mips_exccode = T_TRAP,
+	  .ct_si_trapno = T_TRAP,
 	  .ct_xfail_reason =
 	    "LLVM assembler generates break rather than trap instruction", },
 
 	{ .ct_name = "test_sandbox_divzero_nocatch",
 	  .ct_desc = "Exercise sandboxed divide-by-zero exception; uncaught",
 	  .ct_func = test_sandbox_divzero_nocatch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_MIPS_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGTRAP,
-	  .ct_mips_exccode = T_TRAP,
+	  .ct_si_trapno = T_TRAP,
 	  .ct_xfail_reason =
 	    "LLVM assembler generates break rather than trap instruction", },
 
 	{ .ct_name = "test_sandbox_vm_rfault_catch",
 	  .ct_desc = "Exercise sandboxed VM read fault; caught",
 	  .ct_func = test_sandbox_vm_rfault_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_MIPS_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGSEGV,
-	  .ct_mips_exccode = T_TLB_LD_MISS },
+	  .ct_si_trapno = T_TLB_LD_MISS },
 
 	{ .ct_name = "test_sandbox_vm_rfault_nocatch",
 	  .ct_desc = "Exercise sandboxed VM read fault; uncaught",
@@ -1325,10 +1279,10 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_vm_wfault_catch",
 	  .ct_desc = "Exercise sandboxed VM write fault; caught",
 	  .ct_func = test_sandbox_vm_wfault_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_MIPS_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGSEGV,
-	  .ct_mips_exccode = T_TLB_ST_MISS },
+	  .ct_si_trapno = T_TLB_ST_MISS },
 
 	{ .ct_name = "test_sandbox_vm_wfault_nocatch",
 	  .ct_desc = "Exercise sandboxed VM write fault; uncaught",
@@ -1339,10 +1293,10 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_vm_xfault_catch",
 	  .ct_desc = "Exercise sandboxed VM exec fault; caught",
 	  .ct_func = test_sandbox_vm_xfault_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_MIPS_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGSEGV,
-	  .ct_mips_exccode = T_TLB_LD_MISS },
+	  .ct_si_trapno = T_TLB_LD_MISS },
 
 	{ .ct_name = "test_sandbox_vm_xfault_nocatch",
 	  .ct_desc = "Exercise sandboxed VM exec fault; uncaught",
@@ -1503,9 +1457,9 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_trustedstack_underflow",
 	  .ct_desc = "Underflow trusted stack",
 	  .ct_func = test_sandbox_trustedstack_underflow,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_MIPS_EXCCODE | CT_FLAG_SANDBOX,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGEMT,
-	  .ct_mips_exccode = T_TRAP },
+	  .ct_si_trapno = T_TRAP },
 
 	/*
 	 * Check various properties to do with global vs. local capabilities
@@ -1519,13 +1473,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sandbox_store_local_capability_in_bss_catch",
 	  .ct_desc = "Try to store local capability to sandbox bss; caught",
 	  .ct_func = test_sandbox_store_local_capability_in_bss_catch,
-	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE |
-		    CT_FLAG_MIPS_EXCCODE | CT_FLAG_CP2_EXCCODE |
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO |
 		    CT_FLAG_SIGNAL_UNWIND | CT_FLAG_SANDBOX,
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_STORELOCAL,
-	  .ct_mips_exccode = T_C2E,
-	  .ct_cp2_exccode = CHERI_EXCCODE_STORE_LOCALCAP },
+	  .ct_si_trapno = TRAPNO_CHERI },
 
 	{ .ct_name = "test_sandbox_store_local_capability_in_bss_nocatch",
 	  .ct_desc = "Try to store local capability to sandbox bss; uncaught",
@@ -1908,8 +1860,8 @@ signal_handler(int signum, siginfo_t *info, void *vuap)
 #endif	/* __mips__ */
 	ccsp->ccs_signum = signum;
 	ccsp->ccs_si_code = info->si_code;
+	ccsp->ccs_si_trapno = info->si_trapno;
 #ifdef __mips__
-	ccsp->ccs_mips_cause = uap->uc_mcontext.cause;
 	ccsp->ccs_cp2_cause = cfp->cf_capcause;
 #endif
 
@@ -2004,9 +1956,6 @@ cheritest_run_test(const struct cheri_test *ctp)
 	char buffer[TEST_BUFFER_LEN];
 	const char *xfail_reason;
 	char* failure_message;
-#ifdef __mips__
-	register_t cp2_exccode, mips_exccode;
-#endif
 	ssize_t len;
 	xo_attr("classname", "%s", ctp->ct_name);
 	xo_attr("name", "%s", ctp->ct_desc);
@@ -2192,29 +2141,13 @@ cheritest_run_test(const struct cheri_test *ctp)
 		    "unwind");
 		goto fail;
 	}
-#ifdef __mips__
-	if (ctp->ct_flags & CT_FLAG_MIPS_EXCCODE) {
-		mips_exccode = (ccsp->ccs_mips_cause & MIPS_CR_EXC_CODE) >>
-		    MIPS_CR_EXC_CODE_SHIFT;
-		if (mips_exccode != ctp->ct_mips_exccode) {
-			snprintf(reason, sizeof(reason),
-			    "Expected MIPS exccode %ju, got %ju",
-			    ctp->ct_mips_exccode, mips_exccode);
-			goto fail;
-		}
+	if ((ctp->ct_flags & CT_FLAG_SI_TRAPNO) &&
+	    ccsp->ccs_si_trapno != ctp->ct_si_trapno) {
+		snprintf(reason, sizeof(reason),
+		    "Expected si_trapno %d, got %d", ctp->ct_si_trapno,
+		    ccsp->ccs_si_trapno);
+		goto fail;
 	}
-	if (ctp->ct_flags & CT_FLAG_CP2_EXCCODE) {
-		cp2_exccode = (ccsp->ccs_cp2_cause &
-		    CHERI_CAPCAUSE_EXCCODE_MASK) >>
-		    CHERI_CAPCAUSE_EXCCODE_SHIFT;
-		if (cp2_exccode != ctp->ct_cp2_exccode) {
-			snprintf(reason, sizeof(reason),
-			    "Expected CP2 exccode %ju, got %ju",
-			    ctp->ct_cp2_exccode, cp2_exccode);
-			goto fail;
-		}
-	}
-#endif
 
 	/*
 	 * Next, we are concerned with whether the test itself reports a

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -84,27 +84,6 @@
 #include "cheritest.h"
 #include "cheritest.h"
 
-#ifndef SIGPROT
-#define	SIGPROT				0
-#define	PROT_CHERI_BOUNDS		0
-#define	PROT_CHERI_TAG			0
-#define	PROT_CHERI_SEALED		0
-#define	PROT_CHERI_TYPE			0
-#define	PROT_CHERI_PERM			0
-#define	PROT_CHERI_STORETAG		0
-#define	PROT_CHERI_IMPRECISE		0
-#define	PROT_CHERI_STORELOCAL		0
-#define	PROT_CHERI_CCALL		0
-#define	PROT_CHERI_CRETURN		0
-#define	PROT_CHERI_SYSREG		0
-#define	PROT_CHERI_UNSEALED		0
-#define	PROT_CHERI_OVERFLOW		0
-#define	PROT_CHERI_UNDERFLOW		0
-#define	PROT_CHERI_CCALLREGS		0
-#define	PROT_CHERI_LOCALARG		0
-#define	PROT_CHERI_LOCALRET		0
-#endif /* SIGPROT */
-
 #ifdef __mips__
 #define	TRAPNO_CHERI	(T_C2E)
 #elif defined(__riscv)

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -70,8 +70,10 @@ struct cheritest_child_state {
 	/* Fields filled in by the child signal handler. */
 	int		ccs_signum;
 	int		ccs_si_code;
-	register_t	ccs_mips_cause;
+	int		ccs_si_trapno;
+#ifdef __mips__
 	register_t	ccs_cp2_cause;
+#endif
 	int		ccs_unwound;  /* If any trusted-stack frames unwound. */
 
 	/* Fields filled in by the test itself. */
@@ -94,8 +96,7 @@ extern struct cheritest_child_state *ccsp;
  * access to configuration state, such as strings passed to/from stdio.
  */
 #define	CT_FLAG_SIGNAL		0x00000001  /* Should fault; checks signum. */
-#define	CT_FLAG_MIPS_EXCCODE	0x00000002  /* Check MIPS exception code. */
-#define	CT_FLAG_CP2_EXCCODE	0x00000004  /* Check CP2 exception code. */
+#define	CT_FLAG_SI_TRAPNO	0x00000002  /* Check signal si_trapno. */
 #define	CT_FLAG_STDOUT_STRING	0x00000008  /* Check stdout for a string. */
 #define	CT_FLAG_STDIN_STRING	0x00000010  /* Provide string on stdin. */
 #define	CT_FLAG_STDOUT_IGNORE	0x00000020  /* Standard output produced,
@@ -123,8 +124,7 @@ struct cheri_test {
 	u_int		 ct_flags;
 	int		 ct_signum;
 	int		 ct_si_code;
-	register_t	 ct_mips_exccode;
-	register_t	 ct_cp2_exccode;
+	int		 ct_si_trapno;
 	const char	*ct_stdin_string;
 	const char	*ct_stdout_string;
 	const char	*ct_xfail_reason;

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -63,7 +63,6 @@
 static char array[ARRAY_LEN];
 static char sink;
 
-#ifdef __mips__
 void
 test_fault_bounds(const struct cheri_test *ctp __unused)
 {
@@ -86,7 +85,6 @@ test_fault_perm_load(const struct cheri_test *ctp __unused)
 
 	cheritest_failure_errx("access without required permissions did not fault");
 }
-#endif	/* __mips__ */
 
 void
 test_nofault_perm_load(const struct cheri_test *ctp __unused)
@@ -121,7 +119,6 @@ test_fault_perm_seal(const struct cheri_test *ctp __unused)
 }
 #endif
 
-#ifdef __mips__
 void
 test_fault_perm_store(const struct cheri_test *ctp __unused)
 {
@@ -129,7 +126,6 @@ test_fault_perm_store(const struct cheri_test *ctp __unused)
 
 	arrayp[0] = sink;
 }
-#endif	/* __mips__ */
 
 void
 test_nofault_perm_store(const struct cheri_test *ctp __unused)
@@ -168,7 +164,6 @@ test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 }
 #endif
 
-#ifdef __mips__
 void
 test_fault_tag(const struct cheri_test *ctp __unused)
 {
@@ -179,6 +174,7 @@ test_fault_tag(const struct cheri_test *ctp __unused)
 	*chp = '\0';
 }
 
+#ifdef __mips__
 void
 test_fault_ccheck_user_fail(const struct cheri_test *ctp __unused)
 {
@@ -208,26 +204,22 @@ test_fault_cgetcause(const struct cheri_test *ctp __unused)
 	cause = cheri_getcause();
 	printf("CP2 cause register: %ju\n", (uintmax_t)cause);
 }
+#endif
 
 void
 test_nofault_cfromptr(const struct cheri_test *ctp __unused)
 {
 	char buf[256];
-	void * __capability cd; /* stored into here */
 	void * __capability cb; /* derived from here */
-	int rt;
+	char * __capability cd; /* stored into here */
 
-	/*
-	 * XXX: Could we be using cheri_cap_from_pointer() here to
-	 * avoid explicit inline assembly?
-	 */
 	cb = cheri_ptr(buf, 256);
-	rt = 10;
-	__asm__ __volatile__ ("cfromptr %0, %1, %2" : "=r"(cd) : "r"(cb),
-	    "r"(rt) : "memory");
+	cd = __builtin_cheri_cap_from_pointer(cb, (void *)(uintptr_t)10);
+	*cd = '\0';
 	cheritest_success();
 }
 
+#ifdef __mips__
 void
 test_fault_read_kr1c(const struct cheri_test *ctp __unused)
 {

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -1384,7 +1384,7 @@ err:
 	ksi.ksi_code = ucode;
 	/* XXXBD: probably not quite right for CheriABI */
 	ksi.ksi_addr = (void * __capability)(intcap_t)addr;
-	ksi.ksi_trapno = type;
+	ksi.ksi_trapno = type & ~T_USER;
 #if defined(CPU_CHERI)
 	if (i == SIGPROT)
 		ksi.ksi_capreg = trapframe->capcause &


### PR DESCRIPTION
This enables CHERI exception tests on RISC-V.  Most of these pass, but one is an XFAIL since QEMU doesn't implement the PTE bits for CHERI.