### PR TITLE
Add tests for passing invalid capabilities to munmap/mprotect/minherit

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -1719,6 +1719,18 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Check that zero-sized mallocs are properly bounded",
 	  .ct_func = test_cheriabi_malloc_zero_size },
 
+	{ .ct_name = "test_cheriabi_munmap_invalid_ptr",
+	  .ct_desc = "Check that munmap() rejects invalid pointer arguments",
+	  .ct_func = test_cheriabi_munmap_invalid_ptr },
+
+	{ .ct_name = "test_cheriabi_mprotect_invalid_ptr",
+	  .ct_desc = "Check that mprotect() rejects invalid pointer arguments",
+	  .ct_func = test_cheriabi_mprotect_invalid_ptr },
+
+	{ .ct_name = "test_cheriabi_minherit_invalid_ptr",
+	  .ct_desc = "Check that minherit() rejects invalid pointer arguments",
+	  .ct_func = test_cheriabi_minherit_invalid_ptr },
+
 	/*
 	 * Tests for pathname handling in open(2).
 	 */

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -165,7 +165,7 @@ void	signal_handler_clear(int sig);
 #define CHERITEST_CHECK_EQ_BOOL(a, b)	\
 	CHERITEST_CHECK_EQ(_Bool, "%d", a, b, __STRING(a), __STRING(b))
 #define CHERITEST_CHECK_EQ_INT(a, b)	\
-	CHERITEST_CHECK_EQ(int, "0x%lx", a, b, __STRING(a), __STRING(b))
+	CHERITEST_CHECK_EQ(int, "0x%x", a, b, __STRING(a), __STRING(b))
 #define CHERITEST_CHECK_EQ_LONG(a, b)	\
 	CHERITEST_CHECK_EQ(long, "0x%lx", a, b, __STRING(a), __STRING(b))
 #define CHERITEST_CHECK_EQ_SIZE(a, b)	\

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -367,6 +367,9 @@ DECLARE_CHERI_TEST(test_cheriabi_mmap_nospace);
 DECLARE_CHERI_TEST(test_cheriabi_mmap_perms);
 DECLARE_CHERI_TEST(test_cheriabi_mmap_unrepresentable);
 DECLARE_CHERI_TEST(test_cheriabi_malloc_zero_size);
+DECLARE_CHERI_TEST(test_cheriabi_munmap_invalid_ptr);
+DECLARE_CHERI_TEST(test_cheriabi_mprotect_invalid_ptr);
+DECLARE_CHERI_TEST(test_cheriabi_minherit_invalid_ptr);
 
 /* cheritest_cheriabi_open.c */
 DECLARE_CHERI_TEST(test_cheriabi_open_ordinary);

--- a/bin/cheritest/cheritest_cheriabi.c
+++ b/bin/cheritest/cheritest_cheriabi.c
@@ -351,6 +351,7 @@ test_cheriabi_mprotect_invalid_ptr(const struct cheri_test *ctp __unused)
 	CHERITEST_CHECK_SYSCALL(mprotect(mappings.middle, mappings.maplen,
 	    PROT_READ));
 
+	/* Unmapping the original capabilities should succeed. */
 	free_adjacent_mappings(&mappings);
 	cheritest_success();
 }
@@ -378,6 +379,7 @@ test_cheriabi_minherit_invalid_ptr(const struct cheri_test *ctp __unused)
 	CHERITEST_CHECK_SYSCALL(minherit(mappings.middle, mappings.maplen,
 	    INHERIT_SHARE));
 
+	/* Unmapping the original capabilities should succeed. */
 	free_adjacent_mappings(&mappings);
 	cheritest_success();
 }

