### PR TITLE
Make userspace sealing root MI and implement on RISC-V

### DIFF
--- a/bin/cheritest/cheritest.c
+++ b/bin/cheritest/cheritest.c
@@ -171,7 +171,6 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Exercise capability load permission success",
 	  .ct_func = test_nofault_perm_load },
 
-#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_fault_perm_seal",
 	  .ct_desc = "Exercise capability seal permission failure",
 	  .ct_func = test_fault_perm_seal,
@@ -179,7 +178,6 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
 	  .ct_si_trapno = TRAPNO_CHERI },
-#endif
 
 	{ .ct_name = "test_fault_perm_store",
 	  .ct_desc = "Exercise capability store permission failure",
@@ -193,7 +191,6 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Exercise capability store permission success",
 	  .ct_func = test_nofault_perm_store },
 
-#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_fault_perm_unseal",
 	  .ct_desc = "Exercise capability unseal permission failure",
 	  .ct_func = test_fault_perm_unseal,
@@ -201,7 +198,6 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_PERM,
 	  .ct_si_trapno = TRAPNO_CHERI },
-#endif
 
 	{ .ct_name = "test_fault_tag",
 	  .ct_desc = "Store via untagged capability",
@@ -268,10 +264,9 @@ static const struct cheri_test cheri_tests[] = {
 	/*
 	 * Tests on the kernel-provided sealing capability (sealcap).
 	 */
-#ifdef CHERI_GET_SEALCAP
-	{ .ct_name = "test_sealcap_sysarch",
-	  .ct_desc = "Retrieve sealcap using sysarch(2)",
-	  .ct_func = test_sealcap_sysarch, },
+	{ .ct_name = "test_sealcap_sysctl",
+	  .ct_desc = "Retrieve sealcap using sysctl(3)",
+	  .ct_func = test_sealcap_sysctl, },
 
 	{ .ct_name = "test_sealcap_seal",
 	  .ct_desc = "Use sealcap to seal a capability",
@@ -280,7 +275,6 @@ static const struct cheri_test cheri_tests[] = {
 	{ .ct_name = "test_sealcap_seal_unseal",
 	  .ct_desc = "Use sealcap to seal and unseal a capability",
 	  .ct_func = test_sealcap_seal_unseal, },
-#endif
 
 	/*
 	 * Tests on function pointers as sentries.
@@ -1758,11 +1752,9 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Path with CHERI_PERM_LOAD permission missing",
 	  .ct_func = test_cheriabi_open_bad_perm, },
 
-#ifdef CHERI_GET_SEALCAP
 	{ .ct_name = "test_cheriabi_open_sealed",
 	  .ct_desc = "Sealed path",
 	  .ct_func = test_cheriabi_open_sealed, },
-#endif
 #endif
 #ifdef CHERI_C_TESTS
 #define	DECLARE_TEST(name, desc)			\

--- a/bin/cheritest/cheritest.h
+++ b/bin/cheritest/cheritest.h
@@ -483,7 +483,7 @@ DECLARE_CHERI_TEST(cheritest_setjmp_longjmp);
 DECLARE_CHERI_TEST(test_printf_cap);
 
 /* cheritest_sealcap.c */
-DECLARE_CHERI_TEST(test_sealcap_sysarch);
+DECLARE_CHERI_TEST(test_sealcap_sysctl);
 DECLARE_CHERI_TEST(test_sealcap_seal);
 DECLARE_CHERI_TEST(test_sealcap_seal_unseal);
 

--- a/bin/cheritest/cheritest_cheriabi_open.c
+++ b/bin/cheritest/cheritest_cheriabi_open.c
@@ -41,8 +41,6 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
-#include <machine/sysarch.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -225,16 +223,18 @@ test_cheriabi_open_bad_perm(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
-#ifdef CHERI_GET_SEALCAP
 void
 test_cheriabi_open_sealed(const struct cheri_test *ctp __unused)
 {
 	char *path;
-	void * sealer;
+	void *sealer;
+	size_t sealer_size;
 	int fd;
 
-	if (sysarch(CHERI_GET_SEALCAP, &sealer) < 0)
-		cheritest_failure_err("CHERI_GET_SEALCAP");
+	sealer_size = sizeof(sealer);
+	if (sysctlbyname("security.cheri.sealcap", &sealer, &sealer_size,
+	    NULL, 0) < 0)
+		cheritest_failure_err("sysctlbyname(security.cheri.sealcap)");
 
 	/* Allocate enough space that it's sealable for 128-bit */
 	path = calloc(1, 1<<12);
@@ -253,4 +253,3 @@ test_cheriabi_open_sealed(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
-#endif

--- a/bin/cheritest/cheritest_fault.c
+++ b/bin/cheritest/cheritest_fault.c
@@ -39,8 +39,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <machine/sysarch.h>
-
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
@@ -96,7 +94,6 @@ test_nofault_perm_load(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
-#ifdef CHERI_GET_SEALCAP
 void
 test_fault_perm_seal(const struct cheri_test *ctp __unused)
 {
@@ -104,9 +101,12 @@ test_fault_perm_seal(const struct cheri_test *ctp __unused)
 	void * __capability ip = &i;
 	void * __capability sealcap;
 	void * __capability sealed;
+	size_t sealcap_size;
 
-	if (sysarch(CHERI_GET_SEALCAP, &sealcap) < 0)
-		cheritest_failure_err("sysarch(CHERI_GET_SEALCAP)");
+	sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
+	    NULL, 0) < 0)
+		cheritest_failure_err("sysctlbyname(security.cheri.sealcap)");
 	sealcap = cheri_andperm(sealcap, ~CHERI_PERM_SEAL);
 	sealed = cheri_seal(ip, sealcap);
 	/*
@@ -117,7 +117,6 @@ test_fault_perm_seal(const struct cheri_test *ctp __unused)
 	    _CHERI_PRINTF_CAP_FMT " with bad sealcap" _CHERI_PRINTF_CAP_FMT,
 	    _CHERI_PRINTF_CAP_ARG(sealed), _CHERI_PRINTF_CAP_ARG(sealcap));
 }
-#endif
 
 void
 test_fault_perm_store(const struct cheri_test *ctp __unused)
@@ -137,7 +136,6 @@ test_nofault_perm_store(const struct cheri_test *ctp __unused)
 	cheritest_success();
 }
 
-#ifdef CHERI_GET_SEALCAP
 void
 test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 {
@@ -146,9 +144,12 @@ test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 	void * __capability sealcap;
 	void * __capability sealed;
 	void * __capability unsealed;
+	size_t sealcap_size;
 
-	if (sysarch(CHERI_GET_SEALCAP, &sealcap) < 0)
-		cheritest_failure_err("sysarch(CHERI_GET_SEALCAP)");
+	sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
+	    NULL, 0) < 0)
+		cheritest_failure_err("sysctlbyname(security.cheri.sealcap)");
 	if ((cheri_getperm(sealcap) & CHERI_PERM_SEAL) == 0)
 		cheritest_failure_errx("unexpected !seal perm on sealcap");
 	sealed = cheri_seal(ip, sealcap);
@@ -162,7 +163,6 @@ test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 	    _CHERI_PRINTF_CAP_FMT " with bad unsealcap" _CHERI_PRINTF_CAP_FMT,
 	    _CHERI_PRINTF_CAP_ARG(unsealed), _CHERI_PRINTF_CAP_ARG(sealcap));
 }
-#endif
 
 void
 test_fault_tag(const struct cheri_test *ctp __unused)

--- a/bin/cheritest/cheritest_sealcap.c
+++ b/bin/cheritest/cheritest_sealcap.c
@@ -35,25 +35,27 @@
 #endif
 
 #include <sys/types.h>
-
-#include <machine/sysarch.h>
+#include <sys/sysctl.h>
 
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #include <err.h>
+#include <stddef.h>
 
 #include "cheritest.h"
 
-#ifdef CHERI_GET_SEALCAP
 void
-test_sealcap_sysarch(const struct cheri_test *ctp __unused)
+test_sealcap_sysctl(const struct cheri_test *ctp __unused)
 {
 	void * __capability sealcap;
+	size_t sealcap_size;
 	u_register_t v;
 
-	if (sysarch(CHERI_GET_SEALCAP, &sealcap) < 0)
-		cheritest_failure_err("sysarch(CHERI_GET_SEALCAP)");
+	sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
+	    NULL, 0) < 0)
+		cheritest_failure_err("sysctlbyname(security.cheri.sealcap)");
 
 	/* Base. */
 	v = cheri_getbase(sealcap);
@@ -146,10 +148,13 @@ test_sealcap_seal(const struct cheri_test *ctp __unused)
 	void * __capability sealdatap;
 	void * __capability sealcap;
 	void * __capability sealed;
+	size_t sealcap_size;
 	u_register_t v;
 
-	if (sysarch(CHERI_GET_SEALCAP, &sealcap) < 0)
-		cheritest_failure_err("sysarch(CHERI_GET_SEALCAP)");
+	sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
+	    NULL, 0) < 0)
+		cheritest_failure_err("sysctlbyname(security.cheri.sealcap)");
 
 	sealdatap = &sealdata;
 	sealed = cheri_seal(sealdatap, sealcap);
@@ -204,10 +209,13 @@ test_sealcap_seal_unseal(const struct cheri_test *ctp __unused)
 	void * __capability sealcap;
 	void * __capability sealed;
 	void * __capability unsealed;
+	size_t sealcap_size;
 	u_register_t v;
 
-	if (sysarch(CHERI_GET_SEALCAP, &sealcap) < 0)
-		cheritest_failure_err("sysarch(CHERI_GET_SEALCAP)");
+	sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
+	    NULL, 0) < 0)
+		cheritest_failure_err("sysctlbyname(security.cheri.sealcap)");
 
 	sealdatap = &sealdata;
 	sealed = cheri_seal(sealdatap, sealcap);
@@ -255,4 +263,3 @@ test_sealcap_seal_unseal(const struct cheri_test *ctp __unused)
 
 	cheritest_success();
 }
-#endif	/* CHERI_GET_SEALCAP */

--- a/contrib/subrepo-cheri-c-tests/clang-hybrid/clang_hybrid_opaque.c
+++ b/contrib/subrepo-cheri-c-tests/clang-hybrid/clang_hybrid_opaque.c
@@ -25,8 +25,10 @@
  * @BERI_LICENSE_HEADER_END@
  */
 
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
 #include <assert.h>
-#include <machine/sysarch.h>
 
 #include "cheri_c_test.h"
 
@@ -66,7 +68,10 @@ void example_init(void)
  * be in the range 0 to 2^24-1.
  */
   void * __capability sealing_cap;
-  assert(sysarch(CHERI_GET_SEALCAP, &sealing_cap) == 0);
+  size_t sealing_cap_size;
+  sealing_cap_size = sizeof(sealing_cap);
+  assert(sysctlbyname("security.cheri.sealcap", &sealing_cap,
+    &sealing_cap_size, NULL, 0) == 0);
   example_key = __builtin_cheri_offset_set(sealing_cap, 4);
 }
 

