### PR TITLE
More bounds

### DIFF
--- a/sys/kern/kern_environment.c
+++ b/sys/kern/kern_environment.c
@@ -307,6 +307,11 @@ init_static_kenv(char *buf, size_t len)
 	if (eval == NULL || strcmp(eval, "1") != 0) {
 		md_envp = buf;
 		md_env_len = len;
+#ifdef __CHERI_PURE_CAPABILITY__
+		if (len != 0)
+			KASSERT(cheri_getlen(md_envp) == len,
+			    ("unbounded static kenv"));
+#endif
 		md_env_pos = 0;
 
 		eval = kern_getenv("static_env.disabled");
@@ -457,7 +462,11 @@ _getenv_static_from(char *chkenv, const char *name)
 		len = ep - cp;
 		ep++;
 		if (!strncmp(name, cp, len) && name[len] == 0)
+#ifdef __CHERI_PURE_CAPABILITY__
+			return (cheri_setbounds(ep, strlen(ep) + 1));
+#else
 			return (ep);
+#endif
 	}
 	return (NULL);
 }

--- a/sys/net/vnet.h
+++ b/sys/net/vnet.h
@@ -288,8 +288,16 @@ extern struct sx vnet_sxlock;
     static t VNET_NAME(n) __section(VNET_SETNAME) __used
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
-#define	_VNET_PTR(b, n)		(__typeof(VNET_NAME(n))*)		\
-	((b) + ((vaddr_t)&VNET_NAME(n) - (vaddr_t)VNET_START))
+/*
+ * XXX: This cannot use exact bounds currently as vnet variables are
+ * not suitably aligned.  In particular, V_ip6qb in
+ * sys/netinet6/frag6.c is a large variable requiring larger
+ * alignment.
+ */
+#define	_VNET_PTR(b, n)						\
+	cheri_setbounds((__typeof(VNET_NAME(n)) *)((b) +	\
+	    ((vaddr_t)&VNET_NAME(n) - (vaddr_t)VNET_START)),	\
+	    sizeof(VNET_NAME(n)))
 #else
 #define	_VNET_PTR(b, n)		(__typeof(VNET_NAME(n))*)		\
 				    ((b) + (uintptr_t)&VNET_NAME(n))

--- a/sys/sys/pcpu.h
+++ b/sys/sys/pcpu.h
@@ -53,6 +53,9 @@
 #define	DPCPU_SYMPREFIX		"pcpu_entry_"
 
 #ifdef _KERNEL
+#ifdef __CHERI_PURE_CAPABILITY__
+#include <cheri/cheric.h>
+#endif
 
 /*
  * Define a set for pcpu data.
@@ -121,8 +124,9 @@ extern uintptr_t dpcpu_off[];
  * subtracted the DPCPU_START, so we do it now.
  */
 #define	_DPCPU_PTR(b, n)					\
-    (__typeof(DPCPU_NAME(n))*)((b) +                            \
-        ((vaddr_t)&DPCPU_NAME(n) - (vaddr_t)DPCPU_START))
+	cheri_setboundsexact((__typeof(DPCPU_NAME(n)) *)((b) +	\
+	    ((vaddr_t)&DPCPU_NAME(n) - (vaddr_t)DPCPU_START)),	\
+	    CHERI_REPRESENTABLE_LENGTH(sizeof(DPCPU_NAME(n))))
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #define	_DPCPU_GET(b, n)	(*_DPCPU_PTR(b, n))
 #define	_DPCPU_SET(b, n, v)	(*_DPCPU_PTR(b, n) = v)


### PR DESCRIPTION
These are some small things I could recall.  Unfortunately, I haven't really tested these.  I don't think we currently can provide kernel environment variables to the kernel usefully, we haven't tested VIMAGE at all with CHERI hybrid much less purecap, and I don't know if anything in the default kernels uses DPCPU.  However, it did boot ok for me (RISC-V) and was able to run cheritests.