### PR TITLE
Restore the value of _ALIGNBYTES for hybrid.

### DIFF
--- a/sys/arm64/include/_align.h
+++ b/sys/arm64/include/_align.h
@@ -38,7 +38,7 @@
  * for all data types (int, long, ...).   The result is unsigned int
  * and must be cast to any desired pointer type.
  */
-#if __has_feature(capabilities)
+#ifdef __CHERI_PURE_CAPABILITY__
 #define	_ALIGNBYTES	(sizeof(void * __capability) - 1)
 #else
 #define	_ALIGNBYTES	(sizeof(long long) - 1)


### PR DESCRIPTION
This is part of the ABI and can't be changed for hybrid.  Only align
to 16 for purecap.