### PR TITLE
Support for CHERI-RISC-V PTE bits

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -990,7 +990,7 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_si_code = PROT_CHERI_STORETAG,
 	  .ct_si_trapno = TRAPNO_CHERI,
 #endif
-	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp },
+	  .ct_check_xfail = xfail_need_writable_tmp },
 
 	{ .ct_name = "cheritest_vm_tag_tmpfile_private",
 	  .ct_desc = "check tags are stored for tmpfile() MAP_PRIVATE pages",

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -981,13 +981,11 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "check tags are not stored for tmpfile() MAP_SHARED pages",
 	  .ct_func = cheritest_vm_notag_tmpfile_shared,
 	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
-#ifdef __riscv
 	  .ct_signum = SIGSEGV,
 	  .ct_si_code = SEGV_STORETAG,
+#ifdef __riscv
 	  .ct_si_trapno = EXCP_STORE_AMO_CAP_PAGE_FAULT,
 #else
-	  .ct_signum = SIGPROT,
-	  .ct_si_code = PROT_CHERI_STORETAG,
 	  .ct_si_trapno = TRAPNO_CHERI,
 #endif
 	  .ct_check_xfail = xfail_need_writable_tmp },

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -981,15 +981,16 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "check tags are not stored for tmpfile() MAP_SHARED pages",
 	  .ct_func = cheritest_vm_notag_tmpfile_shared,
 	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+#ifdef __riscv
+	  .ct_signum = SIGSEGV,
+	  .ct_si_code = SEGV_STORETAG,
+	  .ct_si_trapno = EXCP_STORE_AMO_CAP_PAGE_FAULT,
+#else
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_STORETAG,
 	  .ct_si_trapno = TRAPNO_CHERI,
-#ifdef __riscv
-	  .ct_xfail_reason = "CHERI-RISC-V doesn't implement CHERI PTE bits",
-#else
-	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp,
 #endif
-	},
+	  .ct_check_xfail = xfail_need_writable_non_tmpfs_tmp },
 
 	{ .ct_name = "cheritest_vm_tag_tmpfile_private",
 	  .ct_desc = "check tags are stored for tmpfile() MAP_PRIVATE pages",

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -534,7 +534,6 @@ DECLARE_CHERI_TEST(cheritest_vm_tag_tmpfile_private_prefault);
 DECLARE_CHERI_TEST(cheritest_vm_cow_read);
 DECLARE_CHERI_TEST(cheritest_vm_cow_write);
 const char	*xfail_need_writable_tmp(const char *name);
-const char	*xfail_need_writable_non_tmpfs_tmp(const char *name);
 
 /* cheritest_vm_swap.c */
 DECLARE_CHERI_TEST(cheritest_vm_swap);

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -433,7 +433,6 @@ cheritest_vm_notag_tmpfile_shared(const struct cheri_test *ctp __unused)
 	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
 	cp_value = cheri_ptr(&v, sizeof(v));
 	*cp = cp_value;
-	/* this test fails if /tmp is on tmpfs as it will silently strip the tag */
 	cheritest_failure_errx("tagged store succeeded");
 }
 
@@ -474,18 +473,6 @@ xfail_need_writable_tmp(const char *name __unused)
 	}
 	reason = "/tmp is not writable";
 	return (reason);
-}
-
-const char*
-xfail_need_writable_non_tmpfs_tmp(const char *name)
-{
-	struct statfs info;
-
-	CHERITEST_CHECK_SYSCALL(statfs("/tmp", &info));
-	if (strcmp(info.f_fstypename, "tmpfs") == 0) {
-		return ("cheritest_vm_notag_tmpfile_shared needs non-tmpfs /tmp");
-	}
-	return (xfail_need_writable_tmp(name));
 }
 
 /*

--- a/sys/fs/tmpfs/tmpfs_subr.c
+++ b/sys/fs/tmpfs/tmpfs_subr.c
@@ -342,6 +342,9 @@ tmpfs_alloc_node(struct mount *mp, struct tmpfs_mount *tmp, enum vtype type,
 		VM_OBJECT_WLOCK(obj);
 		/* OBJ_TMPFS is set together with the setting of vp->v_object */
 		vm_object_set_flag(obj, OBJ_TMPFS_NODE);
