### PR TITLE
nvme: fix passthrough commands

### DIFF
--- a/sys/cam/cam_ccb.h
+++ b/sys/cam/cam_ccb.h
@@ -1562,6 +1562,23 @@ cam_fill_nvmeio(struct ccb_nvmeio *nvmeio, u_int32_t retries,
 	nvmeio->dxfer_len = dxfer_len;
 }
 
+#ifdef _KERNEL
+static __inline void
+cam_fill_nvmeio_user(struct ccb_nvmeio *nvmeio, u_int32_t retries,
+	      void (*cbfcnp)(struct cam_periph *, union ccb *),
+	      u_int32_t flags, u_int8_t * __capability data_ptr,
+	      u_int32_t dxfer_len, u_int32_t timeout)
+{
+	nvmeio->ccb_h.func_code = XPT_NVME_IO;
+	nvmeio->ccb_h.flags = flags;
+	nvmeio->ccb_h.retry_count = retries;
+	nvmeio->ccb_h.cbfcnp = cbfcnp;
+	nvmeio->ccb_h.timeout = timeout;
+	nvmeio->user_data_ptr = data_ptr;
+	nvmeio->dxfer_len = dxfer_len;
+}
+#endif
+
 static __inline void
 cam_fill_nvmeadmin(struct ccb_nvmeio *nvmeio, u_int32_t retries,
 	      void (*cbfcnp)(struct cam_periph *, union ccb *),

--- a/sys/cam/nvme/nvme_da.c
+++ b/sys/cam/nvme/nvme_da.c
@@ -415,7 +415,7 @@ ndaioctl(struct disk *dp, u_long cmd, void *data, int fflag,
 		ccb = xpt_alloc_ccb();
 		xpt_setup_ccb(&ccb->ccb_h, periph->path, CAM_PRIORITY_NORMAL);
 		ccb->ccb_state = NDA_CCB_PASS;
-		cam_fill_nvmeio(&ccb->nvmeio,
+		cam_fill_nvmeio_user(&ccb->nvmeio,
 		    0,			/* Retries */
 		    ndadone,
 		    (pt->is_read ? CAM_DIR_IN : CAM_DIR_OUT) | CAM_DATA_VADDR,

--- a/sys/dev/nvme/nvme.h
+++ b/sys/dev/nvme/nvme.h
@@ -1502,7 +1502,7 @@ struct nvme_pt_command {
 	struct nvme_completion	cpl;
 
 	/* buf is the data buffer associated with this passthrough command. */
-	void *			buf;
+	void * __kerncap	buf;
 
 	/*
 	 * len is the length of the data buffer associated with this

--- a/sys/dev/nvme/nvme_ctrlr.c
+++ b/sys/dev/nvme/nvme_ctrlr.c
@@ -1245,7 +1245,7 @@ nvme_ctrlr_passthrough_cmd(struct nvme_controller *ctrlr,
 		 * pages. Ensure this request has fewer than MAXPHYS bytes when
 		 * extended to full pages.
 		 */
-		addr = (vm_offset_t)pt->buf;
+		addr = (__cheri_addr vm_offset_t)pt->buf;
 		end = round_page(addr + pt->len);
 		addr = trunc_page(addr);
 		if (end - addr > MAXPHYS)
@@ -1273,7 +1273,8 @@ nvme_ctrlr_passthrough_cmd(struct nvme_controller *ctrlr,
 			req = nvme_allocate_request_vaddr(buf->b_data, pt->len, 
 			    nvme_pt_done, pt);
 		} else
-			req = nvme_allocate_request_vaddr(pt->buf, pt->len,
+			req = nvme_allocate_request_vaddr(
+			    (__cheri_fromcap void *)pt->buf, pt->len,
 			    nvme_pt_done, pt);
 	} else
 		req = nvme_allocate_request_null(nvme_pt_done, pt);


### PR DESCRIPTION
This pulls in the key fix from #765 with the intent to loop it back into morello-dev.