### PR TITLE
truss: decode compat32/compat64 arguments

### DIFF
--- a/sys/sys/cdefs.h
+++ b/sys/sys/cdefs.h
@@ -1094,25 +1094,24 @@
 #define	__static_assert_power_of_two(val)
 #endif
 
-/* Allow use of __builtin_is_aligned/align_up/align_down unconditionally */
+/* Alignment builtins for better type checking and improved code generation. */
+/* Provide fallback versions for other compilers (GCC/Clang < 10): */
 #if !__has_builtin(__builtin_is_aligned)
-#define __builtin_is_aligned(addr, align) \
-	({ __static_assert_power_of_two(align);			\
-	(((vaddr_t)addr & ((vaddr_t)(align) - 1)) == 0); })
+#define __builtin_is_aligned(x, align)	\
+	(((__uintptr_t)x & ((align) - 1)) == 0)
 #endif
 #if !__has_builtin(__builtin_align_up)
-#define __builtin_align_up(addr, align) \
-	({ __static_assert_power_of_two(align);					\
-	vaddr_t unaligned_bits = (vaddr_t)addr & ((align) - 1);			\
-	unaligned_bits == 0 ? addr :						\
-	    (__typeof__(addr))((uintptr_t)addr + ((align) - unaligned_bits)); })
+#define __builtin_align_up(x, align)	\
+	((__typeof__(x))(((__uintptr_t)(x)+((align)-1))&(~((align)-1))))
 #endif
 #if !__has_builtin(__builtin_align_down)
-#define __builtin_align_down(addr, align) ({					\
-	__static_assert_power_of_two(align);					\
-	vaddr_t unaligned_bits = (vaddr_t)addr & ((align) - 1);			\
-	(__typeof__(addr))((uintptr_t)addr - unaligned_bits); })
+#define __builtin_align_down(x, align)	\
+	((__typeof__(x))((x)&(~((align)-1))))
 #endif
+
+#define __align_up(x, y) __builtin_align_up(x, y)
+#define __align_down(x, y) __builtin_align_down(x, y)
+#define __is_aligned(x, y) __builtin_is_aligned(x, y)
 
 #endif /* !_SYS_CDEFS_H_ */
 // CHERI CHANGES START

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -317,9 +317,9 @@
 #define	nitems(x)	(sizeof((x)) / sizeof((x)[0]))
 #define	is_aligned(x, y) __builtin_is_aligned(x, y)
 #define	rounddown(x, y)	(((x)/(y))*(y))
-#define	rounddown2(x, y) __builtin_align_down((x), (y))
+#define	rounddown2(x, y) __align_down(x, y) /* if y is power of two */
 #define	roundup(x, y)	((((x)+((y)-1))/(y))*(y))  /* to any y */
-#define	roundup2(x, y)	__builtin_align_up((x), (y))
+#define	roundup2(x, y)	__align_up(x, y) /* if y is powers of two */
 #define powerof2(x)	((((x)-1)&(x))==0)
 
 /* Macros for min/max. */

--- a/usr.bin/truss/main.c
+++ b/usr.bin/truss/main.c
@@ -87,7 +87,6 @@ main(int ac, char **av)
 	trussinfo->strsize = 32;
 	trussinfo->curthread = NULL;
 	LIST_INIT(&trussinfo->proclist);
