### PR TITLE
Purecap kernel cleanup fix

### DIFF
--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -117,19 +117,14 @@ cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
  * Test whether a capability is a subset of another.
  * This mimics the semantics of the experimental ctestsubset instruction.
  */
-static __inline bool
+static __inline _Bool
 cheri_is_subset(const void * __capability parent, const void * __capability ptr)
 {
-	if (cheri_gettag(parent) != cheri_gettag(ptr))
-		return false;
-	if (cheri_getbase(ptr) < cheri_getbase(parent))
-		return false;
-	if (cheri_getbase(ptr) + cheri_getlen(ptr) >
-	    cheri_getbase(parent) + cheri_getlen(parent))
-		return false;
-	if ((cheri_getperm(ptr) & cheri_getperm(parent)) != cheri_getperm(ptr))
-		return false;
-	return true;
+
+	return (cheri_gettag(parent) == cheri_gettag(ptr) &&
+		cheri_getbase(ptr) >= cheri_getbase(parent) &&
+		cheri_gettop(ptr) <= cheri_gettop(parent) &&
+		(cheri_getperm(ptr) & cheri_getperm(parent)) == cheri_getperm(ptr));
 }
 #endif
 

--- a/sys/compat/linux/linux_mmap.c
+++ b/sys/compat/linux/linux_mmap.c
@@ -158,7 +158,7 @@ linux_mmap_common(struct thread *td, uintptr_t addr, size_t len, int prot,
 		 * fixed size of (STACK_SIZE - GUARD_SIZE).
 		 */
 
-		if ((caddr_t)addr + len > vms->vm_maxsaddr) {
+		if (addr + len > vms->vm_maxsaddr) {
 			/*
 			 * Some Linux apps will attempt to mmap
 			 * thread stacks near the top of their


### PR DESCRIPTION
We may need this extra userland change, I'm not sure whether it is the best way to do this but we essentially need `bool` because we end up including `cheri/cheric.h` as libprocstat pretends to be the kernel when including mount.h.