### PR TITLE
Don't have memcpy_c and friends duplicate their non-_c versions for purecap

### DIFF
--- a/bin/cheri_bench/cheri_bench.c
+++ b/bin/cheri_bench/cheri_bench.c
@@ -80,7 +80,6 @@ struct cheri_object cheri_bench;
 #else
 
 #define __capability
-#define memcpy_c memcpy
 #define cheri_ptr(c,l) c
 
 // Manually assembled due to gcc/gas refusing to recognise custom rdhwr registers:

--- a/include/string.h
+++ b/include/string.h
@@ -136,7 +136,7 @@ typedef	__ssize_t	ssize_t;
 void	 swab(const void * __restrict, void * __restrict, ssize_t);
 #endif /* _SWAB_DECLARED */
 
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void * __capability
 	 memcpy_c(void * __capability __restrict,
 	    const void * __capability __restrict, size_t);
@@ -145,6 +145,10 @@ void * __capability
 	    const void * __capability __restrict, size_t);
 void * __capability
 	memset_c(void * __capability, int, size_t);
+#else
+#define	memcpy_c	memcpy
+#define	memmove_c	memmove
+#define	memset_c	memset
 #endif
 
 int	 timingsafe_bcmp(const void *, const void *, size_t);

--- a/lib/libc/mips/string/Makefile.inc
+++ b/lib/libc/mips/string/Makefile.inc
@@ -15,10 +15,13 @@ MDSRCS+= \
 .endif
 
 .if ${MACHINE_CPU:Mcheri}
+.if !${MACHINE_ABI:Mpurecap}
 CHERI_MDSRCS=	\
 		memcpy_c.c \
 		memmove_c.c \
 		memset_c.c
+.endif
+
 CHERI_MISRCS=	\
 		bcopy.c \
 		memcpy.c \

--- a/lib/libc/string/Makefile.inc
+++ b/lib/libc/string/Makefile.inc
@@ -27,7 +27,7 @@ MISRCS+=bcmp.c bcopy.c bzero.c explicit_bzero.c \
 	wmemcmp.c \
 	wmemcpy.c wmemmove.c wmemset.c
 
-.if ${MACHINE_CPU:Mcheri}
+.if ${MACHINE_CPU:Mcheri} && !${MACHINE_ABI:Mpurecap}
 MISRCS+=memcpy_c.c memmove_c.c memset_c.c
 .endif
 


### PR DESCRIPTION
In purecap code, both are equivalent (and should be identical
implementations), so this is just a waste of space. Instead we can just
define the explicit capability versions to the normal pointer versions.
For convenience, like how we define __capability to nothing when CHERI
is not available, also define them as aliases for their pointer versions
when CHERI isn't available, meaning hybrid code can make use of CHERI
features without needing so many #ifdef's. The kernel currently does
this with memcpy_c for non-CHERI builds, too.