### PR TITLE
purecap-kernel: Refactor vmem to enable capability handling per-arena.

### DIFF
--- a/sys/amd64/amd64/pmap.c
+++ b/sys/amd64/amd64/pmap.c
@@ -2183,7 +2183,7 @@ pmap_init(void)
 		    lm_ents, (u_long)lm_ents * (NBPML4 / 1024 / 1024 / 1024));
 	if (lm_ents != 0) {
 		large_vmem = vmem_create("large", LARGEMAP_MIN_ADDRESS,
-		    (vmem_size_t)lm_ents * NBPML4, PAGE_SIZE, 0, M_WAITOK);
+		    (vmem_size_t)lm_ents * NBPML4, PAGE_SIZE, 0, M_WAITOK, 0);
 		if (large_vmem == NULL) {
 			printf("pmap: cannot create large map\n");
 			lm_ents = 0;

--- a/sys/amd64/sgx/sgx.c
+++ b/sys/amd64/sgx/sgx.c
@@ -1101,7 +1101,7 @@ sgx_get_epc_area(struct sgx_softc *sc)
 	}
 
 	sc->vmem_epc = vmem_create("SGX EPC", sc->epc_base, sc->epc_size,
-	    PAGE_SIZE, PAGE_SIZE, M_FIRSTFIT | M_WAITOK);
+	    PAGE_SIZE, PAGE_SIZE, M_FIRSTFIT | M_WAITOK, 0);
 	if (sc->vmem_epc == NULL) {
 		printf("%s: Can't create vmem arena.\n", __func__);
 		free(sc->epc_pages, M_SGX);

--- a/sys/arm/annapurna/alpine/alpine_pci_msix.c
+++ b/sys/arm/annapurna/alpine/alpine_pci_msix.c
@@ -217,7 +217,7 @@ al_msix_attach(device_t dev)
 	mtx_init(&sc->msi_mtx, "msi_mtx", NULL, MTX_DEF);
 
 	sc->irq_alloc = vmem_create("Alpine MSI-X IRQs", 0, sc->irq_count,
-	    1, 0, M_FIRSTFIT | M_WAITOK);
+	    1, 0, M_FIRSTFIT | M_WAITOK, 0);
 
 	device_printf(dev, "MSI-X SPI IRQ %d-%d\n", sc->irq_min, sc->irq_max);
 

--- a/sys/arm64/arm64/gicv3_its.c
+++ b/sys/arm64/arm64/gicv3_its.c
@@ -886,7 +886,7 @@ gicv3_its_attach(device_t dev)
 	 * system.
 	 */
 	sc->sc_irq_alloc = vmem_create(device_get_nameunit(dev), 0,
-	    gicv3_get_nirqs(dev), 1, 0, M_FIRSTFIT | M_WAITOK);
+	    gicv3_get_nirqs(dev), 1, 0, M_FIRSTFIT | M_WAITOK, 0);
 
 	sc->sc_irqs = malloc(sizeof(*sc->sc_irqs) * sc->sc_irq_length,
 	    M_GICV3_ITS, M_WAITOK | M_ZERO);

--- a/sys/arm64/intel/stratix10-svc.c
+++ b/sys/arm64/intel/stratix10-svc.c
@@ -178,7 +178,7 @@ s10_get_memory(struct s10_svc_softc *sc)
 		return (ENXIO);
 
 	vmem = vmem_create("stratix10 vmem", 0, 0, PAGE_SIZE,
-	    PAGE_SIZE, M_BESTFIT | M_WAITOK);
+	    PAGE_SIZE, M_BESTFIT | M_WAITOK, 0);
 	if (vmem == NULL)
 		return (ENXIO);
 

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -148,10 +148,16 @@ cheri_is_subset(const void * __capability parent, const void * __capability ptr)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 
-/* Check that a capability is dereferenceable */
+/* Check that a capability is tagged */
 #define	CHERI_ASSERT_VALID(ptr)						\
