### PR TITLE
SysV shared memory cleanup

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -1725,6 +1725,10 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Check that minherit() rejects invalid pointer arguments",
 	  .ct_func = test_cheriabi_minherit_invalid_ptr },
 
+	{ .ct_name = "test_cheriabi_shmdt_invalid_ptr",
+	  .ct_desc = "Check that shmdt() rejects invalid pointer arguments",
+	  .ct_func = test_cheriabi_shmdt_invalid_ptr },
+
 	/*
 	 * Tests for pathname handling in open(2).
 	 */

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -370,6 +370,7 @@ DECLARE_CHERIBSD_TEST(test_cheriabi_malloc_zero_size);
 DECLARE_CHERIBSD_TEST(test_cheriabi_munmap_invalid_ptr);
 DECLARE_CHERIBSD_TEST(test_cheriabi_mprotect_invalid_ptr);
 DECLARE_CHERIBSD_TEST(test_cheriabi_minherit_invalid_ptr);
+DECLARE_CHERIBSD_TEST(test_cheriabi_shmdt_invalid_ptr);
 
 /* cheribsdtest_cheriabi_open.c */
 DECLARE_CHERIBSD_TEST(test_cheriabi_open_ordinary);

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -105,6 +105,17 @@ cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
 	return (addr >= cheri_getbase(cap) && addr < cheri_gettop(cap));
 }
 
+#ifdef __cplusplus
+static __always_inline inline bool
+#else
+static __always_inline inline _Bool
+#endif
+cheri_is_null_derived(const void * __capability cap)
+{
+	return (__builtin_cheri_equal_exact((uintcap_t)cheri_getaddress(cap),
+	    cap));
+}
+
 /*
  * Two variations on cheri_ptr() based on whether we are looking for a code or
  * data capability.  The compiler's use of CFromPtr will be with respect to

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -480,10 +480,10 @@ kern_shmat_locked(struct thread *td, int shmid,
 	KASSERT(size == CHERI_REPRESENTABLE_LENGTH(size),
 	    ("shmget left unrepresentable size %zu", size));
 #endif
-	prot = VM_PROT_READ | VM_PROT_READ_CAP;
+	prot = VM_PROT_READ;
 	cow = MAP_INHERIT_SHARE | MAP_PREFAULT_PARTIAL;
 	if ((shmflg & SHM_RDONLY) == 0)
-		prot |= VM_PROT_WRITE | VM_PROT_WRITE_CAP;
+		prot |= VM_PROT_WRITE;
 	if (shmaddr != NULL) {
 		attach_va = (__cheri_addr vm_offset_t)shmaddr;
 		if ((shmflg & SHM_RND) != 0)


### PR DESCRIPTION
- Fix issues around validating capabilities passed to shmdt (#728).
- Improve handling of shmaddr != NULL in shmat (needed for tests of the shmdt fixes).
- Disable loading or storing capabilities in shared memory mapping.