### PR TITLE
Enable freebsd64 on RISC-V and MACHINE_ARCH fixes

### DIFF
--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -340,11 +340,11 @@ __DEFAULT_YES_OPTIONS+=LIB32
 .else
 BROKEN_OPTIONS+=LIB32
 .endif
-# LIB64 on mips64*c*
-.if ${__T:Mmips64*c*}
+# LIB64 on mips64*c* and riscv64*c*
+.if ${__T:Mmips64*c*} || ${__T:Mriscv64*c*}
 __DEFAULT_YES_OPTIONS+=LIB64
-# In principal, LIB32 could work, but Makefile.libcompat only supports
-# one compat layer.
+# In principle, LIB32 could work on architectures where it's supported, but
+# Makefile.libcompat only supports one compat layer.
 BROKEN_OPTIONS+=LIB32
 .else
 BROKEN_OPTIONS+=LIB64

--- a/sys/kern/kern_mib.c
+++ b/sys/kern/kern_mib.c
@@ -279,6 +279,10 @@ proc_machine_arch(struct proc *p)
 	if (SV_PROC_FLAG(p, SV_ILP32))
 		return (MACHINE_ARCH32);
 #endif
+#ifdef COMPAT_FREEBSD64
+	if (!SV_PROC_FLAG(p, SV_CHERI))
+		return (MACHINE_ARCH64);
+#endif
 	return (MACHINE_ARCH);
 }
 
@@ -298,8 +302,10 @@ SYSCTL_PROC(_hw, HW_MACHINE_ARCH, machine_arch, CTLTYPE_STRING | CTLFLAG_RD |
     "System architecture");
 
 #ifndef MACHINE_ARCHES
-#ifdef COMPAT_FREEBSD32
+#if defined(COMPAT_FREEBSD32)
 #define	MACHINE_ARCHES	MACHINE_ARCH " " MACHINE_ARCH32
+#elif defined(COMPAT_FREEBSD64)
+#define	MACHINE_ARCHES	MACHINE_ARCH " " MACHINE_ARCH64
 #else
 #define	MACHINE_ARCHES	MACHINE_ARCH
 #endif

--- a/sys/mips/include/param.h
+++ b/sys/mips/include/param.h
@@ -75,15 +75,26 @@
 # define _HF_SUFFIX ""
 #endif
 
+#if defined(__CHERI_PURE_CAPABILITY__) || (defined(_KERNEL) && __has_feature(capabilities))
+# define _PURECAP_SUFFIX "c128"
+#else
+# define _PURECAP_SUFFIX ""
+#endif
+
 #ifndef MACHINE
 # define MACHINE	"mips"
 #endif
 #ifndef MACHINE_ARCH
-# define MACHINE_ARCH 	"mips" _N64_SUFFIX _EL_SUFFIX _HF_SUFFIX
+# define MACHINE_ARCH 	"mips" _N64_SUFFIX _EL_SUFFIX _HF_SUFFIX _PURECAP_SUFFIX
 #endif
 #ifdef __mips_n64
 # ifndef MACHINE_ARCH32
 #  define MACHINE_ARCH32 "mips" _EL_SUFFIX _HF_SUFFIX
+# endif
+#endif
+#if __has_feature(capabilities)
+# ifndef MACHINE_ARCH64
+#  define MACHINE_ARCH64 "mips64" _EL_SUFFIX _HF_SUFFIX
 # endif
 #endif
 

--- a/sys/riscv/include/param.h
+++ b/sys/riscv/include/param.h
@@ -45,17 +45,39 @@
 #ifndef MACHINE
 #define	MACHINE		"riscv"
 #endif
-#ifndef MACHINE_ARCH
 
 /* Always use the hard-float arch for the kernel. */
 #if !defined(_KERNEL) && defined(__riscv_float_abi_soft)
-#define	MACHINE_ARCH	"riscv64sf"
+#define	_SF_SUFFIX	"sf"
 #else
-#define	MACHINE_ARCH	"riscv64"
+#define	_SF_SUFFIX	""
 #endif
