### PR TITLE
Hybrid capability varargs cleanups

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -72,11 +72,11 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Confirm precise lower bound: offset of zero. */
 	CHERIBSDTEST_VERIFY2(offset == 0,
-	    "offset (%jd) not zero: %#.16lp", offset, c);
+	    "offset (%jd) not zero: %#lp", offset, c);
 
 	/* Confirm precise upper bound: length of expected size for type. */
 	CHERIBSDTEST_VERIFY2(len == expected_len,
-	    "length (%jd) not expected %jd: %#.16lp", len, expected_len, c);
+	    "length (%jd) not expected %jd: %#lp", len, expected_len, c);
 #else
 	/*
 	 * In hybrid mode we don't increase alignment of allocations to ensure
@@ -87,11 +87,11 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 	 * See https://github.com/CTSRD-CHERI/llvm-project/issues/431
 	 */
 	CHERIBSDTEST_VERIFY2(len >= expected_len,
-	    "length (%jd) smaller than expected lower bound %jd: %#.16lp",
+	    "length (%jd) smaller than expected lower bound %jd: %#lp",
 	    len, expected_len, c);
 #ifndef __riscv  /* RISC-V does not bound __cheri_tocap casts in hybrid mode */
 	CHERIBSDTEST_VERIFY2(len <= 2 * expected_len,
-	    "length (%jd) greater than expected upper bound %jd: %#.16lp",
+	    "length (%jd) greater than expected upper bound %jd: %#lp",
 	    len, 2 * expected_len, c);
 #endif
 #endif

--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -72,13 +72,11 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Confirm precise lower bound: offset of zero. */
 	CHERIBSDTEST_VERIFY2(offset == 0,
-	    "offset (%jd) not zero: " _CHERI_PRINTF_CAP_FMT, offset,
-	    _CHERI_PRINTF_CAP_ARG(c));
+	    "offset (%jd) not zero: %#.16lp", offset, c);
 
 	/* Confirm precise upper bound: length of expected size for type. */
 	CHERIBSDTEST_VERIFY2(len == expected_len,
-	    "length (%jd) not expected %jd: " _CHERI_PRINTF_CAP_FMT, len,
-	    expected_len, _CHERI_PRINTF_CAP_ARG(c));
+	    "length (%jd) not expected %jd: %#.16lp", len, expected_len, c);
 #else
 	/*
 	 * In hybrid mode we don't increase alignment of allocations to ensure
@@ -89,12 +87,12 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 	 * See https://github.com/CTSRD-CHERI/llvm-project/issues/431
 	 */
 	CHERIBSDTEST_VERIFY2(len >= expected_len,
-	    "length (%jd) smaller than expected lower bound %jd: " _CHERI_PRINTF_CAP_FMT,
-	    len, expected_len, _CHERI_PRINTF_CAP_ARG(c));
+	    "length (%jd) smaller than expected lower bound %jd: %#.16lp",
+	    len, expected_len, c);
 #ifndef __riscv  /* RISC-V does not bound __cheri_tocap casts in hybrid mode */
 	CHERIBSDTEST_VERIFY2(len <= 2 * expected_len,
-	    "length (%jd) greater than expected upper bound %jd: " _CHERI_PRINTF_CAP_FMT,
-	    len, 2 * expected_len, _CHERI_PRINTF_CAP_ARG(c));
+	    "length (%jd) greater than expected upper bound %jd: %#.16lp",
+	    len, 2 * expected_len, c);
 #endif
 #endif
 	cheribsdtest_success();

--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -114,7 +114,7 @@ test_fault_perm_seal(const struct cheri_test *ctp __unused)
 	 * instruction can be optimized away since it is dead.
 	 */
 	cheribsdtest_failure_errx("cheri_seal() performed successfully "
-	    "%#.16lp with bad sealcap %#.16lp", sealed, sealcap);
+	    "%#lp with bad sealcap %#lp", sealed, sealcap);
 }
 
 void
@@ -159,7 +159,7 @@ test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 	 * instruction can be optimized away since it is dead.
 	 */
 	cheribsdtest_failure_errx("cheri_unseal() performed successfully "
-	    "%#.16lp with bad unsealcap %#.16lp", unsealed, sealcap);
+	    "%#lp with bad unsealcap %#lp", unsealed, sealcap);
 }
 
 void

--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -114,8 +114,7 @@ test_fault_perm_seal(const struct cheri_test *ctp __unused)
 	 * instruction can be optimized away since it is dead.
 	 */
 	cheribsdtest_failure_errx("cheri_seal() performed successfully "
-	    _CHERI_PRINTF_CAP_FMT " with bad sealcap" _CHERI_PRINTF_CAP_FMT,
-	    _CHERI_PRINTF_CAP_ARG(sealed), _CHERI_PRINTF_CAP_ARG(sealcap));
+	    "%#.16lp with bad sealcap %#.16lp", sealed, sealcap);
 }
 
 void
@@ -160,8 +159,7 @@ test_fault_perm_unseal(const struct cheri_test *ctp __unused)
 	 * instruction can be optimized away since it is dead.
 	 */
 	cheribsdtest_failure_errx("cheri_unseal() performed successfully "
-	    _CHERI_PRINTF_CAP_FMT " with bad unsealcap" _CHERI_PRINTF_CAP_FMT,
-	    _CHERI_PRINTF_CAP_ARG(unsealed), _CHERI_PRINTF_CAP_ARG(sealcap));
+	    "%#.16lp with bad unsealcap %#.16lp", unsealed, sealcap);
 }
 
 void

