### PR TITLE
Fixes for the purecap signal code.

### DIFF
--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -837,10 +837,26 @@ initstack:
 	.space	(PAGE_SIZE * KSTACK_PAGES)
 initstack_end:
 
+/*
+ * sigcode has to be labeled as an #object type so that the symbols
+ * resolve to the correct address as a source for copies.  This also
+ * ensures that captable pointers to it will be able to read it.  This
+ * is fine as the code is never executed directly in the kernel, just
+ * copied to places for userland to execute.
+ */
+#define	SIGCODE(sym)						\
+	.text; .globl sym; .align 2; .type sym,#object; sym:
 
-ENTRY(sigcode)
+SIGCODE(sigcode)
+#if __has_feature(capabilities)
+#ifndef __CHERI_PURE_CAPABILITY__
+	.arch_extension c64
+#endif
+	add	c0, csp, #SF_UC
+#else
 	mov	x0, sp
 	add	x0, x0, #SF_UC
+#endif
 
 1:
 	mov	x8, #SYS_sigreturn
@@ -851,6 +867,12 @@ ENTRY(sigcode)
 	svc	0
 
 	b	1b
+#if __has_feature(capabilities)
+#ifndef __CHERI_PURE_CAPABILITY__
+	.arch_extension noc64
+	.arch_extension a64c
+#endif
+#endif
 END(sigcode)
 	/* This may be copied to the stack, keep it 16-byte aligned */
 	.align	3
@@ -863,7 +885,7 @@ szsigcode:
 	.quad	esigcode - sigcode
 
 #ifdef COMPAT_FREEBSD64
-ENTRY(freebsd64_sigcode)
+SIGCODE(freebsd64_sigcode)
 	mov	x0, sp
 	add	x0, x0, #SF_UC64
 
@@ -888,7 +910,7 @@ freebsd64_szsigcode:
 	.quad	freebsd64_esigcode - freebsd64_sigcode
 #endif
 
-ENTRY(aarch32_sigcode)
+SIGCODE(aarch32_sigcode)
 	.word 0xe1a0000d	// mov r0, sp
 	.word 0xe2800040	// add r0, r0, #SIGF_UC
 	.word 0xe59f700c	// ldr r7, [pc, #12]

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -521,7 +521,10 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 		tf->tf_elr = entry;
 		cheri_set_mmap_capability(td, imgp,
 		    (void * __capability)tf->tf_sp);
-		td->td_proc->p_md.md_sigcode = cheri_sigcode_capability(td);
+
+		/* Set LSB of the signal code address since it is C64. */
+		td->td_proc->p_md.md_sigcode = cheri_incoffset(
+		    cheri_sigcode_capability(td), 1);
 		tf->tf_spsr |= PSR_C64;
 	} else
 #endif


### PR DESCRIPTION
- Mark the sigcode as C64 and set c0 from csp instead of setting x0
  for the purecap signal code.  While here, trim an instruction from
  the sigcode for purecap.

- Mark sigcode as #object instead of #function as is done for the
  RISC-V purecap kernel.  The purecap kernel will eventually need
  this, but this also ensures the address of 'sigcode' is correct when
  used as a pointer passed as a source to memcpy().

- Explicitly set the LSB in the sigcode capability for purecap since
  it is C64.