--- a/lib/libcheri/libcheri_type.c
+++ b/lib/libcheri/libcheri_type.c
@@ -34,11 +34,10 @@ __REQUIRE_CAPABILITIES
 
 #include <sys/types.h>
 #include <sys/param.h>
+#include <sys/sysctl.h>
 
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
-
-#include <machine/sysarch.h>
 
 #include <assert.h>
 #include <stdatomic.h>
@@ -67,6 +66,7 @@ static const int libcheri_system_type_max = 1<<(libcheri_cap_type_bits-1);
 static void
 libcheri_type_init(void)
 {
+	size_t sealcap_size;
 
 	/*
 	 * Request a root sealing capability from the kernel.  Ensure it is
@@ -75,7 +75,9 @@ libcheri_type_init(void)
 	 * properties of the capability later, should compartmentalisation
 	 * actually be used by the application.
 	 */
-	if (sysarch(CHERI_GET_SEALCAP, &libcheri_sealing_root) < 0)
+	sealer_size = sizeof(libcheri_sealing_root);
+	if (sysctlbyname("security.cheri.sealcap", &libcheri_sealing_root,
+	    &sealcap_size, NULL, 0) < 0)
 		libcheri_sealing_root = NULL;
 	assert((cheri_getperm(libcheri_sealing_root) & CHERI_PERM_SEAL) != 0);
 	assert(cheri_getlen(libcheri_sealing_root) != 0);

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -97,8 +97,11 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
  * Global capabilities used to construct other capabilities.
  */
 
-/* Root of all userspace capabilities. */
+/* Root of all unsealed userspace capabilities. */
 extern void * __capability userspace_cap;
+
+/* Root of all sealed userspace capabilities. */
+extern void * __capability userspace_sealcap;
 
 /*
  * Omnipotent capability for restoring swapped capabilities.
@@ -139,10 +142,7 @@ void	hybridabi_sendsig(struct thread *td);
  * Functions to set up and manipulate CHERI contexts and stacks.
  */
 struct pcb;
-struct proc;
-void	cheri_sealcap_copy(struct proc *dst, struct proc *src);
 void	cheri_signal_copy(struct pcb *dst, struct pcb *src);
-int	cheri_sysarch_getsealcap(struct thread *td, void * __capability ucap);
 
 /*
  * Functions to manage object types.

--- a/sys/cheri/cheri_sealcap.c
+++ b/sys/cheri/cheri_sealcap.c
@@ -1,10 +1,12 @@
 /*-
- * Copyright (c) 2015, 2017 Robert N. M. Watson
- * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2020 Jessica Clarke
  *
  * This software was developed by SRI International and the University of
- * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
- * ("CTSRD"), as part of the DARPA CRASH research programme.
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,45 +30,14 @@
  * SUCH DAMAGE.
  */
 
-#include "opt_ddb.h"
-
 #include <sys/param.h>
-#include <sys/kernel.h>
-#include <sys/lock.h>
-#include <sys/mutex.h>
-#include <sys/proc.h>
-#include <sys/syscall.h>
 #include <sys/sysctl.h>
-#include <sys/sysproto.h>
-
-#include <ddb/ddb.h>
-#include <sys/kdb.h>
+#include <sys/systm.h>
 
 #include <cheri/cheri.h>
 
-#include <machine/atomic.h>
-#include <machine/pcb.h>
-#include <machine/sysarch.h>
-
-/*
- * Propagate the root object-type sealing capability across fork().
- */
-void
-cheri_sealcap_copy(struct proc *dst, struct proc *src)
-{
-
-	memcpy(&dst->p_md.md_cheri_sealcap, &src->p_md.md_cheri_sealcap,
-	    sizeof(dst->p_md.md_cheri_sealcap));
-}
-
-/*
- * Allow userspace to query a root object-type sealing capability using
- * sysarch(2).
- */
-int
-cheri_sysarch_getsealcap(struct thread *td, void * __capability ucap)
-{
-
-	return (copyoutcap(&td->td_proc->p_md.md_cheri_sealcap, ucap,
-	    sizeof(td->td_proc->p_md.md_cheri_sealcap)));
-}
+/* Set to -1 to prevent it from being zeroed with the rest of BSS */
+void * __capability userspace_sealcap = (void * __capability)(intcap_t)-1;
+SYSCTL_OPAQUE(_security_cheri, OID_AUTO, sealcap, CTLFLAG_RD | CTLFLAG_PTROUT,
+    &userspace_sealcap, sizeof(userspace_sealcap), "",
+    "CHERI sealing root capability");

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -137,8 +137,7 @@ cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
 /*
  * Construct a capability suitable to describe a type identified by 'ptr';
  * set it to zero-length with the offset equal to the base.  The caller must
- * provide a root capability (in the old world order, derived from $ddc, but
- * in the new world order, likely extracted from the kernel using sysarch(2)).
+ * provide a root sealing capability.
  *
  * The caller may wish to assert various properties about the returned
  * capability, including that CHERI_PERM_SEAL is set.

--- a/sys/cheri/cherireg.h
+++ b/sys/cheri/cherireg.h
@@ -98,8 +98,7 @@
 #define	CHERI_CAP_USER_MMAP_OFFSET	0x0
 
 /*
- * Root sealing capability for all userspace object capabilities.  This is
- * made available to userspace via a sysarch(2).
+ * Root sealing capability for all userspace object capabilities.
  */
 #define	CHERI_SEALCAP_USERSPACE_PERMS	CHERI_PERMS_USERSPACE_SEALCAP
 #define	CHERI_SEALCAP_USERSPACE_BASE	CHERI_OTYPE_USER_MIN

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -317,6 +317,7 @@ cheri/cheri_asserts.c			optional cpu_cheri
 cheri/cheri_exec.c			optional cpu_cheri
 cheri/cheri_sysctl.c			optional cpu_cheri
 cheri/cheri_otype.c			optional cpu_cheri
+cheri/cheri_sealcap.c			optional cpu_cheri
 cheri/cheri_syscall.c			optional cpu_cheri
 cheri/cheri_usercap.c			optional cpu_cheri
 

--- a/sys/conf/files.mips
+++ b/sys/conf/files.mips
@@ -9,7 +9,6 @@ mips/cheri/cheri.c			optional cpu_cheri
 mips/cheri/cheri_debug.c		optional cpu_cheri
 mips/cheri/cheri_exception.c		optional cpu_cheri
 mips/cheri/cheri_memcpy_c.S		optional cpu_cheri
-mips/cheri/cheri_sealcap.c		optional cpu_cheri
 mips/cheri/cheri_signal.c		optional cpu_cheri
 mips/cheri/cheriabi_machdep.c		optional cpu_cheri
 mips/cheri/copystr_c.S			optional cpu_cheri

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -84,9 +84,6 @@ CTASSERT(sizeof(void *) == 8);
 CTASSERT(sizeof(void * __capability) == 16);
 CTASSERT(sizeof(struct cheri_object) == 32);
 
-/* Set to -1 to prevent it from being zeroed with the rest of BSS */
-void * __capability user_sealcap = (void * __capability)(intcap_t)-1;
-
 /*
  * For now, all we do is declare what we support, as most initialisation took
  * place in the MIPS machine-dependent assembly.  CHERI doesn't need a lot of
@@ -115,10 +112,3 @@ cheri_cpu_startup(void)
 }
 SYSINIT(cheri_cpu_startup, SI_SUB_CPU, SI_ORDER_FIRST, cheri_cpu_startup,
     NULL);
-
-void
-cheri_capability_set_user_sealcap(void * __capability *cp)
-{
-
-	*cp = user_sealcap;
-}

--- a/sys/mips/cheri/cheriabi_machdep.c
+++ b/sys/mips/cheri/cheriabi_machdep.c
@@ -181,10 +181,4 @@ cheriabi_newthread_init(struct thread *td)
 	bzero(csigp, sizeof(*csigp));
 	/* Note: csig_{ddc,idc,pcc} are set to NULL in the pure-capability abi */
 	csigp->csig_sigcode = cheri_sigcode_capability(td);
-
-	/*
-	 * Set up root for the userspace object-type sealing capability tree.
-	 * This can be queried using sysarch(2).
-	 */
-	cheri_capability_set_user_sealcap(&td->td_proc->p_md.md_cheri_sealcap);
 }

