### PR TITLE
Allow compiling with overloaded CHERI builtins

### DIFF
--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -214,7 +214,14 @@ test_nofault_cfromptr(const struct cheri_test *ctp __unused)
 	char * __capability cd; /* stored into here */
 
 	cb = cheri_ptr(buf, 256);
-	cd = __builtin_cheri_cap_from_pointer(cb, (void *)(uintptr_t)10);
+	/*
+	 * This pragma is require to allow compiling this file both with and
+	 * without overloaded CHERI builtins.
+	 *
+	 * FIXME: remove once everyone has updated to overloaded builtins.
+	 */
+#pragma clang diagnostic ignored "-Wint-conversion"
+	cd = __builtin_cheri_cap_from_pointer(cb, 10);
 	*cd = '\0';
 	cheritest_success();
 }

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -175,7 +175,8 @@ do_crt_init_globals(const Elf_Phdr *phdr, long phnum)
 			/* TODO: should we allow a single RWX segment? */
 			__builtin_trap();
 		}
-		data_cap = cheri_setaddress(phdr, writable_start);
+		data_cap =
+		    cheri_setaddress(__DECONST(void *, phdr), writable_start);
 		/* Bound the result and clear execute permissions. */
 		data_cap = cheri_clearperm(data_cap, CHERI_PERM_EXECUTE);
 		/* TODO: should we use exact setbounds? */

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -235,8 +235,10 @@ dl_init_phdr_info(void)
 #ifndef __CHERI_PURE_CAPABILITY__
 			    (void*)phdr_info.dlpi_phdr[i].p_vaddr;
 #else
-			    cheri_setbounds(cheri_setaddress(phdr_info.dlpi_phdr,
-				phdr_info.dlpi_phdr[i].p_vaddr),
+			    cheri_setbounds(
+				cheri_setaddress(
+				    __DECONST(void *, phdr_info.dlpi_phdr),
+				    phdr_info.dlpi_phdr[i].p_vaddr),
 				phdr_info.dlpi_phdr[i].p_memsz);
 #endif
 		}

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -331,9 +331,9 @@ morecore(int bucket)
 	 * Add new memory allocated to that on
 	 * free list for this hash bucket.
 	 */
-	nextf[bucket] = op = cheri_setbounds(buf, sz);
+	nextf[bucket] = op = (union overhead *)(void *)cheri_setbounds(buf, sz);
 	while (--nblks > 0) {
-		op->ov_next = (union overhead *)cheri_setbounds(buf + sz, sz);
+		op->ov_next = (union overhead *)(void *)cheri_setbounds(buf + sz, sz);
 		buf += sz;
 		op = op->ov_next;
 	}

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -269,9 +269,9 @@ morecore(int bucket)
 	 * Add new memory allocated to that on
 	 * free list for this hash bucket.
 	 */
-	nextf[bucket] = op = cheri_setbounds(buf, sz);
+	nextf[bucket] = op = (union overhead *)(void *)cheri_setbounds(buf, sz);
 	while (--nblks > 0) {
-		op->ov_next = (union overhead *)cheri_setbounds(buf + sz, sz);
+		op->ov_next = (union overhead *)(void *)cheri_setbounds(buf + sz, sz);
 		buf += sz;
 		op = op->ov_next;
 	}

