### PR TITLE
Archive sysroot, images and kernels in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ def jobProperties = [rateLimitBuilds([count: 1, durationName: 'hour', userBoost:
 def archiveBranches = ['master', 'dev']
 if (/* !env.CHANGE_ID && archiveBranches.contains(env.BRANCH_NAME) */ true) {
     GlobalVars.archiveArtifacts = true
-    cheribuildArgs.add("--use-all-cores")
     // For branches other than the master branch, only keep the last two artifacts to save disk space
     if (env.BRANCH_NAME != 'master') {
         jobProperties.add(buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2')))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,15 @@ rm -rf tarball
 mkdir tarball && mv -f cherisdk/sysroot tarball/sysroot
 ./cheribuild/jenkins-cheri-build.py --tarball cheribsd-sysroot-${suffix} --tarball-name cheribsd-sysroot.tar.xz
 ls -la
+# Seems like some Java versions require write permissions:
+# java.nio.file.AccessDeniedException: /usr/local/jenkins/jobs/CheriBSD-pipeline/branches/PR-616/builds/14/archive/kernel.xz
+#	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84)
+#	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
+#	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
+#	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
+#	at java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:434)
+#	at java.nio.file.Files.newOutputStream(Files.java:216)
+chmod +w *.xz
 """
             archiveArtifacts allowEmptyArchive: false, artifacts: "cheribsd-sysroot.tar.xz, *.img.xz, kernel*.xz", fingerprint: true, onlyIfSuccessful: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,11 +83,13 @@ find cheribsd-test-results
             }
             // Use xz -T0 to speed up compression by using multiple threads
             sh label: 'Compress kernel and images', script: 'xz -T0 *.img kernel*'
-	    sh 'find . -maxdepth 2'
+            // Create sysroot archive (this is installed to cherisdk rather than the tarball)
+            sh label: 'Create sysroot archive', script: """
+mkdir tarball && mv -f cherisdk/sysroot tarball/sysroot
+./cheribuild/jenkins-cheri-build.py --tarball cheribsd-sysroot-${suffix} --tarball-name cheribsd-sysroot
+ls -la
+"""
             archiveArtifacts allowEmptyArchive: false, artifacts: "*.img.xz, kernel*.xz", fingerprint: true, onlyIfSuccessful: true
-            // Archive sysroot (this is installed to cherisdk rather than the tarball)
-            sh 'mkdir tarball && mv -f cherisdk/sysroot tarball/sysroot'
-            sh "./cheribuild/jenkins-cheri-build.py --tarball cheribsd-sysroot-${suffix} --tarball-name cheribsd-sysroot"
             archiveArtifacts allowEmptyArchive: false, artifacts: "cheribsd-sysroot.tar.xz", fingerprint: true, onlyIfSuccessful: true
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ find cheribsd-test-results
                 customGitCheckoutDir: 'cheribsd',
                 gitHubStatusContext: "ci/${suffix}",
                 // Delete stale compiler/sysroot
-                beforeBuild: { params -> dir('cherisdk') { deleteDir() }
+                beforeBuild: { params -> dir('cherisdk') { deleteDir() } },
                 /* Custom function to run tests since --test will not work (yet) */
                 runTests: false, afterBuild: { params -> buildImageAndRunTests(params, suffix) })
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,8 @@ find cheribsd-test-results
             }
             // Use xz -T0 to speed up compression by using multiple threads
             sh label: 'Compress kernel and images', script: 'xz -T0 *.img kernel*'
-            archiveArtifacts allowEmptyArchive: false, artifacts: "*.img.xz kernel*.xz", fingerprint: true, onlyIfSuccessful: true
+	    sh 'find . -maxdepth 2'
+            archiveArtifacts allowEmptyArchive: false, artifacts: "*.img.xz, kernel*.xz", fingerprint: true, onlyIfSuccessful: true
             // Archive sysroot (this is installed to cherisdk rather than the tarball)
             sh 'mkdir tarball && mv -f cherisdk/sysroot tarball/sysroot'
             sh "./cheribuild/jenkins-cheri-build.py --tarball cheribsd-syroot-${suffix} --tarball-name cheribsd-sysroot"
@@ -92,7 +93,8 @@ find cheribsd-test-results
     }
 }
 
-["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
+// ["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
+["mips-nocheri", "riscv64", "aarch64"].each { suffix ->
     String name = "cheribsd-${suffix}"
     jobs[suffix] = { ->
         cheribuildProject(target: "cheribsd-${suffix}", architecture: suffix,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,15 +91,15 @@ find cheribsd-test-results
 
 ["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
     String name = "cheribsd-${suffix}"
-    jobs[suffix] = { ->
-        // Delete stale compiler/sysroot
-        dir('cherisdk') { deleteDir() }
+    jobs[suffix] = { ->        
         cheribuildProject(target: "cheribsd-${suffix}", architecture: suffix,
                 extraArgs: '--cheribsd/build-options=-s --cheribsd/no-debug-info --keep-install-dir --install-prefix=/rootfs --cheribsd/build-tests',
                 skipArchiving: true, skipTarball: true,
                 sdkCompilerOnly: true, // We only need clang not the CheriBSD sysroot since we are building that.
                 customGitCheckoutDir: 'cheribsd',
                 gitHubStatusContext: "ci/${suffix}",
+                // Delete stale compiler/sysroot
+                beforeBuild: { params -> dir('cherisdk') { deleteDir() }
                 /* Custom function to run tests since --test will not work (yet) */
                 runTests: false, afterBuild: { params -> buildImageAndRunTests(params, suffix) })
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ find cheribsd-test-results
     if (GlobalVars.archiveArtifacts) {
         stage("Archiving artifacts") {
             // Archive disk image
-	    sh 'rm -fv *.img *.xz && mv -v tarball/*.img /rootfs/boot/kernel/kernel .'
+	    sh 'rm -fv *.img *.xz && mv -v tarball/*.img tarball/rootfs/boot/kernel/kernel .'
             dir('tarball') {
                 sh 'find . -maxdepth 2'
                 deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ find cheribsd-test-results
 
 ["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
     String name = "cheribsd-${suffix}"
-    jobs[suffix] = { ->        
+    jobs[suffix] = { ->
         cheribuildProject(target: "cheribsd-${suffix}", architecture: suffix,
                 extraArgs: '--cheribsd/build-options=-s --cheribsd/no-debug-info --keep-install-dir --install-prefix=/rootfs --cheribsd/build-tests',
                 skipArchiving: true, skipTarball: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ find cheribsd-test-results
             archiveArtifacts allowEmptyArchive: false, artifacts: "*.img.xz, kernel*.xz", fingerprint: true, onlyIfSuccessful: true
             // Archive sysroot (this is installed to cherisdk rather than the tarball)
             sh 'mkdir tarball && mv -f cherisdk/sysroot tarball/sysroot'
-            sh "./cheribuild/jenkins-cheri-build.py --tarball cheribsd-syroot-${suffix} --tarball-name cheribsd-sysroot"
+            sh "./cheribuild/jenkins-cheri-build.py --tarball cheribsd-sysroot-${suffix} --tarball-name cheribsd-sysroot"
             archiveArtifacts allowEmptyArchive: false, artifacts: "cheribsd-sysroot.tar.xz", fingerprint: true, onlyIfSuccessful: true
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,7 @@ chmod +w *.xz
     }
 }
 
-// ["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
-["mips-nocheri", "riscv64", "aarch64"].each { suffix ->
+["mips-nocheri", "mips-hybrid", "mips-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap", "amd64", "aarch64"].each { suffix ->
     String name = "cheribsd-${suffix}"
     jobs[suffix] = { ->
         cheribuildProject(target: "cheribsd-${suffix}", architecture: suffix,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def jobProperties = [rateLimitBuilds([count: 1, durationName: 'hour', userBoost:
 ]
 // Don't archive sysroot/disk image/kernel images for pull requests and non-default branches:
 def archiveBranches = ['master', 'dev']
-if (/* !env.CHANGE_ID && archiveBranches.contains(env.BRANCH_NAME) */ true) {
+if (!env.CHANGE_ID && archiveBranches.contains(env.BRANCH_NAME)) {
     GlobalVars.archiveArtifacts = true
     // For branches other than the master branch, only keep the last two artifacts to save disk space
     if (env.BRANCH_NAME != 'master') {


### PR DESCRIPTION
This is only done for the master and dev branches to avoid
wasting space. The dev branch also only retains the last two
builds for the same reason.

This should allow migrating downstream jobs to using the sysroot
and kernel provided by this job.