### PR TITLE
mips: Remove pointless cheri_signal_copy

### DIFF
--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -139,12 +139,6 @@ int	cheri_signal_sandboxed(struct thread *td);
 void	hybridabi_sendsig(struct thread *td);
 
 /*
- * Functions to set up and manipulate CHERI contexts and stacks.
- */
-struct pcb;
-void	cheri_signal_copy(struct pcb *dst, struct pcb *src);
-
-/*
  * Functions to manage object types.
  */
 otype_t	cheri_otype_alloc(void);

--- a/sys/mips/cheri/cheri_signal.c
+++ b/sys/mips/cheri/cheri_signal.c
@@ -45,20 +45,6 @@
 #include <machine/sysarch.h>
 
 /*
- * When new threads are forked, by default simply replicate the parent
- * thread's CHERI-related signal-handling state.
- *
- * XXXRW: Is this, in fact, the right thing?
- */
-void
-cheri_signal_copy(struct pcb *dst, struct pcb *src)
-{
-
-	memcpy(&dst->pcb_cherisignal, &src->pcb_cherisignal,
-	    sizeof(dst->pcb_cherisignal));
-}
-
-/*
  * As with system calls, handling signal delivery connotes special authority
  * in the runtime environment.  In the signal delivery code, we need to
  * determine whether to trust the executing thread to have valid stack state,

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -116,9 +116,6 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	 * longer (this copy does them both) 
 	 */
 	bcopy(td1->td_pcb, pcb2, sizeof(*pcb2));
-#ifdef CPU_CHERI
-	cheri_signal_copy(pcb2, td1->td_pcb);
-#endif
 
 	/* Point mdproc and then copy over td1's contents */
 	td2->td_md.md_flags = td1->td_md.md_flags & MDTD_FPUSED;
@@ -438,9 +435,6 @@ cpu_copy_thread(struct thread *td, struct thread *td0)
 	 * is needed.
 	 */
 	bcopy(td0->td_pcb, pcb2, sizeof(*pcb2));
-#ifdef CPU_CHERI
-	cheri_signal_copy(pcb2, td0->td_pcb);
-#endif
 
 	/*
 	 * Set registers for trampoline to user mode.


### PR DESCRIPTION
I noticed the MI cheri.h had this MIPS-specific prototype. However, rather than moving it to an MD header, it can just be deleted as both uses of it are immediately preceded by a bcopy of the entire PCB so this function is a complete and utter waste of time.
