### PR TITLE
More PTR2CAP

### DIFF
--- a/sys/amd64/linux/linux_machdep.c
+++ b/sys/amd64/linux/linux_machdep.c
@@ -102,8 +102,7 @@ linux_execve(struct thread *td, struct linux_execve_args *args)
 
 	LINUX_CTR(execve);
 
-	error = exec_copyin_args(&eargs,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE,
+	error = exec_copyin_args(&eargs, PTR2CAP(path), UIO_SYSSPACE,
 	    __USER_CAP_UNBOUND(args->argp), __USER_CAP_UNBOUND(args->envp));
 	free(path, M_TEMP);
 	if (error == 0)

--- a/sys/amd64/linux32/linux32_machdep.c
+++ b/sys/amd64/linux32/linux32_machdep.c
@@ -133,8 +133,7 @@ linux_execve(struct thread *td, struct linux_execve_args *args)
 
 	LCONVPATHEXIST(td, args->path, &path);
 
-	error = exec_copyin_args(&eargs,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE,
+	error = exec_copyin_args(&eargs, PTR2CAP(path), UIO_SYSSPACE,
 	    __USER_CAP_UNBOUND(args->argp), __USER_CAP_UNBOUND(args->envp));
 	free(path, M_TEMP);
 	if (error == 0)

--- a/sys/arm64/linux/linux_machdep.c
+++ b/sys/arm64/linux/linux_machdep.c
@@ -68,8 +68,7 @@ linux_execve(struct thread *td, struct linux_execve_args *uap)
 
 	LCONVPATHEXIST(td, uap->path, &path);
 
-	error = exec_copyin_args(&eargs,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE,
+	error = exec_copyin_args(&eargs, PTR2CAP(path), UIO_SYSSPACE,
 	    __USER_CAP_UNBOUND(uap->argp), __USER_CAP_UNBOUND(uap->envp));
 	free(path, M_TEMP);
 	if (error == 0)

--- a/sys/cddl/compat/opensolaris/sys/vnode.h
+++ b/sys/cddl/compat/opensolaris/sys/vnode.h
@@ -269,9 +269,8 @@ vn_rename(char *from, char *to, enum uio_seg seg)
 
 	ASSERT(seg == UIO_SYSSPACE);
 
-	return (kern_renameat(curthread, AT_FDCWD,
-	    (__cheri_tocap const char * __capability)from, AT_FDCWD,
-	    (__cheri_tocap const char * __capability)to, seg));
+	return (kern_renameat(curthread, AT_FDCWD, PTR2CAP(from), AT_FDCWD,
+	    PTR2CAP(to), seg));
 }
 
 static __inline int
@@ -281,9 +280,8 @@ vn_remove(char *fnamep, enum uio_seg seg, enum rm dirflag)
 	ASSERT(seg == UIO_SYSSPACE);
 	ASSERT(dirflag == RMFILE);
 
-	return (kern_funlinkat(curthread, AT_FDCWD,
-	    (__cheri_tocap const char * __capability)fnamep, FD_NONE, seg,
-	    0, 0));
+	return (kern_funlinkat(curthread, AT_FDCWD, PTR2CAP(fnamep), FD_NONE,
+	    seg, 0, 0));
 }
 
 #endif	/* _KERNEL */

--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -157,8 +157,7 @@ cloudabi_sys_file_create(struct thread *td,
 	 */
 	switch (uap->type) {
 	case CLOUDABI_FILETYPE_DIRECTORY:
-		error = kern_mkdirat(td, uap->fd,
-		    (__cheri_tocap char * __capability)path, UIO_SYSSPACE,
+		error = kern_mkdirat(td, uap->fd, PTR2CAP(path), UIO_SYSSPACE,
 		    0777);
 		break;
 	default:
@@ -185,9 +184,8 @@ cloudabi_sys_file_link(struct thread *td,
 		return (error);
 	}
 
-	error = kern_linkat(td, uap->fd1.fd, uap->fd2,
-	    (__cheri_tocap const char * __capability)path1,
-	    (__cheri_tocap const char * __capability)path2,
+	error = kern_linkat(td, uap->fd1.fd, uap->fd2, PTR2CAP(path1),
+	    PTR2CAP(path2),
 	    UIO_SYSSPACE, (uap->fd1.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) ?
 	    FOLLOW : NOFOLLOW);
 	cloudabi_freestr(path1);
@@ -505,8 +503,7 @@ cloudabi_sys_file_readlink(struct thread *td,
 	if (error != 0)
 		return (error);
 
-	error = kern_readlinkat(td, uap->fd,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE,
+	error = kern_readlinkat(td, uap->fd, PTR2CAP(path), UIO_SYSSPACE,
 	    __USER_CAP(uap->buf, uap->buf_len), UIO_USERSPACE, uap->buf_len);
 	cloudabi_freestr(path);
 	return (error);
@@ -528,9 +525,8 @@ cloudabi_sys_file_rename(struct thread *td,
 		return (error);
 	}
 
-	error = kern_renameat(td, uap->fd1,
-	    (__cheri_tocap char * __capability)old, uap->fd2,
-	    (__cheri_tocap char * __capability)new, UIO_SYSSPACE);
+	error = kern_renameat(td, uap->fd1, PTR2CAP(old), uap->fd2, PTR2CAP(new),
+	    UIO_SYSSPACE);
 	cloudabi_freestr(old);
 	cloudabi_freestr(new);
 	return (error);
@@ -660,8 +656,7 @@ cloudabi_sys_file_stat_get(struct thread *td,
 
 	error = kern_statat(td,
 	    (uap->fd.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) != 0 ? 0 :
-	    AT_SYMLINK_NOFOLLOW, uap->fd.fd,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE, &sb, NULL);
+	    AT_SYMLINK_NOFOLLOW, uap->fd.fd, PTR2CAP(path), UIO_SYSSPACE, &sb, NULL);
 	cloudabi_freestr(path);
 	if (error != 0)
 		return (error);
@@ -714,10 +709,8 @@ cloudabi_sys_file_stat_put(struct thread *td,
 		return (error);
 
 	convert_utimens_arguments(&fs, uap->flags, ts);
-	error = kern_utimensat(td, uap->fd.fd,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE,
-	    &ts[0], UIO_SYSSPACE,
-	    (uap->fd.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) ?
+	error = kern_utimensat(td, uap->fd.fd, PTR2CAP(path), UIO_SYSSPACE, ts,
+	    UIO_SYSSPACE, (uap->fd.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) ?
 	    0 : AT_SYMLINK_NOFOLLOW);
 	cloudabi_freestr(path);
 	return (error);
@@ -739,9 +732,8 @@ cloudabi_sys_file_symlink(struct thread *td,
 		return (error);
 	}
 
-	error = kern_symlinkat(td,
-	    (__cheri_tocap char * __capability)path1, uap->fd,
-	    (__cheri_tocap char * __capability)path2, UIO_SYSSPACE);
+	error = kern_symlinkat(td, PTR2CAP(path1), uap->fd, PTR2CAP(path2),
+	    UIO_SYSSPACE);
 	cloudabi_freestr(path1);
 	cloudabi_freestr(path2);
 	return (error);
@@ -759,12 +751,10 @@ cloudabi_sys_file_unlink(struct thread *td,
 		return (error);
 
 	if (uap->flags & CLOUDABI_UNLINK_REMOVEDIR)
-		error = kern_frmdirat(td, uap->fd,
-		    (__cheri_tocap char * __capability)path, FD_NONE,
+		error = kern_frmdirat(td, uap->fd, PTR2CAP(path), FD_NONE,
 		    UIO_SYSSPACE, 0);
 	else
-		error = kern_funlinkat(td, uap->fd,
-		    (__cheri_tocap char * __capability)path, FD_NONE,
+		error = kern_funlinkat(td, uap->fd, PTR2CAP(path), FD_NONE,
 		    UIO_SYSSPACE, 0, 0);
 	cloudabi_freestr(path);
 	return (error);

--- a/sys/compat/cloudabi/cloudabi_sock.c
+++ b/sys/compat/cloudabi/cloudabi_sock.c
@@ -78,7 +78,7 @@ cloudabi_sock_recv(struct thread *td, cloudabi_fd_t fd, struct iovec *data,
     cloudabi_roflags_t *rflags)
 {
 	struct msghdr hdr = {
-		.msg_iov = (__cheri_tocap struct iovec * __capability)data,
+		.msg_iov = PTR2CAP(data),
 		.msg_iovlen = datalen,
 	};
 	struct mbuf *control;
@@ -111,8 +111,7 @@ cloudabi_sock_recv(struct thread *td, cloudabi_fd_t fd, struct iovec *data,
 	if (control != NULL) {
 		struct cmsghdr *chdr;
 
-		hdr.msg_control =
-		    (__cheri_tocap void * __capability)mtod(control, void *);
+		hdr.msg_control = PTR2CAP(mtod(control, void *));
 		hdr.msg_controllen = control->m_len;
 		for (chdr = CMSG_FIRSTHDR(&hdr); chdr != NULL;
 		    chdr = CMSG_NXTHDR(&hdr, chdr)) {
@@ -152,7 +151,7 @@ cloudabi_sock_send(struct thread *td, cloudabi_fd_t fd, struct iovec *data,
     size_t datalen, const cloudabi_fd_t *fds, size_t fdslen, size_t *rdatalen)
 {
 	struct msghdr hdr = {
-		.msg_iov = (__cheri_tocap struct iovec * __capability)data,
+		.msg_iov = PTR2CAP(data),
 		.msg_iovlen = datalen,
 	};
 	struct mbuf *control;

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -135,7 +135,7 @@ freebsd64_copyinmsghdr(struct msghdr64 * __capability umsg, struct msghdr *msg,
 	    m64->msg_iovlen, &iov, EMSGSIZE);
 	if (error)
 		return (error);
-	msg->msg_iov = (__cheri_tocap struct iovec * __capability)iov;
+	msg->msg_iov = PTR2CAP(iov);
 	msg->msg_iovlen = m64->msg_iovlen;
 
 	msg->msg_control = __USER_CAP(m64->msg_control, m64->msg_controllen);
@@ -346,7 +346,7 @@ freebsd64_sendmsg(struct thread *td, struct freebsd64_sendmsg_args *uap)
 		error = getsockaddr(&to, msg.msg_name, msg.msg_namelen);
 		if (error)
 			goto out;
-		msg.msg_name = (__cheri_tocap struct sockaddr * __capability)to;
+		msg.msg_name = PTR2CAP(to);
 	}
 
 	/* No COMPAT_OLDSOCK support, no 64-bit 43BSD binaries should exist. */

--- a/sys/compat/linux/linux_file.c
+++ b/sys/compat/linux/linux_file.c
@@ -77,7 +77,7 @@ linux_creat(struct thread *td, struct linux_creat_args *args)
 
 	LCONVPATHEXIST(td, args->path, &path);
 
-	error = kern_openat(td, AT_FDCWD, path, UIO_SYSSPACE,
+	error = kern_openat(td, AT_FDCWD, PTR2CAP(path), UIO_SYSSPACE,
 	    O_WRONLY | O_CREAT | O_TRUNC, args->mode);
 	LFREEPATH(path);
 	return (error);
@@ -131,7 +131,7 @@ linux_common_open(struct thread *td, int dirfd, char *path, int l_flags, int mod
 		bsd_flags |= O_DIRECTORY;
 	/* XXX LINUX_O_NOATIME: unable to be easily implemented. */
 
-	error = kern_openat(td, dirfd, path, UIO_SYSSPACE, bsd_flags, mode);
+	error = kern_openat(td, dirfd, PTR2CAP(path), UIO_SYSSPACE, bsd_flags, mode);
 	if (error != 0) {
 		if (error == EMLINK)
 			error = ELOOP;
@@ -505,7 +505,7 @@ linux_access(struct thread *td, struct linux_access_args *args)
 
 	LCONVPATHEXIST(td, args->path, &path);
 
-	error = kern_accessat(td, AT_FDCWD, path, UIO_SYSSPACE, 0,
+	error = kern_accessat(td, AT_FDCWD, PTR2CAP(path), UIO_SYSSPACE, 0,
 	    args->amode);
 	LFREEPATH(path);
 
@@ -526,7 +526,7 @@ linux_faccessat(struct thread *td, struct linux_faccessat_args *args)
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->dfd;
 	LCONVPATHEXIST_AT(td, args->filename, &path, dfd);
 
-	error = kern_accessat(td, dfd, path, UIO_SYSSPACE, 0, args->amode);
+	error = kern_accessat(td, dfd, PTR2CAP(path), UIO_SYSSPACE, 0, args->amode);
 	LFREEPATH(path);
 
 	return (error);
@@ -571,10 +571,11 @@ linux_unlinkat(struct thread *td, struct linux_unlinkat_args *args)
 	LCONVPATHEXIST_AT(td, args->pathname, &path, dfd);
 
 	if (args->flag & LINUX_AT_REMOVEDIR)
-		error = kern_frmdirat(td, dfd, path, FD_NONE, UIO_SYSSPACE, 0);
+		error = kern_frmdirat(td, dfd, PTR2CAP(path), FD_NONE,
+		    UIO_SYSSPACE, 0);
 	else
-		error = kern_funlinkat(td, dfd, path, FD_NONE, UIO_SYSSPACE, 0,
-		    0);
+		error = kern_funlinkat(td, dfd, PTR2CAP(path), FD_NONE,
+		    UIO_SYSSPACE, 0, 0);
 	if (error == EPERM && !(args->flag & LINUX_AT_REMOVEDIR)) {
 		/* Introduce POSIX noncompliant behaviour of Linux */
 		if (kern_statat(td, AT_SYMLINK_NOFOLLOW, dfd, PTR2CAP(path),
@@ -592,7 +593,7 @@ linux_chdir(struct thread *td, struct linux_chdir_args *args)
 
 	LCONVPATHEXIST(td, args->path, &path);
 
-	error = kern_chdir(td, (char * __capability)path, UIO_SYSSPACE);
+	error = kern_chdir(td, PTR2CAP(path), UIO_SYSSPACE);
 	LFREEPATH(path);
 	return (error);
 }
@@ -636,7 +637,7 @@ linux_mkdir(struct thread *td, struct linux_mkdir_args *args)
 
 	LCONVPATHCREAT(td, args->path, &path);
 
-	error = kern_mkdirat(td, AT_FDCWD, path, UIO_SYSSPACE, args->mode);
+	error = kern_mkdirat(td, AT_FDCWD, PTR2CAP(path), UIO_SYSSPACE, args->mode);
 	LFREEPATH(path);
 	return (error);
 }
@@ -651,7 +652,7 @@ linux_mkdirat(struct thread *td, struct linux_mkdirat_args *args)
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->dfd;
 	LCONVPATHCREAT_AT(td, args->pathname, &path, dfd);
 
-	error = kern_mkdirat(td, dfd, path, UIO_SYSSPACE, args->mode);
+	error = kern_mkdirat(td, dfd, PTR2CAP(path), UIO_SYSSPACE, args->mode);
 	LFREEPATH(path);
 	return (error);
 }
@@ -665,7 +666,7 @@ linux_rmdir(struct thread *td, struct linux_rmdir_args *args)
 
 	LCONVPATHEXIST(td, args->path, &path);
 
-	error = kern_frmdirat(td, AT_FDCWD, path, FD_NONE, UIO_SYSSPACE, 0);
+	error = kern_frmdirat(td, AT_FDCWD, PTR2CAP(path), FD_NONE, UIO_SYSSPACE, 0);
 	LFREEPATH(path);
 	return (error);
 }
@@ -684,7 +685,8 @@ linux_rename(struct thread *td, struct linux_rename_args *args)
 		return (error);
 	}
 
-	error = kern_renameat(td, AT_FDCWD, from, AT_FDCWD, to, UIO_SYSSPACE);
+	error = kern_renameat(td, AT_FDCWD, PTR2CAP(from), AT_FDCWD,
+	    PTR2CAP(to), UIO_SYSSPACE);
 	LFREEPATH(from);
 	LFREEPATH(to);
 	return (error);
@@ -734,7 +736,8 @@ linux_renameat2(struct thread *td, struct linux_renameat2_args *args)
 		return (error);
 	}
 
-	error = kern_renameat(td, olddfd, from, newdfd, to, UIO_SYSSPACE);
+	error = kern_renameat(td, olddfd, PTR2CAP(from), newdfd, PTR2CAP(to),
+	    UIO_SYSSPACE);
 	LFREEPATH(from);
 	LFREEPATH(to);
 	return (error);
@@ -755,7 +758,7 @@ linux_symlink(struct thread *td, struct linux_symlink_args *args)
 		return (error);
 	}
 
-	error = kern_symlinkat(td, path, AT_FDCWD, to, UIO_SYSSPACE);
+	error = kern_symlinkat(td, PTR2CAP(path), AT_FDCWD, to, UIO_SYSSPACE);
 	LFREEPATH(path);
 	LFREEPATH(to);
 	return (error);
@@ -777,7 +780,7 @@ linux_symlinkat(struct thread *td, struct linux_symlinkat_args *args)
 		return (error);
 	}
 
-	error = kern_symlinkat(td, path, dfd, to, UIO_SYSSPACE);
+	error = kern_symlinkat(td, PTR2CAP(path), dfd, to, UIO_SYSSPACE);
 	LFREEPATH(path);
 	LFREEPATH(to);
 	return (error);
@@ -792,7 +795,7 @@ linux_readlink(struct thread *td, struct linux_readlink_args *args)
 
 	LCONVPATHEXIST(td, args->name, &name);
 
-	error = kern_readlinkat(td, AT_FDCWD, name, UIO_SYSSPACE,
+	error = kern_readlinkat(td, AT_FDCWD, PTR2CAP(name), UIO_SYSSPACE,
 	    args->buf, UIO_USERSPACE, args->count);
 	LFREEPATH(name);
 	return (error);
@@ -808,7 +811,7 @@ linux_readlinkat(struct thread *td, struct linux_readlinkat_args *args)
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->dfd;
 	LCONVPATHEXIST_AT(td, args->path, &name, dfd);
 
-	error = kern_readlinkat(td, dfd, name, UIO_SYSSPACE, args->buf,
+	error = kern_readlinkat(td, dfd, PTR2CAP(name), UIO_SYSSPACE, args->buf,
 	    UIO_USERSPACE, args->bufsiz);
 	LFREEPATH(name);
 	return (error);
@@ -821,7 +824,7 @@ linux_truncate(struct thread *td, struct linux_truncate_args *args)
 	int error;
 
 	LCONVPATHEXIST(td, args->path, &path);
-	error = kern_truncate(td, path, UIO_SYSSPACE, args->length);
+	error = kern_truncate(td, PTR2CAP(path), UIO_SYSSPACE, args->length);
 	LFREEPATH(path);
 	return (error);
 }
@@ -841,7 +844,7 @@ linux_truncate64(struct thread *td, struct linux_truncate64_args *args)
 #endif
 
 	LCONVPATHEXIST(td, args->path, &path);
-	error = kern_truncate(td, path, UIO_SYSSPACE, length);
+	error = kern_truncate(td, PTR2CAP(path), UIO_SYSSPACE, length);
 	LFREEPATH(path);
 	return (error);
 }
@@ -885,8 +888,8 @@ linux_link(struct thread *td, struct linux_link_args *args)
 		return (error);
 	}
 
-	error = kern_linkat(td, AT_FDCWD, AT_FDCWD, path, to, UIO_SYSSPACE,
-	    FOLLOW);
+	error = kern_linkat(td, AT_FDCWD, AT_FDCWD, PTR2CAP(path), PTR2CAP(to),
+	    UIO_SYSSPACE, FOLLOW);
 	LFREEPATH(path);
 	LFREEPATH(to);
 	return (error);
@@ -914,7 +917,8 @@ linux_linkat(struct thread *td, struct linux_linkat_args *args)
 
 	follow = (args->flag & LINUX_AT_SYMLINK_FOLLOW) == 0 ? NOFOLLOW :
 	    FOLLOW;
-	error = kern_linkat(td, olddfd, newdfd, path, to, UIO_SYSSPACE, follow);
+	error = kern_linkat(td, olddfd, newdfd, PTR2CAP(path), PTR2CAP(to),
+	    UIO_SYSSPACE, follow);
 	LFREEPATH(path);
 	LFREEPATH(to);
 	return (error);

--- a/sys/compat/linux/linux_ipc.c
+++ b/sys/compat/linux/linux_ipc.c
@@ -662,7 +662,7 @@ linux_msgsnd(struct thread *td, struct linux_msgsnd_args *args)
 		return (error);
 	mtype = (long)lmtype;
 	return (kern_msgsnd(td, args->msqid,
-	    (__cheri_tocap const char * __capability)msgp + sizeof(lmtype),
+	    PTR2CAP((const char *)msgp) + sizeof(lmtype),
 	    args->msgsz, args->msgflg, mtype));
 }
 
@@ -678,8 +678,8 @@ linux_msgrcv(struct thread *td, struct linux_msgrcv_args *args)
 		return (EINVAL);
 	msgp = PTRIN(args->msgp);
 	if ((error = kern_msgrcv(td, args->msqid,
-	    (__cheri_tocap char * __capability)msgp + sizeof(lmtype),
-	    args->msgsz, args->msgtyp, args->msgflg, &mtype)) != 0)
+	    PTR2CAP((char *)msgp) + sizeof(lmtype), args->msgsz,
+	    args->msgtyp, args->msgflg, &mtype)) != 0)
 		return (error);
 	lmtype = (l_long)mtype;
 	return (copyout(&lmtype, msgp, sizeof(lmtype)));

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -530,11 +530,9 @@ linux_select(struct thread *td, struct linux_select_args *args)
 	} else
 		tvp = NULL;
 
-	error = kern_select(td, args->nfds,
-	    (__cheri_tocap fd_set * __capability)args->readfds,
-	    (__cheri_tocap fd_set * __capability)args->writefds,
-	    (__cheri_tocap fd_set * __capability)args->exceptfds,
-	    tvp, LINUX_NFDBITS);
+	error = kern_select(td, args->nfds, __USER_CAP_UNBOUND(args->readfds),
+	    __USER_CAP_UNBOUND(args->writefds),
+	    __USER_CAP_UNBOUND(args->exceptfds), tvp, LINUX_NFDBITS);
 	if (error)
 		goto select_out;
 
@@ -2189,11 +2187,9 @@ linux_pselect6(struct thread *td, struct linux_pselect6_args *args)
 	} else
 		tvp = NULL;
 
-	error = kern_pselect(td, args->nfds,
-	    (__cheri_tocap fd_set * __capability)args->readfds,
-	    (__cheri_tocap fd_set * __capability)args->writefds,
-	    (__cheri_tocap fd_set * __capability)args->exceptfds,
-	    tvp, ssp, LINUX_NFDBITS);
+	error = kern_pselect(td, args->nfds, __USER_CAP_UNBOUND(args->readfds),
+	    __USER_CAP_UNBOUND(args->writefds),
+	    __USER_CAP_UNBOUND(args->exceptfds), tvp, ssp, LINUX_NFDBITS);
 
 	if (error == 0 && args->tsp != NULL) {
 		if (td->td_retval[0] != 0) {
@@ -2256,9 +2252,8 @@ linux_ppoll(struct thread *td, struct linux_ppoll_args *args)
 	} else
 		tsp = NULL;
 
-	error = kern_poll(td,
-	    (__cheri_tocap struct pollfd * __capability)args->fds, args->nfds,
-	    tsp, ssp);
+	error = kern_poll(td, __USER_CAP_ARRAY(args->fds, args->nfds),
+	    args->nfds, tsp, ssp);
 
 	if (error == 0 && args->tsp != NULL) {
 		if (td->td_retval[0]) {

--- a/sys/compat/linux/linux_stats.c
+++ b/sys/compat/linux/linux_stats.c
@@ -82,8 +82,7 @@ linux_kern_statat(struct thread *td, int flag, int fd, char *path,
     struct stat *sbp)
 {
 
-	return (kern_statat(td, flag, fd,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE, sbp,
+	return (kern_statat(td, flag, fd, PTR2CAP(path), UIO_SYSSPACE, sbp,
 	    translate_vnhook_major_minor));
 }
 
@@ -397,8 +396,7 @@ linux_statfs(struct thread *td, struct linux_statfs_args *args)
 	LCONVPATHEXIST(td, args->path, &path);
 
 	bsd_statfs = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, (__cheri_tocap char * __capability)path,
-	    UIO_SYSSPACE, bsd_statfs);
+	error = kern_statfs(td, PTR2CAP(path), UIO_SYSSPACE, bsd_statfs);
 	LFREEPATH(path);
 	if (error == 0)
 		error = bsd_to_linux_statfs(bsd_statfs, &linux_statfs);
@@ -442,8 +440,7 @@ linux_statfs64(struct thread *td, struct linux_statfs64_args *args)
 	LCONVPATHEXIST(td, args->path, &path);
 
 	bsd_statfs = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, (__cheri_tocap char * __capability)path,
-	    UIO_SYSSPACE, bsd_statfs);
+	error = kern_statfs(td, PTR2CAP(path), UIO_SYSSPACE, bsd_statfs);
 	LFREEPATH(path);
 	if (error == 0)
 		bsd_to_linux_statfs64(bsd_statfs, &linux_statfs);

--- a/sys/compat/linux/linux_uid16.c
+++ b/sys/compat/linux/linux_uid16.c
@@ -123,8 +123,7 @@ linux_chown16(struct thread *td, struct linux_chown16_args *args)
 	    args->gid);
 	LIN_SDT_PROBE1(uid16, linux_chown16, conv_path, path);
 
-	error = kern_fchownat(td, AT_FDCWD,
-	    (__cheri_tocap const char * __capability)path, UIO_SYSSPACE,
+	error = kern_fchownat(td, AT_FDCWD, PTR2CAP(path), UIO_SYSSPACE,
 	    CAST_NOCHG(args->uid), CAST_NOCHG(args->gid), 0);
 	LFREEPATH(path);
 
@@ -149,8 +148,7 @@ linux_lchown16(struct thread *td, struct linux_lchown16_args *args)
 	    args->gid);
 	LIN_SDT_PROBE1(uid16, linux_lchown16, conv_path, path);
 
-	error = kern_fchownat(td, AT_FDCWD,
-	    (__cheri_tocap const char * __capability)path, UIO_SYSSPACE,
+	error = kern_fchownat(td, AT_FDCWD, PTR2CAP(path), UIO_SYSSPACE,
 	    CAST_NOCHG(args->uid), CAST_NOCHG(args->gid), AT_SYMLINK_NOFOLLOW);
 	LFREEPATH(path);
 

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -821,9 +821,7 @@ linux_remap_address(void * __capability *uaddr, size_t len)
 		}
 
 		/* re-add kernel buffer address */
-		*uaddr =
-		    (__cheri_tocap char * __capability)pts->bsd_ioctl_data +
-		    uaddr_val;
+		*uaddr = PTR2CAP((char *)pts->bsd_ioctl_data) + uaddr_val;
 		return (1);
 	}
 	return (0);

--- a/sys/fs/nfsclient/nfs_clrpcops.c
+++ b/sys/fs/nfsclient/nfs_clrpcops.c
@@ -5922,7 +5922,7 @@ nfscl_doiods(vnode_t vp, struct uio *uiop, int *iomode, int *must_commit,
 				 */
 				uiop->uio_offset = offs;
 				uiop->uio_resid = resid;
-				IOVEC_INIT(uiop->uio_iov, iovbase, iovlen);
+				IOVEC_INIT_C(uiop->uio_iov, iovbase, iovlen);
 			}
 		}
 	}

--- a/sys/fs/nfsclient/nfs_clvnops.c
+++ b/sys/fs/nfsclient/nfs_clvnops.c
@@ -569,7 +569,7 @@ nfs_access(struct vop_access_args *ap)
 			char buf[1];
 
 			NFSUNLOCKNODE(np);
-			IOVEC_INIT(&aiov, buf, 1);
+			IOVEC_INIT_C(&aiov, buf, 1);
 			auio.uio_iov = &aiov;
 			auio.uio_iovcnt = 1;
 			auio.uio_offset = 0;

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -3524,7 +3524,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 				goto out;
 			}
 			cp[nfsdarg.addrlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.addr = (__cheri_tocap char * __capability)cp;
+			nfsdarg.addr = PTR2CAP(cp);
 			cp = malloc(nfsdarg.dnshostlen + 1, M_TEMP, M_WAITOK);
 			error = copyin(nfsdarg.dnshost, cp, nfsdarg.dnshostlen);
 			if (error != 0) {
@@ -3534,7 +3534,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 				goto out;
 			}
 			cp[nfsdarg.dnshostlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.dnshost = (__cheri_tocap char * __capability)cp;
+			nfsdarg.dnshost = PTR2CAP(cp);
 			cp = malloc(nfsdarg.dspathlen + 1, M_TEMP, M_WAITOK);
 			error = copyin(nfsdarg.dspath, cp, nfsdarg.dspathlen);
 			if (error != 0) {
@@ -3546,7 +3546,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 				goto out;
 			}
 			cp[nfsdarg.dspathlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.dspath = (__cheri_tocap char * __capability)cp;
+			nfsdarg.dspath = PTR2CAP(cp);
 			cp = malloc(nfsdarg.mdspathlen + 1, M_TEMP, M_WAITOK);
 			error = copyin(nfsdarg.mdspath, cp, nfsdarg.mdspathlen);
 			if (error != 0) {
@@ -3560,7 +3560,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 				goto out;
 			}
 			cp[nfsdarg.mdspathlen] = '\0';	/* Ensure nul term. */
-			nfsdarg.mdspath = (__cheri_tocap char * __capability)cp;
+			nfsdarg.mdspath = PTR2CAP(cp);
 		} else {
 			nfsdarg.addr = NULL;
 			nfsdarg.addrlen = 0;

--- a/sys/fs/smbfs/smbfs_smb.c
+++ b/sys/fs/smbfs/smbfs_smb.c
@@ -105,8 +105,7 @@ smbfs_smb_lockandx(struct smbnode *np, int op, u_int32_t pid, off_t start, off_t
 	mb_put_uint8(mbp, 0xff);	/* secondary command */
 	mb_put_uint8(mbp, 0);		/* MBZ */
 	mb_put_uint16le(mbp, 0);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&np->n_fid), 2, MB_MSYSTEM);
 	mb_put_uint8(mbp, ltype);	/* locktype */
 	mb_put_uint8(mbp, 0);		/* oplocklevel - 0 seems is NO_OPLOCK */
 	mb_put_uint32le(mbp, 0);	/* timeout - break immediately */
@@ -285,8 +284,7 @@ smbfs_smb_seteof(struct smbnode *np, int64_t newsize, struct smb_cred *scred)
 		return error;
 	mbp = &t2p->t2_tparam;
 	mb_init(mbp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&np->n_fid), 2, MB_MSYSTEM);
 	mb_put_uint16le(mbp, SMB_SET_FILE_END_OF_FILE_INFO);
 	mb_put_uint32le(mbp, 0);
 	mbp = &t2p->t2_tdata;
@@ -317,8 +315,7 @@ smb_smb_flush(struct smbnode *np, struct smb_cred *scred)
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&np->n_fid), 2, MB_MSYSTEM);
 	smb_rq_wend(rqp);
 	smb_rq_bstart(rqp);
 	smb_rq_bend(rqp);
@@ -355,8 +352,7 @@ smbfs_smb_setfsize(struct smbnode *np, int64_t newsize, struct smb_cred *scred)
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&np->n_fid), 2, MB_MSYSTEM);
 	mb_put_uint16le(mbp, 0);
 	mb_put_uint32le(mbp, (uint32_t)newsize);
 	mb_put_uint16le(mbp, 0);
@@ -601,8 +597,7 @@ smbfs_smb_setftime(struct smbnode *np, struct timespec *mtime,
 	tzoff = SSTOVC(ssp)->vc_sopt.sv_tz;
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&np->n_fid), 2, MB_MSYSTEM);
 	mb_put_uint32le(mbp, 0);		/* creation time */
 
 	if (atime)
@@ -647,8 +642,7 @@ smbfs_smb_setfattrNT(struct smbnode *np, u_int16_t attr, struct timespec *mtime,
 	svtz = SSTOVC(ssp)->vc_sopt.sv_tz;
 	mbp = &t2p->t2_tparam;
 	mb_init(mbp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&np->n_fid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&np->n_fid), 2, MB_MSYSTEM);
 	mb_put_uint16le(mbp, SMB_SET_FILE_BASIC_INFO);
 	mb_put_uint32le(mbp, 0);
 	mbp = &t2p->t2_tdata;
@@ -742,8 +736,7 @@ smbfs_smb_close(struct smb_share *ssp, u_int16_t fid, struct timespec *mtime,
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
-	    sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&fid), sizeof(fid), MB_MSYSTEM);
 	if (mtime) {
 		smb_time_local2server(mtime, SSTOVC(ssp)->vc_sopt.sv_tz, &time);
 	} else
@@ -1073,8 +1066,7 @@ smbfs_findnextLM1(struct smbfs_fctx *ctx, int limit)
 	md_get_uint16le(mbp, &date);
 	md_get_uint32le(mbp, &size);
 	cp = ctx->f_name;
-	md_get_mem(mbp, (__cheri_tocap char * __capability)cp,
-	    sizeof(ctx->f_fname), MB_MSYSTEM);
+	md_get_mem(mbp, PTR2CAP(cp), sizeof(ctx->f_fname), MB_MSYSTEM);
 	cp[sizeof(ctx->f_fname) - 1] = 0;
 	cp += strlen(cp) - 1;
 	while (*cp == ' ' && cp >= ctx->f_name)
@@ -1144,17 +1136,13 @@ smbfs_smb_trans2find2(struct smbfs_fctx *ctx)
 		ctx->f_t2 = t2p;
 		mbp = &t2p->t2_tparam;
 		mb_init(mbp);
-		mb_put_mem(mbp,
-		    (__cheri_tocap char * __capability)(char *)&ctx->f_Sid, 2,
-		    MB_MSYSTEM);
+		mb_put_mem(mbp, PTR2CAP((char *)&ctx->f_Sid), 2, MB_MSYSTEM);
 		mb_put_uint16le(mbp, ctx->f_limit);
 		mb_put_uint16le(mbp, ctx->f_infolevel);
 		mb_put_uint32le(mbp, 0);		/* resume key */
 		mb_put_uint16le(mbp, flags);
 		if (ctx->f_rname)
-			mb_put_mem(mbp,
-			    (__cheri_tocap const char * __capability)
-			    ctx->f_rname, ctx->f_rnamelen + 1, MB_MSYSTEM);
+			mb_put_mem(mbp, PTR2CAP(ctx->f_rname), ctx->f_rnamelen + 1, MB_MSYSTEM);
 		else
 			mb_put_uint8(mbp, 0);	/* resume file name */
 #if 0
@@ -1225,8 +1213,7 @@ smbfs_smb_findclose2(struct smbfs_fctx *ctx)
 		return (error);
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&ctx->f_Sid,
-	    2, MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&ctx->f_Sid), 2, MB_MSYSTEM);
 	smb_rq_wend(rqp);
 	smb_rq_bstart(rqp);
 	smb_rq_bend(rqp);
