### PR TITLE
By design the swap test can't work on purecap.

### DIFF
--- a/bin/cheritest/Makefile
+++ b/bin/cheritest/Makefile
@@ -36,13 +36,10 @@ SRCS+=	cheritest_bounds_globals.c					\
 	cheritest_tls.c							\
 	cheritest_util.c						\
 	cheritest_vm.c							\
-	cheritest_vm_swap.c						\
 	cheritest_zlib.c
 .if ${MACHINE_ABI:Mpurecap}
 SRCS+=	cheritest_sentries.c
 .endif
-# This test is broken
-CFLAGS.cheritest_vm_swap.c+=-Wno-cheri-capability-misuse
 
 CHERITEST_DIR:=	${.PARSEDIR}
 
@@ -50,6 +47,10 @@ CHERITEST_DIR:=	${.PARSEDIR}
 SRCS+=	cheritest_cheriabi.c
 SRCS+=	cheritest_cheriabi_open.c
 .endif
+
+# This test is broken as written
+#SRCS+=	cheritest_vm_swap.c
+#CFLAGS.cheritest_vm_swap.c+=-Wno-cheri-capability-misuse
 
 .if ${MACHINE} == mips
 .PATH: ${SRCTOP}/sys/mips/cheri

--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1030,10 +1030,12 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "read capabilities from a faulted copy-on-write page",
 	  .ct_func = cheritest_vm_cow_write, },
 
+#if 0
 	{ .ct_name = "cheritest_vm_swap",
 	  .ct_desc = "check tags are swapped out by swap pager",
 	  .ct_func = cheritest_vm_swap,
 	  .ct_check_xfail = xfail_swap_required},
+#endif
 
 #ifdef CHERI_LIBCHERI_TESTS
 #if 0

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -556,9 +556,11 @@ DECLARE_CHERI_TEST(cheritest_vm_cow_read);
 DECLARE_CHERI_TEST(cheritest_vm_cow_write);
 const char	*xfail_need_writable_tmp(const char *name);
 
+#if 0
 /* cheritest_vm_swap.c */
 DECLARE_CHERI_TEST(cheritest_vm_swap);
 const char	*xfail_swap_required(const char *name);
+#endif
 
 /* cheritest_zlib.c */
 DECLARE_CHERI_TEST(test_deflate_zeroes);


### PR DESCRIPTION
(It produces arbitrary capabilities using DDC).