### PR TITLE
Add syscon power and reset control device driver for RISC-V

### DIFF
--- a/sys/conf/files
+++ b/sys/conf/files
@@ -1739,6 +1739,7 @@ dev/extres/regulator/regulator_fixed.c	optional ext_resources regulator fdt
 dev/extres/syscon/syscon.c		optional ext_resources syscon
 dev/extres/syscon/syscon_generic.c	optional ext_resources syscon fdt
 dev/extres/syscon/syscon_if.m		optional ext_resources syscon
+dev/extres/syscon/syscon_power.c	optional ext_resources syscon syscon_power fdt
 dev/fb/fbd.c			optional fbd | vt
 dev/fb/fb_if.m			standard
 dev/fb/splash.c			optional sc splash

--- a/sys/conf/files.riscv
+++ b/sys/conf/files.riscv
@@ -62,6 +62,7 @@ riscv/riscv/ofw_machdep.c	optional	fdt
 riscv/riscv/plic.c		standard
 riscv/riscv/pmap.c		standard
 riscv/riscv/riscv_console.c	optional	rcons
+riscv/riscv/riscv_syscon.c	optional	ext_resources syscon riscv_syscon fdt
 riscv/riscv/sbi.c		standard
 riscv/riscv/soc.c		standard
 riscv/riscv/stack_machdep.c	optional	ddb | stack

--- a/sys/dev/extres/syscon/syscon_power.c
+++ b/sys/dev/extres/syscon/syscon_power.c
@@ -1,0 +1,198 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2020 Jessica Clarke <jrtc27@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Driver for simple syscon poweroff and reset devices. The device tree
+ * specifications are fully described at:
+ *
+ * https://www.kernel.org/doc/Documentation/devicetree/bindings/power/reset/syscon-poweroff.txt
+ * https://www.kernel.org/doc/Documentation/devicetree/bindings/power/reset/syscon-reboot.txt
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/types.h>
+#include <sys/eventhandler.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/reboot.h>
+
+#include <machine/bus.h>
+
+#include <dev/ofw/ofw_bus.h>
+#include <dev/ofw/ofw_bus_subr.h>
+#include <dev/ofw/openfirm.h>
+
+#include "syscon_if.h"
+#include "syscon.h"
+
+struct syscon_power_softc {
+	struct syscon		*regmap;
+	uint32_t		offset;
+	uint32_t		value;
+	uint32_t		mask;
+	bool			reboot;
+	eventhandler_tag	shutdown_tag;
+};
+
+static void
+syscon_power_shutdown_final(device_t dev, int howto)
+{
+	struct syscon_power_softc *sc;
+	bool write;
+
+	sc = device_get_softc(dev);
+	if (sc->reboot)
+		write = (howto & RB_HALT) == 0;
+	else
+		write = (howto & RB_POWEROFF) != 0;
+
+	if (write)
+		SYSCON_MODIFY_4(sc->regmap, sc->offset, sc->mask,
+		    sc->value & sc->mask);
+}
+
+static int
+syscon_power_probe(device_t dev)
+{
+
+	if (!ofw_bus_status_okay(dev))
+		return (ENXIO);
+
+	if (ofw_bus_is_compatible(dev, "syscon-poweroff")) {
+		device_set_desc(dev, "Syscon poweroff");
+		return (BUS_PROBE_DEFAULT);
+	} else if (ofw_bus_is_compatible(dev, "syscon-reboot")) {
+		device_set_desc(dev, "Syscon reboot");
+		return (BUS_PROBE_DEFAULT);
+	}
+
+	return (ENXIO);
+}
+
+static int
+syscon_power_attach(device_t dev)
+{
+	struct syscon_power_softc *sc;
+	phandle_t node;
+	int error, len;
+	bool has_mask;
+
+	sc = device_get_softc(dev);
+	node = ofw_bus_get_node(dev);
+
+	if (!OF_hasprop(node, "regmap")) {
+		device_printf(dev, "could not find regmap\n");
+		return (ENXIO);
+	}
+
+	error = syscon_get_by_ofw_property(dev, node, "regmap", &sc->regmap);
+	if (error != 0) {
+		device_printf(dev, "could not get syscon\n");
+		return (ENXIO);
+	}
+
+	len = OF_getproplen(node, "offset");
+	if (len != 4) {
+		device_printf(dev, "could not get offset\n");
+		return (ENXIO);
+	}
+
+	OF_getencprop(node, "offset", &sc->offset, sizeof(sc->offset));
+
+	/* Optional mask */
+	has_mask = OF_hasprop(node, "mask");
+	if (has_mask) {
+		len = OF_getproplen(node, "mask");
+		if (len != 4) {
+			device_printf(dev, "cannot handle mask\n");
+			return (ENXIO);
+		}
+
+		OF_getencprop(node, "mask", &sc->mask, sizeof(sc->mask));
+	} else {
+		sc->mask = 0xffffffff;
+	}
+
+	/*
+	 * From the device tree specification:
+	 *
+	 *   Legacy usage: If a node doesn't contain a value property but
+	 *   contains a mask property, the mask property is used as the value.
+	 */
+	if (!OF_hasprop(node, "value")) {
+		if (!has_mask) {
+			device_printf(dev, "must have a value or a mask\n");
+			return (ENXIO);
+		}
+
+		sc->value = sc->mask;
+	} else {
+		len = OF_getproplen(node, "value");
+		if (len != 4) {
+			device_printf(dev, "cannot handle value\n");
+			return (ENXIO);
+		}
+
+		OF_getencprop(node, "value", &sc->value, sizeof(sc->value));
+	}
+
+	sc->reboot = ofw_bus_is_compatible(dev, "syscon-reboot");
+	sc->shutdown_tag = EVENTHANDLER_REGISTER(shutdown_final,
+	    syscon_power_shutdown_final, dev, SHUTDOWN_PRI_LAST);
+
+	return (0);
+}
+
+static int
+syscon_power_detach(device_t dev)
+{
+	struct syscon_power_softc *sc;
+
+	sc = device_get_softc(dev);
+	EVENTHANDLER_DEREGISTER(shutdown_final, sc->shutdown_tag);
+
+	return (0);
+}
+
+static device_method_t syscon_power_methods[] = {
+	DEVMETHOD(device_probe,		syscon_power_probe),
+	DEVMETHOD(device_attach,	syscon_power_attach),
+	DEVMETHOD(device_detach,	syscon_power_detach),
+
+	DEVMETHOD_END
+};
+
+DEFINE_CLASS_0(syscon_power, syscon_power_driver, syscon_power_methods,
+    sizeof(struct syscon_power_softc));
+static devclass_t syscon_power_devclass;
+
+DRIVER_MODULE(syscon_power, simplebus, syscon_power_driver,
+    syscon_power_devclass, NULL, NULL);

