### PR TITLE
cheriabitest: Check that the return cap is a sentry

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -121,6 +121,9 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_func = test_initregs_stack_user_perms,
 	  .ct_xfail_reason = "CHERI_PERM_CHERIABI_VMMAP "
 	    "unnecessarily set in stack capability" },
+	{ .ct_name = "test_initregs_returncap",
+	  .ct_desc = "Test value of return capability",
+	  .ct_func = test_initregs_returncap },
 #endif
 #ifdef __mips__
 	{ .ct_name = "test_initregs_idc",

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -502,6 +502,7 @@ DECLARE_CHERI_TEST(test_initregs_default);
 #ifdef __CHERI_PURE_CAPABILITY__
 DECLARE_CHERI_TEST(test_initregs_stack);
 DECLARE_CHERI_TEST(test_initregs_stack_user_perms);
+DECLARE_CHERI_TEST(test_initregs_returncap);
 #endif
 DECLARE_CHERI_TEST(test_initregs_idc);
 DECLARE_CHERI_TEST(test_initregs_pcc);

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -478,23 +478,27 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 void
 test_initregs_returncap(const struct cheri_test *ctp __unused)
 {
+	void *retcap;
+	uintmax_t v;
+	
 	/* The return capability should always be a sentry capability */
-	void *retcap = __builtin_return_address(0);
-	uintmax_t perms = cheri_getperm(retcap);
+	c = __builtin_return_address(0);
+	v = cheri_getperm(retcap);
 
 	CHERITEST_VERIFY(cheri_gettag(retcap));
 	/* Check that execute is present and store permissions aren't */
 	CHERITEST_VERIFY2((perms & CHERI_PERM_EXECUTE) == CHERI_PERM_EXECUTE,
-	    "perms %jx (executable should be set)", perms);
+	    "perms %jx (execute missing)", perms);
 	CHERITEST_VERIFY2((perms & CHERI_PERM_STORE) == 0,
-	    "perms %jx (store should not be set)", perms);
+	    "perms %jx (store present)", perms);
 	CHERITEST_VERIFY2((perms & CHERI_PERM_STORE_CAP) == 0,
-	    "perms %jx (store_cap should not be set)", perms);
+	    "perms %jx (storecap present)", perms);
 	CHERITEST_VERIFY2((perms & CHERI_PERM_STORE_LOCAL_CAP) == 0,
-	    "perms %jx (store_local_cap should not be set)", perms);
+	    "perms %jx (store_local_cap present)", perms);
 
-	CHERITEST_VERIFY2(cheri_gettype(retcap) == CHERI_OTYPE_SENTRY,
-	    "expected a sentry and not type %ld", (long)cheri_gettype(retcap));
+	v = cheri_gettype(retcap);
+	CHERITEST_VERIFY2(v == (uintmax_t)CHERI_OTYPE_SENTRY,
+	    "otype %jx (expected %jx)", v, (uintmax_t)CHERI_OTYPE_SENTRY);
 
 	/* __builtin_extract_return_addr() should be a no-op */
 	CHERITEST_CHECK_EQ_CAP(retcap, __builtin_extract_return_addr(retcap));

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -478,7 +478,7 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 void
 test_initregs_returncap(const struct cheri_test *ctp __unused)
 {
-	void *retcap;
+	void *c;
 	uintmax_t v;
 	
 	/* The return capability should always be a sentry capability */

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -483,7 +483,7 @@ test_initregs_returncap(const struct cheri_test *ctp __unused)
 	
 	/* The return capability should always be a sentry capability */
 	c = __builtin_return_address(0);
-	v = cheri_getperm(retcap);
+	v = cheri_getperm(c);
 
 	CHERITEST_VERIFY(cheri_gettag(c));
 	/* Check that execute is present and store permissions aren't */
@@ -496,7 +496,7 @@ test_initregs_returncap(const struct cheri_test *ctp __unused)
 	CHERITEST_VERIFY2((v & CHERI_PERM_STORE_LOCAL_CAP) == 0,
 	    "perms %jx (store_local_cap present)", v);
 
-	v = cheri_gettype(retcap);
+	v = cheri_gettype(c);
 	CHERITEST_VERIFY2(v == (uintmax_t)CHERI_OTYPE_SENTRY,
 	    "otype %jx (expected %jx)", v, (uintmax_t)CHERI_OTYPE_SENTRY);
 

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -485,23 +485,23 @@ test_initregs_returncap(const struct cheri_test *ctp __unused)
 	c = __builtin_return_address(0);
 	v = cheri_getperm(retcap);
 
-	CHERITEST_VERIFY(cheri_gettag(retcap));
+	CHERITEST_VERIFY(cheri_gettag(c));
 	/* Check that execute is present and store permissions aren't */
-	CHERITEST_VERIFY2((perms & CHERI_PERM_EXECUTE) == CHERI_PERM_EXECUTE,
-	    "perms %jx (execute missing)", perms);
-	CHERITEST_VERIFY2((perms & CHERI_PERM_STORE) == 0,
-	    "perms %jx (store present)", perms);
-	CHERITEST_VERIFY2((perms & CHERI_PERM_STORE_CAP) == 0,
-	    "perms %jx (storecap present)", perms);
-	CHERITEST_VERIFY2((perms & CHERI_PERM_STORE_LOCAL_CAP) == 0,
-	    "perms %jx (store_local_cap present)", perms);
+	CHERITEST_VERIFY2((v & CHERI_PERM_EXECUTE) == CHERI_PERM_EXECUTE,
+	    "perms %jx (execute missing)", v);
+	CHERITEST_VERIFY2((v & CHERI_PERM_STORE) == 0,
+	    "perms %jx (store present)", v);
+	CHERITEST_VERIFY2((v & CHERI_PERM_STORE_CAP) == 0,
+	    "perms %jx (storecap present)", v);
+	CHERITEST_VERIFY2((v & CHERI_PERM_STORE_LOCAL_CAP) == 0,
+	    "perms %jx (store_local_cap present)", v);
 
 	v = cheri_gettype(retcap);
 	CHERITEST_VERIFY2(v == (uintmax_t)CHERI_OTYPE_SENTRY,
 	    "otype %jx (expected %jx)", v, (uintmax_t)CHERI_OTYPE_SENTRY);
 
 	/* __builtin_extract_return_addr() should be a no-op */
-	CHERITEST_CHECK_EQ_CAP(retcap, __builtin_extract_return_addr(retcap));
+	CHERITEST_CHECK_EQ_CAP(c, __builtin_extract_return_addr(c));
 
 	cheritest_success();
 }


### PR DESCRIPTION
Succeeds for MIPS and RISC-V once the various pull requests are merged.

Partially addresses #555. We probably also want tests for function pointers.