### PR TITLE
Fix potentially tag stripping copy in jemalloc

### DIFF
--- a/contrib/jemalloc/include/jemalloc/internal/atomic.h
+++ b/contrib/jemalloc/include/jemalloc/internal/atomic.h
@@ -81,6 +81,8 @@ JEMALLOC_GENERATE_INT_ATOMICS(uint32_t, u32, 2)
 JEMALLOC_GENERATE_INT_ATOMICS(uint64_t, u64, 3)
 #endif
 
+JEMALLOC_GENERATE_ATOMICS(uintptr_t, uptr, this_should_not_be_used)
+
 #undef ATOMIC_INLINE
 
 #endif /* JEMALLOC_INTERNAL_ATOMIC_H */

--- a/contrib/jemalloc/include/jemalloc/internal/seq.h
+++ b/contrib/jemalloc/include/jemalloc/internal/seq.h
@@ -10,8 +10,8 @@
 #define seq_define(type, short_type)					\
 typedef struct {							\
 	atomic_zu_t seq;						\
-	atomic_zu_t data[						\
-	    (sizeof(type) + sizeof(size_t) - 1) / sizeof(size_t)];	\
+	atomic_uptr_t data[						\
+	    (sizeof(type) + sizeof(uintptr_t) - 1) / sizeof(uintptr_t)];	\
 } seq_##short_type##_t;							\
 									\
 /*									\
@@ -20,14 +20,14 @@ typedef struct {							\
  */									\
 static inline void							\
 seq_store_##short_type(seq_##short_type##_t *dst, type *src) {		\
-	size_t buf[sizeof(dst->data) / sizeof(size_t)];			\
-	buf[sizeof(buf) / sizeof(size_t) - 1] = 0;			\
+	uintptr_t buf[sizeof(dst->data) / sizeof(uintptr_t)];		\
+	buf[sizeof(buf) / sizeof(uintptr_t) - 1] = 0;			\
 	memcpy(buf, src, sizeof(type));					\
 	size_t old_seq = atomic_load_zu(&dst->seq, ATOMIC_RELAXED);	\
 	atomic_store_zu(&dst->seq, old_seq + 1, ATOMIC_RELAXED);	\
 	atomic_fence(ATOMIC_RELEASE);					\
-	for (size_t i = 0; i < sizeof(buf) / sizeof(size_t); i++) {	\
-		atomic_store_zu(&dst->data[i], buf[i], ATOMIC_RELAXED);	\
+	for (size_t i = 0; i < sizeof(buf) / sizeof(buf[0]); i++) {	\
+		atomic_store_uptr(&dst->data[i], buf[i], ATOMIC_RELAXED);	\
 	}								\
 	atomic_store_zu(&dst->seq, old_seq + 2, ATOMIC_RELEASE);	\
 }									\
@@ -35,13 +35,13 @@ seq_store_##short_type(seq_##short_type##_t *dst, type *src) {		\
 /* Returns whether or not the read was consistent. */			\
 static inline bool							\
 seq_try_load_##short_type(type *dst, seq_##short_type##_t *src) {	\
-	size_t buf[sizeof(src->data) / sizeof(size_t)];			\
+	uintptr_t buf[sizeof(src->data) / sizeof(uintptr_t)];		\
 	size_t seq1 = atomic_load_zu(&src->seq, ATOMIC_ACQUIRE);	\
 	if (seq1 % 2 != 0) {						\
 		return false;						\
 	}								\
-	for (size_t i = 0; i < sizeof(buf) / sizeof(size_t); i++) {	\
-		buf[i] = atomic_load_zu(&src->data[i], ATOMIC_RELAXED);	\
+	for (size_t i = 0; i < sizeof(buf) / sizeof(buf[0]); i++) {	\
+		buf[i] = atomic_load_uptr(&src->data[i], ATOMIC_RELAXED);	\
 	}								\
 	atomic_fence(ATOMIC_ACQUIRE);					\
 	size_t seq2 = atomic_load_zu(&src->seq, ATOMIC_RELAXED);	\


### PR DESCRIPTION
The compiler warns about a potentially tag-stripping copy of
hooks_internal_t. Fix this by using a uintptr_t array instead of an array
of size_t.
A better solution would be language support for atomic memcpy (e.g.
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1478r5.html)
but until then using uintptr_t should be fine.