### PR TITLE
Create sentries for userspace code capabilities

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1560,6 +1560,11 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_signal_sigaltstack_disable",
 	  .ct_desc = "Check signal handlers don't use a given alternate stack when re-disabled",
 	  .ct_func = test_signal_sigaltstack_disable },
+#ifdef __CHERI_PURE_CAPABILITY__
+	{ .ct_name = "test_signal_returncap",
+	  .ct_desc = "Test value of signal handler return capability",
+	  .ct_func = test_signal_returncap },
+#endif
 
 	/*
 	 * Standard library string tests.

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -479,6 +479,9 @@ DECLARE_CHERI_TEST(test_signal_handler_usr1);
 DECLARE_CHERI_TEST(test_signal_sigaction_usr1);
 DECLARE_CHERI_TEST(test_signal_sigaltstack);
 DECLARE_CHERI_TEST(test_signal_sigaltstack_disable);
+#ifdef __CHERI_PURE_CAPABILITY__
+DECLARE_CHERI_TEST(test_signal_returncap);
+#endif
 
 /* cheritest_string.c */
 DECLARE_CHERI_TEST(test_string_kern_memcpy_c);

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -75,17 +75,17 @@ struct cheri_signal {
  * capabilities themselves.
  */
 #ifdef _KERNEL
-void * __capability	_cheri_capability_build_user_code(uint32_t perms,
-			    vaddr_t basep, size_t length, off_t off,
-			    const char* func, int line);
+void * __capability	_cheri_capability_build_user_code(struct thread *td,
+			    uint32_t perms, vaddr_t basep, size_t length,
+			    off_t off, const char* func, int line);
 void * __capability	_cheri_capability_build_user_data(uint32_t perms,
 			    vaddr_t basep, size_t length, off_t off,
 			    const char* func, int line);
 void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 			    vaddr_t basep, size_t length, off_t off,
 			    const char* func, int line);
