### PR TITLE
Remove NDINIT_*C

### DIFF
--- a/sys/cam/ctl/ctl_backend_block.c
+++ b/sys/cam/ctl/ctl_backend_block.c
@@ -2145,7 +2145,8 @@ ctl_be_block_open(struct ctl_be_block_lun *be_lun, struct ctl_lun_req *req)
 		flags |= FWRITE;
 
 again:
-	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, be_lun->dev_path, curthread);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(be_lun->dev_path),
+	    curthread);
 	error = vn_open(&nd, &flags, 0, NULL);
 	if ((error == EROFS || error == EACCES) && (flags & FWRITE)) {
 		flags &= ~FWRITE;

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_kobj.c
@@ -73,7 +73,7 @@ kobj_open_file_vnode(const char *file)
 	pwd_ensure_dirs();
 
 	flags = FREAD | O_NOFOLLOW;
-	NDINIT(&nd, LOOKUP, 0, UIO_SYSSPACE, file, td);
+	NDINIT(&nd, LOOKUP, 0, UIO_SYSSPACE, PTR2CAP(file), td);
 	error = vn_open_cred(&nd, &flags, 0, 0, curthread->td_ucred, NULL);
 	if (error != 0)
 		return (NULL);

--- a/sys/cddl/compat/opensolaris/kern/opensolaris_lookup.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_lookup.c
@@ -35,7 +35,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/vnode.h>
 
 int
-lookupname(char *dirname, enum uio_seg seg, enum symfollow follow,
+lookupname(char * __capability dirname, enum uio_seg seg, enum symfollow follow,
     vnode_t **dirvpp, vnode_t **compvpp)
 {
 
@@ -43,7 +43,7 @@ lookupname(char *dirname, enum uio_seg seg, enum symfollow follow,
 }
 
 int
-lookupnameat(char *dirname, enum uio_seg seg, enum symfollow follow,
+lookupnameat(char * __capability dirname, enum uio_seg seg, enum symfollow follow,
     vnode_t **dirvpp, vnode_t **compvpp, vnode_t *startvp)
 {
 	struct nameidata nd;

--- a/sys/cddl/compat/opensolaris/sys/pathname.h
+++ b/sys/cddl/compat/opensolaris/sys/pathname.h
@@ -34,9 +34,10 @@
 #include <sys/param.h>
 #include <sys/vnode.h>
 
-int lookupname(char *, enum uio_seg, enum symfollow, vnode_t **, vnode_t **);
-int lookupnameat(char *, enum uio_seg, enum symfollow, vnode_t **, vnode_t **,
-    vnode_t *);
+int lookupname(char * __capability, enum uio_seg, enum symfollow, vnode_t **,
+    vnode_t **);
+int lookupnameat(char * __capability, enum uio_seg, enum symfollow, vnode_t **,
+    vnode_t **, vnode_t *);
 
 #endif	/* _KERNEL */
 

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -179,7 +179,8 @@ vn_openat(char *pnamep, enum uio_seg seg, int filemode, int createmode,
 
 	if (startvp != NULL)
 		vref(startvp);
-	NDINIT_ATVP(&nd, operation, 0, UIO_SYSSPACE, pnamep, startvp, td);
+	NDINIT_ATVP(&nd, operation, 0, UIO_SYSSPACE, PTR2CAP(pnamep), startvp,
+	    td);
 	filemode |= O_NOFOLLOW;
 	error = vn_open_cred(&nd, &filemode, createmode, 0, td->td_ucred, NULL);
 	NDFREE(&nd, NDF_ONLY_PNBUF);

--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -267,8 +267,8 @@ cloudabi_sys_file_open(struct thread *td,
 		fdrop(fp, td);
 		return (error);
 	}
-	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, path, uap->dirfd.fd,
-	    &rights, td);
+	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(path),
+	    uap->dirfd.fd, &rights, td);
 	error = vn_open(&nd, &fflags, 0777 & ~td->td_proc->p_fd->fd_cmask, fp);
 	cloudabi_freestr(path);
 	if (error != 0) {

--- a/sys/fs/cd9660/cd9660_vfsops.c
+++ b/sys/fs/cd9660/cd9660_vfsops.c
@@ -161,7 +161,8 @@ cd9660_mount(struct mount *mp)
 	 * Not an update, or updating the name: look up the name
 	 * and verify that it refers to a sensible block device.
 	 */
-	NDINIT(&ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, fspec, td);
+	NDINIT(&ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(fspec),
+	    td);
 	if ((error = namei(&ndp)))
 		return (error);
 	NDFREE(&ndp, NDF_ONLY_PNBUF);

--- a/sys/fs/ext2fs/ext2_vfsops.c
+++ b/sys/fs/ext2fs/ext2_vfsops.c
@@ -241,7 +241,8 @@ ext2_mount(struct mount *mp)
 	 */
 	if (fspec == NULL)
 		return (EINVAL);
-	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, fspec, td);
+	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(fspec),
+	    td);
 	if ((error = namei(ndp)) != 0)
 		return (error);
 	NDFREE(ndp, NDF_ONLY_PNBUF);

--- a/sys/fs/fuse/fuse_vfsops.c
+++ b/sys/fs/fuse/fuse_vfsops.c
@@ -149,7 +149,7 @@ fuse_getdevice(const char *fspec, struct thread *td, struct cdev **fdevp)
 	 * and verify that it refers to a sensible disk device.
 	 */
 
-	NDINIT(ndp, LOOKUP, FOLLOW, UIO_SYSSPACE, fspec, td);
+	NDINIT(ndp, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(fspec), td);
 	if ((err = namei(ndp)) != 0)
 		return err;
 	NDFREE(ndp, NDF_ONLY_PNBUF);

--- a/sys/fs/msdosfs/msdosfs_vfsops.c
+++ b/sys/fs/msdosfs/msdosfs_vfsops.c
@@ -338,7 +338,8 @@ msdosfs_mount(struct mount *mp)
 	 */
 	if (vfs_getopt(mp->mnt_optnew, "from", (void **)&from, NULL))
 		return (EINVAL);
-	NDINIT(&ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, from, td);
+	NDINIT(&ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(from),
+	    td);
 	error = namei(&ndp);
 	if (error)
 		return (error);

--- a/sys/fs/nfs/nfs_commonport.c
+++ b/sys/fs/nfs/nfs_commonport.c
@@ -242,7 +242,7 @@ nfsrv_lookupfilename(struct nameidata *ndp, char * __capability fname, NFSPROC_T
 {
 	int error;
 
-	NDINIT_C(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE, fname,
+	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_USERSPACE, fname,
 	    p);
 	error = namei(ndp);
 	if (!error) {

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -3270,7 +3270,7 @@ nfsrv_v4rootexport(void *argp, struct ucred *cred, struct thread *p)
 		/*
 		 * If fspec != NULL, this is the v4root path.
 		 */
-		NDINIT_C(&nd, LOOKUP, FOLLOW, UIO_USERSPACE,
+		NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE,
 		    nfsexargp->fspec, p);
 		if ((error = namei(&nd)) != 0)
 			goto out;

--- a/sys/fs/nfsserver/nfs_nfsdstate.c
+++ b/sys/fs/nfsserver/nfs_nfsdstate.c
@@ -7604,7 +7604,7 @@ nfsrv_setdsserver(char *dspathp, char *mdspathp, NFSPROC_T *p,
 	NFSD_DEBUG(4, "setdssrv path=%s\n", dspathp);
 	*dsp = NULL;
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF, UIO_SYSSPACE,
-	    dspathp, p);
+	    PTR2CAP(dspathp), p);
 	error = namei(&nd);
 	NFSD_DEBUG(4, "lookup=%d\n", error);
 	if (error != 0)
@@ -7640,7 +7640,7 @@ nfsrv_setdsserver(char *dspathp, char *mdspathp, NFSPROC_T *p,
 	for (i = 0; i < nfsrv_dsdirsize; i++) {
 		snprintf(dsdirpath, dsdirsize, "%s/ds%d", dspathp, i);
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF,
-		    UIO_SYSSPACE, dsdirpath, p);
+		    UIO_SYSSPACE, PTR2CAP(dsdirpath), p);
 		error = namei(&nd);
 		NFSD_DEBUG(4, "dsdirpath=%s lookup=%d\n", dsdirpath, error);
 		if (error != 0)
@@ -7668,7 +7668,7 @@ nfsrv_setdsserver(char *dspathp, char *mdspathp, NFSPROC_T *p,
 		 * system.
 		 */
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF,
-		    UIO_SYSSPACE, mdspathp, p);
+		    UIO_SYSSPACE, PTR2CAP(mdspathp), p);
 		error = namei(&nd);
 		NFSD_DEBUG(4, "mds lookup=%d\n", error);
 		if (error != 0)
@@ -8528,7 +8528,7 @@ nfsrv_mdscopymr(char *mdspathp, char *dspathp, char *curdspathp, char *buf,
 	 */
 	NFSD_DEBUG(4, "mdsopen path=%s\n", mdspathp);
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF, UIO_SYSSPACE,
-	    mdspathp, p);
+	    PTR2CAP(mdspathp), p);
 	error = namei(&nd);
 	NFSD_DEBUG(4, "lookup=%d\n", error);
 	if (error != 0)
@@ -8547,7 +8547,7 @@ nfsrv_mdscopymr(char *mdspathp, char *dspathp, char *curdspathp, char *buf,
 		 */
 		NFSD_DEBUG(4, "curmdsdev path=%s\n", curdspathp);
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF,
-		    UIO_SYSSPACE, curdspathp, p);
+		    UIO_SYSSPACE, PTR2CAP(curdspathp), p);
 		error = namei(&nd);
 		NFSD_DEBUG(4, "ds lookup=%d\n", error);
 		if (error != 0) {
@@ -8587,7 +8587,7 @@ nfsrv_mdscopymr(char *mdspathp, char *dspathp, char *curdspathp, char *buf,
 		/* Look up the nfsdev path and find the nfsdev structure. */
 		NFSD_DEBUG(4, "mdsdev path=%s\n", dspathp);
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF,
-		    UIO_SYSSPACE, dspathp, p);
+		    UIO_SYSSPACE, PTR2CAP(dspathp), p);
 		error = namei(&nd);
 		NFSD_DEBUG(4, "ds lookup=%d\n", error);
 		if (error != 0) {

--- a/sys/fs/nullfs/null_vfsops.c
+++ b/sys/fs/nullfs/null_vfsops.c
@@ -123,7 +123,8 @@ nullfs_mount(struct mount *mp)
 	 * Find lower node
 	 */
 	ndp = &nd;
-	NDINIT(ndp, LOOKUP, FOLLOW|LOCKLEAF, UIO_SYSSPACE, target, curthread);
+	NDINIT(ndp, LOOKUP, FOLLOW|LOCKLEAF, UIO_SYSSPACE, PTR2CAP(target),
+	    curthread);
 	error = namei(ndp);
 
 	/*

--- a/sys/fs/udf/udf_vfsops.c
+++ b/sys/fs/udf/udf_vfsops.c
@@ -227,7 +227,8 @@ udf_mount(struct mount *mp)
 	/* Check that the mount device exists */
 	if (fspec == NULL)
 		return (EINVAL);
-	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, fspec, td);
+	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(fspec),
+	    td);
 	if ((error = namei(ndp)))
 		return (error);
 	NDFREE(ndp, NDF_ONLY_PNBUF);

--- a/sys/fs/unionfs/union_vfsops.c
+++ b/sys/fs/unionfs/union_vfsops.c
@@ -233,7 +233,8 @@ unionfs_domount(struct mount *mp)
 	/*
 	 * Find upper node
 	 */
-	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, target, td);
+	NDINIT(ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(target),
+	    td);
 	if ((error = namei(ndp)))
 		return (error);
 

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -818,7 +818,7 @@ __elfN(load_file)(struct proc *p, const char *file, u_long *addr,
 	imgp->attr = attr;
 
 	NDINIT(nd, LOOKUP, ISOPEN | FOLLOW | LOCKSHARED | LOCKLEAF,
-	    UIO_SYSSPACE, file, curthread);
+	    UIO_SYSSPACE, PTR2CAP(file), curthread);
 	if ((error = namei(nd)) != 0) {
 		nd->ni_vp = NULL;
 		goto fail;

--- a/sys/kern/kern_acct.c
+++ b/sys/kern/kern_acct.c
@@ -225,7 +225,7 @@ kern_acct(struct thread *td, const char * __capability path)
 	 * appending and make sure it's a 'normal'.
 	 */
 	if (path != NULL) {
-		NDINIT_C(&nd, LOOKUP, NOFOLLOW | AUDITVNODE1,
+		NDINIT(&nd, LOOKUP, NOFOLLOW | AUDITVNODE1,
 		    UIO_USERSPACE, path, td);
 		flags = FWRITE | O_APPEND;
 		error = vn_open(&nd, &flags, 0, NULL);

--- a/sys/kern/kern_alq.c
+++ b/sys/kern/kern_alq.c
@@ -445,7 +445,7 @@ alq_open_flags(struct alq **alqp, const char *file, struct ucred *cred, int cmod
 	*alqp = NULL;
 	td = curthread;
 
-	NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, file, td);
+	NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(file), td);
 	oflags = FWRITE | O_NOFOLLOW | O_CREAT;
 
 	error = vn_open_cred(&nd, &oflags, cmode, 0, cred, NULL);

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -443,7 +443,8 @@ do_execve(struct thread *td, struct image_args *args,
 	 */
 	if (args->fname != NULL) {
 		NDINIT(&nd, LOOKUP, ISOPEN | LOCKLEAF | LOCKSHARED | FOLLOW |
-		    SAVENAME | AUDITVNODE1, UIO_SYSSPACE, args->fname, td);
+		    SAVENAME | AUDITVNODE1, UIO_SYSSPACE, PTR2CAP(args->fname),
+		    td);
 	}
 
 	SDT_PROBE1(proc, , , exec, args->fname);
@@ -664,7 +665,8 @@ interpret:
 		imgp->freepath = NULL;
 		/* set new name to that of the interpreter */
 		NDINIT(&nd, LOOKUP, ISOPEN | LOCKLEAF | LOCKSHARED | FOLLOW |
-		    SAVENAME, UIO_SYSSPACE, imgp->interpreter_name, td);
+		    SAVENAME, UIO_SYSSPACE, PTR2CAP(imgp->interpreter_name),
+		    td);
 		args->fname = imgp->interpreter_name;
 		goto interpret;
 	}

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -953,7 +953,7 @@ kern_jail_set(struct thread *td, struct uio *optuio, int flags)
 			goto done_free;
 		}
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE,
-		    path, td);
+		    PTR2CAP(path), td);
 		error = namei(&nd);
 		if (error)
 			goto done_free;

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -999,7 +999,7 @@ kern_ktrace(struct thread *td, const char * __capability fname, int uops,
 		/*
 		 * an operation which requires a file argument.
 		 */
-		NDINIT_C(&nd, LOOKUP, NOFOLLOW, UIO_USERSPACE, fname, td);
+		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_USERSPACE, fname, td);
 		flags = FREAD | FWRITE | O_NOFOLLOW;
 		error = vn_open(&nd, &flags, 0, NULL);
 		if (error) {

--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -1835,7 +1835,7 @@ linker_lookup_file(const char *path, int pathlen, const char *name,
 		 * Attempt to open the file, and return the path if
 		 * we succeed and it's a regular file.
 		 */
-		NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, result, td);
+		NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(result), td);
 		flags = FREAD;
 		error = vn_open(&nd, &flags, 0, NULL);
 		if (error == 0) {
@@ -1885,7 +1885,7 @@ linker_hints_lookup(const char *path, int pathlen, const char *modname,
 	snprintf(pathbuf, reclen, "%.*s%s%s", pathlen, path, sep,
 	    linker_hintfile);
 
-	NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, pathbuf, td);
+	NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(pathbuf), td);
 	flags = FREAD;
 	error = vn_open(&nd, &flags, 0, NULL);
 	if (error)

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -3522,7 +3522,7 @@ corefile_open_last(struct thread *td, char *name, int indexpos,
 		    i);
 		name[indexpos + indexlen] = ch;
 
