### PR TITLE
Log ENOSYS in init

### DIFF
--- a/sbin/init/init.c
+++ b/sbin/init/init.c
@@ -118,7 +118,6 @@ static void stall(const char *, ...) __printflike(1, 2);
 static void warning(const char *, ...) __printflike(1, 2);
 static void emergency(const char *, ...) __printflike(1, 2);
 static void disaster(int);
-static void badsys(int);
 static void revoke_ttys(void);
 static int  runshutdown(void);
 static char *strk(char *);
@@ -319,9 +318,8 @@ invalid:
 	 * We catch or block signals rather than ignore them,
 	 * so that they get reset on exec.
 	 */
-	handle(badsys, SIGSYS, 0);
-	handle(disaster, SIGABRT, SIGFPE, SIGILL, SIGSEGV, SIGBUS, SIGXCPU,
-	    SIGXFSZ,
+	handle(disaster, SIGABRT, SIGFPE, SIGILL, SIGSEGV, SIGBUS, SIGSYS,
+	    SIGXCPU, SIGXFSZ,
 #ifdef SIGPROT
 	    /*
 	     * Don't keep going if we receive SIGPROT since that will cause
@@ -537,22 +535,6 @@ emergency(const char *message, ...)
 
 	vsyslog(LOG_EMERG, message, ap);
 	va_end(ap);
-}
-
-/*
- * Catch a SIGSYS signal.
- *
- * These may arise if a system does not support sysctl.
- * We tolerate up to 25 of these, then throw in the towel.
- */
-static void
-badsys(int sig)
-{
-	static int badcount = 0;
-
-	if (badcount++ < 25)
-		return;
-	disaster(sig);
 }
 
 /*

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -3895,7 +3895,7 @@ nosys(struct thread *td, struct nosys_args *args)
 		uprintf("pid %d comm %s: nosys %d\n", p->p_pid, p->p_comm,
 		    td->td_sa.code);
 	}
-	if (kern_lognosys == 2 || kern_lognosys == 3) {
+	if (p->p_pid == 1 || kern_lognosys == 2 || kern_lognosys == 3) {
 		printf("pid %d comm %s: nosys %d\n", p->p_pid, p->p_comm,
 		    td->td_sa.code);
 	}


### PR DESCRIPTION
While rare, encountering an unimplemented system call early in init is
catastrophic and difficult to debug.  As such, always log such events
for pid 1.