### PR TITLE
vm_fault_quick_hold_pages: check cap permissions

### DIFF
--- a/sys/vm/vm_extern.h
+++ b/sys/vm/vm_extern.h
@@ -85,6 +85,9 @@ void kmeminit(void);
 
 int kernacc(void *, int, int);
 int useracc(void * __capability, int, int);
+#if __has_feature(capabilities)
+bool vm_cap_allows_prot(const void * __capability, vm_prot_t);
+#endif
 int vm_fault(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
     int fault_flags, vm_page_t *m_hold);
 void vm_fault_copy_entry(vm_map_t, vm_map_t, vm_map_entry_t, vm_map_entry_t,

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -1840,7 +1840,7 @@ vm_fault_quick_hold_pages(vm_map_t map, void * __capability addr, vm_size_t len,
 	if (len == 0)
 		return (0);
 #if __has_feature(capabilities)
-	if (!__CAP_CHECK(addr, len))
+	if (!__CAP_CHECK(addr, len) || !vm_cap_allows_prot(addr, prot))
 		return (-1);
 #endif
 	start = (__cheri_addr vm_offset_t)trunc_page(addr);

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -159,28 +159,12 @@ useracc(void * __capability cap, int len, int rw)
 	boolean_t rv;
 	vm_prot_t prot;
 	vm_map_t map;
-#if __has_feature(capabilities)
-	register_t reqperm;
-#endif
 
 	KASSERT((rw & ~VM_PROT_ALL) == 0,
 	    ("illegal ``rw'' argument to useracc (%x)\n", rw));
 	prot = rw;
 #if __has_feature(capabilities)
-	if (!__CAP_CHECK(cap, len))
-		return (FALSE);
-	reqperm = CHERI_PERM_GLOBAL;
-	if (prot & VM_PROT_READ)
-		reqperm |= CHERI_PERM_LOAD;
-	if (prot & VM_PROT_READ_CAP)
-		reqperm |= CHERI_PERM_LOAD_CAP;
-	if (prot & VM_PROT_WRITE)
-		reqperm |= CHERI_PERM_STORE;
-	if (prot & VM_PROT_WRITE_CAP)
-		reqperm |= CHERI_PERM_STORE_CAP;
-	if (prot & VM_PROT_EXECUTE)
-		reqperm |= CHERI_PERM_EXECUTE;
-	if ((cheri_getperm(cap) & reqperm) != reqperm)
+	if (!__CAP_CHECK(cap, len) || !vm_cap_allows_prot(cap, prot))
 		return (FALSE);
 #endif
 	addr = (__cheri_addr vm_offset_t)cap;
@@ -670,6 +654,29 @@ kick_proc0(void)
 
 	wakeup(&proc0);
 }
+
+#if __has_feature(capabilities)
+bool
+vm_cap_allows_prot(const void * __capability cap, vm_prot_t prot)
+{
+	register_t reqperm;
+
+	reqperm = 0;
+	if (prot & VM_PROT_READ)
+		reqperm |= CHERI_PERM_LOAD;
+	if (prot & VM_PROT_READ_CAP)
+		reqperm |= CHERI_PERM_LOAD_CAP;
+	if (prot & VM_PROT_WRITE)
+		reqperm |= CHERI_PERM_STORE;
+	if (prot & VM_PROT_WRITE_CAP)
+		reqperm |= CHERI_PERM_STORE_CAP;
+	if (prot & VM_PROT_EXECUTE)
+		reqperm |= CHERI_PERM_EXECUTE;
+	if ((cheri_getperm(cap) & reqperm) != reqperm)
+		return (false);
+	return (true);
+}
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20181114,


### PR DESCRIPTION
Add a vm_cap_allows_prot() to check if a capability has permissions
matching a given vm_prot_t.

Also use vm_cap_allows_prot in useracc and as a result drop the
requirement that the capability be global.  There is reason to belive
that most capabilities will be local in a co-process world.

Fixes #735

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ctsrd-cheri/cheribsd/742)
<!-- Reviewable:end -->
