### PR TITLE
riscv: Add cast for PRINT_REG_ARG in hybrid kernels not just purecap

### DIFF
--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -188,12 +188,15 @@ cpu_fetch_syscall_args(struct thread *td)
 
 #include "../../kern/subr_syscall.c"
 
+/*
+ * This cannot use _CHERI_PRINTF_CAP_ARG due to the casts (the trapframe stores
+ * uintcap_t rather than void * __capability).
+ */
 #if __has_feature(capabilities)
-/* This cannot use _CHERI_PRINTF_CAP_ARG due to the cast for purecap. */
 #ifdef __CHERI_PURE_CAPABILITY__
 #define	PRINT_REG_ARG(value)	((void * __capability)(value))
 #else
-#define	PRINT_REG_ARG(value)	(&(value))
+#define	PRINT_REG_ARG(value)	((void * __capability *)&(value))
 #endif
 #define PRINT_REG(name, value)					\
 	printf(name " = " _CHERI_PRINTF_CAP_FMT "\n",		\


### PR DESCRIPTION
Currently Clang will accept any non-capability pointer for %lp in hybrid, but I have a PR open that, among other things, adds proper type checking for %lp, so (uintcap_t *) becomes forbidden just like uintptr_t isn't a valid argument for %p.
