### PR TITLE
Fix panic triggered by pkill j test

### DIFF
--- a/sys/compat/freebsd32/freebsd32_util.h
+++ b/sys/compat/freebsd32/freebsd32_util.h
@@ -121,8 +121,8 @@ struct iovec32;
 struct rusage32;
 int	freebsd32_copyout_strings(struct image_params *imgp,
 	    uintptr_t *stack_base);
-int	freebsd32_copyiniov(struct iovec32 * __capability iovp, u_int iovcnt,
-	    struct iovec **iov, int error);
+int	freebsd32_copyiniov(const struct iovec * __capability cb_arg,
+	    u_int iovcnt, struct iovec **iov, int error);
 void	freebsd32_rusage_out(const struct rusage *s, struct rusage32 *s32);
 
 #endif /* !_COMPAT_FREEBSD32_FREEBSD32_UTIL_H_ */

--- a/sys/compat/freebsd64/freebsd64_generic.c
+++ b/sys/compat/freebsd64/freebsd64_generic.c
@@ -83,7 +83,7 @@ freebsd64_readv(struct thread *td, struct freebsd64_readv_args *uap)
 {
 
 	return (user_readv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, (copyinuio_t *)freebsd64_copyinuio));
+	    uap->iovcnt), uap->iovcnt, freebsd64_copyinuio));
 }
 
 int
@@ -91,8 +91,7 @@ freebsd64_preadv(struct thread *td, struct freebsd64_preadv_args *uap)
 {
 
 	return (user_preadv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, uap->offset,
-	    (copyinuio_t *)freebsd64_copyinuio));
+	    uap->iovcnt), uap->iovcnt, uap->offset, freebsd64_copyinuio));
 }
 
 int
@@ -127,16 +126,16 @@ freebsd64_writev(struct thread *td, struct freebsd64_writev_args *uap)
 {
 
 	return (user_writev(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, (copyinuio_t *)freebsd64_copyinuio));
+	    uap->iovcnt), uap->iovcnt, freebsd64_copyinuio));
 }
 
 int
 freebsd64_pwritev(struct thread *td, struct freebsd64_pwritev_args *uap)
 {
 
-	return (user_pwritev(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
-	    uap->iovcnt), uap->iovcnt, uap->offset,
-	    (copyinuio_t *)freebsd64_copyinuio));
+	return (user_pwritev(td, uap->fd,
+	    (struct iovec *__capability)__USER_CAP_ARRAY(uap->iovp,
+		uap->iovcnt), uap->iovcnt, uap->offset, freebsd64_copyinuio));
 }
 
 int

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -130,8 +130,8 @@ freebsd64_copyinmsghdr(struct msghdr64 * __capability umsg, struct msghdr *msg,
 
 	msg->msg_iov = NULL;
 	error = freebsd64_copyiniov(
-            __USER_CAP_ARRAY((struct iovec64 *)(uintptr_t)m64->msg_iov,
-                m64->msg_iovlen),
+	    (struct iovec *__capability)__USER_CAP_ARRAY(
+		(struct iovec64 *)(uintptr_t)m64->msg_iov, m64->msg_iovlen),
 	    m64->msg_iovlen, &iov, EMSGSIZE);
 	if (error)
 		return (error);

--- a/sys/compat/freebsd64/freebsd64_util.h
+++ b/sys/compat/freebsd64/freebsd64_util.h
@@ -105,10 +105,10 @@ int    freebsd64_syscall_helper_unregister(struct syscall_helper_data *sd);
 struct iovec64;
 int	freebsd64_copyout_strings(struct image_params *imgp,
 	    uintcap_t *);
-int	freebsd64_copyiniov(struct iovec64 * __capability iovp, u_int iovcnt,
-	    struct iovec **iov, int error);
-int	freebsd64_copyinuio(struct iovec64 * __capability iovp, u_int iovcnt,
-	    struct uio **uiop);
+int	freebsd64_copyiniov(const struct iovec * __capability cb_arg,
+	    u_int iovcnt, struct iovec **iov, int error);
+int	freebsd64_copyinuio(const struct iovec * __capability cb_arg,
+	    u_int iovcnt, struct uio **uiop);
 
 int	freebsd64_get_mcontext(struct thread *td, mcontext64_t *mcp, int flags);
 int	freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp);

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -476,13 +476,13 @@ int
 sys_jail_set(struct thread *td, struct jail_set_args *uap)
 {
 
-	return (user_jail_set(td, uap->iovp,
-	    uap->iovcnt, uap->flags, (copyinuio_t *)copyinuio));
+	return (user_jail_set(td, uap->iovp, uap->iovcnt, uap->flags,
+	    copyinuio));
 }
 
 int
