### PR TITLE
Add initial morello CI support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,11 @@ def buildImageAndRunTests(params, String suffix) {
             sh "./cheribuild/jenkins-cheri-build.py --build cheribsd-mfs-root-kernel-${suffix} --cheribsd-mfs-root-kernel-${suffix}/build-fpga-kernels ${params.extraArgs}"
         }
     }
+    if (suffix.startsWith("morello")) {
+        echo("Can't run tests on the FVP yet!")
+        maybeArchiveArtifacts(params, suffix)
+        return
+    }
     stage("Running tests") {
         // copy qemu archive and run directly on the host
         dir("qemu-${params.buildOS}") { deleteDir() }
@@ -99,6 +104,10 @@ find test-results
             archiveArtifacts allowEmptyArchive: true, artifacts: "test-results/${suffix}/*.xml", onlyIfSuccessful: false
         }
     }
+    maybeArchiveArtifacts(params, suffix)
+}
+
+def maybeArchiveArtifacts(params, String suffix) {
     if (GlobalVars.archiveArtifacts) {
         if (GlobalVars.isTestSuiteJob) {
             error("Should not happen!")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,7 +156,7 @@ selectedArchitectures.each { suffix ->
                 extraArgs: cheribuildArgs.join(" "),
                 skipArchiving: true, skipTarball: true,
                 sdkCompilerOnly: true, // We only need clang not the CheriBSD sysroot since we are building that.
-                customGitCheckoutDir: 'cheribsd',
+                customGitCheckoutDir: suffix.startsWith('morello') ? 'morello-cheribsd' : 'cheribsd',
                 gitHubStatusContext: GlobalVars.isTestSuiteJob ? "testsuite/${suffix}" : "ci/${suffix}",
                 // Delete stale compiler/sysroot
                 beforeBuild: { params -> dir('cherisdk') { deleteDir() } },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,8 @@ if (!env.CHANGE_ID && archiveBranches.contains(env.BRANCH_NAME)) {
 }
 // Add an architecture selector for manual builds
 def allArchitectures = ["aarch64", "amd64", "mips64", "mips64-hybrid", "mips64-purecap", "riscv64", "riscv64-hybrid", "riscv64-purecap"]
+// Build a subset of the architectures for morello-dev: Just check that we didn't break aarch64 (with CHERI LLVM) and *-purecap
+allArchitectures = ["morello-hybrid", "morello-purecap", "aarch64", "mips64-purecap", "riscv64-purecap"]
 jobProperties.add(parameters([text(defaultValue: allArchitectures.join('\n'),
         description: 'The architectures (cheribuild suffixes) to build for (one per line)',
         name: 'architectures')]))


### PR DESCRIPTION
This may require additional cheribuild changes to extract
the compiler to the right directory. For now we only build a
subset of the architectures since this branch is only used
for morello changes and the full CI will run once we merge
back into dev.

The required jenkins-scripts change is https://github.com/CTSRD-CHERI/jenkins-scripts/commit/ec2fafe89f5456033920d144de41aac46f5e2bee