### PR TITLE
Use a uint64_t for the user pointer in struct ioc_read_toc_entry64.

### DIFF
--- a/sys/cam/scsi/scsi_cd.c
+++ b/sys/cam/scsi/scsi_cd.c
@@ -244,7 +244,7 @@ struct ioc_read_toc_entry64 {
 	u_char	address_format;
 	u_char	starting_track;
 	u_short	data_len;
-	struct cd_toc_entry *data;
+	uint64_t data;  /* (struct cd_toc_entry *) */
 };
 #define	CDIOREADTOCENTRYS_64	\
     _IOC_NEWTYPE(CDIOREADTOCENTRYS, struct ioc_read_toc_entry64)
@@ -1749,8 +1749,8 @@ te_data_get_ptr(void *irtep, u_long cmd)
 		return (irteup->irte.data);
 #ifdef COMPAT_FREEBSD32
 	case sizeof(irteup->irte32):
-		return (__USER_CAP((struct cd_toc_entry *)(uintptr_t)
-		    irteup->irte32.data, irteup->irte32.data_len));
+		return (__USER_CAP(irteup->irte32.data,
+		    irteup->irte32.data_len));
 #endif
 #ifdef COMPAT_FREEBSD64
 	case sizeof(irteup->irte64):


### PR DESCRIPTION
I had this lying around in a stale branch.  I think it helps for purecap?