### PR TITLE
Include procstat and cpuset in cheribsdbox

### DIFF
--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -92,6 +92,7 @@ CRUNCH_SHLIBS+=	-pthread
 
 # ktrace:
 CRUNCH_LIBS+=	-lsysdecode
+CRUNCH_LIBS+= -lprocstat -lelf
 
 # needed by ifconfig
 CRUNCH_LIBS+=	-l80211
@@ -254,6 +255,7 @@ CRUNCH_PROGS_usr.bin+= \
 		mktemp \
 		nc \
 		passwd \
+		procstat \
 		resizewin \
 		sed \
 		seq \

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -232,6 +232,7 @@ CRUNCH_PROGS_usr.bin+= \
 		basename \
 		bmake \
 		bzip2 \
+		cpuset \
 		diff \
 		dirname \
 		du \


### PR DESCRIPTION
These have come in handy for debugging minimal images in the past, but I'm not sure if it's worth doing in general.