### PR TITLE
Base headers and initial machine-dependant changes.

### DIFF
--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -93,6 +93,9 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 	_cheri_capability_build_user_rwx(perms, basep, length, off,	\
 	    __func__, __LINE__)
 
+/* Root of all userspace capabilities. */
+extern void * __capability userspace_cap;
+
 /*
  * Global capabilities used to construct other capabilities.
  */
@@ -113,6 +116,15 @@ extern void * __capability swap_restore_cap;
 
 /* Root of all sealed kernel capabilities. */
 extern void * __capability kernel_sealcap;
+
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Kernel root capability
+ * has all permissions
+ * This spans the whole address-space
+ */
+extern void * __capability cheri_kall_capability;
+#endif
 
 /*
  * Functions to create capabilities used in exec.
@@ -164,3 +176,12 @@ extern u_int	security_cheri_bound_legacy_capabilities;
 #include <machine/cheri.h>
 
 #endif /* _SYS_CHERI_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "support"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -196,7 +196,7 @@ cheri_is_subset(const void * __capability parent, const void * __capability ptr)
 
 #define cheri_ptr(ptr, len)	\
 	cheri_setbounds(    \
-	    (__cheri_tocap __typeof__((ptr)[0]) *__capability)ptr, len)
+	    (__cheri_tocap __typeof__(&*(ptr)) __capability)ptr, len)
 
 #define cheri_ptrperm(ptr, len, perm)	\
 	cheri_andperm(cheri_ptr(ptr, len), perm | CHERI_PERM_GLOBAL)

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -112,6 +112,16 @@ cheri_is_null_derived(const void * __capability cap)
 }
 
 #ifdef _KERNEL
+/*
+ * Test whether a capability is a subset of another.
+ * This mimics the semantics of the experimental ctestsubset instruction.
+ */
+static __inline _Bool
+cheri_is_subset(const void * __capability parent, const void * __capability ptr)
+{
+
+	return (__builtin_cheri_subset_test(parent, ptr));
+}
 
 #ifdef __CHERI_PURE_CAPABILITY__
 

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -111,6 +111,59 @@ cheri_is_null_derived(const void * __capability cap)
 	    cap));
 }
 
+#ifdef _KERNEL
+
+#ifdef __CHERI_PURE_CAPABILITY__
+
+/* Check that a capability is tagged */
+#define	CHERI_ASSERT_VALID(ptr)						\
+	KASSERT(cheri_gettag(ptr),					\
+	    ("Expect valid capability %s %s:%d", __func__,		\
+	        __FILE__, __LINE__))
+
+/* Check that a capability is not sealed */
+#define	CHERI_ASSERT_UNSEALED(ptr)					\
+	KASSERT(!cheri_getsealed(ptr),					\
+	    ("Expect unsealed capability %s %s:%d", __func__,		\
+	        __FILE__, __LINE__))
+
+/*
+ * Check that bounds are within the given size, padded to
+ * representable size
+ */
+#define	CHERI_ASSERT_BOUNDS(ptr, expect) do {				\
+		KASSERT(cheri_getlen(ptr) <=				\
+		    CHERI_REPRESENTABLE_LENGTH(expect),			\
+		    ("Invalid bounds on pointer in %s %s:%d "		\
+			 "expected %zx, found %zx",			\
+			__func__, __FILE__, __LINE__,			\
+			(size_t)expect,					\
+			(size_t)cheri_getlen(ptr)));			\
+	} while (0)
+
+/* Check that bounds are exactly the given size */
+#define	CHERI_ASSERT_EXBOUNDS(ptr, len) do {				\
+		KASSERT(cheri_getlen(ptr) == len,			\
+		    ("Inexact bounds on pointer in %s %s:%d "		\
+			"expected %zx, found %zx",			\
+			__func__, __FILE__, __LINE__,			\
+			(size_t)len,					\
+			(size_t)cheri_getlen(ptr)));			\
+	} while (0)
+
+#else /* !__CHERI_PURE_CAPABILITY__ */
+#define	CHERI_ASSERT_VALID(ptr)
+#define	CHERI_ASSERT_UNSEALED(ptr)
+#define	CHERI_ASSERT_BOUNDS(ptr, expect)
+#define	CHERI_ASSERT_EXBOUNDS(ptr, expect)
+#endif /* !__CHERI_PURE_CAPABILITY__ */
+
+/* Check that bounds are exactly the size of a pointer */
+#define	CHERI_ASSERT_PTRSIZE_BOUNDS(ptr)		\
+	CHERI_ASSERT_EXBOUNDS(ptr, sizeof(void * __capability))
+
+#endif
+
 /*
  * Two variations on cheri_ptr() based on whether we are looking for a code or
  * data capability.  The compiler's use of CFromPtr will be with respect to
@@ -206,7 +259,14 @@ cheri_bytes_remaining(const void * __capability cap)
 #define cheri_cap_to_typed_ptr(cap, type)				\
 	(type *)cheri_cap_to_ptr(cap, sizeof(type))
 
-#endif	/* __has_feature(capabilities) */
+#else /* ! __has_feature(capabilities) */
+#ifdef _KERNEL
+#define	CHERI_ASSERT_VALID(ptr)
+#define	CHERI_ASSERT_BOUNDS(ptr, expect)
+#define	CHERI_ASSERT_EXBOUNDS(ptr, len)
+#define	CHERI_ASSERT_PTRSIZE_BOUNDS(ptr)
+#endif
+#endif /* ! __has_feature(capabilities) */
 
 /*
  * The cheri_{get,set,clear}_low_pointer_bits() functions work both with and

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -34,8 +34,9 @@
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
-#if __has_feature(capabilities)
 #include <cheri/cherireg.h>	/* Permission definitions. */
