### PR TITLE
Handle additional user-accessible capabilities on Morello.

### DIFF
--- a/sys/arm64/arm64/genassym.c
+++ b/sys/arm64/arm64/genassym.c
@@ -62,6 +62,8 @@ ASSYM(PCB_REGS, offsetof(struct pcb, pcb_x));
 ASSYM(PCB_SP, offsetof(struct pcb, pcb_sp));
 #if __has_feature(capabilities)
 ASSYM(PCB_TPIDR, offsetof(struct pcb, pcb_tpidr_el0));
+ASSYM(PCB_CID, offsetof(struct pcb, pcb_cid_el0));
+ASSYM(PCB_RDDC, offsetof(struct pcb, pcb_rddc_el0));
 #else
 ASSYM(PCB_TPIDRRO, offsetof(struct pcb, pcb_tpidrro_el0));
 #endif

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -449,10 +449,10 @@ fill_capregs(struct thread *td, struct capreg *regs)
 	regs->ddc = frame->tf_ddc;
 	regs->ctpidr = td->td_pcb->pcb_tpidr_el0;
 	regs->ctpidrro = td->td_pcb->pcb_tpidrro_el0;
-	regs->cid = READ_SPECIALREG_CAP(cid_el0);
-	regs->rcsp = READ_SPECIALREG_CAP(rcsp_el0);
-	regs->rddc = READ_SPECIALREG_CAP(rddc_el0);
-	regs->rctpidr = READ_SPECIALREG_CAP(rctpidr_el0);
+	regs->cid = td->td_pcb->pcb_cid_el0;
+	regs->rcsp = td->td_pcb->pcb_rcsp_el0;
+	regs->rddc = td->td_pcb->pcb_rddc_el0;
+	regs->rctpidr = td->td_pcb->pcb_rctpidr_el0;
 
 	for (i = 0; i < nitems(frame->tf_x); i++) {
 		regs->c[i] = frame->tf_x[i];
@@ -570,6 +570,16 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 #else
 	WRITE_SPECIALREG(tpidrro_el0, 0);
 	WRITE_SPECIALREG(tpidr_el0, 0);
+#endif
+#if __has_feature(capabilities)
+	td->td_pcb->pcb_cid_el0 = 0;
+	td->td_pcb->pcb_rcsp_el0 = 0;
+	td->td_pcb->pcb_rddc_el0 = 0;
+	td->td_pcb->pcb_rctpidr_el0 = 0;
+	WRITE_SPECIALREG_CAP(cid_el0, 0);
+	WRITE_SPECIALREG_CAP(rcsp_el0, 0);
+	WRITE_SPECIALREG_CAP(rddc_el0, 0);
+	WRITE_SPECIALREG_CAP(rctpidr_el0, 0);
 #endif
 }
 

--- a/sys/arm64/arm64/swtch.S
+++ b/sys/arm64/arm64/swtch.S
@@ -91,6 +91,12 @@ ENTRY(cpu_throw)
 	ldp	c5, c6, [x4, #PCB_TPIDR]
 	msr	ctpidr_el0, c5
 	msr	ctpidrro_el0, c6
+	ldp	c5, c6, [x4, #PCB_CID]
+	msr	cid_el0, c5
+	msr	rcsp_el0, c6
+	ldp	c5, c6, [x4, #PCB_RDDC]
+	msr	rddc_el0, c5
+	msr	rctpidr_el0, c6
 #else
 	ldp	x5, x6, [x4, #PCB_SP]
 	mov	sp, x5
@@ -148,6 +154,12 @@ ENTRY(cpu_switch)
 	mrs	c5, ctpidr_el0
 	mrs	c6, ctpidrro_el0
 	stp	c5, c6, [x4, #PCB_TPIDR]
+	mrs	c5, cid_el0
+	mrs	c6, rcsp_el0
+	stp	c5, c6, [x4, #PCB_CID]
+	mrs	c5, rddc_el0
+	mrs	c6, rctpidr_el0
+	stp	c5, c6, [x4, #PCB_RDDC]
 #else
 	mrs	x6, tpidrro_el0
 	str	x6, [x4, #PCB_TPIDRRO]
@@ -203,6 +215,12 @@ ENTRY(cpu_switch)
 	ldp	c5, c6, [x4, #PCB_TPIDR]
 	msr	ctpidr_el0, c5
 	msr	ctpidrro_el0, c6
+	ldp	c5, c6, [x4, #PCB_CID]
+	msr	cid_el0, c5
+	msr	rcsp_el0, c6
+	ldp	c5, c6, [x4, #PCB_RDDC]
+	msr	rddc_el0, c5
+	msr	rctpidr_el0, c6
 #else
 	ldp	x5, x6, [x4, #PCB_SP]
 	mov	sp, x5
@@ -341,6 +359,12 @@ ENTRY(savectx)
 	mrs	c5, ctpidr_el0
 	mrs	c6, ctpidrro_el0
 	stp	c5, c6, [x4, #PCB_TPIDR]
+	mrs	c5, cid_el0
+	mrs	c6, rcsp_el0
+	stp	c5, c6, [x4, #PCB_CID]
+	mrs	c5, rddc_el0
+	mrs	c6, rctpidr_el0
+	stp	c5, c6, [x4, #PCB_RDDC]
 #else
 	mrs	x6, tpidrro_el0
 	str	x6, [x0, #PCB_TPIDRRO]

--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -92,6 +92,12 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 		if ((td1->td_pcb->pcb_fpflags & PCB_FP_STARTED) != 0)
 			vfp_save_state(td1, td1->td_pcb);
 #endif
+#if __has_feature(capabilities)
+		td1->td_pcb->pcb_cid_el0 = READ_SPECIALREG_CAP(cid_el0);
+		td1->td_pcb->pcb_rcsp_el0 = READ_SPECIALREG_CAP(rcsp_el0);
+		td1->td_pcb->pcb_rddc_el0 = READ_SPECIALREG_CAP(rddc_el0);
+		td1->td_pcb->pcb_rctpidr_el0 = READ_SPECIALREG_CAP(rctpidr_el0);
+#endif
 	}
 
 	pcb2 = (struct pcb *)(td2->td_kstack +

--- a/sys/arm64/include/pcb.h
+++ b/sys/arm64/include/pcb.h
@@ -44,6 +44,12 @@ struct pcb {
 	uint64_t	pcb_sp;
 	uintcap_t	pcb_tpidr_el0;
 	uintcap_t	pcb_tpidrro_el0;
+#if __has_feature(capabilities)
+	uintcap_t	pcb_cid_el0;
+	uintcap_t	pcb_rcsp_el0;
+	uintcap_t	pcb_rddc_el0;
+	uintcap_t	pcb_rctpidr_el0;
+#endif
 
 	/* Fault handler, the error value is passed in x0 */
 	vm_offset_t	pcb_onfault;


### PR DESCRIPTION
Specifically the 'cid' and restricted capability registers.  These are
handled similarly to TLS registers except that there are no kernel
paths which set these values currently.  Userland is responsible for
managing intra-process compartments.  The registers are saved in the
PCB for context switches, copied on fork, and cleared during exec.