### PR TITLE
WIP: Explicit int -> cap conversions

### DIFF
--- a/sys/cam/ctl/ctl.c
+++ b/sys/cam/ctl/ctl.c
@@ -3459,8 +3459,9 @@ ctl_ioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag,
 				stats->status = CTL_SS_NEED_MORE_SPACE;
 				break;
 			}
-			retval = copyout(&lun->stats, &stats->stats[i++],
-					 sizeof(lun->stats));
+			retval = copyout(&lun->stats,
+			    __CAP_ADDROF(stats->stats[i++]),
+			    sizeof(lun->stats));
 			if (retval != 0)
 				break;
 			stats->fill_len += sizeof(lun->stats);
@@ -3492,8 +3493,9 @@ ctl_ioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag,
 				stats->status = CTL_SS_NEED_MORE_SPACE;
 				break;
 			}
-			retval = copyout(&port->stats, &stats->stats[i++],
-					 sizeof(port->stats));
+			retval = copyout(&port->stats,
+			    __CAP_ADDROF(stats->stats[i++]),
+			    sizeof(port->stats));
 			if (retval != 0)
 				break;
 			stats->fill_len += sizeof(port->stats);

--- a/sys/cam/ctl/ctl_ha.c
+++ b/sys/cam/ctl/ctl_ha.c
@@ -325,7 +325,7 @@ ctl_ha_sock_setup(struct ha_softc *softc)
 	opt.sopt_dir = SOPT_SET;
 	opt.sopt_level = SOL_SOCKET;
 	opt.sopt_name = SO_KEEPALIVE;
-	opt.sopt_val = &val;
+	opt.sopt_val = __CAP_ADDROF(val);
 	opt.sopt_valsize = sizeof(val);
 	val = 1;
 	error = sosetopt(so, &opt);
@@ -452,7 +452,7 @@ ctl_ha_listen(struct ha_softc *softc)
 		opt.sopt_dir = SOPT_SET;
 		opt.sopt_level = SOL_SOCKET;
 		opt.sopt_name = SO_REUSEADDR;
-		opt.sopt_val = &val;
+		opt.sopt_val = __CAP_ADDROF(val);
 		opt.sopt_valsize = sizeof(val);
 		val = 1;
 		error = sosetopt(softc->ha_lso, &opt);
@@ -464,7 +464,7 @@ ctl_ha_listen(struct ha_softc *softc)
 		opt.sopt_dir = SOPT_SET;
 		opt.sopt_level = SOL_SOCKET;
 		opt.sopt_name = SO_REUSEPORT;
-		opt.sopt_val = &val;
+		opt.sopt_val = __CAP_ADDROF(val);
 		opt.sopt_valsize = sizeof(val);
 		val = 1;
 		error = sosetopt(softc->ha_lso, &opt);

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_ioctl.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_ioctl.c
@@ -820,7 +820,7 @@ zfs_secpolicy_deleg_share(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 	vnode_t *vp;
 	int error;
 
-	if ((error = lookupname(zc->zc_value, UIO_SYSSPACE,
+	if ((error = lookupname(__CAP_DECAY(zc->zc_value), UIO_SYSSPACE,
 	    NO_FOLLOW, NULL, &vp)) != 0)
 		return (error);
 

--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_vnops.c
@@ -5538,7 +5538,7 @@ vop_getextattr {
 	}
 
 	flags = FREAD;
-	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, attrname,
+	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, __CAP_DECAY(attrname),
 	    xvp, td);
 	error = vn_open_cred(&nd, &flags, VN_OPEN_INVFS, 0, ap->a_cred, NULL);
 	vp = nd.ni_vp;
@@ -5606,8 +5606,8 @@ vop_deleteextattr {
 		return (error);
 	}
 
-	NDINIT_ATVP(&nd, DELETE, NOFOLLOW | LOCKPARENT | LOCKLEAF,
-	    UIO_SYSSPACE, attrname, xvp, td);
+	NDINIT_ATVP(&nd, DELETE, NOFOLLOW | LOCKPARENT | LOCKLEAF, UIO_SYSSPACE,
+	    __CAP_DECAY(attrname), xvp, td);
 	error = namei(&nd);
 	vp = nd.ni_vp;
 	if (error != 0) {
@@ -5675,7 +5675,7 @@ vop_setextattr {
 	}
 
 	flags = FFLAGS(O_WRONLY | O_CREAT);
-	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, attrname,
+	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, __CAP_DECAY(attrname),
 	    xvp, td);
 	error = vn_open_cred(&nd, &flags, 0600, VN_OPEN_INVFS, ap->a_cred,
 	    NULL);
@@ -5757,8 +5757,8 @@ vop_listextattr {
 		return (error);
 	}
 
-	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW | LOCKLEAF | LOCKSHARED,
-	    UIO_SYSSPACE, ".", xvp, td);
+	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW | LOCKLEAF | LOCKSHARED, UIO_SYSSPACE,
+	    __CAP_DECAY("."), xvp, td);
 	error = namei(&nd);
 	vp = nd.ni_vp;
 	NDFREE(&nd, NDF_ONLY_PNBUF);

--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -635,7 +635,8 @@ cloudabi_sys_file_stat_fput(struct thread *td,
 		    CLOUDABI_FILESTAT_MTIM_NOW)) != 0)
 			return (EINVAL);
 		convert_utimens_arguments(&fs, uap->flags, ts);
