### PR TITLE
riscv: Remove (and consolidate) several casts

### DIFF
--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -93,7 +93,7 @@ cheri_signal_sandboxed(struct thread *td)
 {
 	uintmax_t c_perms;
 
-	c_perms = cheri_getperm((void * __capability)td->td_frame->tf_sepc);
+	c_perms = cheri_getperm(td->td_frame->tf_sepc);
 	if ((c_perms & CHERI_PERM_SYSCALL) == 0) {
 		atomic_add_int(&security_cheri_sandboxed_signals, 1);
 		return (ECAPMODE);

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -197,18 +197,16 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 		/* XXX: Permit userland to change GPRs for sigreturn? */
 
 		/* Honor 64-bit PC. */
-		mc.mc_capregs.cp_sepcc = (uintcap_t)cheri_setoffset(
-		    (void * __capability)mc.mc_capregs.cp_sepcc,
-		    mcp->mc_gpregs.gp_sepc);
+		mc.mc_capregs.cp_sepcc = cheri_setoffset(
+		    mc.mc_capregs.cp_sepcc, mcp->mc_gpregs.gp_sepc);
 	} else {
 		creg = (uintcap_t *)&mc.mc_capregs;
 		greg = (register_t *)&mcp->mc_gpregs;
 		for (i = 0; i < CONTEXT64_GPREGS; i++)
 			creg[i] = (uintcap_t)greg[i];
 
-		mc.mc_capregs.cp_sepcc = (uintcap_t)cheri_setoffset(
-		    (void * __capability)td->td_frame->tf_sepc,
-		    mcp->mc_gpregs.gp_sepc);
+		mc.mc_capregs.cp_sepcc = cheri_setoffset(
+		    td->td_frame->tf_sepc, mcp->mc_gpregs.gp_sepc);
 		mc.mc_capregs.cp_ddc = td->td_frame->tf_ddc;
 		mc.mc_capregs.cp_sstatus = mcp->mc_gpregs.gp_sstatus;
 	}

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -256,8 +256,7 @@ set_regs(struct thread *td, struct reg *regs)
 
 	frame = td->td_frame;
 #if __has_feature(capabilities)
-	frame->tf_sepc = (uintcap_t)cheri_setaddress(
-	    (void * __capability)frame->tf_sepc, regs->sepc);
+	frame->tf_sepc = cheri_setaddress(frame->tf_sepc, regs->sepc);
 #else
 	frame->tf_sepc = regs->sepc;
 #endif
@@ -365,7 +364,7 @@ fill_capregs(struct thread *td, struct capreg *regs)
 	regs->ddc = frame->tf_ddc;
 	pcap = (uintcap_t *)regs;
 	for (i = 0; i < NCAPREGS; i++) {
-		if (cheri_gettag((void * __capability)pcap[i]))
+		if (cheri_gettag(pcap[i]))
 			regs->tagmask |= (uint64_t)1 << i;
 	}
 	return (0);
@@ -388,8 +387,7 @@ ptrace_set_pc(struct thread *td, u_long addr)
 	    !cheri_is_address_inbounds(
 	    (void * __capability)td->td_frame->tf_sepc, addr))
 		return (EINVAL);
-	td->td_frame->tf_sepc = (uintcap_t)cheri_setaddress(
-	    (void * __capability)td->td_frame->tf_sepc, addr);
+	td->td_frame->tf_sepc = cheri_setaddress(td->td_frame->tf_sepc, addr);
 #else
 	td->td_frame->tf_sepc = addr;
 #endif


### PR DESCRIPTION
Most of these exploit the polymorphic builtins, but call_trapsignal instead pushes the (void * __capability) into itself so the callers can just give it a uintcap_t. This would arguably make sense to be upstreamed with the uint64_t/register_t given every upstream caller has to cast its argument to void *, but upstream has fewer cases to deal with, and also doesn't have the round-tripping through uintcap_t.