-		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, name, td);
+		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(name), td);
 		error = vn_open_cred(&nd, &flags, cmode, oflags, td->td_ucred,
 		    NULL);
 		if (error != 0)
@@ -3700,7 +3700,7 @@ corefile_open(const char *comm, uid_t uid, pid_t pid, struct thread *td,
 		if ((td->td_proc->p_flag & P_SUGID) != 0)
 			flags |= O_EXCL;
 
-		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, name, td);
+		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(name), td);
 		error = vn_open_cred(&nd, &flags, cmode, oflags, td->td_ucred,
 		    NULL);
 		if (error == 0) {

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -957,7 +957,7 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 	lf = NULL;
 	shstrs = NULL;
 
-	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, filename, td);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(filename), td);
 	flags = FREAD;
 	error = vn_open(&nd, &flags, 0, NULL);
 	if (error != 0)

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -668,7 +668,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 	hdr = NULL;
 
 	nd = malloc(sizeof(struct nameidata), M_TEMP, M_WAITOK);
-	NDINIT(nd, LOOKUP, FOLLOW, UIO_SYSSPACE, filename, td);
+	NDINIT(nd, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(filename), td);
 	flags = FREAD;
 	error = vn_open(nd, &flags, 0, NULL);
 	if (error) {

--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -608,7 +608,8 @@ uipc_bindat(int fd, struct socket *so, struct sockaddr *nam, struct thread *td)
 
 restart:
 	NDINIT_ATRIGHTS(&nd, CREATE, NOFOLLOW | LOCKPARENT | SAVENAME | NOCACHE,
-	    UIO_SYSSPACE, buf, fd, cap_rights_init(&rights, CAP_BINDAT), td);
+	    UIO_SYSSPACE, PTR2CAP(buf), fd,
+	    cap_rights_init(&rights, CAP_BINDAT), td);
 /* SHOULD BE ABLE TO ADOPT EXISTING AND wakeup() ALA FIFO's */
 	error = namei(&nd);
 	if (error)

