### PR TITLE
Revert "Assert on pg_jobc state."

### DIFF
--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -763,11 +763,9 @@ pgadjustjobc(struct pgrp *pgrp, int entering)
 {
 
 	PGRP_LOCK(pgrp);
-	if (entering) {
-		MPASS(pgrp->pg_jobc >= 0);
+	if (entering)
 		pgrp->pg_jobc++;
-	} else {
-		MPASS(pgrp->pg_jobc > 0);
+	else {
 		--pgrp->pg_jobc;
 		if (pgrp->pg_jobc == 0)
 			orphanpg(pgrp);


### PR DESCRIPTION
The assert valid, but the bug is fairly harmless and panic on debugger exit is unhelpful.

This reverts commit a8ea5ca76fea33a70e4998f2999c6e9e48a5d637.