-user_jail_set(struct thread *td, void * __capability iovp, unsigned int iovcnt,
-    int flags, copyinuio_t *copyinuio_f)
+user_jail_set(struct thread *td, struct iovec * __capability iovp,
+    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f)
 {
 	struct uio *auio;
 	int error;
@@ -1929,14 +1929,14 @@ int
 sys_jail_get(struct thread *td, struct jail_get_args *uap)
 {
 
-	return (user_jail_get(td, uap->iovp,
-	    uap->iovcnt, uap->flags, (copyinuio_t *)copyinuio,
-	    (updateiov_t *)updateiov));
+	return (user_jail_get(td, uap->iovp, uap->iovcnt, uap->flags,
+	    copyinuio, updateiov));
 }
 
 int
-user_jail_get(struct thread *td, void * __capability iovp, unsigned int iovcnt,
-    int flags, copyinuio_t *copyinuio_f, updateiov_t *updateiov_f)
+user_jail_get(struct thread *td, struct iovec * __capability iovp,
+    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f,
+    updateiov_t *updateiov_f)
 {
 	struct uio *auio;
 	int error;

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -491,7 +491,7 @@ user_jail_set(struct thread *td, struct iovec * __capability iovp,
 	if (iovcnt & 1)
 		return (EINVAL);
 
-	error = copyinuio(iovp, iovcnt, &auio);
+	error = copyinuio_f(iovp, iovcnt, &auio);
 	if (error)
 		return (error);
 	error = kern_jail_set(td, auio, flags);

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1325,7 +1325,7 @@ sys_sendfile(struct thread *td, struct sendfile_args *uap)
  
 	return (kern_sendfile(td, uap->fd, uap->s, uap->offset,
 	    uap->nbytes, uap->hdtr, uap->sbytes, uap->flags, 0,
-	    (copyin_hdtr_t *)copyin_hdtr, (copyinuio_t *)copyinuio));
+	    (copyin_hdtr_t *)copyin_hdtr, copyinuio));
 }
 
 #ifdef COMPAT_FREEBSD4
