### PR TITLE
cheriabitest RISC-V fixes

### DIFF
--- a/bin/cheritest/cheritest_cheriabi_open.c
+++ b/bin/cheritest/cheritest_cheriabi_open.c
@@ -155,7 +155,7 @@ test_cheriabi_open_bad_len(const struct cheri_test *ctp __unused)
 	char *path;
 	int fd;
 
-	path = cheri_setbounds(pathbuf, strlen(path));
+	path = cheri_setbounds(pathbuf, strlen(pathbuf));
 
 	fd = open(path, O_RDONLY);
 	if (fd > 0)

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -385,10 +385,9 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 	register_t v;
 
 	/* Base. */
-	v = cheri_getbase(c);
-	if (v == CHERI_CAP_USER_DATA_BASE)
-		cheritest_failure_errx("base 0x%jx (did not expect 0x%jx)", v,
-		    (uintmax_t)CHERI_CAP_USER_DATA_BASE);
+	if (cheri_getbase(c) == CHERI_CAP_USER_DATA_BASE)
+		cheritest_failure_errx("base 0x%jx (did not expect 0x%jx)",
+		    cheri_getbase(c), (uintmax_t)CHERI_CAP_USER_DATA_BASE);
 
 	/* Length. */
 	/* Technically dynamic, but defaults to MAXSSIZ. */
@@ -404,10 +403,9 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 		    cheri_getlen(c) - cheri_getoffset(c));
 
 	/* Type -- should be zero for an unsealed capability. */
-	v = cheri_gettype(c);
-	if (v != -1)
-		cheritest_failure_errx("otype 0x%jx (expected 0x%jx)", v,
-		    (uintmax_t)0);
+	if (cheri_gettype(c) != -1)
+		cheritest_failure_errx("otype 0x%jx (expected 0x%jx)",
+		    cheri_gettype(c), (uintmax_t)0);
 
 	/* Permissions. */
 	v = cheri_getperm(c);

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -148,7 +148,7 @@ check_initreg_code(void * __capability c)
 	 * length).
 	 */
 	vaddr_t upper_bound =
-	    CHERI_REPRESENTABLE_LENGTH(cheri_getaddress(c) + 0x100000);
+	    CHERI_REPRESENTABLE_LENGTH(cheri_getaddress(c) + 0x1000000);
 	CHERITEST_VERIFY2(cheri_getlength(c) < upper_bound,
 	    "code length 0x%jx should be < than 0x%jx)", cheri_getlength(c),
 	    upper_bound);

--- a/bin/cheritest/cheritest_registers.c
+++ b/bin/cheritest/cheritest_registers.c
@@ -396,7 +396,7 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 	/* Base. */
 	v = cheri_getbase(c);
 	if (v == CHERI_CAP_USER_DATA_BASE)
-		cheritest_failure_errx("base %jx (did not expect %jx)", v,
+		cheritest_failure_errx("base 0x%jx (did not expect 0x%jx)", v,
 		    (uintmax_t)CHERI_CAP_USER_DATA_BASE);
 
 	/* Length. */
@@ -408,14 +408,13 @@ test_initregs_stack(const struct cheri_test *ctp __unused)
 	/* Offset. */
 	v = cheri_getoffset(c);
 	if (v > CHERI_STACK_OFFSET_MAX || v < CHERI_STACK_OFFSET_MIN)
-		cheritest_failure_errx("stack offset %jx (expected range %jx "
-		    "to %jx)", v, (uintmax_t)CHERI_STACK_OFFSET_MIN,
-		    (uintmax_t)CHERI_STACK_OFFSET_MIN);
+		cheritest_failure_errx("stack offset 0x%jx (expected range "			    "0x%jx to 0x%jx)", v, (uintmax_t)CHERI_STACK_OFFSET_MIN,
+		    (uintmax_t)CHERI_STACK_OFFSET_MAX);
 
 	/* Type -- should be zero for an unsealed capability. */
 	v = cheri_gettype(c);
 	if (v != -1)
-		cheritest_failure_errx("otype %jx (expected %jx)", v,
+		cheritest_failure_errx("otype 0x%jx (expected 0x%jx)", v,
 		    (uintmax_t)0);
 
 	/* Permissions. */


### PR DESCRIPTION
"Fix" PCC length and stack offset tests.  In the former case, just increase the constant.  In the latter, test something closer to what we meant to test.