@@ -1324,8 +1311,7 @@ smbfs_findnextLM2(struct smbfs_fctx *ctx, int limit)
 	} else
 		nmlen = min(size, SMB_MAXFNAMELEN);
 	cp = ctx->f_name;
-	error = md_get_mem(mbp, (__cheri_tocap char * __capability)cp, nmlen,
-	    MB_MSYSTEM);
+	error = md_get_mem(mbp, PTR2CAP(cp), nmlen, MB_MSYSTEM);
 	if (error)
 		return error;
 	if (next) {

--- a/sys/i386/linux/linux_machdep.c
+++ b/sys/i386/linux/linux_machdep.c
@@ -106,8 +106,7 @@ linux_execve(struct thread *td, struct linux_execve_args *args)
 
 	LCONVPATHEXIST(td, args->path, &newpath);
 
-	error = exec_copyin_args(&eargs,
-	    (__cheri_tocap char * __capability)newpath, UIO_SYSSPACE,
+	error = exec_copyin_args(&eargs, PTR2CAP(newpath), UIO_SYSSPACE,
 	    __USER_CAP_UNBOUND(args->argp), __USER_CAP_UNBOUND(args->envp));
 	free(newpath, M_TEMP);
 	if (error == 0)

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -734,12 +734,10 @@ start_init(void *dummy)
 			panic("%s: Can't allocate space for init arguments %d",
 			    __func__, error);
 
-		error = exec_args_add_fname(&args,
-		    (__cheri_tocap char * __capability)path, UIO_SYSSPACE);
+		error = exec_args_add_fname(&args, PTR2CAP(path), UIO_SYSSPACE);
 		if (error != 0)
 			panic("%s: Can't add fname %d", __func__, error);
-		error = exec_args_add_arg(&args,
-		    (__cheri_tocap char * __capability)path, UIO_SYSSPACE);
+		error = exec_args_add_arg(&args, PTR2CAP(path), UIO_SYSSPACE);
 		if (error != 0)
 			panic("%s: Can't add argv[0] %d", __func__, error);
 		if (boothowto & RB_SINGLE)

--- a/sys/kern/kern_environment.c
+++ b/sys/kern/kern_environment.c
@@ -98,9 +98,7 @@ int
 sys_kenv(struct thread *td, struct kenv_args *uap)
 {
 
-	return (kern_kenv(td, uap->what,
-	    (__cheri_tocap const char * __capability)uap->name,
-	    (__cheri_tocap char * __capability)uap->value, uap->len));
+	return (kern_kenv(td, uap->what, uap->name, uap->value, uap->len));
 }
 
 int

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -1846,11 +1846,11 @@ sysctl_old_kernel(struct sysctl_req *req, const void *p, size_t l)
 				memcpy_c((char * __capability)req->oldptr +
 				    req->oldidx,
 				    (__cheri_tocap const char * __capability)p,
-				    l);
+				    i);
 			else
 #endif
 				memcpy((__cheri_fromcap char *)req->oldptr +
-				    req->oldidx, p, l);
+				    req->oldidx, p, i);
 		}
 	}
 	req->oldidx += l;

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -330,7 +330,7 @@ sysctl_load_tunable_by_oid_locked(struct sysctl_oid *oidp)
 		if (penv == NULL)
 			return;
 		req.newlen = strlen(penv);
