### PR TITLE
RISC-V -NODEBUG kernels

### DIFF
--- a/sys/riscv/conf/CHERI-FETT
+++ b/sys/riscv/conf/CHERI-FETT
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "FETT"
+include "std.CHERI"
+
+ident CHERI-FETT

--- a/sys/riscv/conf/CHERI-FETT-NODEBUG
+++ b/sys/riscv/conf/CHERI-FETT-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI-FETT"
+include "std.NODEBUG"
+
+ident CHERI-FETT-NODEBUG

--- a/sys/riscv/conf/CHERI-GFE
+++ b/sys/riscv/conf/CHERI-GFE
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "GFE"
+include "std.CHERI"
+
+ident CHERI-GFE

--- a/sys/riscv/conf/CHERI-GFE-NODEBUG
+++ b/sys/riscv/conf/CHERI-GFE-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI-GFE"
+include "std.NODEBUG"
+
+ident CHERI-GFE-NODEBUG

--- a/sys/riscv/conf/CHERI-QEMU
+++ b/sys/riscv/conf/CHERI-QEMU
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "QEMU"
+include "std.CHERI"
+
+ident CHERI-QEMU

--- a/sys/riscv/conf/CHERI-QEMU-MFS-ROOT
+++ b/sys/riscv/conf/CHERI-QEMU-MFS-ROOT
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI-QEMU"
+include "std.MFS-ROOT"
+
+ident CHERI-QEMU-MFS-ROOT

--- a/sys/riscv/conf/CHERI-QEMU-MFS-ROOT-NODEBUG
+++ b/sys/riscv/conf/CHERI-QEMU-MFS-ROOT-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI-QEMU-MFS-ROOT"
+include "std.NODEBUG"
+
+ident CHERI-QEMU-MFS-ROOT-NODEBUG

--- a/sys/riscv/conf/CHERI-QEMU-NODEBUG
+++ b/sys/riscv/conf/CHERI-QEMU-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI-QEMU"
+include "std.NODEBUG"
+
+ident CHERI-QEMU-NODEBUG

--- a/sys/riscv/conf/CHERI-SPIKE
+++ b/sys/riscv/conf/CHERI-SPIKE
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "SPIKE"
+include "std.CHERI"
+
+ident CHERI-SPIKE

--- a/sys/riscv/conf/CHERI-SPIKE-NODEBUG
+++ b/sys/riscv/conf/CHERI-SPIKE-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "CHERI-SPIKE"
+include "std.NODEBUG"
+
+ident CHERI-SPIKE-NODEBUG

--- a/sys/riscv/conf/CHERI_FETT
+++ b/sys/riscv/conf/CHERI_FETT
@@ -1,6 +1,3 @@
 #NO_UNIVERSE
 
-include "FETT"
-include "std.CHERI"
-
-ident CHERI_FETT
+include "CHERI-FETT"

--- a/sys/riscv/conf/CHERI_GFE
+++ b/sys/riscv/conf/CHERI_GFE
@@ -1,6 +1,3 @@
 #NO_UNIVERSE
 
-include "GFE"
-include "std.CHERI"
-
-ident CHERI_GFE
+include "CHERI-GFE"

--- a/sys/riscv/conf/CHERI_QEMU
+++ b/sys/riscv/conf/CHERI_QEMU
@@ -1,6 +1,3 @@
 #NO_UNIVERSE
 
-include "QEMU"
-include "std.CHERI"
-
-ident CHERI_QEMU
+include "CHERI-QEMU"

--- a/sys/riscv/conf/CHERI_QEMU_MFS_ROOT
+++ b/sys/riscv/conf/CHERI_QEMU_MFS_ROOT
@@ -1,6 +1,3 @@
 #NO_UNIVERSE
 
-include "CHERI_QEMU"
-include "std.MFS_ROOT"
-
-ident CHERI_QEMU_MFS_ROOT
+include "CHERI-QEMU-MFS-ROOT"

--- a/sys/riscv/conf/CHERI_SPIKE
+++ b/sys/riscv/conf/CHERI_SPIKE
@@ -1,6 +1,3 @@
 #NO_UNIVERSE
 
-include "SPIKE"
-include "std.CHERI"
-
-ident CHERI_SPIKE
+include "CHERI-SPIKE"

