### PR TITLE
Remove some more CHERI-256 bits based on _MIPS_SZCAP

### DIFF
--- a/libexec/rtld-cheri-elf/mips/rtld_machdep.h
+++ b/libexec/rtld-cheri-elf/mips/rtld_machdep.h
@@ -327,19 +327,14 @@ reloc_jmpslot(Elf_Addr *where __unused, Elf_Addr target, const Obj_Entry *defobj
 }
 
 // Validating e_flags (and ABI version):
-#if _MIPS_SZCAP == 128
-#define _RTLD_EXPECTED_MIPS_MACH EF_MIPS_MACH_CHERI128
-#else
-static_assert(_MIPS_SZCAP == 256, "CHERI bits != 256?");
-#define _RTLD_EXPECTED_MIPS_MACH EF_MIPS_MACH_CHERI256
-#endif
+static_assert(_MIPS_SZCAP == 128, "CHERI bits != 128?");
 
 #define rtld_validate_target_eflags(path, hdr, main_path)	\
 	_rtld_validate_target_eflags(path, hdr, main_path)
 static inline bool
 _rtld_validate_target_eflags(const char* path, Elf_Ehdr *hdr, const char* main_path)
 {
-	if ((hdr->e_flags & EF_MIPS_MACH) != _RTLD_EXPECTED_MIPS_MACH) {
+	if ((hdr->e_flags & EF_MIPS_MACH) != EF_MIPS_MACH_CHERI128) {
 		_rtld_error("%s: cannot load %s since it is not CHERI-" __XSTRING(_MIPS_SZCAP)
 		    " (e_flags=0x%zx)", main_path, path, (size_t)hdr->e_flags);
 		return false;

--- a/libexec/rtld-cheri-elf/tests/abi-mismatch/utils.h
+++ b/libexec/rtld-cheri-elf/tests/abi-mismatch/utils.h
@@ -63,11 +63,11 @@ get_executable_dir(void)
 }
 
 #ifdef __mips__
-#if _MIPS_SZCAP != 128 && _MIPS_SZCAP != 256
+#if _MIPS_SZCAP != 128
 #error BAD _MIPS_SZCAP
 #endif
-#define GOOD_CHERI_MACH (_MIPS_SZCAP == 128 ? 0xc1 : 0xc2)
-#define BAD_CHERI_MACH (_MIPS_SZCAP == 128 ? 0xc2 : 0xc1)
+#define GOOD_CHERI_MACH (0xc1)
+#define BAD_CHERI_MACH (0xc2)
 #endif
 
 #define CHECK_DLERROR_NULL()	do { \

--- a/sys/cheri/cherireg.h
+++ b/sys/cheri/cherireg.h
@@ -120,27 +120,10 @@
 #define	CHERI_OTYPE_UNSEALED	(-1l)
 #define	CHERI_OTYPE_SENTRY	(-2l)
 
-#if defined(_MIPS_SZCAP) && _MIPS_SZCAP == 256
-/*
- * XXXAR: __builtin_cheri_round_representable_length and
- * __builtin_cheri_representable_alignment_mask are currently not constant
- * evaluated by the compiler for CHERI256 so we use different macros here
- * instead.
- *
- * CHERI256 capabilities are precise so we can return the length unchanged
- * and use a mask of all ones.
- */
-#define	CHERI_REPRESENTABLE_LENGTH(len) (len)
-#define	CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) UINT64_MAX
-
-#else /* (!(_MIPS_SZCAP == 256)) */
-
 #define	CHERI_REPRESENTABLE_LENGTH(len) \
 	__builtin_cheri_round_representable_length(len)
 #define	CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) \
 	__builtin_cheri_representable_alignment_mask(len)
-
-#endif /* (!(_MIPS_SZCAP == 256)) */
 
 /* Provide macros to make it easier to work with the raw CRAM/CRRL results: */
 #define	CHERI_REPRESENTABLE_ALIGNMENT(len) \
@@ -165,10 +148,6 @@
 #define	CHERI_SEAL_ALIGN_MASK(l)	~(CHERI_SEALABLE_ALIGNMENT_MASK(l))
 #define	CHERI_ALIGN_MASK(l)		~(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
 
-#if defined(_MIPS_SZCAP) && _MIPS_SZCAP == 256
-#define	CHERI_ALIGN_SHIFT(l)	0ULL
-#define	CHERI_SEAL_ALIGN_SHIFT(l)	0ULL
-#else
 /*
  * TODO: avoid using these since count leading/trailing zeroes is expensive on
  * BERI/CHERI
@@ -177,6 +156,5 @@
 	__builtin_ctzll(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
 #define	CHERI_SEAL_ALIGN_SHIFT(l)	\
 	__builtin_ctzll(CHERI_SEALABLE_ALIGNMENT_MASK(l))
-#endif
 
 #endif /* !__SYS_CHERIREG_H__ */


### PR DESCRIPTION
I grepped for _MIPS_SZCAP and axed cases that handled 256.  I left `__XSTRING(_MIPS_SZCAP)` instances around, and I've left uses of the value for sizing jmpbuf, etc. around also.

There were some other instances I saw in libunwind and cheri-c-tests that should be fixed in their respective upstream repositories at some point.