### PR TITLE
mips: Clean up CHERI_MALTA64 config

### DIFF
--- a/sys/mips/conf/CHERI_MALTA64
+++ b/sys/mips/conf/CHERI_MALTA64
@@ -1,24 +1,13 @@
 # CHERI_MALTA64 -- 64-bit kernel config for MALTA boards + CHERI
 #
 # $FreeBSD$
- 
-ident		CHERI_MALTA64
 
-include		"std.MALTA"
+include		"MALTA64"
 include		"std.CHERI"
 
-machine		mips mips64	# Malta supports both, so it isn't in std.malta
- 
-makeoptions 	KERNLOADADDR=0xffffffff80100000
+ident		CHERI_MALTA64
 
 options 	KTRACE
-
-#
-# Features required for CHERI CPU and CheriBSD support.
-#
-options 	KSTACK_LARGE_PAGE
-options 	NO_SWAPPING
-options 	TMPFS
 
 #
 # Qemu-CHERI tracing is permitted per thread, not just globally.

--- a/sys/mips/conf/std.CHERI
+++ b/sys/mips/conf/std.CHERI
@@ -7,6 +7,9 @@
 nomakeoptions	ARCH_FLAGS
 makeoptions	ARCH_FLAGS="-target mips64-unknown-freebsd -march=beri -mabi=64 -mcpu=beri -cheri -Wno-unused-command-line-argument"
 options 	CPU_CHERI
+nooptions	COMPAT_FREEBSD32
 options 	COMPAT_FREEBSD64
 
+options 	KSTACK_LARGE_PAGE	# Use a 16K page for kernel stack
+options 	NO_SWAPPING
 options 	TMPFS


### PR DESCRIPTION
Include MALTA64, override and add to it rather than just duplicating most of it. Also move options to std.CHERI that are common for any CHERI-MIPS kernel, even if some end up being no-ops for BERI kernels.