--- a/sys/mips/cheri/hybridabi_machdep.c
+++ b/sys/mips/cheri/hybridabi_machdep.c
@@ -148,12 +148,6 @@ hybridabi_thread_init(struct thread *td, unsigned long entry_addr)
 	hybridabi_capability_set_user_idc(&csigp->csig_idc);
 	hybridabi_capability_set_user_pcc(td, &csigp->csig_pcc);
 	csigp->csig_sigcode = cheri_sigcode_capability(td);
-
-        /*
-         * Set up root for the userspace object-type sealing capability tree.
-         * This can be queried using sysarch(2).
-         */
-        cheri_capability_set_user_sealcap(&td->td_proc->p_md.md_cheri_sealcap);
 }
 
 /*

--- a/sys/mips/include/cheri.h
+++ b/sys/mips/include/cheri.h
@@ -120,7 +120,6 @@ struct cheri_kframe {
 struct cheri_frame;
 struct sysentvec;
 struct trapframe;
-void	cheri_capability_set_user_sealcap(void * __capability *);
 int	cheri_capcause_to_sicode(register_t capcause);
 void	cheri_log_cheri_frame(struct trapframe *frame);
 void	cheri_log_exception(struct trapframe *frame, int trap_type);

--- a/sys/mips/include/proc.h
+++ b/sys/mips/include/proc.h
@@ -85,14 +85,7 @@ struct mdthread {
 #endif
 
 struct mdproc {
-	/*
-	 * Used only on CHERI kernels, but defined everywhere as we need
-	 * something in the struct as empty struct are undefined behavior.
-	 *
-	 * XXX-BD: In a coprocess world this might make more sense
-	 * attached to the vmspace (or at least near it).
-	 */
-	void * __kerncap md_cheri_sealcap;	/* Root of object-type tree. */
+	long md_dummy;
 };
 
 struct syscall_args {

--- a/sys/mips/include/sysarch.h
+++ b/sys/mips/include/sysarch.h
@@ -55,13 +55,6 @@
 #define	CHERI_SET_STACK		5	/* Set trusted stack. */
 
 /*
- * Query the root of the object-type sealing capability provenance tree.  This
- * allows us to avoid setting CHERI_PERM_SEAL and CHERI_PERM_UNSEAL on data
- * and code capabilities.
- */
-#define	CHERI_GET_SEALCAP	6	/* Get root sealing capability. */
-
-/*
  * Manipulate the mmap capability.
  */
 #define	CHERI_MMAP_GETPERM	7	/* Get permissions */

--- a/sys/mips/mips/freebsd64_machdep.c
+++ b/sys/mips/mips/freebsd64_machdep.c
@@ -551,10 +551,6 @@ freebsd64_sysarch(struct thread *td, struct freebsd64_sysarch_args *uap)
 		return (0);
 #endif
 
-	case CHERI_GET_SEALCAP:
-		return (cheri_sysarch_getsealcap(td,
-		    __USER_CAP(uap->parms, sizeof(void * __capability))));
-
 	default:
 		return (EINVAL);
 	}

