### PR TITLE
Remove mc_pc entirely from the purecap mcontext_t.

### DIFF
--- a/lib/libc/mips/gen/makecontext.c
+++ b/lib/libc/mips/gen/makecontext.c
@@ -98,7 +98,6 @@ __makecontext(ucontext_t *ucp, void (*func)(void), int argc, ...)
 	mc->mc_cheriframe.cf_c16 = ucp;
 	mc->mc_cheriframe.cf_c12 = func;
 	mc->mc_cheriframe.cf_pcc = _ctx_start;
-	mc->mc_pc = (__cheri_offset register_t)mc->mc_cheriframe.cf_pcc;
 #else
 	mc->mc_regs[SP] = (intptr_t)sp;
 	mc->mc_regs[S0] = (intptr_t)ucp;

--- a/sys/mips/include/cheri_machdep.h
+++ b/sys/mips/include/cheri_machdep.h
@@ -51,8 +51,10 @@ _update_pcc_offset(trapf_pc_t pcc, register_t pc, const char *func)
 	 */
 	if (cheri_gettype(pcc) == CHERI_OTYPE_UNSEALED) {
 		void* __capability result = cheri_setoffset(pcc, pc);
-		KASSERT(cheri_gettag(result),
-		    ("created untagged pcc: " _CHERI_PRINT_PTR_FMT(result)));
+		if (!cheri_gettag(result))
+			printf("%s: created untagged $pcc: "
+			    _CHERI_PRINTF_CAP_FMT "\n", func,
+			    _CHERI_PRINTF_CAP_ARG(result));
 		return result;
 	} else if (cheri_getoffset(pcc) == pc) {
 		/* Don't warn if the values match (not modifying $pcc) */

--- a/sys/mips/include/ucontext.h
+++ b/sys/mips/include/ucontext.h
@@ -53,7 +53,12 @@ typedef struct	__mcontext {
 	 * struct sigcontext and ucontext_t at the same time.
 	 */
 	int		mc_onstack;	/* sigstack state to restore */
+#if (defined(_KERNEL) && __has_feature(capabilities)) || \
+    defined(__CHERI_PURE_CAPABILITY__)
+	__register_t	__unused_pc;	/* purecap only uses pcc */
+#else
 	__register_t	mc_pc;		/* pc at time of signal */
+#endif
 	__register_t	mc_regs[32];	/* processor regs 0 to 31 */
 	__register_t	sr;		/* status register */
 	__register_t	mullo, mulhi;	/* mullo and mulhi registers... */

--- a/sys/mips/mips/freebsd64_machdep.c
+++ b/sys/mips/mips/freebsd64_machdep.c
@@ -68,6 +68,7 @@
 #include <cheri/cheric.h>
 
 #include <machine/abi.h>
+#include <machine/cheri_machdep.h>
 #include <machine/cpuinfo.h>
 #include <machine/md_var.h>
 #include <machine/pcb.h>
@@ -191,7 +192,7 @@ freebsd64_get_mcontext(struct thread *td, mcontext64_t *mcp, int flags)
 		return (error);
 
 	mcp->mc_onstack = mc.mc_onstack;
-	mcp->mc_pc = mc.mc_pc;
+	mcp->mc_pc = cheri_getoffset(mc.mc_cheriframe.cf_pcc);
 	for (i = 0; i < 32; i++)
 		mcp->mc_regs[i] = mc.mc_regs[i];
 	mcp->sr = mc.sr;
@@ -247,7 +248,8 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 	}
 
 	mc.mc_onstack = mcp->mc_onstack;
-	mc.mc_pc = mcp->mc_pc;
+	mc.mc_cheriframe.cf_pcc = update_pcc_offset(mc.mc_cheriframe.cf_pcc,
+	    mcp->mc_pc);
 	for (i = 0; i < 32; i++)
 		mc.mc_regs[i] = mcp->mc_regs[i];
 	mc.sr = mcp->sr;


### PR DESCRIPTION
Instead, purecap is expected to always manipulate mc_cheriframe.cf_pcc
directly.  freebsd64_setmcontext() now takes care of applying the
64-bit mc_pc as an offset to pcc and freebsd64_getmcontext() stores
the offset of pcc in mc_pc.

get/set_mcontext() in a CHERI kernel (hybrid and purecap) only operate
on pcc.

This did entail fixing some some code in the CHERI C tests.  Some of
it is still dubious (specifically how CJR/CJALR are handled for the
hybrid case), but I suspect hybrid just never uses those instructions.