### PR TITLE
Riscv init cap

### DIFF
--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -108,6 +108,9 @@ extern void * __capability userspace_cap;
  */
 extern void * __capability swap_restore_cap;
 
+/* Root of all sealed kernel capabilities. */
+extern void * __capability kernel_sealcap;
+
 /*
  * Functions to create capabilities used in exec.
  */

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -101,6 +101,14 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 extern void * __capability userspace_cap;
 
 /*
+ * Omnipotent capability for restoring swapped capabilities.
+ *
+ * XXXBD: These should be a way to do this without storing such a potent
+ * capability.  Splitting sealed and unsealed caps would be a start.
+ */
+extern void * __capability swap_restore_cap;
+
+/*
  * Functions to create capabilities used in exec.
  */
 struct image_params;

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -70,11 +70,10 @@ struct cheri_signal {
 	void * __capability	csig_sigcode;
 };
 
-/*
- * APIs that act on C language representations of capabilities -- but not
- * capabilities themselves.
- */
 #ifdef _KERNEL
+/*
+ * Functions to construct userspace capabilities.
+ */
 void * __capability	_cheri_capability_build_user_code(struct thread *td,
 			    uint32_t perms, vaddr_t basep, size_t length,
 			    off_t off, const char* func, int line);
@@ -93,6 +92,13 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 #define cheri_capability_build_user_rwx(perms, basep, length, off)	\
 	_cheri_capability_build_user_rwx(perms, basep, length, off,	\
 	    __func__, __LINE__)
+
+/*
+ * Global capabilities used to construct other capabilities.
+ */
+
+/* Root of all userspace capabilities. */
+extern void * __capability userspace_cap;
 
 /*
  * Functions to create capabilities used in exec.

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -41,17 +41,19 @@
 #include <machine/riscvreg.h>
 #include <machine/vmparam.h>
 
-/* XXX: CHERI TODO: Probably should init this in locore on the BSP. */
 extern void * __capability userspace_cap;
 
-static void
-cheri_cpu_startup(void)
+void
+cheri_init_capabilities(void * __capability kroot)
 {
+	void * __capability ctemp;
 
-	userspace_cap = scr_read(ddc);
+	ctemp = cheri_setaddress(kroot, CHERI_CAP_USER_DATA_BASE);
+	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);
+	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |
+	    CHERI_CAP_USER_CODE_PERMS);
+	userspace_cap = ctemp;
 }
-SYSINIT(cheri_cpu_startup, SI_SUB_CPU, SI_ORDER_FIRST, cheri_cpu_startup,
-    NULL);
 
 void
 hybridabi_thread_setregs(struct thread *td, unsigned long entry_addr)

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -53,6 +53,8 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS);
 	userspace_cap = ctemp;
+
+	swap_restore_cap = kroot;
 }
 
 void

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -41,7 +41,7 @@
 #include <machine/riscvreg.h>
 #include <machine/vmparam.h>
 
-extern void * __capability userspace_cap;
+void *cheri_kall_capability = (void *)(intcap_t)-1;
 
 void
 cheri_init_capabilities(void * __capability kroot)

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -48,6 +48,11 @@ cheri_init_capabilities(void * __capability kroot)
 {
 	void * __capability ctemp;
 
+	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_KERNEL_BASE);
+	ctemp = cheri_setbounds(kroot, CHERI_SEALCAP_KERNEL_LENGTH);
+	ctemp = cheri_andperm(kroot, CHERI_SEALCAP_KERNEL_PERMS);
+	kernel_sealcap = ctemp;
+
 	ctemp = cheri_setaddress(kroot, CHERI_CAP_USER_DATA_BASE);
 	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);
 	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |

--- a/sys/riscv/include/cheri.h
+++ b/sys/riscv/include/cheri.h
@@ -41,6 +41,7 @@
 /*
  * CHERI-RISC-V-specific kernel utility functions.
  */
+void	cheri_init_capabilities(void * __capability kroot);
 int	cheri_stval_to_sicode(register_t stval);
 void	hybridabi_thread_setregs(struct thread *td, unsigned long entry_addr);
 #endif

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -222,6 +222,15 @@ va:
 	sw	a0, 0(t0)
 #endif
 
+	/* Save DTB physical pointer in s1. */
+	mv	s1, a1
+
+#if __has_feature(capabilities)
+	/* Initialize capabilities. */
+	cspecialr ca0, ddc
+	call	_C_LABEL(cheri_init_capabilities)
+#endif
+
 	/* Fill riscv_bootparams */
 	la	t0, pagetable_l1
 	sd	t0, RISCV_BOOTPARAMS_KERN_L1PT(sp)
@@ -233,10 +242,10 @@ va:
 	li	t0, (VM_EARLY_DTB_ADDRESS)
 	/* Add offset of DTB within superpage */
 	li	t1, (L2_OFFSET)
-	and	t1, a1, t1
+	and	t1, s1, t1
 	add	t0, t0, t1
 	sd	t0, RISCV_BOOTPARAMS_DTBP_VIRT(sp)
-	sd	a1, RISCV_BOOTPARAMS_DTBP_PHYS(sp)
+	sd	s1, RISCV_BOOTPARAMS_DTBP_PHYS(sp)
 
 	mv	a0, sp
 	call	_C_LABEL(initriscv)	/* Off we go */

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -177,12 +177,6 @@ int swap_pager_avail;
 static struct sx swdev_syscall_lock;	/* serialize swap(on|off) */
 
 #if __has_feature(capabilities)
-/*
- * Omnipotent capability for restoring swapped capabilities.
- *
- * XXXBD: These should be a way to do this without storing such a potent
- * capability.  Splitting sealed and unsealed caps would be a start.
- */
 void * __capability swap_restore_cap;
 #endif
 


### PR DESCRIPTION
The first bits of this for `userspace_cap` are pulled from the purecap changes.  The other bits are just things I failed to initialize on RISC-V previously.  `user_sealcap` is still missing on RISC-V as well since we haven't added the custom `sysarch()` methods to work with it.