--- a/sys/riscv/conf/GENERIC
+++ b/sys/riscv/conf/GENERIC
@@ -76,6 +76,13 @@ options 	INTRNG
 # RISC-V SBI console
 device		rcons
 
+# EXT_RESOURCES pseudo devices
+options 	EXT_RESOURCES
+device		clk
+device		syscon
+device		syscon_power
+device		riscv_syscon
+
 # Bus drivers
 device		pci
 

--- a/sys/riscv/riscv/riscv_syscon.c
+++ b/sys/riscv/riscv/riscv_syscon.c
@@ -1,0 +1,84 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2018 Kyle Evans <kevans@FreeBSD.org>
+ * Copyright (c) 2020 Jessica Clarke <jrtc27@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * RISC-V syscon driver. Used as a generic interface by QEMU's virt machine for
+ * describing the SiFive test finisher as a power and reset controller.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/mutex.h>
+#include <sys/rman.h>
+#include <machine/bus.h>
+
+#include <dev/ofw/openfirm.h>
+#include <dev/ofw/ofw_bus.h>
+#include <dev/ofw/ofw_bus_subr.h>
+
+#include <dev/extres/syscon/syscon.h>
+#include <dev/extres/syscon/syscon_generic.h>
+
+static struct ofw_compat_data compat_data[] = {
+	{"sifive,test0",	1},
+	{"sifive,test1",	1},
+	{NULL,			0}
+};
+
+static int
+riscv_syscon_probe(device_t dev)
+{
+
+	if (!ofw_bus_status_okay(dev))
+		return (ENXIO);
+	if (ofw_bus_search_compatible(dev, compat_data)->ocd_data == 0)
+		return (ENXIO);
+
+	device_set_desc(dev, "RISC-V syscon");
+	return (BUS_PROBE_DEFAULT);
+}
+
+static device_method_t riscv_syscon_methods[] = {
+	DEVMETHOD(device_probe, riscv_syscon_probe),
+
+	DEVMETHOD_END
+};
+
+DEFINE_CLASS_1(riscv_syscon, riscv_syscon_driver, riscv_syscon_methods,
+    sizeof(struct syscon_generic_softc), syscon_generic_driver);
+
+static devclass_t riscv_syscon_devclass;
+/* riscv_syscon needs to attach prior to syscon_power */
+EARLY_DRIVER_MODULE(riscv_syscon, simplebus, riscv_syscon_driver,
+    riscv_syscon_devclass, 0, 0, BUS_PASS_SCHEDULER + BUS_PASS_ORDER_LAST);
+MODULE_VERSION(riscv_syscon, 1);


### PR DESCRIPTION
This device driver supports both syscon-power and syscon-reset devices,
as specified in [1] and [2]. These provide a very simple interface for
power and reset control, and among other things are used by QEMU's virt
machine on RISC-V. Thus, include them as part of the RISC-V GENERIC
kernel config.

We also need to ensure that we have attached the syscon_generic device
before attaching any syscon_power devices, and so we introduce a new
riscv_syscon device akin to aw_syscon added in r327936.

[1] https://www.kernel.org/doc/Documentation/devicetree/bindings/power/reset/syscon-poweroff.txt
[2] https://www.kernel.org/doc/Documentation/devicetree/bindings/power/reset/syscon-reboot.txt