### PR TITLE
Reduce some diffs in exec_copyout_strings

### DIFF
--- a/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c
@@ -13789,7 +13789,7 @@ freebsd64_dof_actdesc(dof_actdesc64_t *actdesc64)
 	actdesc.dofa_kind = actdesc64->dofa_kind;
 	actdesc.dofa_ntuple = actdesc64->dofa_ntuple;
 	actdesc.dofa_arg = actdesc64->dofa_arg;
-	actdesc.dofa_uarg = (uintcap_t)cheri_fromint(actdesc64->dofa_uarg);
+	actdesc.dofa_uarg = actdesc64->dofa_uarg;
 	return actdesc;
 }
 #endif

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -650,7 +650,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	if (szsigcode != 0) {
 		destp -= szsigcode;
-		destp = __builtin_align_down(destp, sizeof(uint64_t));
+		destp = rounddown2(destp, sizeof(uint64_t));
 		error = copyout(p->p_sysent->sv_sigcode,
 		    (void * __capability)destp, szsigcode);
 		if (error != 0)
@@ -662,7 +662,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	if (execpath_len != 0) {
 		destp -= execpath_len;
-		destp = __builtin_align_down(destp, sizeof(uint64_t));
+		destp = rounddown2(destp, sizeof(uint64_t));
 		imgp->execpathp = (void * __capability)
 		    cheri_setbounds(destp, execpath_len);
 		error = copyout(imgp->execpath, imgp->execpathp, execpath_len);
@@ -686,7 +686,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 * Prepare the pagesizes array.
 	 */
 	destp -= szps;
-	destp = __builtin_align_down(destp, sizeof(uint64_t));
+	destp = rounddown2(destp, sizeof(uint64_t));
 	imgp->pagesizes = (void * __capability)cheri_setbounds(destp, szps);
 	error = copyout(pagesizes, imgp->pagesizes, szps);
 	if (error != 0)
@@ -697,7 +697,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 * Allocate room for the argument and environment strings.
 	 */
 	destp -= ARG_MAX - imgp->args->stringspace;
-	destp = __builtin_align_down(destp, sizeof(uint64_t));
+	destp = rounddown2(destp, sizeof(uint64_t));
 	ustringp = cheri_setbounds(destp, ARG_MAX - imgp->args->stringspace);
 
 	if (imgp->sysent->sv_stackgap != NULL)
@@ -709,7 +709,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		 * array.  It has up to AT_COUNT entries.
 		 */
 		destp -= AT_COUNT * sizeof(Elf64_Auxinfo);
-		destp = __builtin_align_down(destp, sizeof(uint64_t));
+		destp = rounddown2(destp, sizeof(uint64_t));
 	}
 
 	vectp = (uint64_t * __capability)destp;

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -637,8 +637,8 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	    CHERI_CAP_USER_DATA_PERMS, rounded_stack_vaddr,
 	    CHERI_REPRESENTABLE_LENGTH(ssiz + stack_offset), stack_offset);
 	destp = cheri_setaddress(destp, p->p_sysent->sv_psstrings);
-	arginfo = (struct freebsd64_ps_strings * __capability)cheri_setbounds(
-	    destp, sizeof(*arginfo));
+	arginfo = (struct freebsd64_ps_strings * __capability)
+	    cheri_setboundsexact(destp, sizeof(*arginfo));
 	imgp->ps_strings = arginfo;
 	if (p->p_sysent->sv_sigcode_base == 0)
 		szsigcode = *(p->p_sysent->sv_szsigcode);
@@ -664,7 +664,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		destp -= execpath_len;
 		destp = rounddown2(destp, sizeof(uint64_t));
 		imgp->execpathp = (void * __capability)
-		    cheri_setbounds(destp, execpath_len);
+		    cheri_setboundsexact(destp, execpath_len);
 		error = copyout(imgp->execpath, imgp->execpathp, execpath_len);
 		if (error != 0)
 			return (error);
@@ -675,7 +675,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	arc4rand(canary, sizeof(canary), 0);
 	destp -= sizeof(canary);