-	KASSERT(cheri_gettag((void * __capability)(ptr)),		\
+	KASSERT(cheri_gettag(ptr),					\
 	    ("Expect valid capability %s %s:%d", __func__,		\
+	        __FILE__, __LINE__))
+
+/* Check that a capability is not sealed */
+#define	CHERI_ASSERT_UNSEALED(ptr)					\
+	KASSERT(!cheri_getsealed(ptr),					\
+	    ("Expect unsealed capability %s %s:%d", __func__,		\
 	        __FILE__, __LINE__))
 
 /*
@@ -159,27 +165,28 @@ cheri_is_subset(const void * __capability parent, const void * __capability ptr)
  * representable size
  */
 #define	CHERI_ASSERT_BOUNDS(ptr, expect) do {				\
-		KASSERT(cheri_getlen((void * __capability)ptr) <=	\
+		KASSERT(cheri_getlen(ptr) <=				\
 		    CHERI_REPRESENTABLE_LENGTH(expect),			\
 		    ("Invalid bounds on pointer in %s %s:%d "		\
-			 "expected %lx, found %lx",			\
+			 "expected %zx, found %zx",			\
 			__func__, __FILE__, __LINE__,			\
-			(u_long)expect,					\
-			(u_long)cheri_getlen((void * __capability)ptr))); \
+			(size_t)expect,					\
+			(size_t)cheri_getlen(ptr)));			\
 	} while (0)
 
 /* Check that bounds are exactly the given size */
 #define	CHERI_ASSERT_EXBOUNDS(ptr, len) do {				\
-		KASSERT(cheri_getlen((void * __capability)ptr) == len,	\
+		KASSERT(cheri_getlen(ptr) == len,			\
 		    ("Inexact bounds on pointer in %s %s:%d "		\
-			"expected %lx, found %lx",			\
+			"expected %zx, found %zx",			\
 			__func__, __FILE__, __LINE__,			\
-			(u_long)len,					\
-			cheri_getlen((void * __capability)ptr)));	\
+			(size_t)len,					\
+			(size_t)cheri_getlen(ptr)));			\
 	} while (0)
 
 #else /* !__CHERI_PURE_CAPABILITY__ */
 #define	CHERI_ASSERT_VALID(ptr)
+#define	CHERI_ASSERT_UNSEALED(ptr)
 #define	CHERI_ASSERT_BOUNDS(ptr, expect)
 #define	CHERI_ASSERT_EXBOUNDS(ptr, expect)
 #endif /* !__CHERI_PURE_CAPABILITY__ */

--- a/sys/dev/cxgbe/iw_cxgbe/resource.c
+++ b/sys/dev/cxgbe/iw_cxgbe/resource.c
@@ -287,7 +287,7 @@ int c4iw_pblpool_create(struct c4iw_rdev *rdev)
 	rdev->pbl_arena = vmem_create("PBL_MEM_POOL",
 					rdev->adap->vres.pbl.start,
 					rdev->adap->vres.pbl.size,
-					1, 0, M_FIRSTFIT| M_NOWAIT);
+					1, 0, M_FIRSTFIT| M_NOWAIT, 0);
 	if (!rdev->pbl_arena)
 		return -ENOMEM;
 
@@ -342,7 +342,7 @@ int c4iw_rqtpool_create(struct c4iw_rdev *rdev)
 	rdev->rqt_arena = vmem_create("RQT_MEM_POOL",
 					rdev->adap->vres.rq.start,
 					rdev->adap->vres.rq.size,
-					1, 0, M_FIRSTFIT| M_NOWAIT);
+					1, 0, M_FIRSTFIT| M_NOWAIT, 0);
 	if (!rdev->rqt_arena)
 		return -ENOMEM;
 

