### PR TITLE
Add kernel make option to capture subobject bounds statistics.

### DIFF
--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -265,6 +265,18 @@ CFLAGS+= -ftrivial-auto-var-init=pattern
 CFLAGS+=	-gdwarf-2
 .endif
 
+#
+# CHERI purecap kernel flags
+#
+.if ${MACHINE_ABI:Mpurecap}
+
+.if defined(CHERI_SUBOBJECT_BOUNDS_STATS)
+CHERI_SUBOBJECT_BOUNDS_STATS_FILE?=kernel-subobject-bounds-stats.csv
+CFLAGS+=	-mllvm -collect-csetbounds-stats=csv \
+	-Xclang -cheri-stats-file="${CHERI_SUBOBJECT_BOUNDS_STATS_FILE}"
+.endif
+.endif
+
 CFLAGS+= ${CWARNFLAGS:M*} ${CWARNFLAGS.${.IMPSRC:T}}
 CFLAGS+= ${CWARNFLAGS.${COMPILER_TYPE}}
 CFLAGS+= ${CFLAGS.${COMPILER_TYPE}} ${CFLAGS.${.IMPSRC:T}}


### PR DESCRIPTION
CHERI_SUBOBJECT_BOUNDS_STATS enables capture of statistics,
CHERI_SUBOBJECT_BOUNDS_STATS_FILE sets the file name for the clang CHERI statistics,
defaults to kernel-subobject-bounds-stats.csv in the kernel build directory.