### PR TITLE
Faster testsuite runs

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2656,6 +2656,7 @@ _bt_clean=	${CLEANDIR}
 .for _tool in \
     ${_tcsh} \
     bin/sh \
+    libexec/atf/sh_static \
     ${LOCAL_TOOL_DIRS} \
     ${_jevents} \
     lib/ncurses/ncurses \

--- a/bin/sh/Makefile
+++ b/bin/sh/Makefile
@@ -10,7 +10,7 @@ ROOTDIR=	/root
 ROOTNAME_dot.shrc=	.shrc
 ROOTNAME_dot.profile=	.profile
 PACKAGE=runtime
-PROG=	sh
+PROG?=	sh
 INSTALLFLAGS= -S
 SHSRCS=	alias.c arith_yacc.c arith_yylex.c cd.c echo.c error.c eval.c \
 	exec.c expand.c \
@@ -27,13 +27,14 @@ SRCS= ${SHSRCS} ${GENSRCS} ${GENHDRS}
 
 LIBADD=	edit
 
-CFLAGS+=-DSHELL -I. -I${.CURDIR}
+SRCDIR:=	${.PARSEDIR}
+CFLAGS+=	-DSHELL -I. -I${SRCDIR}
 # for debug:
 # DEBUG_FLAGS+= -g -DDEBUG=2 -fno-inline
-
-.PATH:	${.CURDIR}/bltin \
-	${.CURDIR:H}/kill \
-	${.CURDIR:H}/test \
+.PATH:	${SRCDIR} \
+	${SRCDIR}/bltin \
+	${SRCDIR:H}/kill \
+	${SRCDIR:H}/test \
 	${SRCTOP}/usr.bin/printf
 
 CLEANFILES+= mknodes mksyntax
@@ -44,7 +45,7 @@ build-tools: mknodes mksyntax
 .ORDER: builtins.c builtins.h
 builtins.h: .NOMETA
 builtins.c builtins.h: mkbuiltins builtins.def
-	sh ${.CURDIR}/mkbuiltins ${.CURDIR}
+	sh ${SRCDIR}/mkbuiltins ${SRCDIR}
 
 DEPENDOBJS+= mknodes mksyntax
 mknodes: mknodes.c ${BUILD_TOOLS_META}
@@ -57,7 +58,7 @@ mksyntax: mksyntax.c ${BUILD_TOOLS_META}
 .ORDER: nodes.c nodes.h
 nodes.h: .NOMETA
 nodes.c nodes.h: mknodes nodetypes nodes.c.pat
-	${BTOOLSPATH:U.}/mknodes ${.CURDIR}/nodetypes ${.CURDIR}/nodes.c.pat
+	${BTOOLSPATH:U.}/mknodes ${SRCDIR}/nodetypes ${SRCDIR}/nodes.c.pat
 
 .ORDER: syntax.c syntax.h
 syntax.h: .NOMETA
@@ -65,8 +66,10 @@ syntax.c syntax.h: mksyntax
 	${BTOOLSPATH:U.}/mksyntax
 
 token.h: mktokens
-	sh ${.CURDIR}/mktokens
+	sh ${SRCDIR}/mktokens
 
+# Don't include tests or .profile for the static sh used by atf.
+.if ${.CURDIR} == ${SRCDIR}
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
 
@@ -75,5 +78,6 @@ beforeinstallconfig:
 
 afterinstallconfig:
 	${INSTALL_LINK} ${TAG_ARGS} ${DESTDIR}/root/.profile ${DESTDIR}/.profile
+.endif
 
 .include <bsd.prog.mk>

--- a/contrib/atf/atf-sh/libatf-sh.subr
+++ b/contrib/atf/atf-sh/libatf-sh.subr
@@ -536,7 +536,18 @@ _atf_list_tcs()
 #
 _atf_normalize()
 {
-    echo ${1} | tr .- __
+    # Check if the string contains any of the forbidden characters using
+    # POSIX parameter expansion (the ${var//} string substitution is
+    # unfortunately not supported in POSIX sh) and only use tr(1) then.
+    # tr(1) is generally not a builtin, so doing the substring check first
+    # avoids unnecessary fork()+execve() calls. As this function is called
+    # many times in each test script startup, those overheads add up
+    # (especially when running on emulated platforms such as QEMU).
+    if [ "${1#*[.-]}" != "$1" ]; then
+        echo "$1" | tr .- __
+    else
+        echo "$1"
+    fi
 }
 
 #

--- a/contrib/atf/atf-sh/libatf-sh.subr
+++ b/contrib/atf/atf-sh/libatf-sh.subr
@@ -745,7 +745,7 @@ main()
             ;;
         esac
     done