--- a/sys/dev/cxgbe/t4_main.c
+++ b/sys/dev/cxgbe/t4_main.c
@@ -1319,7 +1319,7 @@ t4_attach(device_t dev)
 #endif
 	if (sc->vres.key.size != 0)
 		sc->key_map = vmem_create("T4TLS key map", sc->vres.key.start,
-		    sc->vres.key.size, 32, 0, M_FIRSTFIT | M_WAITOK);
+		    sc->vres.key.size, 32, 0, M_FIRSTFIT | M_WAITOK, 0);
 
 	/*
 	 * Second pass over the ports.  This time we know the number of rx and

--- a/sys/dev/cxgbe/tom/t4_ddp.c
+++ b/sys/dev/cxgbe/tom/t4_ddp.c
@@ -1224,7 +1224,7 @@ t4_init_ppod_region(struct ppod_region *pr, struct t4_range *r, u_int psz,
 	pr->pr_invalid_bit = 1 << (pr->pr_alias_shift - 1);
 
 	pr->pr_arena = vmem_create(name, 0, pr->pr_len, PPOD_SIZE, 0,
-	    M_FIRSTFIT | M_NOWAIT);
+	    M_FIRSTFIT | M_NOWAIT, 0);
 	if (pr->pr_arena == NULL)
 		return (ENOMEM);
 

--- a/sys/dev/xdma/xdma.c
+++ b/sys/dev/xdma/xdma.c
@@ -422,7 +422,7 @@ xdma_get_memory(device_t dev)
 		return (NULL);
 
 	vmem = vmem_create("xDMA vmem", 0, 0, PAGE_SIZE,
-	    PAGE_SIZE, M_BESTFIT | M_WAITOK);
+	    PAGE_SIZE, M_BESTFIT | M_WAITOK, 0);
 	if (vmem == NULL)
 		return (NULL);
 

--- a/sys/dev/xdma/xdma_iommu.c
+++ b/sys/dev/xdma/xdma_iommu.c
@@ -142,7 +142,7 @@ xdma_iommu_init(struct xdma_iommu *xio)
 #endif
 
 	xio->vmem = vmem_create("xDMA vmem", 0, 0, PAGE_SIZE,
-	    PAGE_SIZE, M_FIRSTFIT | M_WAITOK);
+	    PAGE_SIZE, M_FIRSTFIT | M_WAITOK, 0);
 	if (xio->vmem == NULL)
 		return (ENXIO);
 

--- a/sys/kern/subr_vmem.c
+++ b/sys/kern/subr_vmem.c
@@ -1227,10 +1227,10 @@ vmem_set_reclaim(vmem_t *vm, vmem_reclaim_t *reclaimfn)
 }
 
 /*
- * _vmem_init: Initializes vmem arena.
+ * vmem_init: Initializes vmem arena.
  */
 vmem_t *
