### PR TITLE
Centralize implemention of some VM macros

### DIFF
--- a/sys/amd64/amd64/mp_machdep.c
+++ b/sys/amd64/amd64/mp_machdep.c
@@ -114,7 +114,7 @@ is_kernel_paddr(vm_paddr_t pa)
 {
 
 	return (pa >= trunc_2mpage(btext - KERNBASE) &&
-	   pa < round_page(_end - KERNBASE));
+	   pa < round_page((vm_paddr_t)_end - KERNBASE));
 }
 
 static bool

--- a/sys/amd64/amd64/pmap.c
+++ b/sys/amd64/amd64/pmap.c
@@ -2084,7 +2084,7 @@ pmap_init(void)
 				ret = vm_page_blacklist_add(0x40000000 +
 				    ptoa(i), FALSE);
 				if (!ret && bootverbose)
-					printf("page at %#lx already used\n",
+					printf("page at %#x already used\n",
 					    0x40000000 + ptoa(i));
 			}
 		}

--- a/sys/amd64/include/param.h
+++ b/sys/amd64/include/param.h
@@ -137,19 +137,12 @@
 /*
  * Mach derived conversion macros
  */
-#define	round_page(x)	((((unsigned long)(x)) + PAGE_MASK) & ~(PAGE_MASK))
-#define	trunc_page(x)	((unsigned long)(x) & ~(PAGE_MASK))
 #define trunc_2mpage(x)	((unsigned long)(x) & ~PDRMASK)
 #define round_2mpage(x)	((((unsigned long)(x)) + PDRMASK) & ~PDRMASK)
 #define trunc_1gpage(x)	((unsigned long)(x) & ~PDPMASK)
 
-#define	atop(x)		((unsigned long)(x) >> PAGE_SHIFT)
-#define	ptoa(x)		((unsigned long)(x) << PAGE_SHIFT)
-
 #define	amd64_btop(x)	((unsigned long)(x) >> PAGE_SHIFT)
 #define	amd64_ptob(x)	((unsigned long)(x) << PAGE_SHIFT)
-
-#define	pgtok(x)	((unsigned long)(x) * (PAGE_SIZE / 1024)) 
 
 #define	INKERNEL(va) (((va) >= DMAP_MIN_ADDRESS && (va) < DMAP_MAX_ADDRESS) \
     || ((va) >= VM_MIN_KERNEL_ADDRESS && (va) < VM_MAX_KERNEL_ADDRESS))

--- a/sys/arm/include/param.h
+++ b/sys/arm/include/param.h
@@ -140,17 +140,10 @@
 /*
  * Mach derived conversion macros
  */
-#define	trunc_page(x)		((x) & ~PAGE_MASK)
-#define	round_page(x)		(((x) + PAGE_MASK) & ~PAGE_MASK)
 #define	trunc_1mpage(x)		((unsigned)(x) & ~PDRMASK)
 #define	round_1mpage(x)		((((unsigned)(x)) + PDRMASK) & ~PDRMASK)
 
-#define	atop(x)			((unsigned)(x) >> PAGE_SHIFT)
-#define	ptoa(x)			((unsigned)(x) << PAGE_SHIFT)
-
 #define	arm32_btop(x)		((unsigned)(x) >> PAGE_SHIFT)
 #define	arm32_ptob(x)		((unsigned)(x) << PAGE_SHIFT)
-
-#define	pgtok(x)		((x) * (PAGE_SIZE / 1024))
 
 #endif /* !_ARM_INCLUDE_PARAM_H_ */

--- a/sys/arm64/include/param.h
+++ b/sys/arm64/include/param.h
@@ -126,15 +126,7 @@
 /*
  * Mach derived conversion macros
  */
-#define	round_page(x)		(((unsigned long)(x) + PAGE_MASK) & ~PAGE_MASK)
-#define	trunc_page(x)		((unsigned long)(x) & ~PAGE_MASK)
-
-#define	atop(x)			((unsigned long)(x) >> PAGE_SHIFT)
-#define	ptoa(x)			((unsigned long)(x) << PAGE_SHIFT)
-
 #define	arm64_btop(x)		((unsigned long)(x) >> PAGE_SHIFT)
 #define	arm64_ptob(x)		((unsigned long)(x) << PAGE_SHIFT)
-
-#define	pgtok(x)		((unsigned long)(x) * (PAGE_SIZE / 1024))
 
 #endif /* !_MACHINE_PARAM_H_ */

--- a/sys/i386/include/param.h
+++ b/sys/i386/include/param.h
@@ -149,18 +149,11 @@
 /*
  * Mach derived conversion macros
  */
