### PR TITLE
Add libcheri/lib64 symlinks for the native ABI

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -1648,6 +1648,25 @@ restage reinstall reinstallsysroot: .MAKE .PHONY
 .if defined(_LIBCOMPAT)
 	${_+_}cd ${.CURDIR}; ${MAKE} -f Makefile.inc1 install${libcompat}
 .endif
+	@echo
+	@echo "--------------------------------------------------------------"
+	@echo ">>> Adding symlinks for native ABI libdir: ${MACHINE_ABI}"
+	@echo "--------------------------------------------------------------"
+.if ${MACHINE_ABI:Mpurecap}
+	@echo "Purecap ABI: creating libcheri links"
+	ln -sfnv lib ${DESTDIR}/libcheri
+	ln -sfnv lib ${DESTDIR}/usr/libcheri
+.elif ${MACHINE_ABI:Mptr64}
+	@echo "64-bit ABI: creating lib64 links"
+	ln -sfnv lib ${DESTDIR}/lib64
+	ln -sfnv lib ${DESTDIR}/usr/lib64
+.elif ${MACHINE_ABI:Mptr32}
+	@echo "32-bit ABI: creating lib32 links"
+	ln -sfnv lib ${DESTDIR}/lib32
+	ln -sfnv lib ${DESTDIR}/usr/lib32
+.else
+.error "MACHINE_ABI incorrect? ${MACHINE_ABI}"
+.endif
 .if make(reinstallsysroot)
 	@echo "Removing $$(find ${DESTDIR} -type d -empty -print | wc -l) empty directories from ${DESTDIR}"
 	find ${DESTDIR} -type d -empty -delete

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -24,6 +24,12 @@ MACHINE_ABI+=	hard-float
 .if (${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
 MACHINE_ABI+=	purecap
 .endif
+# Currently all 64-bit architectures include 64 in their name (see arch(7)).
+.if ${MACHINE_ARCH:M*64*}
+MACHINE_ABI+=	ptr64
+.else
+MACHINE_ABI+=	ptr32
+.endif
 
 
 __DEFAULT_YES_OPTIONS+= \


### PR DESCRIPTION
Without this change, cheribuild's test scripts have to know whether we are
running a hybrid rootfs/sysroot or a purecap one to determine whether to
use /usr/lib or /usr/libcheri for libraries (and the same for lib64).

Having libcheri always point to CHERI libraries (either by being a symlink
to lib or a real directory makes writing tests much simpler since we can
always use /usr/libcheri for pure-capability libraries and /usr/lib64 for
hybrid/non-CHERI ones.

A hybrid sysroot now looks as follows:
```
$ ll sdk/sysroot128
drwxrwxr-x 4 alr48 alr48   4096 Jun 17 10:44 lib
lrwxrwxrwx 1 alr48 alr48      3 Jun 17 10:44 lib64 -> lib
-rw-rw-r-- 1 alr48 alr48 443439 Jun 17 10:44 METALOG
drwxrwxr-x 7 alr48 alr48   4096 Jun 17 10:44 usr
$ ll sdk/sysroot128/usr
drwxrwxr-x 51 alr48 alr48 12288 Jun 17 10:44 include
drwxrwxr-x  7 alr48 alr48 20480 Jun 17 10:44 lib
lrwxrwxrwx  1 alr48 alr48     3 Jun 17 10:44 lib64 -> lib
drwxrwxr-x  7 alr48 alr48 20480 Jun 17 10:44 libcheri
drwxrwxr-x  3 alr48 alr48  4096 Jun 17 10:44 libdata
drwxrwxr-x  6 alr48 alr48  4096 Jun 17 10:44 share
```
And the purecap one has symlinks for libcheri:
```
$ ll sdk/sysroot-purecap128
drwxrwxr-x 4 alr48 alr48   4096 Jun 17 10:46 lib
lrwxrwxrwx 1 alr48 alr48      3 Jun 17 10:46 libcheri -> lib
-rw-rw-r-- 1 alr48 alr48 418618 Jun 17 10:46 METALOG
drwxrwxr-x 7 alr48 alr48   4096 Jun 17 10:46 usr
ll sdk/sysroot-purecap128/usr
drwxrwxr-x 49 alr48 alr48 12288 Jun 17 10:46 include
drwxrwxr-x  7 alr48 alr48 20480 Jun 17 10:46 lib
drwxrwxr-x  7 alr48 alr48 20480 Jun 17 10:46 lib64
lrwxrwxrwx  1 alr48 alr48     3 Jun 17 10:46 libcheri -> lib
drwxrwxr-x  3 alr48 alr48  4096 Jun 17 10:46 libdata
drwxrwxr-x  6 alr48 alr48  4096 Jun 17 10:46 share
```