### PR TITLE
Propagate pmap flags to pmap_enter_quick and pmap_enter_object

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -954,11 +954,8 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "cheritest_vm_shm_open_anon_unix_surprise",
 	  .ct_desc = "test SHM_ANON vs SCM_RIGHTS",
 	  .ct_func = cheritest_vm_shm_open_anon_unix_surprise,
-#ifdef mips
 	  .ct_xfail_reason =
-	    "Tags currently survive cross-AS aliasing of SHM_ANON objects",
-#endif
-	},
+	    "Tags currently survive cross-AS aliasing of SHM_ANON objects", },
 
 #ifdef CHERIABI_TESTS
 	{ .ct_name = "cheritest_vm_cap_share_fd_kqueue",

--- a/sys/amd64/amd64/pmap.c
+++ b/sys/amd64/amd64/pmap.c
@@ -6467,7 +6467,7 @@ pmap_enter_pde(pmap_t pmap, vm_offset_t va, pd_entry_t newpde, u_int flags,
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	struct rwlock *lock;
 	vm_offset_t va;
@@ -6508,7 +6508,8 @@ pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
  */
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 	struct rwlock *lock;
 

--- a/sys/arm/arm/pmap-v4.c
+++ b/sys/arm/arm/pmap-v4.c
@@ -3244,7 +3244,7 @@ do_l2b_alloc:
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_page_t m;
 	vm_pindex_t diff, psize;
@@ -3275,7 +3275,8 @@ pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
  */
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 
 	rw_wlock(&pvh_global_lock);

--- a/sys/arm/arm/pmap-v6.c
+++ b/sys/arm/arm/pmap-v6.c
@@ -4660,7 +4660,8 @@ pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
 }
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 
 	rw_wlock(&pvh_global_lock);
@@ -4805,7 +4806,7 @@ pmap_enter_pte1(pmap_t pmap, vm_offset_t va, pt1_entry_t pte1, u_int flags,
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_offset_t va;
 	vm_page_t m, mpt2pg;

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -3889,7 +3889,7 @@ pmap_enter_l2(pmap_t pmap, vm_offset_t va, pd_entry_t new_l2, u_int flags,
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	struct rwlock *lock;
 	vm_offset_t va;
@@ -3929,7 +3929,8 @@ pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
  */
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 	struct rwlock *lock;
 

--- a/sys/i386/i386/pmap.c
+++ b/sys/i386/i386/pmap.c
@@ -4058,7 +4058,7 @@ pmap_enter_pde(pmap_t pmap, vm_offset_t va, pd_entry_t newpde, u_int flags,
  */
 static void
 __CONCAT(PMTYPE, enter_object)(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_offset_t va;
 	vm_page_t m, mpte;
@@ -4097,7 +4097,7 @@ __CONCAT(PMTYPE, enter_object)(pmap_t pmap, vm_offset_t start, vm_offset_t end,
 
 static void
 __CONCAT(PMTYPE, enter_quick)(pmap_t pmap, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot)
+    vm_prot_t prot, u_int flags)
 {
 
 	rw_wlock(&pvh_global_lock);

--- a/sys/i386/i386/pmap_base.c
+++ b/sys/i386/i386/pmap_base.c
@@ -686,17 +686,19 @@ pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 
-	pmap_methods_ptr->pm_enter_object(pmap, start, end, m_start, prot);
+	pmap_methods_ptr->pm_enter_object(pmap, start, end, m_start, prot,
+	    flags);
 }
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 
-	pmap_methods_ptr->pm_enter_quick(pmap, va, m, prot);
+	pmap_methods_ptr->pm_enter_quick(pmap, va, m, prot, flags);
 }
 
 void *

--- a/sys/i386/include/pmap_base.h
+++ b/sys/i386/include/pmap_base.h
@@ -81,8 +81,9 @@ struct pmap_methods {
 	int (*pm_enter)(pmap_t, vm_offset_t, vm_page_t, vm_prot_t, u_int,
 	    int8_t);
 	void (*pm_enter_object)(pmap_t, vm_offset_t, vm_offset_t,
-	    vm_page_t, vm_prot_t);
-	void (*pm_enter_quick)(pmap_t, vm_offset_t, vm_page_t, vm_prot_t);
+	    vm_page_t, vm_prot_t, u_int);
+	void (*pm_enter_quick)(pmap_t, vm_offset_t, vm_page_t, vm_prot_t,
+	    u_int);
 	void *(*pm_kenter_temporary)(vm_paddr_t pa, int);
 	void (*pm_object_init_pt)(pmap_t, vm_offset_t, vm_object_t,
 	    vm_pindex_t, vm_size_t);

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -2707,7 +2707,12 @@ pmap_copy_page_internal(vm_page_t src, vm_page_t dst, int flags)
 	} else {
 		va_src = pmap_lmem_map2(phys_src, phys_dst);
 		va_dst = va_src + PAGE_SIZE;
-		bcopy((void *)va_src, (void *)va_dst, PAGE_SIZE);
+#if __has_feature(capabilities)
+		if ((flags & PMAP_COPY_TAGS) == 0)
+		    bcopynocap((void *)va_src, (void *)va_dst, PAGE_SIZE);
+		else
+#endif
+		    bcopy((void *)va_src, (void *)va_dst, PAGE_SIZE);
 		mips_dcache_wbinv_range(va_dst, PAGE_SIZE);
 		pmap_lmem_unmap();
 	}

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -167,7 +167,7 @@ static pv_entry_t pmap_pvh_remove(struct md_page *pvh, pmap_t pmap,
     vm_offset_t va);
 static vm_page_t pmap_alloc_direct_page(unsigned int index, int req);
 static vm_page_t pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va,
-    vm_page_t m, vm_prot_t prot, vm_page_t mpte);
+    vm_page_t m, vm_prot_t prot, u_int flags, vm_page_t mpte);
 static void pmap_grow_direct_page(int req);
 static int pmap_remove_pte(struct pmap *pmap, pt_entry_t *ptq, vm_offset_t va,
     pd_entry_t pde);
@@ -2336,19 +2336,20 @@ validate:
  */
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 
 	rw_wlock(&pvh_global_lock);
 	PMAP_LOCK(pmap);
-	(void)pmap_enter_quick_locked(pmap, va, m, prot, NULL);
+	(void)pmap_enter_quick_locked(pmap, va, m, prot, flags, NULL);
 	rw_wunlock(&pvh_global_lock);
 	PMAP_UNLOCK(pmap);
 }
 
 static vm_page_t
 pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot, vm_page_t mpte)