-		req.newptr = (__cheri_tocap char * __capability)penv;
+		req.newptr = PTR2CAP(penv);
 		break;
 	default:
 		return;
@@ -1844,9 +1844,7 @@ sysctl_old_kernel(struct sysctl_req *req, const void *p, size_t l)
 #if __has_feature(capabilities)
 			if (req->flags & SCTL_PTROUT)
 				memcpy_c((char * __capability)req->oldptr +
-				    req->oldidx,
-				    (__cheri_tocap const char * __capability)p,
-				    i);
+				    req->oldidx, PTR2CAP(p), i);
 			else
 #endif
 				memcpy((__cheri_fromcap char *)req->oldptr +
@@ -1868,7 +1866,7 @@ sysctl_new_kernel(struct sysctl_req *req, void *p, size_t l)
 		return (EINVAL);
 #if __has_feature(capabilities)
 	if (req->flags & SCTL_PTRIN)
-		memcpy_c((__cheri_tocap char * __capability)p,
+		memcpy_c(PTR2CAP(p),
 		    (const char * __capability)req->newptr + req->newidx, l);
 	else
 #endif
@@ -1895,12 +1893,12 @@ kernel_sysctl(struct thread *td, int *name, u_int namelen, void *old,
 	req.validlen = req.oldlen;
 
 	if (old) {
-		req.oldptr= (__cheri_tocap void * __capability)old;
+		req.oldptr= PTR2CAP(old);
 	}
 
 	if (new != NULL) {
 		req.newlen = newlen;
-		req.newptr = (__cheri_tocap void * __capability)new;
+		req.newptr = PTR2CAP(new);
 	}
 
 	req.oldfunc = sysctl_old_kernel;

--- a/sys/kern/subr_mchain.c
+++ b/sys/kern/subr_mchain.c
@@ -140,8 +140,7 @@ mb_put_padbyte(struct mbchain *mbp)
 
 	/* Only add padding if address is odd */
 	if ((unsigned long)dst & 1)
-		return (mb_put_mem(mbp,
-		    (__cheri_tocap char * __capability)(char *)&x, sizeof(x),
+		return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x),
 		    MB_MSYSTEM));
 	else
 		return (0);
@@ -150,56 +149,49 @@ mb_put_padbyte(struct mbchain *mbp)
 int
 mb_put_uint8(struct mbchain *mbp, uint8_t x)
 {
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint16be(struct mbchain *mbp, uint16_t x)
 {
 	x = htobe16(x);
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint16le(struct mbchain *mbp, uint16_t x)
 {
 	x = htole16(x);
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint32be(struct mbchain *mbp, uint32_t x)
 {
 	x = htobe32(x);
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_uint32le(struct mbchain *mbp, uint32_t x)
 {
 	x = htole32(x);
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_int64be(struct mbchain *mbp, int64_t x)
 {
 	x = htobe64(x);
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
 mb_put_int64le(struct mbchain *mbp, int64_t x)
 {
 	x = htole64(x);
-	return (mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&x,
-	    sizeof(x), MB_MSYSTEM));
+	return (mb_put_mem(mbp, PTR2CAP((char *)&x), sizeof(x), MB_MSYSTEM));
 }
 
 int
@@ -385,15 +377,13 @@ md_next_record(struct mdchain *mdp)
 int
 md_get_uint8(struct mdchain *mdp, uint8_t *x)
 {
-	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
-	    1, MB_MINLINE));
+	return (md_get_mem(mdp, PTR2CAP((char *)x), 1, MB_MINLINE));
 }
 
 int
 md_get_uint16(struct mdchain *mdp, uint16_t *x)
 {
-	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
-	    2, MB_MINLINE));
+	return (md_get_mem(mdp, PTR2CAP((char *)x), 2, MB_MINLINE));
 }
 
 int
@@ -421,8 +411,7 @@ md_get_uint16be(struct mdchain *mdp, uint16_t *x)
 int
 md_get_uint32(struct mdchain *mdp, uint32_t *x)
 {
-	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
-	    4, MB_MINLINE));
+	return (md_get_mem(mdp, PTR2CAP((char *)x), 4, MB_MINLINE));
 }
 
 int
@@ -452,8 +441,7 @@ md_get_uint32le(struct mdchain *mdp, uint32_t *x)
 int
 md_get_int64(struct mdchain *mdp, int64_t *x)
 {
-	return (md_get_mem(mdp, (__cheri_tocap char * __capability)(char *)x,
-	    8, MB_MINLINE));
+	return (md_get_mem(mdp, PTR2CAP((char *)x), 8, MB_MINLINE));
 }
 
 int

--- a/sys/kern/subr_sglist.c
+++ b/sys/kern/subr_sglist.c
@@ -324,8 +324,7 @@ sglist_append(struct sglist *sg, void *buf, size_t len)
 	if (sg->sg_maxseg == 0)
 		return (EINVAL);
 	SGLIST_SAVE(sg, save);
-	error = _sglist_append_buf(sg, (__cheri_tocap void * __capability)buf,
-	    len, NULL, NULL);
+	error = _sglist_append_buf(sg, PTR2CAP(buf), len, NULL, NULL);
 	if (error)
 		SGLIST_RESTORE(sg, save);
 	return (error);

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -562,7 +562,7 @@ sys_ptrace(struct thread *td, struct ptrace_args *uap)
 		error = copyincap(uap->addr, &r.pve, sizeof(r.pve));
 		break;
 	default:
-		addr = (__cheri_tocap void * __capability)uap->addr;
+		addr = uap->addr;
 		break;
 	}
 	if (error)

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -2954,7 +2954,7 @@ so_setsockopt(struct socket *so, int level, int optname, void *optval,
 	sopt.sopt_level = level;
 	sopt.sopt_name = optname;
 	sopt.sopt_dir = SOPT_SET;
-	sopt.sopt_val = (__cheri_tocap void * __capability)optval;
+	sopt.sopt_val = PTR2CAP(optval);
 	sopt.sopt_valsize = optlen;
 	sopt.sopt_td = NULL;
 	return (sosetopt(so, &sopt));

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -691,7 +691,7 @@ user_sendit(struct thread *td, int s, struct msghdr *mp, int flags)
 			to = NULL;
 			goto bad;
 		}
