### PR TITLE
Stack unwind fixes

### DIFF
--- a/sys/arm64/arm64/db_trace.c
+++ b/sys/arm64/arm64/db_trace.c
@@ -73,7 +73,7 @@ db_stack_trace_cmd(struct unwind_state *frame)
 	db_expr_t offset;
 
 	while (1) {
-		uint64_t pc = frame->pc;
+		uintptr_t pc = frame->pc;
 		int ret;
 
 		ret = unwind_frame(frame);
@@ -109,9 +109,9 @@ db_trace_thread(struct thread *thr, int count)
 	if (thr != curthread) {
 		ctx = kdb_thr_ctx(thr);
 
-		frame.sp = (uint64_t)ctx->pcb_sp;
-		frame.fp = (uint64_t)ctx->pcb_x[29];
-		frame.pc = (uint64_t)ctx->pcb_x[30];
+		frame.sp = (uintptr_t)ctx->pcb_sp;
+		frame.fp = (uintptr_t)ctx->pcb_x[29];
+		frame.pc = (uintptr_t)ctx->pcb_x[30];
 		db_stack_trace_cmd(&frame);
 	} else
 		db_trace_self();
@@ -122,12 +122,12 @@ void
 db_trace_self(void)
 {
 	struct unwind_state frame;
-	uint64_t sp;
+	uintptr_t sp;
 
 	__asm __volatile("mov %0, sp" : "=&r" (sp));
 
 	frame.sp = sp;
-	frame.fp = (uint64_t)__builtin_frame_address(0);
-	frame.pc = (uint64_t)db_trace_self;
+	frame.fp = (uintptr_t)__builtin_frame_address(0);
+	frame.pc = (uintptr_t)db_trace_self;
 	db_stack_trace_cmd(&frame);
 }

--- a/sys/arm64/arm64/stack_machdep.c
+++ b/sys/arm64/arm64/stack_machdep.c
@@ -81,13 +81,13 @@ void
 stack_save(struct stack *st)
 {
 	struct unwind_state frame;
-	uint64_t sp;
+	uintptr_t sp;
 
 	__asm __volatile("mov %0, sp" : "=&r" (sp));
 
 	frame.sp = sp;
-	frame.fp = (uint64_t)__builtin_frame_address(0);
-	frame.pc = (uint64_t)stack_save;
+	frame.fp = (uintptr_t)__builtin_frame_address(0);
+	frame.pc = (uintptr_t)stack_save;
 
 	stack_capture(st, &frame);
 }

--- a/sys/arm64/arm64/stack_machdep.c
+++ b/sys/arm64/arm64/stack_machdep.c
@@ -43,14 +43,14 @@ __FBSDID("$FreeBSD$");
 #include <machine/stack.h>
 
 static void
-stack_capture(struct stack *st, struct unwind_state *frame)
+stack_capture(struct thread *td, struct stack *st, struct unwind_state *frame)
 {
 
 	stack_zero(st);
 	while (1) {
-		unwind_frame(frame);
-		if (!INKERNEL((vm_offset_t)frame->fp) ||
-		     !INKERNEL((vm_offset_t)frame->pc))
+		if (!unwind_frame(td, frame))
+			break;
+		if (!INKERNEL((vm_offset_t)frame->pc))
 			break;
 		if (stack_put(st, frame->pc) == -1)
 			break;
@@ -73,7 +73,7 @@ stack_save_td(struct stack *st, struct thread *td)
 	frame.fp = td->td_pcb->pcb_x[29];
 	frame.pc = td->td_pcb->pcb_x[30];
 
-	stack_capture(st, &frame);
+	stack_capture(td, st, &frame);
 	return (0);
 }
 
@@ -89,5 +89,5 @@ stack_save(struct stack *st)
 	frame.fp = (uintptr_t)__builtin_frame_address(0);
 	frame.pc = (uintptr_t)stack_save;
 
-	stack_capture(st, &frame);
+	stack_capture(curthread, st, &frame);
 }

--- a/sys/arm64/arm64/unwind.c
+++ b/sys/arm64/arm64/unwind.c
@@ -37,17 +37,17 @@ __FBSDID("$FreeBSD$");
 int
 unwind_frame(struct unwind_state *frame)
 {
-	uint64_t fp;
+	uintptr_t fp;
 
 	fp = frame->fp;
 	if (!INKERNEL(fp))
 		return (-1);
 
-	frame->sp = fp + 0x10;
+	frame->sp = fp + sizeof(uintptr_t) * 2;
 	/* FP to previous frame (X29) */
-	frame->fp = *(uint64_t *)(fp);
+	frame->fp = ((uintptr_t *)fp)[0];
 	/* LR (X30) */
-	frame->pc = *(uint64_t *)(fp + 8) - 4;
+	frame->pc = ((uintptr_t *)fp)[1] - 4;
 
 	return (0);
 }

--- a/sys/arm64/arm64/unwind.c
+++ b/sys/arm64/arm64/unwind.c
@@ -30,18 +30,20 @@
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 #include <sys/param.h>
+#include <sys/proc.h>
 
 #include <machine/stack.h>
 #include <machine/vmparam.h>
 
-int
-unwind_frame(struct unwind_state *frame)
+bool
+unwind_frame(struct thread *td, struct unwind_state *frame)
 {
 	uintptr_t fp;
 
 	fp = frame->fp;
-	if (!INKERNEL(fp))
-		return (-1);
+
+	if (!kstack_contains(td, fp, sizeof(uintptr_t) * 2))
+		return (false);
 
 	frame->sp = fp + sizeof(uintptr_t) * 2;
 	/* FP to previous frame (X29) */
@@ -49,5 +51,5 @@ unwind_frame(struct unwind_state *frame)
 	/* LR (X30) */
 	frame->pc = ((uintptr_t *)fp)[1] - 4;
 
-	return (0);
+	return (true);
 }

--- a/sys/arm64/include/csan.h
+++ b/sys/arm64/include/csan.h
@@ -87,9 +87,9 @@ kcsan_md_unwind(void)
 	nsym = 0;
 
 	while (1) {
-		unwind_frame(&frame);
-		if (!INKERNEL((vm_offset_t)frame.fp) ||
-		     !INKERNEL((vm_offset_t)frame.pc))
+		if (!unwind_frame(curthread, &frame))
+			break;
+		if (!INKERNEL((vm_offset_t)frame.pc))
 			break;
 
 #ifdef DDB

--- a/sys/arm64/include/csan.h
+++ b/sys/arm64/include/csan.h
@@ -76,14 +76,14 @@ kcsan_md_unwind(void)
 	const char *symname;
 #endif
 	struct unwind_state frame;
-	uint64_t sp;
+	uintptr_t sp;
 	int nsym;
 
 	__asm __volatile("mov %0, sp" : "=&r" (sp));
 
 	frame.sp = sp;
-	frame.fp = (uint64_t)__builtin_frame_address(0);
-	frame.pc = (uint64_t)kcsan_md_unwind;
+	frame.fp = (uintptr_t)__builtin_frame_address(0);
+	frame.pc = (uintptr_t)kcsan_md_unwind;
 	nsym = 0;
 
 	while (1) {

--- a/sys/arm64/include/stack.h
+++ b/sys/arm64/include/stack.h
@@ -38,6 +38,6 @@ struct unwind_state {
 	uintptr_t pc;
 };
 
-int unwind_frame(struct unwind_state *);
+bool unwind_frame(struct thread *, struct unwind_state *);
 
 #endif /* !_MACHINE_STACK_H_ */

--- a/sys/arm64/include/stack.h
+++ b/sys/arm64/include/stack.h
@@ -33,9 +33,9 @@
 	((va) >= VM_MIN_KERNEL_ADDRESS && (va) <= VM_MAX_KERNEL_ADDRESS)
 
 struct unwind_state {
-	uint64_t fp;
-	uint64_t sp;
-	uint64_t pc;
+	uintptr_t fp;
+	uintptr_t sp;
+	uintptr_t pc;
 };
 
 int unwind_frame(struct unwind_state *);

--- a/sys/cddl/dev/dtrace/aarch64/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/aarch64/dtrace_isa.c
@@ -83,9 +83,9 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 
 	__asm __volatile("mov %0, sp" : "=&r" (sp));
 
-	state.fp = (uint64_t)__builtin_frame_address(0);
+	state.fp = (uintptr_t)__builtin_frame_address(0);
 	state.sp = sp;
-	state.pc = (uint64_t)dtrace_getpcstack;
+	state.pc = (uintptr_t)dtrace_getpcstack;
 
 	while (depth < pcstack_limit) {
 		if (!INKERNEL(state.pc) || !INKERNEL(state.fp))
@@ -281,9 +281,9 @@ dtrace_getstackdepth(int aframes)
 
 	__asm __volatile("mov %0, sp" : "=&r" (sp));
 
-	state.fp = (uint64_t)__builtin_frame_address(0);
+	state.fp = (uintptr_t)__builtin_frame_address(0);
 	state.sp = sp;
-	state.pc = (uint64_t)dtrace_getstackdepth;
+	state.pc = (uintptr_t)dtrace_getstackdepth;
 
 	do {
 		done = unwind_frame(&state);

--- a/sys/cddl/dev/dtrace/amd64/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/amd64/dtrace_isa.c
@@ -73,12 +73,8 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 	frame = (struct amd64_frame *)rbp;
 	td = curthread;
 	while (depth < pcstack_limit) {
-		if (!INKERNEL((long) frame))
-			break;
-
-		if ((vm_offset_t)frame >=
-		    td->td_kstack + ptoa(td->td_kstack_pages) ||
-		    (vm_offset_t)frame < td->td_kstack)
+		if (!kstack_contains(curthread, (vm_offset_t)frame,
+		    sizeof(*frame))
 			break;
 
 		callpc = frame->f_retaddr;
@@ -466,14 +462,11 @@ dtrace_getstackdepth(int aframes)
 	frame = (struct amd64_frame *)rbp;
 	depth++;
 	for(;;) {
-		if (!INKERNEL((long) frame))
-			break;
-		if (!INKERNEL((long) frame->f_frame))
+		if (!kstack_contains(curthread, (vm_offset_t)frame,
+		    sizeof(*frame))
 			break;
 		depth++;
-		if (frame->f_frame <= frame ||
-		    (vm_offset_t)frame->f_frame >= curthread->td_kstack +
-		    curthread->td_kstack_pages * PAGE_SIZE)
+		if (frame->f_frame <= frame)
 			break;
 		frame = frame->f_frame;
 	}

--- a/sys/cddl/dev/dtrace/i386/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/i386/dtrace_isa.c
@@ -73,7 +73,8 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 
 	frame = (struct i386_frame *)ebp;
 	while (depth < pcstack_limit) {
-		if (!INKERNEL(frame))
+		if (!kstack_contains(curthread, (vm_offset_t)frame,
+		    sizeof(*frame))
 			break;
 
 		callpc = frame->f_retaddr;
@@ -91,9 +92,7 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 			pcstack[depth++] = callpc;
 		}
 
-		if (frame->f_frame <= frame ||
-		    (vm_offset_t)frame->f_frame >= curthread->td_kstack +
-		    curthread->td_kstack_pages * PAGE_SIZE)
+		if (frame->f_frame <= frame)
 			break;
 		frame = frame->f_frame;
 	}
@@ -484,14 +483,10 @@ dtrace_getstackdepth(int aframes)
 	frame = (struct i386_frame *)ebp;
 	depth++;
 	for(;;) {
-		if (!INKERNEL((long) frame))
-			break;
-		if (!INKERNEL((long) frame->f_frame))
+		if (!kstack_contains((vm_offset_t)frame, sizeof(*frame))
 			break;
 		depth++;
-		if (frame->f_frame <= frame ||
-		    (vm_offset_t)frame->f_frame >= curthread->td_kstack +
-		    curthread->td_kstack_pages * PAGE_SIZE)
+		if (frame->f_frame <= frame)
 			break;
 		frame = frame->f_frame;
 	}

--- a/sys/cddl/dev/dtrace/riscv/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/riscv/dtrace_isa.c
@@ -85,9 +85,9 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 
 	__asm __volatile("mv %0, sp" : "=&r" (sp));
 
-	state.fp = (uint64_t)__builtin_frame_address(0);
+	state.fp = (uintptr_t)__builtin_frame_address(0);
 	state.sp = sp;
-	state.pc = (uint64_t)dtrace_getpcstack;
+	state.pc = (uintptr_t)dtrace_getpcstack;
 
 	while (depth < pcstack_limit) {
 		if (!unwind_frame(curthread, &state))
@@ -266,9 +266,9 @@ dtrace_getstackdepth(int aframes)
 
 	__asm __volatile("mv %0, sp" : "=&r" (sp));
 
-	state.fp = (uint64_t)__builtin_frame_address(0);
+	state.fp = (uintptr_t)__builtin_frame_address(0);
 	state.sp = sp;
-	state.pc = (uint64_t)dtrace_getstackdepth;
+	state.pc = (uintptr_t)dtrace_getstackdepth;
 
 	do {
 		done = !unwind_frame(curthread, &state);

--- a/sys/cddl/dev/dtrace/riscv/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/riscv/dtrace_isa.c
@@ -90,7 +90,7 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 	state.pc = (uint64_t)dtrace_getpcstack;
 
 	while (depth < pcstack_limit) {
-		if (unwind_frame(&state))
+		if (!unwind_frame(curthread, &state))
 			break;
 
 		if (!INKERNEL(state.pc) || !INKERNEL(state.fp))
@@ -259,10 +259,10 @@ dtrace_getstackdepth(int aframes)
 	int scp_offset;
 	register_t sp;
 	int depth;
-	int done;
+	bool done;
 
 	depth = 1;
-	done = 0;
+	done = false;
 
 	__asm __volatile("mv %0, sp" : "=&r" (sp));
 
@@ -271,7 +271,7 @@ dtrace_getstackdepth(int aframes)
 	state.pc = (uint64_t)dtrace_getstackdepth;
 
 	do {
-		done = unwind_frame(&state);
+		done = !unwind_frame(curthread, &state);
 		if (!INKERNEL(state.pc) || !INKERNEL(state.fp))
 			break;
 		depth++;

--- a/sys/ddb/db_ps.c
+++ b/sys/ddb/db_ps.c
@@ -527,8 +527,7 @@ db_findstack_cmd(db_expr_t addr, bool have_addr, db_expr_t dummy3 __unused,
 
 	FOREACH_PROC_IN_SYSTEM(p) {
 		FOREACH_THREAD_IN_PROC(p, td) {
-			if (td->td_kstack <= saddr && saddr < td->td_kstack +
-			    PAGE_SIZE * td->td_kstack_pages) {
+			if (kstack_contains(td, saddr, 1)) {
 				db_printf("Thread %p\n", td);
 				return;
 			}

--- a/sys/kern/vfs_subr.c
+++ b/sys/kern/vfs_subr.c
@@ -4015,8 +4015,9 @@ vn_printf(struct vnode *vp, const char *fmt, ...)
 	if (vp->v_vflag & VV_READLINK)
 		strlcat(buf, "|VV_READLINK", sizeof(buf));
 	flags = vp->v_vflag & ~(VV_ROOT | VV_ISTTY | VV_NOSYNC | VV_ETERNALDEV |
-	    VV_CACHEDLABEL | VV_COPYONWRITE | VV_SYSTEM | VV_PROCDEP |
-	    VV_NOKNOTE | VV_DELETED | VV_MD | VV_FORCEINSMQ);
+	    VV_CACHEDLABEL | VV_VMSIZEVNLOCK | VV_COPYONWRITE | VV_SYSTEM |
+	    VV_PROCDEP | VV_NOKNOTE | VV_DELETED | VV_MD | VV_FORCEINSMQ |
+	    VV_READLINK);
 	if (flags != 0) {
 		snprintf(buf2, sizeof(buf2), "|VV(0x%lx)", flags);
 		strlcat(buf, buf2, sizeof(buf));
@@ -4044,9 +4045,10 @@ vn_printf(struct vnode *vp, const char *fmt, ...)
 		snprintf(buf2, sizeof(buf2), "|VMP(0x%lx)", flags);
 		strlcat(buf, buf2, sizeof(buf));
 	}
-	printf("    flags (%s)\n", buf + 1);
+	printf("    flags (%s)", buf + 1);
 	if (mtx_owned(VI_MTX(vp)))
 		printf(" VI_LOCKed");
+	printf("\n");
 	if (vp->v_object != NULL)
 		printf("    v_object %p ref %d pages %d "
 		    "cleanbuf %d dirtybuf %d\n",

--- a/sys/mips/mips/db_trace.c
+++ b/sys/mips/mips/db_trace.c
@@ -178,10 +178,8 @@ loop:
 		subr = (uintptr_t)savectx;
 	else if (pcBetween(cpu_throw, cpu_switch))
 		subr = (uintptr_t)cpu_throw;
-#if defined(CPU_HAVEFPU)
 	else if (pcBetween(cpu_switch, MipsSwitchFPState))
 		subr = (uintptr_t)cpu_switch;
-#endif
 	else if (pcBetween(_locore, _locoreEnd)) {
 		subr = (uintptr_t)_locore;
 		ra = 0;

--- a/sys/mips/mips/db_trace.c
+++ b/sys/mips/mips/db_trace.c
@@ -471,19 +471,11 @@ db_trace_self(void)
 {
 	register_t pc, ra, sp;
 
+	pc = (intptr_t)&&here;
 	sp = (register_t)(intptr_t)__builtin_frame_address(0);
 	ra = (register_t)(intptr_t)__builtin_return_address(0);
-
-	__asm __volatile(
-		"jal 99f\n"
-		"nop\n"
-		"99:\n"
-		 "move %0, $31\n" /* get ra */
-		 "move $31, %1\n" /* restore ra */
-		 : "=r" (pc)
-		 : "r" (ra));
+here:
 	stacktrace_subr(pc, sp, ra);
-	return;
 }
 
 int

--- a/sys/mips/mips/stack_machdep.c
+++ b/sys/mips/mips/stack_machdep.c
@@ -41,31 +41,34 @@ __FBSDID("$FreeBSD$");
 #include <machine/pcb.h>
 #include <machine/regnum.h>
 
-static u_register_t
-stack_register_fetch(u_register_t sp, u_register_t stack_pos)
-{
-	u_register_t * stack = 
-	    ((u_register_t *)(intptr_t)sp + (size_t)stack_pos/sizeof(u_register_t));
-
-	return *stack;
-}
+#define	VALID_PC(addr)		((addr) >= (uintptr_t)btext && (addr) % 4 == 0)
 
 static void
-stack_capture(struct stack *st, vaddr_t pc, vaddr_t sp)
+stack_capture(struct stack *st, struct thread *td, uintptr_t pc, uintptr_t sp)
 {
-	u_register_t  ra = 0, i, stacksize;
-	short ra_stack_pos = 0;
+	u_register_t ra;
+	uintptr_t i, ra_addr;
+	int ra_stack_pos, stacksize;
 	InstFmt insn;
 
 	stack_zero(st);
 
 	/* XXXRW: appears to be inadequately robust? */
 	for (;;) {
-		stacksize = 0;
-		if (pc <= (u_register_t)(intptr_t)btext)
+		if (!VALID_PC(pc))
 			break;
-		for (i = pc; i >= (u_register_t)(intptr_t)btext; i -= sizeof (insn)) {
-			bcopy((void *)(intptr_t)i, &insn, sizeof insn);
+
+		/*
+		 * Walk backward from the PC looking for the function
+		 * start.  Assume a subtraction from SP is the start
+		 * of a function.  Hope that we find the store of RA
+		 * into the stack frame along the way and save the
+		 * offset of the saved RA relative to SP.
+		 */
+		ra_stack_pos = -1;
+		stacksize = 0;
+		for (i = pc; VALID_PC(i); i -= sizeof(insn)) {
+			bcopy((void *)i, &insn, sizeof(insn));
 			switch (insn.IType.op) {
 			case OP_ADDI:
 			case OP_ADDIU:
@@ -73,6 +76,17 @@ stack_capture(struct stack *st, vaddr_t pc, vaddr_t sp)
 			case OP_DADDIU:
 				if (insn.IType.rs != SP || insn.IType.rt != SP)
 					break;
+
+				/*
+				 * Ignore stack fixups in "early"
+				 * returns in a function, or if the
+				 * call was from an unlikely branch
+				 * moved after the end of the normal
+				 * return.
+				 */
+				if ((short)insn.IType.imm > 0)
+					break;
+
 				stacksize = -(short)insn.IType.imm;
 				break;
 
@@ -86,26 +100,35 @@ stack_capture(struct stack *st, vaddr_t pc, vaddr_t sp)
 				break;
 			}
 
-			if (stacksize)
+			if (stacksize != 0)
 				break;
 		}
 
 		if (stack_put(st, pc) == -1)
 			break;
 
-		for (i = pc; !ra; i += sizeof (insn)) {
-			bcopy((void *)(intptr_t)i, &insn, sizeof insn);
+		if (ra_stack_pos == -1)
+			break;
+
+		/*
+		 * Walk forward from the PC to find the function end
+		 * (jr RA).  If eret is hit instead, stop unwinding.
+		 */
+		ra_addr = sp + ra_stack_pos;
+		ra = 0;
+		for (i = pc; VALID_PC(i); i += sizeof(insn)) {
+			bcopy((void *)i, &insn, sizeof(insn));
 
 			switch (insn.IType.op) {
 			case OP_SPECIAL:
 				if (insn.RType.func == OP_JR) {
-					if (ra >= (u_register_t)(intptr_t)btext)
-						break;
 					if (insn.RType.rs != RA)
 						break;
-					ra = stack_register_fetch(sp, 
-					    ra_stack_pos);
-					if (!ra)
+					if (!kstack_contains(td, ra_addr,
+					    sizeof(ra)))
+						goto done;
+					ra = *(u_register_t *)ra_addr;
+					if (ra == 0)
 						goto done;
 					ra -= 8;
 				}
@@ -113,9 +136,13 @@ stack_capture(struct stack *st, vaddr_t pc, vaddr_t sp)
 			default:
 				break;
 			}
+
 			/* eret */
 			if (insn.word == 0x42000018)
 				goto done;
+
+			if (ra != 0)
+				break;
 		}
 
 		if (pc == ra && stacksize == 0)
@@ -123,7 +150,6 @@ stack_capture(struct stack *st, vaddr_t pc, vaddr_t sp)
 
 		sp += stacksize;
 		pc = ra;
-		ra = 0;
 	}
 done:
 	return;
@@ -132,7 +158,7 @@ done:
 int
 stack_save_td(struct stack *st, struct thread *td)
 {
-	vaddr_t pc, sp;
+	uintptr_t pc, sp;
 
 	THREAD_LOCK_ASSERT(td, MA_OWNED);
 	KASSERT(!TD_IS_SWAPPED(td),
@@ -141,23 +167,19 @@ stack_save_td(struct stack *st, struct thread *td)
 	if (TD_IS_RUNNING(td))
 		return (EOPNOTSUPP);
 
-	/* XXXRW: Should be pcb_context? */
-	pc = TRAPF_PC(&td->td_pcb->pcb_regs);
-	sp = td->td_pcb->pcb_regs.sp; // FIXME: use $c11 for CHERI purecap
-	stack_capture(st, pc, sp);
+	pc = td->td_pcb->pcb_context[PCB_REG_RA];
+	sp = td->td_pcb->pcb_context[PCB_REG_SP];
+	stack_capture(st, td, pc, sp);
 	return (0);
 }
 
 void
 stack_save(struct stack *st)
 {
-	u_register_t pc, sp;
+	uintptr_t pc, sp;
 
-	if (curthread == NULL)
-		panic("stack_save: curthread == NULL");
-
-	/* XXXRW: Should be pcb_context? */
-	pc = TRAPF_PC(&curthread->td_pcb->pcb_regs);
-	sp = curthread->td_pcb->pcb_regs.sp; // FIXME: use $c11 for CHERI purecap
-	stack_capture(st, pc, sp);
+	pc = (uintptr_t)&&here;
+	sp = (uintptr_t)__builtin_frame_address(0);
+here:
+	stack_capture(st, curthread, pc, sp);
 }

--- a/sys/riscv/include/stack.h
+++ b/sys/riscv/include/stack.h
@@ -46,6 +46,6 @@ struct unwind_state {
 	uintptr_t pc;
 };
 
-int unwind_frame(struct unwind_state *);
+bool unwind_frame(struct thread *, struct unwind_state *);
 
 #endif /* !_MACHINE_STACK_H_ */

--- a/sys/riscv/riscv/db_trace.c
+++ b/sys/riscv/riscv/db_trace.c
@@ -73,7 +73,7 @@ db_md_set_watchpoint(db_expr_t addr, db_expr_t size)
 }
 
 static void
-db_stack_trace_cmd(struct unwind_state *frame)
+db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 {
 	const char *name;
 	db_expr_t offset;
@@ -100,6 +100,11 @@ db_stack_trace_cmd(struct unwind_state *frame)
 			struct trapframe *tf;
 
 			tf = (struct trapframe *)(uintptr_t)frame->sp;
+			if (!kstack_contains(td, (vm_offset_t)tf,
+			    sizeof(*tf))) {
+				db_printf("--- invalid trapframe %p\n", tf);
+				break;
+			}
 
 			if (tf->tf_scause & EXCP_INTR)
 				db_printf("--- interrupt %ld\n",
@@ -119,7 +124,7 @@ db_stack_trace_cmd(struct unwind_state *frame)
 		if (strcmp(name, "fork_trampoline") == 0)
 			break;
 
-		if (unwind_frame(frame) < 0)
+		if (!unwind_frame(td, frame))
 			break;
 	}
 }
@@ -135,7 +140,7 @@ db_trace_thread(struct thread *thr, int count)
 	frame.sp = ctx->pcb_sp;
 	frame.fp = ctx->pcb_s[0];
 	frame.pc = ctx->pcb_ra;
-	db_stack_trace_cmd(&frame);
+	db_stack_trace_cmd(thr, &frame);
 	return (0);
 }
 
@@ -150,5 +155,5 @@ db_trace_self(void)
 	frame.sp = sp;
 	frame.fp = (uintptr_t)__builtin_frame_address(0);
 	frame.pc = (uintptr_t)db_trace_self;
-	db_stack_trace_cmd(&frame);
+	db_stack_trace_cmd(curthread, &frame);
 }

--- a/sys/riscv/riscv/stack_machdep.c
+++ b/sys/riscv/riscv/stack_machdep.c
@@ -53,9 +53,8 @@ stack_capture(struct thread *td, struct stack *st, struct unwind_state *frame)
 	stack_zero(st);
 
 	while (1) {
-		if ((vm_offset_t)frame->fp < td->td_kstack ||
-		    (vm_offset_t)frame->fp >= td->td_kstack +
-		    td->td_kstack_pages * PAGE_SIZE)
+		if (!kstack_contains(td, (vm_offset_t)frame->fp -
+		    (sizeof(uintptr_t) * 2), sizeof(uintptr_t) * 2))
 			break;
 		unwind_frame(frame);
 		if (!INKERNEL((vm_offset_t)frame->pc))

--- a/sys/riscv/riscv/stack_machdep.c
+++ b/sys/riscv/riscv/stack_machdep.c
@@ -53,10 +53,8 @@ stack_capture(struct thread *td, struct stack *st, struct unwind_state *frame)
 	stack_zero(st);
 
 	while (1) {
-		if (!kstack_contains(td, (vm_offset_t)frame->fp -
-		    (sizeof(uintptr_t) * 2), sizeof(uintptr_t) * 2))
+		if (!unwind_frame(td, frame))
 			break;
-		unwind_frame(frame);
 		if (!INKERNEL((vm_offset_t)frame->pc))
 			break;
 		if (stack_put(st, frame->pc) == -1)

--- a/sys/riscv/riscv/unwind.c
+++ b/sys/riscv/riscv/unwind.c
@@ -35,23 +35,24 @@
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 #include <sys/param.h>
+#include <sys/proc.h>
 
 #include <machine/stack.h>
 #include <machine/vmparam.h>
 
-int
-unwind_frame(struct unwind_state *frame)
+bool
+unwind_frame(struct thread *td, struct unwind_state *frame)
 {
 	uintptr_t fp;
 
 	fp = frame->fp;
 
-	if (!INKERNEL(fp))
-		return (-1);
+	if (!kstack_contains(td, fp - sizeof(fp) * 2, sizeof(fp) * 2))
+		return (false);
 
 	frame->sp = fp;
 	frame->fp = ((uintptr_t *)fp)[-2];
 	frame->pc = ((uintptr_t *)fp)[-1] - 4;
 
-	return (0);
+	return (true);
 }

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -1203,6 +1203,13 @@ curthread_pflags2_restore(int save)
 	curthread->td_pflags2 &= save;
 }
 
+static __inline bool
+kstack_contains(struct thread *td, vm_offset_t va, size_t len)
+{
+	return (va >= td->td_kstack && va + len >= va &&
+	    va + len <= td->td_kstack + td->td_kstack_pages * PAGE_SIZE);
+}
+
 static __inline __pure2 struct td_sched *
 td_get_sched(struct thread *td)
 {

--- a/sys/x86/x86/stack_machdep.c
+++ b/sys/x86/x86/stack_machdep.c
@@ -79,9 +79,7 @@ stack_capture(struct thread *td, struct stack *st, register_t fp)
 	stack_zero(st);
 	frame = (x86_frame_t)fp;
 	while (1) {
-		if ((vm_offset_t)frame < td->td_kstack ||
-		    (vm_offset_t)frame >= td->td_kstack +
-		    td->td_kstack_pages * PAGE_SIZE)
+		if (!kstack_contains(td, (vm_offset_t)frame, sizeof(*frame)))
 			break;
 		callpc = frame->f_retaddr;
 		if (!INKERNEL(callpc))


### PR DESCRIPTION
Some of these are from the purecap branch.  kstack_contains() is new however, and I plan to upstream this entire series.  Alex ran into infinite recursion in the DDB stack unwinder for RISC-V that I think the last patch addresses.

I haven't yet tested this fully (still building)