### PR TITLE
Set ksi_addr to badvaddr for all TLB faults regardless of signal.

### DIFF
--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -973,6 +973,8 @@ dofault:
 				}
 				goto err;
 			}
+			addr = (void * __capability)(intcap_t)
+			    trapframe->badvaddr;
 
 			msg = "BAD_PAGE_FAULT";
 			log_bad_page_fault(msg, trapframe, type);
@@ -1166,6 +1168,8 @@ dofault:
 		    CHERI_EXCCODE_TLBSTORE) {
 			i = SIGSEGV;
 			ucode = SEGV_STORETAG;
+			addr = (void * __capability)(intcap_t)
+			    trapframe->badvaddr;
 		} else {
 			i = SIGPROT;
 			ucode = cheri_capcause_to_sicode(trapframe->capcause);
@@ -1390,8 +1394,6 @@ err:
 	ksiginfo_init_trap(&ksi);
 	ksi.ksi_signo = i;
 	ksi.ksi_code = ucode;
-	if (i == SIGSEGV)
-		addr = (void * __capability)(intcap_t)trapframe->badvaddr;
 	/* XXXBD: probably not quite right for CheriABI */
 	ksi.ksi_addr = addr;
 	ksi.ksi_trapno = type & ~T_USER;


### PR DESCRIPTION
This is what I merged upstream to FreeBSD.