### PR TITLE
Optionally restore historic vulnerabilities

### DIFF
--- a/sys/conf/options
+++ b/sys/conf/options
@@ -1021,3 +1021,15 @@ CPU_CHERI	opt_global.h
 # Disable system-call authorisation for compartmentalised user code.
 #
 CPU_CHERI_NO_SYSCALL_AUTHORIZE opt_global.h
+
+#
+# Enable resurected bugs for purecap kernel testing.  These vulnerabilities
+# are expected to be defeated by spatial memory safety.  The LOCAL ones
+# are believe to require local access such as a maliciously constructed
+# system call.  REMOTE ones may require a service (e.g. an nfs server) to
+# be configured.
+#
+# DO NOT ENABLE except in a controlled environment for research purposes.
+#
+ENABLE_PAST_LOCAL_VULNERABILITIES	opt_global.h
+ENABLE_PAST_REMOTE_VULNERABILITIES	opt_global.h

--- a/sys/fs/nfsserver/nfs_nfsdsocket.c
+++ b/sys/fs/nfsserver/nfs_nfsdsocket.c
@@ -828,6 +828,12 @@ nfsrvd_compound(struct nfsrv_descript *nd, int isdgram, u_char *tag,
 		*repp = *tl;
 		op = fxdr_unsigned(int, *tl);
 		NFSD_DEBUG(4, "op=%d\n", op);
+#ifdef ENABLE_PAST_REMOTE_VULNERABILITIES
+		/* FreeBSD-SA-18:13.nfs */
+		binuptime(&start_time);
+		nfsrvd_statstart(op, &start_time);
+		statsinprog = 1;
+#endif
 		if (op < NFSV4OP_ACCESS || op >= NFSV42_NOPS ||
 		    (op >= NFSV4OP_NOPS && (nd->nd_flag & ND_NFSV41) == 0) ||
 		    (op >= NFSV41_NOPS && (nd->nd_flag & ND_NFSV42) == 0)) {
@@ -840,9 +846,11 @@ nfsrvd_compound(struct nfsrv_descript *nd, int isdgram, u_char *tag,
 			repp++;
 		}
 
+#ifndef ENABLE_PAST_REMOTE_VULNERABILITIES
 		binuptime(&start_time);
 		nfsrvd_statstart(op, &start_time);
 		statsinprog = 1;
+#endif
 
 		if (i == 0)
 			op0 = op;

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -389,6 +389,24 @@ SYSINIT(diagwarn2, SI_SUB_LAST, SI_ORDER_FIFTH,
     print_caddr_t, diag_warn);
 #endif
 
+#ifdef ENABLE_PAST_LOCAL_VULNERABILITIES
+static char local_vuln_warn[] =
+    "WARNING: ENABLE_PAST_LOCAL_VULNERABILITIES option enabled.\nWARNING: Kernel contains locally-exploitable vulnerabilities.\n";
+SYSINIT(localvulnwarn, SI_SUB_COPYRIGHT, SI_ORDER_SIXTH,
+    print_caddr_t, local_vuln_warn);
+SYSINIT(localvulnwarn2, SI_SUB_LAST, SI_ORDER_SIXTH,
+    print_caddr_t, local_vuln_warn);
+#endif
+
+#ifdef ENABLE_PAST_REMOTE_VULNERABILITIES
+static char remote_vuln_warn[] =
+    "WARNING: ENABLE_PAST_REMOTE_VULNERABILITIES option enabled.\nWARNING: Kernel contains remotely-exploitable vulnerabilities!!!\n";
+SYSINIT(remotevulnwarn, SI_SUB_COPYRIGHT, SI_ORDER_SEVENTH,
+    print_caddr_t, remote_vuln_warn);
+SYSINIT(remotevulnwarn2, SI_SUB_LAST, SI_ORDER_SEVENTH,
+    print_caddr_t, remote_vuln_warn);
+#endif
+
 static int
 null_fetch_syscall_args(struct thread *td __unused)
 {

--- a/sys/kern/kern_time.c
+++ b/sys/kern/kern_time.c
@@ -1333,7 +1333,12 @@ itimer_find(struct proc *p, int timerid)
 
 	PROC_LOCK_ASSERT(p, MA_OWNED);
 	if ((p->p_itimers == NULL) ||
+#ifdef ENABLE_PAST_LOCAL_VULNERABILITIES
+	    /* FreeBSD-SA-09:06.ktimer */
+	    (timerid >= TIMER_MAX) ||
+#else
 	    (timerid < 0) || (timerid >= TIMER_MAX) ||
+#endif
 	    (it = p->p_itimers->its_timers[timerid]) == NULL) {
 		return (NULL);
 	}

--- a/sys/netinet/in_mcast.c
+++ b/sys/netinet/in_mcast.c
@@ -1710,8 +1710,11 @@ inp_get_source_filters(struct inpcb *inp, struct sockopt *sopt)
 	 * has asked for, but we always tell userland how big the
 	 * buffer really needs to be.
 	 */
+#ifndef ENABLE_PAST_LOCAL_VULNERABILITIES
+	/* FreeBSD-SA-13:09.ip_multicast */
 	if (msfr.msfr_nsrcs > in_mcast_maxsocksrc)
 		msfr.msfr_nsrcs = in_mcast_maxsocksrc;
+#endif
 	tss = NULL;
 	if (msfr.msfr_srcs != NULL && msfr.msfr_nsrcs > 0) {
 		tss = malloc(sizeof(struct sockaddr_storage) * msfr.msfr_nsrcs,

--- a/sys/netinet6/in6_mcast.c
+++ b/sys/netinet6/in6_mcast.c
@@ -1685,8 +1685,11 @@ in6p_get_source_filters(struct inpcb *inp, struct sockopt *sopt)
 	 * has asked for, but we always tell userland how big the
 	 * buffer really needs to be.
 	 */
+#ifndef ENABLE_PAST_LOCAL_VULNERABILITIES
+	/* FreeBSD-SA-13:09.ip_multicast */
 	if (msfr.msfr_nsrcs > in6_mcast_maxsocksrc)
 		msfr.msfr_nsrcs = in6_mcast_maxsocksrc;
+#endif
 	tss = NULL;
 	if (msfr.msfr_srcs != NULL && msfr.msfr_nsrcs > 0) {
 		tss = malloc(sizeof(struct sockaddr_storage) * msfr.msfr_nsrcs,


### PR DESCRIPTION
Add options to enable historic vulnerabilities as a target for attackers in red-team or capture-the-flag exercises.