@@ -1335,7 +1335,7 @@ freebsd4_sendfile(struct thread *td, struct freebsd4_sendfile_args *uap)
 
 	return (kern_sendfile(td, uap->fd, uap->s, uap->offset,
 	    uap->nbytes, uap->hdtr, uap->sbytes, uap->flags, 1,
-	    (copyin_hdtr_t *)copyin_hdtr, (copyinuio_t *)copyinuio));
+	    (copyin_hdtr_t *)copyin_hdtr, copyinuio));
 }
 #endif /* COMPAT_FREEBSD4 */
 // CHERI CHANGES START

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -437,7 +437,7 @@ copyinuio(const struct iovec * __capability iovp, u_int iovcnt,
  * iovec.
  */
 int
-updateiov(const struct uio *uiop, struct iovec *iovp)
+updateiov(const struct uio *uiop, struct iovec * __capability iovp)
 {
 	int i, error;
 

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -444,7 +444,7 @@ updateiov(const struct uio *uiop, struct iovec *iovp)
 	for (i = 0; i < uiop->uio_iovcnt; i++) {
 		error = suword(&iovp[i].iov_len, uiop->uio_iov[i].iov_len);
 		if (error != 0)
-			return (error);
+			return (EFAULT);
 	}
 	return (0);
 }

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -269,13 +269,12 @@ int
 sys_readv(struct thread *td, struct readv_args *uap)
 {
 
-	return (user_readv(td, uap->fd, uap->iovp, uap->iovcnt,
-	    (copyinuio_t *)copyinuio));
+	return (user_readv(td, uap->fd, uap->iovp, uap->iovcnt, copyinuio));
 }
 
 int
-user_readv(struct thread *td, int fd, void * __capability iovp, u_int iovcnt,
-    copyinuio_t *copyinuio_f)
+user_readv(struct thread *td, int fd, struct iovec * __capability iovp,
+    u_int iovcnt, copyinuio_t *copyinuio_f)
 {
 	struct uio *auio;
 	int error;
@@ -318,12 +317,12 @@ sys_preadv(struct thread *td, struct preadv_args *uap)
 {
 
 	return (user_preadv(td, uap->fd, uap->iovp, uap->iovcnt, uap->offset,
-	    (copyinuio_t *)copyinuio));
+	    copyinuio));
 }
 
 int
-user_preadv(struct thread *td, int fd, void * __capability iovp, u_int iovcnt,
-    off_t offset, copyinuio_t *copyinuio_f)
+user_preadv(struct thread *td, int fd, struct iovec * __capability iovp,
+    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f)
 {
 	struct uio *auio;
 	int error;
@@ -495,13 +494,12 @@ int
 sys_writev(struct thread *td, struct writev_args *uap)
 {
 
-	return (user_writev(td, uap->fd, uap->iovp, uap->iovcnt,
-	    (copyinuio_t *)copyinuio));
+	return (user_writev(td, uap->fd, uap->iovp, uap->iovcnt, copyinuio));
 }
 
 int
-user_writev(struct thread *td, int fd, void * __capability iovp, u_int iovcnt,
-    copyinuio_t *copyinuio_f)
+user_writev(struct thread *td, int fd, struct iovec * __capability iovp,
+    u_int iovcnt, copyinuio_t *copyinuio_f)
 {
 	struct uio *auio;
 	int error;
@@ -544,12 +542,12 @@ sys_pwritev(struct thread *td, struct pwritev_args *uap)
 {
 
 	return (user_pwritev(td, uap->fd, uap->iovp, uap->iovcnt, uap->offset,
-	    (copyinuio_t *)copyinuio));
+	    copyinuio));
 }
 
 int
-user_pwritev(struct thread *td, int fd, void *__capability iovp, u_int iovcnt,
-    off_t offset, copyinuio_t *copyinuio_f)
+user_pwritev(struct thread *td, int fd, struct iovec * __capability iovp,
+    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f)
 {
 	struct uio *auio;
 	int error;
@@ -1542,7 +1540,7 @@ sys_ppoll(struct thread *td, struct ppoll_args *uap)
 }
 
 int
-user_ppoll(struct thread *td, struct pollfd *__capability fds, u_int nfds,
+user_ppoll(struct thread *td, struct pollfd * __capability fds, u_int nfds,
     const struct timespec * __capability uts,
     const sigset_t * __capability uset)
 {

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -410,11 +410,11 @@ sys_nmount(struct thread *td, struct nmount_args *uap)
 {
 
 	return (kern_nmount(td, uap->iovp, uap->iovcnt, uap->flags,
-	    (copyinuio_t *)copyinuio));
+	    copyinuio));
 }
 
 int
