### PR TITLE
Riscv fixes

### DIFF
--- a/lib/libc/db/hash/Makefile.inc
+++ b/lib/libc/db/hash/Makefile.inc
@@ -1,6 +1,8 @@
 #       from @(#)Makefile.inc	8.1 (Berkeley) 6/4/93
 # $FreeBSD$
 
+.include <src.opts.mk>
+
 .PATH: ${LIBC_SRCTOP}/db/hash
 
 SRCS+=	hash.c hash_bigkey.c hash_buf.c hash_func.c hash_log2.c \

--- a/libexec/rtld-cheri-elf-debug/Makefile
+++ b/libexec/rtld-cheri-elf-debug/Makefile
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+.include <src.opts.mk>
+
 .if ${MACHINE_ABI:Mpurecap}
 PROG=ld-elf-debug.so.1
 .else

--- a/libexec/rtld-cheri-elf/tests/abi-mismatch/Makefile
+++ b/libexec/rtld-cheri-elf/tests/abi-mismatch/Makefile
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+.include <src.opts.mk>
+
 TESTSDIR=	${TESTSBASE}/libexec/rtld-cheri-elf/abi-mismatch
 
 # Disable when building a pure-cap world as we don't support

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -474,3 +474,20 @@ CFLAGS_NO_SIMD += ${CFLAGS_NO_SIMD.${COMPILER_TYPE}}
 CFLAGS += ${CFLAGS.${MACHINE_ARCH}}
 CXXFLAGS += ${CXXFLAGS.${MACHINE_ARCH}}
 
+#
+# MACHINE_ABI is a list of properties about the ABI used for MACHINE_ARCH.
+#
+.if (${MACHINE_ARCH:Mmips*} && !${MACHINE_ARCH:Mmips*hf*}) || ${MACHINE_ARCH:Mriscv*sf*}
+MACHINE_ABI+=	soft-float
+.else
+MACHINE_ABI+=	hard-float
+.endif
+.if (${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
+MACHINE_ABI+=	purecap
+.endif
+# Currently all 64-bit architectures include 64 in their name (see arch(7)).
+.if ${MACHINE_ARCH:M*64*}
+MACHINE_ABI+=	ptr64
+.else
+MACHINE_ABI+=	ptr32
+.endif

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -16,21 +16,6 @@ unix		?=	We run FreeBSD, not UNIX.
 __TO_CPUARCH=C/mips(n32|64)?(el)?(hf)?(c(128|256))?/mips/:C/arm(v[67])?(eb)?/arm/:C/powerpc(64|spe)/powerpc/:C/riscv64(sf)?c?/riscv/
 MACHINE_CPUARCH=${MACHINE_ARCH:${__TO_CPUARCH}}
 .endif
-.if (${MACHINE_ARCH:Mmips*} && !${MACHINE_ARCH:Mmips*hf*}) || ${MACHINE_ARCH:Mriscv*sf*}
-MACHINE_ABI+=	soft-float
-.else
-MACHINE_ABI+=	hard-float
-.endif
-.if (${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
-MACHINE_ABI+=	purecap
-.endif
-# Currently all 64-bit architectures include 64 in their name (see arch(7)).
-.if ${MACHINE_ARCH:M*64*}
-MACHINE_ABI+=	ptr64
-.else
-MACHINE_ABI+=	ptr32
-.endif
-
 
 __DEFAULT_YES_OPTIONS+= \
 	UNIFIED_OBJDIR

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -135,11 +135,7 @@ INLINE_LIMIT?=	8000
 # code model as "medium" and "medany" respectively.
 #
 .if ${MACHINE_CPUARCH} == "riscv"
-.if ${MACHINE_ARCH:Mriscv*sf}
-RISCV_MARCH=	rv64imac
-.else
 RISCV_MARCH=	rv64imafdc
-.endif
 .if ${MACHINE_CPU:Mcheri}
 RISCV_MARCH:=	${RISCV_MARCH}xcheri
 .endif


### PR DESCRIPTION
The second change is required so that `MACHINE_ABI` is set correctly in kern*.mk which purecap kernels need.