--- a/sys/mips/mips/locore.S
+++ b/sys/mips/mips/locore.S
@@ -196,7 +196,7 @@ VECTOR(_locore, unknown)
 	csetbounds	CHERI_REG_C27, CHERI_REG_C27, t0
 	REG_LI	t0, CHERI_SEALCAP_USERSPACE_PERMS
 	candperm	CHERI_REG_C27, CHERI_REG_C27, t0
-	PTR_LA	t0, _C_LABEL(user_sealcap)
+	PTR_LA	t0, _C_LABEL(userspace_sealcap)
 	csc	CHERI_REG_C27, t0, 0($ddc)
 
 	/*

--- a/sys/mips/mips/sys_machdep.c
+++ b/sys/mips/mips/sys_machdep.c
@@ -90,9 +90,6 @@ sysarch(struct thread *td, struct sysarch_args *uap)
 #endif
 
 #ifdef CPU_CHERI
-	case CHERI_GET_SEALCAP:
-		return (cheri_sysarch_getsealcap(td, uap->parms));
-
 	/*
 	 * CheriABI specific operations.
 	 */

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -118,7 +118,6 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	bcopy(td1->td_pcb, pcb2, sizeof(*pcb2));
 #ifdef CPU_CHERI
 	cheri_signal_copy(pcb2, td1->td_pcb);
-	cheri_sealcap_copy(p2, td1->td_proc);
 #endif
 
 	/* Point mdproc and then copy over td1's contents */

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -59,6 +59,11 @@ cheri_init_capabilities(void * __capability kroot)
 	    CHERI_CAP_USER_CODE_PERMS);
 	userspace_cap = ctemp;
 
+	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_USERSPACE_BASE);
+	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
+	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
+	userspace_sealcap = ctemp;
+
 	swap_restore_cap = kroot;
 }
 


### PR DESCRIPTION
The concept of sealing is shared by all CHERI implementations, including Morello, yet the current sysarch(2)-based implementation for userspace to obtain a sealing root is MIPS-specific. Instead, replace it with a new sysctl that is shared by all CHERI implementations.

Unlike the old implementation this is now a kernel global rather than a field attached to the proc. However, in practice the previous implementation had the same value for the field for every single process. If future compartmentalisation work needs to further split up the root amongst proceses (such as the coprocess work) then the sysctl can be made a SYSCTL_PROC and various code added to implement that as needed, but for now that's not necessary. 