### PR TITLE
Add AArch64 to Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ find cheribsd-test-results
     }
 }
 
-["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64"].each { suffix ->
+["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
     String name = "cheribsd-${suffix}"
     jobs[suffix] = { ->
         cheribuildProject(target: "cheribsd-${suffix}", architecture: suffix,


### PR DESCRIPTION
This ensures that we don't break the build.