### PR TITLE
Test fixes

### DIFF
--- a/lib/libc/mips/gen/_ctx_start.S
+++ b/lib/libc/mips/gen/_ctx_start.S
@@ -53,7 +53,12 @@ __FBSDID("$FreeBSD$");
 ENTRY(_ctx_start)
 #ifdef __CHERI_PURE_CAPABILITY__
 	PIC_PROLOGUE(_ctx_start)
-#endif
+	cjalr $c12, $c17
+
+	cmove	$c3, $c16
+	PIC_LOAD_CALL_PTR($c12, t9, _ctx_done)
+	cjalr $c12, $c17
+#else
 
 #ifdef __mips_o32
 	move	s1, gp
@@ -64,13 +69,8 @@ ENTRY(_ctx_start)
 	move	gp, s1
 #endif
 	move	a0, s0
-#ifndef __CHERI_PURE_CAPABILITY__
 	PTR_LA	t9, _ctx_done
 	jalr	t9
-#else
-	PIC_LOAD_CALL_PTR($c12, t9, _ctx_done)
-	cjalr $c12, $c17;
-	nop;
 #endif
 	break	0
 END(_ctx_start)

--- a/lib/libc/mips/gen/makecontext.c
+++ b/lib/libc/mips/gen/makecontext.c
@@ -93,10 +93,18 @@ __makecontext(ucontext_t *ucp, void (*func)(void), int argc, ...)
 #endif
 	sp = __builtin_align_down(sp, STACK_ALIGN);
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	mc->mc_cheriframe.cf_csp = sp;
+	mc->mc_cheriframe.cf_c16 = ucp;
+	mc->mc_cheriframe.cf_c12 = func;
+	mc->mc_cheriframe.cf_pcc = _ctx_start;
+	mc->mc_pc = (__cheri_offset register_t)mc->mc_cheriframe.cf_pcc;
+#else
 	mc->mc_regs[SP] = (intptr_t)sp;
 	mc->mc_regs[S0] = (intptr_t)ucp;
 	mc->mc_regs[T9] = (intptr_t)func;
 	mc->mc_pc = (intptr_t)_ctx_start;
+#endif
 
 	/* Construct argument list. */
 	va_start(ap, argc);

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -549,7 +549,12 @@ vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base, int len, off_t offset,
 		return (EINVAL);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-	IOVEC_INIT(&aiov, base, len);
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
+	if (segflg == UIO_USERSPACE)
+		IOVEC_INIT_C(&aiov, __USER_CAP(base, len), len);
+	else
+#endif
+		IOVEC_INIT(&aiov, base, len);
 	auio.uio_resid = len;
 	auio.uio_offset = offset;
 	auio.uio_segflg = segflg;


### PR DESCRIPTION
This fixes issues I ran into while running the FreeBSD test suite with a MIPS purecap world.  I might rework the second one to remove 'mc_pc' entirely from the purecap mcontext_t though, or perhaps add a followup commit that does it.