### PR TITLE
Minor changes to kern_proc_vmmap_out

### DIFF
--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -2629,7 +2629,7 @@ note_procstat_vmmap(void *arg, struct sbuf *sb, size_t *sizep)
 		sbuf_set_drain(sb, sbuf_count_drain, &size);
 		sbuf_bcat(sb, &structsize, sizeof(structsize));
 		PROC_LOCK(p);
-		kern_proc_vmmap_out(p, sb, -1, vmmap_flags);
+		kern_proc_vmmap_out(p, sb, -1, 0, 0, vmmap_flags);
 		sbuf_finish(sb);
 		sbuf_delete(sb);
 		*sizep = size;
@@ -2637,7 +2637,7 @@ note_procstat_vmmap(void *arg, struct sbuf *sb, size_t *sizep)
 		sbuf_bcat(sb, &structsize, sizeof(structsize));
 		PROC_LOCK(p);
 		kern_proc_vmmap_out(p, sb, *sizep - sizeof(structsize),
-		    vmmap_flags);
+		    0, 0, vmmap_flags);
 	}
 }
 

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2681,6 +2681,7 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 	unsigned int last_timestamp;
 	int error;
 	bool super;
+	size_t pathlen;
 
 	PROC_LOCK_ASSERT(p, MA_OWNED);
 
@@ -2805,16 +2806,16 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 			kve->kve_shadow_count = 0;
 		}
 
-		strlcpy(kve->kve_path, fullpath, sizeof(kve->kve_path));
+		pathlen = strlcpy(kve->kve_path, fullpath, sizeof(kve->kve_path));
 		if (freepath != NULL)
 			free(freepath, M_TEMP);
 
 		/* Pack record size down */
-		if ((flags & KERN_VMMAP_PACK_KINFO) != 0)
+		if ((flags & KERN_VMMAP_PACK_KINFO) != 0) {
 			kve->kve_structsize =
 			    offsetof(struct kinfo_vmentry, kve_path) +
-			    strlen(kve->kve_path) + 1;
-		else
+			    pathlen + 1;
+		} else
 			kve->kve_structsize = sizeof(*kve);
 		kve->kve_structsize = roundup(kve->kve_structsize,
 		    sizeof(uint64_t));

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2757,12 +2757,16 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen,
 		if (entry->protection & VM_PROT_EXECUTE)
 			kve->kve_protection |= KVME_PROT_EXEC;
 #ifdef OBJ_NOLOADTAGS
-		if (obj != NULL && (obj->flags & OBJ_NOLOADTAGS) == 0)
+		if (obj != NULL && (obj->flags & OBJ_NOLOADTAGS) == 0) {
+			kve->kve_max_protection |= KVME_PROT_LOADTAGS;
 			kve->kve_protection |= KVME_PROT_LOADTAGS;
+		}
 #endif
 #ifdef OBJ_NOSTORETAGS
-		if (obj != NULL && (obj->flags & OBJ_NOSTORETAGS) == 0)
+		if (obj != NULL && (obj->flags & OBJ_NOSTORETAGS) == 0) {
+			kve->kve_max_protection |= KVME_PROT_STORETAGS;
 			kve->kve_protection |= KVME_PROT_STORETAGS;
+		}
 #endif
 
 		if (entry->max_protection & VM_PROT_READ)

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2765,6 +2765,13 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen,
 			kve->kve_protection |= KVME_PROT_STORETAGS;
 #endif
 
+		if (entry->max_protection & VM_PROT_READ)
+			kve->kve_max_protection |= KVME_PROT_READ;
+		if (entry->max_protection & VM_PROT_WRITE)
+			kve->kve_max_protection |= KVME_PROT_WRITE;
+		if (entry->max_protection & VM_PROT_EXECUTE)
+			kve->kve_max_protection |= KVME_PROT_EXEC;
+
 		if (entry->eflags & MAP_ENTRY_COW)
 			kve->kve_flags |= KVME_FLAG_COW;
 		if (entry->eflags & MAP_ENTRY_NEEDS_COPY)

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2822,22 +2822,22 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 		/* Halt filling and truncate rather than exceeding maxlen */
 		if (maxlen != -1 && maxlen < kve->kve_structsize) {
 			error = 0;
-			vm_map_lock_read(map);
-			break;
+			goto out_nolock;
 		} else if (maxlen != -1)
 			maxlen -= kve->kve_structsize;
 
 		if (sbuf_bcat(sb, kve, kve->kve_structsize) != 0)
 			error = ENOMEM;
-		vm_map_lock_read(map);
 		if (error != 0)
-			break;
+			goto out_nolock;
+		vm_map_lock_read(map);
 		if (last_timestamp != map->timestamp) {
 			vm_map_lookup_entry(map, addr - 1, &tmp_entry);
 			entry = tmp_entry;
 		}
 	}
 	vm_map_unlock_read(map);
+out_nolock:
 	vmspace_free(vm);
 	PRELE(p);
 	free(kve, M_TEMP);

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2666,7 +2666,8 @@ next:;
  * Must be called with the process locked and will return unlocked.
  */
 int
-kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
+kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen,
+	vm_offset_t startaddr, size_t n, int flags)
 {
 	vm_map_entry_t entry, tmp_entry;
 	struct vattr va;
@@ -2681,7 +2682,7 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 	unsigned int last_timestamp;
 	int error;
 	bool super;
-	size_t pathlen;
+	size_t pathlen, i;
 
 	PROC_LOCK_ASSERT(p, MA_OWNED);
 
@@ -2697,7 +2698,24 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 	error = 0;
 	map = &vm->vm_map;
 	vm_map_lock_read(map);
-	VM_MAP_ENTRY_FOREACH(entry, map) {
+
+	/* XXX I really wish this could be 0, not 1. But...
+	 *
+	 * Someone is too damn smart and sees NULL for the new ptr and
+	 * zorches the new length, causing the kernel to do a full sweep
+	 * at first.  Pass 1 instead of 0 for the first query base.
+	 */
+	if (startaddr <= 1) {
+		entry = vm_map_entry_first(map);
+	} else {
+		boolean_t in = vm_map_lookup_entry(map, startaddr, &entry);
+		if (!in) {
+			entry = vm_map_entry_succ(entry);
+		}
+	}
+
+	for (i = 0; (entry != &map->header) && (n == 0 || i < n);
+	     entry = vm_map_entry_succ(entry), i++) {
 		if (entry->eflags & MAP_ENTRY_IS_SUB_MAP)
 			continue;
 
@@ -2842,6 +2860,7 @@ out_nolock:
 	vmspace_free(vm);
 	PRELE(p);
 	free(kve, M_TEMP);
+
 	return (error);
 }
 
@@ -2851,8 +2870,17 @@ sysctl_kern_proc_vmmap(SYSCTL_HANDLER_ARGS)
 	struct proc *p;
 	struct sbuf sb;
 	int error, error2, *name;
+	vm_offset_t base;
+	size_t n;
 
 	name = (int *)arg1;
+
+	base = (__cheri_addr vm_offset_t)req->newptr;
+	req->newptr = NULL;
+
+	n = req->newlen;
+	req->newlen = 0;
+
 	sbuf_new_for_sysctl(&sb, NULL, sizeof(struct kinfo_vmentry), req);
 	sbuf_clear_flags(&sb, SBUF_INCLUDENUL);
 	error = pget((pid_t)name[0], PGET_CANDEBUG | PGET_NOTWEXIT, &p);
@@ -2860,7 +2888,8 @@ sysctl_kern_proc_vmmap(SYSCTL_HANDLER_ARGS)
 		sbuf_delete(&sb);
 		return (error);
 	}
-	error = kern_proc_vmmap_out(p, &sb, -1, KERN_VMMAP_PACK_KINFO);
+	error = kern_proc_vmmap_out(p, &sb, -1, base, n,
+		KERN_VMMAP_PACK_KINFO);
 	error2 = sbuf_finish(&sb);
 	sbuf_delete(&sb);
 	return (error != 0 ? error : error2);
@@ -3436,8 +3465,10 @@ static SYSCTL_NODE(_kern_proc, KERN_PROC_OVMMAP, ovmmap, CTLFLAG_RD |
 	CTLFLAG_MPSAFE, sysctl_kern_proc_ovmmap, "Old Process vm map entries");
 #endif
 
-static SYSCTL_NODE(_kern_proc, KERN_PROC_VMMAP, vmmap, CTLFLAG_RD |
-	CTLFLAG_MPSAFE, sysctl_kern_proc_vmmap, "Process vm map entries");
+/* XXXNWF CTLFLAG_RW is a hack to sneak a parameter in! */
+static SYSCTL_NODE(_kern_proc, KERN_PROC_VMMAP, vmmap, CTLFLAG_RW |
+	CTLFLAG_MPSAFE, sysctl_kern_proc_vmmap,
+	"Process vm map entries");
 
 #if defined(STACK) || defined(DDB)
 static SYSCTL_NODE(_kern_proc, KERN_PROC_KSTACK, kstack, CTLFLAG_RD |

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -529,7 +529,8 @@ struct kinfo_vmentry {
 	uint64_t kve_vn_fsid;			/* dev_t of vnode location */
 	uint64_t kve_vn_rdev;			/* Device id if device. */
 	uint64_t kve_reservation;		/* Map reservation */
-	int	 _kve_ispare[6];		/* Space for more stuff. */
+	int      kve_max_protection;		/* Maximum protection bitmask */
+	int	 _kve_ispare[5];		/* Space for more stuff. */
 	/* Truncated before copyout in sysctl */
 	char	 kve_path[PATH_MAX];		/* Path to VM obj, if any. */
 };

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -611,7 +611,7 @@ int	kern_proc_filedesc_out(struct proc *p, struct sbuf *sb, ssize_t maxlen,
 int	kern_proc_cwd_out(struct proc *p, struct sbuf *sb, ssize_t maxlen);
 int	kern_proc_out(struct proc *p, struct sbuf *sb, int flags);
 int	kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen,
-	int flags);
+	vm_offset_t startaddr, size_t max, int flags);
 
 int	vntype_to_kinfo(int vtype);
 void	pack_kinfo(struct kinfo_file *kif);


### PR DESCRIPTION
We once thought that this sysctl would be integral to the revocation game, but once we moved the sweeper up to the kernel (where it pretty rightfully belongs), this became much more just for information and debugging.  Some of these changes may merit going upstream, or the whole thing may just be a useless curiosity from times past.