+
+#if __has_feature(capabilities)
 
 /*
  * Programmer-friendly macros for CHERI-aware C code -- requires use of

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -83,7 +83,7 @@
 #define cheri_copyaddress(dst, src)	(cheri_setaddress(dst, cheri_getaddress(src)))
 
 /* Get the top of a capability (i.e. one byte past the last accessible one) */
-static __always_inline inline vaddr_t
+static inline vaddr_t
 cheri_gettop(const void * __capability cap)
 {
 	return (cheri_getbase(cap) + cheri_getlen(cap));
@@ -91,9 +91,9 @@ cheri_gettop(const void * __capability cap)
 
 /* Check if the address is between cap.base and cap.top, i.e. in bounds */
 #ifdef __cplusplus
-static __always_inline inline bool
+static inline bool
 #else
-static __always_inline inline _Bool
+static inline _Bool
 #endif
 cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
 {
@@ -101,9 +101,9 @@ cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
 }
 
 #ifdef __cplusplus
-static __always_inline inline bool
+static inline bool
 #else
-static __always_inline inline _Bool
+static inline _Bool
 #endif
 cheri_is_null_derived(const void * __capability cap)
 {
@@ -216,7 +216,7 @@ cheri_bytes_remaining(const void * __capability cap)
  * XXXAR: Should kept in sync with the version from clang's cheri.h.
  */
 
-static inline __always_inline __result_use_check size_t
+static inline __result_use_check size_t
 __cheri_get_low_ptr_bits(uintptr_t ptr, size_t mask) {
   /*
    * Note: we continue to use bitwise and on the uintcap value and silence the
@@ -234,7 +234,7 @@ __cheri_get_low_ptr_bits(uintptr_t ptr, size_t mask) {
 #pragma clang diagnostic pop
 }
 
-static inline __always_inline __result_use_check uintptr_t
+static inline __result_use_check uintptr_t
 __cheri_set_low_ptr_bits(uintptr_t ptr, size_t bits) {
   /*
    * We want to return a LHS-derived capability here so using the default
@@ -243,7 +243,7 @@ __cheri_set_low_ptr_bits(uintptr_t ptr, size_t bits) {
   return ptr | bits;
 }
 
-static inline __always_inline __result_use_check uintptr_t
+static inline __result_use_check uintptr_t
 __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcheri-bitwise-operations"

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -266,7 +266,7 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #endif
 #define __runtime_assert_sensible_low_bits(bits)                               \
   __extension__({                                                              \
-    _cheri_bits_assert(bits < 32 && "Should only use the low 5 pointer bits"); \
+    _cheri_bits_assert((bits) < 32 && "Should only use the low 5 pointer bits"); \
     bits;                                                                      \
   })
 #else
@@ -274,7 +274,7 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #endif
 #define __static_assert_sensible_low_bits(bits)                                \
   __extension__({                                                              \
-    _Static_assert(bits < 32, "Should only use the low 5 pointer bits");       \
+    _Static_assert((bits) < 32, "Should only use the low 5 pointer bits");     \
     bits;                                                                      \
   })
 

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -268,6 +268,23 @@ cheri_bytes_remaining(const void * __capability cap)
 #endif
 #endif /* ! __has_feature(capabilities) */
 
+#if defined(_KERNEL) && defined(__CHERI_PURE_CAPABILITY__)
+#define	cheri_kern_gettag(x)		cheri_gettag(x)
+#define	cheri_kern_setbounds(x, y)	cheri_setbounds(x, y)
+#define	cheri_kern_setboundsexact(x, y)	cheri_setboundsexact(x, y)
+#define	cheri_kern_setaddress(x, y)	cheri_setaddress(x, y)
+#define	cheri_kern_getaddress(x)	cheri_setaddress(x)
+#define	cheri_kern_getbase(x)		cheri_getbase(x)
+#else
+#define	cheri_kern_gettag(x)					\
+	(((x) == NULL || (vm_offset_t)(x) < 4096) ? 0 : 1)
+#define	cheri_kern_setbounds(x, y)	(x)
+#define	cheri_kern_setboundsexact(x, y)	(x)
+#define	cheri_kern_setaddress(x, y)	((__typeof__(x))(y))
+#define	cheri_kern_getaddress(x)	((uintptr_t)(x))
+#define	cheri_kern_getbase(x)		((uintptr_t)(x))
+#endif
+
 /*
  * The cheri_{get,set,clear}_low_pointer_bits() functions work both with and
  * without CHERI support so can be used unconditionally to fix

--- a/sys/cheri/cherireg.h
+++ b/sys/cheri/cherireg.h
@@ -41,6 +41,8 @@
 #ifndef __SYS_CHERIREG_H__
 #define	__SYS_CHERIREG_H__
 
+#if __has_feature(capabilities)
+
 #include <machine/cherireg.h>
 
 /* Machine-independent capability field values. */
@@ -119,10 +121,33 @@
 #define	CHERI_OTYPE_UNSEALED	(-1l)
 #define	CHERI_OTYPE_SENTRY	(-2l)
 
+/* Shorthand for RWX permission bits */
+#define	CHERI_CAP_PERM_READ	(CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)
+#define	CHERI_CAP_PERM_WRITE                                            \
+    (CHERI_PERM_STORE | CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP)
+#define	CHERI_CAP_PERM_EXEC	(CHERI_PERM_EXECUTE)
+#define	CHERI_CAP_PERM_RWX                                              \
+    (CHERI_CAP_PERM_READ | CHERI_CAP_PERM_WRITE | CHERI_CAP_PERM_EXEC)
+
+
 #define	CHERI_REPRESENTABLE_LENGTH(len) \
 	__builtin_cheri_round_representable_length(len)
 #define	CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) \
 	__builtin_cheri_representable_alignment_mask(len)
+
+/*
+ * TODO: avoid using these since count leading/trailing zeroes is expensive on
+ * BERI/CHERI
+ */
+#define	CHERI_ALIGN_SHIFT(l)	\
+	__builtin_ctzll(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
+#define	CHERI_SEAL_ALIGN_SHIFT(l)	\
+	__builtin_ctzll(CHERI_SEALABLE_ALIGNMENT_MASK(l))
+
+#else /* !__has_feature(capabilities) */
+#define	CHERI_REPRESENTABLE_LENGTH(len) (len)
+#define	CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) UINT64_MAX
+#endif /* !__has_feature(capabilities) */
 
 /* Provide macros to make it easier to work with the raw CRAM/CRRL results: */
 #define	CHERI_REPRESENTABLE_ALIGNMENT(len) \
@@ -146,14 +171,5 @@
 /* A mask for the lower bits, i.e. the negated alignment mask */
 #define	CHERI_SEAL_ALIGN_MASK(l)	~(CHERI_SEALABLE_ALIGNMENT_MASK(l))
 #define	CHERI_ALIGN_MASK(l)		~(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
-
-/*
- * TODO: avoid using these since count leading/trailing zeroes is expensive on
- * BERI/CHERI
- */
-#define	CHERI_ALIGN_SHIFT(l)	\
-	__builtin_ctzll(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
-#define	CHERI_SEAL_ALIGN_SHIFT(l)	\
-	__builtin_ctzll(CHERI_SEALABLE_ALIGNMENT_MASK(l))
 
 #endif /* !__SYS_CHERIREG_H__ */

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -78,11 +78,29 @@ CTASSERT(offsetof(struct thread, td_cheri_mmap_cap) % CHERICAP_SIZE == 0);
 /*
  * Ensure that the compiler being used to build the kernel agrees with the
  * kernel configuration on the size of a capability, and that we are compiling
- * for the hybrid ABI.
+ * for the hybrid or pure ABI.
  */
+#ifndef __CHERI_PURE_CAPABILITY__
 CTASSERT(sizeof(void *) == 8);
+#else
+CTASSERT(sizeof(void *) == 16);
+#endif
 CTASSERT(sizeof(void * __capability) == 16);
 CTASSERT(sizeof(struct cheri_object) == 32);
+
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Global capabilities for various address-space segments.
+ */
+caddr_t cheri_xkphys_capability = (void *)(intcap_t)-1;
+caddr_t cheri_xkseg_capability = (void *)(intcap_t)-1;
+caddr_t cheri_kseg0_capability = (void *)(intcap_t)-1;
+caddr_t cheri_kseg1_capability = (void *)(intcap_t)-1;
+caddr_t cheri_kseg2_capability = (void *)(intcap_t)-1;
+caddr_t cheri_kcode_capability = (void *)(intcap_t)-1;
+caddr_t cheri_kdata_capability = (void *)(intcap_t)-1;
+void *cheri_kall_capability = (void *)(intcap_t)-1;
+#endif /* __CHERI_PURE_CAPABILITY__ */
 
 /*
  * For now, all we do is declare what we support, as most initialisation took
@@ -112,3 +130,12 @@ cheri_cpu_startup(void)
 }
 SYSINIT(cheri_cpu_startup, SI_SUB_CPU, SI_ORDER_FIRST, cheri_cpu_startup,
     NULL);
+// CHERI CHANGES START
+// {
+//   "updated": 20200429,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "support"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/include/cherireg.h
+++ b/sys/mips/include/cherireg.h
@@ -276,7 +276,7 @@
 /*
  * Location of the CHERI CCall/CReturn software-path exception vector.
  */
-#define	CHERI_CCALL_EXC_VEC	((intptr_t)(int32_t)0x80000280)
+#define	CHERI_CCALL_EXC_VEC	MIPS_KSEG0((intptr_t)(int32_t)0x80000280)
 
 /*
  * CHERI_BASELEN_BITS is used in cheribsdtest_cheriabi.c.  The others are
@@ -288,3 +288,13 @@
 #define	CHERI_SEAL_MIN_ALIGN	12
 
 #endif /* _MIPS_INCLUDE_CHERIREG_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "pointer_as_integer",
+//     "support"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/include/sf_buf.h
+++ b/sys/mips/include/sf_buf.h
@@ -39,7 +39,7 @@ sf_buf_kva(struct sf_buf *sf)
 	vm_page_t	m;
 
 	m = (vm_page_t)sf;
-	return (MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m)));
+	return ((vm_ptr_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m)));
 }
 
 static inline struct vm_page *
@@ -69,3 +69,12 @@ sf_buf_unmap(struct sf_buf *sf)
 #endif	/* __mips_n64 */
 
 #endif /* !_MACHINE_SF_BUF_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/include/vmparam.h
+++ b/sys/mips/include/vmparam.h
@@ -100,9 +100,9 @@
 #define	SHAREDPAGE		(VM_MAXUSER_ADDRESS - PAGE_SIZE)
 /*
  * To ensure that the stack base address that is sufficiently aligned to create
- * a precisely bounded capability we must round down by 16 pages (0x7ffbff0000).
+ * a precisely bounded capability we must round down by 32 pages (0x7ffbfe0000).
  */
-#define	USRSTACK		(SHAREDPAGE - (15 * PAGE_SIZE))
+#define	USRSTACK		(SHAREDPAGE - (31 * PAGE_SIZE))
 #ifdef __mips_n64
 #define	FREEBSD32_SHAREDPAGE	(((vm_offset_t)0x80000000) - PAGE_SIZE)
 #define	FREEBSD32_USRSTACK	FREEBSD32_SHAREDPAGE
@@ -217,11 +217,14 @@
 #endif /* !_MACHINE_VMPARAM_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20180629,
+//   "updated": 20200824,
 //   "target_type": "header",
 //   "changes": [
 //     "support"
 //   ],
+//   "changes_purecap": [
+//     "bounds_compression"
+//   ]
 //   "change_comment": ""
 // }
 // CHERI CHANGES END

--- a/sys/mips/malta/gt_pci.c
+++ b/sys/mips/malta/gt_pci.c
@@ -312,9 +312,9 @@ gt_pci_attach(device_t dev)
 	if (bus_space_map(sc->sc_st, IO_ICU2, 2, 0, &sc->sc_ioh_icu2) != 0)
 		device_printf(dev, "unable to map ICU2 registers\n");
 #else
-	sc->sc_ioh_elcr = MIPS_PHYS_TO_KSEG1(sc->sc_io + 0x4d0);
-	sc->sc_ioh_icu1 = MIPS_PHYS_TO_KSEG1(sc->sc_io + IO_ICU1);
-	sc->sc_ioh_icu2 = MIPS_PHYS_TO_KSEG1(sc->sc_io + IO_ICU2);
+	sc->sc_ioh_elcr = (vm_offset_t)MIPS_PHYS_TO_KSEG1(sc->sc_io + 0x4d0);
+	sc->sc_ioh_icu1 = (vm_offset_t)MIPS_PHYS_TO_KSEG1(sc->sc_io + IO_ICU1);
+	sc->sc_ioh_icu2 = (vm_offset_t)MIPS_PHYS_TO_KSEG1(sc->sc_io + IO_ICU2);
 #endif	
 
 	/* All interrupts default to "masked off". */

--- a/sys/mips/malta/obio.c
+++ b/sys/mips/malta/obio.c
@@ -85,7 +85,7 @@ obio_attach(device_t dev)
 	struct obio_softc *sc = device_get_softc(dev);
 
 	sc->oba_st = mips_bus_space_generic;
-	sc->oba_addr = MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
+	sc->oba_addr = (vm_ptr_t)MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
 	sc->oba_size = MALTA_PCIMEM3_SIZE;
 	sc->oba_rman.rm_type = RMAN_ARRAY;
 	sc->oba_rman.rm_descr = "OBIO I/O";
@@ -182,3 +182,12 @@ static driver_t obio_driver = {
 static devclass_t obio_devclass;
 
 DRIVER_MODULE(obio, pci, obio_driver, obio_devclass, 0, 0);
+// CHERI CHANGES START
+// {
+//   "updated": 20180613,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/malta/uart_bus_maltausart.c
+++ b/sys/mips/malta/uart_bus_maltausart.c
@@ -84,10 +84,21 @@ uart_malta_probe(device_t dev)
 	sc->sc_class = &uart_ns8250_class;
 	bcopy(&sc->sc_sysdev->bas, &sc->sc_bas, sizeof(sc->sc_bas));
 	sc->sc_sysdev->bas.bst = mips_bus_space_generic;
-	sc->sc_sysdev->bas.bsh = MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
+	sc->sc_sysdev->bas.bsh = (bus_space_handle_t)
+	    MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
 	sc->sc_bas.bst = mips_bus_space_generic;
-	sc->sc_bas.bsh = MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
+	sc->sc_bas.bsh = (bus_space_handle_t)
+	    MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
 	return(uart_bus_probe(dev, 0, 0, 0, 0, 0, 0));
 }
 
 DRIVER_MODULE(uart, obio, uart_malta_driver, uart_devclass, 0, 0);
+// CHERI CHANGES START
+// {
+//   "updated": 20190605,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/malta/uart_cpu_maltausart.c
+++ b/sys/mips/malta/uart_cpu_maltausart.c
@@ -66,7 +66,7 @@ uart_cpu_getdev(int devtype, struct uart_devinfo *di)
 	di->ops = uart_getops(&uart_ns8250_class);
 	di->bas.chan = 0;
 	di->bas.bst = mips_bus_space_generic;
-	di->bas.bsh = MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
+	di->bas.bsh = (bus_space_handle_t)MIPS_PHYS_TO_KSEG1(MALTA_UART0ADR);
 	di->bas.regshft = 0;
 	di->bas.rclk = 0;
 	di->baudrate = 0;	/* retain the baudrate configured by YAMON */
@@ -78,3 +78,12 @@ uart_cpu_getdev(int devtype, struct uart_devinfo *di)
 	uart_bus_space_mem = mips_bus_space_generic;
 	return (0);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20190605,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/mips/cache_mipsNN.c
+++ b/sys/mips/mips/cache_mipsNN.c
@@ -183,7 +183,7 @@ mipsNN_icache_sync_all_16(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + picache_size;
 
 	/*
@@ -206,7 +206,7 @@ mipsNN_icache_sync_all_32(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + picache_size;
 
 	/*
@@ -229,7 +229,7 @@ mipsNN_icache_sync_all_64(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + picache_size;
 
 	/*
@@ -328,7 +328,7 @@ mipsNN_icache_sync_range_index_16(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
 
 	eva = round_line16(va + size);
 	va = trunc_line16(va);
@@ -371,7 +371,7 @@ mipsNN_icache_sync_range_index_32(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
 
 	eva = round_line32(va + size);
 	va = trunc_line32(va);
@@ -414,7 +414,7 @@ mipsNN_icache_sync_range_index_64(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
 
 	eva = round_line64(va + size);
 	va = trunc_line64(va);
@@ -450,7 +450,7 @@ mipsNN_pdcache_wbinv_all_16(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + pdcache_size;
 
 	/*
@@ -472,7 +472,7 @@ mipsNN_pdcache_wbinv_all_32(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + pdcache_size;
 
 	/*
@@ -494,7 +494,7 @@ mipsNN_pdcache_wbinv_all_64(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + pdcache_size;
 
 	/*
@@ -589,7 +589,7 @@ mipsNN_pdcache_wbinv_range_index_16(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
 
 	eva = round_line16(va + size);
 	va = trunc_line16(va);
@@ -630,7 +630,7 @@ mipsNN_pdcache_wbinv_range_index_32(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
 
 	eva = round_line32(va + size);
 	va = trunc_line32(va);
@@ -671,7 +671,7 @@ mipsNN_pdcache_wbinv_range_index_64(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
 
 	eva = round_line64(va + size);
 	va = trunc_line64(va);
@@ -879,7 +879,7 @@ mipsNN_icache_sync_all_128(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + picache_size;
 
 	/*
@@ -932,7 +932,7 @@ mipsNN_icache_sync_range_index_128(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & picache_way_mask);
 
 	eva = round_line128(va + size);
 	va = trunc_line128(va);
@@ -968,7 +968,7 @@ mipsNN_pdcache_wbinv_all_128(void)
 {
 	vm_offset_t va, eva;
 
-	va = MIPS_PHYS_TO_KSEG0(0);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	eva = va + pdcache_size;
 
 	/*
@@ -1019,7 +1019,7 @@ mipsNN_pdcache_wbinv_range_index_128(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & pdcache_way_mask);
 
 	eva = round_line128(va + size);
 	va = trunc_line128(va);
@@ -1095,7 +1095,7 @@ mipsNN_pdcache_wb_range_128(vm_offset_t va, vm_size_t size)
 void
 mipsNN_sdcache_wbinv_all_32(void)
 {
-	vm_offset_t va = MIPS_PHYS_TO_KSEG0(0);
+	vm_offset_t va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	vm_offset_t eva = va + sdcache_size;
 
 	while (va < eva) {
@@ -1108,7 +1108,7 @@ mipsNN_sdcache_wbinv_all_32(void)
 void
 mipsNN_sdcache_wbinv_all_64(void)
 {
-	vm_offset_t va = MIPS_PHYS_TO_KSEG0(0);
+	vm_offset_t va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	vm_offset_t eva = va + sdcache_size;
 
 	while (va < eva) {
@@ -1167,7 +1167,7 @@ mipsNN_sdcache_wbinv_range_index_32(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & (sdcache_size - 1));
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & (sdcache_size - 1));
 
 	eva = round_line32(va + size);
 	va = trunc_line32(va);
@@ -1195,7 +1195,7 @@ mipsNN_sdcache_wbinv_range_index_64(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & (sdcache_size - 1));
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & (sdcache_size - 1));
 
 	eva = round_line64(va + size);
 	va = trunc_line64(va);
@@ -1287,7 +1287,7 @@ mipsNN_sdcache_wb_range_64(vm_offset_t va, vm_size_t size)
 void
 mipsNN_sdcache_wbinv_all_128(void)
 {
-	vm_offset_t va = MIPS_PHYS_TO_KSEG0(0);
+	vm_offset_t va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(0);
 	vm_offset_t eva = va + sdcache_size;
 
 	while (va < eva) {
@@ -1327,7 +1327,7 @@ mipsNN_sdcache_wbinv_range_index_128(vm_offset_t va, vm_size_t size)
 	 * bits that determine the cache index, and make a KSEG0
 	 * address out of them.
 	 */
-	va = MIPS_PHYS_TO_KSEG0(va & (sdcache_size - 1));
+	va = (vm_offset_t)MIPS_PHYS_TO_KSEG0(va & (sdcache_size - 1));
 
 	eva = round_line128(va + size);
 	va = trunc_line128(va);
@@ -1379,3 +1379,12 @@ mipsNN_sdcache_wb_range_128(vm_offset_t va, vm_size_t size)
 		va += 128;
 	}
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20171208,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/riscv/include/param.h
+++ b/sys/riscv/include/param.h
@@ -133,3 +133,13 @@
 #define	riscv_ptob(x)		((unsigned long)(x) << PAGE_SHIFT)
 
 #endif /* !_MACHINE_PARAM_H_ */
+
+// CHERI CHANGES START
+// {
+//   "updated": 20201007,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "support"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/types.h
+++ b/sys/sys/types.h
@@ -251,6 +251,12 @@ struct cap_rights;
 typedef	struct cap_rights	cap_rights_t;
 #endif
 
+#ifdef __CHERI_PURE_CAPABILITY__
+typedef __uintptr_t	vm_ptr_t;
+#else
+typedef __vm_offset_t	vm_ptr_t;
+#endif
+
 /*
  * Types suitable for exporting physical addresses, virtual addresses
  * (pointers), and memory object sizes from the kernel independent of native
@@ -445,11 +451,15 @@ typedef	void * __capability	otype_t;
 #endif /* !_SYS_TYPES_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20200706,
 //   "target_type": "header",
 //   "changes": [
 //     "support",
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "support",
+//     "pointer_as_integer"
 //   ]
 // }
 // CHERI CHANGES END


### PR DESCRIPTION
This introduces the changes to base common headers, adds the `vm_ptr_t` typedef and definitions of the top-level kernel capabilities that will be initialized at boot.