### PR TITLE
Default to mounting root from /dev/ufs/root.

### DIFF
--- a/sys/mips/conf/std.MALTA
+++ b/sys/mips/conf/std.MALTA
@@ -42,7 +42,7 @@ options 	FFS			#Berkeley Fast Filesystem
 options 	SOFTUPDATES		#Enable FFS soft updates support
 options 	UFS_ACL			#Support for access control lists
 options 	UFS_DIRHASH		#Improve performance on big directories
-options 	ROOTDEVNAME=\"ufs:ada0\"
+options 	ROOTDEVNAME=\"ufs:/dev/ufs/root\nufs:ada0\"
 
 options 	GEOM_LABEL		# Provides labelization
 options 	GEOM_PART_GPT		# GUID Partition Tables.

--- a/sys/riscv/conf/FETT
+++ b/sys/riscv/conf/FETT
@@ -7,7 +7,7 @@ ident FETT
 device		virtio_random	# VirtIO Entropy device
 
 options 	HZ=100
-options 	ROOTDEVNAME=\"ufs:/dev/vtbd0\"
+options 	ROOTDEVNAME=\"ufs:/dev/ufs/root\nufs:/dev/vtbd0\"
 
 makeoptions 	KERNEL_LMA=0xc0200000
 

--- a/sys/riscv/conf/QEMU
+++ b/sys/riscv/conf/QEMU
@@ -8,7 +8,7 @@ ident QEMU
 
 options 	CPU_QEMU_RISCV
 options 	HZ=100
-options 	ROOTDEVNAME=\"ufs:/dev/vtbd0\"
+options 	ROOTDEVNAME=\"ufs:/dev/ufs/root\nufs:/dev/vtbd0\"
 
 # Access host files on QEMU
 options 	SMBFS


### PR DESCRIPTION
Fall back to the previous default if not present.  This allows us boot
independent of the existance of a partition table provided that
the root filesystem is named "root".  A followup change to cheribuild
will make this so.