### PR TITLE
Sysctl nocap

### DIFF
--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -1847,8 +1847,8 @@ sysctl_old_kernel(struct sysctl_req *req, const void *p, size_t l)
 				    req->oldidx, PTR2CAP(p), i);
 			else
 #endif
-				memcpy((__cheri_fromcap char *)req->oldptr +
-				    req->oldidx, p, i);
+				memcpynocap_c((char * __capability)req->oldptr +
+				    req->oldidx, PTR2CAP(p), i);
 		}
 	}
 	req->oldidx += l;
@@ -1870,7 +1870,8 @@ sysctl_new_kernel(struct sysctl_req *req, void *p, size_t l)
 		    (const char * __capability)req->newptr + req->newidx, l);
 	else
 #endif
-		memcpy(p, (__cheri_fromcap const char *)req->newptr + req->newidx, l);
+		memcpynocap_c(PTR2CAP(p),
+		    (const char * __capability)req->newptr + req->newidx, l);
 	req->newidx += l;
 	return (0);
 }

--- a/sys/libkern/bcopy.c
+++ b/sys/libkern/bcopy.c
@@ -182,6 +182,14 @@ void
 }
 
 #if __has_feature(capabilities)
+void *
+memcpynocap(void *dst0, const void *src0, size_t length)
+{
+	return _memcpy(dst0, src0, length, false);
+}
+
+__strong_reference(memcpynocap, memmovenocap);
+
 void
 bcopynocap(const void *src0, void *dst0, size_t length)
 {

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -33,6 +33,8 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 
+#include <cheri/cheric.h>
+
 void * __capability
 memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 {
@@ -143,3 +145,12 @@ bcopy_c(const void * __capability src, void * __capability dst, size_t len)
 
 	memcpy_c(dst, src, len);
 }
+
+void * __capability
+memcpynocap_c(void * __capability dst, const void *  __capability src,
+    size_t len)
+{
+	return (memcpy_c(dst, cheri_andperm(src, ~CHERI_PERM_LOAD_CAP), len));
+}
+
+__strong_reference(memcpynocap_c, memmovenocap_c);

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -397,15 +397,18 @@ void	hexdump(const void *ptr, int length, const char *hdr, int flags);
 
 #define ovbcopy(f, t, l) bcopy((f), (t), (l))
 void	bcopy(const void * _Nonnull from, void * _Nonnull to, size_t len);
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void	bcopy_c(const void * _Nonnull __capability from,
 	    void * _Nonnull __capability to, size_t len);
 void	bcopynocap_c(const void * _Nonnull __capability from,
 	    void * _Nonnull __capability to, size_t len);
-void	bcopynocap(const void *src0, void *dst0, size_t length);
 #else
 #define	bcopy_c		bcopy
-#define	bcopynocap_c	bcopy
+#define	bcopynocap_c	bcopynocap
+#endif
+#if __has_feature(capabilities)
+void	bcopynocap(const void *src0, void *dst0, size_t length);
+#else
 #define	bcopynocap	bcopy
 #endif
 void	bzero(void * _Nonnull buf, size_t len);
@@ -414,20 +417,36 @@ int	bcmp(const void *b1, const void *b2, size_t len);
 
 void	*memset(void * _Nonnull buf, int c, size_t len);
 void	*memcpy(void * _Nonnull to, const void * _Nonnull from, size_t len);
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void	* __capability memcpy_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
 void	* __capability memcpynocap_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
 #else
 #define	memcpy_c	memcpy
+#define	memcpynocap_c	memcpynocap
+#endif
+#if __has_feature(capabilities)
+void	*memcpynocap(void * _Nonnull to, const void * _Nonnull from,
+    size_t len);
+#else
+#define	memcpynocap	memcpy
 #endif
 void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void	* __capability memmove_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
 void	* __capability memmovenocap_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
+#else
+#define	memmove_c	memmove
+#define	memmovenocap_c	memmovenocap
+#endif
+#if __has_feature(capabilities)
+void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
+    size_t n);
+#else
+#define	memmovenocap	memmove
 #endif
 
 struct copy_map {


### PR DESCRIPTION
This does pull in some purecap #ifdef's, but it seems cleaner to do that than to try to untangle them and then deal with merge conflicts down in the purecap branch.

There is one purecap-only MIPS change in the riscv branch that this doesn't include that will need to be pulled into the main purecap kernel branch if this is looped back before the riscv branch is merged.