### PR TITLE
Riscv stack alignment fixes

### DIFF
--- a/libexec/rtld-elf/riscv/rtld_start.S
+++ b/libexec/rtld-elf/riscv/rtld_start.S
@@ -114,7 +114,8 @@ ENTRY(_rtld_bind_start)
 	unimp
 #else /* defined(__CHERI_PURE_CAPABILITY__) */
 	/* Save the arguments and ra */
-	addi	sp, sp, -(8 * 17)
+	/* We require 17 dwords, but the stack must be aligned to 16-bytes */
+	addi	sp, sp, -(8 * 18)
 	sd	a0, (8 * 0)(sp)
 	sd	a1, (8 * 1)(sp)
 	sd	a2, (8 * 2)(sp)
@@ -172,7 +173,7 @@ ENTRY(_rtld_bind_start)
 	fld	fa6, (8 * 15)(sp)
 	fld	fa7, (8 * 16)(sp)
 #endif
-	addi	sp, sp, (8 * 17)
+	addi	sp, sp, (8 * 18)
 
 	/* Call into the correct function */
 	jr	t0

--- a/sys/riscv/conf/FETT
+++ b/sys/riscv/conf/FETT
@@ -10,6 +10,7 @@ options 	HZ=100
 options 	ROOTDEVNAME=\"ufs:/dev/ufs/root\nufs:/dev/vtbd0\"
 
 makeoptions 	KERNEL_LMA=0xc0200000
+makeoptions	NO_MODULES=yes
 
 options 	BREAK_TO_DEBUGGER
 options 	ALT_BREAK_TO_DEBUGGER

--- a/sys/riscv/riscv/genassym.c
+++ b/sys/riscv/riscv/genassym.c
@@ -91,7 +91,7 @@ ASSYM(TD_MD, offsetof(struct thread, td_md));
 ASSYM(TD_LOCK, offsetof(struct thread, td_lock));
 ASSYM(TD_MDFLAGS, offsetof(struct thread, td_md.md_flags));
 
-ASSYM(TF_SIZE, sizeof(struct trapframe));
+ASSYM(TF_SIZE, roundup2(sizeof(struct trapframe), STACKALIGNBYTES + 1));
 ASSYM(TF_RA, offsetof(struct trapframe, tf_ra));
 ASSYM(TF_SP, offsetof(struct trapframe, tf_sp));
 ASSYM(TF_GP, offsetof(struct trapframe, tf_gp));


### PR DESCRIPTION
Also a tweak the FETT kernels to skip modules.