### PR TITLE
Make vm_fault_quick_hold_pages take a pointer

### DIFF
--- a/sys/amd64/vmm/vmm.c
+++ b/sys/amd64/vmm/vmm.c
@@ -1002,7 +1002,7 @@ vm_gpa_hold(struct vm *vm, int vcpuid, vm_paddr_t gpa, size_t len, int reqprot,
 		if (sysmem_mapping(vm, mm) && gpa >= mm->gpa &&
 		    gpa < mm->gpa + mm->len) {
 			count = vm_fault_quick_hold_pages(&vm->vmspace->vm_map,
-			    trunc_page(gpa), PAGE_SIZE, reqprot, &m, 1);
+			    (void *)(uintptr_t)trunc_page(gpa), PAGE_SIZE, reqprot, &m, 1);
 			break;
 		}
 	}

--- a/sys/cam/cam_periph.c
+++ b/sys/cam/cam_periph.c
@@ -970,9 +970,6 @@ cam_periph_mapmem(union ccb *ccb, struct cam_periph_map_info *mapinfo,
 		 */
 		mapinfo->bp[i] = uma_zalloc(pbuf_zone, M_WAITOK);
 
-		/* put our pointer in the data slot */
-		mapinfo->bp[i]->b_data = (__cheri_fromcap void *)*data_ptrs[i];
-
 		/* set the transfer length, we know it's < MAXPHYS */
 		mapinfo->bp[i]->b_bufsize = lengths[i];
 
@@ -981,7 +978,7 @@ cam_periph_mapmem(union ccb *ccb, struct cam_periph_map_info *mapinfo,
 		    BIO_WRITE : BIO_READ;
 
 		/* Map the buffer into kernel memory. */
-		if (vmapbuf(mapinfo->bp[i], 1) < 0) {
+		if (vmapbuf(mapinfo->bp[i], *data_ptrs[i], 1) < 0) {
 			uma_zfree(pbuf_zone, mapinfo->bp[i]);
 			goto fail;
 		}

--- a/sys/compat/linuxkpi/common/src/linux_page.c
+++ b/sys/compat/linuxkpi/common/src/linux_page.c
@@ -200,7 +200,7 @@ linux_get_user_pages_internal(vm_map_t map, unsigned long start, int nr_pages,
 
 	prot = write ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
 	len = ((size_t)nr_pages) << PAGE_SHIFT;
-	count = vm_fault_quick_hold_pages(map, start, len, prot, pages, nr_pages);
+	count = vm_fault_quick_hold_pages(map, (void *)(uintptr_t)start, len, prot, pages, nr_pages);
 	return (count == -1 ? -EFAULT : nr_pages);
 }
 

--- a/sys/dev/cxgbe/tom/t4_ddp.c
+++ b/sys/dev/cxgbe/tom/t4_ddp.c
@@ -1243,8 +1243,8 @@ t4_free_ppod_region(struct ppod_region *pr)
 }
 
 static int
-pscmp(struct pageset *ps, struct vmspace *vm, vm_offset_t start, int npages,
-    int pgoff, int len)
+pscmp(struct pageset *ps, struct vmspace *vm, void * __capability start,
+    int npages, int pgoff, int len)
 {
 
 	if (ps->start != start || ps->npages != npages ||
@@ -1259,7 +1259,8 @@ hold_aio(struct toepcb *toep, struct kaiocb *job, struct pageset **pps)
 {
 	struct vmspace *vm;
 	vm_map_t map;
-	vm_offset_t start, end, pgoff;
+	char * __capability start, * __capability end;
+	vm_offset_t pgoff;
 	struct pageset *ps;
 	int n;
 
@@ -1272,8 +1273,8 @@ hold_aio(struct toepcb *toep, struct kaiocb *job, struct pageset **pps)
 	 */
 	vm = job->userproc->p_vmspace;
 	map = &vm->vm_map;
-	start = (uintptr_t)job->uaiocb.aio_buf;
-	pgoff = start & PAGE_MASK;
+	start = __DEVOLATILE(char * __capability, job->uaiocb.aio_buf);
+	pgoff = (__cheri_addr vm_offset_t)start & PAGE_MASK;
 	end = round_page(start + job->uaiocb.aio_nbytes);
 	start = trunc_page(start);
 

--- a/sys/dev/cxgbe/tom/t4_tom.h
+++ b/sys/dev/cxgbe/tom/t4_tom.h
@@ -146,7 +146,7 @@ struct pageset {
 	int len;
 	struct ppod_reservation prsv;
 	struct vmspace *vm;
-	vm_offset_t start;
+	void * __capability start;
 	u_int vm_timestamp;
 };
 

--- a/sys/dev/nvme/nvme_ctrlr.c
+++ b/sys/dev/nvme/nvme_ctrlr.c
@@ -1264,10 +1264,9 @@ nvme_ctrlr_passthrough_cmd(struct nvme_controller *ctrlr,
 			 */
 			PHOLD(curproc);
 			buf = uma_zalloc(pbuf_zone, M_WAITOK);
-			buf->b_data = pt->buf;
 			buf->b_bufsize = pt->len;
 			buf->b_iocmd = pt->is_read ? BIO_READ : BIO_WRITE;
-			if (vmapbuf(buf, 1) < 0) {
+			if (vmapbuf(buf, pt->buf, 1) < 0) {
 				ret = EFAULT;
 				goto err;
 			}

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -868,7 +868,7 @@ pipe_build_write_buffer(struct pipe *wpipe, struct uio *uio)
 	wpipe->pipe_state |= PIPE_DIRECTW;
 	PIPE_UNLOCK(wpipe);
 	i = vm_fault_quick_hold_pages(&curproc->p_vmspace->vm_map,
-	    (__cheri_addr vm_offset_t)uio->uio_iov->iov_base, size, VM_PROT_READ,
+	    uio->uio_iov->iov_base, size, VM_PROT_READ,
 	    wpipe->pipe_map.ms, PIPENPAGES);
 	PIPE_LOCK(wpipe);
 	if (i < 0) {

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1291,8 +1291,8 @@ aio_qbio(struct proc *p, struct kaiocb *job)
 	if (cb->aio_lio_opcode == LIO_READ)
 		prot |= VM_PROT_WRITE;	/* Less backwards than it looks */
 	job->npages = vm_fault_quick_hold_pages(&curproc->p_vmspace->vm_map,
-	    (__cheri_addr vm_offset_t)cb->aio_buf, bp->bio_length, prot, job->pages,
-	    nitems(job->pages));
+	    __DEVOLATILE_CAP(void * __capability, cb->aio_buf), bp->bio_length,
+	    prot, job->pages, nitems(job->pages));
 	if (job->npages < 0) {
 		error = EFAULT;
 		goto doerror;

--- a/sys/kern/vfs_bio.c
+++ b/sys/kern/vfs_bio.c
@@ -4886,7 +4886,7 @@ vm_hold_free_pages(struct buf *bp, int newbsize)
  * This function only works with pager buffers.
  */
 int
-vmapbuf(struct buf *bp, int mapbuf)
+vmapbuf(struct buf *bp, void * __capability uaddr, int mapbuf)
 {
 	vm_prot_t prot;
 	int pidx;
@@ -4897,11 +4897,10 @@ vmapbuf(struct buf *bp, int mapbuf)
 	if (bp->b_iocmd == BIO_READ)
 		prot |= VM_PROT_WRITE;	/* Less backwards than it looks */
 	if ((pidx = vm_fault_quick_hold_pages(&curproc->p_vmspace->vm_map,
-	    (vm_offset_t)bp->b_data, bp->b_bufsize, prot, bp->b_pages,
-	    btoc(MAXPHYS))) < 0)
+	    uaddr, bp->b_bufsize, prot, bp->b_pages, btoc(MAXPHYS))) < 0)
 		return (-1);
 	bp->b_npages = pidx;
-	bp->b_offset = ((vm_offset_t)bp->b_data) & PAGE_MASK;
+	bp->b_offset = ((__cheri_addr vm_offset_t)uaddr) & PAGE_MASK;
 	if (mapbuf || !unmapped_buf_allowed) {
 		pmap_qenter((vm_offset_t)bp->b_kvabase, bp->b_pages, pidx);
 		bp->b_data = bp->b_kvabase + bp->b_offset;

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1055,7 +1055,7 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 	struct iovec short_iovec[1];
 	vm_page_t *prev_td_ma;
 	vm_prot_t prot;
-	vm_offset_t addr, end;
+	char * __capability addr, * __capability end;
 	size_t len, resid;
 	ssize_t adv;
 	int error, cnt, saveheld, prev_td_ma_cnt;
@@ -1108,7 +1108,7 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 		}
 		if (len > io_hold_cnt * PAGE_SIZE)
 			len = io_hold_cnt * PAGE_SIZE;
-		addr = (__cheri_addr vaddr_t)uio_clone->uio_iov->iov_base;
+		addr = uio_clone->uio_iov->iov_base;
 		end = round_page(addr + len);
 		if (end < addr) {
 			error = EFAULT;

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -208,7 +208,7 @@ SUBDIR=	\
 	libiconv \
 	libmchain \
 	lindebugfs \
-	linuxkpi \
+	${_linuxkpi} \
 	${_lio} \
 	lpt \
 	mac_biba \
@@ -800,6 +800,10 @@ _cloudabi64=	cloudabi64
 .if ${MACHINE_ARCH:Marmv[67]*} != "" || ${MACHINE_CPUARCH} == "aarch64"
 _bcm283x_clkman=  bcm283x_clkman
 _bcm283x_pwm=  bcm283x_pwm
+.endif
+
+.if ${CPUTYPE} != "cheri"
+_linuxkpi=	linuxkpi
 .endif
 
 SUBDIR+=${MODULES_EXTRA}

--- a/sys/net/bpf.h
+++ b/sys/net/bpf.h
@@ -116,9 +116,9 @@ struct bpf_version {
  * buffer as used by BPF.
  */
 struct bpf_zbuf {
-	void	*bz_bufa;	/* Location of 'a' zero-copy buffer. */
-	void	*bz_bufb;	/* Location of 'b' zero-copy buffer. */
-	size_t	 bz_buflen;	/* Size of zero-copy buffers. */
+	void * __kerncap bz_bufa;	/* Location of 'a' zero-copy buffer. */
+	void * __kerncap bz_bufb;	/* Location of 'b' zero-copy buffer. */
+	size_t	 bz_buflen;		/* Size of zero-copy buffers. */
 };
 
 #define	BIOCGBLEN	_IOR('B', 102, u_int)

--- a/sys/sys/buf.h
+++ b/sys/sys/buf.h
@@ -570,7 +570,7 @@ void	vfs_bio_set_flags(struct buf *bp, int ioflags);
 void	vfs_bio_set_valid(struct buf *, int base, int size);
 void	vfs_busy_pages(struct buf *, int clear_modify);
 void	vfs_unbusy_pages(struct buf *);
-int	vmapbuf(struct buf *, int);
+int	vmapbuf(struct buf *, void * __capability, int);
 void	vunmapbuf(struct buf *);
 void	brelvp(struct buf *);
 void	bgetvp(struct vnode *, struct buf *);

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -192,8 +192,8 @@
 /*
  * Mach derived conversion macros
  */
-#define	round_page(x)	(((x) + PAGE_MASK) & ~(PAGE_MASK))
-#define	trunc_page(x)	((x) & ~(PAGE_MASK))
+#define	round_page(x)	roundup2(x, PAGE_SIZE)
+#define	trunc_page(x)	rounddown2(x, PAGE_SIZE)
 
 #define	atop(x)		((x) >> PAGE_SHIFT)
 #define	ptoa(x)		((x) << PAGE_SHIFT)

--- a/sys/ufs/ffs/ffs_rawread.c
+++ b/sys/ufs/ffs/ffs_rawread.c
@@ -217,7 +217,6 @@ ffs_rawread_readahead(struct vnode *vp,
 	bp->b_flags = 0;	/* XXX necessary ? */
 	bp->b_iocmd = BIO_READ;
 	bp->b_iodone = bdone;
-	bp->b_data = (__cheri_fromcap void *)udata;
 	blockno = offset / bsize;
 	blockoff = (offset % bsize) / DEV_BSIZE;
 	if ((daddr_t) blockno != blockno) {
@@ -237,7 +236,7 @@ ffs_rawread_readahead(struct vnode *vp,
 			bp->b_bcount = bsize - blockoff * DEV_BSIZE;
 		bp->b_bufsize = bp->b_bcount;
 		
-		if (vmapbuf(bp, 1) < 0)
+		if (vmapbuf(bp, udata, 1) < 0)
 			return EFAULT;
 		
 		maybe_yield();
@@ -256,7 +255,7 @@ ffs_rawread_readahead(struct vnode *vp,
 		bp->b_bcount = bsize * (1 + bforwards) - blockoff * DEV_BSIZE;
 	bp->b_bufsize = bp->b_bcount;
 	
-	if (vmapbuf(bp, 1) < 0)
+	if (vmapbuf(bp, udata, 1) < 0)
 		return EFAULT;
 	
 	BO_STRATEGY(&dp->v_bufobj, bp);

--- a/sys/vm/vm_extern.h
+++ b/sys/vm/vm_extern.h
@@ -91,8 +91,8 @@ void vm_fault_copy_entry(vm_map_t, vm_map_t, vm_map_entry_t, vm_map_entry_t,
     vm_ooffset_t *);
 int vm_fault_disable_pagefaults(void);
 void vm_fault_enable_pagefaults(int save);
-int vm_fault_quick_hold_pages(vm_map_t map, vm_offset_t addr, vm_size_t len,
-    vm_prot_t prot, vm_page_t *ma, int max_count);
+int vm_fault_quick_hold_pages(vm_map_t map, void * __capability addr,
+    vm_size_t len, vm_prot_t prot, vm_page_t *ma, int max_count);
 int vm_fault_trap(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
     int fault_flags, int *signo, int *ucode);
 int vm_forkproc(struct thread *, struct proc *, struct thread *,


### PR DESCRIPTION
Rather than passing a virtual address (usually cast from a pointer),
pass a pointer to vm_fault_quick_hold_pages as the starting address.
With CHERI this allows the bounds to be checked before mapping the
memory in question for use by the caller.

Doing this completely correctly requires making data types in struct buf
and struct bio be capabilities and I've skipped that large change for
now.

Note: this compiles, but does not boot.