--- a/bin/cheribsdtest/cheribsdtest_printf.c
+++ b/bin/cheribsdtest/cheribsdtest_printf.c
@@ -46,8 +46,6 @@
 
 #include "cheribsdtest.h"
 
-#define	CAP_ARG(p)	(p)
-
 static void
 test_printf_cap_one(void * __capability p, int expected_tokens,
     const char *descr)
@@ -61,7 +59,7 @@ test_printf_cap_one(void * __capability p, int expected_tokens,
 	assert(expected_tokens == 1 || expected_tokens == 4 ||
 	    expected_tokens == 5);
 
-	asprintf(&str, "%#lp", CAP_ARG(p));
+	asprintf(&str, "%#lp", p);
 	tokens = sscanf(str, "%lx [%15[^,],%lx-%lx] %31s", &addr, perms, &base,
 	    &top, attr);
 	free(str);
@@ -163,26 +161,26 @@ test_printf_cap(const struct cheri_test *ctp __unused)
 	void * __capability scalar = (void * __capability)(uintcap_t)4;
 	char * __capability datap = data;
 
-	snprintf(data, sizeof(data), "%#lp", CAP_ARG(scalar));
+	snprintf(data, sizeof(data), "%#lp", scalar);
 	if (strcmp(data, "0x4") != 0)
 		cheribsdtest_failure_errx("Wrong output for simple scalar");
 
-	snprintf(data, sizeof(data), "%#.4lp", CAP_ARG(scalar));
+	snprintf(data, sizeof(data), "%#.4lp", scalar);
 	if (strcmp(data, "0x0004") != 0)
 		cheribsdtest_failure_errx("Wrong output for simple scalar "
 		    "with precision");
 
-	snprintf(data, sizeof(data), "%#8lp", CAP_ARG(scalar));
+	snprintf(data, sizeof(data), "%#8lp", scalar);
 	if (strcmp(data, "     0x4") != 0)
 		cheribsdtest_failure_errx("Wrong output for simple scalar "
 		    "with padding");
 
-	snprintf(data, sizeof(data), "%#-8lp", CAP_ARG(scalar));
+	snprintf(data, sizeof(data), "%#-8lp", scalar);
 	if (strcmp(data, "0x4     ") != 0)
 		cheribsdtest_failure_errx("Wrong output for simple scalar "
 		    "with left adjust padding");
 
-	snprintf(data, sizeof(data), "%#8.4lp", CAP_ARG(scalar));
+	snprintf(data, sizeof(data), "%#8.4lp", scalar);
 	if (strcmp(data, "  0x0004") != 0)
 		cheribsdtest_failure_errx("Wrong output for simple scalar "
 		    "with precision and padding");

--- a/bin/cheribsdtest/cheribsdtest_printf.c
+++ b/bin/cheribsdtest/cheribsdtest_printf.c
@@ -46,11 +46,7 @@
 
 #include "cheribsdtest.h"
 
-#ifdef __CHERI_PURE_CAPABILITY__
 #define	CAP_ARG(p)	(p)
-#else
-#define	CAP_ARG(p)	(&(p))
-#endif
 
 static void
 test_printf_cap_one(void * __capability p, int expected_tokens,

--- a/bin/cheribsdtest/cheribsdtest_registers.c
+++ b/bin/cheribsdtest/cheribsdtest_registers.c
@@ -132,7 +132,7 @@ check_initreg_code(void * __capability c)
 {
 	uintmax_t v;
 
-	fprintf(stderr, "c %#.16lp\n", c);
+	fprintf(stderr, "c %#lp\n", c);
 
 #if defined(__CHERI_PURE_CAPABILITY__)
 	/*

--- a/bin/cheribsdtest/cheribsdtest_registers.c
+++ b/bin/cheribsdtest/cheribsdtest_registers.c
@@ -132,7 +132,7 @@ check_initreg_code(void * __capability c)
 {
 	uintmax_t v;
 
-	CHERI_FPRINT_PTR(stderr, c);
+	fprintf(stderr, "c %#.16lp\n", c);
 
 #if defined(__CHERI_PURE_CAPABILITY__)
 	/*

--- a/bin/cheribsdtest/cheribsdtest_syscall.c
+++ b/bin/cheribsdtest/cheribsdtest_syscall.c
@@ -116,7 +116,7 @@ test_sig_dfl_neq_ign(const struct cheri_test *ctp __unused)
 	 */
 	int eq = (SIG_IGN == SIG_DFL);
 
-	fprintf(stderr, "sic %#.16lp\n", sic);
+	fprintf(stderr, "sic %#lp\n", sic);
 	fprintf(stderr, "IGN=%ld(%p) DFL=%ld(%p) EQ=%d(%d)\n",
 		(long)SIG_IGN, SIG_IGN,
 		(long)SIG_DFL, SIG_DFL, SIG_IGN == SIG_DFL, eq);

--- a/bin/cheribsdtest/cheribsdtest_syscall.c
+++ b/bin/cheribsdtest/cheribsdtest_syscall.c
@@ -116,7 +116,7 @@ test_sig_dfl_neq_ign(const struct cheri_test *ctp __unused)
 	 */
 	int eq = (SIG_IGN == SIG_DFL);
 
-	CHERI_FPRINT_PTR(stderr, sic);
+	fprintf(stderr, "sic %#.16lp\n", sic);
 	fprintf(stderr, "IGN=%ld(%p) DFL=%ld(%p) EQ=%d(%d)\n",
 		(long)SIG_IGN, SIG_IGN,
 		(long)SIG_DFL, SIG_DFL, SIG_IGN == SIG_DFL, eq);

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -292,7 +292,7 @@ cheribsdtest_vm_cap_share_fd_kqueue(const struct cheri_test *ctp __unused)
 		CHERIBSDTEST_VERIFY2(oke.ident == 0x2BAD, "Bad identifier from kqueue");
 		CHERIBSDTEST_VERIFY2(oke.filter == EVFILT_USER, "Bad filter from kqueue");
 
-		CHERI_FPRINT_PTR(stderr, oke.udata);
+		fprintf(stderr, "oke.udata %#.16lp\n", oke.udata);
 
 		exit(cheri_gettag(oke.udata));
 	} else {
@@ -362,7 +362,7 @@ cheribsdtest_vm_cap_share_sigaction(const struct cheri_test *ctp __unused)
 		/* Read it again and check that we get the same value back. */
 		CHERIBSDTEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
 		fprintf(stderr, "child value read from sigaction(): ");
-		CHERI_FPRINT_PTR(stderr, sa.sa_handler);
+		fprintf(stderr, "sa.sa_handler %#.16lp\n", sa.sa_handler);
 		CHERIBSDTEST_CHECK_EQ_CAP(sa.sa_handler, passme);
 
 		exit(0);
@@ -376,7 +376,7 @@ cheribsdtest_vm_cap_share_sigaction(const struct cheri_test *ctp __unused)
 
 		CHERIBSDTEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
 		fprintf(stderr, "parent sa read from sigaction(): ");
-		CHERI_FPRINT_PTR(stderr, sa.sa_handler);
+		fprintf(stderr, "sa.sa_handler %#.16lp\n", sa.sa_handler);
 
 		/* Flags should be zero on read */
 		CHERIBSDTEST_CHECK_EQ_LONG(sa.sa_flags, 0);

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -292,7 +292,7 @@ cheribsdtest_vm_cap_share_fd_kqueue(const struct cheri_test *ctp __unused)
 		CHERIBSDTEST_VERIFY2(oke.ident == 0x2BAD, "Bad identifier from kqueue");
 		CHERIBSDTEST_VERIFY2(oke.filter == EVFILT_USER, "Bad filter from kqueue");
 
-		fprintf(stderr, "oke.udata %#.16lp\n", oke.udata);
+		fprintf(stderr, "oke.udata %#lp\n", oke.udata);
 
 		exit(cheri_gettag(oke.udata));
 	} else {
@@ -362,7 +362,7 @@ cheribsdtest_vm_cap_share_sigaction(const struct cheri_test *ctp __unused)
 		/* Read it again and check that we get the same value back. */
 		CHERIBSDTEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
 		fprintf(stderr, "child value read from sigaction(): ");
-		fprintf(stderr, "sa.sa_handler %#.16lp\n", sa.sa_handler);
+		fprintf(stderr, "sa.sa_handler %#lp\n", sa.sa_handler);
 		CHERIBSDTEST_CHECK_EQ_CAP(sa.sa_handler, passme);
 
 		exit(0);
@@ -376,7 +376,7 @@ cheribsdtest_vm_cap_share_sigaction(const struct cheri_test *ctp __unused)
 
 		CHERIBSDTEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
 		fprintf(stderr, "parent sa read from sigaction(): ");
-		fprintf(stderr, "sa.sa_handler %#.16lp\n", sa.sa_handler);
+		fprintf(stderr, "sa.sa_handler %#lp\n", sa.sa_handler);
 
 		/* Flags should be zero on read */
 		CHERIBSDTEST_CHECK_EQ_LONG(sa.sa_flags, 0);

--- a/lib/libc/stdio/printf-pos.c
+++ b/lib/libc/stdio/printf-pos.c
@@ -85,7 +85,11 @@ enum typeid {
 	T_LONG, T_U_LONG, TP_LONG, T_LLONG, T_U_LLONG, TP_LLONG,
 	T_PTRDIFFT, TP_PTRDIFFT, T_SSIZET, T_SIZET, TP_SSIZET,
 	T_INTMAXT, T_UINTMAXT, TP_INTMAXT, T_INTPTRT, T_UINTPTRT, TP_INTPTRT,
-	TP_VOID, TP_CHAR, TP_SCHAR,
+	TP_VOID,
+#if __has_feature(capabilities)
+	TC_VOID,
+#endif
+	TP_CHAR, TP_SCHAR,
 	T_DOUBLE, T_LONG_DOUBLE, T_WINT, TP_WCHAR
 };
 
@@ -430,7 +434,11 @@ reswitch:	switch (ch) {
 				goto error;
 			break;
 		case 'p':
-			if ((error = addtype(&types, TP_VOID)))
+			if ((error = addtype(&types,
+#if __has_feature(capabilities)
+			    (flags & LONGINT) ? TC_VOID :
+#endif
+			    TP_VOID)));
 				goto error;
 			break;
 		case 'S':
@@ -626,7 +634,11 @@ reswitch:	switch (ch) {
 				goto error;
 			break;
 		case 'p':
-			if ((error = addtype(&types, TP_VOID)))
+			if ((error = addtype(&types,
+#if __has_feature(capabilities)
+			    (flags & LONGINT) ? TC_VOID :
+#endif
+			    TP_VOID)));
 				goto error;
 			break;
 		case 'S':
@@ -800,6 +812,11 @@ build_arg_table(struct typetable *types, va_list ap, union arg **argtable)
 		    case TP_VOID:
 			(*argtable) [n].pvoidarg = va_arg (ap, void *);
 			break;
+#if __has_feature(capabilities)
+		    case TC_VOID:
+			(*argtable) [n].cvoidarg = va_arg (ap, void * __capability);
+			break;
+#endif
 		    case T_WINT:
 			(*argtable) [n].wintarg = va_arg (ap, wint_t);
 			break;

--- a/lib/libc/stdio/printflocal.h
+++ b/lib/libc/stdio/printflocal.h
@@ -88,6 +88,9 @@ union arg {
 	intptr_t intptrarg;
 	uintptr_t uintptrarg;
 	void	*pvoidarg;
+#if __has_feature(capabilities)
+	void	* __capability cvoidarg;
+#endif
 	char	*pchararg;
 	signed char *pschararg;
 	short	*pshortarg;

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -862,18 +862,16 @@ fp_common:
 			 *	-- ANSI X3J11
 			 */
 #if __has_feature(capabilities)
-#ifdef __CHERI_PURE_CAPABILITY__
-			cap = GETARG(void *);
-			ujval = cheri_getaddress(cap);
-#else
-			if (flags & LONGINT) {
-				cap = *GETARG(void * __capability *);
-				ujval = cheri_getaddress(cap);
-			} else {
+#ifndef __CHERI_PURE_CAPABILITY__
+			if (!(flags & LONGINT)) {
 				ujval = (uintmax_t)(uintptr_t)GETARG(void *);
 				flags &= ~ALT;
-			}
+			} else
 #endif
+			{
+				cap = GETARG(void * __capability);
+				ujval = cheri_getaddress(cap);
+			}
 			if (flags & ALT) {
 				cp = buf + BUF;
 				cp = __cheri_ptr_alt(cap, cp, xdigs_lower,

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -915,18 +915,16 @@ fp_common:
 			 *	-- ANSI X3J11
 			 */
 #if __has_feature(capabilities)
-#ifdef __CHERI_PURE_CAPABILITY__
-			cap = GETARG(void *);
-			ujval = cheri_getaddress(cap);
-#else
-			if (flags & LONGINT) {
-				cap = *GETARG(void * __capability *);
-				ujval = cheri_getaddress(cap);
-			} else {
+#ifndef __CHERI_PURE_CAPABILITY__
+			if (!(flags & LONGINT)) {
 				ujval = (uintmax_t)(uintptr_t)GETARG(void *);
 				flags &= ~ALT;
-			}
+			} else
 #endif
+			{
+				cap = GETARG(void * __capability);
+				ujval = cheri_getaddress(cap);
+			}
 			if (flags & ALT) {
 				cp = buf + BUF;
 				cp = __cheri_ptr_alt(cap, cp, xdigs_lower,

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -323,7 +323,7 @@ find_overhead(void * cp)
 	 */
 	error_printf("%s: Attempting to free or realloc unallocated memory\n",
 	    __func__);
-	error_printf(_CHERI_PRINT_PTR_FMT(cp));
+	error_printf("%s: cp %#.16lp\n", __func__, cp);
 	return (NULL);
 }
 

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -323,7 +323,7 @@ find_overhead(void * cp)
 	 */
 	error_printf("%s: Attempting to free or realloc unallocated memory\n",
 	    __func__);
-	error_printf("%s: cp %#.16lp\n", __func__, cp);
+	error_printf("%s: cp %#lp\n", __func__, cp);
 	return (NULL);
 }
 

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -102,8 +102,7 @@ _cheri_capability_build_user_rwx(uint32_t perms, vaddr_t basep, size_t length,
 
 	KASSERT(cheri_getlen(tmpcap) == length,
 	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx: "
-	    _CHERI_PRINTF_CAP_FMT, func, line, cheri_getlen(tmpcap), length,
-	    _CHERI_PRINTF_CAP_ARG(tmpcap)));
+	     "%#.16lp", func, line, cheri_getlen(tmpcap), length, tmpcap));
 
 	return (tmpcap);
 }

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -102,7 +102,7 @@ _cheri_capability_build_user_rwx(uint32_t perms, vaddr_t basep, size_t length,
 
 	KASSERT(cheri_getlen(tmpcap) == length,
 	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx: "
-	     "%#.16lp", func, line, cheri_getlen(tmpcap), length, tmpcap));
+	     "%#lp", func, line, cheri_getlen(tmpcap), length, tmpcap));
 
 	return (tmpcap);
 }

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -211,11 +211,7 @@ cheri_bytes_remaining(const void * __capability cap)
 #define cheri_cap_to_typed_ptr(cap, type)				\
 	(type *)cheri_cap_to_ptr(cap, sizeof(type))
 
-#ifdef __CHERI_PURE_CAPABILITY__
 #define _CHERI_PRINTF_CAP_ARG(ptr)	(ptr)
-#else
-#define _CHERI_PRINTF_CAP_ARG(ptr)	(&(ptr))
-#endif
 #define _CHERI_PRINTF_CAP_FMT  "%#.16lp"
 
 #define _CHERI_PRINT_PTR_FMT(ptr)					\

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -211,19 +211,6 @@ cheri_bytes_remaining(const void * __capability cap)
 #define cheri_cap_to_typed_ptr(cap, type)				\
 	(type *)cheri_cap_to_ptr(cap, sizeof(type))
 
-#define _CHERI_PRINTF_CAP_ARG(ptr)	(ptr)
-#define _CHERI_PRINTF_CAP_FMT  "%#.16lp"
-
-#define _CHERI_PRINT_PTR_FMT(ptr)					\
-	    "%s: " #ptr " " _CHERI_PRINTF_CAP_FMT "\n", __func__,	\
-	    _CHERI_PRINTF_CAP_ARG(ptr)
-
-#define CHERI_PRINT_PTR(ptr)						\
-	printf(_CHERI_PRINT_PTR_FMT(ptr))
-
-#define CHERI_FPRINT_PTR(f, ptr)					\
-	fprintf(f, _CHERI_PRINT_PTR_FMT(ptr))
-
 #endif	/* __has_feature(capabilities) */
 
 /*

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -806,18 +806,16 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			goto handle_nosign;
 		case 'p':
 #if __has_feature(capabilities)
-#ifdef __CHERI_PURE_CAPABILITY__
-			cap = va_arg(ap, void *);
-			num = cheri_getaddress(cap);
-#else
-			if (lflag) {
-				cap = *va_arg(ap, void * __capability *);
-				num = cheri_getaddress(cap);
-			} else {
-				num = (uintptr_t)va_arg(ap, void *);
+#ifndef __CHERI_PURE_CAPABILITY__
+			if (!lflag) {
+				num = (uintmax_t)va_arg(ap, void *);
 				sharpflag = 0;
-			}
+			} else
 #endif
+			{
+				cap = va_arg(ap, void * __capability);
+				num = cheri_getaddress(cap);
+			}
 			if (sharpflag) {
 				int orig_dwidth;
 

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -379,9 +379,8 @@ kern_shmdt_locked(struct thread *td, const void * __capability shmaddr)
 #if __has_feature(capabilities)
 	if (!__CAP_CHECK(shmaddr, shmseg->u.shm_segsz)) {
 		KASSERT(SV_PROC_FLAG(td->td_proc, SV_CHERI),
-		    ("!__CAP_CHECK(" _CHERI_PRINTF_CAP_FMT
-		    ", %zx) for non-CheriABI program",
-		    _CHERI_PRINTF_CAP_ARG(shmaddr), shmseg->u.shm_segsz));
+		    ("!__CAP_CHECK(%#.16lp, %zx) for non-CheriABI program",
+		    shmaddr, shmseg->u.shm_segsz));
 		return (EPROT);
 	}
 #endif

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -379,7 +379,7 @@ kern_shmdt_locked(struct thread *td, const void * __capability shmaddr)
 #if __has_feature(capabilities)
 	if (!__CAP_CHECK(shmaddr, shmseg->u.shm_segsz)) {
 		KASSERT(SV_PROC_FLAG(td->td_proc, SV_CHERI),
-		    ("!__CAP_CHECK(%#.16lp, %zx) for non-CheriABI program",
+		    ("!__CAP_CHECK(%#lp, %zx) for non-CheriABI program",
 		    shmaddr, shmseg->u.shm_segsz));
 		return (EPROT);
 	}

--- a/sys/mips/cheri/cheri_debug.c
+++ b/sys/mips/cheri/cheri_debug.c
@@ -51,8 +51,7 @@
 static inline void
 db_print_cap(const char* msg, void * __capability cap)
 {
-	db_printf("%s" _CHERI_PRINTF_CAP_FMT "\n", msg,
-	    _CHERI_PRINTF_CAP_ARG(cap));
+	db_printf("%s%#.16lp\n", msg, cap);
 }
 
 static void * __capability
@@ -133,8 +132,7 @@ db_show_cheri_trapframe(struct trapframe *frame)
 	/* Laboriously load and print each trapframe capability. */
 	for (i = 1; i < 31; i++) {
 		void * __capability cap = *(&frame->ddc + i);
-		db_printf("$c%02d: " _CHERI_PRINTF_CAP_FMT "\n", i,
-		    _CHERI_PRINTF_CAP_ARG(cap));
+		db_printf("$c%02d: %#.16lp\n", i, cap);
 	}
 }
 

--- a/sys/mips/cheri/cheri_debug.c
+++ b/sys/mips/cheri/cheri_debug.c
@@ -48,12 +48,6 @@
 
 #ifdef DDB
 
-static inline void
-db_print_cap(const char* msg, void * __capability cap)
-{
-	db_printf("%s%#.16lp\n", msg, cap);
-}
-
 static void * __capability
 cheri_getculr(void)
 {
@@ -96,15 +90,15 @@ DB_SHOW_COMMAND(cp2, ddb_dump_cp2)
 		db_printf("RegNum: invalid (%d) ", regnum);
 	db_printf("(%s)\n", cheri_exccode_string(exccode));
 
-	db_print_cap("$ddc: ",  cheri_getdefault());
-	db_print_cap("$pcc: ",  cheri_getpcc());
-	db_print_cap("$culr: ", cheri_getculr());
-	db_print_cap("$cplr: ", cheri_getcplr());
-	db_print_cap("$kcc: ",  cheri_getkcc());
-	db_print_cap("$kdc: ",  cheri_getkdc());
-	db_print_cap("$epcc: ",  cheri_getepcc());
-	db_print_cap("$kr1c: ",  cheri_getkr1c());
-	db_print_cap("$kr2c: ",  cheri_getkr2c());
+	db_printf("$ddc: %#.16lp\n",  cheri_getdefault());
+	db_printf("$pcc: %#.16lp\n",  cheri_getpcc());
+	db_printf("$culr: %#.16lp\n", cheri_getculr());
+	db_printf("$cplr: %#.16lp\n", cheri_getcplr());
+	db_printf("$kcc: %#.16lp\n",  cheri_getkcc());
+	db_printf("$kdc: %#.16lp\n",  cheri_getkdc());
+	db_printf("$epcc: %#.16lp\n",  cheri_getepcc());
+	db_printf("$kr1c: %#.16lp\n",  cheri_getkr1c());
+	db_printf("$kr2c: %#.16lp\n",  cheri_getkr2c());
 }
 
 static void
@@ -127,8 +121,8 @@ db_show_cheri_trapframe(struct trapframe *frame)
 		db_printf("RegNum: invalid (%d) ", regnum);
 	db_printf("(%s)\n", cheri_exccode_string(exccode));
 
-	db_print_cap("$ddc: ", frame->ddc);
-	db_print_cap("$pcc: ", frame->pcc);
+	db_printf("$ddc: %#.16lp\n", frame->ddc);
+	db_printf("$pcc: %#.16lp\n", frame->pcc);
 	/* Laboriously load and print each trapframe capability. */
 	for (i = 1; i < 31; i++) {
 		void * __capability cap = *(&frame->ddc + i);

--- a/sys/mips/cheri/cheri_exception.c
+++ b/sys/mips/cheri/cheri_exception.c
@@ -230,93 +230,39 @@ void
 cheri_log_exception_registers(struct trapframe *frame)
 {
 
-	cheri_log_cheri_frame(frame);
-}
-
-static inline void
-cheri_cap_print(void* __capability cap)
-{
-
-	printf("%#.16lp\n", cap);
-}
-
-#define	CHERI_REG_PRINT(cap, num) do {					\
-	printf("$c%02u: ", num);					\
-	cheri_cap_print(cap);						\
-} while (0)
-
-void
-cheri_log_cheri_frame(struct trapframe *frame)
-{
-
-	/* C0 - $ddc */
-	printf("$ddc: ");
-	cheri_cap_print(frame->ddc);
-	/* C1 */
-	CHERI_REG_PRINT(frame->c1, 1);
-	/* C2 */
-	CHERI_REG_PRINT(frame->c2, 2);
-	/* C3 */
-	CHERI_REG_PRINT(frame->c3, 3);
-	/* C4 */
-	CHERI_REG_PRINT(frame->c4, 4);
-	/* C5 */
-	CHERI_REG_PRINT(frame->c5, 5);
-	/* C6 */
-	CHERI_REG_PRINT(frame->c6, 6);
-	/* C7 */
-	CHERI_REG_PRINT(frame->c7, 7);
-	/* C8 */
-	CHERI_REG_PRINT(frame->c8, 8);
-	/* C9 */
-	CHERI_REG_PRINT(frame->c9, 9);
-	/* C10 */
-	CHERI_REG_PRINT(frame->c10, 10);
-	/* C11 */
-	CHERI_REG_PRINT(frame->csp, 11);
-	/* C12 */
-	CHERI_REG_PRINT(frame->c12, 12);
-	/* C13 */
-	CHERI_REG_PRINT(frame->c13, 13);
-	/* C14 */
-	CHERI_REG_PRINT(frame->c14, 14);
-	/* C15 */
-	CHERI_REG_PRINT(frame->c15, 15);
-	/* C16 */
-	CHERI_REG_PRINT(frame->c16, 16);
-	/* C17 */
-	CHERI_REG_PRINT(frame->c17, 17);
-	/* C18 */
-	CHERI_REG_PRINT(frame->c18, 18);
-	/* C19 */
-	CHERI_REG_PRINT(frame->c19, 19);
-	/* C20 */
-	CHERI_REG_PRINT(frame->c20, 20);
-	/* C21 */
-	CHERI_REG_PRINT(frame->c21, 21);
-	/* C22 */
-	CHERI_REG_PRINT(frame->c22, 22);
-	/* C23 */
-	CHERI_REG_PRINT(frame->c23, 23);
-	/* C24 */
-	CHERI_REG_PRINT(frame->c24, 24);
-	/* C25 */
-	CHERI_REG_PRINT(frame->c25, 25);
-	/* C26 - $idc / $cgp */
-	CHERI_REG_PRINT(frame->idc, 26);
-	/* C27 */
-	CHERI_REG_PRINT(frame->c27, 27);
-	/* C28 */
-	CHERI_REG_PRINT(frame->c28, 28);
-	/* C29 */
-	CHERI_REG_PRINT(frame->c29, 29);
-	/* C30 */
-	CHERI_REG_PRINT(frame->c30, 30);
-	/* C31 */
-	CHERI_REG_PRINT(frame->c31, 31);
-	/* saved $pcc */
-	printf("$pcc: ");
-	cheri_cap_print(frame->pcc);
+	printf("$ddc: %#.16lp\n", frame->ddc);
+	printf("$c01: %#.16lp\n", frame->c1);
+	printf("$c02: %#.16lp\n", frame->c2);
+	printf("$c03: %#.16lp\n", frame->c3);
+	printf("$c04: %#.16lp\n", frame->c4);
+	printf("$c05: %#.16lp\n", frame->c5);
+	printf("$c06: %#.16lp\n", frame->c6);
+	printf("$c07: %#.16lp\n", frame->c7);
+	printf("$c08: %#.16lp\n", frame->c8);
+	printf("$c09: %#.16lp\n", frame->c9);
+	printf("$c10: %#.16lp\n", frame->c10);
+	printf("$c11: %#.16lp\n", frame->csp);
+	printf("$c12: %#.16lp\n", frame->c12);
+	printf("$c13: %#.16lp\n", frame->c13);
+	printf("$c14: %#.16lp\n", frame->c14);
+	printf("$c15: %#.16lp\n", frame->c15);
+	printf("$c16: %#.16lp\n", frame->c16);
+	printf("$c17: %#.16lp\n", frame->c17);
+	printf("$c18: %#.16lp\n", frame->c18);
+	printf("$c19: %#.16lp\n", frame->c19);
+	printf("$c20: %#.16lp\n", frame->c20);
+	printf("$c21: %#.16lp\n", frame->c21);
+	printf("$c22: %#.16lp\n", frame->c22);
+	printf("$c23: %#.16lp\n", frame->c23);
+	printf("$c24: %#.16lp\n", frame->c24);
+	printf("$c25: %#.16lp\n", frame->c25);
+	printf("$c26: %#.16lp\n", frame->idc);
+	printf("$c27: %#.16lp\n", frame->c27);
+	printf("$c28: %#.16lp\n", frame->c28);
+	printf("$c29: %#.16lp\n", frame->c29);
+	printf("$c30: %#.16lp\n", frame->c30);
+	printf("$c31: %#.16lp\n", frame->c31);
+	printf("$pcc: %#.16lp\n", frame->pcc);
 }
 
 void

--- a/sys/mips/cheri/cheri_exception.c
+++ b/sys/mips/cheri/cheri_exception.c
@@ -237,7 +237,7 @@ static inline void
 cheri_cap_print(void* __capability cap)
 {
 
-	printf(_CHERI_PRINTF_CAP_FMT "\n", _CHERI_PRINTF_CAP_ARG(cap));
+	printf("%#.16lp\n", cap);
 }
 
 #define	CHERI_REG_PRINT(cap, num) do {					\

--- a/sys/mips/include/cheri.h
+++ b/sys/mips/include/cheri.h
@@ -121,7 +121,6 @@ struct cheri_frame;
 struct sysentvec;
 struct trapframe;
 int	cheri_capcause_to_sicode(register_t capcause);
-void	cheri_log_cheri_frame(struct trapframe *frame);
 void	cheri_log_exception(struct trapframe *frame, int trap_type);
 void	cheri_log_exception_registers(struct trapframe *frame);
 void	cheri_trapframe_from_cheriframe(struct trapframe *frame,

--- a/sys/mips/include/cheri_machdep.h
+++ b/sys/mips/include/cheri_machdep.h
@@ -52,9 +52,8 @@ _update_pcc_offset(trapf_pc_t pcc, register_t pc, const char *func)
 	if (cheri_gettype(pcc) == CHERI_OTYPE_UNSEALED) {
 		void* __capability result = cheri_setoffset(pcc, pc);
 		if (!cheri_gettag(result))
-			printf("%s: created untagged $pcc: "
-			    _CHERI_PRINTF_CAP_FMT "\n", func,
-			    _CHERI_PRINTF_CAP_ARG(result));
+			printf("%s: created untagged $pcc: %#.16lp\n", func,
+			    result);
 		return result;
 	} else if (cheri_getoffset(pcc) == pc) {
 		/* Don't warn if the values match (not modifying $pcc) */
@@ -62,7 +61,7 @@ _update_pcc_offset(trapf_pc_t pcc, register_t pc, const char *func)
 	} else {
 		printf("%s: attempted to change sealed $pcc offset 0x%jx\n",
 		    func, (intmax_t)pc);
-		CHERI_PRINT_PTR(pcc);
+		printf("%s: pcc %#.16lp\n", __func__, pcc);
 		return cheri_fromint(pc);
 	}
 }

--- a/sys/mips/include/cheri_machdep.h
+++ b/sys/mips/include/cheri_machdep.h
@@ -52,7 +52,7 @@ _update_pcc_offset(trapf_pc_t pcc, register_t pc, const char *func)
 	if (cheri_gettype(pcc) == CHERI_OTYPE_UNSEALED) {
 		void* __capability result = cheri_setoffset(pcc, pc);
 		if (!cheri_gettag(result))
-			printf("%s: created untagged $pcc: %#.16lp\n", func,
+			printf("%s: created untagged $pcc: %#lp\n", func,
 			    result);
 		return result;
 	} else if (cheri_getoffset(pcc) == pc) {
@@ -61,7 +61,7 @@ _update_pcc_offset(trapf_pc_t pcc, register_t pc, const char *func)
 	} else {
 		printf("%s: attempted to change sealed $pcc offset 0x%jx\n",
 		    func, (intmax_t)pc);
-		printf("%s: pcc %#.16lp\n", __func__, pcc);
+		printf("%s: pcc %#lp\n", __func__, pcc);
 		return cheri_fromint(pc);
 	}
 }

--- a/sys/riscv/cheri/cheri_debug.c
+++ b/sys/riscv/cheri/cheri_debug.c
@@ -48,12 +48,6 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
-static inline void
-db_print_cap(const char* msg, void * __capability cap)
-{
-	db_printf("%s%#.16lp\n", msg, cap);
-}
-
 /*
  * Show the special capability registers that aren't GPRs.
  */
@@ -65,12 +59,12 @@ DB_SHOW_COMMAND(scr, ddb_dump_scr)
 	db_printf("sccsr: %s, %s\n", sccsr & SCCSR_E ? "enabled" : "disabled",
 	    sccsr & SCCSR_D ? "dirty" : "clean");
 
-	db_print_cap("ddc: ",  scr_read(ddc));
-	db_print_cap("pcc: ",  scr_read(pcc));
-	db_print_cap("stcc: ",  scr_read(stcc));
-	db_print_cap("stdc: ",  scr_read(stdc));
-	db_print_cap("sscratchc: ",  scr_read(sscratchc));
-	db_print_cap("sepcc: ",  scr_read(sepcc));
+	db_printf("ddc: %#.16lp\n",  scr_read(ddc));
+	db_printf("pcc: %#.16lp\n",  scr_read(pcc));
+	db_printf("stcc: %#.16lp\n",  scr_read(stcc));
+	db_printf("stdc: %#.16lp\n",  scr_read(stdc));
+	db_printf("sscratchc: %#.16lp\n",  scr_read(sscratchc));
+	db_printf("sepcc: %#.16lp\n",  scr_read(sepcc));
 
 	/* XXX: Do user-mode registers if we support N? */
 }

