### PR TITLE
Fix ELF core dump for hybrid and purecap kernels.

### DIFF
--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -549,18 +549,15 @@ vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base, int len, off_t offset,
 		return (EINVAL);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
-#ifdef __CHERI_PURE_CAPABILITY__
-	IOVEC_INIT_C(&aiov, base, len);
-#elif __has_feature(capabilities)
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 	if (segflg == UIO_USERSPACE)
 		IOVEC_INIT_C(&aiov,
 		    cheri_capability_build_user_data(CHERI_CAP_USER_DATA_PERMS,
 			(vaddr_t)base, len, 0), len);
 	else
-		IOVEC_INIT(&aiov, base, len);
-#else
-	IOVEC_INIT(&aiov, base, len);
 #endif
+	IOVEC_INIT(&aiov, base, len);
+
 	auio.uio_resid = len;
 	auio.uio_offset = offset;
 	auio.uio_segflg = segflg;

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -48,10 +48,14 @@ struct iovec {
 };
 
 #if defined(_KERNEL)
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	IOVEC_INIT IOVEC_INIT_C
+#else /* ! __CHERI_PURE_CAPABILITY__ */
 #define	IOVEC_INIT(iovp, base, len)	do {				\
 	(iovp)->iov_base = PTR2CAP((base));				\
 	(iovp)->iov_len = (len);					\
 } while(0)
+#endif /* ! __CHERI_PURE_CAPABILITY__ */
 #define IOVEC_INIT_C(iovp, base, len)	do {				\
 	(iovp)->iov_base = (base);					\
 	(iovp)->iov_len = (len);					\


### PR DESCRIPTION
Replace __USER_CAP in vn_rdwr with a capability derived from userspace_cap,
this properly generates a capability instead of deriving from a NULL DDC
in the case of a purecap binary on an hybrid kernel.
In the purecap kernel case, the ELF coredump generates the capability.
Add assertion in IOVEC_INIT_C to make sure that the capability given is valid.