-	imgp->canary = (void * __capability)cheri_setbounds(destp,
+	imgp->canary = (void * __capability)cheri_setboundsexact(destp,
 	    sizeof(canary));
 	error = copyout(canary, imgp->canary, sizeof(canary));
 	if (error != 0)
@@ -687,7 +687,8 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	destp -= szps;
 	destp = rounddown2(destp, sizeof(uint64_t));
-	imgp->pagesizes = (void * __capability)cheri_setbounds(destp, szps);
+	imgp->pagesizes = (void * __capability)cheri_setboundsexact(destp,
+	    szps);
 	error = copyout(pagesizes, imgp->pagesizes, szps);
 	if (error != 0)
 		return (error);

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1667,8 +1667,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	if (szsigcode != 0) {
 		destp -= szsigcode;
-		destp = __builtin_align_down(destp,
-		    sizeof(void * __capability));
+		destp = rounddown2(destp, sizeof(void * __capability));
 		error = copyout(p->p_sysent->sv_sigcode,
 		    (void * __capability)destp, szsigcode);
 		if (error != 0)
@@ -1680,8 +1679,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	if (execpath_len != 0) {
 		destp -= execpath_len;
-		destp = __builtin_align_down(destp,
-		    sizeof(void * __capability));
+		destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
 		imgp->execpathp = (void * __capability)
 		    cheri_setbounds(destp, execpath_len);
@@ -1713,7 +1711,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 * Prepare the pagesizes array.
 	 */
 	destp -= szps;
-	destp = __builtin_align_down(destp, sizeof(void * __capability));
+	destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
 	imgp->pagesizes = (void * __capability)cheri_setbounds(destp, szps);
 #else
@@ -1728,7 +1726,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 * Allocate room for the argument and environment strings.
 	 */
 	destp -= ARG_MAX - imgp->args->stringspace;
-	destp = __builtin_align_down(destp, sizeof(void * __capability));
+	destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
 	ustringp = cheri_setbounds(destp, ARG_MAX - imgp->args->stringspace);
 #else
@@ -1744,8 +1742,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		 * array.  It has up to AT_COUNT entries.
 		 */
 		destp -= AT_COUNT * sizeof(Elf_Auxinfo);
-		destp = __builtin_align_down(destp,
-		    sizeof(void * __capability));
+		destp = rounddown2(destp, sizeof(void * __capability));
 	}
 
 	vectp = (char * __capability * __capability)destp;

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1650,7 +1650,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	    CHERI_CAP_USER_DATA_PERMS, rounded_stack_vaddr,
 	    CHERI_REPRESENTABLE_LENGTH(ssiz + stack_offset), stack_offset);
 	destp = cheri_setaddress(destp, p->p_sysent->sv_psstrings);
-	arginfo = (struct ps_strings * __capability)cheri_setbounds(destp,
+	arginfo = (struct ps_strings * __capability)cheri_setboundsexact(destp,
 	    sizeof(*arginfo));
 #else
 	arginfo = (struct ps_strings *)p->p_sysent->sv_psstrings;
@@ -1682,7 +1682,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
 		imgp->execpathp = (void * __capability)
-		    cheri_setbounds(destp, execpath_len);
+		    cheri_setboundsexact(destp, execpath_len);
 #else
 		imgp->execpathp = (void *)destp;
 #endif
@@ -1697,7 +1697,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	arc4rand(canary, sizeof(canary), 0);
 	destp -= sizeof(canary);
 #if __has_feature(capabilities)
-	imgp->canary = (void * __capability)cheri_setbounds(destp,
+	imgp->canary = (void * __capability)cheri_setboundsexact(destp,
 	    sizeof(canary));
 #else
 	imgp->canary = (void *)destp;
@@ -1713,7 +1713,8 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	destp -= szps;
 	destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
-	imgp->pagesizes = (void * __capability)cheri_setbounds(destp, szps);
+	imgp->pagesizes = (void * __capability)cheri_setboundsexact(destp,
+	    szps);
 #else
 	imgp->pagesizes = (void *)destp;
 #endif


### PR DESCRIPTION
Originally I was going to try to look for places where we could remove casts due to the builtins working with uintcap_t, but exec_copyout_strings() was the only place I found.