+    vm_prot_t prot, u_int flags, vm_page_t mpte)
 {
 	pt_entry_t *pte, npte;
 	vm_paddr_t pa;
@@ -2430,6 +2431,12 @@ pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
 	 * Now validate mapping with RO protection
 	 */
 	npte = PTE_RO | TLBLO_PA_TO_PFN(pa) | PTE_V;
+#ifdef CPU_CHERI
+	if ((flags & PMAP_ENTER_NOLOADTAGS) != 0)
+		npte |= PTE_LC;
+	if ((flags & PMAP_ENTER_NOSTORETAGS) != 0)
+		npte |= PTE_SC;
+#endif
 	if ((m->oflags & VPO_UNMANAGED) == 0)
 		npte |= PTE_MANAGED;
 
@@ -2517,7 +2524,7 @@ pmap_kenter_temporary_free(vm_paddr_t pa)
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_page_t m, mpte;
 	vm_pindex_t diff, psize;
@@ -2531,7 +2538,7 @@ pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
 	PMAP_LOCK(pmap);
 	while (m != NULL && (diff = m->pindex - m_start->pindex) < psize) {
 		mpte = pmap_enter_quick_locked(pmap, start + ptoa(diff), m,
-		    prot, mpte);
+		    prot, flags, mpte);
 		m = TAILQ_NEXT(m, listq);
 	}
 	rw_wunlock(&pvh_global_lock);

