### PR TITLE
[UPSTREAM] Speed up newvers.sh git_tree_modified

### DIFF
--- a/sys/conf/newvers.sh
+++ b/sys/conf/newvers.sh
@@ -159,29 +159,7 @@ findvcs()
 
 git_tree_modified()
 {
-	# git diff-index lists both files that are known to have changes as
-	# well as those with metadata that does not match what is recorded in
-	# git's internal state.  The latter case is indicated by an all-zero
-	# destination file hash.
-
-	local fifo
-
-	fifo=$(mktemp -u)
-	mkfifo -m 600 "$fifo" || exit 1
-	$git_cmd "--work-tree=${VCSTOP}" diff-index HEAD > "$fifo" &
-	while read -r smode dmode ssha dsha status file; do
-		if ! expr "$dsha" : '^00*$' >/dev/null; then
-			rm "$fifo"
-			return 0
-		fi
-		if ! $git_cmd "--work-tree=${VCSTOP}" diff --quiet -- "${file}"; then
-			rm "$fifo"
-			return 0
-		fi
-	done < "$fifo"
-	# No files with content differences.
-	rm "$fifo"
-	return 1
+	$git_cmd "--work-tree=${VCSTOP}" -c core.checkStat=minimal -c core.fileMode=off diff --quiet
 }
 
 LC_ALL=C; export LC_ALL


### PR DESCRIPTION
We're looking for file content differences, so ask the question of git
more directly.  This helps a lot, saving tens of thousands of fork()s,
when the builder and editor see different stat() results (e.g., UIDs),
as they might with containers.