### PR TITLE
Fix core dumps (taken from purecap kernel)

### DIFF
--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -567,7 +567,9 @@ vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base, int len, off_t offset,
 	auio.uio_iovcnt = 1;
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 	if (segflg == UIO_USERSPACE)
-		IOVEC_INIT_C(&aiov, __USER_CAP(base, len), len);
+		IOVEC_INIT_C(&aiov,
+		    cheri_capability_build_user_data(CHERI_CAP_USER_DATA_PERMS,
+			(vaddr_t)base, len, 0), len);
 	else
 #endif
 		IOVEC_INIT(&aiov, base, len);

--- a/sys/sys/_iovec.h
+++ b/sys/sys/_iovec.h
@@ -48,10 +48,14 @@ struct iovec {
 };
 
 #if defined(_KERNEL)
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	IOVEC_INIT IOVEC_INIT_C
+#else /* ! __CHERI_PURE_CAPABILITY__ */
 #define	IOVEC_INIT(iovp, base, len)	do {				\
 	(iovp)->iov_base = PTR2CAP((base));				\
 	(iovp)->iov_len = (len);					\
 } while(0)
+#endif /* ! __CHERI_PURE_CAPABILITY__ */
 #define IOVEC_INIT_C(iovp, base, len)	do {				\
 	(iovp)->iov_base = (base);					\
 	(iovp)->iov_len = (len);					\


### PR DESCRIPTION
This pulls in #766 as it is also needed for a hybrid kernel dumping a purecap binary. I've reordered, untangled and squashed fixup commits to clean up the history (as well as resolved conflicts with recent upstream changes and reduced the diff size slightly). Technically the IOVEC_INIT_C commit is not needed yet, but this ever so slightly chips away at the diff so might as well be pulled in.
