### PR TITLE
Bring in devel/kyua patches to mitigate gettimeofday() jumps.

### DIFF
--- a/contrib/kyua/utils/datetime.cpp
+++ b/contrib/kyua/utils/datetime.cpp
@@ -590,11 +590,12 @@ datetime::timestamp::operator-=(const datetime::delta& other)
 datetime::delta
 datetime::timestamp::operator-(const datetime::timestamp& other) const
 {
-    if ((*this) < other) {
-        throw std::runtime_error(
-            F("Cannot subtract %s from %s as it would result in a negative "
-              "datetime::delta, which are not supported") % other % (*this));
-    }
+    /*
+     * XXX-BD: gettimeofday isn't necessicarily monotonic so return the
+     * smallest non-zero delta if time went backwards.
+     */
+    if ((*this) < other)
+        return datetime::delta::from_microseconds(1);
     return datetime::delta::from_microseconds(to_microseconds() -
                                               other.to_microseconds());
 }

--- a/contrib/kyua/utils/datetime_test.cpp
+++ b/contrib/kyua/utils/datetime_test.cpp
@@ -532,11 +532,11 @@ ATF_TEST_CASE_BODY(timestamp__subtraction)
     ATF_REQUIRE_EQ(datetime::delta(100, 0), ts3 - ts1);
     ATF_REQUIRE_EQ(datetime::delta(99, 999988), ts3 - ts2);
 
-    ATF_REQUIRE_THROW_RE(
-        std::runtime_error,
-        "Cannot subtract 1291970850123456us from 1291970750123468us "
-        ".*negative datetime::delta.*not supported",
-        ts2 - ts3);
+    /*
+     * NOTE (ngie): behavior change for
+     * https://github.com/jmmv/kyua/issues/155 .
+     */
+    ATF_REQUIRE_EQ(datetime::delta::from_microseconds(1), ts2 - ts3);
 }
 
 


### PR DESCRIPTION
This probably needs to be done upstream as well?

Hopefully this lets my FreeBSD test suites run over the weekend under qemu.