--- a/libexec/rtld-cheri-elf/mips/cheri_plt.cpp
+++ b/libexec/rtld-cheri-elf/mips/cheri_plt.cpp
@@ -73,14 +73,14 @@ struct SimpleExternalCallTrampoline {
 	static SimpleExternalCallTrampoline*
 	create(const Obj_Entry* defobj, const Elf_Sym *sym, bool tight_bounds);
 	inline dlfunc_t pcc_value() const {
-		void* result = cheri_incoffset(this, offsetof(SimpleExternalCallTrampoline, code));
+		const void* result = cheri_incoffset(this, offsetof(SimpleExternalCallTrampoline, code));
 		result = cheri_clearperm(result, FUNC_PTR_REMOVE_PERMS);
 #if __has_builtin(__builtin_cheri_seal_entry)
 		result = __builtin_cheri_seal_entry(result);
 #else
 #warning "__builtin_cheri_seal_entry not supported, please update LLVM"
 #endif
-		return (dlfunc_t)result;
+		return __DECONST(dlfunc_t, result);
 	}
 };
 

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1877,7 +1877,7 @@ digest_phdr(const Elf_Phdr *phdr, int phnum, dlfunc_t entry, const char *path)
      * Derive text_rodata cap from AT_ENTRY (but set the address to the beginning
      * of the object). Note: csetbounds is done after parsing .dynamic
      */
-    obj->text_rodata_cap = cheri_copyaddress(entry, obj->relocbase);
+    obj->text_rodata_cap = (const char *)cheri_copyaddress(entry, obj->relocbase);
     fix_obj_mapping_cap_permissions(obj, path);
 #endif
 

--- a/sbin/dhclient/Makefile
+++ b/sbin/dhclient/Makefile
@@ -59,3 +59,5 @@ HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
 
 .include <bsd.prog.mk>
+
+CWARNFLAGS.clang+=	-Wno-error=address-of-packed-member

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -119,24 +119,13 @@ cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
  * appears not currently to be the case, so manually derive using
  * cheri_getpcc() for now.
  */
-static __inline void * __capability
-cheri_codeptr(void *ptr, size_t len)
-{
-#ifdef NOTYET
-	void (* __capability c)(void) = ptr;
-#else
-	void * __capability c = cheri_setaddress(cheri_getpcc(),
-	    (register_t)ptr);
-#endif
-
-	/* Assume CFromPtr without base set, availability of CSetBounds. */
-	return (cheri_setbounds(c, len));
-}
+#define cheri_codeptr(ptr, len)	\
+	cheri_setbounds(__builtin_cheri_cap_from_pointer(cheri_getpcc(), ptr), len));
 
 #define cheri_codeptrperm(ptr, len, perm)	\
 	cheri_andperm(cheri_codeptr(ptr, len), perm | CHERI_PERM_GLOBAL)
 
-#define cheri_ptr(ptr, len) \
+#define cheri_ptr(ptr, len)	\
 	cheri_setbounds(    \
 	    (__cheri_tocap __typeof__((ptr)[0]) *__capability)ptr, len)
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -636,7 +636,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	    rounded_stack_vaddr,
 	    CHERI_REPRESENTABLE_LENGTH(ssiz + stack_offset), stack_offset);
 	destp = cheri_setaddress(destp, p->p_sysent->sv_psstrings);
-	arginfo = cheri_setbounds(destp, sizeof(*arginfo));
+	arginfo = cheri_setbounds((void * __capability)destp, sizeof(*arginfo));
 	imgp->ps_strings = arginfo;
 	if (p->p_sysent->sv_sigcode_base == 0)
 		szsigcode = *(p->p_sysent->sv_szsigcode);

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -636,7 +636,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	    rounded_stack_vaddr,
 	    CHERI_REPRESENTABLE_LENGTH(ssiz + stack_offset), stack_offset);
 	destp = cheri_setaddress(destp, p->p_sysent->sv_psstrings);
-	arginfo = cheri_setbounds((void * __capability)destp, sizeof(*arginfo));
+	arginfo = (void * __capability)cheri_setbounds(destp, sizeof(*arginfo));
 	imgp->ps_strings = arginfo;
 	if (p->p_sysent->sv_sigcode_base == 0)
 		szsigcode = *(p->p_sysent->sv_szsigcode);


### PR DESCRIPTION
We need to add a few __DECONST/type casts since the builtins are now type
and const preserving.
I also had to silence a -Waddress-of-packed-member in dhlient since that
appears to be triggered now that the builtins are type preserving.