### PR TITLE
Small additions to cheritest

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -265,6 +265,15 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_si_trapno = TRAPNO_CHERI },
 #endif
 
+#if __has_builtin(__builtin_cheri_cap_load_tags) && defined(__mips__)
+	{ .ct_name = "test_fault_cloadtags_misaligned",
+	  .ct_desc = "CLoadTags on not-cacheline-aligned address",
+	  .ct_func = test_fault_cloadtags_misaligned,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGBUS,
+	  .ct_si_trapno = T_ADDR_ERR_LD, },
+#endif
+
 	/*
 	 * Tests on the kernel-provided sealing capability (sealcap).
 	 */
@@ -1035,6 +1044,19 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "check tags are swapped out by swap pager",
 	  .ct_func = cheritest_vm_swap,
 	  .ct_check_xfail = xfail_swap_required},
+#endif
+
+#if __has_builtin(__builtin_cheri_cap_load_tags) && defined(__mips__)
+	{ .ct_name = "test_fault_cloadtags_mapped",
+	  .ct_desc = "CLoadTags on mapped address",
+	  .ct_func = test_cloadtags_mapped, },
+
+	{ .ct_name = "test_fault_cloadtags_unmapped",
+	  .ct_desc = "CLoadTags on unmapped address",
+	  .ct_func = test_fault_cloadtags_unmapped,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGSEGV,
+	  .ct_si_trapno = T_TLB_LD_MISS, },
 #endif
 
 #ifdef CHERI_LIBCHERI_TESTS

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -367,6 +367,9 @@ DECLARE_CHERI_TEST(test_fault_read_kr2c);
 DECLARE_CHERI_TEST(test_fault_read_kcc);
 DECLARE_CHERI_TEST(test_fault_read_kdc);
 DECLARE_CHERI_TEST(test_fault_read_epcc);
+#if __has_builtin(__builtin_cheri_cap_load_tags) && defined(__mips__)
+DECLARE_CHERI_TEST(test_fault_cloadtags_misaligned);
+#endif
 DECLARE_CHERI_TEST(test_nofault_ccheck_user_pass);
 
 /* cheritest_fd.c */
@@ -555,6 +558,10 @@ DECLARE_CHERI_TEST(cheritest_vm_tag_tmpfile_private);
 DECLARE_CHERI_TEST(cheritest_vm_tag_tmpfile_private_prefault);
 DECLARE_CHERI_TEST(cheritest_vm_cow_read);
 DECLARE_CHERI_TEST(cheritest_vm_cow_write);
+#if __has_builtin(__builtin_cheri_cap_load_tags)
+DECLARE_CHERI_TEST(test_cloadtags_mapped);
+DECLARE_CHERI_TEST(test_fault_cloadtags_unmapped);
+#endif
 const char	*xfail_need_writable_tmp(const char *name);
 
 #if 0

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -267,7 +267,7 @@ test_fault_read_epcc(const struct cheri_test *ctp __unused)
 void
 test_fault_cloadtags_misaligned(const struct cheri_test *ctp __unused)
 {
-	uint64_t tags = 0xDEADFEED;
+	uint64_t tags;
 	void * __capability p[20] __attribute__((aligned(512))) = { 0 } ;
 	void * __capability c = &p[1];
 

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -262,3 +262,19 @@ test_fault_read_epcc(const struct cheri_test *ctp __unused)
 	CHERI_CAP_PRINT(cheri_getepcc());
 }
 #endif	/* __mips__ */
+
+#if __has_builtin(__builtin_cheri_cap_load_tags) && defined(__mips__)
+void
+test_fault_cloadtags_misaligned(const struct cheri_test *ctp __unused)
+{
+	uint64_t tags = 0xDEADFEED;
+	void * __capability p[20] __attribute__((aligned(512))) = { 0 } ;
+	void * __capability c = &p[1];
+
+	tags = __builtin_cheri_cap_load_tags(c);
+
+	printf("cloadtags misaligned left tags=0x%" PRIx64 "\n", tags);
+
+	cheritest_success();
+}
+#endif

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -193,9 +193,8 @@ cheritest_vm_shm_open_anon_unix_surprise(const struct cheri_test *ctp __unused)
 						0));
 		c = *map;
 
