### PR TITLE
Consistently use the inline keyword in cheric header.

### DIFF
--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -148,7 +148,7 @@ cheri_is_null_derived(const void * __capability cap)
  * The caller may wish to assert various properties about the returned
  * capability, including that CHERI_PERM_SEAL is set.
  */
-static __inline otype_t
+static inline otype_t
 cheri_maketype(void * __capability root_type, register_t type)
 {
 	void * __capability c;
@@ -160,13 +160,13 @@ cheri_maketype(void * __capability root_type, register_t type)
 	return (c);
 }
 
-static __inline void * __capability
+static inline void * __capability
 cheri_zerocap(void)
 {
 	return (void * __capability)0;
 }
 
-static __inline uint64_t
+static inline uint64_t
 cheri_bytes_remaining(const void * __capability cap)
 {
 	if (cheri_getoffset(cap) >= cheri_getlen(cap))

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -83,7 +83,7 @@
 #define cheri_copyaddress(dst, src)	(cheri_setaddress(dst, cheri_getaddress(src)))
 
 /* Get the top of a capability (i.e. one byte past the last accessible one) */
-static __always_inline inline vaddr_t
+static inline vaddr_t
 cheri_gettop(const void * __capability cap)
 {
 	return (cheri_getbase(cap) + cheri_getlen(cap));
@@ -91,9 +91,9 @@ cheri_gettop(const void * __capability cap)
 
 /* Check if the address is between cap.base and cap.top, i.e. in bounds */
 #ifdef __cplusplus
-static __always_inline inline bool
+static inline bool
 #else
-static __always_inline inline _Bool
+static inline _Bool
 #endif
 cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
 {
@@ -216,7 +216,7 @@ cheri_bytes_remaining(const void * __capability cap)
  * XXXAR: Should kept in sync with the version from clang's cheri.h.
  */
 
-static inline __always_inline __result_use_check size_t
+static inline __result_use_check size_t
 __cheri_get_low_ptr_bits(uintptr_t ptr, size_t mask) {
   /*
    * Note: we continue to use bitwise and on the uintcap value and silence the
@@ -234,7 +234,7 @@ __cheri_get_low_ptr_bits(uintptr_t ptr, size_t mask) {
 #pragma clang diagnostic pop
 }
 
-static inline __always_inline __result_use_check uintptr_t
+static inline __result_use_check uintptr_t
 __cheri_set_low_ptr_bits(uintptr_t ptr, size_t bits) {
   /*
    * We want to return a LHS-derived capability here so using the default
@@ -243,7 +243,7 @@ __cheri_set_low_ptr_bits(uintptr_t ptr, size_t bits) {
   return ptr | bits;
 }
 
-static inline __always_inline __result_use_check uintptr_t
+static inline __result_use_check uintptr_t
 __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcheri-bitwise-operations"


### PR DESCRIPTION
This also removes `__always_inline` as it is not necessary.