-		mp->msg_name = (__cheri_tocap struct sockaddr * __capability)to;
+		mp->msg_name = PTR2CAP(to);
 	} else {
 		to = NULL;
 	}
@@ -915,7 +915,7 @@ sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 	error = copyiniov(msg.msg_iov, msg.msg_iovlen, &iov, EMSGSIZE);
 	if (error != 0)
 		return (error);
-	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
+	msg.msg_iov = PTR2CAP(iov);
 #ifdef COMPAT_OLDSOCK
 	if (SV_PROC_FLAG(td->td_proc, SV_AOUT))
 		msg.msg_flags = 0;
@@ -1220,7 +1220,7 @@ sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 		msg.msg_flags &= ~MSG_COMPAT;
 #endif
 	uiov = msg.msg_iov;
-	msg.msg_iov = (__cheri_tocap struct iovec * __capability)iov;
+	msg.msg_iov = PTR2CAP(iov);
 	error = recvit(td, uap->s, &msg, NULL);
 	if (error == 0) {
 		msg.msg_iov = uiov;

--- a/sys/kern/vfs_mountroot.c
+++ b/sys/kern/vfs_mountroot.c
@@ -592,8 +592,8 @@ parse_dir_md(char **conf)
 		return (error);
 
 	/* Get file status. */
-	error = kern_statat(td, 0, AT_FDCWD,
-	    (__cheri_tocap char * __capability)path, UIO_SYSSPACE, &sb, NULL);
+	error = kern_statat(td, 0, AT_FDCWD, PTR2CAP(path), UIO_SYSSPACE, &sb,
+	    NULL);
 	if (error)
 		goto out;
 
@@ -606,7 +606,7 @@ parse_dir_md(char **conf)
 		root_mount_mddev = -1;
 	}
 
