### PR TITLE
Fix NFSv4 exports.

### DIFF
--- a/sys/fs/nfs/nfsport.h
+++ b/sys/fs/nfs/nfsport.h
@@ -1077,7 +1077,7 @@ bool ncl_pager_setsize(struct vnode *vp, u_quad_t *nsizep);
  * Define a structure similar to ufs_args for use in exporting the V4 root.
  */
 struct nfsex_args {
-	char	*fspec;
+	char * __kerncap	fspec;
 	struct export_args	export;
 };
 

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -3270,7 +3270,7 @@ nfsrv_v4rootexport(void *argp, struct ucred *cred, struct thread *p)
 		/*
 		 * If fspec != NULL, this is the v4root path.
 		 */
-		NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE,
+		NDINIT_C(&nd, LOOKUP, FOLLOW, UIO_USERSPACE,
 		    nfsexargp->fspec, p);
 		if ((error = namei(&nd)) != 0)
 			goto out;
@@ -3679,7 +3679,7 @@ nfssvc_srvcall(struct thread *p, struct nfssvc_args *uap, struct ucred *cred)
 		if (!error)
 			nfs_pubfhset = 1;
 	} else if (uap->flag & NFSSVC_V4ROOTEXPORT) {
-		error = copyin(uap->argp,(caddr_t)&export,
+		error = copyincap(uap->argp,(caddr_t)&export,
 		    sizeof (struct nfsex_args));
 		if (!error)
 			error = nfsrv_v4rootexport(&export, cred, p);


### PR DESCRIPTION
struct nfsex_args contains pointers and requires both annotation
and the use of copyincap().