-    shift `expr ${OPTIND} - 1`
+    shift $((OPTIND - 1))
 
     case ${Source_Dir} in
         /*)

--- a/contrib/netbsd-tests/lib/libc/db/t_db.sh
+++ b/contrib/netbsd-tests/lib/libc/db/t_db.sh
@@ -837,6 +837,10 @@ bsize_ffactor_head()
 }
 bsize_ffactor_body()
 {
+	if [ "$(atf_config_get include_slow_tests false)" != "true" ]; then
+		atf_skip "test_suites.FreeBSD.include_slow_tests is false"
+	fi
+
 	TMPDIR="$(pwd)/db_dir"; export TMPDIR
 	mkdir ${TMPDIR}
 
@@ -955,6 +959,9 @@ bsize_torture_head()
 }
 bsize_torture_body()
 {
+	if [ "$(atf_config_get include_slow_tests false)" != "true" ]; then
+		atf_skip "test_suites.FreeBSD.include_slow_tests is false"
+	fi
 	TMPDIR="$(pwd)/db_dir"; export TMPDIR
 	mkdir ${TMPDIR}
 	# Begin FreeBSD

--- a/libexec/atf/Makefile
+++ b/libexec/atf/Makefile
@@ -25,6 +25,6 @@
 #
 # $FreeBSD$
 
-SUBDIR=	atf-check atf-sh tests
+SUBDIR=	atf-check atf-sh sh_static tests
 
 .include <bsd.subdir.mk>

--- a/libexec/atf/atf-check/Makefile
+++ b/libexec/atf/atf-check/Makefile
@@ -28,6 +28,15 @@
 .include <src.opts.mk>
 .include <bsd.init.mk>
 
+# We build atf-check statically linked and non-CHERI to speed up testsuite runs.
+# This is noticeably faster on QEMU since we don't have to emulate CHERI and
+# also means we don't have to process capability relocations on startup.
+.if ${MACHINE_ABI:Mpurecap}
+NEED_COMPAT=	64
+.include <bsd.compat.mk>
+.endif
+NO_SHARED=	yes
+
 ATF=		${SRCTOP}/contrib/atf
 .PATH:		${ATF}/atf-sh
 
@@ -45,12 +54,5 @@ LIBADD=		atf_cxx
 
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
-
-# Allow building atf as a static MIPS binary to speed up running tests
-# on QEMU (since QEMU it can only 'JIT' plain MIPS instructions)
-.if ${MK_CHERI_PURE} != "no" && defined(ATF_BUILD_STATIC_MIPS)
-WANT_CHERI:=hybrid
-NO_SHARED:=yes
-.endif
 
 .include <bsd.prog.mk>

--- a/libexec/atf/atf-check/Makefile
+++ b/libexec/atf/atf-check/Makefile
@@ -36,7 +36,7 @@ SRCS=		atf-check.cpp
 MAN=		atf-check.1
 
 CFLAGS+=	-I${ATF}
-CFLAGS+=	-DATF_SHELL='"/bin/sh"'
+CFLAGS+=	-DATF_SHELL='"/usr/libexec/sh_static"'
 
 # Silence warnings about usage of deprecated std::auto_ptr
 CXXWARNFLAGS+=	-Wno-deprecated-declarations

--- a/libexec/atf/atf-sh/Makefile
+++ b/libexec/atf/atf-sh/Makefile
@@ -28,6 +28,15 @@
 .include <src.opts.mk>
 .include <bsd.init.mk>
 
+# We build atf-sh statically linked and non-CHERI to speed up testsuite runs.
+# This is noticeably faster on QEMU since we don't have to emulate CHERI and
+# also means we don't have to process capability relocations on startup.
+.if ${MACHINE_ABI:Mpurecap}
+NEED_COMPAT=	64
+.include <bsd.compat.mk>
+.endif
+NO_SHARED=	yes
+
 ATF=		${SRCTOP}/contrib/atf
 .PATH:		${ATF}/atf-sh
 
@@ -77,13 +86,6 @@ SUBR=		libatf-sh.subr
 
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
-
-# Allow building atf as a static MIPS binary to speed up running tests
-# on QEMU (since QEMU it can only 'JIT' plain MIPS instructions)
-.if ${MK_CHERI_PURE} != "no" && defined(ATF_BUILD_STATIC_MIPS)
-WANT_CHERI:=hybrid
-NO_SHARED:=yes
-.endif
 
 .include "../../../lib/atf/common.mk"
 .include <bsd.prog.mk>

--- a/libexec/atf/atf-sh/Makefile
+++ b/libexec/atf/atf-sh/Makefile
@@ -62,7 +62,7 @@ MLINKS+=	\
 CFLAGS+=	-DHAVE_CONFIG_H
 CFLAGS+=	-DATF_LIBEXECDIR='"${LIBEXECDIR}"'
 CFLAGS+=	-DATF_PKGDATADIR='"${SHAREDIR}/atf"'
-CFLAGS+=	-DATF_SHELL='"/bin/sh"'
+CFLAGS+=	-DATF_SHELL='"/usr/libexec/sh_static"'
 CFLAGS+=	-I${ATF}
 
 # Silence warnings about usage of deprecated std::auto_ptr

--- a/libexec/atf/sh_static/Makefile
+++ b/libexec/atf/sh_static/Makefile
@@ -1,0 +1,16 @@
+# $FreeBSD$
+# We build a statically linked non-CHERI shell for atf-sh tests
+# This is noticeably faster on QEMU since we don't have to emulate
+# CHERI instructions (shouldn't make much of a difference on HW though).
+# It also means we don't have to process capability relocations on startup.
+.include <src.opts.mk>
+
+.if ${MACHINE_ABI:Mpurecap}
+NEED_COMPAT=	64
+.include <bsd.compat.mk>
+.endif
+
+PROG=	sh_static
+NO_SHARED=	yes
+
+.include	"${SRCTOP}/bin/sh/Makefile"

--- a/tests/sys/kern/coredump_phnum_test.sh
+++ b/tests/sys/kern/coredump_phnum_test.sh
@@ -91,8 +91,13 @@ coredump_phnum_body()
 	atf_check -o "match: 00000(0000000000)?1 .* 66[0-9]{3} " \
 	    -x 'readelf -S coredump_phnum_helper.core | grep -A1 "^  \[ 0\] "'
 
-	atf_check -o "match:66[0-9]{3}" \
-	    -x 'procstat -v coredump_phnum_helper.core | wc -l'
+	if [ "$(atf_config_get include_slow_tests false)" = "true" ]; then
+		# Running procstat -v takes a many minutes to format the 66K
+		# output lines on QEMU RISC-V purecap
+		atf_check -o "match:66[0-9]{3}" \
+		    -x 'procstat -v coredump_phnum_helper.core | wc -l'
+	fi
+
 }
 coredump_phnum_cleanup()
 {

--- a/usr.bin/mkimg/Makefile
+++ b/usr.bin/mkimg/Makefile
@@ -34,10 +34,7 @@ BINDIR?=/usr/bin
 
 LIBADD=	util
 
-.if ${MACHINE_CPUARCH} != "mips"
-# XXX: the process of listing tests times out under qemu
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
-.endif
 
 .include <bsd.prog.mk>

--- a/usr.bin/mkimg/tests/mkimg_test.sh
+++ b/usr.bin/mkimg/tests/mkimg_test.sh
@@ -142,6 +142,18 @@ atf_init_test_cases()
 {
     local B F G S nm
 
+    # Note: These tests take 2.5 minutes each on purecap CHERI-RISC-V, so if the
+    # unless the include_slow_tests option is set, we skip most of these tests
+    # to reduce test run time by almost 6 hours.
+    # FIXME: vhdx seems broken on RISC-V purecap so we run one of the failing
+    # tests (mbr_63x255_4096_vhdx) instead of the full matrix
+    if [ "$(atf_config_get include_slow_tests false)" != "true" ]; then
+	mkimg_blksz_list="4096"
+	mkimg_format_list="vhdx"
+	mkimg_geom_list="63x255"
+	mkimg_scheme_list="mbr"
+    fi
+
     for G in $mkimg_geom_list; do
 	for B in $mkimg_blksz_list; do
 	    for S in $mkimg_scheme_list; do

--- a/usr.bin/mkimg/tests/mkimg_test.sh
+++ b/usr.bin/mkimg/tests/mkimg_test.sh
@@ -142,14 +142,15 @@ atf_init_test_cases()
 {
     local B F G S nm
 
-    # Note: These tests take 2.5 minutes each on purecap CHERI-RISC-V, so if the
-    # unless the include_slow_tests option is set, we skip most of these tests
-    # to reduce test run time by almost 6 hours.
-    # FIXME: vhdx seems broken on RISC-V purecap so we run one of the failing
-    # tests (mbr_63x255_4096_vhdx) instead of the full matrix
+    # Note: These tests take 30 seconds each on purecap CHERI-RISC-V (i.e. 90
+    # minutes for all of them, or approximately 40% of the total test runtime),
+    # so unless the include_slow_tests option is set, we reduce the
+    # configuration matrix to run only one per file format.
+    # TODO: the majority of the time is spent in hexdump, so we could massively
+    # speed up the test if we used sparse files for the partition data and
+    # added SEEK_HOLE/SEEK_DATA support to hexdump.
     if [ "$(atf_config_get include_slow_tests false)" != "true" ]; then
 	mkimg_blksz_list="4096"
-	mkimg_format_list="vhdx"
 	mkimg_geom_list="63x255"
 	mkimg_scheme_list="mbr"
     fi

--- a/usr.sbin/etcupdate/Makefile
+++ b/usr.sbin/etcupdate/Makefile
@@ -5,7 +5,12 @@
 SCRIPTS=etcupdate.sh
 MAN=	etcupdate.8
 
+# FIXME: These tests take a really long time to run on QEMU and are unlikely to
+# catch any bugs in CheriBSD that don't also exist upstream. They are plain
+# shell scripts so we can't use "atf_config_get include_slow_tests"
+.if 0
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
+.endif
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
Speed up running the testsuite by skipping some slow tests and/or reducing the configuration matrix and using a statically linked non-CHERI shell.
The full testsuite can still be run with `kyua -v test_suites.FreeBSD.include_slow_tests=true test ...` 

This should significantly reduce the testing time.

See also https://github.com/CTSRD-CHERI/cheribuild/commit/ca2d209683c7711dc0f48a0f8dc8e8e7fabb1845

I submitted two atf-sh improvements that significantly improve test startup times as https://github.com/freebsd/atf/pull/6 and https://github.com/freebsd/atf/pull/5.