-	mdr.md_file = (__cheri_tocap char * __capability)path;
+	mdr.md_file = PTR2CAP(path);
 	mdr.md_file_seg = UIO_SYSSPACE;
 	mdr.md_options = MD_AUTOUNIT | MD_READONLY;
 	mdr.md_mediasize = sb.st_size;

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -3901,8 +3901,7 @@ freebsd11_kern_getdirentries(struct thread *td, int fd,
 
 	dirbuf = malloc(count, M_TEMP, M_WAITOK);
 
-	error = kern_getdirentries(td, fd,
-	    (__cheri_tocap char * __capability)dirbuf, count, &base, &resid,
+	error = kern_getdirentries(td, fd, PTR2CAP(dirbuf), count, &base, &resid,
 	    UIO_SYSSPACE);
 	if (error != 0)
 		goto done;

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -3049,7 +3049,6 @@ getutimes(const struct timeval * __capability usrtvp, enum uio_seg tvpseg,
 {
 	struct timeval tv[2];
 	const struct timeval * __capability tvp;
-	struct timeval *tmptvp;
 	int error;
 
 	if (usrtvp == NULL) {
@@ -3059,11 +3058,9 @@ getutimes(const struct timeval * __capability usrtvp, enum uio_seg tvpseg,
 		if (tvpseg == UIO_SYSSPACE) {
 			tvp = usrtvp;
 		} else {
-			tmptvp = &tv[0];
-			if ((error = copyin(usrtvp, tmptvp, sizeof(tv))) != 0)
+			if ((error = copyin(usrtvp, tv, sizeof(tv))) != 0)
 				return (error);
-			tvp = (__cheri_tocap struct timeval * __capability)
-			    tmptvp;
+			tvp = tv;
 		}
 
 		if (tvp[0].tv_usec < 0 || tvp[0].tv_usec >= 1000000 ||

--- a/sys/netgraph/ng_ksocket.c
+++ b/sys/netgraph/ng_ksocket.c
@@ -825,8 +825,7 @@ ng_ksocket_rcvmsg(node_p node, item_p item, hook_p lasthook)
 			sopt.sopt_td = NULL;
 			sopt.sopt_valsize = NG_KSOCKET_MAX_OPTLEN;
 			ksopt = (struct ng_ksocket_sockopt *)resp->data;
-			sopt.sopt_val =
-			    (__cheri_tocap void * __capability)&ksopt->value[0];
+			sopt.sopt_val = PTR2CAP(&ksopt->value[0]);
 			if ((error = sogetopt(so, &sopt)) != 0) {
 				NG_FREE_MSG(resp);
 				break;
@@ -855,8 +854,7 @@ ng_ksocket_rcvmsg(node_p node, item_p item, hook_p lasthook)
 			sopt.sopt_dir = SOPT_SET;
 			sopt.sopt_level = ksopt->level;
 			sopt.sopt_name = ksopt->name;
-			sopt.sopt_val =
-			    (__cheri_tocap void * __capability)&ksopt->value[0];
+			sopt.sopt_val = PTR2CAP(&ksopt->value[0]);
 			sopt.sopt_valsize = valsize;
 			sopt.sopt_td = NULL;
 			error = sosetopt(so, &sopt);

--- a/sys/netinet/tcp_log_buf.c
+++ b/sys/netinet/tcp_log_buf.c
@@ -2111,8 +2111,7 @@ tcp_log_expandlogbuf(struct tcp_log_dev_queue *param)
 #endif
 		return (NULL);
 	}
-	sopt.sopt_val =
-	    (__cheri_tocap struct tcp_log_header * __capability)hdr + 1;
+	sopt.sopt_val = PTR2CAP(hdr + 1);
 	sopt.sopt_valsize -= sizeof(struct tcp_log_header);
 	sopt.sopt_td = NULL;
 

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -854,7 +854,7 @@ nsmb_dev_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int flag, struct thre
 		} else
 #endif
 			rwrq = (struct smbioc_rw *)data;
-		IOVEC_INIT(&iov, rwrq->ioc_base, rwrq->ioc_cnt);
+		IOVEC_INIT_C(&iov, rwrq->ioc_base, rwrq->ioc_cnt);
 		auio.uio_iov = &iov;
 		auio.uio_iovcnt = 1;
 		auio.uio_offset = rwrq->ioc_offset;

--- a/sys/netsmb/smb_rq.c
+++ b/sys/netsmb/smb_rq.c
@@ -630,9 +630,7 @@ smb_t2_request_int(struct smb_t2rq *t2p)
 	smb_rq_bstart(rqp);
 	/* TDUNICODE */
 	if (t2p->t_name)
-		mb_put_mem(mbp,
-		    (__cheri_tocap const char * __capability)t2p->t_name,
-		    nmlen, MB_MSYSTEM);
+		mb_put_mem(mbp, PTR2CAP(t2p->t_name), nmlen, MB_MSYSTEM);
 	mb_put_uint8(mbp, 0);	/* terminating zero */
 	len = mb_fixhdr(mbp);
 	if (txpcount) {

--- a/sys/netsmb/smb_smb.c
+++ b/sys/netsmb/smb_smb.c
@@ -400,8 +400,7 @@ again:
 		mb_put_uint32le(mbp, 0);
 		smb_rq_wend(rqp);
 		smb_rq_bstart(rqp);
-		mb_put_mem(mbp, (__cheri_tocap char * __capability)pp, plen,
-		    MB_MSYSTEM);
+		mb_put_mem(mbp, PTR2CAP(pp), plen, MB_MSYSTEM);
 		smb_put_dstring(mbp, vcp, up, SMB_CS_NONE);
 	} else {
 		mb_put_uint16le(mbp, uniplen);
@@ -409,11 +408,8 @@ again:
 		mb_put_uint32le(mbp, caps);
 		smb_rq_wend(rqp);
 		smb_rq_bstart(rqp);
-		mb_put_mem(mbp, (__cheri_tocap char * __capability)pp, plen,
-		    MB_MSYSTEM);
-		mb_put_mem(mbp,
-		    (__cheri_tocap char * __capability)(char *)unipp, uniplen,
-		    MB_MSYSTEM);
+		mb_put_mem(mbp, PTR2CAP(pp), plen, MB_MSYSTEM);
+		mb_put_mem(mbp, PTR2CAP((char *)unipp), uniplen, MB_MSYSTEM);
 		smb_put_dstring(mbp, vcp, up, SMB_CS_NONE);		/* AccountName */
 		smb_put_dstring(mbp, vcp, vcp->vc_domain, SMB_CS_NONE);	/* PrimaryDomain */
 		smb_put_dstring(mbp, vcp, "FreeBSD", SMB_CS_NONE);	/* Client's OS */
@@ -565,8 +561,7 @@ again:
 	mb_put_uint16le(mbp, plen);
 	smb_rq_wend(rqp);
 	smb_rq_bstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)pp, plen,
-	    MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)pp), plen, MB_MSYSTEM);
 	smb_put_dmem(mbp, vcp, "\\\\", 2, caseopt);
 	pp = vcp->vc_srvname;
 	smb_put_dmem(mbp, vcp, pp, strlen(pp), caseopt);
@@ -647,8 +642,7 @@ smb_smb_readx(struct smb_share *ssp, u_int16_t fid, int *len, int *rresid,
 	mb_put_uint8(mbp, 0xff);	/* no secondary command */
 	mb_put_uint8(mbp, 0);		/* MBZ */
 	mb_put_uint16le(mbp, 0);	/* offset to secondary */
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
-	    sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&fid), sizeof(fid), MB_MSYSTEM);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	*len = min(SSTOVC(ssp)->vc_rxmax, *len);
 	mb_put_uint16le(mbp, *len);	/* MaxCount */
@@ -728,8 +722,7 @@ smb_smb_writex(struct smb_share *ssp, u_int16_t fid, int *len, int *rresid,
 	mb_put_uint8(mbp, 0xff);	/* no secondary command */
 	mb_put_uint8(mbp, 0);		/* MBZ */
 	mb_put_uint16le(mbp, 0);	/* offset to secondary */
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
-	    sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&fid), sizeof(fid), MB_MSYSTEM);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	mb_put_uint32le(mbp, 0);	/* MBZ (timeout) */
 	mb_put_uint16le(mbp, 0);	/* !write-thru */
@@ -790,8 +783,7 @@ smb_smb_read(struct smb_share *ssp, u_int16_t fid,
 
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
-	    sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&fid), sizeof(fid), MB_MSYSTEM);
 	mb_put_uint16le(mbp, rlen);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	mb_put_uint16le(mbp, min(uio->uio_resid, 0xffff));
