### PR TITLE
Avoid a race between printing the prompt and accepting input.

### DIFF
--- a/contrib/openpam/lib/libpam/openpam_ttyconv.c
+++ b/contrib/openpam/lib/libpam/openpam_ttyconv.c
@@ -94,12 +94,6 @@ prompt_tty(int ifd, int ofd, const char *message, char *response, int echo)
 	int pos, ret;
 	char ch;
 
-	/* write prompt */
-	if (write(ofd, message, strlen(message)) < 0) {
-		openpam_log(PAM_LOG_ERROR, "write(): %m");
-		return (-1);
-	}
-
 	/* turn echo off if requested */
 	slflag = 0; /* prevent bogus uninitialized variable warning */
 	if (!echo) {
@@ -113,6 +107,12 @@ prompt_tty(int ifd, int ofd, const char *message, char *response, int echo)
 			openpam_log(PAM_LOG_ERROR, "tcsetattr(): %m");
 			return (-1);
 		}
+	}
+
+	/* write prompt */
+	if (write(ofd, message, strlen(message)) < 0) {
+		openpam_log(PAM_LOG_ERROR, "write(): %m");
+		return (-1);
 	}
 
 	/* install signal handlers */


### PR DESCRIPTION
On a sufficently slow system controlled by an expect script, it's
possible to lose this race and lose some password input.