-	init_syscalls();
 	while ((c = getopt(ac, av, "p:o:facedDs:SH")) != -1) {
 		switch (c) {
 		case 'p':	/* specified pid */

--- a/usr.bin/truss/main.c
+++ b/usr.bin/truss/main.c
@@ -55,7 +55,7 @@ __FBSDID("$FreeBSD$");
 #include "extern.h"
 #include "syscall.h"
 
-static void
+static __dead2 void
 usage(void)
 {
 	fprintf(stderr, "%s\n%s\n",
@@ -118,7 +118,8 @@ main(int ac, char **av)
 			fname = optarg;
 			break;
 		case 's':	/* Specified string size */
-			trussinfo->strsize = strtonum(optarg, 0, INT_MAX, &errstr);
+			trussinfo->strsize = (int)strtonum(optarg, 0, INT_MAX,
+			    &errstr);
 			if (errstr)
 				errx(1, "maximum string size is %s: %s", errstr, optarg);
 			break;

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -106,7 +106,7 @@ static struct procabi freebsd32 = {
 	.type = "FreeBSD32",
 	.abi = SYSDECODE_ABI_FREEBSD32,
 	.pointer_size = sizeof(uint32_t),
-	.compat_prefix = "freebsd32",
+	.compat_prefix = "freebsd32_",
 	.extra_syscalls = STAILQ_HEAD_INITIALIZER(freebsd32.extra_syscalls),
 	.syscalls = { NULL }
 };

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -126,7 +126,7 @@ static struct procabi freebsd64 = {
 static struct procabi linux = {
 	.type = "Linux",
 	.abi = SYSDECODE_ABI_LINUX,
-	.pointer_size = sizeof(void *),
+	.pointer_size = sizeof(ptraddr_t),
 	.extra_syscalls = STAILQ_HEAD_INITIALIZER(linux.extra_syscalls),
 	.syscalls = { NULL }
 };

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -92,7 +92,7 @@ static struct procabi cloudabi64 = {
 static struct procabi freebsd = {
 	.type = "FreeBSD",
 	.abi = SYSDECODE_ABI_FREEBSD,
-	.pointer_size = sizeof(void *),
+	.pointer_size = sizeof(void * __capability),
 	.extra_syscalls = STAILQ_HEAD_INITIALIZER(freebsd.extra_syscalls),
 	.syscalls = { NULL }
 };
@@ -112,7 +112,8 @@ static struct procabi freebsd32 = {
 };
 #endif
 
-#ifdef __CHERI_PURE_CAPABILITY__
+#if __has_feature(capabilities)
+_Static_assert(sizeof(ptraddr_t) == 8, "Missing 64-bit capability support");
 static struct procabi freebsd64 = {
 	.type = "FreeBSD64",
 	.abi = SYSDECODE_ABI_FREEBSD64,
@@ -144,15 +145,13 @@ static struct procabi linux32 = {
 static struct procabi_table abis[] = {
 	{ "CloudABI ELF32", &cloudabi32 },
 	{ "CloudABI ELF64", &cloudabi64 },
-#ifdef __CHERI_PURE_CAPABILITY__
+#if __has_feature(capabilities)
 	{ "FreeBSD ELF64C", &freebsd },
 	{ "FreeBSD ELF64", &freebsd64 },
 	{ "FreeBSD ELF32", &freebsd32 },
 #elif __SIZEOF_POINTER__ == 4
 	{ "FreeBSD ELF32", &freebsd },
 #elif __SIZEOF_POINTER__ == 8
-	/* This permits hybrid truss to trace CheriABI. */
-	{ "FreeBSD ELF64C", &freebsd },
 	{ "FreeBSD ELF64", &freebsd },
 	{ "FreeBSD ELF32", &freebsd32 },
 #else
@@ -173,10 +172,6 @@ static struct procabi_table abis[] = {
 #else
 	{ "Linux ELF32", &linux },
 #endif
-	/*
-	 * XXX: Temporary hack for COMPAT_CHERIABI.
-	 */
-	{ "CheriABI ELF64", &freebsd },
 };
 
 /*

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -117,6 +117,7 @@ static struct procabi freebsd64 = {
 	.type = "FreeBSD64",
 	.abi = SYSDECODE_ABI_FREEBSD64,
 	.pointer_size = sizeof(uint64_t),
+	.compat_prefix = "freebsd64_",
 	.extra_syscalls = STAILQ_HEAD_INITIALIZER(freebsd64.extra_syscalls),
 	.syscalls = { NULL }
 };
@@ -146,6 +147,7 @@ static struct procabi_table abis[] = {
 #ifdef __CHERI_PURE_CAPABILITY__
 	{ "FreeBSD ELF64C", &freebsd },
 	{ "FreeBSD ELF64", &freebsd64 },
+	{ "FreeBSD ELF32", &freebsd32 },
 #elif __SIZEOF_POINTER__ == 4
 	{ "FreeBSD ELF32", &freebsd },
 #elif __SIZEOF_POINTER__ == 8

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -74,57 +74,69 @@ static void	new_proc(struct trussinfo *, pid_t, lwpid_t);
 
 
 static struct procabi cloudabi32 = {
-	"CloudABI32",
-	SYSDECODE_ABI_CLOUDABI32,
-	STAILQ_HEAD_INITIALIZER(cloudabi32.extra_syscalls),
-	{ NULL }
+	.type = "CloudABI32",
+	.abi = SYSDECODE_ABI_CLOUDABI32,
+	.pointer_size = sizeof(uint32_t),
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(cloudabi32.extra_syscalls),
+	.syscalls = { NULL }
 };
 
 static struct procabi cloudabi64 = {
-	"CloudABI64",
-	SYSDECODE_ABI_CLOUDABI64,
-	STAILQ_HEAD_INITIALIZER(cloudabi64.extra_syscalls),
-	{ NULL }
+	.type = "CloudABI64",
+	.abi = SYSDECODE_ABI_CLOUDABI64,
+	.pointer_size = sizeof(uint64_t),
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(cloudabi64.extra_syscalls),
+	.syscalls = { NULL }
 };
 
 static struct procabi freebsd = {
-	"FreeBSD",
-	SYSDECODE_ABI_FREEBSD,
-	STAILQ_HEAD_INITIALIZER(freebsd.extra_syscalls),
-	{ NULL }
+	.type = "FreeBSD",
+	.abi = SYSDECODE_ABI_FREEBSD,
+	.pointer_size = sizeof(void *),
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(freebsd.extra_syscalls),
+	.syscalls = { NULL }
 };
 
-#ifdef __LP64__
+#if !defined(__SIZEOF_POINTER__)
+#error "Use a modern compiler."
+#endif
+
+#if __SIZEOF_POINTER__ > 4
 static struct procabi freebsd32 = {
-	"FreeBSD32",
-	SYSDECODE_ABI_FREEBSD32,
-	STAILQ_HEAD_INITIALIZER(freebsd32.extra_syscalls),
-	{ NULL }
+	.type = "FreeBSD32",
+	.abi = SYSDECODE_ABI_FREEBSD32,
+	.pointer_size = sizeof(uint32_t),
+	.compat_prefix = "freebsd32",
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(freebsd32.extra_syscalls),
+	.syscalls = { NULL }
 };
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
 static struct procabi freebsd64 = {
-	"FreeBSD64",
-	SYSDECODE_ABI_FREEBSD64,
-	STAILQ_HEAD_INITIALIZER(freebsd64.extra_syscalls),
-	{ NULL }
+	.type = "FreeBSD64",
+	.abi = SYSDECODE_ABI_FREEBSD64,
+	.pointer_size = sizeof(uint64_t),
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(freebsd64.extra_syscalls),
+	.syscalls = { NULL }
 };
 #endif
 
 static struct procabi linux = {
-	"Linux",
-	SYSDECODE_ABI_LINUX,
-	STAILQ_HEAD_INITIALIZER(linux.extra_syscalls),
-	{ NULL }
+	.type = "Linux",
+	.abi = SYSDECODE_ABI_LINUX,
+	.pointer_size = sizeof(void *),
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(linux.extra_syscalls),
+	.syscalls = { NULL }
 };
 
-#ifdef __LP64__
+#if __SIZEOF_POINTER__ > 4
 static struct procabi linux32 = {
-	"Linux32",
-	SYSDECODE_ABI_LINUX32,
-	STAILQ_HEAD_INITIALIZER(linux32.extra_syscalls),
-	{ NULL }
+	.type = "Linux32",
+	.abi = SYSDECODE_ABI_LINUX32,
+	.pointer_size = sizeof(uint32_t),
+	.extra_syscalls = STAILQ_HEAD_INITIALIZER(linux32.extra_syscalls),
+	.syscalls = { NULL }
 };
 #endif
 
@@ -133,21 +145,19 @@ static struct procabi_table abis[] = {
 	{ "CloudABI ELF64", &cloudabi64 },
 #ifdef __CHERI_PURE_CAPABILITY__
 	{ "FreeBSD ELF64C", &freebsd },
-#elif defined(__LP64__)
+	{ "FreeBSD ELF64", &freebsd64 },
+#elif __SIZEOF_POINTER__ == 4
+	{ "FreeBSD ELF32", &freebsd },
+#elif __SIZEOF_POINTER__ == 8
 	/* This permits hybrid truss to trace CheriABI. */
 	{ "FreeBSD ELF64C", &freebsd },
 	{ "FreeBSD ELF64", &freebsd },
+	{ "FreeBSD ELF32", &freebsd32 },
 #else
-	{ "FreeBSD ELF32", &freebsd },
+#error "Unsupported pointer size"
 #endif
 #if defined(__powerpc64__)
 	{ "FreeBSD ELF64 V2", &freebsd },
-#endif
-#ifdef __CHERI_PURE_CAPABILITY__
-	{ "FreeBSD ELF64", &freebsd64 },
-#endif
-#ifdef __LP64__
-	{ "FreeBSD ELF32", &freebsd32 },
 #endif
 #if defined(__amd64__)
 	{ "FreeBSD a.out", &freebsd32 },
@@ -155,11 +165,11 @@ static struct procabi_table abis[] = {
 #if defined(__i386__)
 	{ "FreeBSD a.out", &freebsd },
 #endif
-#ifdef __LP64__
+#if __SIZEOF_POINTER__ >= 8
 	{ "Linux ELF64", &linux },
 	{ "Linux ELF32", &linux32 },
 #else
-	{ "Linux ELF", &linux },
+	{ "Linux ELF32", &linux },
 #endif
 	/*
 	 * XXX: Temporary hack for COMPAT_CHERIABI.

--- a/usr.bin/truss/syscall.h
+++ b/usr.bin/truss/syscall.h
@@ -210,18 +210,28 @@ enum Argtype {
 _Static_assert(ARG_MASK > MAX_ARG_TYPE,
     "ARG_MASK overlaps with Argtype values");
 
-struct syscall_args {
+struct syscall_arg {
 	enum Argtype type;
 	int offset;
 };
 
+struct syscall_decode {
+	const char *name; /* Name for calling convention lookup. */
+	/*
+	 * Syscall return type:
+	 * 0: no return value (e.g. exit)
+	 * 1: normal return value (a single int/long/pointer)
+	 * 2: off_t return value (two values for 32-bit ABIs)
+	 */
+	u_int ret_type;
+	u_int nargs;		     /* number of meaningful arguments */
+	struct syscall_arg args[10]; /* Hopefully no syscalls with > 10 args */
+};
+
 struct syscall {
 	STAILQ_ENTRY(syscall) entries;
-	const char *name;
-	u_int ret_type;	/* 0, 1, or 2 return values */
-	u_int nargs;	/* actual number of meaningful arguments */
-			/* Hopefully, no syscalls with > 10 args */
-	struct syscall_args args[10];
+	const char *name;	/* Name to be displayed, might be malloc()'d */
+	struct syscall_decode decode;
 	struct timespec time; /* Time spent for this call */
 	int ncalls;	/* Number of calls */
 	int nerror;	/* Number of calls that returned with error */
@@ -229,7 +239,7 @@ struct syscall {
 };
 
 struct syscall *get_syscall(struct threadinfo *, u_int, u_int);
-char *print_arg(struct syscall_args *, syscallarg_t *, syscallarg_t *,
+char *print_arg(struct syscall_arg *, syscallarg_t *, syscallarg_t *,
     struct trussinfo *);
 
 /*
@@ -272,7 +282,6 @@ struct linux_socketcall_args {
     char args_l_[PADL_(l_ulong)]; l_ulong args; char args_r_[PADR_(l_ulong)];
 };
 
-void init_syscalls(void);
 void print_syscall(struct trussinfo *);
 void print_syscall_ret(struct trussinfo *, int, syscallarg_t *);
 void print_summary(struct trussinfo *trussinfo);

--- a/usr.bin/truss/syscalls.c
+++ b/usr.bin/truss/syscalls.c
@@ -46,8 +46,10 @@ __FBSDID("$FreeBSD$");
 #include <sys/ioccom.h>
 #include <sys/mman.h>
 #include <sys/mount.h>
+#include <sys/poll.h>
 #include <sys/ptrace.h>
 #include <sys/resource.h>
+#include <sys/sched.h>
 #include <sys/socket.h>
 #define _WANT_FREEBSD11_STAT
 #include <sys/stat.h>
@@ -69,8 +71,6 @@ __FBSDID("$FreeBSD$");
 #define _WANT_KERNEL_ERRNO
 #include <errno.h>
 #include <fcntl.h>
-#include <poll.h>
-#include <sched.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -88,8 +88,13 @@ __FBSDID("$FreeBSD$");
 
 /*
  * This should probably be in its own file, sorted alphabetically.
+ *
+ * Note: We only scan this table on the initial syscall number to calling
+ * convention lookup, i.e. once each time a new syscall is encountered. This
+ * is unlikely to be a performance issue, but if it is we could sort this array
+ * and use a binary search instead.
  */
-static struct syscall decoded_syscalls[] = {
+static const struct syscall_decode decoded_syscalls[] = {
 	/* Native ABI */
 	{ .name = "__acl_aclcheck_fd", .ret_type = 1, .nargs = 3,
 	  .args = { { Int, 0 }, { Acltype, 1 }, { Ptr, 2 } } },
@@ -684,10 +689,8 @@ static struct syscall decoded_syscalls[] = {
 	{ .name = "cloudabi_sys_thread_exit", .ret_type = 1, .nargs = 2,
 	  .args = { { Ptr, 0 }, { CloudABIMFlags, 1 } } },
 	{ .name = "cloudabi_sys_thread_yield", .ret_type = 1, .nargs = 0 },
-
-	{ .name = 0 },
 };
-static STAILQ_HEAD(, syscall) syscalls;
+static STAILQ_HEAD(, syscall) seen_syscalls;
 
 /* Xlat idea taken from strace */
 struct xlat {
@@ -924,7 +927,7 @@ print_mask_arg32(bool (*decoder)(FILE *, uint32_t, uint32_t *), FILE *fp,
  * decoding arguments.
  */
 static void
-quad_fixup(struct syscall *sc)
+quad_fixup(struct syscall_decode *sc)
 {
 	int offset, prev;
 	u_int i;
@@ -962,20 +965,6 @@ quad_fixup(struct syscall *sc)
 }
 #endif
 
-void
-init_syscalls(void)
-{
-	struct syscall *sc;
-
-	STAILQ_INIT(&syscalls);
-	for (sc = decoded_syscalls; sc->name != NULL; sc++) {
-#ifndef __LP64__
-		quad_fixup(sc);
-#endif
-		STAILQ_INSERT_HEAD(&syscalls, sc, entries);
-	}
-}
-
 static struct syscall *
 find_syscall(struct procabi *abi, u_int number)
 {
@@ -995,6 +984,11 @@ add_syscall(struct procabi *abi, u_int number, struct syscall *sc)
 {
 	struct extra_syscall *es;
 
+#ifndef __LP64__
+	/* FIXME: should be based on syscall ABI not truss ABI */
+	quad_fixup(&sc->decode);
+#endif
+
 	if (number < nitems(abi->syscalls)) {
 		assert(abi->syscalls[number] == NULL);
 		abi->syscalls[number] = sc;
@@ -1004,6 +998,8 @@ add_syscall(struct procabi *abi, u_int number, struct syscall *sc)
 		es->number = number;
 		STAILQ_INSERT_TAIL(&abi->extra_syscalls, es, entries);
 	}
+
+	STAILQ_INSERT_HEAD(&seen_syscalls, sc, entries);
 }
 
 /*
@@ -1014,24 +1010,28 @@ struct syscall *
 get_syscall(struct threadinfo *t, u_int number, u_int nargs)
 {
 	struct syscall *sc;
+	const char *sysdecode_name;
 	const char *name;
-	char *new_name;
 	u_int i;
 
 	sc = find_syscall(t->proc->abi, number);
 	if (sc != NULL)
 		return (sc);
 
-	name = sysdecode_syscallname(t->proc->abi->abi, number);
-	if (name == NULL) {
-		asprintf(&new_name, "#%d", number);
-		name = new_name;
-	} else
-		new_name = NULL;
-	STAILQ_FOREACH(sc, &syscalls, entries) {
-		if (strcmp(name, sc->name) == 0) {
+	/* Memory is not explicitly deallocated, it's released on exit(). */
+	sysdecode_name = sysdecode_syscallname(t->proc->abi->abi, number);
+	if (sysdecode_name == NULL)
+		asprintf(__DECONST(char **, &name), "#%d", number);
+	else
+		name = sysdecode_name;
+
+	sc = calloc(1, sizeof(*sc));
+	sc->name = name;
+
+	for (i = 0; i < nitems(decoded_syscalls); i++) {
+		if (strcmp(name, decoded_syscalls[i].name) == 0) {
+			sc->decode = decoded_syscalls[i];
 			add_syscall(t->proc->abi, number, sc);
-			free(new_name);
 			return (sc);
 		}
 	}
@@ -1041,21 +1041,15 @@ get_syscall(struct threadinfo *t, u_int number, u_int nargs)
 	fprintf(stderr, "unknown syscall %s -- setting args to %d\n", name,
 	    nargs);
 #endif
-
-	sc = calloc(1, sizeof(struct syscall));
-	sc->name = name;
-	if (new_name != NULL)
-		sc->unknown = true;
-	sc->ret_type = 1;
-	sc->nargs = nargs;
+	sc->unknown = sysdecode_name == NULL;
+	sc->decode.ret_type = 1; /* Assume 1 return value. */
+	sc->decode.nargs = nargs;
 	for (i = 0; i < nargs; i++) {
-		sc->args[i].offset = i;
+		sc->decode.args[i].offset = i;
 		/* Treat all unknown arguments as LongHex. */
-		sc->args[i].type = LongHex;
+		sc->decode.args[i].type = LongHex;
 	}
-	STAILQ_INSERT_HEAD(&syscalls, sc, entries);
 	add_syscall(t->proc->abi, number, sc);
-
 	return (sc);
 }
 
@@ -1619,7 +1613,7 @@ print_sysctl(FILE *fp, int *oid, size_t len)
  * an array of all of the system call arguments.
  */
 char *
-print_arg(struct syscall_args *sc, syscallarg_t *args, syscallarg_t *retval,
+print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
     struct trussinfo *trussinfo)
 {
 	FILE *fp;
@@ -2799,7 +2793,7 @@ print_syscall_ret(struct trussinfo *trussinfo, int error, syscallarg_t *retval)
 		    strerror(error));
 	}
 #ifndef __LP64__
-	else if (sc->ret_type == 2) {
+	else if (sc->decode.ret_type == 2) {
 		off_t off;
 
 #if _BYTE_ORDER == _LITTLE_ENDIAN
@@ -2811,7 +2805,7 @@ print_syscall_ret(struct trussinfo *trussinfo, int error, syscallarg_t *retval)
 		    (intmax_t)off);
 	}
 #endif
-	else if (sc->ret_type == 3) {
+	else if (sc->decode.ret_type == 3) {
 #ifdef __CHERI_PURE_CAPABILITY__
 		char tmp[128];
 		strfcap(tmp, sizeof(tmp), "%T%C", retval[0]);
@@ -2834,7 +2828,7 @@ print_summary(struct trussinfo *trussinfo)
 	fprintf(trussinfo->outfile, "%-20s%15s%8s%8s\n",
 	    "syscall", "seconds", "calls", "errors");
 	ncall = nerror = 0;
-	STAILQ_FOREACH(sc, &syscalls, entries)
+	STAILQ_FOREACH(sc, &seen_syscalls, entries) {
 		if (sc->ncalls) {
 			fprintf(trussinfo->outfile, "%-20s%5jd.%09ld%8d%8d\n",
 			    sc->name, (intmax_t)sc->time.tv_sec,
@@ -2843,6 +2837,7 @@ print_summary(struct trussinfo *trussinfo)
 			ncall += sc->ncalls;
 			nerror += sc->nerror;
 		}
+	}
 	fprintf(trussinfo->outfile, "%20s%15s%8s%8s\n",
 	    "", "-------------", "-------", "-------");
 	fprintf(trussinfo->outfile, "%-20s%5jd.%09ld%8d%8d\n",

--- a/usr.bin/truss/syscalls.c
+++ b/usr.bin/truss/syscalls.c
@@ -1806,32 +1806,29 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 		fputs(" ]", fp);
 		break;
 	}
-#ifdef __LP64__
-	case Quad:
-		fprintf(fp, "%ld", (long)args[sc->offset]);
-		break;
-	case QuadHex:
-		fprintf(fp, "0x%lx", (unsigned long)args[sc->offset]);
-		break;
-#else
 	case Quad:
 	case QuadHex: {
-		unsigned long long ll;
+		uint64_t value;
+		size_t pointer_size =
+		    trussinfo->curthread->proc->abi->pointer_size;
 
+		if (pointer_size == 4) {
 #if _BYTE_ORDER == _LITTLE_ENDIAN
-		ll = (unsigned long long)args[sc->offset + 1] << 32 |
-		    args[sc->offset];
+			value = (uint64_t)args[sc->offset + 1] << 32 |
+			    args[sc->offset];
 #else
-		ll = (unsigned long long)args[sc->offset] << 32 |
-		    args[sc->offset + 1];
+			value = (uint64_t)args[sc->offset] << 32 |
+			    args[sc->offset + 1];
 #endif
+		} else {
+			value = (uint64_t)args[sc->offset];
+		}
 		if ((sc->type & ARG_MASK) == Quad)
-			fprintf(fp, "%lld", ll);
+			fprintf(fp, "%jd", (intmax_t)value);
 		else
-			fprintf(fp, "0x%llx", ll);
+			fprintf(fp, "0x%jx", (intmax_t)value);
 		break;
 	}
-#endif
 	case PQuadHex: {
 		uint64_t val;
 
@@ -2818,11 +2815,9 @@ print_syscall_ret(struct trussinfo *trussinfo, int error, syscallarg_t *retval)
 		fprintf(trussinfo->outfile, " ERR#%d '%s'\n",
 		    sysdecode_freebsd_to_abi_errno(t->proc->abi->abi, error),
 		    strerror(error));
-	}
-#ifndef __LP64__
-	else if (sc->decode.ret_type == 2) {
+	} else if (sc->decode.ret_type == 2 &&
+	    t->proc->abi->pointer_size == 4) {
 		off_t off;
-
 #if _BYTE_ORDER == _LITTLE_ENDIAN
 		off = (off_t)retval[1] << 32 | retval[0];
 #else
@@ -2830,9 +2825,7 @@ print_syscall_ret(struct trussinfo *trussinfo, int error, syscallarg_t *retval)
 #endif
 		fprintf(trussinfo->outfile, " = %jd (0x%jx)\n", (intmax_t)off,
 		    (intmax_t)off);
-	}
-#endif
-	else if (sc->decode.ret_type == 3) {
+	} else if (sc->decode.ret_type == 3) {
 #ifdef __CHERI_PURE_CAPABILITY__
 		char tmp[128];
 		strfcap(tmp, sizeof(tmp), "%T%C", retval[0]);
@@ -2840,9 +2833,10 @@ print_syscall_ret(struct trussinfo *trussinfo, int error, syscallarg_t *retval)
 #else
 		fprintf(trussinfo->outfile, " = %p\n", (void *)retval[0]);
 #endif
-	} else
+	} else {
 		fprintf(trussinfo->outfile, " = %jd (0x%jx)\n",
 		    (intmax_t)retval[0], (intmax_t)retval[0]);
+	}
 }
 
 void

--- a/usr.bin/truss/syscalls.c
+++ b/usr.bin/truss/syscalls.c
@@ -1745,6 +1745,9 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 		union {
 			int32_t strarray32[PAGE_SIZE / sizeof(int32_t)];
 			int64_t strarray64[PAGE_SIZE / sizeof(int64_t)];
+#if __has_feature(capabilities)
+			intcap_t strarray_cap[PAGE_SIZE / sizeof(intcap_t)];
+#endif
 			char buf[PAGE_SIZE];
 		} u;
 		char *string;
@@ -1788,6 +1791,11 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 		i = 0;
 		for (;;) {
 			psaddr_t straddr;
+#if __has_feature(capabilities)
+			if (pointer_size == sizeof(intcap_t)) {
+				straddr = (psaddr_t)u.strarray_cap[i];
+			} else
+#endif
 			if (pointer_size == 4) {
 				straddr = user_ptr32_to_psaddr(u.strarray32[i]);
 			} else if (pointer_size == 8) {

--- a/usr.bin/truss/syscalls.c
+++ b/usr.bin/truss/syscalls.c
@@ -918,7 +918,6 @@ print_mask_arg32(bool (*decoder)(FILE *, uint32_t, uint32_t *), FILE *fp,
 		fprintf(fp, "|0x%x", rem);
 }
 
-#ifndef __LP64__
 /*
  * Add argument padding to subsequent system calls after Quad
  * syscall arguments as needed.  This used to be done by hand in the
@@ -963,7 +962,6 @@ quad_fixup(struct syscall_decode *sc)
 		}
 	}
 }
-#endif
 
 static struct syscall *
 find_syscall(struct procabi *abi, u_int number)
@@ -984,10 +982,13 @@ add_syscall(struct procabi *abi, u_int number, struct syscall *sc)
 {
 	struct extra_syscall *es;
 
-#ifndef __LP64__
-	/* FIXME: should be based on syscall ABI not truss ABI */
-	quad_fixup(&sc->decode);
-#endif
+	/*
+	 * quad_fixup() is currently needed for all 32-bit ABIs.
+	 * TODO: This should probably be a function pointer inside struct
+	 *  procabi instead.
+	 */
+	if (abi->pointer_size == 4)
+		quad_fixup(&sc->decode);
 
 	if (number < nitems(abi->syscalls)) {
 		assert(abi->syscalls[number] == NULL);
@@ -1010,16 +1011,19 @@ struct syscall *
 get_syscall(struct threadinfo *t, u_int number, u_int nargs)
 {
 	struct syscall *sc;
+	struct procabi *procabi;
 	const char *sysdecode_name;
+	const char *lookup_name;
 	const char *name;
 	u_int i;
 
-	sc = find_syscall(t->proc->abi, number);
+	procabi = t->proc->abi;
+	sc = find_syscall(procabi, number);
 	if (sc != NULL)
 		return (sc);
 
 	/* Memory is not explicitly deallocated, it's released on exit(). */
-	sysdecode_name = sysdecode_syscallname(t->proc->abi->abi, number);
+	sysdecode_name = sysdecode_syscallname(procabi->abi, number);
 	if (sysdecode_name == NULL)
 		asprintf(__DECONST(char **, &name), "#%d", number);
 	else
@@ -1028,8 +1032,14 @@ get_syscall(struct threadinfo *t, u_int number, u_int nargs)
 	sc = calloc(1, sizeof(*sc));
 	sc->name = name;
 
+	/* Also decode compat syscalls arguments by stripping the prefix. */
+	lookup_name = name;
+	if (procabi->compat_prefix != NULL && strncmp(procabi->compat_prefix,
+	    name, strlen(procabi->compat_prefix)) == 0)
+		lookup_name += strlen(procabi->compat_prefix);
+
 	for (i = 0; i < nitems(decoded_syscalls); i++) {
-		if (strcmp(name, decoded_syscalls[i].name) == 0) {
+		if (strcmp(lookup_name, decoded_syscalls[i].name) == 0) {
 			sc->decode = decoded_syscalls[i];
 			add_syscall(t->proc->abi, number, sc);
 			return (sc);
@@ -1719,12 +1729,15 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 	case StringArray: {
 		uintptr_t addr;
 		union {
-			char *strarray[0];
+			int32_t strarray32[PAGE_SIZE / sizeof(int32_t)];
+			int64_t strarray64[PAGE_SIZE / sizeof(int64_t)];
 			char buf[PAGE_SIZE];
 		} u;
 		char *string;
 		size_t len;
 		u_int first, i;
+		size_t pointer_size =
+		    trussinfo->curthread->proc->abi->pointer_size;
 
 		/*
 		 * Only parse argv[] and environment arrays from exec calls
@@ -1744,7 +1757,7 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 		 * a partial page.
 		 */
 		addr = args[sc->offset];
-		if ((vaddr_t)addr % sizeof(char *) != 0) {
+		if (addr % pointer_size != 0) {
 			print_pointer(fp, args[sc->offset]);
 			break;
 		}
@@ -1754,22 +1767,36 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 			print_pointer(fp, args[sc->offset]);
 			break;
 		}
+		assert(len > 0);
 
 		fputc('[', fp);
 		first = 1;
 		i = 0;
-		while (u.strarray[i] != NULL) {
-			string = get_string(pid, (uintptr_t)u.strarray[i], 0);
+		for (;;) {
+			uintptr_t straddr;
+			if (pointer_size == 4) {
+				if (u.strarray32[i] == 0)
+					break;
+				/* sign-extend 32-bit pointers */
+				straddr = (intptr_t)u.strarray32[i];
+			} else if (pointer_size == 8) {
+				if (u.strarray64[i] == 0)
+					break;
+				straddr = (intptr_t)u.strarray64[i];
+			} else {
+				errx(1, "Unsupported pointer size: %zu",
+				    pointer_size);
+			}
+			string = get_string(pid, straddr, 0);
 			fprintf(fp, "%s \"%s\"", first ? "" : ",", string);
 			free(string);
 			first = 0;
 
 			i++;
-			if (i == len / sizeof(char *)) {
+			if (i == len / pointer_size) {
 				addr += len;
 				len = PAGE_SIZE;
-				if (get_struct(pid, addr, u.buf, len) ==
-				    -1) {
+				if (get_struct(pid, addr, u.buf, len) == -1) {
 					fprintf(fp, ", <inval>");
 					break;
 				}

--- a/usr.bin/truss/truss.h
+++ b/usr.bin/truss/truss.h
@@ -58,6 +58,8 @@ struct extra_syscall {
 struct procabi {
 	const char *type;
 	enum sysdecode_abi abi;
+	size_t pointer_size;
+	const char *compat_prefix;
 	STAILQ_HEAD(, extra_syscall) extra_syscalls;
 	struct syscall *syscalls[SYSCALL_NORMAL_COUNT];
 };


### PR DESCRIPTION
Currently running a pure-capability `truss -a -e` does not decode any
argument values for freebsd64_* syscalls (open/readlink/etc.).

This cherry-picks my upstreamed fixes for compat32 decoding and
makes some minor adjustments to allow using a hybrid truss to trace
purecap programs.