-#define trunc_page(x)		((x) & ~PAGE_MASK)
-#define round_page(x)		(((x) + PAGE_MASK) & ~PAGE_MASK)
 #define trunc_4mpage(x)		((x) & ~PDRMASK)
 #define round_4mpage(x)		((((x)) + PDRMASK) & ~PDRMASK)
 
-#define atop(x)			((x) >> PAGE_SHIFT)
-#define ptoa(x)			((x) << PAGE_SHIFT)
-
 #define i386_btop(x)		((x) >> PAGE_SHIFT)
 #define i386_ptob(x)		((x) << PAGE_SHIFT)
-
-#define	pgtok(x)		((x) * (PAGE_SIZE / 1024))
 
 #define INKERNEL(va)		(TRUE)
 

--- a/sys/mips/include/param.h
+++ b/sys/mips/include/param.h
@@ -207,15 +207,8 @@
 /*
  * Mach derived conversion macros
  */
-#define	round_page(x)		(((x) + PAGE_MASK) & ~PAGE_MASK)
-#define	trunc_page(x)		((x) & ~PAGE_MASK)
 #define	round_2mpage(x)		(((x) + PDRMASK) & ~PDRMASK)
 #define	trunc_2mpage(x)		((x) & ~PDRMASK)
-
-#define	atop(x)			((x) >> PAGE_SHIFT)
-#define	ptoa(x)			((x) << PAGE_SHIFT)
-
-#define	pgtok(x)		((x) * (PAGE_SIZE / 1024))
 
 #endif /* !_MIPS_INCLUDE_PARAM_H_ */
 // CHERI CHANGES START

--- a/sys/powerpc/include/param.h
+++ b/sys/powerpc/include/param.h
@@ -140,19 +140,12 @@
 /*
  * Mach derived conversion macros
  */
-#define	trunc_page(x)		((x) & ~(PAGE_MASK))
-#define	round_page(x)		(((x) + PAGE_MASK) & ~PAGE_MASK)
 #define	trunc_2mpage(x)		((unsigned long)(x) & ~L3_PAGE_MASK)
 #define	round_2mpage(x)		((((unsigned long)(x)) + L3_PAGE_MASK) & ~L3_PAGE_MASK)
 #define	trunc_1gpage(x)		((unsigned long)(x) & ~L2_PAGE_MASK)
 
-#define	atop(x)			((x) >> PAGE_SHIFT)
-#define	ptoa(x)			((x) << PAGE_SHIFT)
-
 #define	powerpc_btop(x)		((x) >> PAGE_SHIFT)
 #define	powerpc_ptob(x)		((x) << PAGE_SHIFT)
-
-#define	pgtok(x)		((x) * (PAGE_SIZE / 1024UL))
 
 #define btoc(x)			((vm_offset_t)(((x)+PAGE_MASK)>>PAGE_SHIFT))
 

--- a/sys/riscv/include/param.h
+++ b/sys/riscv/include/param.h
@@ -125,15 +125,7 @@
 /*
  * Mach derived conversion macros
  */
-#define	round_page(x)		(((unsigned long)(x) + PAGE_MASK) & ~PAGE_MASK)
-#define	trunc_page(x)		((unsigned long)(x) & ~PAGE_MASK)
-
-#define	atop(x)			((unsigned long)(x) >> PAGE_SHIFT)
-#define	ptoa(x)			((unsigned long)(x) << PAGE_SHIFT)
-
 #define	riscv_btop(x)		((unsigned long)(x) >> PAGE_SHIFT)
 #define	riscv_ptob(x)		((unsigned long)(x) << PAGE_SHIFT)
-
-#define	pgtok(x)		((unsigned long)(x) * (PAGE_SIZE / 1024))
 
 #endif /* !_MACHINE_PARAM_H_ */

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -190,6 +190,17 @@
 #define	MJUM16BYTES	(16 * 1024)	/* jumbo cluster 16k */
 
 /*
+ * Mach derived conversion macros
+ */
+#define	round_page(x)	(((x) + PAGE_MASK) & ~(PAGE_MASK))
+#define	trunc_page(x)	((x) & ~(PAGE_MASK))
+
+#define	atop(x)		((x) >> PAGE_SHIFT)
+#define	ptoa(x)		((x) << PAGE_SHIFT)
+
+#define	pgtok(x)	((x) * (PAGE_SIZE / 1024))
+
+/*
  * Some macros for units conversion
  */
 


### PR DESCRIPTION
These macros have substantially identical implementations on each
platfrom and we need to change round_page and trunc_page to use
__builtin_round_(up|down) for purecap to work.

This version standardizes on not adding an explicit cast as that
appears to be required on at least one powerpc and the builtins
are type-preserving.