--- a/sys/riscv/cheri/cheri_debug.c
+++ b/sys/riscv/cheri/cheri_debug.c
@@ -51,8 +51,7 @@
 static inline void
 db_print_cap(const char* msg, void * __capability cap)
 {
-	db_printf("%s" _CHERI_PRINTF_CAP_FMT "\n", msg,
-	    _CHERI_PRINTF_CAP_ARG(cap));
+	db_printf("%s%#.16lp\n", msg, cap);
 }
 
 /*

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -198,13 +198,10 @@ cpu_fetch_syscall_args(struct thread *td)
 #include "../../kern/subr_syscall.c"
 
 #if __has_feature(capabilities)
-#define	PRINT_REG_ARG(value)	((void * __capability)(value))
-#define PRINT_REG(name, value)					\
-	printf(name " = " _CHERI_PRINTF_CAP_FMT "\n",		\
-	    PRINT_REG_ARG(value));
-#define PRINT_REG_N(name, n, array)				\
-	printf(name "[%d] = " _CHERI_PRINTF_CAP_FMT "\n", n,	\
-	    PRINT_REG_ARG((array)[n]));
+#define PRINT_REG(name, value)	\
+	printf(name " = %#.16lp\n", (void * __capability)(value));
+#define PRINT_REG_N(name, n, array)	\
+	printf(name "[%d] = %#.16lp\n", n, (void * __capability)(array)[n]);
 #else
 #define PRINT_REG(name, value)	printf(name " = 0x%016lx\n", value)
 #define PRINT_REG_N(name, n, array)	\

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -197,16 +197,8 @@ cpu_fetch_syscall_args(struct thread *td)
 
 #include "../../kern/subr_syscall.c"
 
-/*
- * This cannot use _CHERI_PRINTF_CAP_ARG due to the casts (the trapframe stores
- * uintcap_t rather than void * __capability).
- */
 #if __has_feature(capabilities)
-#ifdef __CHERI_PURE_CAPABILITY__
 #define	PRINT_REG_ARG(value)	((void * __capability)(value))
-#else
-#define	PRINT_REG_ARG(value)	((void * __capability *)&(value))
-#endif
 #define PRINT_REG(name, value)					\
 	printf(name " = " _CHERI_PRINTF_CAP_FMT "\n",		\
 	    PRINT_REG_ARG(value));


### PR DESCRIPTION
Clang now supports capabilities for hybrid varargs and knows that %lp takes a capability, so we can avoid this hack.