-		return (kern_futimens(td, uap->fd, &ts[0], UIO_SYSSPACE));
+		return (kern_futimens(td, uap->fd, __CAP_ADDROF(ts[0]),
+		    UIO_SYSSPACE));
 	}
 	return (EINVAL);
 }
@@ -710,9 +711,10 @@ cloudabi_sys_file_stat_put(struct thread *td,
 		return (error);
 
 	convert_utimens_arguments(&fs, uap->flags, ts);
-	error = kern_utimensat(td, uap->fd.fd, PTR2CAP(path), UIO_SYSSPACE, ts,
-	    UIO_SYSSPACE, (uap->fd.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) ?
-	    0 : AT_SYMLINK_NOFOLLOW);
+	error = kern_utimensat(td, uap->fd.fd, PTR2CAP(path), UIO_SYSSPACE,
+	    __CAP_DECAY(ts), UIO_SYSSPACE,
+	    (uap->fd.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) ? 0 :
+	    AT_SYMLINK_NOFOLLOW);
 	cloudabi_freestr(path);
 	return (error);
 }

--- a/sys/compat/freebsd64/freebsd64_jail.c
+++ b/sys/compat/freebsd64/freebsd64_jail.c
@@ -86,8 +86,9 @@ freebsd64_jail(struct thread *td, struct freebsd64_jail_args *uap)
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j0.ip_number);
 		return (kern_jail(td, __USER_CAP_STR(j0.path),
-		    __USER_CAP_STR(j0.hostname), NULL, &ip4, 1,
-		    NULL, 0, UIO_SYSSPACE)); }
+		    __USER_CAP_STR(j0.hostname), NULL, __CAP_ADDROF(ip4), 1,
+		    NULL, 0, UIO_SYSSPACE));
+	}
 
 	case 1:
 		/*

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1445,9 +1445,9 @@ freebsd64___sysctlbyname(struct thread *td, struct
 			return (EFAULT);
 
 	error = kern___sysctlbyname(td, __USER_CAP(uap->name, uap->namelen),
-	    uap->namelen, __USER_CAP(uap->old, oldlen),
-	    &oldlen, __USER_CAP(uap->new, uap->newlen),
-	    uap->newlen, &rv, SCTL_MASK64, 1);
+	    uap->namelen, __USER_CAP(uap->old, oldlen), __CAP_ADDROF(oldlen),
+	    __USER_CAP(uap->new, uap->newlen), uap->newlen, &rv, SCTL_MASK64,
+	    1);
 	if (error != 0)
 		return (error);
 	if (uap->oldlenp != NULL)

--- a/sys/compat/freebsd64/freebsd64_process.c
+++ b/sys/compat/freebsd64/freebsd64_process.c
@@ -167,7 +167,7 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 	AUDIT_ARG_PID(uap->pid);
 	AUDIT_ARG_CMD(uap->req);
 	AUDIT_ARG_VALUE(uap->data);
-	addr = &r;
+	addr = __CAP_ADDROF(r);
 	data = uap->data;
 	switch (uap->req) {
 	case PT_GET_EVENT_MASK:

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -275,6 +275,14 @@ CHERI_SUBOBJECT_BOUNDS_STATS_FILE?=kernel-subobject-bounds-stats.csv
 CFLAGS+=	-mllvm -collect-csetbounds-stats=csv \
 	-Xclang -cheri-stats-file="${CHERI_SUBOBJECT_BOUNDS_STATS_FILE}"
 .endif
+#
+# CHERI hybrid kernel flags
+#
+.elif ${MACHINE_CPU:Mcheri}
+# FIXME: despite being accepted by the frontend, these flags are not forwarded
+#        to -cc1, so we need to use -Xclang for now
+# Avoid implicit int -> ddc-relative cap conversions
+CFLAGS+=	-Xclang -cheri-int-to-cap=explicit
 .endif
 
 CFLAGS+= ${CWARNFLAGS:M*} ${CWARNFLAGS.${.IMPSRC:T}}

--- a/sys/dev/amr/amr.c
+++ b/sys/dev/amr/amr.c
@@ -673,7 +673,9 @@ amr_linux_ioctl_int(struct cdev *dev, u_long cmd, caddr_t addr, int32_t flag,
 		    break;
 	    }
 	    error = copyout(ap->ap_request_sense_area,
-		uap->ap_request_sense_area, ap->ap_request_sense_length);
+		__CAP_DECAY_LEN(uap->ap_request_sense_area,
+		    ap->ap_request_sense_length),
+		ap->ap_request_sense_length);
 	    if (error)
 		break;
 

--- a/sys/dev/iscsi/icl_soft.c
+++ b/sys/dev/iscsi/icl_soft.c
@@ -1315,7 +1315,7 @@ icl_conn_start(struct icl_conn *ic)
 	opt.sopt_dir = SOPT_SET;
 	opt.sopt_level = IPPROTO_TCP;
 	opt.sopt_name = TCP_NODELAY;
-	opt.sopt_val = &one;
+	opt.sopt_val = __CAP_ADDROF(one);
 	opt.sopt_valsize = sizeof(one);
 	error = sosetopt(ic->ic_socket, &opt);
 	if (error != 0) {

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -1444,7 +1444,7 @@ mdcreate_vnode(struct md_s *sc, struct md_req *mdr, struct thread *td)
 	 */
 	flags = FREAD | ((mdr->md_options & MD_READONLY) ? 0 : FWRITE) \
 	    | ((mdr->md_options & MD_VERIFY) ? O_VERIFY : 0);
