### PR TITLE
Port the tag stripping memcpy detection to RISC-V

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1647,12 +1647,24 @@ static const struct cheri_test cheri_tests[] = {
 	/* Unaligned memcpy/memmove with capabilities */
 	{ .ct_name = "test_unaligned_capability_copy_memcpy",
 	  .ct_desc = "Check that a memcpy() of valid capabilities to an "
-		     "unaligned destination strips tags",
+		     "unaligned destination fails",
 	  .ct_func = test_unaligned_capability_copy_memcpy },
 	{ .ct_name = "test_unaligned_capability_copy_memmove",
 	  .ct_desc = "Check that a memmove() of valid capabilities to an "
-		     "unaligned destination strips tags",
+		     "unaligned destination does not abort()",
 	  .ct_func = test_unaligned_capability_copy_memmove },
+	{ .ct_name = "test_unaligned_capability_copy_memcpy",
+	  .ct_desc = "Check that a memcpy() of valid capabilities to an "
+		     "unaligned destination calls abort() if requested.",
+	  .ct_func = test_unaligned_capability_copy_memcpy_abort,
+	  .ct_flags = CT_FLAG_SIGEXIT,
+	  .ct_signum = SIGABRT },
+	{ .ct_name = "test_unaligned_capability_copy_memmove",
+	  .ct_desc = "Check that a memmove() of valid capabilities to an "
+		     "unaligned destination calls abort() if requested.",
+	  .ct_func = test_unaligned_capability_copy_memmove_abort,
+	  .ct_flags = CT_FLAG_SIGEXIT,
+	  .ct_signum = SIGABRT },
 
 	/*
 	 * Thread-Local Storage (TLS) tests.

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -505,7 +505,9 @@ DECLARE_CHERI_TEST(test_string_memmove);
 DECLARE_CHERI_TEST(test_string_memmove_c);
 
 DECLARE_CHERI_TEST(test_unaligned_capability_copy_memcpy);
+DECLARE_CHERI_TEST(test_unaligned_capability_copy_memcpy_abort);
 DECLARE_CHERI_TEST(test_unaligned_capability_copy_memmove);
+DECLARE_CHERI_TEST(test_unaligned_capability_copy_memmove_abort);
 
 /* cheritest_syscall.c */
 DECLARE_CHERI_TEST(test_sandbox_syscall);

--- a/contrib/jemalloc/include/jemalloc/internal/atomic.h
+++ b/contrib/jemalloc/include/jemalloc/internal/atomic.h
@@ -81,6 +81,9 @@ JEMALLOC_GENERATE_INT_ATOMICS(uint32_t, u32, 2)
 JEMALLOC_GENERATE_INT_ATOMICS(uint64_t, u64, 3)
 #endif
 
+JEMALLOC_GENERATE_ATOMICS(uintptr_t, uptr, this_should_not_be_used)
+
+
 #undef ATOMIC_INLINE
 
 #endif /* JEMALLOC_INTERNAL_ATOMIC_H */

--- a/contrib/jemalloc/include/jemalloc/internal/seq.h
+++ b/contrib/jemalloc/include/jemalloc/internal/seq.h
@@ -10,8 +10,8 @@
 #define seq_define(type, short_type)					\
 typedef struct {							\
 	atomic_zu_t seq;						\
-	atomic_zu_t data[						\
-	    (sizeof(type) + sizeof(size_t) - 1) / sizeof(size_t)];	\
+	atomic_uptr_t data[						\
+	    (sizeof(type) + sizeof(uintptr_t) - 1) / sizeof(uintptr_t)];	\
 } seq_##short_type##_t;							\
 									\
 /*									\
@@ -20,14 +20,14 @@ typedef struct {							\
  */									\
 static inline void							\
 seq_store_##short_type(seq_##short_type##_t *dst, type *src) {		\
-	size_t buf[sizeof(dst->data) / sizeof(size_t)];			\
-	buf[sizeof(buf) / sizeof(size_t) - 1] = 0;			\
+	uintptr_t buf[sizeof(dst->data) / sizeof(uintptr_t)];		\
+	buf[sizeof(buf) / sizeof(uintptr_t) - 1] = 0;			\
 	memcpy(buf, src, sizeof(type));					\
 	size_t old_seq = atomic_load_zu(&dst->seq, ATOMIC_RELAXED);	\
 	atomic_store_zu(&dst->seq, old_seq + 1, ATOMIC_RELAXED);	\
 	atomic_fence(ATOMIC_RELEASE);					\
-	for (size_t i = 0; i < sizeof(buf) / sizeof(size_t); i++) {	\
-		atomic_store_zu(&dst->data[i], buf[i], ATOMIC_RELAXED);	\
+	for (size_t i = 0; i < sizeof(buf) / sizeof(buf[0]); i++) {	\
+		atomic_store_uptr(&dst->data[i], buf[i], ATOMIC_RELAXED);	\
 	}								\
 	atomic_store_zu(&dst->seq, old_seq + 2, ATOMIC_RELEASE);	\
 }									\
@@ -35,13 +35,13 @@ seq_store_##short_type(seq_##short_type##_t *dst, type *src) {		\
 /* Returns whether or not the read was consistent. */			\
 static inline bool							\
 seq_try_load_##short_type(type *dst, seq_##short_type##_t *src) {	\
-	size_t buf[sizeof(src->data) / sizeof(size_t)];			\
+	uintptr_t buf[sizeof(src->data) / sizeof(uintptr_t)];		\
 	size_t seq1 = atomic_load_zu(&src->seq, ATOMIC_ACQUIRE);	\
 	if (seq1 % 2 != 0) {						\
 		return false;						\
 	}								\
-	for (size_t i = 0; i < sizeof(buf) / sizeof(size_t); i++) {	\
-		buf[i] = atomic_load_zu(&src->data[i], ATOMIC_RELAXED);	\
+	for (size_t i = 0; i < sizeof(buf) / sizeof(buf[0]); i++) {	\
+		buf[i] = atomic_load_uptr(&src->data[i], ATOMIC_RELAXED);	\
 	}								\
 	atomic_fence(ATOMIC_ACQUIRE);					\
 	size_t seq2 = atomic_load_zu(&src->seq, ATOMIC_RELAXED);	\

--- a/lib/libc/string/tag_strip_dbg.inc
+++ b/lib/libc/string/tag_strip_dbg.inc
@@ -1,0 +1,143 @@
+/*-
+ * Copyright 2019-2020 Alex Richardson <arichardson@FreeBSD.org>
+ *
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract FA8750-10-C-0237
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * This file implements a debug check to find memcpy() calls to unaligned
+ * destinations that would result in tag stripping even though the user
+ * intended to retain tags. It has been extremely useful in the past to detect
+ * incorrect casts or missing _Alignas annotations in certain software.
+ *
+ * However, we can't assume that any tag-stripping memcpy() is always a real
+ * bug: It can also happen when copying large stack-allocated unions that were
+ * partially initialized or structures with a large NUL-terminated char[].
+ *
+ * To simplify debugging this warning message can be turned into an abort()
+ * by setting the CHERI_ABORT_ON_TAG_STRIPPING_COPY environment variable.
+ *
+ */
+
+#if __has_feature(capabilities)
+extern ssize_t __sys_write(int, const void *, size_t);
+#define write_to_stderr(str) __sys_write(2, (str), __builtin_strlen(str))
+extern int __sysctlbyname(const char *name, size_t namelen, void *oldp,
+    size_t *oldlenp, const void *newp, size_t newlen);
+#define ABORT_ON_TAG_LOSS_SYSCTL "security.cheri.abort_on_memcpy_tag_loss"
+#define ABORT_ON_TAG_LOSS_ENVVAR "CHERI_ABORT_ON_TAG_STRIPPING_COPY"
+
+static void
+handle_untagged_copy(const void *__capability taggedcap, vaddr_t src_addr,
+    vaddr_t dst_addr, size_t offset)
+{
+	char errmsg_buffer[1024];
+	/* XXXAR: These functions do not exist yet... */
+	snprintf(errmsg_buffer, sizeof(errmsg_buffer),
+	    "%s: Attempting to copy a tagged capability (%#p) from 0x%jx to "
+	    "underaligned destination 0x%jx. Use memmove_nocap()/memcpy_nocap()"
+	    " if you intended to strip tags.\n", getprogname(),
+#ifdef __CHERI_PURE_CAPABILITY__
+	    taggedcap,
+#else
+	    /* Can't use capabilities in fprintf in hybrid mode */
+	    (void *)(uintptr_t)(__cheri_addr vaddr_t)(taggedcap),
+#endif
+	    (uintmax_t)(src_addr + offset), (uintmax_t)(dst_addr + offset));
+	write_to_stderr(errmsg_buffer);
+	/* TODO: allow overriding the behaviour with a function pointer? */
+	static int abort_on_tag_loss = -1;
+	if (abort_on_tag_loss == -1) {
+		const char *from_env = getenv(ABORT_ON_TAG_LOSS_ENVVAR);
+		if (from_env != NULL) {
+			/* Enabled unless empty or starts with zero. */
+			if (*from_env == '\0' || *from_env == '0')
+				abort_on_tag_loss = 0;
+			else
+				abort_on_tag_loss = 1;
+		}
+	}
+	if (abort_on_tag_loss == -1) {
+		/* If the env var is not set fall back to the global sysctl */
+		size_t olen = sizeof(abort_on_tag_loss);
+		if (__sysctlbyname(ABORT_ON_TAG_LOSS_SYSCTL,
+		    __builtin_strlen(ABORT_ON_TAG_LOSS_SYSCTL),
+		    &abort_on_tag_loss, &olen, NULL, 0) == -1) {
+			write_to_stderr(
+			    "ERROR: could not determine whether "
+			    "tag stripping memcpy should abort. Assuming it "
+			    "shouldn't.\n");
+			abort_on_tag_loss = 0;
+		}
+	}
+	if (abort_on_tag_loss) {
+		write_to_stderr("Note: accidental tag stripping is fatal, set "
+				"the " ABORT_ON_TAG_LOSS_ENVVAR " environment "
+				"variable or the " ABORT_ON_TAG_LOSS_SYSCTL
+				" sysctl to 0 to disable this behaviour.\n");
+		abort();
+	}
+}
+
+/*
+ * Check that we aren't attempting to copy a capabilities to a misaligned
+ * destination (which would strip the tag bit instead of raising an exception).
+ */
+static void
+check_no_tagged_capabilities_in_copy(
+    const char *__CAP src, const char *__CAP dst, size_t len)
+{
+	static int error_logged = 0;
+
+	if (len < sizeof(void *__capability)) {
+		return; /* Return early if copying less than a capability. */
+	}
+	if (error_logged) {
+		return; /* Only report one error and skip checks afterwards. */
+	}
+	const vaddr_t src_addr = (__cheri_addr vaddr_t)src;
+	const vaddr_t to_first_cap =
+	    __builtin_align_up(src_addr, sizeof(void *__capability)) - src_addr;
+	const vaddr_t last_clc_offset = len - sizeof(void *__capability);
+	for (vaddr_t offset = to_first_cap; offset <= last_clc_offset;
+	     offset += sizeof(void *__capability)) {
+		const void *__capability const *__CAP aligned_src =
+		    (const void *__capability const *__CAP)(src + offset);
+		if (__predict_true(!__builtin_cheri_tag_get(*aligned_src))) {
+			continue; /* untagged values are fine */
+		}
+
+		if (error_logged)
+			break;
+		error_logged = 1;
+		/* Got a tagged value, this is always an error! */
+		handle_untagged_copy(
+		    *aligned_src, src_addr, (__cheri_addr vaddr_t)dst, offset);
+	}
+}
+#endif

--- a/lib/libc/string/tag_strip_dbg.inc
+++ b/lib/libc/string/tag_strip_dbg.inc
@@ -49,7 +49,7 @@ extern ssize_t __sys_write(int, const void *, size_t);
 #define write_to_stderr(str) __sys_write(2, (str), __builtin_strlen(str))
 extern int __sysctlbyname(const char *name, size_t namelen, void *oldp,
     size_t *oldlenp, const void *newp, size_t newlen);
-#define ABORT_ON_TAG_LOSS_SYSCTL "security.cheri.abort_on_memcpy_tag_loss"
+#define ABORT_ON_TAG_LOSS_SYSCTL "debug.cheri.abort_on_memcpy_tag_loss"
 #define ABORT_ON_TAG_LOSS_ENVVAR "CHERI_ABORT_ON_TAG_STRIPPING_COPY"
 
 static void

--- a/libexec/rtld-elf/rtld-libc/rtld_libc.c
+++ b/libexec/rtld-elf/rtld-libc/rtld_libc.c
@@ -139,20 +139,19 @@ sysctl(const int *name, u_int namelen, void *oldp, size_t *oldlenp,
 	return (retval);
 }
 
-#ifdef __mips__
+#if __has_feature(capabilities)
 /*
- * Add rtld_fdprintf as the implementation of dprintf() to avoid pulling in
- * all the locale code just for the one warning in CHERI memcpy/memmove
+ * Use rtld_snprintf as the implementation of snprintf() to avoid pulling in
+ * all the locale code just for the one warning in CHERI memcpy/memmove.
  */
-extern int dprintf(int fd, const char *fmt, ...);
 int
-dprintf(int fd, const char *fmt, ...)
+snprintf(char *str, size_t size, const char *fmt, ...)
 {
 	va_list ap;
 	int retval;
 
 	va_start(ap, fmt);
-	retval = rtld_vfdprintf(fd, fmt, ap);
+	retval = rtld_vsnprintf(str, size, fmt, ap);
 	va_end(ap);
 	return (retval);
 }

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -80,12 +80,15 @@ SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sigprot, CTLFLAG_RW,
     &security_cheri_debugger_on_sigprot, 0,
     "Enter KDB when SIGPROT is delivered to an unsandboxed thread");
 
-u_int	security_cheri_abort_on_memcpy_tag_loss;
-SYSCTL_UINT(_security_cheri, OID_AUTO, abort_on_memcpy_tag_loss,
-    CTLFLAG_RW, &security_cheri_abort_on_memcpy_tag_loss, 0,
-    "abort() when memcpy() detects a tag loss due to misaligned copies.");
-
 u_int	security_cheri_bound_legacy_capabilities;
 SYSCTL_INT(_security_cheri, OID_AUTO, bound_legacy_capabilities,
     CTLFLAG_RWTUN, &security_cheri_bound_legacy_capabilities, 0,
     "Set bounds on userspace capabilities created by legacy ABIs.");
+
+SYSCTL_NODE(_debug, OID_AUTO, cheri, CTLFLAG_RD, 0,
+    "CHERI debug settings and statistics");
+
+u_int	security_cheri_abort_on_memcpy_tag_loss;
+SYSCTL_UINT(_debug_cheri, OID_AUTO, abort_on_memcpy_tag_loss,
+    CTLFLAG_RW, &security_cheri_abort_on_memcpy_tag_loss, 0,
+    "abort() when memcpy() detects a tag loss due to misaligned copies.");


### PR DESCRIPTION
This debugging features has been extremely useful in the past when
debugging tag losses in complex software. I made one minor change compared
to jdw57_memcpy: it can also be configured by setting the environment
variable CHERI_ABORT_ON_TAG_STRIPPING_COPY to 0/1 rather than being
restricted to a root-only global sysctl.