-#define cheri_capability_build_user_code(perms, basep, length, off)	\
-	_cheri_capability_build_user_code(perms, basep, length, off,	\
+#define cheri_capability_build_user_code(td, perms, basep, length, off)	\
+	_cheri_capability_build_user_code(td, perms, basep, length, off,\
 	    __func__, __LINE__)
 #define cheri_capability_build_user_data(perms, basep, length, off)	\
 	_cheri_capability_build_user_data(perms, basep, length, off,	\
@@ -101,7 +101,8 @@ struct image_params;
 struct thread;
 void * __capability cheri_auxv_capability(struct image_params *imgp,
 	    uintcap_t stack);
-void * __capability cheri_exec_pcc(struct image_params *imgp);
+void * __capability cheri_exec_pcc(struct thread *td,
+	    struct image_params *imgp);
 void * __capability cheri_exec_stack_pointer(struct image_params *imgp,
 	    uintcap_t stack);
 void	cheri_set_mmap_capability(struct thread *td, struct image_params *imgp,

--- a/sys/cheri/cheri_exec.c
+++ b/sys/cheri/cheri_exec.c
@@ -135,7 +135,7 @@ cheri_set_mmap_capability(struct thread *td, struct image_params *imgp,
 }
 
 void * __capability
-cheri_exec_pcc(struct image_params *imgp)
+cheri_exec_pcc(struct thread *td, struct image_params *imgp)
 {
 	vm_offset_t code_start, code_end;
 	size_t code_length;
@@ -160,7 +160,7 @@ cheri_exec_pcc(struct image_params *imgp)
 	code_length = CHERI_REPRESENTABLE_LENGTH(code_length);
 	KASSERT(code_start + code_length >= code_end,
 	    ("%s: truncated PCC", __func__));
-	return (cheri_capability_build_user_code(CHERI_CAP_USER_CODE_PERMS,
+	return (cheri_capability_build_user_code(td, CHERI_CAP_USER_CODE_PERMS,
 	    code_start, code_length, imgp->entry_addr - code_start));
 }
 
@@ -172,7 +172,7 @@ cheri_sigcode_capability(struct thread *td)
 	sv = td->td_proc->p_sysent;
 	KASSERT(sv->sv_sigcode_base != 0,
 	    ("CheriABI requires shared page for sigcode"));
-	return (cheri_capability_build_user_code(CHERI_CAP_USER_CODE_PERMS,
+	return (cheri_capability_build_user_code(td, CHERI_CAP_USER_CODE_PERMS,
 	    sv->sv_sigcode_base, *sv->sv_szsigcode, 0));
 }
 

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -41,9 +41,9 @@ void * __capability userspace_cap = (void * __capability)(intcap_t)-1;
 /*
  * Build a new userspace capability derived from userspace_cap.
  * The resulting capability may include both read and execute permissions,
- * but not write. For architectures that use flags, the flags for the resulting
- * capability will be set based on what is expected by userspace for the
- * specified thread.
+ * but not write, and will be a sentry capability. For architectures that use
+ * flags, the flags for the resulting capability will be set based on what is
+ * expected by userspace for the specified thread.
  */
 void * __capability
 _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
@@ -63,7 +63,7 @@ _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
 		tmpcap = cheri_setflags(tmpcap, CHERI_FLAGS_CAP_MODE);
 #endif
 
-	return (tmpcap);
+	return (cheri_sealentry(tmpcap));
 }
 
 /*

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -63,6 +63,7 @@
 
 #define	cheri_seal(x, y)	__builtin_cheri_seal((x), (y))
 #define	cheri_unseal(x, y)	__builtin_cheri_unseal((x), (y))
+#define	cheri_sealentry(x)	__builtin_cheri_seal_entry((x))
 
 #define	cheri_ccheckperm(c, p)	__builtin_cheri_perms_check((c), (p))
 #define	cheri_cchecktype(c, t)	__builtin_cheri_type_check((c), (t))

--- a/sys/mips/mips/pm_machdep.c
+++ b/sys/mips/mips/pm_machdep.c
@@ -641,7 +641,7 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 
 		td->td_frame->csp = cheri_exec_stack_pointer(imgp, stack);
 		cheri_set_mmap_capability(td, imgp, td->td_frame->csp);
-		td->td_frame->pcc = cheri_exec_pcc(imgp);
+		td->td_frame->pcc = cheri_exec_pcc(td, imgp);
 		td->td_frame->c12 = td->td_frame->pc;
 
 		/*

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -67,7 +67,7 @@ hybridabi_thread_setregs(struct thread *td, unsigned long entry_addr)
 
 	/* Use 'entry_addr' as offset of PCC. */
 	tf->tf_sepc = (uintcap_t)cheri_capability_build_user_code(
-	    CHERI_CAP_USER_CODE_PERMS, CHERI_CAP_USER_CODE_BASE,
+	    td, CHERI_CAP_USER_CODE_PERMS, CHERI_CAP_USER_CODE_BASE,
 	    CHERI_CAP_USER_CODE_LENGTH, entry_addr);
 }
 

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -258,6 +258,10 @@ initstack:
 	.space  (PAGE_SIZE * KSTACK_PAGES)
 initstack_end:
 
+.option push
+#if __has_feature(capabilities)
+.option capmode
+#endif
 ENTRY(sigcode)
 #if __has_feature(capabilities)
 	cincoffset ca0, csp, SF_UC
@@ -279,8 +283,13 @@ END(sigcode)
 	/* This may be copied to the stack, keep it 16-byte aligned */
 	.align	3
 esigcode:
+.option pop
 
 #ifdef COMPAT_FREEBSD64
+.option push
+#if __has_feature(capabilities)
+.option nocapmode
+#endif
 ENTRY(freebsd64_sigcode)
 	mv	a0, sp
 	addi	a0, a0, SF64_UC
@@ -298,6 +307,7 @@ END(freebsd64_sigcode)
 	/* This may be copied to the stack, keep it 16-byte aligned */
 	.align	3
 freebsd64_esigcode:
+.option pop
 #endif
 
 	.data

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -419,14 +419,7 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 		cheri_set_mmap_capability(td, imgp,
 		    (void * __capability)tf->tf_sp);
 
-		/*
-		 * XXX: RISC-V needs purecap mode enabled in flags.
-		 * Our current set of macros from <machine/cherireg.h>
-		 * don't provide a way to handle this, so fix it up
-		 * here.
-		 */
-		tf->tf_sepc = (uintcap_t)cheri_setflags(cheri_exec_pcc(imgp),
-		    CHERI_FLAGS_CAP_MODE);
+		tf->tf_sepc = (uintcap_t)cheri_exec_pcc(td, imgp);
 		td->td_proc->p_md.md_sigcode = cheri_sigcode_capability(td);
 	} else
 #endif


### PR DESCRIPTION
This ensures signal handlers see a sentry for their return capability. Test was confirmed to be broken (saw otype -1) without the kernel change.