### PR TITLE
Allow a hybrid Morello userland to be built

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,16 +160,7 @@ selectedArchitectures.each { suffix ->
             // Enable additional debug checks when running the testsuite
             extraBuildOptions += ' -DMALLOC_DEBUG'
         }
-        def cheribuildArgs = ["'--cheribsd/build-options=${extraBuildOptions}'",
-                              '--keep-install-dir',
-                              '--install-prefix=/rootfs',
-                              '--cheribsd/build-tests',]
-        if (GlobalVars.isTestSuiteJob) {
-            cheribuildArgs.add('--cheribsd/debug-info')
-        } else {
-            cheribuildArgs.add('--cheribsd/no-debug-info')
-        }
-        // XXX: Remove once dev can build world
+        // XXX: Remove once dev can build a purecap world
         if (suffix.startsWith("morello")) {
             def gitBranch = 'master'
             if (env.CHANGE_ID) {
@@ -178,8 +169,17 @@ selectedArchitectures.each { suffix ->
                 gitBranch = env.BRANCH_NAME
             }
             if (gitBranch != 'morello-dev') {
-                cheribuildArgs.add('--skip-world')
+                extraBuildOptions += ' -DWITHOUT_COMPAT_CHERIABI'
             }
+        }
+        def cheribuildArgs = ["'--cheribsd/build-options=${extraBuildOptions}'",
+                              '--keep-install-dir',
+                              '--install-prefix=/rootfs',
+                              '--cheribsd/build-tests',]
+        if (GlobalVars.isTestSuiteJob) {
+            cheribuildArgs.add('--cheribsd/debug-info')
+        } else {
+            cheribuildArgs.add('--cheribsd/no-debug-info')
         }
         cheribuildProject(target: "cheribsd-${suffix}", architecture: suffix,
                 extraArgs: cheribuildArgs.join(" "),
@@ -192,7 +192,7 @@ selectedArchitectures.each { suffix ->
                 beforeBuild: { params -> dir('cherisdk') { deleteDir() } },
                 /* Custom function to run tests since --test will not work (yet) */
                 runTests: false,
-                afterBuild: { params -> if (!cheribuildArgs.contains('--skip-world')) { buildImageAndRunTests(params, suffix) } })
+                afterBuild: { params -> buildImageAndRunTests(params, suffix) })
     }
 }
 

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2643,7 +2643,7 @@ _libmagic=lib/libmagic
 .endif
 
 .if ${MK_PMC} != "no" && \
