### PR TITLE
Upstream cherry-picks

### DIFF
--- a/sys/conf/kern.opts.mk
+++ b/sys/conf/kern.opts.mk
@@ -79,10 +79,6 @@ BROKEN_OPTIONS+= ZFS SSP
 BROKEN_OPTIONS+= ZFS
 .endif
 
-.if ${MACHINE_CPUARCH} == "riscv"
-BROKEN_OPTIONS+= FORMAT_EXTENSIONS
-.endif
-
 # Things that don't work because the kernel doesn't have the support
 # for them.
 .if ${MACHINE} != "i386" && ${MACHINE} != "amd64"

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -51,25 +51,14 @@ OBJCOPY?=	objcopy
 SIZE?=		size
 
 .if defined(DEBUG)
-.if ${MACHINE_ARCH} == "powerpc" || ${MACHINE_ARCH} == "powerpcspe"
-# Work around clang 11 miscompile on 32 bit powerpc.
-_MINUS_O=	-O2
-.else
-_MINUS_O=	-O
-.endif
 CTFFLAGS+=	-g
-.else
-_MINUS_O=	-O2
 .endif
-.if ${MACHINE_CPUARCH} == "amd64"
-.if ${COMPILER_TYPE} == "clang"
-COPTFLAGS?=-O2 -pipe
+.if ${MACHINE_CPUARCH} == "amd64" && ${COMPILER_TYPE} != "clang"
+_COPTFLAGS_EXTRA=-frename-registers
 .else
-COPTFLAGS?=-O2 -frename-registers -pipe
+_COPTFLAGS_EXTRA=
 .endif
-.else
-COPTFLAGS?=${_MINUS_O} -pipe
-.endif
+COPTFLAGS?=-O2 -pipe ${_COPTFLAGS_EXTRA}
 .if !empty(COPTFLAGS:M-O[23s]) && empty(COPTFLAGS:M-fno-strict-aliasing)
 COPTFLAGS+= -fno-strict-aliasing
 .endif

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -51,14 +51,15 @@ OBJCOPY?=	objcopy
 SIZE?=		size
 
 .if defined(DEBUG)
+.if ${MACHINE_ARCH} == "powerpc" || ${MACHINE_ARCH} == "powerpcspe"
+# Work around clang 11 miscompile on 32 bit powerpc.
+_MINUS_O=	-O2
+.else
 _MINUS_O=	-O
+.endif
 CTFFLAGS+=	-g
 .else
-.if ${MACHINE_CPUARCH} == "powerpc"
-_MINUS_O=	-O	# gcc miscompiles some code at -O2
-.else
 _MINUS_O=	-O2
-.endif
 .endif
 .if ${MACHINE_CPUARCH} == "amd64"
 .if ${COMPILER_TYPE} == "clang"

