### PR TITLE
Add an ACPI attachment for if_smc

### DIFF
--- a/sys/conf/files
+++ b/sys/conf/files
@@ -3054,6 +3054,7 @@ dev/smbus/smbconf.c		optional smbus
 dev/smbus/smbus.c		optional smbus
 dev/smbus/smbus_if.m		optional smbus
 dev/smc/if_smc.c		optional smc
+dev/smc/if_smc_acpi.c		optional smc acpi
 dev/smc/if_smc_fdt.c		optional smc fdt
 dev/snp/snp.c			optional snp
 dev/sound/clone.c		optional sound

--- a/sys/dev/smc/if_smc.c
+++ b/sys/dev/smc/if_smc.c
@@ -80,6 +80,8 @@ __FBSDID("$FreeBSD$");
 #include <dev/mii/mii_bitbang.h>
 #include <dev/mii/miivar.h>
 
+#include "miibus_if.h"
+
 #define	SMC_LOCK(sc)		mtx_lock(&(sc)->smc_mtx)
 #define	SMC_UNLOCK(sc)		mtx_unlock(&(sc)->smc_mtx)
 #define	SMC_ASSERT_LOCKED(sc)	mtx_assert(&(sc)->smc_mtx, MA_OWNED)
@@ -479,6 +481,27 @@ smc_detach(device_t dev)
 
 	return (0);
 }
+
+static device_method_t smc_methods[] = {
+	/* Device interface */
+	DEVMETHOD(device_attach,	smc_attach),
+	DEVMETHOD(device_detach,	smc_detach),
+
+	/* MII interface */
+	DEVMETHOD(miibus_readreg,	smc_miibus_readreg),
+	DEVMETHOD(miibus_writereg,	smc_miibus_writereg),
+	DEVMETHOD(miibus_statchg,	smc_miibus_statchg),
+
+	{ 0, 0 }
+};
+
+driver_t smc_driver = {
+	"smc",
+	smc_methods,
+	sizeof(struct smc_softc),
+};
+
+DRIVER_MODULE(miibus, smc, miibus_driver, miibus_devclass, 0, 0);
 
 static void
 smc_start(struct ifnet *ifp)

--- a/sys/dev/smc/if_smcvar.h
+++ b/sys/dev/smc/if_smcvar.h
@@ -68,6 +68,8 @@ struct smc_softc {
 	void			*smc_read_arg;
 };
 
+DECLARE_CLASS(smc_driver);
+
 int	smc_probe(device_t);
 int	smc_attach(device_t);
 int	smc_detach(device_t);


### PR DESCRIPTION
This is needed by some of the Arm simulators as they implement a smc based
network interface, but use ACPI rather than FDT.

Sponsored by:	Innovate UK