-    (${TARGET_ARCH} == "aarch64" || ${TARGET_ARCH} == "amd64" || \
+    (${TARGET_ARCH} == "amd64" || ${TARGET} == "arm64" || \
     ${TARGET_ARCH} == "i386")
 _jevents=lib/libpmc/pmu-events
 .endif

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -153,12 +153,13 @@ TARGET_ABI=	gnueabi
 .endif
 .endif
 _MACHINE_ABI?=	unknown
-MACHINE_MACHINE=${MACHINE_ARCH:S/amd64/x86_64/:C/[hs]f$//:S/mipsn32/mips64/:C/mips.*c.*/mips64/:S/riscv64c/riscv64/}
+MACHINE_MACHINE=${MACHINE_ARCH:S/aarch64c/aarch64/:S/amd64/x86_64/:C/[hs]f$//:S/mipsn32/mips64/:C/mips.*c.*/mips64/:S/riscv64c/riscv64/}
 MACHINE_TRIPLE?=${MACHINE_MACHINE}-${_MACHINE_ABI}-freebsd13.0
 TARGET_ABI?=	unknown
-TARGET_MACHINE=	${TARGET_ARCH:S/amd64/x86_64/:C/[hs]f$//:S/mipsn32/mips64/:C/mips.*c.*/mips64/:S/riscv64c/riscv64/}
+TARGET_MACHINE=	${TARGET_ARCH:S/aarch64c/aarch64/:S/amd64/x86_64/:C/[hs]f$//:S/mipsn32/mips64/:C/mips.*c.*/mips64/:S/riscv64c/riscv64/}
 TARGET_TRIPLE?=	${TARGET_MACHINE}-${TARGET_ABI}-freebsd13.0
 KNOWN_ARCHES?=	aarch64/arm64 \
+		aarch64c/arm64 \
 		amd64 \
 		armv6/arm \
 		armv7/arm \

--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -73,7 +73,7 @@ LIBCOMPATIMAKE+=	${LIBCOMPATWMAKE:NINSTALL=*:NDESTDIR=*} \
 .if ${MK_FILE} != "no"
 _libmagic=	lib/libmagic
 .endif
-.if ${MK_PMC} != "no" && ${TARGET_ARCH} == "amd64"
+.if ${MK_PMC} != "no" && (${TARGET_ARCH} == "amd64" || ${TARGET} == "arm64")
 _jevents=	lib/libpmc/pmu-events
 .endif
 

--- a/bin/cheribsdtest/Makefile
+++ b/bin/cheribsdtest/Makefile
@@ -1,13 +1,20 @@
 # $FreeBSD$
 
-SUBDIR=	hybrid \
-	hybrid-dynamic \
-	hybrid-dynamic-mt \
-	hybrid-mt \
-	purecap \
-	purecap-dynamic \
-	purecap-dynamic-mt \
-	purecap-mt
+.include <src.opts.mk>
+
+.if !${MACHINE_ABI:Mpurecap} || ${MK_LIB64} == "yes"
+SUBDIR+=	hybrid \
+		hybrid-dynamic \
+		hybrid-dynamic-mt \
+		hybrid-mt
+.endif
+
+.if ${MACHINE_ABI:Mpurecap} || ${MK_COMPAT_CHERIABI} == "yes"
+SUBDIR+=	purecap \
+		purecap-dynamic \
+		purecap-dynamic-mt \
+		purecap-mt
+.endif
 
 SUBDIR_PARALLEL=
 

--- a/lib/csu/aarch64/Makefile
+++ b/lib/csu/aarch64/Makefile
@@ -3,6 +3,7 @@
 .PATH: ${.CURDIR:H}/common
 
 CFLAGS+=	-DCRT_IRELOC_SUPPRESS
+CFLAGS+=	-I${.CURDIR:H}/common-cheri
 
 CRT1OBJS+=	crt1_s.o
 

--- a/lib/libc/aarch64/string/Makefile.inc
+++ b/lib/libc/aarch64/string/Makefile.inc
@@ -9,8 +9,6 @@
 MDSRCS+= \
 	memchr.S \
 	memcmp.S \
-	memcpy.S \
-	memmove.S \
 	memset.S \
 	strchr.S \
 	strcmp.S \
@@ -18,3 +16,10 @@ MDSRCS+= \
 	strlen.S \
 	strncmp.S \
 	strnlen.S
+
+# Hybrid CHERI needs a tag-preserving memcpy and friends
+.if !${MACHINE_CPU:Mcheri}
+MDSRCS+= \
+	memcpy.S \
+	memmove.S
+.endif

--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -104,6 +104,18 @@ LIB32_MACHINE_ABI=	${MACHINE_ABI}
 # -------------------------------------------------------------------
 # 64 bit world
 .if ${MK_LIB64} != "no"
+.if ${COMPAT_ARCH:Maarch64*c*}
+HAS_COMPAT=64
+LIB64_MACHINE=	arm64
+LIB64_MACHINE_ARCH=aarch64
+LIB64WMAKEENV=	MACHINE_CPU="arm64 cheri"
+LIB64WMAKEFLAGS= LD="${XLD}" CPUTYPE=morello
+# XXX: clang specific
+LIB64CPUFLAGS=	-target aarch64-unknown-freebsd13.0
+# XXX: Drop -fno-emulated-tls once bsd.cpu.mk no longer enables it
+LIB64CPUFLAGS+=	-march=morello -mabi=aapcs -fno-emulated-tls
+.endif
+
 .if ${COMPAT_ARCH:Mmips64*c*}
 HAS_COMPAT=64
 # XXX: clang specific
@@ -151,7 +163,14 @@ LIB64_MACHINE_ABI=	${MACHINE_ABI:Npurecap}
 # -------------------------------------------------------------------
 # CHERI world
 .if ${MK_COMPAT_CHERIABI} != "no"
-.if ${COMPAT_ARCH:Mmips64*} && !${COMPAT_ARCH:Mmips64*c*}
+.if ${COMPAT_ARCH} == "aarch64"
+HAS_COMPAT+=CHERI
+LIBCHERI_MACHINE=	arm64
+LIBCHERI_MACHINE_ARCH=	aarch64c
+LIBCHERICPUFLAGS=	-target aarch64-unknown-freebsd13.0
+# XXX: Drop -femulated-tls once bsd.cpu.mk no longer passes it
+LIBCHERICPUFLAGS+=	-march=morello+c64 -mabi=purecap -femulated-tls
+.elif ${COMPAT_ARCH:Mmips64*} && !${COMPAT_ARCH:Mmips64*c*}
 .if ${COMPAT_ARCH:Mmips*el*}
 .error No little endian CHERI
 .endif

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -7,7 +7,10 @@
 .if !defined(CPUTYPE) || empty(CPUTYPE)
 _CPUCFLAGS =
 . if ${MACHINE_CPUARCH} == "aarch64"
-MACHINE_CPU = arm64
+.  if ${MACHINE_ARCH:Maarch64*c*}
+MACHINE_CPU = cheri morello
+.  endif
+MACHINE_CPU += arm64
 . elif ${MACHINE_CPUARCH} == "amd64"
 MACHINE_CPU = amd64 sse2 sse mmx
 . elif ${MACHINE_CPUARCH} == "arm"
@@ -153,9 +156,13 @@ _CPUCFLAGS = -cheri=128
 _CPUCFLAGS = -march=${CPUTYPE:S/^mips//}
 . endif
 . elif ${MACHINE_CPUARCH} == "aarch64"
-.  if ${CPUTYPE:Marmv*} != "" || ${CPUTYPE:Mmorello*} != ""
+.  if ${CPUTYPE:Marmv*} != ""
 # Use -march when the CPU type is an architecture value, e.g. armv8.1-a
 _CPUCFLAGS = -march=${CPUTYPE}
+.  elif ${CPUTYPE} == "morello"
+# Don't use -march; we will add -march=morello or -march=morello+c64 later but
+# adding -march=morello here would override that as _CPUCFLAGS is added late.
+# It is also not a valid value for -mcpu.
 .  else
 # Otherwise assume we have a CPU type
 _CPUCFLAGS = -mcpu=${CPUTYPE}
@@ -287,8 +294,8 @@ MACHINE_CPU = sse3
 MACHINE_CPU += amd64 sse2 sse mmx
 ########## arm64
 . elif ${MACHINE_CPUARCH} == "aarch64"
-.  if ${CPUTYPE} == "cheri"
-MACHINE_CPU = cheri
+.  if ${CPUTYPE} == "morello"
+MACHINE_CPU = cheri morello
 .  endif
 MACHINE_CPU += arm64
 ########## Mips
@@ -308,6 +315,19 @@ MACHINE_CPU = booke softfp
 MACHINE_CPU = cheri
 .  endif
 MACHINE_CPU += riscv
+. endif
+.endif
+
+.if ${MACHINE_CPUARCH} == "aarch64"
+. if ${MACHINE_ARCH:Maarch64*c*}
+# XXX: Stop using emulated TLS once purecap TLSDESC is properly specified (and
+# CheriBSD implements the resolvers) or the Morello toolchain implements a
+# pure-capability traditional TLS like MIPS or RISC-V.
+CFLAGS+=	-march=morello+c64 -mabi=purecap -femulated-tls
+LDFLAGS+=	-march=morello+c64 -mabi=purecap
+. elif defined(CPUTYPE) && ${CPUTYPE} == "morello"
+CFLAGS+=	-march=morello -mabi=aapcs
+LDFLAGS+=	-march=morello -mabi=aapcs
 . endif
 .endif
 
@@ -456,7 +476,7 @@ MACHINE_ABI+=	soft-float
 .else
 MACHINE_ABI+=	hard-float
 .endif
-.if (${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
+.if (${MACHINE_ARCH:Maarch64*c*} || ${MACHINE_ARCH:Mmips*c*} || ${MACHINE_ARCH:Mriscv*c*})
 MACHINE_ABI+=	purecap
 .endif
 # Currently all 64-bit architectures include 64 in their name (see arch(7)).

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -291,7 +291,7 @@ __LLVM_TARGET_FILT=	C/(amd64|i386)/x86/:C/powerpc.*/powerpc/:C/armv[67]/arm/:C/r
 .if ${__T:${__LLVM_TARGET_FILT}} == ${__llt}
 __DEFAULT_YES_OPTIONS+=	LLVM_TARGET_${__llt:${__LLVM_TARGET_FILT}:tu}
 # aarch64 needs arm for -m32 support.
-.elif ${__T} == "aarch64" && ${__llt:Marm*} != ""
+.elif ${__T:Maarch64*} && ${__llt:Marm*} != ""
 __DEFAULT_DEPENDENT_OPTIONS+=	LLVM_TARGET_ARM/LLVM_TARGET_AARCH64
 # Default the rest of the LLVM_TARGETs to the value of MK_LLVM_TARGET_ALL.
 .else
@@ -327,7 +327,7 @@ BROKEN_OPTIONS+=OFED
 .endif
 
 # In-tree gdb is an older versions without modern architecture support.
-.if ${__T} == "aarch64" || ${__T:Mriscv*} != ""
+.if ${__T:Maarch64*} || ${__T:Mriscv*} != ""
 BROKEN_OPTIONS+=GDB
 .endif
 .if ${__T:Mriscv*} != ""
@@ -344,8 +344,8 @@ __DEFAULT_YES_OPTIONS+=LIB32
 .else
 BROKEN_OPTIONS+=LIB32
 .endif
-# LIB64 on mips64*c* and riscv64*c*
-.if ${__T:Mmips64*c*} || ${__T:Mriscv64*c*}
+# LIB64 is supported on aarch64*c*, mips64*c* and riscv64*c*
+.if ${__T:Maarch64*c*} || ${__T:Mmips64*c*} || ${__T:Mriscv64*c*}
 __DEFAULT_YES_OPTIONS+=LIB64
 # In principle, LIB32 could work on architectures where it's supported, but
 # Makefile.libcompat only supports one compat layer.
@@ -356,6 +356,12 @@ BROKEN_OPTIONS+=LIB64
 # Only doing soft float API stuff on armv6 and armv7
 .if ${__T} != "armv6" && ${__T} != "armv7"
 BROKEN_OPTIONS+=LIBSOFT
+.endif
+# XXX: Fails to link due to old broken C++ mangling; remove once
+# https://git.morello-project.org/morello/llvm-project/-/merge_requests/23
+# has been merged.
+.if ${__T:Maarch64*c*}
+BROKEN_OPTIONS+=GOOGLETEST
 .endif
 .if ${__T:Mmips*}
 # GOOGLETEST cannot currently be compiled on mips due to external circumstances.
@@ -373,8 +379,8 @@ BROKEN_OPTIONS+=NS_CACHING
 .endif
 
 .if ${__C} == "cheri" || ${__C} == "morello" || \
-    ${__T} == "aarch64c" || ${__T:Mmips64*c*} || \
-    ${__T:Mriscv*c*} || ${.MAKE.OS} == "Linux"
+    ${__T:Maarch64*c*} || ${__T:Mmips64*c*} || ${__T:Mriscv*c*} || \
+    ${.MAKE.OS} == "Linux"
 # Broken post OpenZFS import
 BROKEN_OPTIONS+=CDDL ZFS
 .endif
@@ -416,7 +422,7 @@ BROKEN_OPTIONS+=LOADER_GELI LOADER_LUA
 # profiling won't work on MIPS64 because there is only assembly for o32
 BROKEN_OPTIONS+=PROFILE
 .endif
-.if ${__T} != "aarch64" && ${__T} != "amd64" && ${__T} != "i386" && \
+.if !${__T:Maarch64*} && ${__T} != "amd64" && ${__T} != "i386" && \
     ${__T} != "powerpc64"
 BROKEN_OPTIONS+=CXGBETOOL
 BROKEN_OPTIONS+=MLX5TOOL
@@ -425,7 +431,8 @@ BROKEN_OPTIONS+=MLX5TOOL
 # We'd really like this to be:
 #    !${MACHINE_CPU:Mcheri} || ${MACHINE_ABI:Mpurecap}
 # but that logic doesn't work in Makefile.inc1...
-.if ${__C} != "cheri" || (${__T:Mmips64*c*} || ${__T:Mriscv64*c*})
+.if (${__C} != "cheri" && ${__C} != "morello") || \
+    (${__T:Maarch64*c*} || ${__T:Mmips64*c*} || ${__T:Mriscv64*c*})
 BROKEN_OPTIONS+=COMPAT_CHERIABI
 .endif
 
@@ -439,8 +446,8 @@ BROKEN_OPTIONS+=CLANG LLD
 BROKEN_OPTIONS+=HYPERV
 .endif
 
-# NVME is only aarch64, x86 and powerpc64*
-.if ${__T} != "aarch64" && ${__T} != "amd64" && ${__T} != "i386" && \
+# NVME is only aarch64*, x86 and powerpc64*
+.if !${__T:Maarch64*} && ${__T} != "amd64" && ${__T} != "i386" && \
     ${__T:Mpowerpc64*} == ""
 BROKEN_OPTIONS+=NVME
 .endif
@@ -450,6 +457,7 @@ BROKEN_OPTIONS+=NVME
 BROKEN_OPTIONS+=GOOGLETEST
 .endif
 
+# XXX: Does not yet build for aarch64c
 .if ${__T} == "aarch64" || ${__T} == "amd64" || ${__T} == "i386" || \
     ${__T:Mpowerpc64*} != ""
 __DEFAULT_YES_OPTIONS+=OPENMP

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -13,7 +13,7 @@ unix		?=	We run FreeBSD, not UNIX.
 # and/or endian.  This is called MACHINE_CPU in NetBSD, but that's used
 # for something different in FreeBSD.
 #
-__TO_CPUARCH=C/mips(n32|64)?(el)?(hf)?(c(128|256))?/mips/:C/arm(v[67])?(eb)?/arm/:C/powerpc(64|64le|spe)/powerpc/:C/riscv64(sf)?c?/riscv/
+__TO_CPUARCH=C/mips(n32|64)?(el)?(hf)?(c(128|256))?/mips/:C/aarch64c/aarch64/:C/arm(v[67])?(eb)?/arm/:C/powerpc(64|64le|spe)/powerpc/:C/riscv64(sf)?c?/riscv/
 MACHINE_CPUARCH=${MACHINE_ARCH:${__TO_CPUARCH}}
 .endif
 
@@ -242,7 +242,8 @@ LFLAGS		?=
 # compiler driver flags (e.g. -mabi=*) that conflict with flags to LD.
 LD		?=	ld
 LDFLAGS		?=
-_LDFLAGS	=	${LDFLAGS:S/-Wl,//g:N-mabi=*:N-march=*:N-fuse-ld=*:N--ld-path=*}
+# XXX: Drop -femulated-tls once bsd.cpu.mk no longer sets it for aarch64c.
+_LDFLAGS	=	${LDFLAGS:S/-Wl,//g:N-mabi=*:N-march=*:N-femulated-tls:N-fuse-ld=*:N--ld-path=*}
 
 MAKE		?=	make
 

--- a/stand/defs.mk
+++ b/stand/defs.mk
@@ -128,6 +128,15 @@ SSP_CFLAGS=
 CFLAGS+=	-ffreestanding ${CFLAGS_NO_SIMD}
 .if ${MACHINE_CPUARCH} == "aarch64"
 CFLAGS+=	-mgeneral-regs-only -ffixed-x18 -fPIC
+# XXX: Disable Morello support in the bootloader. EFI needs to understand
+# capabilities before we can enable this as it may have interrupts enabled
+# so will need to save/restore the full capability registers. We also can't use
+# a pure-capability ABI until there is a pure-capability interface specified
+# and implemented.
+.if ${MACHINE_CPU:Mmorello}
+CFLAGS+=	-march=morello+noa64c -mabi=aapcs
+LDFLAGS+=	-march=morello+noa64c -mabi=aapcs
+.endif
 .elif ${MACHINE_CPUARCH} == "riscv"
 CFLAGS+=	-march=rv64imac -mabi=lp64 -fPIC
 CFLAGS.clang+=	-mcmodel=medium

--- a/stand/efi/libefi/Makefile
+++ b/stand/efi/libefi/Makefile
@@ -27,8 +27,13 @@ SRCS+=  teken.c
 
 .if ${MACHINE_CPUARCH} == "amd64" || ${MACHINE_CPUARCH} == "i386"
 SRCS+=	time.c
-.elif ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "arm" || \
-    ${MACHINE_CPUARCH} == "riscv"
+.elif ${MACHINE_CPUARCH} == "aarch64"
+# XXX: Both time.c and time_event.c behave poorly on the FVP. The former counts
+# down far too quickly, jumping from 10 seconds to a huge negative, but
+# time_event.c takes hours to count down so is even less usable. Thus we use
+# time.c as the lesser of two evils.
+SRCS+=	time.c
+.elif ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "riscv"
 SRCS+=	time_event.c
 .endif
 


### PR DESCRIPTION
This is enough to build a Morello hybrid userland. With it I can build userland with `TARGET_CPUTYPE=morello`.

Although there is further refinement of the build infrastructure in the `morello-dev` branch we could start building a Morello hybrid world in Jenkins to check for build failures from future changes.