+#if __has_feature(capabilities)
+		vm_object_set_flag(obj, OBJ_NOLOADTAGS | OBJ_NOSTORETAGS);
+#endif
 		VM_OBJECT_WUNLOCK(obj);
 		break;
 

--- a/sys/mips/cheri/cheri_debug.c
+++ b/sys/mips/cheri/cheri_debug.c
@@ -86,9 +86,8 @@ DB_SHOW_COMMAND(cp2, ddb_dump_cp2)
 	uint8_t exccode, regnum;
 
 	cause = cheri_getcause();
-	exccode = (cause & CHERI_CAPCAUSE_EXCCODE_MASK) >>
-	    CHERI_CAPCAUSE_EXCCODE_SHIFT;
-	regnum = cause & CHERI_CAPCAUSE_REGNUM_MASK;
+	exccode = CHERI_CAPCAUSE_EXCCODE(cause);
+	regnum = CHERI_CAPCAUSE_REGNUM(cause);
 	db_printf("CHERI cause: ExcCode: 0x%02x ", exccode);
 	if (regnum < 32)
 		db_printf("RegNum: $c%02d ", regnum);
@@ -118,9 +117,8 @@ db_show_cheri_trapframe(struct trapframe *frame)
 
 	db_printf("Trapframe at %p\n", frame);
 	cause = frame->capcause;
-	exccode = (cause & CHERI_CAPCAUSE_EXCCODE_MASK) >>
-	    CHERI_CAPCAUSE_EXCCODE_SHIFT;
-	regnum = cause & CHERI_CAPCAUSE_REGNUM_MASK;
+	exccode = CHERI_CAPCAUSE_EXCCODE(cause);
+	regnum = CHERI_CAPCAUSE_REGNUM(cause);
 	db_printf("CHERI cause: ExcCode: 0x%02x ", exccode);
 	if (regnum < 32)
 		db_printf("RegNum: $c%02d ", regnum);