--- a/sys/dev/mpr/mpr_user.c
+++ b/sys/dev/mpr/mpr_user.c
@@ -661,7 +661,8 @@ mpr_user_command(struct mpr_softc *sc, struct mpr_usr_command *cmd)
 	hdr = (MPI2_REQUEST_HEADER *)cm->cm_req;
 
 	mpr_dprint(sc, MPR_USER, "%s: req %p %d  rpl %p %d\n", __func__,
-	    cmd->req, cmd->req_len, cmd->rpl, cmd->rpl_len);
+	    (__cheri_fromcap void *)cmd->req, cmd->req_len,
+	    (__cheri_fromcap void *)cmd->rpl, cmd->rpl_len);
 
 	if (cmd->req_len > (int)sc->reqframesz) {
 		err = EINVAL;
@@ -789,9 +790,11 @@ mpr_user_pass_thru(struct mpr_softc *sc, mpr_pass_thru_t *data)
 
 	mpr_dprint(sc, MPR_USER, "%s: req %p %d  rpl %p %d "
 	    "data in %p %d data out %p %d data dir %d\n", __func__,
-	    data->PtrRequest, data->RequestSize, data->PtrReply,
-	    data->ReplySize, data->PtrData, data->DataSize,
-	    data->PtrDataOut, data->DataOutSize, data->DataDirection);
+	    (__cheri_fromcap void *)data->PtrRequest, data->RequestSize,
+	    (__cheri_fromcap void *)data->PtrReply, data->ReplySize,
+	    (__cheri_fromcap void *)data->PtrData, data->DataSize,
+	    (__cheri_fromcap void *)data->PtrDataOut, data->DataOutSize,
+	    data->DataDirection);
 
 	/*
 	 * copy in the header so we know what we're dealing with before we

--- a/sys/dev/mps/mps_user.c
+++ b/sys/dev/mps/mps_user.c
@@ -675,7 +675,8 @@ mps_user_command(struct mps_softc *sc, struct mps_usr_command *cmd)
 	hdr = (MPI2_REQUEST_HEADER *)cm->cm_req;
 
 	mps_dprint(sc, MPS_USER, "%s: req %p %d  rpl %p %d\n", __func__,
-	    cmd->req, cmd->req_len, cmd->rpl, cmd->rpl_len);
+	    (__cheri_fromcap void *)cmd->req, cmd->req_len,
+	    (__cheri_fromcap void *)cmd->rpl, cmd->rpl_len);
 
 	if (cmd->req_len > (int)sc->reqframesz) {
 		err = EINVAL;
@@ -800,9 +801,11 @@ mps_user_pass_thru(struct mps_softc *sc, mps_pass_thru_t *data)
 
 	mps_dprint(sc, MPS_USER, "%s: req %p %d  rpl %p %d "
 	    "data in %p %d data out %p %d data dir %d\n", __func__,
-	    data->PtrRequest, data->RequestSize, data->PtrReply,
-	    data->ReplySize, data->PtrData, data->DataSize,
-	    data->PtrDataOut, data->DataOutSize, data->DataDirection);
+	    (__cheri_fromcap void *)data->PtrRequest, data->RequestSize,
+	    (__cheri_fromcap void *)data->PtrReply, data->ReplySize,
+	    (__cheri_fromcap void *)data->PtrData, data->DataSize,
+	    (__cheri_fromcap void *)data->PtrDataOut, data->DataOutSize,
+	    data->DataDirection);
 
 	/*
 	 * copy in the header so we know what we're dealing with before we

--- a/sys/dev/xilinx/axidma.c
+++ b/sys/dev/xilinx/axidma.c
@@ -363,7 +363,7 @@ axidma_desc_alloc(struct axidma_softc *sc, struct xdma_channel *xchan,
 	chan->mem_vaddr = kva_alloc(chan->mem_size);
 	pmap_kenter_device(chan->mem_vaddr, chan->mem_size, chan->mem_paddr);
 
-	device_printf(sc->dev, "Allocated chunk %lx %d\n",
+	device_printf(sc->dev, "Allocated chunk %lx %lu\n",
 	    chan->mem_paddr, chan->mem_size);
 
 	for (i = 0; i < nsegments; i++) {

--- a/sys/riscv/include/param.h
+++ b/sys/riscv/include/param.h
@@ -42,6 +42,8 @@
 #define	STACKALIGNBYTES	(16 - 1)
 #define	STACKALIGN(p)	(__builtin_align_down((p), STACKALIGNBYTES + 1))
 
+#define __PCI_REROUTE_INTERRUPT
+
 #ifndef MACHINE
 #define	MACHINE		"riscv"
 #endif

--- a/sys/riscv/include/pte.h
+++ b/sys/riscv/include/pte.h
@@ -95,6 +95,9 @@ typedef	uint64_t	pn_t;			/* page number */
 #define	PTE_PROMOTE	(PTE_V | PTE_RWX | PTE_D | PTE_A | PTE_G | PTE_U | \
 			 PTE_SW_MANAGED | PTE_SW_WIRED | PTE_PROMOTE_CHERI)
 
+/* Bits 63 - 54 are reserved for future use. */
+#define PTE_HI_MASK	0xFFC0000000000000ULL
+
 #define	PTE_PPN0_S	10
 #define	PTE_PPN1_S	19
 #define	PTE_PPN2_S	28

--- a/sys/riscv/riscv/db_disasm.c
+++ b/sys/riscv/riscv/db_disasm.c
@@ -416,7 +416,7 @@ oprint(struct riscv_op *op, vm_offset_t loc, int insn)
 				imm |= ((insn >> 12) & 0x1) << 5;
 				if (imm & (1 << 5))
 					imm |= (0x7ffffff << 5); /* sign ext */
-				db_printf("0x%lx", imm);
+				db_printf("0x%x", imm);
 				break;
 			case 'o':
 				imm = ((insn >> 2) & 0x1f) << 0;
@@ -524,7 +524,7 @@ oprint(struct riscv_op *op, vm_offset_t loc, int insn)
 			imm = (insn >> 12) & 0xfffff;
 			if (imm & (1 << 20))
 				imm |= (0xfff << 20);	/* sign extend */
-			db_printf("0x%lx", imm);
+			db_printf("0x%x", imm);
 			break;
 		case 'j':
 			/* imm[11:0] << 20 */

