### PR TITLE
rtld-cheri-elf: Create sentries on RISC-V

### DIFF
--- a/libexec/rtld-cheri-elf/mips/rtld_machdep.h
+++ b/libexec/rtld-cheri-elf/mips/rtld_machdep.h
@@ -160,13 +160,13 @@ make_code_pointer(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 		/* PC-relative ABI needs full DSO bounds */
 		dbg_assert(defobj->cheri_captable_abi == DF_MIPS_CHERI_ABI_PCREL);
 	}
-	ret = cheri_incoffset(ret, addend); // TODO: remove addend support
+	/*
+	 * Note: The addend is required for C++ exceptions since capabilities
+	 * for catch blocks point to the middle of a function.
+	 */
+	ret = cheri_incoffset(ret, addend);
 	/* All code pointers should be sentries: */
-#if __has_builtin(__builtin_cheri_seal_entry)
 	ret = __builtin_cheri_seal_entry(ret);
-#else
-#warning "__builtin_cheri_seal_entry not supported, please update LLVM"
-#endif
 	return __DECONST(dlfunc_t, ret);
 }
 

--- a/libexec/rtld-cheri-elf/riscv/rtld_machdep.h
+++ b/libexec/rtld-cheri-elf/riscv/rtld_machdep.h
@@ -90,12 +90,13 @@ make_code_pointer(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 	if (tight_bounds) {
 		ret = cheri_setbounds(ret, def->st_size);
 	}
-	ret = cheri_incoffset(ret, addend); /* TODO: remove addend support */
-	/* Enable once supported in the toolchain, hardware and emulators */
-#if 0
+	/*
+	 * Note: The addend is required for C++ exceptions since capabilities
+	 * for catch blocks point to the middle of a function.
+	 */
+	ret = cheri_incoffset(ret, addend);
 	/* All code pointers should be sentries: */
 	ret = __builtin_cheri_seal_entry(ret);
-#endif
 	return __DECONST(dlfunc_t, ret);
 }
 


### PR DESCRIPTION
While changing this line also update the comment above to ensure that we
don't remove the required addend support.