@@ -872,8 +864,7 @@ smb_smb_write(struct smb_share *ssp, u_int16_t fid, int *len, int *rresid,
 		return error;
 	smb_rq_getrequest(rqp, &mbp);
 	smb_rq_wstart(rqp);
-	mb_put_mem(mbp, (__cheri_tocap char * __capability)(char *)&fid,
-	    sizeof(fid), MB_MSYSTEM);
+	mb_put_mem(mbp, PTR2CAP((char *)&fid), sizeof(fid), MB_MSYSTEM);
 	mb_put_uint16le(mbp, resid);
 	mb_put_uint32le(mbp, uio->uio_offset);
 	mb_put_uint16le(mbp, min(uio->uio_resid, 0xffff));

--- a/sys/netsmb/smb_subr.c
+++ b/sys/netsmb/smb_subr.c
@@ -337,16 +337,13 @@ smb_put_dmem(struct mbchain *mbp, struct smb_vc *vcp, const char *src,
 	if (size == 0)
 		return 0;
 	if (dp == NULL) {
-		return mb_put_mem(mbp,
-		    (__cheri_tocap const char * __capability)src, size,
-		    MB_MSYSTEM);
+		return mb_put_mem(mbp, PTR2CAP(src), size, MB_MSYSTEM);
 	}
 	mbp->mb_copy = smb_copy_iconv;
 	mbp->mb_udata = dp;
 	if (SMB_UNICODE_STRINGS(vcp))
 		mb_put_padbyte(mbp);
-	return mb_put_mem(mbp, (__cheri_tocap const char * __capability)src,
-	    size, MB_MCUSTOM);
+	return mb_put_mem(mbp, PTR2CAP(src), size, MB_MCUSTOM);
 }
 
 int

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -133,9 +133,7 @@ nb_put_name(struct mbchain *mbp, struct sockaddr_nb *snb)
 	NBDEBUG("[%s]\n", cp);
 	for (;;) {
 		seglen = (*cp) + 1;
-		error = mb_put_mem(mbp,
-		    (__cheri_tocap unsigned char * __capability)cp, seglen,
-		    MB_MSYSTEM);
+		error = mb_put_mem(mbp, PTR2CAP(cp), seglen, MB_MSYSTEM);
 		if (error)
 			return error;
 		if (seglen == 1)
@@ -270,9 +268,7 @@ nbssn_rq_request(struct nbpcb *nbp, struct thread *td)
 			error = ECONNABORTED;
 			break;
 		}
-		md_get_mem(mdp,
-		    (__cheri_tocap char * __capability)(char *)&sin.sin_addr,
-		    4, MB_MSYSTEM);
+		md_get_mem(mdp, PTR2CAP((char *)&sin.sin_addr), 4, MB_MSYSTEM);
 		md_get_uint16(mdp, &port);
 		sin.sin_port = port;
 		nbp->nbp_state = NBST_RETARGET;

--- a/sys/opencrypto/criov.c
+++ b/sys/opencrypto/criov.c
@@ -71,8 +71,8 @@ cuio_copydata(struct uio* uio, int off, int len, caddr_t cp)
 	while (len > 0) {
 		KASSERT(iol >= 0, ("%s: empty", __func__));
 		count = min(iov->iov_len - off, len);
-		bcopy_c(((char * __capability)iov->iov_base) + off,
-		    (__cheri_tocap char * __capability)cp, count);
+		bcopy_c(((char * __capability)iov->iov_base) + off, PTR2CAP(cp),
+		    count);
 		len -= count;
 		cp += count;
 		off = 0;
@@ -92,8 +92,8 @@ cuio_copyback(struct uio* uio, int off, int len, c_caddr_t cp)
 	while (len > 0) {
 		KASSERT(iol >= 0, ("%s: empty", __func__));
 		count = min(iov->iov_len - off, len);
-		bcopy_c((__cheri_tocap const char * __capability)cp,
-		    ((char * __capability)iov->iov_base) + off, count);
+		bcopy_c(PTR2CAP(cp), ((char * __capability)iov->iov_base) + off,
+		    count);
 		len -= count;
 		cp += count;
 		off = 0;

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -49,7 +49,7 @@ struct iovec {
 
 #if defined(_KERNEL)
 #define	IOVEC_INIT(iovp, base, len)	do {				\
-	(iovp)->iov_base = (__cheri_tocap void * __capability)(base);	\
+	(iovp)->iov_base = PTR2CAP((base));				\
 	(iovp)->iov_len = (len);					\
 } while(0)
 #define IOVEC_INIT_C(iovp, base, len)	do {				\

--- a/sys/sys/malloc.h
+++ b/sys/sys/malloc.h
@@ -261,7 +261,7 @@ static inline void * __capability
 malloc_c(unsigned long size, struct malloc_type *type, int flags)
 {
 
-	return ((__cheri_tocap void * __capability)malloc(size, type, flags));
+	return (PTR2CAP(malloc(size, type, flags)));
 }
 
 struct malloc_type *malloc_desc2type(const char *desc);

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -374,7 +374,8 @@ __END_DECLS
  * capability.  NB: For purecap kernels this is a no-op.
  */
 #define	PTR2CAP(p)	({					\
-	KASSERT((vaddr_t)((p)) >= VM_MAXUSER_ADDRESS,		\
+	KASSERT((vaddr_t)((p)) == 0 ||				\
+	    (vaddr_t)((p)) >= VM_MAXUSER_ADDRESS,		\
 	    ("PTR2CAP on user address: %p", (p)));		\
 	(__cheri_tocap __typeof__((p)) __capability)(p);	\
 	})


### PR DESCRIPTION
Ostensibly, the goal of this series is the last commit which uses `PTR2CAP` more widely to try to reduce our diff and/or make our changes a bit more readable.  (Note that `PTR2CAP` is only needed for hybrid kernels.)  The other changes are some small bugs I found along the way.