--- a/sys/kern/vfs_acl.c
+++ b/sys/kern/vfs_acl.c
@@ -372,7 +372,7 @@ kern___acl_get_path(struct thread *td, const char *__capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error == 0) {
 		error = vacl_get_acl(td, nd.ni_vp, type, aclp);
@@ -410,7 +410,7 @@ kern___acl_set_path(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error == 0) {
 		error = vacl_set_acl(td, nd.ni_vp, type, aclp);
@@ -502,7 +502,7 @@ kern___acl_delete_path(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, follow, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error == 0) {
 		error = vacl_delete(td, nd.ni_vp, type);
@@ -560,7 +560,7 @@ kern___acl_aclcheck_path(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, follow, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error == 0) {
 		error = vacl_aclcheck(td, nd.ni_vp, type, aclp);

--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -2656,7 +2656,7 @@ vn_path_to_global_path(struct thread *td, struct vnode *vp, char *path,
 	 * If vnode was renamed, return ENOENT.
 	 */
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
-	    UIO_SYSSPACE, path, td);
+	    UIO_SYSSPACE, PTR2CAP(path), td);
 	error = namei(&nd);
 	if (error != 0) {
 		vrele(vp);

--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -2206,7 +2206,7 @@ kern___realpathat(struct thread *td, int fd, const char * __capability path,
 
 	if (flags != 0)
 		return (EINVAL);
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP,
+	NDINIT_ATRIGHTS(&nd, LOOKUP,
 	    FOLLOW | SAVENAME | WANTPARENT | AUDITVNODE1,
 	    pathseg, path, fd, &cap_fstat_rights, td);
 	if ((error = namei(&nd)) != 0)

--- a/sys/kern/vfs_extattr.c
+++ b/sys/kern/vfs_extattr.c
@@ -103,7 +103,7 @@ kern_extattrctl(struct thread *td, const char * __capability path, int cmd,
 	mp = NULL;
 	filename_vp = NULL;
 	if (filename != NULL) {
-		NDINIT_C(&nd, LOOKUP, FOLLOW | AUDITVNODE2,
+		NDINIT(&nd, LOOKUP, FOLLOW | AUDITVNODE2,
 		    UIO_USERSPACE, filename, td);
 		error = namei(&nd);
 		if (error)
@@ -113,7 +113,7 @@ kern_extattrctl(struct thread *td, const char * __capability path, int cmd,
 	}
 
 	/* path is always defined. */
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
 	    UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error)
@@ -314,7 +314,7 @@ kern_extattr_set_path(struct thread *td,
 		return (error);
 	AUDIT_ARG_TEXT(attrname);
 
-	NDINIT_C(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error)
 		return (error);
@@ -489,7 +489,7 @@ kern_extattr_get_path(struct thread *td, const char * __capability path,
 		return (error);
 	AUDIT_ARG_TEXT(attrname);
 
-	NDINIT_C(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error)
 		return (error);
@@ -630,7 +630,7 @@ kern_extattr_delete_path(struct thread *td, const char * __capability path,
 		return(error);
 	AUDIT_ARG_TEXT(attrname);
 
-	NDINIT_C(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error)
 		return(error);
@@ -780,7 +780,7 @@ kern_extattr_list_path(struct thread *td, const char * __capability path,
 	int error;
 
 	AUDIT_ARG_VALUE(attrnamespace);
-	NDINIT_C(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
+	NDINIT(&nd, LOOKUP, follow | AUDITVNODE1, UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error)
 		return (error);

--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -1317,17 +1317,6 @@ bad:
 
 void
 NDINIT_ALL(struct nameidata *ndp, u_long op, u_long flags, enum uio_seg segflg,
-    const char *namep, int dirfd, struct vnode *startdir, cap_rights_t *rightsp,
-    struct thread *td)
-{
-
-	NDINIT_ALL_C(ndp, op, flags, segflg,
-	    (__cheri_tocap const char * __capability)namep,
-	    dirfd, startdir, rightsp, td);
-}
-
-void
-NDINIT_ALL_C(struct nameidata *ndp, u_long op, u_long flags, enum uio_seg segflg,
     const char * __capability namep, int dirfd, struct vnode *startdir, cap_rights_t *rightsp,
     struct thread *td)
 {

--- a/sys/kern/vfs_lookup.c
+++ b/sys/kern/vfs_lookup.c
@@ -1472,13 +1472,13 @@ kern_alternate_path(struct thread *td, const char *prefix,
 		for (cp = &ptr[len] - 1; *cp != '/'; cp--);
 		*cp = '\0';
 
-		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, buf, td);
+		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(buf), td);
 		error = namei(&nd);
 		*cp = '/';
 		if (error != 0)
 			goto keeporig;
 	} else {
-		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, buf, td);
+		NDINIT(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(buf), td);
 
 		error = namei(&nd);
 		if (error != 0)
@@ -1492,7 +1492,7 @@ kern_alternate_path(struct thread *td, const char *prefix,
 		 * root directory and never finding it, because "/" resolves
 		 * to the emulation root directory. This is expensive :-(
 		 */
-		NDINIT(&ndroot, LOOKUP, FOLLOW, UIO_SYSSPACE, prefix,
+		NDINIT(&ndroot, LOOKUP, FOLLOW, UIO_SYSSPACE, PTR2CAP(prefix),
 		    td);
 
 		/* We shouldn't ever get an error from this namei(). */

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -1267,7 +1267,7 @@ vfs_domount(
 	 * Get vnode to be covered or mount point's vnode in case of MNT_UPDATE.
 	 */
 	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
-	    UIO_SYSSPACE, fspath, td);
+	    UIO_SYSSPACE, PTR2CAP(fspath), td);
 	error = namei(&nd);
 	if (error != 0)
 		return (error);
@@ -1356,7 +1356,7 @@ kern_unmount(struct thread *td, const char * __capability path, int flags)
 		 * Try to find global path for path argument.
 		 */
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
-		    UIO_SYSSPACE, pathbuf, td);
+		    UIO_SYSSPACE, PTR2CAP(pathbuf), td);
 		if (namei(&nd) == 0) {
 			NDFREE(&nd, NDF_ONLY_PNBUF);
 			error = vn_path_to_global_path(td, nd.ni_vp, pathbuf,

--- a/sys/kern/vfs_mountroot.c
+++ b/sys/kern/vfs_mountroot.c
@@ -360,13 +360,13 @@ vfs_mountroot_shuffle(struct thread *td, struct mount *mpdevfs)
 		/* Remount old root under /.mount or /mnt */
 		fspath = "/.mount";
 		NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE,
-		    fspath, td);
+		    PTR2CAP(fspath), td);
 		error = namei(&nd);
 		if (error) {
 			NDFREE(&nd, NDF_ONLY_PNBUF);
 			fspath = "/mnt";
 			NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE,
-			    fspath, td);
+			    PTR2CAP(fspath), td);
 			error = namei(&nd);
 		}
 		if (!error) {
@@ -714,7 +714,8 @@ parse_mount_dev_present(const char *dev)
 	struct nameidata nd;
 	int error;
 
-	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, dev, curthread);
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(dev),
+	    curthread);
 	error = namei(&nd);
 	if (!error)
 		vput(nd.ni_vp);

--- a/sys/kern/vfs_subr.c
+++ b/sys/kern/vfs_subr.c
@@ -414,7 +414,7 @@ sysctl_try_reclaim_vnode(SYSCTL_HANDLER_ARGS)
 	buf[req->newlen] = '\0';
 
 	ndflags = LOCKLEAF | NOFOLLOW | AUDITVNODE1 | NOCACHE | SAVENAME;
-	NDINIT(&nd, LOOKUP, ndflags, UIO_SYSSPACE, buf, curthread);
+	NDINIT(&nd, LOOKUP, ndflags, UIO_SYSSPACE, PTR2CAP(buf), curthread);
 	if ((error = namei(&nd)) != 0)
 		goto out;
 	vp = nd.ni_vp;

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -182,7 +182,7 @@ kern_quotactl(struct thread *td, const char * __capability path, int cmd,
 	AUDIT_ARG_UID(uid);
 	if (!prison_allow(td->td_ucred, PR_ALLOW_QUOTAS))
 		return (EPERM);
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, UIO_USERSPACE,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, UIO_USERSPACE,
 	    path, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
@@ -323,7 +323,7 @@ kern_statfs(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
 	    pathseg, path, td);
 	error = namei(&nd);
 	if (error != 0)
@@ -913,7 +913,7 @@ kern_chdir(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
 	    pathseg, path, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
@@ -952,7 +952,7 @@ kern_chroot(struct thread *td, const char * __capability path)
 	error = priv_check(td, PRIV_VFS_CHROOT);
 	if (error != 0)
 		return (error);
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
 	    UIO_USERSPACE, path, td);
 	error = namei(&nd);
 	if (error != 0)
@@ -1748,7 +1748,7 @@ kern_undelete(struct thread *td, const char * __capability path, enum uio_seg pa
 
 restart:
 	bwillwrite();
-	NDINIT_C(&nd, DELETE, LOCKPARENT | DOWHITEOUT | AUDITVNODE1,
+	NDINIT(&nd, DELETE, LOCKPARENT | DOWHITEOUT | AUDITVNODE1,
 	    pathseg, path, td);
 	error = namei(&nd);
 	if (error != 0)
@@ -2537,7 +2537,7 @@ kern_pathconf(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, LOCKSHARED | LOCKLEAF | AUDITVNODE1 | flags,
+	NDINIT(&nd, LOOKUP, LOCKSHARED | LOCKLEAF | AUDITVNODE1 | flags,
 	    pathseg, path, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
@@ -3241,7 +3241,7 @@ kern_lutimes(struct thread *td,
 
 	if ((error = getutimes(tptr, tptrseg, ts)) != 0)
 		return (error);
-	NDINIT_C(&nd, LOOKUP, NOFOLLOW | AUDITVNODE1, pathseg, path, td);
+	NDINIT(&nd, LOOKUP, NOFOLLOW | AUDITVNODE1, pathseg, path, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
 	NDFREE(&nd, NDF_ONLY_PNBUF);
@@ -3396,7 +3396,7 @@ kern_truncate(struct thread *td, const char * __capability path,
 
 	if (length < 0)
 		return(EINVAL);
-	NDINIT_C(&nd, LOOKUP, FOLLOW | AUDITVNODE1, pathseg, path, td);
+	NDINIT(&nd, LOOKUP, FOLLOW | AUDITVNODE1, pathseg, path, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
 	vp = nd.ni_vp;
@@ -4210,7 +4210,7 @@ kern_revoke(struct thread *td, const char * __capability path,
 	struct nameidata nd;
 	int error;
 
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, pathseg,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1, pathseg,
 	    path, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -2593,7 +2593,7 @@ kern_readlinkat(struct thread *td, int fd, const char * __capability path,
 	if (count > IOSIZE_MAX)
 		return (EINVAL);
 
-	NDINIT_AT_C(&nd, LOOKUP, NOFOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
+	NDINIT_AT(&nd, LOOKUP, NOFOLLOW | LOCKSHARED | LOCKLEAF | AUDITVNODE1,
 	    pathseg, path, fd, td);
 
 	if ((error = namei(&nd)) != 0)
@@ -4344,7 +4344,7 @@ kern_getfhat(struct thread *td, int flags, int fd,
 	error = priv_check(td, PRIV_VFS_GETFH);
 	if (error != 0)
 		return (error);
-	NDINIT_AT_C(&nd, LOOKUP,
+	NDINIT_AT(&nd, LOOKUP,
 	    ((flags & AT_SYMLINK_NOFOLLOW) != 0 ? NOFOLLOW : FOLLOW) |
 	    ((flags & AT_BENEATH) != 0 ? BENEATH : 0) | LOCKLEAF | AUDITVNODE1,
 	    pathseg, path, fd, td);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -1115,7 +1115,7 @@ kern_openat(struct thread *td, int fd, char const * __capability path,
 	/* Set the flags early so the finit in devfs can pick them up. */
 	fp->f_flag = flags & FMASK;
 	cmode = ((mode & ~fdp->fd_cmask) & ALLPERMS) & ~S_ISTXT;
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, FOLLOW | AUDITVNODE1, pathseg, path, fd,
+	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | AUDITVNODE1, pathseg, path, fd,
 	    &rights, td);
 	td->td_dupfd = -1;		/* XXX check for fdopen */
 	error = vn_open(&nd, &flags, cmode, fp);
@@ -1301,7 +1301,7 @@ kern_mknodat(struct thread *td, int fd, const char * __capability path,
 		return (error);
 restart:
 	bwillwrite();
-	NDINIT_ATRIGHTS_C(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
+	NDINIT_ATRIGHTS(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
 	    NOCACHE, pathseg, path, fd, &cap_mknodat_rights,
 	    td);
 	if ((error = namei(&nd)) != 0)
@@ -1408,7 +1408,7 @@ kern_mkfifoat(struct thread *td, int fd, const char * __capability path,
 	AUDIT_ARG_MODE(mode);
 restart:
 	bwillwrite();
-	NDINIT_ATRIGHTS_C(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
+	NDINIT_ATRIGHTS(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
 	    NOCACHE, pathseg, path, fd, &cap_mkfifoat_rights,
 	    td);
 	if ((error = namei(&nd)) != 0)
@@ -1539,7 +1539,7 @@ kern_linkat(struct thread *td, int fd1, int fd2,
 
 	do {
 		bwillwrite();
-		NDINIT_ATRIGHTS_C(&nd, LOOKUP, follow | AUDITVNODE1, segflag,
+		NDINIT_ATRIGHTS(&nd, LOOKUP, follow | AUDITVNODE1, segflag,
 		    path1, fd1, &cap_linkat_source_rights, td);
 		if ((error = namei(&nd)) != 0)
 			return (error);
@@ -1561,7 +1561,7 @@ kern_linkat_vp(struct thread *td, struct vnode *vp, int fd,
 		vrele(vp);
 		return (EPERM);		/* POSIX */
 	}
-	NDINIT_ATRIGHTS_C(&nd, CREATE,
+	NDINIT_ATRIGHTS(&nd, CREATE,
 	    LOCKPARENT | SAVENAME | AUDITVNODE2 | NOCACHE, segflag, path, fd,
 	    &cap_linkat_target_rights, td);
 	if ((error = namei(&nd)) == 0) {
@@ -1678,7 +1678,7 @@ kern_symlinkat(struct thread *td, const char * __capability path1, int fd,
 	AUDIT_ARG_TEXT(syspath);
 restart:
 	bwillwrite();
-	NDINIT_ATRIGHTS_C(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
+	NDINIT_ATRIGHTS(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
 	    NOCACHE, segflg, path2, fd, &cap_symlinkat_rights,
 	    td);
 	if ((error = namei(&nd)) != 0)
@@ -1859,7 +1859,7 @@ kern_funlinkat(struct thread *td, int dfd, const char * __capability path,
 
 restart:
 	bwillwrite();
-	NDINIT_ATRIGHTS_C(&nd, DELETE, LOCKPARENT | LOCKLEAF | AUDITVNODE1 |
+	NDINIT_ATRIGHTS(&nd, DELETE, LOCKPARENT | LOCKLEAF | AUDITVNODE1 |
 	    ((flag & AT_BENEATH) != 0 ? BENEATH : 0),
 	    pathseg, path, dfd, &cap_unlinkat_rights, td);
 	if ((error = namei(&nd)) != 0) {
@@ -2083,7 +2083,7 @@ kern_accessat(struct thread *td, int fd, const char * __capability path,
 	} else
 		usecred = cred;
 	AUDIT_ARG_VALUE(amode);
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF |
+	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF |
 	    AUDITVNODE1 | ((flag & AT_BENEATH) != 0 ? BENEATH : 0),
 	    pathseg, path, fd, &cap_fstat_rights, td);
 	if ((error = namei(&nd)) != 0)
@@ -2386,7 +2386,7 @@ kern_statat(struct thread *td, int flag, int fd, const char * __capability path,
 	if ((flag & ~(AT_SYMLINK_NOFOLLOW | AT_BENEATH)) != 0)
 		return (EINVAL);
 
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, ((flag & AT_SYMLINK_NOFOLLOW) != 0 ?
+	NDINIT_ATRIGHTS(&nd, LOOKUP, ((flag & AT_SYMLINK_NOFOLLOW) != 0 ?
 	    NOFOLLOW : FOLLOW) | ((flag & AT_BENEATH) != 0 ? BENEATH : 0) |
 	    LOCKSHARED | LOCKLEAF | AUDITVNODE1, pathseg, path, fd,
 	    &cap_fstat_rights, td);
@@ -2744,7 +2744,7 @@ kern_chflagsat(struct thread *td, int fd, const char * __capability path,
 	AUDIT_ARG_FFLAGS(flags);
 	follow = (atflag & AT_SYMLINK_NOFOLLOW) ? NOFOLLOW : FOLLOW;
 	follow |= (atflag & AT_BENEATH) != 0 ? BENEATH : 0;
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, follow | AUDITVNODE1, pathseg, path, fd,
+	NDINIT_ATRIGHTS(&nd, LOOKUP, follow | AUDITVNODE1, pathseg, path, fd,
 	    &cap_fchflags_rights, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
@@ -2873,7 +2873,7 @@ kern_fchmodat(struct thread *td, int fd, const char * __capability path,
 	AUDIT_ARG_MODE(mode);
 	follow = (flag & AT_SYMLINK_NOFOLLOW) != 0 ? NOFOLLOW : FOLLOW;
 	follow |= (flag & AT_BENEATH) != 0 ? BENEATH : 0;
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, follow | AUDITVNODE1, pathseg, path, fd,
+	NDINIT_ATRIGHTS(&nd, LOOKUP, follow | AUDITVNODE1, pathseg, path, fd,
 	    &cap_fchmod_rights, td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
@@ -2985,7 +2985,7 @@ kern_fchownat(struct thread *td, int fd, const char * __capability path,
 	AUDIT_ARG_OWNER(uid, gid);
 	follow = (flag & AT_SYMLINK_NOFOLLOW) ? NOFOLLOW : FOLLOW;
 	follow |= (flag & AT_BENEATH) != 0 ? BENEATH : 0;
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, follow | AUDITVNODE1, pathseg, path, fd,
+	NDINIT_ATRIGHTS(&nd, LOOKUP, follow | AUDITVNODE1, pathseg, path, fd,
 	    &cap_fchown_rights, td);
 
 	if ((error = namei(&nd)) != 0)
@@ -3202,7 +3202,7 @@ kern_utimesat(struct thread *td, int fd,
 
 	if ((error = getutimes(tptr, tptrseg, ts)) != 0)
 		return (error);
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP, FOLLOW | AUDITVNODE1, pathseg, path, fd,
+	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | AUDITVNODE1, pathseg, path, fd,
 	    &cap_futimes_rights, td);
 
 	if ((error = namei(&nd)) != 0)
@@ -3347,7 +3347,7 @@ kern_utimensat(struct thread *td, int fd,
 
 	if ((error = getutimens(tptr, tptrseg, ts, &flags)) != 0)
 		return (error);
-	NDINIT_ATRIGHTS_C(&nd, LOOKUP,
+	NDINIT_ATRIGHTS(&nd, LOOKUP,
 	    ((flag & AT_SYMLINK_NOFOLLOW) ? NOFOLLOW : FOLLOW) |
 	    ((flag & AT_BENEATH) != 0 ? BENEATH : 0) | AUDITVNODE1,
 	    pathseg, path, fd, &cap_futimes_rights, td);
@@ -3571,11 +3571,11 @@ kern_renameat(struct thread *td, int oldfd, const char * __capability old,
 again:
 	bwillwrite();
 #ifdef MAC
-	NDINIT_ATRIGHTS_C(&fromnd, DELETE, LOCKPARENT | LOCKLEAF | SAVESTART |
+	NDINIT_ATRIGHTS(&fromnd, DELETE, LOCKPARENT | LOCKLEAF | SAVESTART |
 	    AUDITVNODE1, pathseg, old, oldfd,
 	    &cap_renameat_source_rights, td);
 #else
-	NDINIT_ATRIGHTS_C(&fromnd, DELETE, WANTPARENT | SAVESTART | AUDITVNODE1,
+	NDINIT_ATRIGHTS(&fromnd, DELETE, WANTPARENT | SAVESTART | AUDITVNODE1,
 	    pathseg, old, oldfd,
 	    &cap_renameat_source_rights, td);
 #endif
@@ -3590,7 +3590,7 @@ again:
 		VOP_UNLOCK(fromnd.ni_vp);
 #endif
 	fvp = fromnd.ni_vp;
-	NDINIT_ATRIGHTS_C(&tond, RENAME, LOCKPARENT | LOCKLEAF | NOCACHE |
+	NDINIT_ATRIGHTS(&tond, RENAME, LOCKPARENT | LOCKLEAF | NOCACHE |
 	    SAVESTART | AUDITVNODE2, pathseg, new, newfd,
 	    &cap_renameat_target_rights, td);
 	if (fromnd.ni_vp->v_type == VDIR)
@@ -3734,7 +3734,7 @@ kern_mkdirat(struct thread *td, int fd, const char * __capability path,
 	AUDIT_ARG_MODE(mode);
 restart:
 	bwillwrite();
-	NDINIT_ATRIGHTS_C(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
+	NDINIT_ATRIGHTS(&nd, CREATE, LOCKPARENT | SAVENAME | AUDITVNODE1 |
 	    NOCACHE, segflg, path, fd, &cap_mkdirat_rights,
 	    td);
 	nd.ni_cnd.cn_flags |= WILLBEDIR;
@@ -3820,7 +3820,7 @@ kern_frmdirat(struct thread *td, int dfd, const char * __capability path,
 
 restart:
 	bwillwrite();
-	NDINIT_ATRIGHTS_C(&nd, DELETE, LOCKPARENT | LOCKLEAF | AUDITVNODE1 |
+	NDINIT_ATRIGHTS(&nd, DELETE, LOCKPARENT | LOCKLEAF | AUDITVNODE1 |
 	    ((flag & AT_BENEATH) != 0 ? BENEATH : 0),
 	    pathseg, path, dfd, &cap_unlinkat_rights, td);
 	if ((error = namei(&nd)) != 0)

--- a/sys/security/audit/audit_syscalls.c
+++ b/sys/security/audit/audit_syscalls.c
@@ -869,7 +869,7 @@ kern_auditctl(struct thread *td, const char * __capability path)
 	if (path == NULL)
 		return (EINVAL);
 
-	NDINIT_C(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF | AUDITVNODE1,
 	    UIO_USERSPACE, path, td);
 	flags = AUDIT_OPEN_FLAGS;
 	error = vn_open(&nd, &flags, 0, NULL);

--- a/sys/security/mac/mac_syscalls.c
+++ b/sys/security/mac/mac_syscalls.c
@@ -384,7 +384,7 @@ kern_mac_get_path(struct thread *td, const char * __capability path_p,
 	}
 
 	buffer = malloc(mac.m_buflen, M_MACTEMP, M_WAITOK | M_ZERO);
-	NDINIT_C(&nd, LOOKUP, LOCKLEAF | follow, UIO_USERSPACE, path_p, td);
+	NDINIT(&nd, LOOKUP, LOCKLEAF | follow, UIO_USERSPACE, path_p, td);
 	error = namei(&nd);
 	if (error)
 		goto out;
@@ -563,7 +563,7 @@ kern_mac_set_path(struct thread *td, const char * __capability path_p,
 	if (error)
 		goto out;
 
-	NDINIT_C(&nd, LOOKUP, LOCKLEAF | follow, UIO_USERSPACE, path_p, td);
+	NDINIT(&nd, LOOKUP, LOCKLEAF | follow, UIO_USERSPACE, path_p, td);
 	error = namei(&nd);
 	if (error == 0) {
 		error = vn_start_write(nd.ni_vp, &mp, V_WAIT | PCATCH);

--- a/sys/security/mac_veriexec/mac_veriexec.c
+++ b/sys/security/mac_veriexec/mac_veriexec.c
@@ -699,7 +699,7 @@ cleanup_file:
 		break;
 	case MAC_VERIEXEC_CHECK_PATH_SYSCALL:
 		/* Look up the path to get the vnode */
-		NDINIT_C(&nd, LOOKUP,
+		NDINIT(&nd, LOOKUP,
 		    FOLLOW | LOCKLEAF | LOCKSHARED | AUDITVNODE1,
 		    UIO_USERSPACE, arg, td);
 		error = namei(&nd);

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -186,7 +186,7 @@ struct nameidata {
 #define	NDINIT_C(ndp, op, flags, segflg, namep, td)			\
 	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_AT(ndp, op, flags, segflg, namep, dirfd, td)		\
-	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
+	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_AT_C(ndp, op, flags, segflg, namep, dirfd, td)		\
 	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_ATRIGHTS(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -187,8 +187,6 @@ struct nameidata {
 	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_AT(ndp, op, flags, segflg, namep, dirfd, td)		\
 	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
-#define	NDINIT_AT_C(ndp, op, flags, segflg, namep, dirfd, td)		\
-	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_ATRIGHTS(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
 	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 #define	NDINIT_ATVP(ndp, op, flags, segflg, namep, vp, td)		\

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -183,8 +183,6 @@ struct nameidata {
  */
 #define	NDINIT(ndp, op, flags, segflg, namep, td)			\
 	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
-#define	NDINIT_C(ndp, op, flags, segflg, namep, td)			\
-	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_AT(ndp, op, flags, segflg, namep, dirfd, td)		\
 	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_ATRIGHTS(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -193,8 +193,6 @@ struct nameidata {
 	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 #define	NDINIT_ATVP(ndp, op, flags, segflg, namep, vp, td)		\
 	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, vp, 0, td)
-#define	NDINIT_ATRIGHTS_C(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
-	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 
 void NDINIT_ALL(struct nameidata *ndp, u_long op, u_long flags,
     enum uio_seg segflg, const char * __capability namep, int dirfd, struct vnode *startdir,

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -182,7 +182,7 @@ struct nameidata {
  * Initialization of a nameidata structure.
  */
 #define	NDINIT(ndp, op, flags, segflg, namep, td)			\
-	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
+	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_C(ndp, op, flags, segflg, namep, td)			\
 	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_AT(ndp, op, flags, segflg, namep, dirfd, td)		\

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -182,24 +182,21 @@ struct nameidata {
  * Initialization of a nameidata structure.
  */
 #define	NDINIT(ndp, op, flags, segflg, namep, td)			\
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_C(ndp, op, flags, segflg, namep, td)			\
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, NULL, 0, td)
 #define	NDINIT_AT(ndp, op, flags, segflg, namep, dirfd, td)		\
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_AT_C(ndp, op, flags, segflg, namep, dirfd, td)		\
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_ATRIGHTS(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 #define	NDINIT_ATVP(ndp, op, flags, segflg, namep, vp, td)		\
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, vp, 0, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, vp, 0, td)
 #define	NDINIT_ATRIGHTS_C(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
-	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
+	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 
 void NDINIT_ALL(struct nameidata *ndp, u_long op, u_long flags,
-    enum uio_seg segflg, const char *namep, int dirfd, struct vnode *startdir,
-    cap_rights_t *rightsp, struct thread *td);
-void NDINIT_ALL_C(struct nameidata *ndp, u_long op, u_long flags,
     enum uio_seg segflg, const char * __capability namep, int dirfd, struct vnode *startdir,
     cap_rights_t *rightsp, struct thread *td);
 

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -192,7 +192,7 @@ struct nameidata {
 #define	NDINIT_ATRIGHTS(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
 	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 #define	NDINIT_ATVP(ndp, op, flags, segflg, namep, vp, td)		\
-	NDINIT_ALL(ndp, op, flags, segflg, namep, AT_FDCWD, vp, 0, td)
+	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, vp, 0, td)
 #define	NDINIT_ATRIGHTS_C(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
 	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 

--- a/sys/sys/namei.h
+++ b/sys/sys/namei.h
@@ -190,7 +190,7 @@ struct nameidata {
 #define	NDINIT_AT_C(ndp, op, flags, segflg, namep, dirfd, td)		\
 	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, 0, td)
 #define	NDINIT_ATRIGHTS(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \
-	NDINIT_ALL(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
+	NDINIT_ALL_C(ndp, op, flags, segflg, namep, dirfd, NULL, rightsp, td)
 #define	NDINIT_ATVP(ndp, op, flags, segflg, namep, vp, td)		\
 	NDINIT_ALL_C(ndp, op, flags, segflg, namep, AT_FDCWD, vp, 0, td)
 #define	NDINIT_ATRIGHTS_C(ndp, op, flags, segflg, namep, dirfd, rightsp, td) \

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -367,4 +367,20 @@ __END_DECLS
 #define __PAST_END(array, offset)	\
     (((__typeof__(*(array)) *)__builtin_no_change_bounds(array))[offset])
 
+#ifdef _KERNEL
+#if __has_feature(capabilities)
+/*
+ * Convenience wrapper to convert an in-kernel pointer to a DDC-derived
+ * capability.  NB: For purecap kernels this is a no-op.
+ */
+#define	PTR2CAP(p)	({					\
+	KASSERT((vaddr_t)((p)) >= VM_MAXUSER_ADDRESS,		\
+	    ("PTR2CAP on user address: %p", (p)));		\
+	(__cheri_tocap __typeof__((p)) __capability)(p);	\
+	})
+#else
+#define	PTR2CAP(p)	(p)
+#endif
+#endif
+
 #endif	/* _SYS_PARAM_H_ */

--- a/sys/ufs/ffs/ffs_snapshot.c
+++ b/sys/ufs/ffs/ffs_snapshot.c
@@ -261,7 +261,7 @@ ffs_snapshot(mp, snapfile)
 	 */
 restart:
 	NDINIT(&nd, CREATE, LOCKPARENT | LOCKLEAF | NOCACHE, UIO_SYSSPACE,
-	    snapfile, td);
+	    PTR2CAP(snapfile), td);
 	if ((error = namei(&nd)) != 0)
 		return (error);
 	if (nd.ni_vp != NULL) {

--- a/sys/ufs/ffs/ffs_vfsops.c
+++ b/sys/ufs/ffs/ffs_vfsops.c
@@ -498,7 +498,8 @@ ffs_mount(struct mount *mp)
 	 * Not an update, or updating the name: look up the name
 	 * and verify that it refers to a sensible disk device.
 	 */
-	NDINIT(&ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, fspec, td);
+	NDINIT(&ndp, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, PTR2CAP(fspec),
+	    td);
 	error = namei(&ndp);
 	if ((mp->mnt_flag & MNT_UPDATE) != 0) {
 		/*

--- a/sys/ufs/ufs/ufs_quota.c
+++ b/sys/ufs/ufs/ufs_quota.c
@@ -515,7 +515,7 @@ quotaon(struct thread *td, struct mount *mp, int type, void * __capability fname
 	ump = VFSTOUFS(mp);
 	dq = NODQUOT;
 
-	NDINIT_C(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, fname, td);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_USERSPACE, fname, td);
 	flags = FREAD | FWRITE;
 	vfs_ref(mp);
 	vfs_unbusy(mp);

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -2433,7 +2433,7 @@ kern_swapon(struct thread *td, const char * __capability name)
 		goto done;
 	}
 
-	NDINIT_C(&nd, LOOKUP, ISOPEN | FOLLOW | AUDITVNODE1, UIO_USERSPACE,
+	NDINIT(&nd, LOOKUP, ISOPEN | FOLLOW | AUDITVNODE1, UIO_USERSPACE,
 	    name, td);
 	error = namei(&nd);
 	if (error)
@@ -2591,7 +2591,7 @@ kern_swapoff(struct thread *td, const char * __capability name)
 
 	sx_xlock(&swdev_syscall_lock);
 
-	NDINIT_C(&nd, LOOKUP, FOLLOW | AUDITVNODE1, UIO_USERSPACE, name, td);
+	NDINIT(&nd, LOOKUP, FOLLOW | AUDITVNODE1, UIO_USERSPACE, name, td);
 	error = namei(&nd);
 	if (error)
 		goto done;


### PR DESCRIPTION
A cleanup inspired by a comment from @brooksdavis on Slack.  This fixes the remaining non-_C versions of NDINIT to take a capability and then removes the capability-specific _C versions.

As a followup, we might consider using the PTR2CAP macro in other places in the kernel where we currently use __cheri_tocap casts to reduce our diff to upstream a bit.