--- a/sys/riscv/riscv/intr_machdep.c
+++ b/sys/riscv/riscv/intr_machdep.c
@@ -73,9 +73,9 @@ struct intc_irqsrc isrcs[INTC_NIRQS];
 static void
 riscv_mask_irq(void *source)
 {
-	uintptr_t irq;
+	int irq;
 
-	irq = (uintptr_t)source;
+	irq = (int)(uintptr_t)source;
 
 	switch (irq) {
 	case IRQ_TIMER_SUPERVISOR:
@@ -95,9 +95,9 @@ riscv_mask_irq(void *source)
 static void
 riscv_unmask_irq(void *source)
 {
-	uintptr_t irq;
+	int irq;
 
-	irq = (uintptr_t)source;
+	irq = (int)(uintptr_t)source;
 
 	switch (irq) {
 	case IRQ_TIMER_SUPERVISOR:

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -359,7 +359,8 @@ pagezero(void *p)
 #define	pmap_l2_index(va)	(((va) >> L2_SHIFT) & Ln_ADDR_MASK)
 #define	pmap_l3_index(va)	(((va) >> L3_SHIFT) & Ln_ADDR_MASK)
 
-#define	PTE_TO_PHYS(pte)	((pte >> PTE_PPN0_S) * PAGE_SIZE)
+#define	PTE_TO_PHYS(pte) \
+    ((((pte) & ~PTE_HI_MASK) >> PTE_PPN0_S) * PAGE_SIZE)
 
 static __inline pd_entry_t *
 pmap_l1(pmap_t pmap, vm_offset_t va)

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -610,7 +610,7 @@ pmap_bootstrap(vm_offset_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 		if (physmap[i + 1] > max_pa)
 			max_pa = physmap[i + 1];
 	}
-	printf("physmap_idx %lx\n", physmap_idx);
+	printf("physmap_idx %u\n", physmap_idx);
 	printf("min_pa %lx\n", min_pa);
 	printf("max_pa %lx\n", max_pa);
 

--- a/sys/riscv/riscv/sbi.c
+++ b/sys/riscv/riscv/sbi.c
@@ -105,7 +105,7 @@ sbi_print_version(void)
 
 	switch (sbi_impl_id) {
 	case (SBI_IMPL_ID_BBL):
-		printf("SBI: Berkely Boot Loader %u\n", sbi_impl_version);
+		printf("SBI: Berkely Boot Loader %lu\n", sbi_impl_version);
 		break;
 	case (SBI_IMPL_ID_OPENSBI):
 		major = sbi_impl_version >> OPENSBI_VERSION_MAJOR_OFFSET;
@@ -113,7 +113,7 @@ sbi_print_version(void)
 		printf("SBI: OpenSBI v%u.%u\n", major, minor);
 		break;
 	default:
-		printf("SBI: Unrecognized Implementation: %u\n", sbi_impl_id);
+		printf("SBI: Unrecognized Implementation: %lu\n", sbi_impl_id);
 		break;
 	}
 

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -406,6 +406,10 @@ do_trap_supervisor(struct trapframe *frame)
 	case EXCP_FAULT_LOAD:
 	case EXCP_FAULT_STORE:
 	case EXCP_FAULT_FETCH:
+		dump_regs(frame);
+		panic("Memory access exception at 0x%016lx\n",
+		    (__cheri_addr unsigned long)frame->tf_sepc);
+		break;
 	case EXCP_STORE_PAGE_FAULT:
 	case EXCP_LOAD_PAGE_FAULT:
 		data_abort(frame, 0);

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -245,7 +245,7 @@ dump_cheri_exception(struct trapframe *frame)
 
 	td = curthread;
 	p = td->td_proc;
-	printf("pid %d tid %ld (%s), uid %d: ", p->p_pid, td->td_tid,
+	printf("pid %d tid %d (%s), uid %d: ", p->p_pid, td->td_tid,
 	    p->p_comm, td->td_ucred->cr_uid);
 	switch (frame->tf_scause & EXCP_MASK) {
 	case EXCP_LOAD_CAP_PAGE_FAULT:
@@ -255,12 +255,12 @@ dump_cheri_exception(struct trapframe *frame)
 		printf("STORE/AMO CAP page fault");
 		break;
 	case EXCP_CHERI:
-		printf("CHERI fault (type %#x), capidx %d",
+		printf("CHERI fault (type %#lx), capidx %ld",
 		    TVAL_CAP_CAUSE(frame->tf_stval),
 		    TVAL_CAP_IDX(frame->tf_stval));
 		break;
 	default:
-		printf("fault %d", frame->tf_scause & EXCP_MASK);
+		printf("fault %ld", frame->tf_scause & EXCP_MASK);
 		break;
 	}
 	printf("\n");
@@ -446,7 +446,7 @@ do_trap_supervisor(struct trapframe *frame)
 			    frame->tf_stval);
 			break;
 		case EXCP_CHERI:
-			panic("CHERI exception %#x at 0x%016lx\n",
+			panic("CHERI exception %#lx at 0x%016lx\n",
 			    TVAL_CAP_CAUSE(frame->tf_stval),
 			    (__cheri_addr unsigned long)frame->tf_sepc);
 			break;

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -454,7 +454,7 @@ do_trap_supervisor(struct trapframe *frame)
 #endif
 	default:
 		dump_regs(frame);
-		panic("Unknown kernel exception %x trap value %lx\n",
+		panic("Unknown kernel exception %lx trap value %lx\n",
 		    exception, frame->tf_stval);
 	}
 }
@@ -550,7 +550,7 @@ do_trap_user(struct trapframe *frame)
 #endif
 	default:
 		dump_regs(frame);
-		panic("Unknown userland exception %x, trap value %lx\n",
+		panic("Unknown userland exception %lx, trap value %lx\n",
 		    exception, frame->tf_stval);
 	}
 }


### PR DESCRIPTION
Recover some performance by cherry-picking the -O2 change (and its dependent commit, to minimise future pain/confusion) and fix PCI interrupts on RISC-V so we can use VirtIO over PCI rather than special-casing RISC-V to use always use MMIO on QEMU.
