### PR TITLE
Remove software CHERI traps

### DIFF
--- a/sys/mips/cheri/cheri_exception.c
+++ b/sys/mips/cheri/cheri_exception.c
@@ -69,11 +69,6 @@ static const char *cheri_exccode_descr[] = {
 	[CHERI_EXCCODE_CCALL_IDC] = "access ccall IDC violation",
 	[CHERI_EXCCODE_PERM_UNSEAL] = "permit unseal violation",
 	[CHERI_EXCCODE_PERM_SET_CID] = "permit CSetCID violation",
-	[CHERI_EXCCODE_SW_LOCALARG] = "local capability in argument",
-	[CHERI_EXCCODE_SW_LOCALRET] = "local capability in return value",
-	[CHERI_EXCCODE_SW_CCALLREGS] = "incorrect CCall registers",
-	[CHERI_EXCCODE_SW_OVERFLOW] = "trusted stack overflow",
-	[CHERI_EXCCODE_SW_UNDERFLOW] = "trusted stack underflow",
 };
 
 const char *
@@ -408,21 +403,6 @@ cheri_capcause_to_sicode(register_t capcause)
 
 	case CHERI_EXCCODE_SYSTEM_REGS:
 		return (PROT_CHERI_SYSREG);
-
-	case CHERI_EXCCODE_SW_OVERFLOW:
-		return (PROT_CHERI_OVERFLOW);
-
-	case CHERI_EXCCODE_SW_UNDERFLOW:
-		return (PROT_CHERI_UNDERFLOW);
-
-	case CHERI_EXCCODE_SW_CCALLREGS:
-		return (PROT_CHERI_CCALLREGS);
-
-	case CHERI_EXCCODE_SW_LOCALARG:
-		return (PROT_CHERI_LOCALARG);
-
-	case CHERI_EXCCODE_SW_LOCALRET:
-		return (PROT_CHERI_LOCALRET);
 
 	case CHERI_EXCCODE_NONE:
 	default:

--- a/sys/mips/include/cherireg.h
+++ b/sys/mips/include/cherireg.h
@@ -269,11 +269,6 @@
  * User-defined CHERI exception codes are numbered 128...255.
  */
 #define	CHERI_EXCCODE_SW_BASE		0x80
-#define	CHERI_EXCCODE_SW_LOCALARG	0x80	/* Non-global CCall argument. */
-#define	CHERI_EXCCODE_SW_LOCALRET	0x81	/* Non-global CReturn value. */
-#define	CHERI_EXCCODE_SW_CCALLREGS	0x82	/* Incorrect CCall registers. */
-#define	CHERI_EXCCODE_SW_OVERFLOW	0x83	/* Trusted stack overflow. */
-#define	CHERI_EXCCODE_SW_UNDERFLOW	0x84	/* Trusted stack underflow. */
 
 /*
  * How to turn the cause register into an exception code and register number.

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -495,12 +495,6 @@ struct siginfo64 {
 #define	PROT_CHERI_CCALL	9	/* CCall fault			*/
 #define	PROT_CHERI_CRETURN	10	/* CReturn fault		*/
 #define	PROT_CHERI_SYSREG	11	/* Capability system register fault */
-#define	PROT_CHERI_UNSEALED	61	/* CCall unsealed argument fault */
-#define	PROT_CHERI_OVERFLOW	62	/* Trusted stack oveflow fault	*/
-#define	PROT_CHERI_UNDERFLOW	63	/* Trusted stack underflow fault */
-#define	PROT_CHERI_CCALLREGS	64	/* CCall argument fault		*/
-#define	PROT_CHERI_LOCALARG	65	/* CCall local argument fault	*/
-#define	PROT_CHERI_LOCALRET	66	/* CReturn local retval fault	*/
 #endif
 
 #if __POSIX_VISIBLE || __XSI_VISIBLE


### PR DESCRIPTION
These were used for the in-kernel trusted stack, but I don't think we will use them again on MIPS and won't use them on RISC-V.