-_vmem_init(vmem_t *vm, const char *name, vmem_addr_t base, vmem_size_t size,
+vmem_init(vmem_t *vm, const char *name, vmem_addr_t base, vmem_size_t size,
     vmem_size_t quantum, vmem_size_t qcache_max, int flags,
     int arena_flags)
 {
@@ -1282,10 +1282,10 @@ _vmem_init(vmem_t *vm, const char *name, vmem_addr_t base, vmem_size_t size,
 }
 
 /*
- * _vmem_create: create an arena.
+ * vmem_create: create an arena.
  */
 vmem_t *
-_vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
+vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
     vmem_size_t quantum, vmem_size_t qcache_max, int flags,
     int arena_flags)
 {
@@ -1295,7 +1295,7 @@ _vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
 	vm = uma_zalloc(vmem_zone, flags & (M_WAITOK|M_NOWAIT));
 	if (vm == NULL)
 		return (NULL);
-	if (_vmem_init(vm, name, base, size, quantum, qcache_max, flags,
+	if (vmem_init(vm, name, base, size, quantum, qcache_max, flags,
 	    arena_flags) == NULL)
 		return (NULL);
 	return (vm);

--- a/sys/sys/vmem.h
+++ b/sys/sys/vmem.h
@@ -62,29 +62,13 @@ typedef void (vmem_reclaim_t)(vmem_t *, int);
  *			  cache for each multiple of quantum up to qcache_max.
  *	flags		- M_* flags
  */
-vmem_t *_vmem_create(const char *name, vmem_addr_t base,
+vmem_t *vmem_create(const char *name, vmem_addr_t base,
     vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags,
     int arena_flags);
-vmem_t *_vmem_init(vmem_t *vm, const char *name, vmem_addr_t base,
+vmem_t *vmem_init(vmem_t *vm, const char *name, vmem_addr_t base,
     vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags,
     int arena_flags);
 void vmem_destroy(vmem_t *);
-
-/* Create arena that does not allocate virtual memory */
-#define	vmem_create(name, base, size, quantum, qcache_max, flags)	\
-	_vmem_create(name, base, size, quantum, qcache_max, flags, 0)
-/* Init arena that does not allocate virtual memory */
-#define	vmem_init(vm, name, base, size, quantum, qcache_max, flags)	\
-	_vmem_init(vm, name, base, size, quantum, qcache_max, flags, 0)
-
-/* Create arena that allocates virtual memory */
-#define	vmem_create_cap(name, base, size, quantum, qcache_max, flags)	\
-	_vmem_create(name, base, size, quantum, qcache_max, flags,	\
-	    VMEM_CAPABILITY_ARENA)
-/* Init arena that allocates virtual memory */
-#define	vmem_init_cap(vm, name, base, size, quantum, qcache_max, flags)	\
-	_vmem_init(vm, name, base, size, quantum, qcache_max, flags,	\
-	    VMEM_CAPABILITY_ARENA)
 
 /*
  * Set callbacks for bringing in dynamic regions:

--- a/sys/sys/vmem.h
+++ b/sys/sys/vmem.h
@@ -49,6 +49,9 @@ typedef int (vmem_import_t)(void *, vmem_size_t, int, vmem_addr_t *);
 typedef void (vmem_release_t)(void *, vmem_addr_t, vmem_size_t);
 typedef void (vmem_reclaim_t)(vmem_t *, int);
 
+/* vmem arena flags for vmem_create() and vmem_init() */
+#define	VMEM_CAPABILITY_ARENA	0x1	/* The arena allocates virtual memory */
+
 /*
  * Create a vmem:
  *	name		- Name of the region
@@ -59,11 +62,29 @@ typedef void (vmem_reclaim_t)(vmem_t *, int);
  *			  cache for each multiple of quantum up to qcache_max.
  *	flags		- M_* flags
  */
-vmem_t *vmem_create(const char *name, vmem_addr_t base,
-    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags);
-vmem_t *vmem_init(vmem_t *vm, const char *name, vmem_addr_t base,
-    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags);
+vmem_t *_vmem_create(const char *name, vmem_addr_t base,
+    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags,
+    int arena_flags);
+vmem_t *_vmem_init(vmem_t *vm, const char *name, vmem_addr_t base,
+    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags,
+    int arena_flags);
 void vmem_destroy(vmem_t *);
+
+/* Create arena that does not allocate virtual memory */
+#define	vmem_create(name, base, size, quantum, qcache_max, flags)	\
+	_vmem_create(name, base, size, quantum, qcache_max, flags, 0)
+/* Init arena that does not allocate virtual memory */
+#define	vmem_init(vm, name, base, size, quantum, qcache_max, flags)	\
+	_vmem_init(vm, name, base, size, quantum, qcache_max, flags, 0)
+
+/* Create arena that allocates virtual memory */
+#define	vmem_create_cap(name, base, size, quantum, qcache_max, flags)	\
+	_vmem_create(name, base, size, quantum, qcache_max, flags,	\
+	    VMEM_CAPABILITY_ARENA)
+/* Init arena that allocates virtual memory */
+#define	vmem_init_cap(vm, name, base, size, quantum, qcache_max, flags)	\
+	_vmem_init(vm, name, base, size, quantum, qcache_max, flags,	\
+	    VMEM_CAPABILITY_ARENA)
 
 /*
  * Set callbacks for bringing in dynamic regions:

--- a/sys/vm/memguard.c
+++ b/sys/vm/memguard.c
@@ -212,8 +212,8 @@ memguard_init(vmem_t *parent)
 	vmem_addr_t base;
 
 	vmem_alloc(parent, memguard_mapsize, M_BESTFIT | M_WAITOK, &base);
-	vmem_init_cap(memguard_arena, "memguard arena", base, memguard_mapsize,
-	    PAGE_SIZE, 0, M_WAITOK);
+	vmem_init(memguard_arena, "memguard arena", base, memguard_mapsize,
+	    PAGE_SIZE, 0, M_WAITOK, VMEM_CAPABILITY_ARENA);
 	memguard_base = base;
 
 	printf("MEMGUARD DEBUGGING ALLOCATOR INITIALIZED:\n");

--- a/sys/vm/memguard.c
+++ b/sys/vm/memguard.c
@@ -212,7 +212,7 @@ memguard_init(vmem_t *parent)
 	vmem_addr_t base;
 
 	vmem_alloc(parent, memguard_mapsize, M_BESTFIT | M_WAITOK, &base);
-	vmem_init(memguard_arena, "memguard arena", base, memguard_mapsize,
+	vmem_init_cap(memguard_arena, "memguard arena", base, memguard_mapsize,
 	    PAGE_SIZE, 0, M_WAITOK);
 	memguard_base = base;
 

--- a/sys/vm/vm_init.c
+++ b/sys/vm/vm_init.c
@@ -226,8 +226,9 @@ again:
 	CHERI_ASSERT_EXBOUNDS(firstaddr, size);
 	kmi->buffer_sva = (vm_offset_t)firstaddr;
 	kmi->buffer_eva = kmi->buffer_sva + size;
-	vmem_init_cap(buffer_arena, "buffer arena", firstaddr, size,
-	    PAGE_SIZE, (mp_ncpus > 4) ? BKVASIZE * 8 : 0, 0);
+	vmem_init(buffer_arena, "buffer arena", firstaddr, size,
+	    PAGE_SIZE, (mp_ncpus > 4) ? BKVASIZE * 8 : 0, 0,
+	    VMEM_CAPABILITY_ARENA);
 
 	/*
 	 * And optionally transient bio space.
@@ -241,8 +242,8 @@ again:
 		CHERI_ASSERT_EXBOUNDS(firstaddr, size);
 		kmi->transient_sva = (vm_offset_t)firstaddr;
 		kmi->transient_eva = kmi->transient_sva + size;
-		vmem_init_cap(transient_arena, "transient arena",
-		    firstaddr, size, PAGE_SIZE, 0, 0);
+		vmem_init(transient_arena, "transient arena",
+		    firstaddr, size, PAGE_SIZE, 0, 0, VMEM_CAPABILITY_ARENA);
 	}
 
 	/*

--- a/sys/vm/vm_init.c
+++ b/sys/vm/vm_init.c
@@ -226,7 +226,7 @@ again:
 	CHERI_ASSERT_EXBOUNDS(firstaddr, size);
 	kmi->buffer_sva = (vm_offset_t)firstaddr;
 	kmi->buffer_eva = kmi->buffer_sva + size;
-	vmem_init(buffer_arena, "buffer arena", firstaddr, size,
+	vmem_init_cap(buffer_arena, "buffer arena", firstaddr, size,
 	    PAGE_SIZE, (mp_ncpus > 4) ? BKVASIZE * 8 : 0, 0);
 
 	/*
@@ -241,7 +241,7 @@ again:
 		CHERI_ASSERT_EXBOUNDS(firstaddr, size);
 		kmi->transient_sva = (vm_offset_t)firstaddr;
 		kmi->transient_eva = kmi->transient_sva + size;
-		vmem_init(transient_arena, "transient arena",
+		vmem_init_cap(transient_arena, "transient arena",
 		    firstaddr, size, PAGE_SIZE, 0, 0);
 	}
 

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -857,7 +857,7 @@ kmem_init(vm_ptr_t start, vm_ptr_t end)
 	/*
 	 * Initialize the kernel_arena.  This can grow on demand.
 	 */
-	vmem_init(kernel_arena, "kernel arena", 0, 0, PAGE_SIZE, 0, 0);
+	vmem_init_cap(kernel_arena, "kernel arena", 0, 0, PAGE_SIZE, 0, 0);
 	vmem_set_import(kernel_arena, kva_import, NULL, NULL, KVA_QUANTUM);
 
 	for (domain = 0; domain < vm_ndomains; domain++) {
@@ -867,7 +867,7 @@ kmem_init(vm_ptr_t start, vm_ptr_t end)
 		 * are backed by memory from the same physical domain,
 		 * maximizing the potential for superpage promotion.
 		 */
-		vm_dom[domain].vmd_kernel_arena = vmem_create(
+		vm_dom[domain].vmd_kernel_arena = vmem_create_cap(
 		    "kernel arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK);
 		vmem_set_import(vm_dom[domain].vmd_kernel_arena,
 		    kva_import_domain, NULL, kernel_arena, KVA_QUANTUM);
@@ -879,7 +879,7 @@ kmem_init(vm_ptr_t start, vm_ptr_t end)
 		 * so as not to inhibit superpage promotion.
 		 */
 #if VM_NRESERVLEVEL > 0
-		vm_dom[domain].vmd_kernel_rwx_arena = vmem_create(
+		vm_dom[domain].vmd_kernel_rwx_arena = vmem_create_cap(
 		    "kernel rwx arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK);
 		vmem_set_import(vm_dom[domain].vmd_kernel_rwx_arena,
 		    kva_import_domain, (vmem_release_t *)vmem_xfree,

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -857,7 +857,8 @@ kmem_init(vm_ptr_t start, vm_ptr_t end)
 	/*
 	 * Initialize the kernel_arena.  This can grow on demand.
 	 */
-	vmem_init_cap(kernel_arena, "kernel arena", 0, 0, PAGE_SIZE, 0, 0);
+	vmem_init(kernel_arena, "kernel arena", 0, 0, PAGE_SIZE, 0, 0,
+	    VMEM_CAPABILITY_ARENA);
 	vmem_set_import(kernel_arena, kva_import, NULL, NULL, KVA_QUANTUM);
 
 	for (domain = 0; domain < vm_ndomains; domain++) {
@@ -867,8 +868,9 @@ kmem_init(vm_ptr_t start, vm_ptr_t end)
 		 * are backed by memory from the same physical domain,
 		 * maximizing the potential for superpage promotion.
 		 */
-		vm_dom[domain].vmd_kernel_arena = vmem_create_cap(
-		    "kernel arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK);
+		vm_dom[domain].vmd_kernel_arena = vmem_create(
+		    "kernel arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK,
+		    VMEM_CAPABILITY_ARENA);
 		vmem_set_import(vm_dom[domain].vmd_kernel_arena,
 		    kva_import_domain, NULL, kernel_arena, KVA_QUANTUM);
 
@@ -879,8 +881,9 @@ kmem_init(vm_ptr_t start, vm_ptr_t end)
 		 * so as not to inhibit superpage promotion.
 		 */
 #if VM_NRESERVLEVEL > 0
-		vm_dom[domain].vmd_kernel_rwx_arena = vmem_create_cap(
-		    "kernel rwx arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK);
+		vm_dom[domain].vmd_kernel_rwx_arena = vmem_create(
+		    "kernel rwx arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK,
+		    VMEM_CAPABILITY_ARENA);
 		vmem_set_import(vm_dom[domain].vmd_kernel_rwx_arena,
 		    kva_import_domain, (vmem_release_t *)vmem_xfree,
 		    kernel_arena, KVA_QUANTUM);

--- a/sys/x86/iommu/intel_intrmap.c
+++ b/sys/x86/iommu/intel_intrmap.c
@@ -350,7 +350,7 @@ dmar_init_irt(struct dmar_unit *unit)
 		return (ENOMEM);
 	unit->irt_phys = pmap_kextract((vm_offset_t)unit->irt);
 	unit->irtids = vmem_create("dmarirt", 0, unit->irte_cnt, 1, 0,
-	    M_FIRSTFIT | M_NOWAIT);
+	    M_FIRSTFIT | M_NOWAIT, 0);
 	DMAR_LOCK(unit);
 	dmar_load_irt_ptr(unit);
 	dmar_qi_invalidate_iec_glob(unit);


### PR DESCRIPTION
When creating a new arena, the flag M_MEMORY_ARENA can be passed.
This will enable capability bounds enforcement, representability
size and alignent adjustments and checks.