+
+/* Always use the purecap arch for the kernel. */
+#if defined(__CHERI_PURE_CAPABILITY__) || (defined(_KERNEL) && __has_feature(capabilities))
+#define	_PURECAP_SUFFIX	"c"
+#else
+#define	_PURECAP_SUFFIX	""
+#endif
+
+#ifndef MACHINE_ARCH
+#define	MACHINE_ARCH	"riscv64" _SF_SUFFIX _PURECAP_SUFFIX
+#endif
+#ifndef MACHINE_ARCHSF
+#define	MACHINE_ARCHSF	"riscv64sf" _PURECAP_SUFFIX
+#endif
+#if __has_feature(capabilities)
+# ifndef MACHINE_ARCH64
+#  define	MACHINE_ARCH64		"riscv64"
+#  define	MACHINE_ARCH64SF	"riscv64sf"
+# endif
 #endif
 #ifdef _KERNEL
-#define	MACHINE_ARCHES	"riscv64 riscv64sf"
+# ifdef COMPAT_FREEBSD64
+#  define	MACHINE_ARCHES		"riscv64c riscv64sfc riscv64 riscv64sf"
+# else
+#  define	MACHINE_ARCHES		MACHINE_ARCH " " MACHINE_ARCHSF
+# endif
 #endif
 
 #ifdef SMP

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -114,7 +114,7 @@ riscv_machine_arch(struct proc *p)
 
 	if ((p->p_elf_flags & EF_RISCV_FLOAT_ABI_MASK) ==
 	    EF_RISCV_FLOAT_ABI_SOFT)
-		return (MACHINE_ARCH "sf");
+		return (MACHINE_ARCHSF);
 	return (MACHINE_ARCH);
 }
 

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -68,6 +68,7 @@ __FBSDID("$FreeBSD$");
 #include <compat/freebsd64/freebsd64_syscall.h>
 #include <compat/freebsd64/freebsd64_util.h>
 
+static const char *freebsd64_riscv_machine_arch(struct proc *p);
 static void	freebsd64_sendsig(sig_t, ksiginfo_t *, sigset_t *);
 
 extern const char *freebsd64_syscallnames[];
@@ -106,8 +107,19 @@ struct sysentvec elf_freebsd_freebsd64_sysvec = {
 	.sv_thread_detach = NULL,
 	.sv_trap	= NULL,
 	.sv_hwcap	= &elf_hwcap,
+	.sv_machine_arch = freebsd64_riscv_machine_arch,
 };
 INIT_SYSENTVEC(freebsd64_sysent, &elf_freebsd_freebsd64_sysvec);