--- a/sys/riscv/conf/FETT-NODEBUG
+++ b/sys/riscv/conf/FETT-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "FETT"
+include "std.NODEBUG"
+
+ident FETT-NODEBUG

--- a/sys/riscv/conf/GENERIC-NODEBUG
+++ b/sys/riscv/conf/GENERIC-NODEBUG
@@ -27,16 +27,6 @@
 # $FreeBSD$
 
 include GENERIC
+include "std.NODEBUG"
 
 ident   GENERIC-NODEBUG
-
-nooptions       INVARIANTS
-nooptions       INVARIANT_SUPPORT
-nooptions       WITNESS
-nooptions       WITNESS_SKIPSPIN
-nooptions       BUF_TRACKING
-nooptions       DEADLKRES
-nooptions       FULL_BUF_TRACKING
-nooptions	COVERAGE
-nooptions	KCOV
-nooptions	MALLOC_DEBUG_MAXZONES

--- a/sys/riscv/conf/GFE
+++ b/sys/riscv/conf/GFE
@@ -1,7 +1,7 @@
 #NO_UNIVERSE
 
 include "GENERIC"
-include "std.MFS_ROOT"
+include "std.MFS-ROOT"
 
 ident GFE
 

--- a/sys/riscv/conf/GFE-NODEBUG
+++ b/sys/riscv/conf/GFE-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "GFE"
+include "std.NODEBUG"
+
+ident GFE-NODEBUG

--- a/sys/riscv/conf/QEMU-MFS-ROOT
+++ b/sys/riscv/conf/QEMU-MFS-ROOT
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "QEMU"
+include "std.MFS-ROOT"
+
+ident QEMU-MFS-ROOT

--- a/sys/riscv/conf/QEMU-MFS-ROOT-NODEBUG
+++ b/sys/riscv/conf/QEMU-MFS-ROOT-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "QEMU-MFS-ROOT"
+include "std.NODEBUG"
+
+ident QEMU-MFS-ROOT-NODEBUG

--- a/sys/riscv/conf/QEMU-NODEBUG
+++ b/sys/riscv/conf/QEMU-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "QEMU"
+include "std.NODEBUG"
+
+ident QEMU-NODEBUG

--- a/sys/riscv/conf/QEMU_MFS_ROOT
+++ b/sys/riscv/conf/QEMU_MFS_ROOT
@@ -1,6 +1,3 @@
 #NO_UNIVERSE
 
-include "QEMU"
-include "std.MFS_ROOT"
-
-ident QEMU_MFS_ROOT
+include "QEMU-MFS-ROOT"

--- a/sys/riscv/conf/SPIKE
+++ b/sys/riscv/conf/SPIKE
@@ -2,7 +2,7 @@
 
 include "GENERIC"
 # Spike does not have a disk device so we need a MFS root
-include "std.MFS_ROOT"
+include "std.MFS-ROOT"
 
 ident SPIKE
 

--- a/sys/riscv/conf/SPIKE-NODEBUG
+++ b/sys/riscv/conf/SPIKE-NODEBUG
@@ -1,0 +1,6 @@
+#NO_UNIVERSE
+
+include "SPIKE"
+include "std.NODEBUG"
+
+ident SPIKE-NODEBUG

--- a/sys/riscv/conf/std.MFS-ROOT
+++ b/sys/riscv/conf/std.MFS-ROOT
@@ -1,4 +1,4 @@
-# MFS_ROOT -- Common kernel config options for kernels with MFS root
+# MFS-ROOT -- Common kernel config options for kernels with MFS root
 
 #NO_UNIVERSE
 

--- a/sys/riscv/conf/std.NODEBUG
+++ b/sys/riscv/conf/std.NODEBUG
@@ -1,0 +1,12 @@
+# NODEBUG -- Common kernel config options for WITNESS and INVARIANTS free kernels
+
+nooptions       INVARIANTS
+nooptions       INVARIANT_SUPPORT
+nooptions       WITNESS
+nooptions       WITNESS_SKIPSPIN
+nooptions       BUF_TRACKING
+nooptions       DEADLKRES
+nooptions       FULL_BUF_TRACKING
+nooptions	COVERAGE
+nooptions	KCOV
+nooptions	MALLOC_DEBUG_MAXZONES


### PR DESCRIPTION
Also switches the canonical RISC-V kernel names to kebab-case rather than snake_case. The old names are left as aliases for compatibility.