### PR TITLE
[UPSTREAM] Add .cfi_{start,end}proc annotations for MIPS assembly

### DIFF
--- a/libexec/rtld-elf/mips/rtld_start.S
+++ b/libexec/rtld-elf/mips/rtld_start.S
@@ -72,7 +72,6 @@
  *      c4      relocabase capability
  */
 LEAF(rtld_start)
-	// .cfi_startproc
 	dli		sp, -SFRAME_SIZE
 	cincoffset	$c11, $c11, sp
 	csc		$c3, zero, SFRAME_AUXARGS($c11)
@@ -131,7 +130,6 @@ LEAF(rtld_start)
 	cmove		$cra, $c12 /* return == PCC signals backtrace routine to stop */
 	cjr		$c12
 	nop
-	// .cfi_endproc
 END(rtld_start)
 
 #define	_XCALLFRAME_SIZ		(11*SZREG + XCALLFRAME_CAPSIZ)
@@ -299,7 +297,6 @@ LEAF(_rtld_bind_start)
 #endif
 	cjr	$c12	# call the resolved target
 	cincoffset $c11, $c11, XCALLFRAME_SIZ	# delay slot
-	// .cfi_endproc
 END(_rtld_bind_start)
 
 #else /* __CHERI_PURE_CAPABILITY__ */
@@ -459,7 +456,6 @@ _rtld_bind_start:
 	move	t9, v0
 	jr	t9
 	nop
-	.cfi_endproc
 END(_rtld_bind_start)
 
 
@@ -551,7 +547,6 @@ _rtld_pltbind_start:
 	move	t9, v0
 	jr	t9
 	nop
-	.cfi_endproc
 END(_rtld_pltbind_start)
 
 #endif /* __CHERI_PURE_CAPABILITY__ */

--- a/sys/mips/include/asm.h
+++ b/sys/mips/include/asm.h
@@ -136,7 +136,7 @@
 	.globl sym; sym:
 
 #define	ENTRY(sym)						\
-	.text; .globl sym; .ent sym; sym:
+	.text; .globl sym; .ent sym; sym: .cfi_startproc;
 
 #define	ASM_ENTRY(sym)						\
 	.text; .globl sym; .type sym,@function; sym:
@@ -160,7 +160,8 @@
 	.ent	_C_LABEL(x);	\
 	.type	_C_LABEL(x),@function;	\
 _C_LABEL(x): ;			\
-	.frame _FRAME_STACK_REG, 0, _FRAME_RETURN_REG;	\
+	.frame _FRAME_STACK_REG, 0, _FRAME_RETURN_REG; \
+	.cfi_startproc; \
 	MCOUNT
 
 /*
@@ -172,7 +173,8 @@ _C_LABEL(x): ;			\
 	.ent	_C_LABEL(x);	\
 	.type	_C_LABEL(x),@function;	\
 _C_LABEL(x): ;			\
-	.frame	_FRAME_STACK_REG, 0, _FRAME_RETURN_REG
+	.frame	_FRAME_STACK_REG, 0, _FRAME_RETURN_REG; \
+	.cfi_startproc
 
 /*
  * XLEAF
@@ -195,6 +197,7 @@ _C_LABEL(x):
 	.type	_C_LABEL(x),@function;	\
 _C_LABEL(x): ;				\
 	.frame	_FRAME_STACK_REG, fsize, retpc;	\
+	.cfi_startproc;	\
 	MCOUNT
 
 /*
@@ -206,7 +209,8 @@ _C_LABEL(x): ;				\
 	.ent	_C_LABEL(x);			\
 	.type	_C_LABEL(x),@function;	\
 _C_LABEL(x): ;					\
-	.frame	_FRAME_STACK_REG, fsize, retpc
+	.frame	_FRAME_STACK_REG, fsize, retpc;	\
+	.cfi_startproc
 
 /*
  * XNESTED
@@ -223,11 +227,12 @@ _C_LABEL(x):
  * END
  *	Mark end of a procedure.
  */
-#define	END(x)			\
+#define	END(x) \
+	.cfi_endproc; \
 	.end _C_LABEL(x)
 
 /*
- * END
+ * XEND
  *	Mark end of an alternate entry point.
  */
 #define	XEND(x)				\
@@ -255,6 +260,7 @@ _C_LABEL(x):
 #define	VECTOR(x, regmask)	\
 	.ent	_C_LABEL(x);	\
 	EXPORT(x);		\
+	.cfi_startproc
 
 #define	VECTOR_END(x)		\
 	EXPORT(x ## End);	\
@@ -280,9 +286,9 @@ _C_LABEL(x):
 	MSG(msg)
 
 #define	MSG(msg)			\
-	.section rdata;	       		\
+	.pushsection .rodata;		\
 9:	.asciiz	msg;			\
-	.text
+	.popsection
 
 #define	ASMSTR(str)			\
 	.asciiz str;			\

--- a/sys/riscv/include/asm.h
+++ b/sys/riscv/include/asm.h
@@ -47,8 +47,8 @@
 #define	_C_LABEL(x)	x
 
 #define	ENTRY(sym)						\
-	.text; .globl sym; .type sym,@function; .align 4; sym:
-#define	END(sym) .size sym, . - sym
+	.text; .globl sym; .type sym,@function; .align 4; sym: .cfi_startproc;
+#define	END(sym) .cfi_endproc; .size sym, . - sym
 
 #define	EENTRY(sym)						\
 	.globl	sym; sym:


### PR DESCRIPTION
This gives me sensible GDB backtraces when I set an breakpoint in an
assembly function such as suword64.

I also had to create https://reviews.llvm.org/D89787 to get sensible error messages from clang when encountering mismatched annotations.