-		fprintf(stderr, "rx cap: v:%lu b:%016jx l:%016zx o:%jx\n",
-			(unsigned long)cheri_gettag(c), cheri_getbase(c),
-			cheri_getlen(c), cheri_getoffset(c));
+		fprintf(stderr, "rx cap: ", _CHERI_PRINTF_CAP_FMT "\n",
+			_CHERI_PRINTF_CAP_ARG(c));
 
 		tag = cheri_gettag(c);
 		CHERITEST_VERIFY2(tag == 0, "tag read");
@@ -229,9 +228,8 @@ cheritest_vm_shm_open_anon_unix_surprise(const struct cheri_test *ctp __unused)
 		c = *map;
 		CHERITEST_VERIFY2(cheri_gettag(c) != 0, "tag written");
 
-		fprintf(stderr, "tx cap: v:%lu b:%016jx l:%016zx o:%jx\n",
-			(unsigned long)cheri_gettag(c), cheri_getbase(c),
-			cheri_getlen(c), cheri_getoffset(c));
+		fprintf(stderr, "tx cap: ", _CHERI_PRINTF_CAP_FMT "\n",
+			_CHERI_PRINTF_CAP_ARG(c));
 
 		CHERITEST_CHECK_SYSCALL(munmap(map, getpagesize()));
 

--- a/bin/cheritest/cheritest_vm.c
+++ b/bin/cheritest/cheritest_vm.c
@@ -194,7 +194,7 @@ cheritest_vm_shm_open_anon_unix_surprise(const struct cheri_test *ctp __unused)
 		c = *map;
 
 		fprintf(stderr, "rx cap: ", _CHERI_PRINTF_CAP_FMT "\n",
-			_CHERI_PRINTF_CAP_ARG(c));
+		    _CHERI_PRINTF_CAP_ARG(c));
 
 		tag = cheri_gettag(c);
 		CHERITEST_VERIFY2(tag == 0, "tag read");
@@ -229,7 +229,7 @@ cheritest_vm_shm_open_anon_unix_surprise(const struct cheri_test *ctp __unused)
 		CHERITEST_VERIFY2(cheri_gettag(c) != 0, "tag written");
 
 		fprintf(stderr, "tx cap: ", _CHERI_PRINTF_CAP_FMT "\n",
-			_CHERI_PRINTF_CAP_ARG(c));
+		    _CHERI_PRINTF_CAP_ARG(c));
 
 		CHERITEST_CHECK_SYSCALL(munmap(map, getpagesize()));
 
@@ -615,7 +615,7 @@ test_cloadtags_mapped(const struct cheri_test *ctp __unused)
 	void * __capability * p;
 
 	p = CHERITEST_CHECK_SYSCALL(mmap(0, PAGE_SIZE, PROT_READ | PROT_WRITE,
-					 MAP_ANON, -1, 0));
+	    MAP_ANON, -1, 0));
 	c = (__cheri_tocap void * __capability * __capability)p;
 
 	p[1] = c;
@@ -624,7 +624,7 @@ test_cloadtags_mapped(const struct cheri_test *ctp __unused)
 	tags = __builtin_cheri_cap_load_tags(c);
 
 	CHERITEST_VERIFY2(tags == 0x6,
-		"incorrect result from cloadtags, 0x%" PRIx64 "\n", tags);
+	    "incorrect result from cloadtags, 0x%" PRIx64 "\n", tags);
 
 	munmap(p, PAGE_SIZE);
 	cheritest_success();
@@ -633,12 +633,12 @@ test_cloadtags_mapped(const struct cheri_test *ctp __unused)
 void
 test_fault_cloadtags_unmapped(const struct cheri_test *ctp __unused)
 {
-	uint64_t tags = 0;
+	uint64_t tags;
 	void * __capability c;
 	void * p;
 
 	p = CHERITEST_CHECK_SYSCALL(mmap(0, PAGE_SIZE, PROT_READ | PROT_WRITE,
-					 MAP_ANON, -1, 0));
+	    MAP_ANON, -1, 0));
 	munmap(p, PAGE_SIZE);
 	c = (__cheri_tocap void * __capability)p;
 


### PR DESCRIPTION
And some tweaks.

Extracted from the long-lived `caprevoke` branch.  No reason, I think, that these can't land in the tree independent of that work, tho'.