-	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, sc->file, td);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, fname, td);
 	error = vn_open(&nd, &flags, 0, NULL);
 	if (error != 0)
 		return (error);

--- a/sys/dev/pci/pci_user.c
+++ b/sys/dev/pci/pci_user.c
@@ -645,7 +645,8 @@ pci_list_vpd(device_t dev, struct pci_list_vpd_io *lvio)
 	error = copyout(&vpd_element, vpd_user, sizeof(vpd_element));
 	if (error)
 		return (error);
-	error = copyout(vpd->vpd_ident, vpd_user->pve_data,
+	error = copyout(vpd->vpd_ident,
+	    __CAP_DECAY_LEN(vpd_user->pve_data, strlen(vpd->vpd_ident)),
 	    strlen(vpd->vpd_ident));
 	if (error)
 		return (error);
@@ -658,7 +659,8 @@ pci_list_vpd(device_t dev, struct pci_list_vpd_io *lvio)
 		error = copyout(&vpd_element, vpd_user, sizeof(vpd_element));
 		if (error)
 			return (error);
-		error = copyout(vpd->vpd_ros[i].value, vpd_user->pve_data,
+		error = copyout(vpd->vpd_ros[i].value,
+		    __CAP_DECAY_LEN(vpd_user->pve_data, vpd->vpd_ros[i].len),
 		    vpd->vpd_ros[i].len);
 		if (error)
 			return (error);
@@ -672,7 +674,8 @@ pci_list_vpd(device_t dev, struct pci_list_vpd_io *lvio)
 		error = copyout(&vpd_element, vpd_user, sizeof(vpd_element));
 		if (error)
 			return (error);
-		error = copyout(vpd->vpd_w[i].value, vpd_user->pve_data,
+		error = copyout(vpd->vpd_w[i].value,
+		    __CAP_DECAY_LEN(vpd_user->pve_data, vpd->vpd_w[i].len),
 		    vpd->vpd_w[i].len);
 		if (error)
 			return (error);

--- a/sys/fs/nfsclient/nfs_clvnops.c
+++ b/sys/fs/nfsclient/nfs_clvnops.c
@@ -569,7 +569,7 @@ nfs_access(struct vop_access_args *ap)
 			char buf[1];
 
 			NFSUNLOCKNODE(np);
-			IOVEC_INIT_C(&aiov, buf, 1);
+			IOVEC_INIT_C(&aiov, __CAP_DECAY(buf), 1);
 			auio.uio_iov = &aiov;
 			auio.uio_iovcnt = 1;
 			auio.uio_offset = 0;

--- a/sys/fs/smbfs/smbfs_smb.c
+++ b/sys/fs/smbfs/smbfs_smb.c
@@ -985,7 +985,8 @@ smbfs_smb_search(struct smbfs_fctx *ctx)
 		mb_put_uint8(mbp, 0);	/* file name length */
 		mb_put_uint8(mbp, SMB_DT_VARIABLE);
 		mb_put_uint16le(mbp, SMB_SKEYLEN);
-		mb_put_mem(mbp, ctx->f_skey, SMB_SKEYLEN, MB_MSYSTEM);
+		mb_put_mem(mbp, __CAP_DECAY(ctx->f_skey), SMB_SKEYLEN,
+		    MB_MSYSTEM);
 	}
 	smb_rq_bend(rqp);
 	error = smb_rq_simple(rqp);
@@ -1060,7 +1061,7 @@ smbfs_findnextLM1(struct smbfs_fctx *ctx, int limit)
 	}
 	rqp = ctx->f_rq;
 	smb_rq_getreply(rqp, &mbp);
-	md_get_mem(mbp, ctx->f_skey, SMB_SKEYLEN, MB_MSYSTEM);
+	md_get_mem(mbp, __CAP_DECAY(ctx->f_skey), SMB_SKEYLEN, MB_MSYSTEM);
 	md_get_uint8(mbp, &battr);
 	md_get_uint16le(mbp, &time);
 	md_get_uint16le(mbp, &date);

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -752,7 +752,8 @@ start_init(void *dummy)
 		if (error != 0)
 			panic("%s: Can't add argv[0] %d", __func__, error);
 		if (boothowto & RB_SINGLE)
-			error = exec_args_add_arg(&args, "-s", UIO_SYSSPACE);
+			error = exec_args_add_arg(&args, __CAP_DECAY("-s"),
+			    UIO_SYSSPACE);
 		if (error != 0)
 			panic("%s: Can't add argv[0] %d", __func__, error);
 

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -2530,8 +2530,8 @@ fdcheckstd(struct thread *td)
 		if (devnull != -1) {
 			error = kern_dup(td, FDDUP_FIXED, 0, devnull, i);
 		} else {
-			error = kern_openat(td, AT_FDCWD, "/dev/null",
-			    UIO_SYSSPACE, O_RDWR, 0);
+			error = kern_openat(td, AT_FDCWD,
+			    __CAP_DECAY("/dev/null"), UIO_SYSSPACE, O_RDWR, 0);
 			if (error == 0) {
 				devnull = td->td_retval[0];
 				KASSERT(devnull == i, ("we didn't get our fd"));

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -282,8 +282,8 @@ sys_jail(struct thread *td, struct jail_args *uap)
 			return (error);
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j0.ip_number);
-		return (kern_jail(td, j0.path, j0.hostname, NULL, &ip4, 1,
-		    NULL, 0, UIO_SYSSPACE));
+		return (kern_jail(td, j0.path, j0.hostname, NULL,
+		    __CAP_ADDROF(ip4), 1, NULL, 0, UIO_SYSSPACE));
 	}
 
 	case 1:

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -246,84 +246,84 @@ sysctl_load_tunable_by_oid_locked(struct sysctl_oid *oidp)
 		    sizeof(int), GETENV_SIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_UINT:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(int), GETENV_UNSIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_LONG:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(long), GETENV_SIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_ULONG:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(long), GETENV_UNSIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_S8:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(int8_t), GETENV_SIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_S16:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(int16_t), GETENV_SIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_S32:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(int32_t), GETENV_SIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_S64:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(int64_t), GETENV_SIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_U8:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(uint8_t), GETENV_UNSIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_U16:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(uint16_t), GETENV_UNSIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_U32:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(uint32_t), GETENV_UNSIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_U64:
 		if (getenv_array(path + rem, data, sizeof(data), &size,
 		    sizeof(uint64_t), GETENV_UNSIGNED) == 0)
 			return;
 		req.newlen = size;
-		req.newptr = data;
+		req.newptr = __CAP_DECAY(data);
 		break;
 	case CTLTYPE_STRING:
 		penv = kern_getenv(path + rem);

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -514,7 +514,7 @@ sys_ptrace(struct thread *td, struct ptrace_args *uap)
 	AUDIT_ARG_PID(uap->pid);
 	AUDIT_ARG_CMD(uap->req);
 	AUDIT_ARG_VALUE(uap->data);
-	addr = &r;
+	addr = __CAP_ADDROF(r);
 	switch (uap->req) {
 	case PT_GET_EVENT_MASK:
 	case PT_LWPINFO:

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -847,7 +847,7 @@ user_sendto(struct thread *td, int s, const char * __capability buf,
 
 	msg.msg_name = __DECONST_CAP(void * __capability, to);
 	msg.msg_namelen = tolen;
-	msg.msg_iov = &aiov;
+	msg.msg_iov = __CAP_ADDROF(aiov);
 	msg.msg_iovlen = 1;
 	msg.msg_control = 0;
 #ifdef COMPAT_OLDSOCK
@@ -1129,7 +1129,7 @@ kern_recvfrom(struct thread *td, int s, void * __capability buf, size_t len,
 		msg.msg_namelen = 0;
 	}
 	msg.msg_name = from;
-	msg.msg_iov = &aiov;
+	msg.msg_iov = __CAP_ADDROF(aiov);
 	msg.msg_iovlen = 1;
 	IOVEC_INIT_C(&aiov, buf, len);
 	msg.msg_control = 0;

--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -1600,7 +1600,8 @@ unp_connectat(int fd, struct socket *so, struct sockaddr *nam,
 
 	sa = malloc(sizeof(struct sockaddr_un), M_SONAME, M_WAITOK);
 	NDINIT_ATRIGHTS(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF,
-	    UIO_SYSSPACE, buf, fd, cap_rights_init(&rights, CAP_CONNECTAT), td);
+	    UIO_SYSSPACE, __CAP_DECAY(buf), fd,
+	    cap_rights_init(&rights, CAP_CONNECTAT), td);
 	error = namei(&nd);
 	if (error)
 		vp = NULL;

--- a/sys/kern/vfs_default.c
+++ b/sys/kern/vfs_default.c
@@ -831,7 +831,7 @@ vop_stdvptocnp(struct vop_vptocnp_args *ap)
 	locked = VOP_ISLOCKED(vp);
 	VOP_UNLOCK(vp);
 	NDINIT_ATVP(&nd, LOOKUP, FOLLOW | LOCKSHARED | LOCKLEAF, UIO_SYSSPACE,
-	    "..", vp, td);
+	    __CAP_DECAY(".."), vp, td);
 	flags = FREAD;
 	error = vn_open_cred(&nd, &flags, 0, VN_OPEN_NOAUDIT, cred, NULL);
 	if (error) {

--- a/sys/kern/vfs_mountroot.c
+++ b/sys/kern/vfs_mountroot.c
@@ -307,7 +307,8 @@ vfs_mountroot_devfs(struct thread *td, struct mount **mpp)
 
 	set_rootvnode();
 
-	error = kern_symlinkat(td, "/", AT_FDCWD, "dev", UIO_SYSSPACE);
+	error = kern_symlinkat(td, __CAP_DECAY("/"), AT_FDCWD,
+	    __CAP_DECAY("dev"), UIO_SYSSPACE);
 	if (error)
 		printf("kern_symlink /dev -> / returns %d\n", error);
 
@@ -392,7 +393,8 @@ vfs_mountroot_shuffle(struct thread *td, struct mount *mpdevfs)
 	}
 
 	/* Remount devfs under /dev */
-	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE, "/dev", td);
+	NDINIT(&nd, LOOKUP, FOLLOW | LOCKLEAF, UIO_SYSSPACE,
+	    __CAP_DECAY("/dev"), td);
 	error = namei(&nd);
 	if (!error) {
 		vp = nd.ni_vp;
@@ -420,8 +422,8 @@ vfs_mountroot_shuffle(struct thread *td, struct mount *mpdevfs)
 	if (mporoot == mpdevfs) {
 		vfs_unbusy(mpdevfs);
 		/* Unlink the no longer needed /dev/dev -> / symlink */
-		error = kern_funlinkat(td, AT_FDCWD, "/dev/dev", FD_NONE,
-		    UIO_SYSSPACE, 0, 0);
+		error = kern_funlinkat(td, AT_FDCWD, __CAP_DECAY("/dev/dev"),
+		    FD_NONE, UIO_SYSSPACE, 0, 0);
 		if (error)
 			printf("mountroot: unable to unlink /dev/dev "
 			    "(error %d)\n", error);
@@ -938,7 +940,8 @@ vfs_mountroot_readconf(struct thread *td, struct sbuf *sb)
 	ssize_t resid;
 	int error, flags, len;
 
-	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, "/.mount.conf", td);
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, __CAP_DECAY("/.mount.conf"),
+	    td);
 	flags = FREAD;
 	error = vn_open(&nd, &flags, 0, NULL);
 	if (error)

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -3061,7 +3061,7 @@ getutimes(const struct timeval * __capability usrtvp, enum uio_seg tvpseg,
 		} else {
 			if ((error = copyin(usrtvp, tv, sizeof(tv))) != 0)
 				return (error);
-			tvp = tv;
+			tvp = __CAP_DECAY(tv);
 		}
 
 		if (tvp[0].tv_usec < 0 || tvp[0].tv_usec >= 1000000 ||

--- a/sys/net/if_vxlan.c
+++ b/sys/net/if_vxlan.c
@@ -970,7 +970,7 @@ vxlan_socket_init(struct vxlan_socket *vso, struct ifnet *ifp)
 		sopt.sopt_dir = SOPT_SET;
 		sopt.sopt_level = IPPROTO_IP;
 		sopt.sopt_name = SO_REUSEPORT;
-		sopt.sopt_val = &val;
+		sopt.sopt_val = __CAP_ADDROF(val);
 		sopt.sopt_valsize = sizeof(val);
 		error = sosetopt(vso->vxlso_sock, &sopt);
 		if (error) {
@@ -1127,7 +1127,7 @@ vxlan_socket_mc_join_group(struct vxlan_socket *vso,
 		sopt.sopt_dir = SOPT_SET;
 		sopt.sopt_level = IPPROTO_IP;
 		sopt.sopt_name = IP_ADD_MEMBERSHIP;
-		sopt.sopt_val = &mreq;
+		sopt.sopt_val = __CAP_ADDROF(mreq);
 		sopt.sopt_valsize = sizeof(mreq);
 		error = sosetopt(vso->vxlso_sock, &sopt);
 		if (error)
@@ -1158,7 +1158,7 @@ vxlan_socket_mc_join_group(struct vxlan_socket *vso,
 		sopt.sopt_dir = SOPT_SET;
 		sopt.sopt_level = IPPROTO_IPV6;
 		sopt.sopt_name = IPV6_JOIN_GROUP;
-		sopt.sopt_val = &mreq;
+		sopt.sopt_val = __CAP_ADDROF(mreq);
 		sopt.sopt_valsize = sizeof(mreq);
 		error = sosetopt(vso->vxlso_sock, &sopt);
 		if (error)
@@ -1193,7 +1193,7 @@ vxlan_socket_mc_leave_group(struct vxlan_socket *vso,
 
 		sopt.sopt_level = IPPROTO_IP;
 		sopt.sopt_name = IP_DROP_MEMBERSHIP;
-		sopt.sopt_val = &mreq;
+		sopt.sopt_val = __CAP_ADDROF(mreq);
 		sopt.sopt_valsize = sizeof(mreq);
 		error = sosetopt(vso->vxlso_sock, &sopt);
 
@@ -1205,7 +1205,7 @@ vxlan_socket_mc_leave_group(struct vxlan_socket *vso,
 
 		sopt.sopt_level = IPPROTO_IPV6;
 		sopt.sopt_name = IPV6_LEAVE_GROUP;
-		sopt.sopt_val = &mreq;
+		sopt.sopt_val = __CAP_ADDROF(mreq);
 		sopt.sopt_valsize = sizeof(mreq);
 		error = sosetopt(vso->vxlso_sock, &sopt);
 

--- a/sys/netgraph/bluetooth/socket/ng_btsocket_rfcomm.c
+++ b/sys/netgraph/bluetooth/socket/ng_btsocket_rfcomm.c
@@ -1327,7 +1327,7 @@ ng_btsocket_rfcomm_session_create(ng_btsocket_rfcomm_session_p *sp,
 	l2sopt.sopt_dir = SOPT_SET;
 	l2sopt.sopt_level = SOL_L2CAP;
 	l2sopt.sopt_name = SO_L2CAP_IMTU;
-	l2sopt.sopt_val = &mtu;
+	l2sopt.sopt_val = __CAP_ADDROF(mtu);
 	l2sopt.sopt_valsize = sizeof(mtu);
 	l2sopt.sopt_td = NULL;
 

--- a/sys/netinet/ip_gre.c
+++ b/sys/netinet/ip_gre.c
@@ -323,7 +323,7 @@ in_gre_setup_socket(struct gre_softc *sc)
 			sopt.sopt_dir = SOPT_SET;
 			sopt.sopt_level = IPPROTO_IP;
 			sopt.sopt_name = IP_BINDANY;
-			sopt.sopt_val = &value;
+			sopt.sopt_val = __CAP_ADDROF(value);
 			sopt.sopt_valsize = sizeof(value);
 			value = 1;
 			error = sosetopt(gs->so, &sopt);

--- a/sys/netinet6/ip6_gre.c
+++ b/sys/netinet6/ip6_gre.c
@@ -319,7 +319,7 @@ in6_gre_setup_socket(struct gre_softc *sc)
 			sopt.sopt_dir = SOPT_SET;
 			sopt.sopt_level = IPPROTO_IPV6;
 			sopt.sopt_name = IPV6_BINDANY;
-			sopt.sopt_val = &value;
+			sopt.sopt_val = __CAP_ADDROF(value);
 			sopt.sopt_valsize = sizeof(value);
 			value = 1;
 			error = sosetopt(gs->so, &sopt);

--- a/sys/netsmb/smb_rq.c
+++ b/sys/netsmb/smb_rq.c
@@ -119,7 +119,7 @@ smb_rq_new(struct smb_rq *rqp, u_char cmd)
 	error = mb_init(mbp);
 	if (error)
 		return error;
-	mb_put_mem(mbp, SMB_SIGNATURE, SMB_SIGLEN, MB_MSYSTEM);
+	mb_put_mem(mbp, __CAP_DECAY(SMB_SIGNATURE), SMB_SIGLEN, MB_MSYSTEM);
 	mb_put_uint8(mbp, cmd);
 	mb_put_uint32le(mbp, 0);		/* DosError */
 	mb_put_uint8(mbp, vcp->vc_hflags);
@@ -130,7 +130,7 @@ smb_rq_new(struct smb_rq *rqp, u_char cmd)
 		flags2 &= ~SMB_FLAGS2_SECURITY_SIGNATURE;
 	mb_put_uint16le(mbp, flags2);
 	if ((flags2 & SMB_FLAGS2_SECURITY_SIGNATURE) == 0) {
-		mb_put_mem(mbp, tzero, 12, MB_MSYSTEM);
+		mb_put_mem(mbp, __CAP_DECAY(tzero), 12, MB_MSYSTEM);
 		rqp->sr_rqsig = NULL;
 	} else {
 		mb_put_uint16le(mbp, 0 /*scred->sc_p->p_pid >> 16*/);

--- a/sys/netsmb/smb_smb.c
+++ b/sys/netsmb/smb_smb.c
@@ -180,7 +180,7 @@ smb_smb_negotiate(struct smb_vc *vcp, struct smb_cred *scred)
 			md_get_uint32le(mdp, &sp->sv_maxraw);
 			md_get_uint32le(mdp, &sp->sv_skey);
 			md_get_uint32le(mdp, &sp->sv_caps);
-			md_get_mem(mdp, stime, 8, MB_MSYSTEM);
+			md_get_mem(mdp, __CAP_DECAY(stime), 8, MB_MSYSTEM);
 			md_get_uint16le(mdp, (u_int16_t*)&sp->sv_tz);
 			md_get_uint8(mdp, &sblen);
 			if (sblen && (sp->sv_sm & SMB_SM_ENCRYPT)) {
@@ -193,7 +193,7 @@ smb_smb_negotiate(struct smb_vc *vcp, struct smb_cred *scred)
 					break;
 				if (sp->sv_caps & SMB_CAP_EXT_SECURITY)
 					md_get_mem(mdp, NULL, 16, MB_MSYSTEM);
-				error = md_get_mem(mdp, vcp->vc_ch, sblen, MB_MSYSTEM);
+				error = md_get_mem(mdp, (char * __capability)__CAP_ADDROF(vcp->vc_ch), sblen, MB_MSYSTEM);
 				if (error)
 					break;
 				vcp->vc_chlen = sblen;
@@ -243,7 +243,8 @@ smb_smb_negotiate(struct smb_vc *vcp, struct smb_cred *scred)
 				if (bc < swlen)
 					break;
 				if (swlen && (sp->sv_sm & SMB_SM_ENCRYPT)) {
-					error = md_get_mem(mdp, vcp->vc_ch, swlen, MB_MSYSTEM);
+					// FIXME: bounds?
+					error = md_get_mem(mdp, (char * __capability)__CAP_ADDROF(vcp->vc_ch), swlen, MB_MSYSTEM);
 					if (error)
 						break;
 					vcp->vc_chlen = swlen;

--- a/sys/netsmb/smb_trantcp.c
+++ b/sys/netsmb/smb_trantcp.c
@@ -87,7 +87,7 @@ nb_setsockopt_int(struct socket *so, int level, int name, int val)
 	bzero(&sopt, sizeof(sopt));
 	sopt.sopt_level = level;
 	sopt.sopt_name = name;
-	sopt.sopt_val = &val;
+	sopt.sopt_val = __CAP_ADDROF(val);
 	sopt.sopt_valsize = sizeof(val);
 	CURVNET_SET(so->so_vnet);
 	error = sosetopt(so, &sopt);

--- a/sys/nlm/nlm_prot_impl.c
+++ b/sys/nlm/nlm_prot_impl.c
@@ -1547,7 +1547,7 @@ nlm_server_main(int addr_count, char * __capability * __capability addrs)
 		opt.sopt_level = IPPROTO_IP;
 		opt.sopt_name = IP_PORTRANGE;
 		portlow = IP_PORTRANGE_LOW;
-		opt.sopt_val = &portlow;
+		opt.sopt_val = __CAP_ADDROF(portlow);
 		opt.sopt_valsize = sizeof(portlow);
 		sosetopt(nlm_socket, &opt);
 
@@ -1566,7 +1566,7 @@ nlm_server_main(int addr_count, char * __capability * __capability addrs)
 		opt.sopt_level = IPPROTO_IPV6;
 		opt.sopt_name = IPV6_PORTRANGE;
 		portlow = IPV6_PORTRANGE_LOW;
-		opt.sopt_val = &portlow;
+		opt.sopt_val = __CAP_ADDROF(portlow);
 		opt.sopt_valsize = sizeof(portlow);
 		sosetopt(nlm_socket6, &opt);
 #endif

--- a/sys/rpc/clnt_vc.c
+++ b/sys/rpc/clnt_vc.c
@@ -195,7 +195,7 @@ clnt_vc_create(
 		sopt.sopt_dir = SOPT_SET;
 		sopt.sopt_level = SOL_SOCKET;
 		sopt.sopt_name = SO_KEEPALIVE;
-		sopt.sopt_val = &one;
+		sopt.sopt_val = __CAP_ADDROF(one);
 		sopt.sopt_valsize = sizeof(one);
 		sosetopt(so, &sopt);
 	}
@@ -205,7 +205,7 @@ clnt_vc_create(
 		sopt.sopt_dir = SOPT_SET;
 		sopt.sopt_level = IPPROTO_TCP;
 		sopt.sopt_name = TCP_NODELAY;
-		sopt.sopt_val = &one;
+		sopt.sopt_val = __CAP_ADDROF(one);
 		sopt.sopt_valsize = sizeof(one);
 		sosetopt(so, &sopt);
 	}

--- a/sys/rpc/rpc_generic.c
+++ b/sys/rpc/rpc_generic.c
@@ -201,7 +201,7 @@ __rpc_socket2sockinfo(struct socket *so, struct __rpc_sockinfo *sip)
 	opt.sopt_dir = SOPT_GET;
 	opt.sopt_level = SOL_SOCKET;
 	opt.sopt_name = SO_TYPE;
-	opt.sopt_val = &type;
+	opt.sopt_val = __CAP_ADDROF(type);
 	opt.sopt_valsize = sizeof type;
 	opt.sopt_td = NULL;
 	error = sogetopt(so, &opt);
@@ -834,7 +834,7 @@ bindresvport(struct socket *so, struct sockaddr *sa)
 		opt.sopt_dir = SOPT_GET;
 		opt.sopt_level = proto;
 		opt.sopt_name = portrange;
-		opt.sopt_val = &old;
+		opt.sopt_val = __CAP_ADDROF(old);
 		opt.sopt_valsize = sizeof(old);
 		error = sogetopt(so, &opt);
 		if (error) {
@@ -842,7 +842,8 @@ bindresvport(struct socket *so, struct sockaddr *sa)
 		}
 
 		opt.sopt_dir = SOPT_SET;
-		opt.sopt_val = &portlow;
+		opt.sopt_val = __CAP_ADDROF(portlow);
+		opt.sopt_valsize = sizeof(portlow);
 		error = sosetopt(so, &opt);
 		if (error)
 			goto out;
@@ -853,7 +854,8 @@ bindresvport(struct socket *so, struct sockaddr *sa)
 	if (*portp == 0) {
 		if (error) {
 			opt.sopt_dir = SOPT_SET;
-			opt.sopt_val = &old;
+			opt.sopt_val = __CAP_ADDROF(old);
+			opt.sopt_valsize = sizeof(old);
 			sosetopt(so, &opt);
 		}
 	}

--- a/sys/rpc/svc_vc.c
+++ b/sys/rpc/svc_vc.c
@@ -218,7 +218,7 @@ svc_vc_create_conn(SVCPOOL *pool, struct socket *so, struct sockaddr *raddr)
 	opt.sopt_dir = SOPT_SET;
 	opt.sopt_level = SOL_SOCKET;
 	opt.sopt_name = SO_KEEPALIVE;
-	opt.sopt_val = &one;
+	opt.sopt_val = __CAP_ADDROF(one);
 	opt.sopt_valsize = sizeof(one);
 	error = sosetopt(so, &opt);
 	if (error) {
@@ -230,7 +230,7 @@ svc_vc_create_conn(SVCPOOL *pool, struct socket *so, struct sockaddr *raddr)
 		opt.sopt_dir = SOPT_SET;
 		opt.sopt_level = IPPROTO_TCP;
 		opt.sopt_name = TCP_NODELAY;
-		opt.sopt_val = &one;
+		opt.sopt_val = __CAP_ADDROF(one);
 		opt.sopt_valsize = sizeof(one);
 		error = sosetopt(so, &opt);
 		if (error) {

--- a/sys/sys/pciio.h
+++ b/sys/sys/pciio.h
@@ -122,7 +122,7 @@ struct pci_vpd_element {
 	char		pve_keyword[2];
 	uint8_t		pve_flags;
 	uint8_t		pve_datalen;
-	uint8_t		pve_data[0];
+	uint8_t		pve_data[];
 };
 
 #define	PVE_FLAG_IDENT		0x01	/* Element is the string identifier */

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -238,6 +238,23 @@ void	kassert_panic(const char *fmt, ...)  __printflike(1, 2);
  */
 #define	__USER_CAP_STR(strp)	__USER_CAP_UNBOUND(strp)
 
+/* TODO: Could use C11 _Generic to avoid two different macros? */
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
+
+#define	__CAP_DECAY_LEN(var, len)						\
+	__builtin_cheri_bounds_set(						\
+	    (__cheri_tocap __typeof__((var)[0]) * __capability)/*decay*/ (var),	\
+	    len)
+#define	__CAP_DECAY(var) __CAP_DECAY_LEN(var, sizeof(var))
+#define	__CAP_ADDROF(var)							\
+	__builtin_cheri_bounds_set(						\
+	    (__cheri_tocap __typeof__(var) * __capability)&(var), sizeof(var))
+#else
+#define	__CAP_ADDROF(var) (&(var))
+#define	__CAP_DECAY_LEN(var, len) /* decay */ (var)
+#define	__CAP_DECAY(var) /* decay */ (var)
+#endif
+
 /*
  * Align variables.
  */


### PR DESCRIPTION
This PR should roughly show how much we need to change for __capability &
and can be converted to that syntax using a simple search+replace.
There are a few cases that are not quite right: &foo->bar should not be
using these macros, but that can be cleaned up later.


The amount of changes does make a polymorphic & quite appealing.