### PR TITLE
Revert "Pull CHERI exception details from stval rather than sccsr."

### DIFF
--- a/sys/riscv/cheri/cheri_exception.c
+++ b/sys/riscv/cheri/cheri_exception.c
@@ -77,11 +77,11 @@ cheri_exccode_string(uint8_t exccode)
 }
 
 int
-cheri_stval_to_sicode(register_t stval)
+cheri_sccsr_to_sicode(register_t sccsr)
 {
 	uint8_t exccode;
 
-	exccode = TVAL_CAP_CAUSE(stval);
+	exccode = (sccsr & SCCSR_CAUSE_MASK) >> SCCSR_CAUSE_SHIFT;
 	switch (exccode) {
 	case CHERI_EXCCODE_LENGTH:
 		return (PROT_CHERI_BOUNDS);

--- a/sys/riscv/include/cheri.h
+++ b/sys/riscv/include/cheri.h
@@ -41,7 +41,7 @@
 /*
  * CHERI-RISC-V-specific kernel utility functions.
  */
-int	cheri_stval_to_sicode(register_t stval);
+int	cheri_sccsr_to_sicode(register_t sccsr);
 void	hybridabi_thread_setregs(struct thread *td, unsigned long entry_addr);
 #endif
 

--- a/sys/riscv/include/riscvreg.h
+++ b/sys/riscv/include/riscvreg.h
@@ -168,14 +168,10 @@
 #if __has_feature(capabilities)
 #define	SCCSR_E			(1 << 0)
 #define	SCCSR_D			(1 << 1)
-#define	TVAL_CAP_CAUSE_SHIFT	0
-#define	TVAL_CAP_CAUSE_MASK	(0x1f << TVAL_CAP_CAUSE_SHIFT)
-#define	TVAL_CAP_CAUSE(tval)						\
-	(((tval) & TVAL_CAP_CAUSE_MASK) >> TVAL_CAP_CAUSE_SHIFT)
-#define	TVAL_CAP_IDX_SHIFT	5
-#define	TVAL_CAP_IDX_MASK	(0x3f << TVAL_CAP_IDX_SHIFT)
-#define	TVAL_CAP_IDX(tval)						\
-	(((tval) & TVAL_CAP_IDX_MASK) >> TVAL_CAP_IDX_SHIFT)
+#define	SCCSR_CAUSE_SHIFT	5
+#define	SCCSR_CAUSE_MASK	(0x1f << SCCSR_CAUSE_SHIFT)
+#define	SCCSR_CAP_IDX_SHIFT	10
+#define	SCCSR_CAP_IDX_MASK	(0x3f << SCCSR_CAP_IDX_SHIFT)
 #endif
 
 #define	XLEN		__riscv_xlen


### PR DESCRIPTION
Tests failing in CI post-commit.

This reverts commit 4d705e60141a0dea8d882c96b6941d73abd6e0f6.