### PR TITLE
src.opts.mk: Mark LIBCHERI as broken on non-MIPS, not just RISC-V

### DIFF
--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -374,8 +374,10 @@ BROKEN_OPTIONS+=CDDL
 
 # Some compilation failure: TODO: investigate
 BROKEN_OPTIONS+=SVN SVNLITE
+.endif
 
-# libcheri has not been ported to RISCV
+# libcheri is MIPS-specific and requires CHERI
+.if !${__T:Mmips64*} || (${__C} != "cheri" && !${__T:Mmips64*c*})
 BROKEN_OPTIONS+=LIBCHERI
 .endif
 


### PR DESCRIPTION
It's in __DEFAULT_NO_OPTIONS so Morello hasn't noticed yet but we should do things properly.