+
+static const char *
+freebsd64_riscv_machine_arch(struct proc *p)
+{
+
+	if ((p->p_elf_flags & EF_RISCV_FLOAT_ABI_MASK) ==
+	    EF_RISCV_FLOAT_ABI_SOFT)
+		return (MACHINE_ARCH64SF);
+	return (MACHINE_ARCH64);
+}
 
 static Elf64_Brandinfo freebsd_freebsd64_brand_info = {
 	.brand		= ELFOSABI_FREEBSD,

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -11,10 +11,10 @@ PROG=	cheribsdbox
 CHERIBSDBOX_DIR?=	/bin
 BINDIR?=${CHERIBSDBOX_DIR}
 
-.if ${MK_LIB64} == "yes"
-# We want to build all these tools as statically linked 64-bit binaries.
-# For MIPS we don't want to build this as purecap yet (it generates a captable
-# that is too large to link).
+# We want to build all these tools as statically linked binaries, but for MIPS
+# we don't want to build this as purecap yet since it generates a captable that
+# is too large to link.
+.if ${MACHINE_ARCH:Mmips64*} && ${MK_LIB64} == "yes"
 NEED_COMPAT=	64
 WANT_CHERI=		none
 CRUNCH_BUILDOPTS+=	WANT_CHERI=none NEED_COMPAT=64


### PR DESCRIPTION
Mostly apply to RISC-V, but as I was fixing MACHINE_ARCH for RISC-V I noticed we never did the same on MIPS.

(Ignore kernel hashes for MIPS, I tweaked some RISC-V things, rebased and didn't bother rebuilding)

mips-hybrid:

```
root@qemu-cheri128-jrtc4:~ # uname -p
mips64
root@qemu-cheri128-jrtc4:~ # /smbfs/output_root/rootfs128/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #5 240e14417342-c327690(riscv-freebsd64): Tue Jun 23 23:47:00 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-mips-hybrid128-build/home/jrtc4/cheri/cheribsd/mips.mips64/sys/CHERI_MALTA64

kern.supported_archs: mips64c128 mips64
hw.machine_arch: mips64
root@qemu-cheri128-jrtc4:~ # /smbfs/output_root/rootfs-purecap128/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #5 240e14417342-c327690(riscv-freebsd64): Tue Jun 23 23:47:00 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-mips-hybrid128-build/home/jrtc4/cheri/cheribsd/mips.mips64/sys/CHERI_MALTA64

kern.supported_archs: mips64c128 mips64
hw.machine_arch: mips64c128
```

mips-purecap:

```
root@qemu-cheri128-jrtc4:~ # uname -p
mips64c128
root@qemu-cheri128-jrtc4:~ # /smbfs/output_root/rootfs128/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #5 240e14417342-c327690(riscv-freebsd64): Tue Jun 23 23:48:45 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-purecap-128-build/home/jrtc4/cheri/cheribsd/mips.mips64c128/sys/CHERI_MALTA64

kern.supported_archs: mips64c128 mips64
hw.machine_arch: mips64
root@qemu-cheri128-jrtc4:~ # /smbfs/output_root/rootfs-purecap128/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #5 240e14417342-c327690(riscv-freebsd64): Tue Jun 23 23:48:45 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-purecap-128-build/home/jrtc4/cheri/cheribsd/mips.mips64c128/sys/CHERI_MALTA64

kern.supported_archs: mips64c128 mips64
hw.machine_arch: mips64c128
```

riscv64-hybrid:

```
root@qemu-cheri-jrtc4:~ # uname -p
riscv64
root@qemu-cheri-jrtc4:~ # /smbfs/output_root/rootfs-riscv64-hybrid/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #2 8ad0dcbccb8b-c327691(riscv-freebsd64): Wed Jun 24 02:30:28 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-riscv64-hybrid-build/home/jrtc4/cheri/cheribsd/riscv.riscv64/sys/CHERI_QEMU

kern.supported_archs: riscv64c riscv64sfc riscv64 riscv64sf
hw.machine_arch: riscv64
root@qemu-cheri-jrtc4:~ # /smbfs/output_root/rootfs-riscv64-purecap/usr/bin/sysctl kern.version kern.supported_archs hw.machine_arch
/smbfs/output_root/rootfs-riscv64-purecap/usr/bin/sysctl: Command not found.
root@qemu-cheri-jrtc4:~ # /smbfs/output_root/rootfs-riscv64-purecap/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #2 8ad0dcbccb8b-c327691(riscv-freebsd64): Wed Jun 24 02:30:28 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-riscv64-hybrid-build/home/jrtc4/cheri/cheribsd/riscv.riscv64/sys/CHERI_QEMU

kern.supported_archs: riscv64c riscv64sfc riscv64 riscv64sf
hw.machine_arch: riscv64c
```

riscv64-purecap:

```
root@qemu-cheri-jrtc4:~ # uname -p
riscv64c
root@qemu-cheri-jrtc4:~ # /smbfs/output_root/rootfs-riscv64-hybrid/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #14 8ad0dcbccb8b-c327691(riscv-freebsd64): Wed Jun 24 01:45:38 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-riscv64-purecap-build/home/jrtc4/cheri/cheribsd/riscv.riscv64c/sys/CHERI_QEMU

kern.supported_archs: riscv64c riscv64sfc riscv64 riscv64sf
hw.machine_arch: riscv64
root@qemu-cheri-jrtc4:~ # /smbfs/output_root/rootfs-riscv64-purecap/sbin/sysctl kern.version kern.supported_archs hw.machine_arch
kern.version: FreeBSD 13.0-CURRENT #14 8ad0dcbccb8b-c327691(riscv-freebsd64): Wed Jun 24 01:45:38 BST 2020
    jrtc4@zeno.sec.cl.cam.ac.uk:/home/jrtc4/cheri/build/cheribsd-riscv64-purecap-build/home/jrtc4/cheri/cheribsd/riscv.riscv64c/sys/CHERI_QEMU

kern.supported_archs: riscv64c riscv64sfc riscv64 riscv64sf
hw.machine_arch: riscv64c
```