--- a/bin/cheritest/cheritest_cheriabi.c
+++ b/bin/cheritest/cheritest_cheriabi.c
@@ -267,7 +267,7 @@ struct adjacent_mappings {
 static void
 create_adjacent_mappings(struct adjacent_mappings *mappings)
 {
-	char *requested_addr;
+	void *requested_addr;
 	size_t len;
 
 	len = getpagesize() * 2;
@@ -275,13 +275,15 @@ create_adjacent_mappings(struct adjacent_mappings *mappings)
 	    mmap(0, len, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
 	CHERITEST_VERIFY(cheri_gettag(mappings->first));
 	/* Try to create a mapping immediately following the latest one. */
-	requested_addr = cheri_cleartag(mappings->first) + len;
+	requested_addr =
+	    (void *)(uintcap_t)(cheri_getaddress(mappings->first) + len);
 	mappings->middle = CHERITEST_CHECK_SYSCALL2(mmap(requested_addr, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0),
 	    "Failed to create mapping at address %p", requested_addr);
 	CHERITEST_CHECK_EQ_LONG((vaddr_t)mappings->middle,
 	    (vaddr_t)mappings->first + len);
-	requested_addr = cheri_cleartag(mappings->middle) + len;
+	requested_addr =
+	    (void *)(uintcap_t)(cheri_getaddress(mappings->middle) + len);
 	CHERITEST_VERIFY(cheri_gettag(mappings->middle));
 	mappings->last = CHERITEST_CHECK_SYSCALL2(mmap(requested_addr, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0),

--- a/bin/cheritest/cheritest_cheriabi.c
+++ b/bin/cheritest/cheritest_cheriabi.c
@@ -309,6 +309,14 @@ test_cheriabi_munmap_invalid_ptr(const struct cheri_test *ctp __unused)
 
 	create_adjacent_mappings(&mappings);
 
+	/* munmap() with an out-of-bounds length should fail. */
+	CHERITEST_CHECK_CALL_ERROR(
+	    munmap(mappings.middle, mappings.maplen * 2), EPROT);
+	mappings.middle[0] = 'a'; /* Check that it still has PROT_WRITE */
+	CHERITEST_CHECK_CALL_ERROR(
+	    munmap(mappings.middle, mappings.maplen + 1), EPROT);
+	mappings.middle[0] = 'a'; /* Check that it still has PROT_WRITE */
+
 	/* munmap() with an in-bounds but untagged capability should fail. */
 	CHERITEST_CHECK_CALL_ERROR(
 	    munmap(cheri_cleartag(mappings.middle), mappings.maplen), EPROT);
@@ -333,6 +341,14 @@ test_cheriabi_mprotect_invalid_ptr(const struct cheri_test *ctp __unused)
 	struct adjacent_mappings mappings;
 
 	create_adjacent_mappings(&mappings);
+
+	/* mprotect() with an out-of-bounds length should fail. */
+	CHERITEST_CHECK_CALL_ERROR(
+	    mprotect(mappings.middle, mappings.maplen * 2, PROT_NONE), EPROT);
+	mappings.middle[0] = 'a'; /* Check that it still has PROT_WRITE */
+	CHERITEST_CHECK_CALL_ERROR(
+	    mprotect(mappings.middle, mappings.maplen + 1, PROT_NONE), EPROT);
+	mappings.middle[0] = 'a'; /* Check that it still has PROT_WRITE */
 
 	/* mprotect() with an in-bounds but untagged capability should fail. */
 	CHERITEST_CHECK_CALL_ERROR(mprotect(cheri_cleartag(mappings.middle),
@@ -364,6 +380,12 @@ test_cheriabi_minherit_invalid_ptr(const struct cheri_test *ctp __unused)
 	struct adjacent_mappings mappings;
 
 	create_adjacent_mappings(&mappings);
+
+	/* minherit() with an out-of-bounds length should fail. */
+	CHERITEST_CHECK_CALL_ERROR(minherit(mappings.middle,
+	    mappings.maplen * 2, INHERIT_NONE), EPROT);
+	CHERITEST_CHECK_CALL_ERROR(minherit(mappings.middle,
+	    mappings.maplen + 1, INHERIT_NONE), EPROT);
 
 	/* minherit() with an in-bounds but untagged capability should fail. */
 	CHERITEST_CHECK_CALL_ERROR(minherit(cheri_cleartag(mappings.middle),


### PR DESCRIPTION
The kernel should reject untagged and out-of-bounds capabilities, but it turns
out we were only doing the latter. This is a regression test for
CTSRD-CHERI/cheribsd#709 (which is fixed by CTSRD-CHERI/cheribsd#710).