-kern_nmount(struct thread *td, void * __capability iovp, u_int iovcnt,
+kern_nmount(struct thread *td, struct iovec * __capability iovp, u_int iovcnt,
     int flags32, copyinuio_t * copyinuio_f)
 {
 	struct uio *auio;

--- a/sys/mips/mips/trap.c
+++ b/sys/mips/mips/trap.c
@@ -436,6 +436,8 @@ trapf_pc_from_kernel_code_ptr(void *ptr)
  * Fetch an instruction from near frame->pc (or frame->pcc for CHERI).
  * Returns the virtual address (relative to $pcc) that was used to fetch the
  * instruction.
+ *
+ * Warning: this clobbers td->td_pcb->pcb_onfault.
  */
 static void * __capability
 fetch_instr_near_pc(struct trapframe *frame, register_t offset_from_pc, int32_t *instr)
@@ -444,6 +446,8 @@ fetch_instr_near_pc(struct trapframe *frame, register_t offset_from_pc, int32_t 
 
 	/* Should only be called from user mode */
 	/* TODO: if KERNLAND() */
+	KASSERT(curthread->td_pcb->pcb_onfault == NULL,
+	    ("This function clobbers td->td_pcb->pcb_onfault"));
 #ifdef CPU_CHERI
 	bad_inst_ptr = (char * __capability)frame->pcc + offset_from_pc;
 	if (!cheri_gettag(bad_inst_ptr)) {
@@ -1347,7 +1351,12 @@ dofault:
 		/* Only allow emulation on a user address */
 		if (allow_unaligned_acc &&
 		    ((vm_offset_t)trapframe->badvaddr < VM_MAXUSER_ADDRESS)) {
+			void *saved_onfault;
 			int mode;
+
+			/* emulate_unaligned_access() clobbers pcb_onfault. */
+			saved_onfault = td->td_pcb->pcb_onfault;
+			td->td_pcb->pcb_onfault = NULL;
 
 			if (type == T_ADDR_ERR_LD)
 				mode = VM_PROT_READ;
@@ -1355,6 +1364,7 @@ dofault:
 				mode = VM_PROT_WRITE;
 
 			access_type = emulate_unaligned_access(trapframe, mode);
+			td->td_pcb->pcb_onfault = saved_onfault;
 			if (access_type != 0)
 				return (trapframe->pc);
 		}

--- a/sys/netinet/sctp_syscalls.c
+++ b/sys/netinet/sctp_syscalls.c
@@ -121,12 +121,12 @@ static int	kern_sys_sctp_generic_sendmsg(struct thread *td, int sd,
 		    const struct sockaddr * __capability uto, socklen_t tolen,
 		    struct sctp_sndrcvinfo * __capability usinfo, int flags);
 static int	kern_sctp_generic_sendmsg_iov(struct thread *td, int sd,
-		    void * __capability uiov, int iovlen,
+		    struct iovec * __capability uiov, int iovlen,
 		    const struct sockaddr * __capability uto, socklen_t tolen,
 		    struct sctp_sndrcvinfo * __capability usinfo, int flags,
 		    copyiniov_t *copyiniov_f);
 static int	kern_sctp_generic_recvmsg(struct thread *td, int sd,
-		    void * __capability uiov, int iovlen,
+		    struct iovec * __capability uiov, int iovlen,
 		    struct sockaddr * __capability from,
 		    socklen_t * __capability fromlenaddr,
 		    struct sctp_sndrcvinfo * __capability usinfo,
@@ -404,10 +404,9 @@ freebsd32_sctp_generic_sendmsg_iov(struct thread *td,
 {
 
 	return (kern_sctp_generic_sendmsg_iov(td, uap->sd,
-	    __USER_CAP_ARRAY(uap->iov, uap->iovlen), uap->iovlen,
-	    __USER_CAP(uap->to, uap->tolen), uap->tolen,
-	    __USER_CAP_OBJ(uap->sinfo), uap->flags,
-	    (copyiniov_t *)freebsd32_copyiniov));
+	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, __USER_CAP(uap->to, uap->tolen), uap->tolen,
+	    __USER_CAP_OBJ(uap->sinfo), uap->flags, freebsd32_copyiniov));
 }
 #endif
 
@@ -418,17 +417,17 @@ freebsd64_sctp_generic_sendmsg_iov(struct thread *td,
 {
 
 	return (kern_sctp_generic_sendmsg_iov(td, uap->sd,
-	    __USER_CAP_ARRAY(uap->iov, uap->iovlen), uap->iovlen,
-	    __USER_CAP(uap->to, uap->tolen), uap->tolen,
-	    __USER_CAP_OBJ(uap->sinfo), uap->flags,
-	    (copyiniov_t *)freebsd64_copyiniov));
+	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, __USER_CAP(uap->to, uap->tolen), uap->tolen,
+	    __USER_CAP_OBJ(uap->sinfo), uap->flags, freebsd64_copyiniov));
 }
 #endif
 
 static int
 kern_sctp_generic_sendmsg_iov(struct thread *td, int sd,
-    void * __capability uiov, int iovlen, const struct sockaddr * __capability uto,
-    socklen_t tolen, struct sctp_sndrcvinfo * __capability usinfo, int flags,
+    struct iovec * __capability uiov, int iovlen,
+    const struct sockaddr * __capability uto, socklen_t tolen,
+    struct sctp_sndrcvinfo * __capability usinfo, int flags,
     copyiniov_t *copyiniov_f)
 {
 #if (defined(INET) || defined(INET6)) && defined(SCTP)
@@ -570,10 +569,10 @@ freebsd32_sctp_generic_recvmsg(struct thread *td,
 {
 
 	return (kern_sctp_generic_recvmsg(td, uap->sd,
-	   __USER_CAP_ARRAY(uap->iov, uap->iovlen), uap->iovlen,
-	   __USER_CAP_UNBOUND(uap->from),
-	   __USER_CAP_OBJ(uap->fromlenaddr), __USER_CAP_OBJ(uap->sinfo),
-	   __USER_CAP_OBJ(uap->msg_flags), (copyiniov_t *)freebsd32_copyiniov));
+	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, __USER_CAP_UNBOUND(uap->from),
+	    __USER_CAP_OBJ(uap->fromlenaddr), __USER_CAP_OBJ(uap->sinfo),
+	    __USER_CAP_OBJ(uap->msg_flags), freebsd32_copyiniov));
 }
 #endif
 
@@ -584,17 +583,17 @@ freebsd64_sctp_generic_recvmsg(struct thread *td,
 {
 
 	return (kern_sctp_generic_recvmsg(td, uap->sd,
-	   __USER_CAP_ARRAY(uap->iov, uap->iovlen), uap->iovlen,
-	   __USER_CAP_UNBOUND(uap->from),
-	   __USER_CAP_OBJ(uap->fromlenaddr), __USER_CAP_OBJ(uap->sinfo),
-	   __USER_CAP_OBJ(uap->msg_flags), (copyiniov_t *)freebsd64_copyiniov));
+	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, __USER_CAP_UNBOUND(uap->from),
+	    __USER_CAP_OBJ(uap->fromlenaddr), __USER_CAP_OBJ(uap->sinfo),
+	    __USER_CAP_OBJ(uap->msg_flags), freebsd64_copyiniov));
 }
 #endif
 
 static int
-kern_sctp_generic_recvmsg(struct thread *td, int sd, void * __capability uiov, 
-    int iovlen, struct sockaddr * __capability from,
-    socklen_t * __capability fromlenaddr,
+kern_sctp_generic_recvmsg(struct thread *td, int sd,
+    struct iovec * __capability uiov, int iovlen,
+    struct sockaddr * __capability from, socklen_t * __capability fromlenaddr,
     struct sctp_sndrcvinfo * __capability usinfo,
     int * __capability umsg_flags, copyiniov_t *copyiniov_f)
 {

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -80,11 +80,12 @@ struct iovec {
 #ifdef _KERNEL
 struct uio;
 
-typedef int (copyiniov_t)(const struct iovec * __capability iovp, u_int iovcnt,
-            struct iovec **iov, int error);
-typedef int (copyinuio_t)(void * __capability iovp, u_int iovcnt,
-	    struct uio **iov);
-typedef int (updateiov_t)(const struct uio *uiop, void * __capability iovp);
+typedef int(copyiniov_t)(const struct iovec * __capability iovp, u_int iovcnt,
+    struct iovec **iov, int error);
+typedef int(copyinuio_t)(const struct iovec * __capability iovp, u_int iovcnt,
+    struct uio **iov);
+typedef int(updateiov_t)(const struct uio *uiop,
+    struct iovec * __capability iovp);
 #endif
 
 #endif /* !_SYS__IOVEC_H_ */

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -358,8 +358,8 @@ int	kern_munlock(struct thread *td, uintptr_t addr, size_t size);
 int	kern_munmap(struct thread *td, uintptr_t addr, size_t size);
 int     kern_nanosleep(struct thread *td, struct timespec *rqt,
 	    struct timespec *rmt);
-int	kern_nmount(struct thread *td, void * __capability iovp, u_int iovcnt,
-	    int flags32, copyinuio_t * copyinuio_f);
+int	kern_nmount(struct thread *td, struct iovec * __capability iovp,
+	    u_int iovcnt, int flags32, copyinuio_t * copyinuio_f);
 int	kern_ntp_adjtime(struct thread *td, struct timex *tp, int *retval);
 int	kern_ntp_gettime(struct thread *td,
 	    struct ntptimeval * __capability ntvp);
@@ -610,10 +610,10 @@ int	user_getsockopt(struct thread *td, int s, int level, int name,
 	    void * __capability val, socklen_t * __capability avalsize);
 int	user_ioctl(struct thread *td, int fd, u_long com,
 	    void * __capability udata, void *datap, int copycaps);
-int	user_jail_get(struct thread *td, void * __capability iovp,
+int	user_jail_get(struct thread *td, struct iovec * __capability iovp,
 	    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f,
 	    updateiov_t *updateiov_f);
-int	user_jail_set(struct thread *td, void * __capability iovp,
+int	user_jail_set(struct thread *td, struct iovec * __capability iovp,
 	    unsigned int iovcnt, int flags, copyinuio_t *copyinuio_f);
 int	user_kldload(struct thread *td, const char * __capability file);
 int	user_pdgetpid(struct thread *td, int fd, pid_t * __capability pidp);
@@ -622,7 +622,7 @@ int	user_poll(struct thread *td, struct pollfd * __capability fds,
 int	user_ppoll(struct thread *td, struct pollfd *__capability fds,
 	    u_int nfds, const struct timespec * __capability uts,
 	    const sigset_t * __capability uset);
-int	user_preadv(struct thread *td, int fd, void * __capability iovp,
+int	user_preadv(struct thread *td, int fd, struct iovec * __capability iovp,
 	    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f);
 int	user_procctl(struct thread *td, enum idtype idtype, id_t id, int com,
 	    void * __capability data);
@@ -630,11 +630,11 @@ int	user_pselect(struct thread *td, int nd, fd_set * __capability in,
 	    fd_set * __capability ou, fd_set * __capability ex,
 	    const struct timespec * __capability uts,
 	    const sigset_t * __capability sm);
-int	user_pwritev(struct thread *td, int fd, void *__capability iovp,
+int	user_pwritev(struct thread *td, int fd, struct iovec * __capability iovp,
 	    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f);
 int	user_read(struct thread *td, int fd, void * __capability buf,
 	    size_t nbyte);
-int	user_readv(struct thread *td, int fd, void * __capability iovp,
+int	user_readv(struct thread *td, int fd, struct iovec * __capability iovp,
 	    u_int iovcnt, copyinuio_t *copyinuio_f);
 int	user_sched_getparam(struct thread *td, pid_t,
 	    struct sched_param * __capability param);
@@ -677,7 +677,7 @@ int	user_uuidgen(struct thread *td, struct uuid * __capability storep,
 int	user_wait6(struct thread *td, enum idtype idtype, id_t id,
 	    int * __capability statusp, int options,
 	    struct __wrusage * __capability wrusage, siginfo_t *sip);
-int	user_writev(struct thread *td, int fd, void * __capability iovp,
+int	user_writev(struct thread *td, int fd, struct iovec * __capability iovp,
 	    u_int iovcnt, copyinuio_t *copyinuio_f);
 
 /* flags for kern_sigaction */

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -99,7 +99,7 @@ int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 	    struct uio *uio);
 int	uiomove_nofault(void *cp, int n, struct uio *uio);
 int	uiomove_object(struct vm_object *obj, off_t obj_size, struct uio *uio);
-int	updateiov(const struct uio *uiop, struct iovec *iovp);
+int	updateiov(const struct uio *uiop, struct iovec * __capability iovp);
 
 #else /* !_KERNEL */
 

--- a/usr.sbin/jls/jls.c
+++ b/usr.sbin/jls/jls.c
@@ -505,17 +505,13 @@ quoted_print(int pflags, char *name, char *value)
 {
 	int qc;
 	char *p = value;
-	char *param_name_value;
 
 	/* An empty string needs quoting. */
 	if (!*p) {
-		asprintf(&param_name_value, "{k:%s}{d:%s/\"\"}", name, name);
-		xo_emit(param_name_value);
-		free(param_name_value);
+		xo_emit("{ea:/%s}{da:/\"\"}", name, value, name);
 		return;
 	}
 
-	asprintf(&param_name_value, "{:%s/%%s}", name);
 	/*
 	 * The value will be surrounded by quotes if it contains spaces
 	 * or quotes.
@@ -528,9 +524,7 @@ quoted_print(int pflags, char *name, char *value)
 	if (qc && pflags & PRINT_QUOTED)
 		xo_emit("{P:/%c}", qc);
 
-	xo_emit(param_name_value, value);
-
-	free(param_name_value);
+	xo_emit("{a:/%s}", name, value);
 
 	if (qc && pflags & PRINT_QUOTED)
 		xo_emit("{P:/%c}", qc);


### PR DESCRIPTION
/usr/tests/bin/pkill/pkill-j_test was causing a kernel panic while running the test suite on CHERI-MIPS

After some extensive debugging it turns out there are four bugs that break this test:

- Root cause: calling convention mismatch for function pointers. Clang doesn't warn even though the argument lists are incompatible. We should probably add this diagnostic. Fix is to change `updateiov(const struct uio *uiop, struct iovec *iovp)` -> `updateiov(const struct uio *uiop, struct iovec * __capability iovp)`. This calling convention mismatch results in updateiov() being passed a iov capability in $c3, but it actually reads whatever happens to be in $a1 (in my case 0xc4).
- This then ends up calling suword64() with this garbage value, which triggers a ADES error. MIPS trap() helpfully tries to emulate the unaligned access, but in doing so clears the pcb_onfault pointer 🤦 (since we use fueword to get the bad instruction) . This fails since the badvaddr is garbage and we fall through to the fatal trap case since pcb_onfault is now NULL.
- After saving pcb_onfault before calling emulate_unaligned_access, the test ends up getting stuck in an infinte ERESTART loop because we don't convert the suword return value to an errno value.
- Finally, /usr/sbin/jls uses broken libxo format strings which cause it to try and read a non-existing string argument from the varargs. This fix has been submitted upstream as https://reviews.freebsd.org/D26885.

I'm not sure if the upstream MIPS trap handler also suffers from the pcb_onfault error since it might still be accessing user memory directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ctsrd-cheri/cheribsd/745)
<!-- Reviewable:end -->