--- a/sys/powerpc/aim/mmu_oea.c
+++ b/sys/powerpc/aim/mmu_oea.c
@@ -278,8 +278,8 @@ void moea_copy_pages(vm_page_t *ma, vm_offset_t a_offset,
 int moea_enter(pmap_t, vm_offset_t, vm_page_t, vm_prot_t, u_int,
     int8_t);
 void moea_enter_object(pmap_t, vm_offset_t, vm_offset_t, vm_page_t,
-    vm_prot_t);
-void moea_enter_quick(pmap_t, vm_offset_t, vm_page_t, vm_prot_t);
+    vm_prot_t, u_int);
+void moea_enter_quick(pmap_t, vm_offset_t, vm_page_t, vm_prot_t, u_int);
 vm_paddr_t moea_extract(pmap_t, vm_offset_t);
 vm_page_t moea_extract_and_hold(pmap_t, vm_offset_t, vm_prot_t);
 void moea_init(void);
@@ -1213,7 +1213,7 @@ moea_enter_locked(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
  */
 void
 moea_enter_object(pmap_t pm, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_page_t m;
 	vm_pindex_t diff, psize;
@@ -1236,7 +1236,7 @@ moea_enter_object(pmap_t pm, vm_offset_t start, vm_offset_t end,
 
 void
 moea_enter_quick(pmap_t pm, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot)
+    vm_prot_t prot, u_int flags)
 {
 
 	rw_wlock(&pvh_global_lock);

--- a/sys/powerpc/aim/mmu_oea64.c
+++ b/sys/powerpc/aim/mmu_oea64.c
@@ -260,8 +260,8 @@ void moea64_copy_pages(vm_page_t *ma, vm_offset_t a_offset,
 int moea64_enter(pmap_t, vm_offset_t, vm_page_t, vm_prot_t,
     u_int flags, int8_t psind);
 void moea64_enter_object(pmap_t, vm_offset_t, vm_offset_t, vm_page_t,
-    vm_prot_t);
-void moea64_enter_quick(pmap_t, vm_offset_t, vm_page_t, vm_prot_t);
+    vm_prot_t, u_int);
+void moea64_enter_quick(pmap_t, vm_offset_t, vm_page_t, vm_prot_t, u_int);
 vm_paddr_t moea64_extract(pmap_t, vm_offset_t);
 vm_page_t moea64_extract_and_hold(pmap_t, vm_offset_t, vm_prot_t);
 void moea64_init(void);
@@ -1578,7 +1578,7 @@ moea64_syncicache(pmap_t pmap, vm_offset_t va, vm_paddr_t pa,
  */
 void
 moea64_enter_object(pmap_t pm, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_page_t m;
 	vm_pindex_t diff, psize;
@@ -1597,7 +1597,7 @@ moea64_enter_object(pmap_t pm, vm_offset_t start, vm_offset_t end,
 
 void
 moea64_enter_quick(pmap_t pm, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot)
+    vm_prot_t prot, u_int flags)
 {
 
 	moea64_enter(pm, va, m, prot & (VM_PROT_READ | VM_PROT_EXECUTE),

--- a/sys/powerpc/aim/mmu_radix.c
+++ b/sys/powerpc/aim/mmu_radix.c
@@ -415,8 +415,8 @@ void mmu_radix_copy(pmap_t, pmap_t, vm_offset_t, vm_size_t, vm_offset_t);
 int mmu_radix_decode_kernel_ptr(vm_offset_t, int *, vm_offset_t *);
 int mmu_radix_enter(pmap_t, vm_offset_t, vm_page_t, vm_prot_t, u_int, int8_t);
 void mmu_radix_enter_object(pmap_t, vm_offset_t, vm_offset_t, vm_page_t,
-	vm_prot_t);
-void mmu_radix_enter_quick(pmap_t, vm_offset_t, vm_page_t, vm_prot_t);
+	vm_prot_t, u_int);
+void mmu_radix_enter_quick(pmap_t, vm_offset_t, vm_page_t, vm_prot_t, u_int);
 vm_paddr_t mmu_radix_extract(pmap_t pmap, vm_offset_t va);
 vm_page_t mmu_radix_extract_and_hold(pmap_t, vm_offset_t, vm_prot_t);
 void mmu_radix_kenter(vm_offset_t, vm_paddr_t);
@@ -3217,7 +3217,7 @@ pmap_enter_l3e(pmap_t pmap, vm_offset_t va, pml3_entry_t newpde, u_int flags,
 
 void
 mmu_radix_enter_object(pmap_t pmap, vm_offset_t start,
-    vm_offset_t end, vm_page_t m_start, vm_prot_t prot)
+    vm_offset_t end, vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 
 	struct rwlock *lock;
@@ -3364,7 +3364,7 @@ mmu_radix_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
 
 void
 mmu_radix_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot)
+    vm_prot_t prot, u_int flags)
 {
 	struct rwlock *lock;
 	bool invalidate;

--- a/sys/powerpc/booke/pmap.c
+++ b/sys/powerpc/booke/pmap.c
@@ -294,9 +294,9 @@ static void		mmu_booke_copy_pages(vm_page_t *,
 static int		mmu_booke_enter(pmap_t, vm_offset_t, vm_page_t,
     vm_prot_t, u_int flags, int8_t psind);
 static void		mmu_booke_enter_object(pmap_t, vm_offset_t, vm_offset_t,
-    vm_page_t, vm_prot_t);
+    vm_page_t, vm_prot_t, u_int);
 static void		mmu_booke_enter_quick(pmap_t, vm_offset_t, vm_page_t,
-    vm_prot_t);
+    vm_prot_t, u_int);
 static vm_paddr_t	mmu_booke_extract(pmap_t, vm_offset_t);
 static vm_page_t	mmu_booke_extract_and_hold(pmap_t, vm_offset_t,
     vm_prot_t);
@@ -1447,7 +1447,7 @@ mmu_booke_enter_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
  */
 static void
 mmu_booke_enter_object(pmap_t pmap, vm_offset_t start,
-    vm_offset_t end, vm_page_t m_start, vm_prot_t prot)
+    vm_offset_t end, vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	vm_page_t m;
 	vm_pindex_t diff, psize;
@@ -1470,7 +1470,7 @@ mmu_booke_enter_object(pmap_t pmap, vm_offset_t start,
 
 static void
 mmu_booke_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot)
+    vm_prot_t prot, u_int flags)
 {
 
 	rw_wlock(&pvh_global_lock);

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -300,7 +300,8 @@ static bool	pmap_demote_l2_locked(pmap_t pmap, pd_entry_t *l2,
 static int	pmap_enter_l2(pmap_t pmap, vm_offset_t va, pd_entry_t new_l2,
 		    u_int flags, vm_page_t m, struct rwlock **lockp);
 static vm_page_t pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va,
-    vm_page_t m, vm_prot_t prot, vm_page_t mpte, struct rwlock **lockp);
+    vm_page_t m, vm_prot_t prot, u_int flags, vm_page_t mpte,
+    struct rwlock **lockp);
 static int pmap_remove_l3(pmap_t pmap, pt_entry_t *l3, vm_offset_t sva,
     pd_entry_t ptepde, struct spglist *free, struct rwlock **lockp);
 static boolean_t pmap_try_insert_pv_entry(pmap_t pmap, vm_offset_t va,
@@ -2912,7 +2913,7 @@ out:
  */
 static bool
 pmap_enter_2mpage(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
-    struct rwlock **lockp)
+    u_int flags, struct rwlock **lockp)
 {
 	pd_entry_t new_l2;
 	pn_t pn;
@@ -2927,6 +2928,12 @@ pmap_enter_2mpage(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
 		new_l2 |= PTE_X;
 	if (va < VM_MAXUSER_ADDRESS)
 		new_l2 |= PTE_U;
+#if __has_feature(capabilities)
+	if ((flags & PMAP_ENTER_NOLOADTAGS) == 0)
+		new_l2 |= PTE_LC;
+	if ((flags & PMAP_ENTER_NOSTORETAGS) == 0)
+		new_l2 |= PTE_SC;
+#endif
 	return (pmap_enter_l2(pmap, va, new_l2, PMAP_ENTER_NOSLEEP |
 	    PMAP_ENTER_NOREPLACE | PMAP_ENTER_NORECLAIM, NULL, lockp) ==
 	    KERN_SUCCESS);
@@ -3058,7 +3065,7 @@ pmap_enter_l2(pmap_t pmap, vm_offset_t va, pd_entry_t new_l2, u_int flags,
  */
 void
 pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
-    vm_page_t m_start, vm_prot_t prot)
+    vm_page_t m_start, vm_prot_t prot, u_int flags)
 {
 	struct rwlock *lock;
 	vm_offset_t va;
@@ -3077,11 +3084,11 @@ pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
 		va = start + ptoa(diff);
 		if ((va & L2_OFFSET) == 0 && va + L2_SIZE <= end &&
 		    m->psind == 1 && pmap_ps_enabled(pmap) &&
-		    pmap_enter_2mpage(pmap, va, m, prot, &lock))
+		    pmap_enter_2mpage(pmap, va, m, prot, flags, &lock))
 			m = &m[L2_SIZE / PAGE_SIZE - 1];
 		else
-			mpte = pmap_enter_quick_locked(pmap, va, m, prot, mpte,
-			    &lock);
+			mpte = pmap_enter_quick_locked(pmap, va, m, prot, flags,
+			    mpte, &lock);
 		m = TAILQ_NEXT(m, listq);
 	}
 	if (lock != NULL)
@@ -3100,14 +3107,15 @@ pmap_enter_object(pmap_t pmap, vm_offset_t start, vm_offset_t end,
  */
 
 void
-pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
+pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot,
+    u_int flags)
 {
 	struct rwlock *lock;
 
 	lock = NULL;
 	rw_rlock(&pvh_global_lock);
 	PMAP_LOCK(pmap);
-	(void)pmap_enter_quick_locked(pmap, va, m, prot, NULL, &lock);
+	(void)pmap_enter_quick_locked(pmap, va, m, prot, flags, NULL, &lock);
 	if (lock != NULL)
 		rw_wunlock(lock);
 	rw_runlock(&pvh_global_lock);
@@ -3116,7 +3124,7 @@ pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_prot_t prot)
 
 static vm_page_t
 pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
-    vm_prot_t prot, vm_page_t mpte, struct rwlock **lockp)
+    vm_prot_t prot, u_int flags, vm_page_t mpte, struct rwlock **lockp)
 {
 	struct spglist free;
 	vm_paddr_t phys;
@@ -3214,6 +3222,12 @@ pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
 		newl3 |= PTE_SW_MANAGED;
 	if (va < VM_MAX_USER_ADDRESS)
 		newl3 |= PTE_U;
+#if __has_feature(capabilities)
+	if ((flags & PMAP_ENTER_NOLOADTAGS) == 0)
+		newl3 |= PTE_LC;
+	if ((flags & PMAP_ENTER_NOSTORETAGS) == 0)
+		newl3 |= PTE_SC;
+#endif
 
 	/*
 	 * Sync the i-cache on all harts before updating the PTE

--- a/sys/vm/pmap.h
+++ b/sys/vm/pmap.h
@@ -138,9 +138,10 @@ void		 pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset,
 int		 pmap_enter(pmap_t pmap, vm_offset_t va, vm_page_t m,
 		    vm_prot_t prot, u_int flags, int8_t psind);
 void		 pmap_enter_object(pmap_t pmap, vm_offset_t start,
-		    vm_offset_t end, vm_page_t m_start, vm_prot_t prot);
+		    vm_offset_t end, vm_page_t m_start, vm_prot_t prot,
+		    u_int flags);
 void		 pmap_enter_quick(pmap_t pmap, vm_offset_t va, vm_page_t m,
-		    vm_prot_t prot);
+		    vm_prot_t prot, u_int flags);
 vm_paddr_t	 pmap_extract(pmap_t pmap, vm_offset_t va);
 vm_page_t	 pmap_extract_and_hold(pmap_t pmap, vm_offset_t va,
 		    vm_prot_t prot);

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -1726,15 +1726,10 @@ vm_fault_prefault(const struct faultstate *fs, vm_offset_t addra,
 			break;
 		}
 
-		/*
-		 * XXXRW: No flags argument we can use to pass NOTAGS!
-		 */
 		if (vm_page_all_valid(m) &&
-#if __has_feature(capabilities)
-		    pmap_tag_flags(entry->object.vm_object) == 0 &&
-#endif
 		    (m->flags & PG_FICTITIOUS) == 0)
-			pmap_enter_quick(pmap, addr, m, entry->protection);
+			pmap_enter_quick(pmap, addr, m, entry->protection,
+			    pmap_tag_flags(entry->object.vm_object));
 		if (!obj_locked || lobject != entry->object.vm_object)
 			VM_OBJECT_RUNLOCK(lobject);
 	}

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -2613,6 +2613,7 @@ vm_map_pmap_enter(vm_map_t map, vm_offset_t addr, vm_prot_t prot,
 	vm_offset_t start;
 	vm_page_t p, p_start;
 	vm_pindex_t mask, psize, threshold, tmpidx;
+	u_int pmap_flags;
 
 	if ((prot & (VM_PROT_READ | VM_PROT_EXECUTE)) == 0 || object == NULL)
 		return;
@@ -2640,6 +2641,13 @@ vm_map_pmap_enter(vm_map_t map, vm_offset_t addr, vm_prot_t prot,
 	start = 0;
 	p_start = NULL;
 	threshold = MAX_INIT_PT;
+	pmap_flags = 0;
+#if __has_feature(capabilities)
+	if (object->flags & OBJ_NOLOADTAGS)
+		pmap_flags |= PMAP_ENTER_NOLOADTAGS;
+	if (object->flags & OBJ_NOSTORETAGS)
+		pmap_flags |= PMAP_ENTER_NOSTORETAGS;
+#endif
 
 	p = vm_page_find_least(object, pindex);
 	/*
@@ -2678,13 +2686,13 @@ vm_map_pmap_enter(vm_map_t map, vm_offset_t addr, vm_prot_t prot,
 			}
 		} else if (p_start != NULL) {
 			pmap_enter_object(map->pmap, start, addr +
-			    ptoa(tmpidx), p_start, prot);
+			    ptoa(tmpidx), p_start, prot, pmap_flags);
 			p_start = NULL;
 		}
 	}
 	if (p_start != NULL)
 		pmap_enter_object(map->pmap, start, addr + ptoa(psize),
-		    p_start, prot);
+		    p_start, prot, pmap_flags);
 	VM_OBJECT_RUNLOCK(object);
 }
 


### PR DESCRIPTION
The pmap_enter_object case fixes the divergence between RISC-V and MIPS
regarding cross-AS SHM_ANON cheritest. On MIPS we failed open, but on
RISC-V we failed closed, as both lacked flags. Since we're doing all
this for pmap_enter_object, which shares code with pmap_enter_quick, we
might as well hook flags up for the latter and remove the restriction on
its use.

This partially reverts 2bd5e17042e3ba083e85468b144c2435a960a9e4.