### PR TITLE
Use ct1 as the target of cjr when entering/exiting capmode.

### DIFF
--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -135,9 +135,9 @@ __FBSDID("$FreeBSD$");
 	cspecialw ddc, ct0
 
 	/* Switch to non-capmode PCC. */
-	cllc	ct0, 1f
-	csetflags ct0, ct0, x0
-	cjr	ct0
+	cllc	ct1, 1f
+	csetflags ct1, ct1, x0
+	cjr	ct1
 .option pop
 1:
 #else
@@ -221,12 +221,12 @@ __FBSDID("$FreeBSD$");
 
 #if __has_feature(capabilities)
 	/* Switch to capmode PCC. */
-	lla	t1, 1f
-	cspecialr ct0, pcc
-	csetaddr ct0, ct0, t1
-	li	t1, 1
-	csetflags ct0, ct0, t1
-	cjr	ct0
+	lla	t0, 1f
+	cspecialr ct1, pcc
+	csetaddr ct1, ct1, t0
+	li	t0, 1
+	csetflags ct1, ct1, t0
+	cjr	ct1
 .option push
 .option capmode
 1:

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -474,12 +474,12 @@ ENTRY(fork_trampoline)
 
 #if __has_feature(capabilities)
 	/* Switch to capmode PCC. */
-	lla	t1, 1f
-	cspecialr ct0, pcc
-	csetaddr ct0, ct0, t1
-	li	t1, 1
-	csetflags ct0, ct0, t1
-	cjr	ct0
+	lla	t0, 1f
+	cspecialr ct1, pcc
+	csetaddr ct1, ct1, t0
+	li	t0, 1
+	csetflags ct1, ct1, t0
+	cjr	ct1
 .option push
 .option capmode
 1:


### PR DESCRIPTION
ct0 is the alternate link register, so u-arch's might infer incorrect
branch prediction hints from these jumps.