### PR TITLE
Use cheri_is_null_derived() in printf().

### DIFF
--- a/lib/libc/stdio/printfcommon.h
+++ b/lib/libc/stdio/printfcommon.h
@@ -307,9 +307,7 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 	int padding, size;
 
 	/* Skip attributes if NULL-derived. */
-	if (cheri_getperm(pointer) == 0 && cheri_getflags(pointer) == 0 &&
-	    cheri_getbase(pointer) == 0 && cheri_getlen(pointer) + 1 == 0 &&
-	    cheri_gettype(pointer) == CHERI_OTYPE_UNSEALED)
+	if (cheri_is_null_derived(pointer))
 		goto address;
 
 	/* tag and sealing */

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -837,11 +837,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 						PCHAR(' ');
 
 				/* Skip attributes if NULL-derived. */
-				if (cheri_getperm(cap) == 0 &&
-				    cheri_getflags(cap) == 0 &&
-				    cheri_getbase(cap) == 0 &&
-				    cheri_getlen(cap) + 1 == 0 &&
-				    cheri_gettype(cap) == CHERI_OTYPE_UNSEALED)
+				if (cheri_is_null_derived(cap))
 					break;
 
 				PCHAR(' ');


### PR DESCRIPTION
This replaces earlier home-grown varieties that checked the value of
various fields instead (and didn't check the tag previously).