### PR TITLE
Fix building bcopy.c for CHERI

### DIFF
--- a/lib/libc/string/Makefile.inc
+++ b/lib/libc/string/Makefile.inc
@@ -28,7 +28,7 @@ MISRCS+=bcmp.c bcopy.c bzero.c explicit_bzero.c \
 	wmemcpy.c wmemmove.c wmemset.c
 
 .if ${MACHINE_CPU:Mcheri}
-MDSRCS+=memcpy_c.c memmove_c.c memset_c.c
+MISRCS+=memcpy_c.c memmove_c.c memset_c.c
 .endif
 
 SYM_MAPS+=	${LIBC_SRCTOP}/string/Symbol.map

--- a/lib/libc/string/Makefile.inc
+++ b/lib/libc/string/Makefile.inc
@@ -27,6 +27,10 @@ MISRCS+=bcmp.c bcopy.c bzero.c explicit_bzero.c \
 	wmemcmp.c \
 	wmemcpy.c wmemmove.c wmemset.c
 
+.if ${MACHINE_CPU:Mcheri}
+MDSRCS+=memcpy_c.c memmove_c.c memset_c.c
+.endif
+
 SYM_MAPS+=	${LIBC_SRCTOP}/string/Symbol.map
 
 

--- a/lib/libc/string/Symbol.map
+++ b/lib/libc/string/Symbol.map
@@ -6,7 +6,9 @@ FBSD_1.0 {
 	bcmp;
 	bcopy;
 	memcpy;
+	memcpy_c;
 	memmove;
+	memmove_c;
 	ffs;
 	ffsl;
 	fls;
@@ -19,6 +21,7 @@ FBSD_1.0 {
 	memmem;
 	bzero;
 	memset;
+	memset_c;
 	strrchr;
 	rindex;
 	stpcpy;

--- a/lib/libc/string/bcopy.c
+++ b/lib/libc/string/bcopy.c
@@ -76,13 +76,13 @@ typedef	int word;		/* "word" used for optimal copy speed */
 #ifdef IN_LIBSYSCALLS
 __attribute__((weak, visibility("hidden")))
 #endif
-__CAP void *
+void * __CAP
 #ifdef MEMCOPY
 __CAPSUFFIX(memcpy)
 #else
 __CAPSUFFIX(memmove)
 #endif
-(__CAP void *dst0, __CAP const void *src0, size_t length)
+(void * __CAP dst0, const void * __CAP src0, size_t length)
 #else
 #include <strings.h>
 
@@ -90,8 +90,8 @@ void
 bcopy(const void *src0, void *dst0, size_t length)
 #endif
 {
-	__CAP char *dst = dst0;
-	__CAP const char *src = src0;
+	char * __CAP dst = dst0;
+	const char * __CAP src = src0;
 	size_t t;
 
 	if (length == 0 || dst == src)		/* nothing to do */
@@ -107,13 +107,13 @@ bcopy(const void *src0, void *dst0, size_t length)
 		/*
 		 * Copy forward.
 		 */
-		t = (size_t)src;	/* only need low bits */
-		if ((t | (size_t)dst) & wmask) {
+		t = (__cheri_addr size_t)src;	/* only need low bits */
+		if ((t | (__cheri_addr size_t)dst) & wmask) {
 			/*
 			 * Try to align operands.  This cannot be done
 			 * unless the low bits match.
 			 */
-			if ((t ^ (size_t)dst) & wmask || length < wsize)
+			if ((t ^ (__cheri_addr size_t)dst) & wmask || length < wsize)
 				t = length;
 			else
 				t = wsize - (t & wmask);
@@ -135,9 +135,9 @@ bcopy(const void *src0, void *dst0, size_t length)
 		 */
 		src += length;
 		dst += length;
-		t = (size_t)src;
-		if ((t | (size_t)dst) & wmask) {
-			if ((t ^ (size_t)dst) & wmask || length <= wsize)
+		t = (__cheri_addr size_t)src;
+		if ((t | (__cheri_addr size_t)dst) & wmask) {
+			if ((t ^ (__cheri_addr size_t)dst) & wmask || length <= wsize)
 				t = length;
 			else
 				t &= wmask;

--- a/lib/libc/string/memcpy_c.c
+++ b/lib/libc/string/memcpy_c.c
@@ -1,0 +1,32 @@
+/*-
+ * Copyright (c) 2014 SRI International
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#define CAPABILITY_VERSION
+#include "memcpy.c"

--- a/lib/libc/string/memmove_c.c
+++ b/lib/libc/string/memmove_c.c
@@ -1,0 +1,32 @@
+/*-
+ * Copyright (c) 2014 SRI International
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#define CAPABILITY_VERSION
+#include "memmove.c"


### PR DESCRIPTION
 - Fix the location of __capability in pointers
 - Use __cheri_addr when getting an address value