### PR TITLE
Purecap world build fixes

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -111,12 +111,8 @@ LIB64_MACHINE_ARCH=aarch64
 LIB64WMAKEENV=	MACHINE_CPU="arm64 cheri"
 LIB64WMAKEFLAGS= LD="${XLD}" CPUTYPE=morello
 # XXX: clang specific
-#LIB64CPUFLAGS=	-target aarch64-unknown-freebsd13.0
-# XXXBFG: some compat64 targets (libc, cheritest) requre capability support, so
-# pass -march=morello. this makes compat binaries hybrid, so we will need to do
-# something else if that is not desired.  the above --target option does not
-# support --gdb-index, so do not use it at all.
-LIB64CPUFLAGS=	-march=morello
+LIB64CPUFLAGS=	-target aarch64-unknown-freebsd13.0
+LIB64CPUFLAGS+=	-march=morello
 # strip existing CFLAGS switches that would force the
 # compiler to emit purecap code
 LIB64_STRIP_CFLAGS=	-mabi=purecap -march=morello+c64 -femulated-tls

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -156,11 +156,15 @@ _CPUCFLAGS = -cheri=128
 _CPUCFLAGS = -march=${CPUTYPE:S/^mips//}
 . endif
 . elif ${MACHINE_CPUARCH} == "aarch64"
-.  if ${CPUTYPE:Marmv*} != "" || ${CPUTYPE:Mmorello*} != ""
+.  if ${CPUTYPE:Marmv*} != ""
 .   if !defined(NO_CHERI)
 # Use -march when the CPU type is an architecture value, e.g. armv8.1-a
 _CPUCFLAGS = -march=${CPUTYPE}
 .   endif
+.  elif ${CPUTYPE:Mmorello*} != ""
+# Don't use -march; we will add -march=morello or -march=morello+c64 later but
+# adding -march=morello here would override that as _CPUCFLAGS is added late.
+# It is also not a valid value for -mcpu.
 .  else
 # Otherwise assume we have a CPU type
 _CPUCFLAGS = -mcpu=${CPUTYPE}

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -374,6 +374,8 @@ BROKEN_OPTIONS+=NS_CACHING
 #   _Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0, "fix pcpu size");
 #
 BROKEN_OPTIONS+=CDDL
+# Broken; see the MIPS comment
+BROKEN_OPTIONS+=OFED
 .endif
 
 .if ${__T:Mriscv*c*}

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -368,6 +368,14 @@ BROKEN_OPTIONS+=GOOGLETEST SSP
 BROKEN_OPTIONS+=NS_CACHING
 .endif
 
+.if ${__T} == "morello"
+# Transitively includes pcpu.h pcpu_aux.h and fails on the:
+#
+#   _Static_assert(PAGE_SIZE % sizeof(struct pcpu) == 0, "fix pcpu size");
+#
+BROKEN_OPTIONS+=CDDL
+.endif
+
 .if ${__T:Mriscv*c*}
 # Crash in ZFS code. TODO: investigate
 BROKEN_OPTIONS+=CDDL


### PR DESCRIPTION
`cheribuild cheribsd-morello-hybrid` worked out of the box but `cheribuild cheribsd-morello-purecap` gave various errors which these commits fix*. This may well duplicate some of Brett's work, but figured I should post these in case things have been missed or done differently.

* My build hasn't actually finished yet but it's still going