--- a/sys/mips/cheri/cheri_exception.c
+++ b/sys/mips/cheri/cheri_exception.c
@@ -346,9 +346,8 @@ cheri_log_exception(struct trapframe *frame, int trap_type)
 #endif
 	if ((trap_type == T_C2E) || (trap_type == T_C2E + T_USER)) {
 		cause = frame->capcause;
-		exccode = (cause & CHERI_CAPCAUSE_EXCCODE_MASK) >>
-		    CHERI_CAPCAUSE_EXCCODE_SHIFT;
-		regnum = cause & CHERI_CAPCAUSE_REGNUM_MASK;
+		exccode = CHERI_CAPCAUSE_EXCCODE(cause);
+		regnum = CHERI_CAPCAUSE_REGNUM(cause);
 		printf("CHERI cause: ExcCode: 0x%02x ", exccode);
 		if (regnum < 32)
 			printf("RegNum: $c%02d ", regnum);
@@ -366,8 +365,7 @@ cheri_capcause_to_sicode(register_t capcause)
 {
 	uint8_t exccode;
 
-	exccode = (capcause & CHERI_CAPCAUSE_EXCCODE_MASK) >>
-	    CHERI_CAPCAUSE_EXCCODE_SHIFT;
+	exccode = CHERI_CAPCAUSE_EXCCODE(capcause);
 	switch (exccode) {
 	case CHERI_EXCCODE_LENGTH:
 		return (PROT_CHERI_BOUNDS);

--- a/sys/mips/cheri/cheri_exception.c
+++ b/sys/mips/cheri/cheri_exception.c
@@ -391,7 +391,7 @@ cheri_capcause_to_sicode(register_t capcause)
 		return (PROT_CHERI_PERM);
 
 	case CHERI_EXCCODE_TLBSTORE:
-		return (PROT_CHERI_STORETAG);
+		panic("TLBSTORE uses SIGSEGV");
 
 	case CHERI_EXCCODE_IMPRECISE:
 		return (PROT_CHERI_IMPRECISE);

--- a/sys/mips/include/cherireg.h
+++ b/sys/mips/include/cherireg.h
@@ -281,6 +281,11 @@
 #define	CHERI_CAPCAUSE_EXCCODE_MASK	0xff00
 #define	CHERI_CAPCAUSE_EXCCODE_SHIFT	8
 #define	CHERI_CAPCAUSE_REGNUM_MASK	0xff
+#define	CHERI_CAPCAUSE_EXCCODE(capcause)				\
+	(((capcause) & CHERI_CAPCAUSE_EXCCODE_MASK) >>			\
+	    CHERI_CAPCAUSE_EXCCODE_SHIFT)
+#define	CHERI_CAPCAUSE_REGNUM(capcause)					\
+	((capcause) & CHERI_CAPCAUSE_REGNUM_MASK)
 
 /*
  * Location of the CHERI CCall/CReturn software-path exception vector.

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -1382,8 +1382,10 @@ err:
 	ksiginfo_init_trap(&ksi);
 	ksi.ksi_signo = i;
 	ksi.ksi_code = ucode;
+	if (i == SIGSEGV)
+		addr = (void * __capability)(intcap_t)trapframe->badvaddr;
 	/* XXXBD: probably not quite right for CheriABI */
-	ksi.ksi_addr = (void * __capability)(intcap_t)addr;
+	ksi.ksi_addr = addr;
 	ksi.ksi_trapno = type & ~T_USER;
 #if defined(CPU_CHERI)
 	if (i == SIGPROT)

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -1160,8 +1160,14 @@ dofault:
 		msg = "USER_CHERI_EXCEPTION";
 		fetch_bad_instr(trapframe);
 		log_c2e_exception(msg, trapframe, type);
-		i = SIGPROT;
-		ucode = cheri_capcause_to_sicode(trapframe->capcause);
+		if (CHERI_CAPCAUSE_EXCCODE(trapframe->capcause) ==
+		    CHERI_EXCCODE_TLBSTORE) {
+			i = SIGSEGV;
+			ucode = SEGV_STORETAG;
+		} else {
+			i = SIGPROT;
+			ucode = cheri_capcause_to_sicode(trapframe->capcause);
+		}
 		break;
 
 #else

--- a/sys/riscv/cheri/cheri_exception.c
+++ b/sys/riscv/cheri/cheri_exception.c
@@ -45,7 +45,6 @@ static const char *cheri_exccode_descr[] = {
 	[CHERI_EXCCODE_CALL] = "call trap",
 	[CHERI_EXCCODE_RETURN] = "return trap",
 	[CHERI_EXCCODE_PERM_USER] = "user-defined permission violation",
-	[CHERI_EXCCODE_TLBSTORE] = "TLB prohibits store capability",
 	[CHERI_EXCCODE_IMPRECISE] = "bounds cannot be represented precisely",
 	[CHERI_EXCCODE_UNALIGNED_BASE] = "Unaligned PCC base",
 	[CHERI_EXCCODE_GLOBAL] = "global violation",
@@ -106,9 +105,6 @@ cheri_sccsr_to_sicode(register_t sccsr)
 	case CHERI_EXCCODE_USER_PERM:
 	case CHERI_EXCCODE_PERM_SET_CID:
 		return (PROT_CHERI_PERM);
-
-	case CHERI_EXCCODE_TLBSTORE:
-		return (PROT_CHERI_STORETAG);
 
 	case CHERI_EXCCODE_IMPRECISE:
 		return (PROT_CHERI_IMPRECISE);

--- a/sys/riscv/include/pte.h
+++ b/sys/riscv/include/pte.h
@@ -66,6 +66,17 @@ typedef	uint64_t	pn_t;			/* page number */
 #define	Ln_ENTRIES	(1 << Ln_ENTRIES_SHIFT)
 #define	Ln_ADDR_MASK	(Ln_ENTRIES - 1)
 
+#if __has_feature(capabilities)
+/* CHERI uses reserved bits in 55:63 */
+#define	PTE_SC		(1UL << 63) /* Store Capability */
+#define	PTE_LC		(1UL << 62) /* Load Capability */
+#define	PTE_KERN_CHERI	(PTE_LC | PTE_SC)
+#define	PTE_PROMOTE_CHERI (PTE_LC | PTE_SC)
+#else
+#define	PTE_KERN_CHERI	0
+#define	PTE_PROMOTE_CHERI 0
+#endif
+
 /* Bits 9:8 are reserved for software */
 #define	PTE_SW_MANAGED	(1 << 9)
 #define	PTE_SW_WIRED	(1 << 8)
@@ -80,8 +91,9 @@ typedef	uint64_t	pn_t;			/* page number */
 #define	PTE_RWX		(PTE_R | PTE_W | PTE_X)
 #define	PTE_RX		(PTE_R | PTE_X)
 #define	PTE_KERN	(PTE_V | PTE_R | PTE_W | PTE_A | PTE_D)
+#define	PTE_KERN_CAP	(PTE_KERN | PTE_KERN_CHERI)
 #define	PTE_PROMOTE	(PTE_V | PTE_RWX | PTE_D | PTE_A | PTE_G | PTE_U | \
-			 PTE_SW_MANAGED | PTE_SW_WIRED)
+			 PTE_SW_MANAGED | PTE_SW_WIRED | PTE_PROMOTE_CHERI)
 
 #define	PTE_PPN0_S	10
 #define	PTE_PPN1_S	19

--- a/sys/riscv/include/riscvreg.h
+++ b/sys/riscv/include/riscvreg.h
@@ -54,6 +54,8 @@
 #define	EXCP_LOAD_PAGE_FAULT		13
 #define	EXCP_STORE_PAGE_FAULT		15
 #if __has_feature(capabilities)
+#define	EXCP_LOAD_CAP_PAGE_FAULT	26
+#define	EXCP_STORE_AMO_CAP_PAGE_FAULT	27
 #define	EXCP_CHERI			28
 #endif
 #define	EXCP_INTR			(1ul << 63)

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -108,7 +108,7 @@ _start:
 	add	t3, t4, t2
 	li	t5, 0
 2:
-	li	t0, (PTE_KERN | PTE_X)
+	li	t0, (PTE_KERN_CAP | PTE_X)
 	slli	t2, t4, PTE_PPN1_S	/* << PTE_PPN1_S */
 	or	t5, t0, t2
 	sd	t5, (s1)		/* Store PTE entry to position */

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -521,7 +521,7 @@ pmap_bootstrap_dmap(vm_offset_t kern_l1, vm_paddr_t min_pa, vm_paddr_t max_pa)
 
 		/* superpages */
 		pn = (pa / PAGE_SIZE);
-		entry = PTE_KERN;
+		entry = PTE_KERN_CAP;
 		entry |= (pn << PTE_PPN0_S);
 		pmap_store(&l1[l1_slot], entry);
 	}
@@ -1031,7 +1031,7 @@ pmap_qenter(vm_offset_t sva, vm_page_t *ma, int count)
 		pn = (pa / PAGE_SIZE);
 		l3 = pmap_l3(kernel_pmap, va);
 
-		entry = PTE_KERN;
+		entry = PTE_KERN_CAP;
 		entry |= (pn << PTE_PPN0_S);
 		pmap_store(l3, entry);
 
@@ -2658,6 +2658,12 @@ pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 		new_l3 |= PTE_W;
 	if (va < VM_MAX_USER_ADDRESS)
 		new_l3 |= PTE_U;
+#if __has_feature(capabilities)
+	if ((flags & PMAP_ENTER_NOLOADTAGS) == 0)
+		new_l3 |= PTE_LC;
+	if ((flags & PMAP_ENTER_NOSTORETAGS) == 0)
+		new_l3 |= PTE_SC;
+#endif
 
 	new_l3 |= (pn << PTE_PPN0_S);
 	if ((flags & PMAP_ENTER_WIRED) != 0)

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -490,7 +490,6 @@ struct siginfo64 {
 #define	PROT_CHERI_SEALED	3	/* Capability sealed fault	*/
 #define	PROT_CHERI_TYPE		4	/* Type mismatch fault		*/
 #define	PROT_CHERI_PERM		5	/* Capability permission fault	*/
-#define	PROT_CHERI_STORETAG	6	/* Tag-store page fault		*/
 #define	PROT_CHERI_IMPRECISE	7	/* Imprecise bounds fault	*/
 #define	PROT_CHERI_STORELOCAL	8	/* Store-local fault		*/
 #define	PROT_CHERI_CCALL	9	/* CCall fault			*/

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -447,6 +447,8 @@ struct siginfo64 {
 #define SEGV_ACCERR	2	/* Invalid permissions for mapped	*/
 				/* object.				*/
 #define	SEGV_PKUERR	100	/* x86: PKU violation			*/
+#define	SEGV_LOADTAG	101	/* Tag-load page fault.                 */
+#define	SEGV_STORETAG	102	/* Tag-store page fault.                */
 
 /* codes for SIGFPE */
 #define FPE_INTOVF	1	/* Integer overflow.			*/

--- a/sys/vm/vm_object.c
+++ b/sys/vm/vm_object.c
@@ -234,7 +234,7 @@ vm_object_zinit(void *mem, int size, int flags)
 }
 
 static void
-_vm_object_allocate(objtype_t type, vm_pindex_t size, u_short flags,
+_vm_object_allocate(objtype_t type, vm_pindex_t size, u_int flags,
     vm_object_t object, void *handle)
 {
 
@@ -319,7 +319,7 @@ vm_object_init(void)
 }
 
 void
-vm_object_clear_flag(vm_object_t object, u_short bits)
+vm_object_clear_flag(vm_object_t object, u_int bits)
 {
 
 	VM_OBJECT_ASSERT_WLOCKED(object);
@@ -425,7 +425,7 @@ vm_object_t
 vm_object_allocate(objtype_t type, vm_pindex_t size)
 {
 	vm_object_t object;
-	u_short flags;
+	u_int flags;
 
 	switch (type) {
 	case OBJT_DEAD:

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -282,7 +282,7 @@ struct vnode;
  *	The object must be locked or thread private.
  */
 static __inline void
-vm_object_set_flag(vm_object_t object, u_short bits)
+vm_object_set_flag(vm_object_t object, u_int bits)
 {
 
 	object->flags |= bits;
@@ -338,7 +338,7 @@ vm_object_mightbedirty(vm_object_t object)
 	return (object->generation != object->cleangeneration);
 }
 
-void vm_object_clear_flag(vm_object_t object, u_short bits);
+void vm_object_clear_flag(vm_object_t object, u_int bits);
 void vm_object_pip_add(vm_object_t object, short i);
 void vm_object_pip_wakeup(vm_object_t object);
 void vm_object_pip_wakeupn(vm_object_t object, short i);


### PR DESCRIPTION
Note that the PTE bits haven't been working on MIPS since January due to a merge-o as far as I can tell.  However, this was masked by the existing test in cheritest being skipped due to tmpfs, so the last commits here turn off storing tags in tmpfs so that the test will be tested in Jenkins going forward.  If we want to revisit the tmpfs case we should fix the test to DTRT.

We still need a test case that tag-stripping DTRT on the load side.  I'm not quite sure how to contrive a case where you can have a tag in memory and then remap the page with LC cleared using our current APIs.  We would almost need a `MAP_NOTAGS` hack or something to be able to test that.