### PR TITLE
Revert "[UPSTREAM] shmat: rely on shmget to have rounded size."

### DIFF
--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -462,9 +462,7 @@ kern_shmat_locked(struct thread *td, int shmid,
 	}
 	if (i >= shminfo.shmseg)
 		return (EMFILE);
-	size = shmseg->u.shm_segsz;
-	KASSERT(is_aligned(size, PAGE_SIZE),
-	    ("shmget should have rounded size %zu", size));
+	size = round_page(shmseg->u.shm_segsz);
 #if __has_feature(capabilities)
 	KASSERT(size == CHERI_REPRESENTABLE_LENGTH(size),
 	    ("shmget left unrepresentable size %zu", size));


### PR DESCRIPTION
This assert was based on a mis-read of the code.

Fixes #716

This reverts commit 80f0c34c812ccbb5a5ea4f194e53d66aa05db294.