### PR TITLE
Rename vm_ptr_t to vm_pointer_t

### DIFF
--- a/sys/ddb/db_main.c
+++ b/sys/ddb/db_main.c
@@ -76,7 +76,7 @@ KDB_BACKEND(ddb, db_init, db_trace_self_wrapper, db_trace_thread_wrapper,
  * the symtab and strtab in memory. This is used when loaded from
  * boot loaders different than the native one (like Xen).
  */
-vm_ptr_t ksymtab, kstrtab;
+vm_pointer_t ksymtab, kstrtab;
 vm_offset_t ksymtab_relbase;
 vm_size_t ksymtab_size;
 
@@ -203,7 +203,7 @@ X_db_symbol_values(db_symtab_t *symtab, c_db_sym_t sym, const char **namep,
 }
 
 int
-db_fetch_ksymtab(vm_ptr_t ksym_start, vm_ptr_t ksym_end, vm_offset_t relbase)
+db_fetch_ksymtab(vm_pointer_t ksym_start, vm_pointer_t ksym_end, vm_offset_t relbase)
 {
 	Elf_Size strsz;
 
@@ -221,9 +221,9 @@ db_fetch_ksymtab(vm_ptr_t ksym_start, vm_ptr_t ksym_end, vm_offset_t relbase)
 			    = 0;
 		} else {
 #ifdef __CHERI_PURE_CAPABILITY__
-			ksymtab = (vm_ptr_t)cheri_setbounds((char *)ksymtab,
+			ksymtab = (vm_pointer_t)cheri_setbounds((char *)ksymtab,
 			    ksymtab_size);
-			kstrtab = (vm_ptr_t)cheri_setbounds((char *)kstrtab,
+			kstrtab = (vm_pointer_t)cheri_setbounds((char *)kstrtab,
 			    strsz);
 #endif
 		}

--- a/sys/ddb/ddb.h
+++ b/sys/ddb/ddb.h
@@ -83,7 +83,7 @@ int	DB_CALL(db_expr_t, db_expr_t *, int, db_expr_t[]);
  * Most users should use db_fetch_symtab in order to set them from the
  * boot loader provided values.
  */
-extern vm_ptr_t ksymtab, kstrtab;
+extern vm_pointer_t ksymtab, kstrtab;
 extern vm_size_t ksymtab_size;
 extern vm_offset_t ksymtab_relbase;
 
@@ -230,7 +230,7 @@ bool		db_value_of_name_vnet(const char *name, db_expr_t *valuep);
 int		db_write_bytes(vm_offset_t addr, size_t size, char *data);
 void		db_command_register(struct command_table *, struct command *);
 void		db_command_unregister(struct command_table *, struct command *);
-int		db_fetch_ksymtab(vm_ptr_t ksym_start, vm_ptr_t ksym_end,
+int		db_fetch_ksymtab(vm_pointer_t ksym_start, vm_pointer_t ksym_end,
 		    vm_offset_t relbase);
 #ifdef __CHERI_PURE_CAPABILITY__
 void		*db_code_ptr(db_addr_t addr);

--- a/sys/dev/ata/ata-lowlevel.c
+++ b/sys/dev/ata/ata-lowlevel.c
@@ -818,7 +818,7 @@ ata_pio_read(struct ata_request *request, int length)
 	struct ata_channel *ch = device_get_softc(request->parent);
 	struct bio *bio;
 	uint8_t *addr;
-	vm_ptr_t page;
+	vm_pointer_t page;
 	int todo, done, off, moff, resid, size, i;
 	uint8_t buf[2] __aligned(2);
 
@@ -908,7 +908,7 @@ ata_pio_write(struct ata_request *request, int length)
 	struct ata_channel *ch = device_get_softc(request->parent);
 	struct bio *bio;
 	uint8_t *addr;
-	vm_ptr_t page;
+	vm_pointer_t page;
 	int todo, done, off, moff, resid, size, i;
 	uint8_t buf[2] __aligned(2);
 

--- a/sys/dev/pci/pci_user.c
+++ b/sys/dev/pci/pci_user.c
@@ -960,7 +960,7 @@ pci_bar_mmap(device_t pcidev, struct pci_bar_mmap *pbm)
 	vm_paddr_t membase;
 	vm_paddr_t pbase;
 	vm_size_t plen;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	vm_prot_t prot;
 	int error, flags;
 

--- a/sys/dev/xdma/xdma.h
+++ b/sys/dev/xdma/xdma.h
@@ -95,7 +95,7 @@ struct xchan_buf {
 	bus_dmamap_t			map;
 	uint32_t			nsegs;
 	uint32_t			nsegs_left;
-	vm_ptr_t			vaddr;
+	vm_pointer_t			vaddr;
 	vm_offset_t			paddr;
 	vm_size_t			size;
 };
@@ -303,9 +303,9 @@ struct xdma_request * xchan_bank_get(xdma_channel_t *xchan);
 int xchan_bank_put(xdma_channel_t *xchan, struct xdma_request *xr);
 
 /* IOMMU */
-void xdma_iommu_add_entry(xdma_channel_t *xchan, vm_ptr_t *va,
+void xdma_iommu_add_entry(xdma_channel_t *xchan, vm_pointer_t *va,
     vm_paddr_t pa, vm_size_t size, vm_prot_t prot);
-void xdma_iommu_remove_entry(xdma_channel_t *xchan, vm_ptr_t va);
+void xdma_iommu_remove_entry(xdma_channel_t *xchan, vm_pointer_t va);
 int xdma_iommu_init(struct xdma_iommu *xio);
 int xdma_iommu_release(struct xdma_iommu *xio);
 

--- a/sys/dev/xdma/xdma_if.m
+++ b/sys/dev/xdma/xdma_if.m
@@ -138,7 +138,7 @@ METHOD int iommu_release {
 METHOD int iommu_enter {
 	device_t dev;
 	struct xdma_iommu *xio;
-	vm_ptr_t va;
+	vm_pointer_t va;
 	vm_offset_t pa;
 };
 
@@ -148,7 +148,7 @@ METHOD int iommu_enter {
 METHOD int iommu_remove {
 	device_t dev;
 	struct xdma_iommu *xio;
-	vm_ptr_t va;
+	vm_pointer_t va;
 };
 # CHERI CHANGES START
 # {

--- a/sys/dev/xdma/xdma_iommu.c
+++ b/sys/dev/xdma/xdma_iommu.c
@@ -61,7 +61,7 @@ __FBSDID("$FreeBSD$");
 #include "xdma_if.h"
 
 void
-xdma_iommu_remove_entry(xdma_channel_t *xchan, vm_ptr_t va)
+xdma_iommu_remove_entry(xdma_channel_t *xchan, vm_pointer_t va)
 {
 	struct xdma_iommu *xio;
 
@@ -76,7 +76,7 @@ xdma_iommu_remove_entry(xdma_channel_t *xchan, vm_ptr_t va)
 }
 
 static void
-xdma_iommu_enter(struct xdma_iommu *xio, vm_ptr_t va,
+xdma_iommu_enter(struct xdma_iommu *xio, vm_pointer_t va,
     vm_paddr_t pa, vm_size_t size, vm_prot_t prot)
 {
 	vm_page_t m;
@@ -99,7 +99,7 @@ xdma_iommu_enter(struct xdma_iommu *xio, vm_ptr_t va,
 }
 
 void
-xdma_iommu_add_entry(xdma_channel_t *xchan, vm_ptr_t *va,
+xdma_iommu_add_entry(xdma_channel_t *xchan, vm_pointer_t *va,
     vm_paddr_t pa, vm_size_t size, vm_prot_t prot)
 {
 	struct xdma_iommu *xio;

--- a/sys/dev/xdma/xdma_sg.c
+++ b/sys/dev/xdma/xdma_sg.c
@@ -326,7 +326,7 @@ xchan_seg_done(xdma_channel_t *xchan,
 	struct xdma_request *xr;
 	xdma_controller_t *xdma;
 	struct xchan_buf *b;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 
 	xdma = xchan->xdma;
 
@@ -494,7 +494,7 @@ _xdma_load_data(xdma_channel_t *xchan, struct xdma_request *xr,
 	struct mbuf *m;
 	uint32_t nsegs;
 	vm_offset_t addr;
-	vm_ptr_t va;
+	vm_pointer_t va;
 	bus_addr_t pa;
 	vm_prot_t prot;
 	xdma_request_addr_t seg_addr;

--- a/sys/dev/xilinx/axidma.c
+++ b/sys/dev/xilinx/axidma.c
@@ -94,7 +94,7 @@ struct axidma_channel {
 
 	vm_size_t		mem_size;
 	vmem_addr_t		mem_paddr;
-	vm_ptr_t		mem_vaddr;
+	vm_pointer_t		mem_vaddr;
 
 	uint32_t		descs_used_count;
 };

--- a/sys/fs/devfs/devfs_vnops.c
+++ b/sys/fs/devfs/devfs_vnops.c
@@ -1956,7 +1956,7 @@ devfs_write_f(struct file *fp, struct uio *uio, struct ucred *cred,
 }
 
 static int
-devfs_mmap_f(struct file *fp, vm_map_t map, vm_ptr_t *addr,
+devfs_mmap_f(struct file *fp, vm_map_t map, vm_pointer_t *addr,
     vm_offset_t max_addr, vm_size_t size, vm_prot_t prot,
     vm_prot_t cap_maxprot, int flags, vm_ooffset_t foff,
     struct thread *td)

--- a/sys/geom/geom_io.c
+++ b/sys/geom/geom_io.c
@@ -745,7 +745,7 @@ SYSCTL_INT(_kern_geom, OID_AUTO, inflight_transient_maps, CTLFLAG_RD,
 static int
 g_io_transient_map_bio(struct bio *bp)
 {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	long size;
 	u_int retried;
 

--- a/sys/kern/imgact_aout.c
+++ b/sys/kern/imgact_aout.c
@@ -159,12 +159,12 @@ exec_aout_imgact(struct image_params *imgp)
 	struct vmspace *vmspace;
 	vm_map_t map;
 	vm_object_t object;
-	vm_ptr_t text_end, data_end;
+	vm_pointer_t text_end, data_end;
 	unsigned long virtual_offset;
 	unsigned long file_offset;
 	unsigned long bss_size;
 	int error;
-	vm_ptr_t reservation;
+	vm_pointer_t reservation;
 	vm_size_t reserv_size;
 
 	/*

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -540,7 +540,7 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	vm_offset_t seg_addr;
 	vm_size_t seg_size;
 	int i, result;
-	vm_ptr_t reservation;
+	vm_pointer_t reservation;
         void * __capability reservation_cap;
 	vm_map_t map;
 

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -646,8 +646,8 @@ proc0_init(void *dummy __unused)
 	minuser_cap = cheri_andperm(minuser_cap, 0);
 
 	vm_map_init(&vmspace0.vm_map, vmspace_pmap(&vmspace0),
-	    (vm_ptr_t)minuser_cap,
-	    (vm_ptr_t)minuser_cap + cheri_getlen(minuser_cap));
+	    (vm_pointer_t)minuser_cap,
+	    (vm_pointer_t)minuser_cap + cheri_getlen(minuser_cap));
 #endif
 
 	/*

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1059,10 +1059,10 @@ exec_new_vmspace(struct image_params *imgp, struct sysentvec *sv)
 	vm_object_t obj;
 	struct rlimit rlim_stack;
 	vm_offset_t sv_minuser;
-	vm_ptr_t stack_addr;
+	vm_pointer_t stack_addr;
 	vm_map_t map;
 	u_long ssiz;
-	vm_ptr_t shared_page_addr;
+	vm_pointer_t shared_page_addr;
 	vm_prot_t stack_prot;
 
 	imgp->vmspace_destroyed = 1;
@@ -1384,7 +1384,7 @@ err_exit:
 }
 
 struct exec_args_kva {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	u_int gen;
 	SLIST_ENTRY(exec_args_kva) next;
 };
@@ -1412,7 +1412,7 @@ exec_prealloc_args_kva(void *arg __unused)
 }
 SYSINIT(exec_args_kva, SI_SUB_EXEC, SI_ORDER_ANY, exec_prealloc_args_kva, NULL);
 
-static vm_ptr_t
+static vm_pointer_t
 exec_alloc_args_kva(void **cookie)
 {
 	struct exec_args_kva *argkva;

--- a/sys/kern/kern_kcov.c
+++ b/sys/kern/kern_kcov.c
@@ -125,7 +125,7 @@ typedef enum {
 struct kcov_info {
 	struct thread	*thread;	/* (l) */
 	vm_object_t	bufobj;		/* (o) */
-	vm_ptr_t	kvaddr;		/* (o) */
+	vm_pointer_t	kvaddr;		/* (o) */
 	size_t		entries;	/* (o) */
 	size_t		bufsize;	/* (o) */
 	kcov_state_t	state;		/* (s) */
@@ -391,7 +391,7 @@ kcov_alloc(struct kcov_info *info, size_t entries)
 	}
 	VM_OBJECT_WUNLOCK(info->bufobj);
 #ifdef __CHERI_PURE_CAPABILITY__
-	info->kvaddr = (vm_ptr_t)cheri_setbounds(
+	info->kvaddr = (vm_pointer_t)cheri_setbounds(
 	    MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m)), info->bufsize);
 #else
 	info->kvaddr = MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m));

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -509,7 +509,7 @@ void
 contigfree(void *addr, unsigned long size, struct malloc_type *type)
 {
 	CHERI_ASSERT_VALID(addr);
-	kmem_free((vm_ptr_t)addr, size);
+	kmem_free((vm_pointer_t)addr, size);
 	malloc_type_freed(type, addr, round_page(size));
 }
 
@@ -603,7 +603,7 @@ static caddr_t __noinline
 malloc_large(size_t *size, struct malloc_type *mtp, struct domainset *policy,
     int flags DEBUG_REDZONE_ARG_DEF)
 {
-	vm_ptr_t kva;
+	vm_pointer_t kva;
 	caddr_t va;
 	size_t sz;
 
@@ -633,7 +633,7 @@ static void
 free_large(void *addr, size_t size)
 {
 
-	kmem_free((vm_ptr_t)addr, size);
+	kmem_free((vm_pointer_t)addr, size);
 	uma_total_dec(size);
 }
 

--- a/sys/kern/kern_sharedpage.c
+++ b/sys/kern/kern_sharedpage.c
@@ -117,7 +117,7 @@ static void
 shared_page_init(void *dummy __unused)
 {
 	vm_page_t m;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 
 	sx_init(&shared_page_alloc_sx, "shpsx");
 	shared_page_obj = vm_pager_allocate(OBJT_PHYS, 0, PAGE_SIZE,

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -671,7 +671,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 	Elf_Shdr *shdr;
 	Elf_Sym *es;
 	int nbytes, i, j;
-	vm_ptr_t mapbase;
+	vm_pointer_t mapbase;
 	size_t mapsize;
 	int error = 0;
 	ssize_t resid;

--- a/sys/kern/subr_busdma_bufalloc.c
+++ b/sys/kern/subr_busdma_bufalloc.c
@@ -169,7 +169,7 @@ void
 busdma_bufalloc_free_uncacheable(void *item, vm_size_t size, uint8_t pflag)
 {
 
-	kmem_free((vm_ptr_t)item, size);
+	kmem_free((vm_pointer_t)item, size);
 }
 // CHERI CHANGES START
 // {

--- a/sys/kern/subr_devmap.c
+++ b/sys/kern/subr_devmap.c
@@ -242,7 +242,7 @@ devmap_ptov(vm_paddr_t pa, vm_size_t size)
  * corresponding physical address, or DEVMAP_PADDR_NOTFOUND if not found.
  */
 vm_paddr_t
-devmap_vtop(vm_ptr_t va, vm_size_t size)
+devmap_vtop(vm_pointer_t va, vm_size_t size)
 {
 	const struct devmap_entry *pd;
 
@@ -271,7 +271,7 @@ devmap_vtop(vm_ptr_t va, vm_size_t size)
 void *
 pmap_mapdev(vm_offset_t pa, vm_size_t size)
 {
-	vm_ptr_t va;
+	vm_pointer_t va;
 	vm_offset_t offset;
 	void * rva;
 
@@ -287,13 +287,13 @@ pmap_mapdev(vm_offset_t pa, vm_size_t size)
 	if (early_boot) {
 #ifdef __CHERI_PURE_CAPABILITY__
 #ifdef INVARIANTS
-		vm_ptr_t oldva = akva_devmap_vaddr;
+		vm_pointer_t oldva = akva_devmap_vaddr;
 #endif
 		akva_devmap_vaddr -= CHERI_REPRESENTABLE_LENGTH(size);
 		akva_devmap_vaddr = CHERI_REPRESENTABLE_BASE(akva_devmap_vaddr,
 		    size);
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr);
-		va = (vm_ptr_t)cheri_setbounds(cheri_setaddress(
+		va = (vm_pointer_t)cheri_setbounds(cheri_setaddress(
 		    devmap_capability, akva_devmap_vaddr), size);
 		KASSERT(va + cheri_getlen((void *)va) <= oldva,
 		    ("%s: early devmap overlaps", __func__));
@@ -349,7 +349,7 @@ pmap_mapdev_attr(vm_offset_t pa, vm_size_t size, vm_memattr_t ma)
  * Unmap device memory and free the kva space.
  */
 void
-pmap_unmapdev(vm_ptr_t va, vm_size_t size)
+pmap_unmapdev(vm_pointer_t va, vm_size_t size)
 {
 	vm_offset_t offset;
 

--- a/sys/kern/subr_sfbuf.c
+++ b/sys/kern/subr_sfbuf.c
@@ -85,7 +85,7 @@ static void
 sf_buf_init(void *arg)
 {
 	struct sf_buf *sf_bufs;
-	vm_ptr_t sf_base;
+	vm_pointer_t sf_base;
 	int i;
 
 	if (PMAP_HAS_DMAP)
@@ -100,7 +100,7 @@ sf_buf_init(void *arg)
 	sf_bufs = malloc(nsfbufs * sizeof(struct sf_buf), M_TEMP,
 	    M_WAITOK | M_ZERO);
 	for (i = 0; i < nsfbufs; i++) {
-		sf_bufs[i].kva = (vm_ptr_t)cheri_kern_setbounds(
+		sf_bufs[i].kva = (vm_pointer_t)cheri_kern_setbounds(
 		    sf_base + i * PAGE_SIZE, PAGE_SIZE);
 		TAILQ_INSERT_TAIL(&sf_buf_freelist, &sf_bufs[i], free_entry);
 	}

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -466,7 +466,7 @@ cloneuio(struct uio *uiop)
  * boundary.
  */
 int
-copyout_map(struct thread *td, vm_ptr_t *addr, size_t sz)
+copyout_map(struct thread *td, vm_pointer_t *addr, size_t sz)
 {
 	struct vmspace *vms;
 	int error;
@@ -477,7 +477,7 @@ copyout_map(struct thread *td, vm_ptr_t *addr, size_t sz)
 	/*
 	 * Map somewhere after heap in process memory.
 	 */
-	*addr = round_page((vm_ptr_t)vms->vm_daddr +
+	*addr = round_page((vm_pointer_t)vms->vm_daddr +
 	    lim_max(td, RLIMIT_DATA));
 
 	/* round size up to page boundary */
@@ -494,7 +494,7 @@ copyout_map(struct thread *td, vm_ptr_t *addr, size_t sz)
  * Unmap memory in user space.
  */
 int
-copyout_unmap(struct thread *td, vm_ptr_t addr, size_t sz)
+copyout_unmap(struct thread *td, vm_pointer_t addr, size_t sz)
 {
 	vm_map_t map;
 	vm_size_t size;

--- a/sys/kern/sys_pipe.c
+++ b/sys/kern/sys_pipe.c
@@ -560,7 +560,7 @@ retry:
 	size = round_page(size);
 	buffer = (caddr_t)(uintptr_t) vm_map_min(pipe_map);
 
-	error = vm_map_find(pipe_map, NULL, 0, (vm_ptr_t *)&buffer, size, 0,
+	error = vm_map_find(pipe_map, NULL, 0, (vm_pointer_t *)&buffer, size, 0,
 	    VMFS_ANY_SPACE, VM_PROT_RW, VM_PROT_RW, 0);
 	if (error != KERN_SUCCESS) {
 		if (cpipe->pipe_buffer.buffer == NULL &&

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -432,7 +432,7 @@ kern_shmat_locked(struct thread *td, int shmid,
 	struct shmid_kernel *shmseg;
 	struct shmmap_state *shmmap_s;
 	vm_offset_t attach_va = 0, max_va;
-	vm_ptr_t attach_addr;
+	vm_pointer_t attach_addr;
 	vm_prot_t prot;
 	vm_size_t size;
 	int cow, error, find_space, i, rv;

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -1430,7 +1430,7 @@ out:
 }
 
 static int
-shm_mmap_large(struct shmfd *shmfd, vm_map_t map, vm_ptr_t *addr,
+shm_mmap_large(struct shmfd *shmfd, vm_map_t map, vm_pointer_t *addr,
     vm_offset_t maxaddr,
     vm_size_t size, vm_prot_t prot, vm_prot_t max_prot, int flags,
     vm_ooffset_t foff, struct thread *td)
@@ -1439,7 +1439,7 @@ shm_mmap_large(struct shmfd *shmfd, vm_map_t map, vm_ptr_t *addr,
 	vm_offset_t align, mask, vaddr;
 	int docow, error, rv, try;
 	bool curmap;
-	vm_ptr_t reservation;
+	vm_pointer_t reservation;
 	bool new_reservation;
 
 	if (shmfd->shm_lp_psind == 0)
@@ -1563,7 +1563,7 @@ fail:
 }
 
 int
-shm_mmap(struct file *fp, vm_map_t map, vm_ptr_t *addr,
+shm_mmap(struct file *fp, vm_map_t map, vm_pointer_t *addr,
     vm_offset_t max_addr, vm_size_t objsize,
     vm_prot_t prot, vm_prot_t cap_maxprot, int flags,
     vm_ooffset_t foff, struct thread *td)
@@ -1726,7 +1726,7 @@ int
 shm_map(struct file *fp, size_t size, off_t offset, void **memp)
 {
 	struct shmfd *shmfd;
-	vm_ptr_t kva;
+	vm_pointer_t kva;
 	vm_offset_t ofs;
 	vm_object_t obj;
 	int rv;

--- a/sys/kern/vfs_bio.c
+++ b/sys/kern/vfs_bio.c
@@ -1459,9 +1459,9 @@ bpmap_qenter(struct buf *bp)
 	 * bp->b_data is relative to bp->b_offset, but
 	 * bp->b_offset may be offset into the first page.
 	 */
-	bp->b_data = (caddr_t)trunc_page((vm_ptr_t)bp->b_data);
+	bp->b_data = (caddr_t)trunc_page((vm_pointer_t)bp->b_data);
 	pmap_qenter((vm_offset_t)bp->b_data, bp->b_pages, bp->b_npages);
-	bp->b_data = (caddr_t)((vm_ptr_t)bp->b_data |
+	bp->b_data = (caddr_t)((vm_pointer_t)bp->b_data |
 	    (vm_offset_t)(bp->b_offset & PAGE_MASK));
 }
 
@@ -2027,7 +2027,7 @@ bufkva_free(struct buf *bp)
 static int
 bufkva_alloc(struct buf *bp, int maxsize, int gbflags)
 {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	int error;
 
 	KASSERT((gbflags & GB_UNMAPPED) == 0 || (gbflags & GB_KVAALLOC) != 0,

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -2569,7 +2569,7 @@ vn_fill_kinfo_vnode(struct vnode *vp, struct kinfo_file *kif)
 }
 
 int
-vn_mmap(struct file *fp, vm_map_t map, vm_ptr_t *addr,
+vn_mmap(struct file *fp, vm_map_t map, vm_pointer_t *addr,
     vm_offset_t max_addr, vm_size_t size, vm_prot_t prot,
     vm_prot_t cap_maxprot, int flags, vm_ooffset_t foff,
     struct thread *td)

--- a/sys/mips/beri/beri_iommu.c
+++ b/sys/mips/beri/beri_iommu.c
@@ -114,7 +114,7 @@ beri_iommu_init(device_t dev, struct xdma_iommu *xio)
 }
 
 static int
-beri_iommu_remove(device_t dev, struct xdma_iommu *xio, vm_ptr_t va)
+beri_iommu_remove(device_t dev, struct xdma_iommu *xio, vm_pointer_t va)
 {
 	struct beri_iommu_softc *sc;
 
@@ -126,7 +126,7 @@ beri_iommu_remove(device_t dev, struct xdma_iommu *xio, vm_ptr_t va)
 }
 
 static int
-beri_iommu_enter(device_t dev, struct xdma_iommu *xio, vm_ptr_t va,
+beri_iommu_enter(device_t dev, struct xdma_iommu *xio, vm_pointer_t va,
     vm_paddr_t pa)
 {
 	struct beri_iommu_softc *sc;

--- a/sys/mips/cheri/cheri_stack_machdep.c
+++ b/sys/mips/cheri/cheri_stack_machdep.c
@@ -55,7 +55,7 @@ __FBSDID("$FreeBSD$");
 static bool
 stack_addr_ok(struct thread *td, uintptr_t sp, u_register_t stack_pos)
 {
-	vm_ptr_t va = sp + stack_pos;
+	vm_pointer_t va = sp + stack_pos;
 
 	return (va >= td->td_kstack && va + sizeof(uintptr_t) <=
 	    td->td_kstack + td->td_kstack_pages * PAGE_SIZE);

--- a/sys/mips/include/_bus.h
+++ b/sys/mips/include/_bus.h
@@ -45,7 +45,7 @@
  * bus_size_t: size of objects in the bus space.
  *
  * bus_addr_t and bus_offset_t mirror the relationship between
- *  vm_ptr_t and vm_offset_t for host memory.
+ *  vm_pointer_t and vm_offset_t for host memory.
  * Ideally if CHERI will support physical capabilities, bus_addr_t
  * will become void* or uintptr_t.
  */

--- a/sys/mips/include/md_var.h
+++ b/sys/mips/include/md_var.h
@@ -55,7 +55,7 @@ extern	char	freebsd64_sigcode[];
 extern	int	freebsd64_szsigcode;
 #endif
 
-extern vm_ptr_t kstack0;
+extern vm_pointer_t kstack0;
 extern vm_offset_t kernel_kseg0_end;
 
 uint32_t MipsFPID(void);

--- a/sys/mips/include/pmap.h
+++ b/sys/mips/include/pmap.h
@@ -167,8 +167,8 @@ struct pv_chunk {
  */
 extern vm_paddr_t physmem_desc[PHYS_AVAIL_COUNT];
 
-extern vm_ptr_t virtual_avail;
-extern vm_ptr_t virtual_end;
+extern vm_pointer_t virtual_avail;
+extern vm_pointer_t virtual_end;
 
 #define	pmap_page_get_memattr(m) (((m)->md.pv_flags & PV_MEMATTR_MASK) >> PV_MEMATTR_SHIFT)
 #define	pmap_page_is_write_mapped(m)	(((m)->a.flags & PGA_WRITEABLE) != 0)
@@ -178,7 +178,7 @@ void *pmap_mapdev(vm_paddr_t, vm_size_t);
 boolean_t pmap_page_is_mapped(vm_page_t m);
 void *pmap_mapdev_attr(vm_paddr_t, vm_size_t, vm_memattr_t);
 void pmap_unmapdev(vm_offset_t, vm_size_t);
-vm_ptr_t pmap_steal_memory(vm_size_t size);
+vm_pointer_t pmap_steal_memory(vm_size_t size);
 void pmap_kenter(vm_offset_t va, vm_paddr_t pa);
 void pmap_kenter_attr(vm_offset_t va, vm_paddr_t pa, vm_memattr_t attr);
 void pmap_kenter_device(vm_offset_t, vm_size_t, vm_paddr_t);

--- a/sys/mips/include/pte.h
+++ b/sys/mips/include/pte.h
@@ -54,7 +54,7 @@ typedef	pt_entry_t *pd_entry_t;
  * Create a CHERI bounded pointer to a page table page.
  */
 static __inline pd_entry_t
-pde_page_bound(vm_ptr_t ptr)
+pde_page_bound(vm_pointer_t ptr)
 {
 	pd_entry_t pde = cheri_setbounds((pd_entry_t)ptr, PAGE_SIZE);
 	return cheri_andperm(pde, (CHERI_PERM_LOAD | CHERI_PERM_STORE |

--- a/sys/mips/include/sf_buf.h
+++ b/sys/mips/include/sf_buf.h
@@ -38,17 +38,17 @@
 #include <cheri/cheric.h>
 #endif
 
-static inline vm_ptr_t
+static inline vm_pointer_t
 sf_buf_kva(struct sf_buf *sf)
 {
 	vm_page_t	m;
 
 	m = (vm_page_t)sf;
 #ifdef __CHERI_PURE_CAPABILITY__
-	return ((vm_ptr_t)cheri_setboundsexact(
+	return ((vm_pointer_t)cheri_setboundsexact(
 	    MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m)), PAGE_SIZE));
 #else
-	return ((vm_ptr_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m)));
+	return ((vm_pointer_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m)));
 #endif
 }
 

--- a/sys/mips/mips/machdep.c
+++ b/sys/mips/mips/machdep.c
@@ -124,7 +124,7 @@ SYSCTL_INT(_hw, OID_AUTO, clockrate, CTLFLAG_RD,
     &cpu_clock, 0, "CPU instruction clock rate");
 int clocks_running = 0;
 
-vm_ptr_t kstack0;
+vm_pointer_t kstack0;
 
 /*
  * Each entry in the pcpu_space[] array is laid out in the following manner:
@@ -325,7 +325,7 @@ mips_proc0_init(void)
 	thread0.td_pcb = cheri_setbounds((struct pcb *)(thread0.td_kstack +
 		thread0.td_kstack_pages * PAGE_SIZE) - 1,
 		sizeof(struct pcb));
-	thread0.td_kstack = (vm_ptr_t) cheri_setbounds((void *)thread0.td_kstack,
+	thread0.td_kstack = (vm_pointer_t) cheri_setbounds((void *)thread0.td_kstack,
 		thread0.td_kstack_pages * PAGE_SIZE - sizeof(struct pcb));
 #endif /* __CHERI_PURE_CAPABILITY__ */
 	thread0.td_frame = &thread0.td_pcb->pcb_regs;
@@ -476,8 +476,8 @@ mips_postboot_fixup(void)
 #ifdef DDB
 	Elf_Size *trampoline_data = (Elf_Size*)kernel_kseg0_end;
 	Elf_Size symtabsize = 0;
-	vm_ptr_t ksym_start;
-	vm_ptr_t ksym_end;
+	vm_pointer_t ksym_start;
+	vm_pointer_t ksym_end;
 
 	if (trampoline_data[0] == SYMTAB_MAGIC) {
 		symtabsize = trampoline_data[1];

--- a/sys/mips/mips/mem.c
+++ b/sys/mips/mips/mem.c
@@ -83,7 +83,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct iovec *iov;
 	int error = 0;
 	vm_offset_t va, eva, off, v;
-	vm_ptr_t kva;
+	vm_pointer_t kva;
 	vm_prot_t prot;
 	struct vm_page m;
 	vm_page_t marr;

--- a/sys/mips/mips/pmap.c
+++ b/sys/mips/mips/pmap.c
@@ -142,8 +142,8 @@ __FBSDID("$FreeBSD$");
 struct pmap kernel_pmap_store;
 pd_entry_t *kernel_segmap;
 
-vm_ptr_t virtual_avail;	/* VA of first avail page (after kernel bss) */
-vm_ptr_t virtual_end;	/* VA of last avail page (end of kernel AS) */
+vm_pointer_t virtual_avail;	/* VA of first avail page (after kernel bss) */
+vm_pointer_t virtual_end;	/* VA of last avail page (end of kernel AS) */
 
 static int need_local_mappings;
 
@@ -263,7 +263,7 @@ pmap_lmem_map1(vm_paddr_t phys)
 	return (PCPU_GET(cmap1_addr));
 }
 
-static __inline vm_ptr_t
+static __inline vm_pointer_t
 pmap_lmem_map2(vm_paddr_t phys1, vm_paddr_t phys2)
 {
 	critical_enter();
@@ -293,21 +293,21 @@ pmap_alloc_lmem_map(void)
 {
 }
 
-static __inline vm_ptr_t
+static __inline vm_pointer_t
 pmap_lmem_map1(vm_paddr_t phys)
 {
 
 	return (0);
 }
 
-static __inline vm_ptr_t
+static __inline vm_pointer_t
 pmap_lmem_map2(vm_paddr_t phys1, vm_paddr_t phys2)
 {
 
 	return (0);
 }
 
-static __inline vm_ptr_t
+static __inline vm_pointer_t
 pmap_lmem_unmap(void)
 {
 
@@ -398,7 +398,7 @@ pmap_pte(pmap_t pmap, vm_offset_t va)
 	return (pmap_pde_to_pte(pde, va));
 }
 
-vm_ptr_t
+vm_pointer_t
 pmap_steal_memory(vm_size_t size)
 {
 	vm_paddr_t bank_size, pa;
@@ -429,7 +429,7 @@ pmap_steal_memory(vm_size_t size)
 	va = cheri_setbounds(va, size);
 #endif
 	bzero(va, size);
-	return ((vm_ptr_t)va);
+	return ((vm_pointer_t)va);
 }
 
 /*
@@ -440,11 +440,11 @@ static void
 pmap_create_kernel_pagetable(void)
 {
 	int i, j;
-	vm_ptr_t ptaddr;
+	vm_pointer_t ptaddr;
 	pt_entry_t *pte;
 #ifdef __mips_n64
 	pd_entry_t *pde;
-	vm_ptr_t pdaddr;
+	vm_pointer_t pdaddr;
 	int npt, npde;
 #endif
 
@@ -587,8 +587,8 @@ again:
 	 * table is allowed to grow.
 	 * XXX-AM: Assume CHERI is always on top of mips64
 	 */
-	virtual_avail = (vm_ptr_t)MIPS_XKSEG(VM_MIN_KERNEL_ADDRESS);
-	virtual_end = (vm_ptr_t)MIPS_XKSEG(VM_MAX_KERNEL_ADDRESS);
+	virtual_avail = (vm_pointer_t)MIPS_XKSEG(VM_MIN_KERNEL_ADDRESS);
+	virtual_end = (vm_pointer_t)MIPS_XKSEG(VM_MAX_KERNEL_ADDRESS);
 
 #ifdef SMP
 	/*
@@ -950,14 +950,14 @@ pmap_kremove(vm_offset_t va)
  * VM_PROT_READ/WRITE_PTR for capability access restrictions may also be useful.
  * Being able to have a different CCALL and EXECUTE permissions may also be useful.
  */
-vm_ptr_t
-pmap_map(vm_ptr_t *virt, vm_paddr_t start, vm_paddr_t end, int prot)
+vm_pointer_t
+pmap_map(vm_pointer_t *virt, vm_paddr_t start, vm_paddr_t end, int prot)
 {
-	vm_ptr_t sva, va;
+	vm_pointer_t sva, va;
 
 	if (MIPS_DIRECT_MAPPABLE(end - 1)) {
 #ifndef __CHERI_PURE_CAPABILITY__
-		return ((vm_ptr_t)MIPS_PHYS_TO_DIRECT(start));
+		return ((vm_pointer_t)MIPS_PHYS_TO_DIRECT(start));
 #else /* __CHERI_PURE_CAPABILITY__ */
 		caddr_t map_addr;
 
@@ -973,7 +973,7 @@ pmap_map(vm_ptr_t *virt, vm_paddr_t start, vm_paddr_t end, int prot)
 		if (!(prot & VM_PROT_EXECUTE))
 		  map_addr = cheri_andperm(map_addr,
 			~(CHERI_PERM_EXECUTE | CHERI_PERM_CCALL));
-		return (vm_ptr_t)map_addr;
+		return (vm_pointer_t)map_addr;
 #endif
 	}
 
@@ -1214,7 +1214,7 @@ pmap_pinit(pmap_t pmap)
 static vm_page_t
 _pmap_allocpte(pmap_t pmap, unsigned ptepindex, u_int flags)
 {
-	vm_ptr_t pageva;
+	vm_pointer_t pageva;
 	vm_page_t m;
 	int req_class;
 
@@ -1242,7 +1242,7 @@ _pmap_allocpte(pmap_t pmap, unsigned ptepindex, u_int flags)
 	 * Map the pagetable page into the process address space, if it
 	 * isn't already there.
 	 */
-	pageva = (vm_ptr_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m));
+	pageva = (vm_pointer_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m));
 
 #ifdef __mips_n64
 	if (ptepindex >= NUPDE) {
@@ -2512,14 +2512,14 @@ pmap_enter_quick_locked(pmap_t pmap, vm_offset_t va, vm_page_t m,
 void *
 pmap_kenter_temporary(vm_paddr_t pa, int i)
 {
-	vm_ptr_t va;
+	vm_pointer_t va;
 
 	if (i != 0)
 		printf("%s: ERROR!!! More than one page of virtual address mapping not supported\n",
 		    __func__);
 
 	if (MIPS_DIRECT_MAPPABLE(pa)) {
-		va = (vm_ptr_t)MIPS_PHYS_TO_DIRECT(pa);
+		va = (vm_pointer_t)MIPS_PHYS_TO_DIRECT(pa);
 	} else {
 #ifndef __mips_n64    /* XXX : to be converted to new style */
 		pt_entry_t *pte, npte;
@@ -2675,11 +2675,11 @@ pmap_copy(pmap_t dst_pmap, pmap_t src_pmap, vm_offset_t dst_addr,
 void
 pmap_zero_page(vm_page_t m)
 {
-	vm_ptr_t va;
+	vm_pointer_t va;
 	vm_paddr_t phys = VM_PAGE_TO_PHYS(m);
 
 	if (MIPS_DIRECT_MAPPABLE(phys)) {
-		va = (vm_ptr_t)MIPS_PHYS_TO_DIRECT(phys);
+		va = (vm_pointer_t)MIPS_PHYS_TO_DIRECT(phys);
 		bzero((caddr_t)va, PAGE_SIZE);
 		mips_dcache_wbinv_range(va, PAGE_SIZE);
 	} else {
@@ -2699,11 +2699,11 @@ pmap_zero_page(vm_page_t m)
 void
 pmap_zero_page_area(vm_page_t m, int off, int size)
 {
-	vm_ptr_t va;
+	vm_pointer_t va;
 	vm_paddr_t phys = VM_PAGE_TO_PHYS(m);
 
 	if (MIPS_DIRECT_MAPPABLE(phys)) {
-		va = (vm_ptr_t)MIPS_PHYS_TO_DIRECT(phys);
+		va = (vm_pointer_t)MIPS_PHYS_TO_DIRECT(phys);
 		bzero((char *)va + off, size);
 		mips_dcache_wbinv_range(va + off, size);
 	} else {
@@ -2726,7 +2726,7 @@ pmap_zero_page_area(vm_page_t m, int off, int size)
 static void
 pmap_copy_page_internal(vm_page_t src, vm_page_t dst, int flags)
 {
-	vm_ptr_t va_src, va_dst;
+	vm_pointer_t va_src, va_dst;
 	vm_paddr_t phys_src = VM_PAGE_TO_PHYS(src);
 	vm_paddr_t phys_dst = VM_PAGE_TO_PHYS(dst);
 
@@ -2739,8 +2739,8 @@ pmap_copy_page_internal(vm_page_t src, vm_page_t dst, int flags)
 		pmap_flush_pvcache(src);
 		mips_dcache_wbinv_range_index(
 		    (vm_offset_t)MIPS_PHYS_TO_DIRECT(phys_dst), PAGE_SIZE);
-		va_src = (vm_ptr_t)MIPS_PHYS_TO_DIRECT(phys_src);
-		va_dst = (vm_ptr_t)MIPS_PHYS_TO_DIRECT(phys_dst);
+		va_src = (vm_pointer_t)MIPS_PHYS_TO_DIRECT(phys_src);
+		va_dst = (vm_pointer_t)MIPS_PHYS_TO_DIRECT(phys_dst);
 #if __has_feature(capabilities)
 		if ((flags & PMAP_COPY_TAGS) == 0)
 			bcopynocap((caddr_t)va_src, (caddr_t)va_dst, PAGE_SIZE);
@@ -2838,11 +2838,11 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 
 
 
-vm_ptr_t
+vm_pointer_t
 pmap_quick_enter_page(vm_page_t m)
 {
 #if defined(__mips_n64)
-	return (vm_ptr_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m));
+	return (vm_pointer_t)MIPS_PHYS_TO_DIRECT(VM_PAGE_TO_PHYS(m));
 #else
 	vm_offset_t qaddr;
 	vm_paddr_t pa;

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -292,7 +292,7 @@ cpu_thread_free(struct thread *td)
 	 * XXX-AM: The ideal solution would be to avoid rederivation altogheter
 	 * and make sure that the kstack cache zone can rebuild the full capability.
 	 */
-	td->td_kstack = (vm_ptr_t)cheri_ptrperm(
+	td->td_kstack = (vm_pointer_t)cheri_ptrperm(
 	    cheri_setaddress(cheri_kall_capability,
 	        cheri_getbase((void *)td->td_kstack)),
 	    td->td_kstack_pages * PAGE_SIZE, CHERI_PERMS_KERNEL_DATA);
@@ -370,9 +370,9 @@ cpu_thread_alloc(struct thread *td)
 	    sizeof(struct pcb);
 
 	td->td_pcb = cheri_setbounds((void *)pcb_base, sizeof(struct pcb));
-	td->td_kstack = (vm_ptr_t)cheri_setbounds(
+	td->td_kstack = (vm_pointer_t)cheri_setbounds(
 	    (void *)td->td_kstack, kstack_size);
-	td->td_kstack = (vm_ptr_t)cheri_andperm((void *)td->td_kstack,
+	td->td_kstack = (vm_pointer_t)cheri_andperm((void *)td->td_kstack,
 	    CHERI_PERMS_KERNEL_DATA);
 #endif
 	td->td_frame = &td->td_pcb->pcb_regs;

--- a/sys/net/if_loop.c
+++ b/sys/net/if_loop.c
@@ -335,7 +335,7 @@ if_simloop(struct ifnet *ifp, struct mbuf *m, int af, int hlen)
 		if (mtod(m, vm_offset_t) & 3) {
 			KASSERT(hlen >= 3, ("if_simloop: hlen too small"));
 			bcopy(m->m_data,
-			    (char *)(mtod(m, vm_ptr_t)
+			    (char *)(mtod(m, vm_pointer_t)
 				- (mtod(m, vm_offset_t) & 3)),
 			    m->m_len);
 			m->m_data -= (mtod(m,vm_offset_t) & 3);

--- a/sys/riscv/include/machdep.h
+++ b/sys/riscv/include/machdep.h
@@ -38,9 +38,9 @@
 #define	_MACHINE_MACHDEP_H_
 
 struct riscv_bootparams {
-	vm_ptr_t	kern_l1pt;	/* Kernel L1 base */
+	vm_pointer_t	kern_l1pt;	/* Kernel L1 base */
 	vm_paddr_t	kern_phys;	/* Kernel base (physical) addr */
-	vm_ptr_t	kern_stack;
+	vm_pointer_t	kern_stack;
 	uintptr_t	dtbp_virt;	/* Device tree blob virtual addr */
 	vm_paddr_t	dtbp_phys;	/* Device tree blob physical addr */
 	uintptr_t	modulep;	/* loader(8) metadata */

--- a/sys/riscv/include/pmap.h
+++ b/sys/riscv/include/pmap.h
@@ -136,8 +136,8 @@ extern struct pmap	kernel_pmap_store;
 #define	PMAP_TRYLOCK(pmap)	mtx_trylock(&(pmap)->pm_mtx)
 #define	PMAP_UNLOCK(pmap)	mtx_unlock(&(pmap)->pm_mtx)
 
-extern vm_ptr_t virtual_avail;
-extern vm_ptr_t virtual_end;
+extern vm_pointer_t virtual_avail;
+extern vm_pointer_t virtual_end;
 
 /*
  * Macros to test if a mapping is mappable with an L1 Section mapping
@@ -150,7 +150,7 @@ struct thread;
 
 void	pmap_activate_boot(pmap_t);
 void	pmap_activate_sw(struct thread *);
-void	pmap_bootstrap(vm_ptr_t, vm_paddr_t, vm_size_t);
+void	pmap_bootstrap(vm_pointer_t, vm_paddr_t, vm_size_t);
 void	pmap_kenter_device(vm_offset_t, vm_size_t, vm_paddr_t);
 vm_paddr_t pmap_kextract(vm_offset_t va);
 void	pmap_kremove(vm_offset_t);
@@ -160,11 +160,11 @@ bool	pmap_ps_enabled(pmap_t);
 
 void	*pmap_mapdev(vm_offset_t, vm_size_t);
 void	*pmap_mapbios(vm_paddr_t, vm_size_t);
-void	pmap_unmapdev(vm_ptr_t, vm_size_t);
-void	pmap_unmapbios(vm_ptr_t, vm_size_t);
+void	pmap_unmapdev(vm_pointer_t, vm_size_t);
+void	pmap_unmapbios(vm_pointer_t, vm_size_t);
 
-boolean_t pmap_map_io_transient(vm_page_t *, vm_ptr_t *, int, boolean_t);
-void	pmap_unmap_io_transient(vm_page_t *, vm_ptr_t *, int, boolean_t);
+boolean_t pmap_map_io_transient(vm_page_t *, vm_pointer_t *, int, boolean_t);
+void	pmap_unmap_io_transient(vm_page_t *, vm_pointer_t *, int, boolean_t);
 
 bool	pmap_get_tables(pmap_t, vm_offset_t, pd_entry_t **, pd_entry_t **,
     pt_entry_t **);

--- a/sys/riscv/include/sf_buf.h
+++ b/sys/riscv/include/sf_buf.h
@@ -35,16 +35,16 @@
  * That pointer references the vm_page that is "mapped" by the sf_buf.  The
  * actual mapping is provided by the direct virtual-to-physical mapping.  
  */
-static inline vm_ptr_t
+static inline vm_pointer_t
 sf_buf_kva(struct sf_buf *sf)
 {
 	vm_page_t	m;
-	vm_ptr_t	va;
+	vm_pointer_t	va;
 
 	m = (vm_page_t)sf;
 	va = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
 #ifdef __CHERI_PURE_CAPABILITY__
-	va = (vm_ptr_t)cheri_setboundsexact((void *)va, PAGE_SIZE);
+	va = (vm_pointer_t)cheri_setboundsexact((void *)va, PAGE_SIZE);
 #endif
 	return (va);
 }

--- a/sys/riscv/include/vmparam.h
+++ b/sys/riscv/include/vmparam.h
@@ -175,7 +175,7 @@
 	KASSERT(PHYS_IN_DMAP(pa),					\
 	    ("%s: PA out of range, PA: 0x%lx", __func__,		\
 	    (vm_paddr_t)(pa)));						\
-	(vm_ptr_t)dmap_capability + ((pa) - dmap_phys_base);		\
+	(vm_pointer_t)dmap_capability + ((pa) - dmap_phys_base);		\
 })
 
 #define	DMAP_TO_PHYS(va)						\

--- a/sys/riscv/riscv/busdma_bounce.c
+++ b/sys/riscv/riscv/busdma_bounce.c
@@ -79,9 +79,9 @@ struct bus_dma_tag {
 };
 
 struct bounce_page {
-	vm_ptr_t	vaddr;		/* kva of bounce buffer */
+	vm_pointer_t	vaddr;		/* kva of bounce buffer */
 	bus_addr_t	busaddr;	/* Physical address */
-	vm_ptr_t	datavaddr;	/* kva of client data */
+	vm_pointer_t	datavaddr;	/* kva of client data */
 	vm_page_t	datapage;	/* physical page of client data */
 	vm_offset_t	dataoffs;	/* page offset of client data */
 	bus_size_t	datacount;	/* client data count */
@@ -119,7 +119,7 @@ SYSCTL_INT(_hw_busdma, OID_AUTO, total_bpages, CTLFLAG_RD, &total_bpages, 0,
 	   "Total bounce pages");
 
 struct sync_list {
-	vm_ptr_t	vaddr;		/* kva of client data */
+	vm_pointer_t	vaddr;		/* kva of client data */
 	bus_addr_t	paddr;		/* physical address */
 	vm_page_t	pages;		/* starting page of client data */
 	bus_size_t	datacount;	/* client data count */
@@ -150,7 +150,7 @@ static int alloc_bounce_pages(bus_dma_tag_t dmat, u_int numpages);
 static int reserve_bounce_pages(bus_dma_tag_t dmat, bus_dmamap_t map,
     int commit);
 static bus_addr_t add_bounce_page(bus_dma_tag_t dmat, bus_dmamap_t map,
-    vm_ptr_t vaddr, bus_addr_t addr, bus_size_t size);
+    vm_pointer_t vaddr, bus_addr_t addr, bus_size_t size);
 static void free_bounce_page(bus_dma_tag_t dmat, struct bounce_page *bpage);
 int run_filter(bus_dma_tag_t dmat, bus_addr_t paddr);
 static void _bus_dmamap_count_pages(bus_dma_tag_t dmat, bus_dmamap_t map,
@@ -532,7 +532,7 @@ bounce_bus_dmamem_free(bus_dma_tag_t dmat, void *vaddr, bus_dmamap_t map)
 	if ((dmat->bounce_flags & BF_KMEM_ALLOC) == 0)
 		free(vaddr, M_DEVBUF);
 	else
-		kmem_free((vm_ptr_t)vaddr, dmat->common.maxsize);
+		kmem_free((vm_pointer_t)vaddr, dmat->common.maxsize);
 	free(map, M_DEVBUF);
 	dmat->map_count--;
 	CTR3(KTR_BUSDMA, "%s: tag %p flags 0x%x", __func__, dmat,
@@ -570,8 +570,8 @@ static void
 _bus_dmamap_count_pages(bus_dma_tag_t dmat, bus_dmamap_t map, pmap_t pmap,
     void *buf, bus_size_t buflen, int flags)
 {
-	vm_ptr_t vaddr;
-	vm_ptr_t vendaddr;
+	vm_pointer_t vaddr;
+	vm_pointer_t vendaddr;
 	bus_addr_t paddr;
 	bus_size_t sg_len;
 
@@ -586,8 +586,8 @@ _bus_dmamap_count_pages(bus_dma_tag_t dmat, bus_dmamap_t map, pmap_t pmap,
 		 * Count the number of bounce pages
 		 * needed in order to complete this transfer
 		 */
-		vaddr = (vm_ptr_t)buf;
-		vendaddr = (vm_ptr_t)buf + buflen;
+		vaddr = (vm_pointer_t)buf;
+		vendaddr = (vm_pointer_t)buf + buflen;
 
 		while (vaddr < vendaddr) {
 			sg_len = PAGE_SIZE - ((vm_offset_t)vaddr & PAGE_MASK);
@@ -758,7 +758,7 @@ bounce_bus_dmamap_load_buffer(bus_dma_tag_t dmat, bus_dmamap_t map, void *buf,
 	struct sync_list *sl;
 	bus_size_t sgsize, max_sgsize;
 	bus_addr_t curaddr, sl_pend;
-	vm_ptr_t kvaddr, vaddr, sl_vend;
+	vm_pointer_t kvaddr, vaddr, sl_vend;
 	int error;
 
 	if (segs == NULL)
@@ -774,7 +774,7 @@ bounce_bus_dmamap_load_buffer(bus_dma_tag_t dmat, bus_dmamap_t map, void *buf,
 	}
 
 	sl = map->slist + map->sync_count - 1;
-	vaddr = (vm_ptr_t)buf;
+	vaddr = (vm_pointer_t)buf;
 	sl_pend = 0;
 	sl_vend = 0;
 
@@ -907,7 +907,7 @@ dma_dcache_sync(struct sync_list *sl, bus_dmasync_op_t op)
 	uint32_t len, offset;
 	vm_page_t m;
 	vm_paddr_t pa;
-	vm_ptr_t va, tempva;
+	vm_pointer_t va, tempva;
 	bus_size_t size;
 
 	offset = sl->paddr & PAGE_MASK;
@@ -967,7 +967,7 @@ bounce_bus_dmamap_sync(bus_dma_tag_t dmat, bus_dmamap_t map,
 {
 	struct bounce_page *bpage;
 	struct sync_list *sl, *end;
-	vm_ptr_t datavaddr, tempvaddr;
+	vm_pointer_t datavaddr, tempvaddr;
 
 	if (op == BUS_DMASYNC_POSTWRITE)
 		return;
@@ -1174,7 +1174,7 @@ alloc_bounce_pages(bus_dma_tag_t dmat, u_int numpages)
 
 		if (bpage == NULL)
 			break;
-		bpage->vaddr = (vm_ptr_t)contigmalloc(PAGE_SIZE, M_DEVBUF,
+		bpage->vaddr = (vm_pointer_t)contigmalloc(PAGE_SIZE, M_DEVBUF,
 		    M_NOWAIT, 0ul, bz->lowaddr, PAGE_SIZE, 0);
 		if (bpage->vaddr == 0) {
 			free(bpage, M_DEVBUF);
@@ -1213,7 +1213,7 @@ reserve_bounce_pages(bus_dma_tag_t dmat, bus_dmamap_t map, int commit)
 }
 
 static bus_addr_t
-add_bounce_page(bus_dma_tag_t dmat, bus_dmamap_t map, vm_ptr_t vaddr,
+add_bounce_page(bus_dma_tag_t dmat, bus_dmamap_t map, vm_pointer_t vaddr,
 		bus_addr_t addr, bus_size_t size)
 {
 	struct bounce_zone *bz;

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -952,7 +952,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 }
 
 static void
-init_proc0(vm_ptr_t kstack)
+init_proc0(vm_pointer_t kstack)
 {
 	struct pcpu *pcpup;
 
@@ -972,14 +972,14 @@ init_proc0(vm_ptr_t kstack)
 static void
 try_load_dtb(caddr_t kmdp)
 {
-	vm_ptr_t dtbp;
+	vm_pointer_t dtbp;
 
 	dtbp = MD_FETCH(kmdp, MODINFOMD_DTBP, vm_offset_t);
 #ifdef __CHERI_PURE_CAPABILITY__
-	if (dtbp != (vm_ptr_t)NULL) {
-		dtbp = (vm_ptr_t)cheri_andperm(cheri_setaddress(
+	if (dtbp != (vm_pointer_t)NULL) {
+		dtbp = (vm_pointer_t)cheri_andperm(cheri_setaddress(
 		    cheri_kall_capability, dtbp), CHERI_PERMS_KERNEL_DATA);
-		dtbp = (vm_ptr_t)cheri_setbounds((void *)dtbp,
+		dtbp = (vm_pointer_t)cheri_setbounds((void *)dtbp,
 		    fdt_totalsize((void *)dtbp));
 	}
 #endif
@@ -989,11 +989,11 @@ try_load_dtb(caddr_t kmdp)
 	 * In case the device tree blob was not retrieved (from metadata) try
 	 * to use the statically embedded one.
 	 */
-	if (dtbp == (vm_ptr_t)NULL)
-		dtbp = (vm_ptr_t)&fdt_static_dtb;
+	if (dtbp == (vm_pointer_t)NULL)
+		dtbp = (vm_pointer_t)&fdt_static_dtb;
 #endif
 
-	if (dtbp == (vm_ptr_t)NULL) {
+	if (dtbp == (vm_pointer_t)NULL) {
 		printf("ERROR loading DTB\n");
 		return;
 	}
@@ -1132,7 +1132,7 @@ parse_metadata(void)
 	caddr_t kmdp;
 	vm_offset_t lastaddr;
 #ifdef DDB
-	vm_ptr_t ksym_start, ksym_end;
+	vm_pointer_t ksym_start, ksym_end;
 #endif
 	char *kern_envp;
 

--- a/sys/riscv/riscv/mp_machdep.c
+++ b/sys/riscv/riscv/mp_machdep.c
@@ -311,7 +311,7 @@ smp_after_idle_runnable(void *arg __unused)
 			pc = pcpu_find(cpu);
 			while (atomic_load_ptr(&pc->pc_curpcb) == NULL)
 				cpu_spinwait();
-			kmem_free((vm_ptr_t)bootstacks[cpu], PAGE_SIZE);
+			kmem_free((vm_pointer_t)bootstacks[cpu], PAGE_SIZE);
 		}
 	}
 }

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -225,8 +225,8 @@ static struct pmaplist allpmaps = LIST_HEAD_INITIALIZER();
 
 struct pmap kernel_pmap_store;
 
-vm_ptr_t virtual_avail;		/* VA of first avail page (after kernel bss) */
-vm_ptr_t virtual_end;		/* VA of last avail page (end of kernel AS) */
+vm_pointer_t virtual_avail;		/* VA of first avail page (after kernel bss) */
+vm_pointer_t virtual_end;		/* VA of last avail page (end of kernel AS) */
 vm_offset_t kernel_vm_end = 0;
 
 vm_paddr_t dmap_phys_base;	/* The start of the dmap region */
@@ -467,7 +467,7 @@ pmap_distribute_l1(struct pmap *pmap, vm_pindex_t l1index,
 }
 
 static pt_entry_t *
-pmap_early_page_idx(vm_ptr_t l1pt, vm_offset_t va, u_int *l1_slot,
+pmap_early_page_idx(vm_pointer_t l1pt, vm_offset_t va, u_int *l1_slot,
     u_int *l2_slot)
 {
 	pt_entry_t *l2;
@@ -488,7 +488,7 @@ pmap_early_page_idx(vm_ptr_t l1pt, vm_offset_t va, u_int *l1_slot,
 }
 
 static vm_paddr_t
-pmap_early_vtophys(vm_ptr_t l1pt, vm_offset_t va)
+pmap_early_vtophys(vm_pointer_t l1pt, vm_offset_t va)
 {
 	u_int l1_slot, l2_slot;
 	pt_entry_t *l2;
@@ -508,7 +508,7 @@ pmap_early_vtophys(vm_ptr_t l1pt, vm_offset_t va)
 }
 
 static void
-pmap_bootstrap_dmap(vm_ptr_t kern_l1, vm_paddr_t min_pa, vm_paddr_t max_pa)
+pmap_bootstrap_dmap(vm_pointer_t kern_l1, vm_paddr_t min_pa, vm_paddr_t max_pa)
 {
 	vm_offset_t va;
 	vm_paddr_t pa;
@@ -552,10 +552,10 @@ pmap_bootstrap_dmap(vm_ptr_t kern_l1, vm_paddr_t min_pa, vm_paddr_t max_pa)
 	sfence_vma();
 }
 
-static vm_ptr_t
-pmap_bootstrap_l3(vm_ptr_t l1pt, vm_offset_t va, vm_ptr_t l3_start)
+static vm_pointer_t
+pmap_bootstrap_l3(vm_pointer_t l1pt, vm_offset_t va, vm_pointer_t l3_start)
 {
-	vm_ptr_t l3pt;
+	vm_pointer_t l3pt;
 	pt_entry_t entry;
 	pd_entry_t *l2;
 	vm_paddr_t pa;
@@ -590,11 +590,11 @@ pmap_bootstrap_l3(vm_ptr_t l1pt, vm_offset_t va, vm_ptr_t l3_start)
  *	Bootstrap the system enough to run with virtual memory.
  */
 void
-pmap_bootstrap(vm_ptr_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
+pmap_bootstrap(vm_pointer_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 {
 	u_int l1_slot, l2_slot;
-	vm_ptr_t freemempos;
-	vm_ptr_t dpcpu, msgbufpv;
+	vm_pointer_t freemempos;
+	vm_pointer_t dpcpu, msgbufpv;
 	vm_paddr_t max_pa, min_pa, pa;
 	pt_entry_t *l2p;
 	int i;
@@ -652,7 +652,7 @@ pmap_bootstrap(vm_ptr_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 
 	freemempos = roundup2(KERNBASE + kernlen, PAGE_SIZE);
 #ifdef __CHERI_PURE_CAPABILITY__
-	freemempos = (vm_ptr_t)cheri_setaddress(cheri_kall_capability,
+	freemempos = (vm_pointer_t)cheri_setaddress(cheri_kall_capability,
 	    freemempos);
 #endif
 
@@ -673,7 +673,7 @@ pmap_bootstrap(vm_ptr_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 #define alloc_pages(var, np)						\
-	(var) = (vm_ptr_t)cheri_setbounds((void *)freemempos,		\
+	(var) = (vm_pointer_t)cheri_setbounds((void *)freemempos,		\
 	    (np * PAGE_SIZE));						\
 	freemempos += cheri_getlen((void *)(var));			\
 	memset((char *)(var), 0, ((np) * PAGE_SIZE));
@@ -695,9 +695,9 @@ pmap_bootstrap(vm_ptr_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 	virtual_avail = roundup2(freemempos, L2_SIZE);
 	virtual_end = VM_MAX_KERNEL_ADDRESS - L2_SIZE;
 #ifdef __CHERI_PURE_CAPABILITY__
-	virtual_avail = (vm_ptr_t)cheri_setbounds((void *)virtual_avail,
+	virtual_avail = (vm_pointer_t)cheri_setbounds((void *)virtual_avail,
 	    (vaddr_t)virtual_end - (vaddr_t)virtual_avail);
-	virtual_end = (vm_ptr_t)cheri_setaddress((void *)virtual_avail,
+	virtual_end = (vm_pointer_t)cheri_setaddress((void *)virtual_avail,
 	    virtual_end);
 #endif
 	kernel_vm_end = virtual_avail;
@@ -1039,8 +1039,8 @@ pmap_kremove_device(vm_offset_t sva, vm_size_t size)
  *	update '*virt' with the first usable address after the mapped
  *	region.
  */
-vm_ptr_t
-pmap_map(vm_ptr_t *virt, vm_paddr_t start, vm_paddr_t end, int prot)
+vm_pointer_t
+pmap_map(vm_pointer_t *virt, vm_paddr_t start, vm_paddr_t end, int prot)
 {
 
 	return PHYS_TO_DMAP(start);
@@ -3427,10 +3427,10 @@ pmap_copy(pmap_t dst_pmap, pmap_t src_pmap, vm_offset_t dst_addr, vm_size_t len,
 void
 pmap_zero_page(vm_page_t m)
 {
-	vm_ptr_t va = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
+	vm_pointer_t va = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	va = (vm_ptr_t)cheri_setboundsexact((void *)va, PAGE_SIZE);
+	va = (vm_pointer_t)cheri_setboundsexact((void *)va, PAGE_SIZE);
 #endif
 	pagezero((void *)va);
 }
@@ -3444,10 +3444,10 @@ pmap_zero_page(vm_page_t m)
 void
 pmap_zero_page_area(vm_page_t m, int off, int size)
 {
-	vm_ptr_t va = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
+	vm_pointer_t va = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	va = (vm_ptr_t)cheri_setboundsexact((void *)va, PAGE_SIZE);
+	va = (vm_pointer_t)cheri_setboundsexact((void *)va, PAGE_SIZE);
 #endif
 	if (off == 0 && size == PAGE_SIZE)
 		pagezero((void *)va);
@@ -3471,12 +3471,12 @@ pmap_zero_page_area(vm_page_t m, int off, int size)
 void
 pmap_copy_page(vm_page_t msrc, vm_page_t mdst)
 {
-	vm_ptr_t src = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(msrc));
-	vm_ptr_t dst = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(mdst));
+	vm_pointer_t src = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(msrc));
+	vm_pointer_t dst = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(mdst));
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	src = (vm_ptr_t)cheri_setboundsexact((void *)src, PAGE_SIZE);
-	dst = (vm_ptr_t)cheri_setboundsexact((void *)dst, PAGE_SIZE);
+	src = (vm_pointer_t)cheri_setboundsexact((void *)src, PAGE_SIZE);
+	dst = (vm_pointer_t)cheri_setboundsexact((void *)dst, PAGE_SIZE);
 #endif
 #if __has_feature(capabilities)
 	pagecopy_cleartags((void *)src, (void *)dst);
@@ -3485,13 +3485,13 @@ pmap_copy_page(vm_page_t msrc, vm_page_t mdst)
 void
 pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 {
-	vm_ptr_t src = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(msrc));
-	vm_ptr_t dst = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(mdst));
+	vm_pointer_t src = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(msrc));
+	vm_pointer_t dst = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(mdst));
 
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
-	src = (vm_ptr_t)cheri_setboundsexact((void *)src, PAGE_SIZE);
-	dst = (vm_ptr_t)cheri_setboundsexact((void *)dst, PAGE_SIZE);
+	src = (vm_pointer_t)cheri_setboundsexact((void *)src, PAGE_SIZE);
+	dst = (vm_pointer_t)cheri_setboundsexact((void *)dst, PAGE_SIZE);
 #endif
 	pagecopy((void *)src, (void *)dst);
 }
@@ -3534,7 +3534,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 	}
 }
 
-vm_ptr_t
+vm_pointer_t
 pmap_quick_enter_page(vm_page_t m)
 {
 
@@ -4325,7 +4325,7 @@ pmap_mapbios(vm_paddr_t pa, vm_size_t size)
 }
 
 void
-pmap_unmapbios(vm_ptr_t pa, vm_size_t size)
+pmap_unmapbios(vm_pointer_t pa, vm_size_t size)
 {
 }
 
@@ -4505,7 +4505,7 @@ pmap_align_superpage(vm_object_t object, vm_ooffset_t offset,
  *
  */
 boolean_t
-pmap_map_io_transient(vm_page_t page[], vm_ptr_t vaddr[], int count,
+pmap_map_io_transient(vm_page_t page[], vm_pointer_t vaddr[], int count,
     boolean_t can_fault)
 {
 	vm_paddr_t paddr;
@@ -4527,7 +4527,7 @@ pmap_map_io_transient(vm_page_t page[], vm_ptr_t vaddr[], int count,
 		} else {
 			vaddr[i] = PHYS_TO_DMAP(paddr);
 #ifdef __CHERI_PURE_CAPABILITY__
-			vaddr[i] = (vm_ptr_t)cheri_setboundsexact(
+			vaddr[i] = (vm_pointer_t)cheri_setboundsexact(
 			    (void *)vaddr[i], PAGE_SIZE);
 #endif
 		}
@@ -4551,7 +4551,7 @@ pmap_map_io_transient(vm_page_t page[], vm_ptr_t vaddr[], int count,
 }
 
 void
-pmap_unmap_io_transient(vm_page_t page[], vm_ptr_t vaddr[], int count,
+pmap_unmap_io_transient(vm_page_t page[], vm_pointer_t vaddr[], int count,
     boolean_t can_fault)
 {
 	vm_paddr_t paddr;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -62,7 +62,7 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 	struct iovec *iov;
 	void *cp;
 	vm_offset_t page_offset;
-	vm_ptr_t vaddr;
+	vm_pointer_t vaddr;
 	size_t cnt;
 	int error = 0;
 	int save = 0;

--- a/sys/sys/devmap.h
+++ b/sys/sys/devmap.h
@@ -99,7 +99,7 @@ void devmap_init_capability(void * __capability _cap);
 #define	DEVMAP_PADDR_NOTFOUND	((vm_paddr_t)(-1))
 
 void *     devmap_ptov(vm_paddr_t _pa, vm_size_t _sz);
-vm_paddr_t devmap_vtop(vm_ptr_t _va, vm_size_t _sz);
+vm_paddr_t devmap_vtop(vm_pointer_t _va, vm_size_t _sz);
 
 /* Print the static mapping table; used for bootverbose output. */
 void devmap_print_table(void);

--- a/sys/sys/file.h
+++ b/sys/sys/file.h
@@ -121,7 +121,7 @@ typedef int fo_seek_t(struct file *fp, off_t offset, int whence,
 		    struct thread *td);
 typedef int fo_fill_kinfo_t(struct file *fp, struct kinfo_file *kif,
 		    struct filedesc *fdp);
-typedef int fo_mmap_t(struct file *fp, vm_map_t map, vm_ptr_t *addr,
+typedef int fo_mmap_t(struct file *fp, vm_map_t map, vm_pointer_t *addr,
 		    vm_offset_t max_addr, vm_size_t size, vm_prot_t prot,
 		    vm_prot_t cap_maxprot, int flags, vm_ooffset_t foff,
 		    struct thread *td);
@@ -415,7 +415,7 @@ fo_fill_kinfo(struct file *fp, struct kinfo_file *kif, struct filedesc *fdp)
 }
 
 static __inline int
-fo_mmap(struct file *fp, vm_map_t map, vm_ptr_t *addr, vm_offset_t max_addr,
+fo_mmap(struct file *fp, vm_map_t map, vm_pointer_t *addr, vm_offset_t max_addr,
     vm_size_t size, vm_prot_t prot, vm_prot_t cap_maxprot, int flags,
     vm_ooffset_t foff, struct thread *td)
 {

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -361,7 +361,7 @@ struct thread {
 	/* LP64 hole */
 	struct callout	td_slpcallout;	/* (h) Callout for sleep. */
 	struct trapframe *td_frame;	/* (k) */
-	vm_ptr_t	td_kstack;	/* (a) Kernel VA of kstack. */
+	vm_pointer_t	td_kstack;	/* (a) Kernel VA of kstack. */
 	int		td_kstack_pages; /* (a) Size of the kstack. */
 	volatile u_int	td_critnest;	/* (k*) Critical section nest level. */
 	struct mdthread td_md;		/* (k) Any machine-dependent fields. */

--- a/sys/sys/sf_buf.h
+++ b/sys/sys/sf_buf.h
@@ -93,7 +93,7 @@ struct sf_buf {
 	LIST_ENTRY(sf_buf)	list_entry;	/* list of buffers */
 	TAILQ_ENTRY(sf_buf)	free_entry;	/* list of buffers */
 	vm_page_t		m;		/* currently mapped page */
-	vm_ptr_t		kva;		/* va or capabiliy of mapping */
+	vm_pointer_t		kva;		/* va or capabiliy of mapping */
 	int			ref_count;	/* usage of this mapping */
 #if defined(SMP) && defined(SFBUF_CPUSET)
 	cpuset_t		cpumask;	/* where mapping is valid */
@@ -112,11 +112,11 @@ struct sf_buf *sf_buf_alloc(struct vm_page *, int);
 void sf_buf_free(struct sf_buf *);
 void sf_buf_ref(struct sf_buf *);
 
-static inline vm_ptr_t
+static inline vm_pointer_t
 sf_buf_kva(struct sf_buf *sf)
 {
 	if (PMAP_HAS_DMAP)
-		return ((vm_ptr_t)cheri_kern_setbounds(
+		return ((vm_pointer_t)cheri_kern_setbounds(
 		    PHYS_TO_DMAP(VM_PAGE_TO_PHYS((vm_page_t)sf)),
 		    PAGE_SIZE));
 

--- a/sys/sys/types.h
+++ b/sys/sys/types.h
@@ -252,9 +252,9 @@ typedef	struct cap_rights	cap_rights_t;
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-typedef __uintptr_t	vm_ptr_t;
+typedef __uintptr_t	vm_pointer_t;
 #else
-typedef __vm_offset_t	vm_ptr_t;
+typedef __vm_offset_t	vm_pointer_t;
 #endif
 
 /*

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -84,8 +84,8 @@ int	copyiniov(const struct iovec * __capability iovp, u_int iovcnt,
 	    struct iovec **iov, int error);
 int	copyinuio(const struct iovec * __capability iovp, u_int iovcnt,
 	    struct uio **uiop);
-int	copyout_map(struct thread *td, vm_ptr_t *addr, size_t sz);
-int	copyout_unmap(struct thread *td, vm_ptr_t addr, size_t sz);
+int	copyout_map(struct thread *td, vm_pointer_t *addr, size_t sz);
+int	copyout_unmap(struct thread *td, vm_pointer_t addr, size_t sz);
 int	physcopyin(void *src, vm_paddr_t dst, size_t len);
 int	physcopyout(vm_paddr_t src, void *dst, size_t len);
 int	physcopyin_vlist(struct bus_dma_segment *src, off_t offset,

--- a/sys/vm/memguard.c
+++ b/sys/vm/memguard.c
@@ -289,7 +289,7 @@ v2sizev(vm_offset_t va)
 void *
 memguard_alloc(unsigned long req_size, int flags)
 {
-	vm_ptr_t addr, origaddr;
+	vm_pointer_t addr, origaddr;
 	u_long size_p, size_v;
 	int do_guard, error, rv;
 
@@ -328,7 +328,7 @@ memguard_alloc(unsigned long req_size, int flags)
 	    &origaddr);
 	if (error != 0) {
 		memguard_fail_kva++;
-		addr = (vm_ptr_t)NULL;
+		addr = (vm_pointer_t)NULL;
 		goto out;
 	}
 	addr = origaddr;
@@ -338,7 +338,7 @@ memguard_alloc(unsigned long req_size, int flags)
 	if (rv != KERN_SUCCESS) {
 		vmem_xfree(memguard_arena, origaddr, size_v);
 		memguard_fail_pgs++;
-		addr = (vm_ptr_t)NULL;
+		addr = (vm_pointer_t)NULL;
 		goto out;
 	}
 	*v2sizep(trunc_page(addr)) = req_size;
@@ -374,7 +374,7 @@ is_memguard_addr(void *addr)
 void
 memguard_free(void *ptr)
 {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	u_long req_size, size, sizev;
 	char *temp;
 	int i;

--- a/sys/vm/pmap.h
+++ b/sys/vm/pmap.h
@@ -147,7 +147,7 @@ boolean_t	 pmap_is_modified(vm_page_t m);
 boolean_t	 pmap_is_prefaultable(pmap_t pmap, vm_offset_t va);
 boolean_t	 pmap_is_referenced(vm_page_t m);
 boolean_t	 pmap_is_valid_memattr(pmap_t, vm_memattr_t);
-vm_ptr_t	 pmap_map(vm_ptr_t *, vm_paddr_t, vm_paddr_t, int);
+vm_pointer_t	 pmap_map(vm_pointer_t *, vm_paddr_t, vm_paddr_t, int);
 int		 pmap_mincore(pmap_t pmap, vm_offset_t addr,
 		    vm_paddr_t *pap);
 void		 pmap_object_init_pt(pmap_t pmap, vm_offset_t addr,
@@ -160,7 +160,7 @@ void		 pmap_pinit0(pmap_t);
 void		 pmap_protect(pmap_t, vm_offset_t, vm_offset_t, vm_prot_t);
 void		 pmap_qenter(vm_offset_t, vm_page_t *, int);
 void		 pmap_qremove(vm_offset_t, int);
-vm_ptr_t	 pmap_quick_enter_page(vm_page_t);
+vm_pointer_t	 pmap_quick_enter_page(vm_page_t);
 void		 pmap_quick_remove_page(vm_offset_t);
 void		 pmap_release(pmap_t);
 void		 pmap_remove(pmap_t, vm_offset_t, vm_offset_t);

--- a/sys/vm/uma_core.c
+++ b/sys/vm/uma_core.c
@@ -176,7 +176,7 @@ static struct rwlock_padalign __exclusive_cache_line uma_rwlock;
  * First available virual address for boot time allocations.
  */
 static vm_offset_t bootstart;
-static vm_ptr_t bootmem;
+static vm_pointer_t bootmem;
 #ifdef __CHERI_PURE_CAPABILITY__
 /*
  * Boundaries of the UMA boot memory pool.
@@ -290,7 +290,7 @@ enum zfreeskip {
 
 /* Prototypes.. */
 
-void	uma_startup1(vm_ptr_t);
+void	uma_startup1(vm_pointer_t);
 void	uma_startup2(void);
 
 static void *noobj_alloc(uma_zone_t, vm_size_t, int, uint8_t *, int);
@@ -1790,7 +1790,7 @@ pcpu_page_alloc(uma_zone_t zone, vm_size_t bytes, int domain, uint8_t *pflag,
     int wait)
 {
 	struct pglist alloctail;
-	vm_ptr_t addr, zkva;
+	vm_pointer_t addr, zkva;
 	int cpu, flags;
 	vm_page_t p, p_next;
 #ifdef NUMA
@@ -1862,7 +1862,7 @@ noobj_alloc(uma_zone_t zone, vm_size_t bytes, int domain, uint8_t *flags,
 {
 	TAILQ_HEAD(, vm_page) alloctail;
 	u_long npages;
-	vm_ptr_t retkva, zkva;
+	vm_pointer_t retkva, zkva;
 	vm_page_t p, p_next;
 	uma_keg_t keg;
 
@@ -1943,7 +1943,7 @@ page_free(void *mem, vm_size_t size, uint8_t flags)
 	KASSERT((flags & UMA_SLAB_KERNEL) != 0,
 	    ("UMA: page_free used with invalid flags %x", flags));
 
-	kmem_free((vm_ptr_t)mem, size);
+	kmem_free((vm_pointer_t)mem, size);
 }
 
 /*
@@ -2914,7 +2914,7 @@ zone_foreach(void (*zfunc)(uma_zone_t, void *arg), void *arg)
  * allocated but before general KVA is available.
  */
 void
-uma_startup1(vm_ptr_t virtual_avail)
+uma_startup1(vm_pointer_t virtual_avail)
 {
 	struct uma_zctor_args args;
 	size_t ksize, zsize, size;
@@ -3000,7 +3000,7 @@ extern void vm_radix_reserve_kva(void);
 void
 uma_startup2(void)
 {
-	vm_ptr_t bootreserv = bootstart;
+	vm_pointer_t bootreserv = bootstart;
 
 	if (bootstart != bootmem) {
 		vm_map_lock(kernel_map);
@@ -4858,7 +4858,7 @@ int
 uma_zone_reserve_kva(uma_zone_t zone, int count)
 {
 	uma_keg_t keg;
-	vm_ptr_t kva;
+	vm_pointer_t kva;
 	u_int pages;
 
 	KEG_GET(zone, keg);

--- a/sys/vm/uma_int.h
+++ b/sys/vm/uma_int.h
@@ -352,7 +352,7 @@ struct uma_keg {
 	uma_free	uk_freef;	/* Free routine */
 
 	u_long		uk_offset;	/* Next free offset from base KVA */
-	vm_ptr_t	uk_kva;		/* Zone base KVA */
+	vm_pointer_t	uk_kva;		/* Zone base KVA */
 
 	uint32_t	uk_pgoff;	/* Offset to uma_slab struct */
 	uint16_t	uk_ppera;	/* pages per allocation from backend */

--- a/sys/vm/vm_extern.h
+++ b/sys/vm/vm_extern.h
@@ -47,40 +47,40 @@ struct cdevsw;
 struct domainset;
 
 /* These operate on kernel virtual addresses only. */
-vm_ptr_t kva_alloc(vm_size_t);
-vm_ptr_t kva_alloc_aligned(vm_size_t, vm_offset_t);
-void kva_free(vm_ptr_t, vm_size_t);
+vm_pointer_t kva_alloc(vm_size_t);
+vm_pointer_t kva_alloc_aligned(vm_size_t, vm_offset_t);
+void kva_free(vm_pointer_t, vm_size_t);
 
 /* These operate on pageable virtual addresses. */
-vm_ptr_t kmap_alloc_wait(vm_map_t, vm_size_t);
+vm_pointer_t kmap_alloc_wait(vm_map_t, vm_size_t);
 void kmap_free_wakeup(vm_map_t, vm_offset_t, vm_size_t);
 
 /* These operate on virtual addresses backed by memory. */
-vm_ptr_t kmem_alloc_attr(vm_size_t size, int flags,
+vm_pointer_t kmem_alloc_attr(vm_size_t size, int flags,
     vm_paddr_t low, vm_paddr_t high, vm_memattr_t memattr);
-vm_ptr_t kmem_alloc_attr_domainset(struct domainset *ds, vm_size_t size,
+vm_pointer_t kmem_alloc_attr_domainset(struct domainset *ds, vm_size_t size,
     int flags, vm_paddr_t low, vm_paddr_t high, vm_memattr_t memattr);
-vm_ptr_t kmem_alloc_contig(vm_size_t size, int flags,
+vm_pointer_t kmem_alloc_contig(vm_size_t size, int flags,
     vm_paddr_t low, vm_paddr_t high, u_long alignment, vm_paddr_t boundary,
     vm_memattr_t memattr);
-vm_ptr_t kmem_alloc_contig_domainset(struct domainset *ds, vm_size_t size,
+vm_pointer_t kmem_alloc_contig_domainset(struct domainset *ds, vm_size_t size,
     int flags, vm_paddr_t low, vm_paddr_t high, u_long alignment,
     vm_paddr_t boundary, vm_memattr_t memattr);
-vm_ptr_t kmem_malloc(vm_size_t size, int flags);
-vm_ptr_t kmem_malloc_domainset(struct domainset *ds, vm_size_t size,
+vm_pointer_t kmem_malloc(vm_size_t size, int flags);
+vm_pointer_t kmem_malloc_domainset(struct domainset *ds, vm_size_t size,
     int flags, vm_size_t align);
-void kmem_free(vm_ptr_t addr, vm_size_t size);
+void kmem_free(vm_pointer_t addr, vm_size_t size);
 
 /* This provides memory for previously allocated address space. */
-int kmem_back(vm_object_t, vm_ptr_t, vm_size_t, int);
-int kmem_back_domain(int, vm_object_t, vm_ptr_t, vm_size_t, int);
+int kmem_back(vm_object_t, vm_pointer_t, vm_size_t, int);
+int kmem_back_domain(int, vm_object_t, vm_pointer_t, vm_size_t, int);
 void kmem_unback(vm_object_t, vm_offset_t, vm_size_t);
 
 /* Bootstrapping. */
 void kmem_bootstrap_free(vm_offset_t, vm_size_t);
-void kmem_subinit(vm_map_t, vm_map_t, vm_ptr_t *, vm_ptr_t *, vm_size_t,
+void kmem_subinit(vm_map_t, vm_map_t, vm_pointer_t *, vm_pointer_t *, vm_size_t,
     bool);
-void kmem_init(vm_ptr_t, vm_ptr_t);
+void kmem_init(vm_pointer_t, vm_pointer_t);
 void kmem_init_zero_region(void);
 void kmeminit(void);
 
@@ -102,9 +102,9 @@ int vm_fault_trap(vm_map_t map, vm_offset_t vaddr, vm_prot_t fault_type,
 int vm_forkproc(struct thread *, struct proc *, struct thread *,
     struct vmspace *, int);
 void vm_waitproc(struct proc *);
-int vm_mmap(vm_map_t, vm_ptr_t *, vm_size_t, vm_prot_t, vm_prot_t, int,
+int vm_mmap(vm_map_t, vm_pointer_t *, vm_size_t, vm_prot_t, vm_prot_t, int,
     objtype_t, void *, vm_ooffset_t);
-int vm_mmap_object(vm_map_t, vm_ptr_t *, vm_offset_t, vm_size_t,
+int vm_mmap_object(vm_map_t, vm_pointer_t *, vm_offset_t, vm_size_t,
     vm_prot_t, vm_prot_t, int, vm_object_t, vm_ooffset_t, boolean_t,
     struct thread *);
 int vm_mmap_to_errno(int rv);
@@ -115,7 +115,7 @@ int vm_mmap_vnode(struct thread *, vm_size_t, vm_prot_t, vm_prot_t *, int *,
 void vm_set_page_size(void);
 void vm_sync_icache(vm_map_t, vm_offset_t, vm_size_t);
 typedef int (*pmap_pinit_t)(struct pmap *pmap);
-struct vmspace *vmspace_alloc(vm_ptr_t, vm_ptr_t, pmap_pinit_t);
+struct vmspace *vmspace_alloc(vm_pointer_t, vm_pointer_t, pmap_pinit_t);
 struct vmspace *vmspace_fork(struct vmspace *, vm_ooffset_t *);
 int vmspace_exec(struct proc *, vm_offset_t, vm_offset_t);
 int vmspace_unshare(struct proc *);

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -305,11 +305,11 @@ SYSCTL_PROC(_vm, OID_AUTO, kstack_cache_size,
 /*
  * Create the kernel stack (including pcb for i386) for a new thread.
  */
-static vm_ptr_t
+static vm_pointer_t
 vm_thread_stack_create(struct domainset *ds, int pages)
 {
 	vm_page_t ma[KSTACK_MAX_PAGES];
-	vm_ptr_t ks;
+	vm_pointer_t ks;
 	int i;
 
 	/*
@@ -350,7 +350,7 @@ vm_thread_stack_create(struct domainset *ds, int pages)
 }
 
 static void
-vm_thread_stack_dispose(vm_ptr_t ks, int pages)
+vm_thread_stack_dispose(vm_pointer_t ks, int pages)
 {
 	vm_page_t m;
 	vm_pindex_t pindex;
@@ -379,7 +379,7 @@ vm_thread_stack_dispose(vm_ptr_t ks, int pages)
 int
 vm_thread_new(struct thread *td, int pages)
 {
-	vm_ptr_t ks;
+	vm_pointer_t ks;
 
 	/* Bounds check */
 	if (pages <= 1)
@@ -389,7 +389,7 @@ vm_thread_new(struct thread *td, int pages)
 
 	ks = 0;
 	if (pages == kstack_pages && kstack_cache != NULL)
-		ks = (vm_ptr_t)uma_zalloc(kstack_cache, M_NOWAIT);
+		ks = (vm_pointer_t)uma_zalloc(kstack_cache, M_NOWAIT);
 
 	/*
 	 * Ensure that kstack objects can draw pages from any memory
@@ -412,7 +412,7 @@ vm_thread_new(struct thread *td, int pages)
 void
 vm_thread_dispose(struct thread *td)
 {
-	vm_ptr_t ks;
+	vm_pointer_t ks;
 	int pages;
 
 	pages = td->td_kstack_pages;
@@ -509,11 +509,11 @@ kstack_import(void *arg, void **store, int cnt, int domain, int flags)
 static void
 kstack_release(void *arg, void **store, int cnt)
 {
-	vm_ptr_t ks;
+	vm_pointer_t ks;
 	int i;
 
 	for (i = 0; i < cnt; i++) {
-		ks = (vm_ptr_t)store[i];
+		ks = (vm_pointer_t)store[i];
 		vm_thread_stack_dispose(ks, kstack_pages);
 	}
 }

--- a/sys/vm/vm_init.c
+++ b/sys/vm/vm_init.c
@@ -153,12 +153,12 @@ vm_mem_init(void *dummy)
 void
 vm_ksubmap_init(struct kva_md_info *kmi)
 {
-	vm_ptr_t firstaddr;
+	vm_pointer_t firstaddr;
 	caddr_t v;
 	vm_size_t size = 0;
 	long physmem_est;
-	vm_ptr_t minaddr;
-	vm_ptr_t maxaddr;
+	vm_pointer_t minaddr;
+	vm_pointer_t maxaddr;
 
 	/*
 	 * Allocate space for system data structures.

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -143,7 +143,7 @@ extern void     uma_startup2(void);
  *	its use, typically with pmap_qenter().  Any attempt to create
  *	a mapping on demand through vm_fault() will result in a panic. 
  */
-vm_ptr_t
+vm_pointer_t
 kva_alloc(vm_size_t size)
 {
 	vmem_addr_t addr;
@@ -155,7 +155,7 @@ kva_alloc(vm_size_t size)
 	return (addr);
 }
 
-vm_ptr_t
+vm_pointer_t
 kva_alloc_aligned(vm_size_t size, vm_offset_t align)
 {
 	vmem_addr_t addr;
@@ -179,7 +179,7 @@ kva_alloc_aligned(vm_size_t size, vm_offset_t align)
  *	This routine may not block on kernel maps.
  */
 void
-kva_free(vm_ptr_t addr, vm_size_t size)
+kva_free(vm_pointer_t addr, vm_size_t size)
 {
 
 	size = round_page(size);
@@ -223,13 +223,13 @@ kmem_alloc_contig_pages(vm_object_t object, vm_pindex_t pindex, int domain,
  *	necessarily physically contiguous.  If M_ZERO is specified through the
  *	given flags, then the pages are zeroed before they are mapped.
  */
-static vm_ptr_t
+static vm_pointer_t
 kmem_alloc_attr_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
     vm_paddr_t high, vm_memattr_t memattr)
 {
 	vmem_t *vmem;
 	vm_object_t object;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	vm_offset_t i, offset;
 	vm_page_t m;
 	int pflags;
@@ -275,7 +275,7 @@ kmem_alloc_attr_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 	return (addr);
 }
 
-vm_ptr_t
+vm_pointer_t
 kmem_alloc_attr(vm_size_t size, int flags, vm_paddr_t low, vm_paddr_t high,
     vm_memattr_t memattr)
 {
@@ -284,12 +284,12 @@ kmem_alloc_attr(vm_size_t size, int flags, vm_paddr_t low, vm_paddr_t high,
 	    high, memattr));
 }
 
-vm_ptr_t
+vm_pointer_t
 kmem_alloc_attr_domainset(struct domainset *ds, vm_size_t size, int flags,
     vm_paddr_t low, vm_paddr_t high, vm_memattr_t memattr)
 {
 	struct vm_domainset_iter di;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	int domain;
 
 	vm_domainset_iter_policy_init(&di, ds, &domain, &flags);
@@ -311,14 +311,14 @@ kmem_alloc_attr_domainset(struct domainset *ds, vm_size_t size, int flags,
  *	through the given flags, then the pages are zeroed before they are
  *	mapped.
  */
-static vm_ptr_t
+static vm_pointer_t
 kmem_alloc_contig_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
     vm_paddr_t high, u_long alignment, vm_paddr_t boundary,
     vm_memattr_t memattr)
 {
 	vmem_t *vmem;
 	vm_object_t object;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	vm_offset_t offset, tmp;
 	vm_page_t end_m, m;
 	u_long npages;
@@ -363,7 +363,7 @@ kmem_alloc_contig_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 	return (addr);
 }
 
-vm_ptr_t
+vm_pointer_t
 kmem_alloc_contig(vm_size_t size, int flags, vm_paddr_t low, vm_paddr_t high,
     u_long alignment, vm_paddr_t boundary, vm_memattr_t memattr)
 {
@@ -372,13 +372,13 @@ kmem_alloc_contig(vm_size_t size, int flags, vm_paddr_t low, vm_paddr_t high,
 	    high, alignment, boundary, memattr));
 }
 
-vm_ptr_t
+vm_pointer_t
 kmem_alloc_contig_domainset(struct domainset *ds, vm_size_t size, int flags,
     vm_paddr_t low, vm_paddr_t high, u_long alignment, vm_paddr_t boundary,
     vm_memattr_t memattr)
 {
 	struct vm_domainset_iter di;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	int domain;
 
 	vm_domainset_iter_policy_init(&di, ds, &domain, &flags);
@@ -406,7 +406,7 @@ kmem_alloc_contig_domainset(struct domainset *ds, vm_size_t size, int flags,
  *	superpage_align	Request that min is superpage aligned
  */
 void
-kmem_subinit(vm_map_t map, vm_map_t parent, vm_ptr_t *min, vm_ptr_t *max,
+kmem_subinit(vm_map_t map, vm_map_t parent, vm_pointer_t *min, vm_pointer_t *max,
     vm_size_t size, bool superpage_align)
 {
 	int ret;
@@ -432,11 +432,11 @@ kmem_subinit(vm_map_t map, vm_map_t parent, vm_ptr_t *min, vm_ptr_t *max,
  *
  *	Allocate wired-down pages in the kernel's address space.
  */
-static vm_ptr_t
+static vm_pointer_t
 kmem_malloc_domain(int domain, vm_size_t size, int flags, vm_size_t align)
 {
 	vmem_t *arena;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	int rv;
 
 	if (__predict_true((flags & M_EXEC) == 0))
@@ -460,19 +460,19 @@ kmem_malloc_domain(int domain, vm_size_t size, int flags, vm_size_t align)
 	return (addr);
 }
 
-vm_ptr_t
+vm_pointer_t
 kmem_malloc(vm_size_t size, int flags)
 {
 
 	return (kmem_malloc_domainset(DOMAINSET_RR(), size, flags, 0));
 }
 
-vm_ptr_t
+vm_pointer_t
 kmem_malloc_domainset(struct domainset *ds, vm_size_t size, int flags,
    vm_size_t align)
 {
 	struct vm_domainset_iter di;
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	int domain;
 
 	vm_domainset_iter_policy_init(&di, ds, &domain, &flags);
@@ -496,7 +496,7 @@ kmem_malloc_domainset(struct domainset *ds, vm_size_t size, int flags,
  *	of the specified size.
  */
 int
-kmem_back_domain(int domain, vm_object_t object, vm_ptr_t addr,
+kmem_back_domain(int domain, vm_object_t object, vm_pointer_t addr,
     vm_size_t size, int flags)
 {
 	vm_offset_t offset, i;
@@ -563,9 +563,9 @@ retry:
  *	Allocate physical pages for the specified virtual address range.
  */
 int
-kmem_back(vm_object_t object, vm_ptr_t addr, vm_size_t size, int flags)
+kmem_back(vm_object_t object, vm_pointer_t addr, vm_size_t size, int flags)
 {
-	vm_ptr_t end, next, start;
+	vm_pointer_t end, next, start;
 	int domain, rv;
 
 	KASSERT(object == kernel_object,
@@ -655,7 +655,7 @@ kmem_unback(vm_object_t object, vm_offset_t addr, vm_size_t size)
  *	original allocation.
  */
 void
-kmem_free(vm_ptr_t addr, vm_size_t size)
+kmem_free(vm_pointer_t addr, vm_size_t size)
 {
 	struct vmem *arena;
 
@@ -673,14 +673,14 @@ kmem_free(vm_ptr_t addr, vm_size_t size)
  *
  *	This routine may block.
  */
-vm_ptr_t
+vm_pointer_t
 kmap_alloc_wait(vm_map_t map, vm_size_t size)
 {
 	int error;
 	vm_size_t padded_size;
 	vm_offset_t alignment;
 	vm_offset_t addr;
-	vm_ptr_t mapped;
+	vm_pointer_t mapped;
 
 	size = round_page(size);
 	if (!swap_reserve(size))
@@ -749,7 +749,7 @@ kmap_free_wakeup(vm_map_t map, vm_offset_t addr, vm_size_t size)
 void
 kmem_init_zero_region(void)
 {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	vm_offset_t i;
 	vm_page_t m;
 
@@ -776,7 +776,7 @@ kmem_init_zero_region(void)
 static int
 kva_import(void *unused, vmem_size_t size, int flags, vmem_addr_t *addrp)
 {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	int result;
 
 	KASSERT((size % KVA_QUANTUM) == 0,
@@ -818,9 +818,9 @@ kva_import_domain(void *arena, vmem_size_t size, int flags, vmem_addr_t *addrp)
  *	Create the kernel vmem arena and its per-domain children.
  */
 void
-kmem_init(vm_ptr_t start, vm_ptr_t end)
+kmem_init(vm_pointer_t start, vm_pointer_t end)
 {
-	vm_ptr_t addr;
+	vm_pointer_t addr;
 	vm_size_t quantum;
 	int domain;
 	vm_size_t size;

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -135,8 +135,8 @@ static uma_zone_t mapentzone;
 static uma_zone_t kmapentzone;
 static uma_zone_t vmspace_zone;
 static int vmspace_zinit(void *mem, int size, int flags);
-static void _vm_map_init(vm_map_t map, pmap_t pmap, vm_ptr_t min,
-    vm_ptr_t max);
+static void _vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min,
+    vm_pointer_t max);
 static void vm_map_entry_deallocate(vm_map_entry_t entry, boolean_t system_map);
 static void vm_map_entry_dispose(vm_map_t map, vm_map_entry_t entry);
 static void vm_map_entry_unwire(vm_map_t map, vm_map_entry_t entry);
@@ -147,7 +147,7 @@ static void vm_map_pmap_enter(vm_map_t map, vm_offset_t addr, vm_prot_t prot,
 #ifdef INVARIANTS
 static void vmspace_zdtor(void *mem, int size, void *arg);
 #endif
-static int vm_map_stack_locked(vm_map_t map, vm_ptr_t addrbos,
+static int vm_map_stack_locked(vm_map_t map, vm_pointer_t addrbos,
     vm_size_t max_ssize, vm_size_t growsize, vm_prot_t prot, vm_prot_t max,
     int cow);
 static void vm_map_wire_entry_failure(vm_map_t map, vm_map_entry_t entry,
@@ -375,7 +375,7 @@ vmspace_zdtor(void *mem, int size, void *arg)
  * and initialize those structures.  The refcnt is set to 1.
  */
 struct vmspace *
-vmspace_alloc(vm_ptr_t min, vm_ptr_t max, pmap_pinit_t pinit)
+vmspace_alloc(vm_pointer_t min, vm_pointer_t max, pmap_pinit_t pinit)
 {
 	struct vmspace *vm;
 
@@ -971,7 +971,7 @@ vmspace_resident_count(struct vmspace *vmspace)
  * such as that in the vmspace structure.
  */
 static void
-_vm_map_init(vm_map_t map, pmap_t pmap, vm_ptr_t min, vm_ptr_t max)
+_vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
 {
 	CHERI_ASSERT_VALID(min);
 	CHERI_ASSERT_VALID(max);
@@ -1005,7 +1005,7 @@ _vm_map_init(vm_map_t map, pmap_t pmap, vm_ptr_t min, vm_ptr_t max)
 }
 
 void
-vm_map_init(vm_map_t map, pmap_t pmap, vm_ptr_t min, vm_ptr_t max)
+vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
 {
 
 	_vm_map_init(map, pmap, min, max);
@@ -1726,7 +1726,7 @@ vm_map_lookup_entry(
  */
 int
 vm_map_insert(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
-    vm_ptr_t start, vm_ptr_t end, vm_prot_t prot, vm_prot_t max, int cow,
+    vm_pointer_t start, vm_pointer_t end, vm_prot_t prot, vm_prot_t max, int cow,
     vm_offset_t reservation)
 {
 	vm_map_entry_t new_entry, next_entry, prev_entry;
@@ -2101,11 +2101,11 @@ vm_map_findspace(vm_map_t map, vm_offset_t start, vm_size_t length)
  */
 int
 vm_map_fixed(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
-    vm_ptr_t start, vm_size_t length, vm_prot_t prot,
+    vm_pointer_t start, vm_size_t length, vm_prot_t prot,
     vm_prot_t max, int cow)
 {
 	vm_map_entry_t entry, next_entry;
-	vm_ptr_t end, reservation;
+	vm_pointer_t end, reservation;
 	int result;
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -2184,7 +2184,7 @@ SYSCTL_INT(_vm, OID_AUTO, cluster_anon, CTLFLAG_RW,
     "Cluster anonymous mappings: 0 = no, 1 = yes if no hint, 2 = always");
 
 static bool
-clustering_anon_allowed(vm_ptr_t addr)
+clustering_anon_allowed(vm_pointer_t addr)
 {
 
 	switch (cluster_anon) {
@@ -2303,14 +2303,14 @@ vm_map_find_aligned(vm_map_t map, vm_offset_t *addr, vm_size_t length,
  */
 int
 vm_map_find(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
-	    vm_ptr_t *addr,	/* IN/OUT */
+	    vm_pointer_t *addr,	/* IN/OUT */
 	    vm_size_t length, vm_offset_t max_addr, int find_space,
 	    vm_prot_t prot, vm_prot_t max, int cow)
 {
 	vm_offset_t alignment, curr_min_addr, min_addr, vaddr;
 	int gap, pidx, rv, try;
 	bool cluster, en_aslr, update_anon;
-	vm_ptr_t reservation;
+	vm_pointer_t reservation;
 	const vm_size_t unpadded_length = length;
 
 	KASSERT((cow & (MAP_STACK_GROWS_DOWN | MAP_STACK_GROWS_UP)) == 0 ||
@@ -2500,11 +2500,11 @@ done:
  */
 int
 vm_map_find_min(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
-    vm_ptr_t *addr, vm_size_t length, vm_offset_t min_addr,
+    vm_pointer_t *addr, vm_size_t length, vm_offset_t min_addr,
     vm_offset_t max_addr, int find_space, vm_prot_t prot, vm_prot_t max,
     int cow)
 {
-	vm_ptr_t hint;
+	vm_pointer_t hint;
 	int rv;
 
 	hint = *addr;
@@ -2815,8 +2815,8 @@ vm_map_clip_end(vm_map_t map, vm_map_entry_t entry, vm_offset_t endaddr)
 int
 vm_map_submap(
 	vm_map_t map,
-	vm_ptr_t start,
-	vm_ptr_t end,
+	vm_pointer_t start,
+	vm_pointer_t end,
 	vm_map_t submap)
 {
 	vm_map_entry_t entry;
@@ -4708,8 +4708,8 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 	    pmap_pinit);
 #else
 	vm2 = vmspace_alloc(
-	    (vm_ptr_t)cheri_setaddress(old_map->map_capability, vm_map_min(old_map)),
-	    (vm_ptr_t)cheri_setaddress(old_map->map_capability, vm_map_max(old_map)),
+	    (vm_pointer_t)cheri_setaddress(old_map->map_capability, vm_map_min(old_map)),
+	    (vm_pointer_t)cheri_setaddress(old_map->map_capability, vm_map_max(old_map)),
 	    pmap_pinit);
 #endif
 
@@ -4916,7 +4916,7 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
  * asked to wire the newly created stack.
  */
 int
-vm_map_stack(vm_map_t map, vm_ptr_t addrbos, vm_size_t max_ssize,
+vm_map_stack(vm_map_t map, vm_pointer_t addrbos, vm_size_t max_ssize,
     vm_prot_t prot, vm_prot_t max, int cow)
 {
 	vm_size_t growsize, init_ssize;
@@ -4952,11 +4952,11 @@ SYSCTL_INT(_security_bsd, OID_AUTO, stack_guard_page, CTLFLAG_RWTUN,
  * the stack address must also be a valid capability.
  */
 static int
-vm_map_stack_locked(vm_map_t map, vm_ptr_t addrbos, vm_size_t max_ssize,
+vm_map_stack_locked(vm_map_t map, vm_pointer_t addrbos, vm_size_t max_ssize,
     vm_size_t growsize, vm_prot_t prot, vm_prot_t max, int cow)
 {
 	vm_map_entry_t new_entry, prev_entry;
-	vm_ptr_t bot, gap_bot, gap_top, top;
+	vm_pointer_t bot, gap_bot, gap_top, top;
 	vm_size_t init_ssize, sgp;
 	int orient, rv;
 
@@ -5074,12 +5074,12 @@ vm_map_growstack(vm_map_t map, vm_offset_t addr, vm_map_entry_t gap_entry)
 	struct proc *p;
 	struct vmspace *vm;
 	struct ucred *cred;
-	vm_ptr_t gap_end, gap_start, grow_start;
+	vm_pointer_t gap_end, gap_start, grow_start;
 	vm_size_t grow_amount, guard, max_grow;
 	rlim_t lmemlim, stacklim, vmemlim;
 	int rv, rv1;
 	bool gap_deleted, grow_down, is_procstack;
-	vm_ptr_t stack_reservation;
+	vm_pointer_t stack_reservation;
 #ifdef notyet
 	uint64_t limit;
 #endif
@@ -5234,12 +5234,12 @@ retry:
 		    stack_entry->end - gap_entry->start,
 		    stack_entry->max_protection);
 
-		grow_start = (vm_ptr_t)cheri_kern_setaddress(
+		grow_start = (vm_pointer_t)cheri_kern_setaddress(
 		    stack_reservation, gap_entry->end - grow_amount);
 		if (gap_entry->start + grow_amount == gap_entry->end) {
-			gap_start = (vm_ptr_t)cheri_kern_setaddress(
+			gap_start = (vm_pointer_t)cheri_kern_setaddress(
 			    stack_reservation, gap_entry->start);
-			gap_end = (vm_ptr_t)cheri_kern_setaddress(
+			gap_end = (vm_pointer_t)cheri_kern_setaddress(
 			    stack_reservation, gap_entry->end);
 			vm_map_entry_delete(map, gap_entry);
 			gap_deleted = true;
@@ -5276,7 +5276,7 @@ retry:
 		stack_reservation = vm_map_buildcap(map, stack_entry->start,
 		    gap_entry->end - stack_entry->start,
 		    stack_entry->max_protection);
-		grow_start = (vm_ptr_t)cheri_kern_setaddress(
+		grow_start = (vm_pointer_t)cheri_kern_setaddress(
 		    stack_reservation, stack_entry->end);
 		cred = stack_entry->cred;
 		if (cred == NULL && stack_entry->object.vm_object != NULL)
@@ -5346,8 +5346,8 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	struct vmspace *newvmspace;
 #ifdef __CHERI_PURE_CAPABILITY__
 	vm_offset_t padded_minuser;
-	vm_ptr_t minuser_cap;
-	vm_ptr_t maxuser_cap;
+	vm_pointer_t minuser_cap;
+	vm_pointer_t maxuser_cap;
 	vm_offset_t user_length;
 #endif
 
@@ -5370,10 +5370,10 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	    ("Unrepresentable length for new vmspace"));
 
 	user_length = CHERI_REPRESENTABLE_LENGTH(user_length);
-	minuser_cap = (vm_ptr_t)cheri_capability_build_user_rwx(
+	minuser_cap = (vm_pointer_t)cheri_capability_build_user_rwx(
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_CAP_USER_DATA_PERMS,
 	    padded_minuser, user_length, minuser);
-	maxuser_cap = (vm_ptr_t)cheri_setaddress((void *)minuser_cap, maxuser);
+	maxuser_cap = (vm_pointer_t)cheri_setaddress((void *)minuser_cap, maxuser);
 	newvmspace = vmspace_alloc(minuser_cap, maxuser_cap, pmap_pinit);
 #else
 	newvmspace = vmspace_alloc(minuser, maxuser, pmap_pinit);
@@ -5784,7 +5784,7 @@ vm_map_prot2perms(vm_prot_t prot)
  * Create a capability for the given map, derived from the map root
  * capability.
  */
-vm_ptr_t
+vm_pointer_t
 _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
     vm_prot_t prot)
 {
@@ -5794,7 +5794,7 @@ _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
 	retcap = cheri_setbounds(cheri_setaddress(vm_map_rootcap(map),
 	    addr), length);
 
-	return ((vm_ptr_t)cheri_andperm(retcap, perms));
+	return ((vm_pointer_t)cheri_andperm(retcap, perms));
 }
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #endif /* has_feature(capabilities) */
@@ -5832,7 +5832,7 @@ vm_map_reservation_insert(vm_map_t map, vm_offset_t addr, vm_size_t length,
  * length must be representable.
  */
 int
-vm_map_reservation_create_locked(vm_map_t map, vm_ptr_t *addr,
+vm_map_reservation_create_locked(vm_map_t map, vm_pointer_t *addr,
     vm_size_t length, vm_prot_t max_prot)
 {
 	vm_offset_t start = *addr;
@@ -5882,12 +5882,12 @@ vm_map_reservation_create_locked(vm_map_t map, vm_ptr_t *addr,
  * ensure CHERI exact representability.
  */
 int
-vm_map_reservation_create(vm_map_t map, vm_ptr_t *addr, vm_size_t length,
+vm_map_reservation_create(vm_map_t map, vm_pointer_t *addr, vm_size_t length,
     vm_offset_t alignment, vm_prot_t max_prot)
 {
 	int result;
 	vm_size_t padded_length = CHERI_REPRESENTABLE_LENGTH(length);
-	vm_ptr_t start = *addr;
+	vm_pointer_t start = *addr;
 
 	if ((map->flags & MAP_RESERVATIONS) == 0) {
 		*addr = vm_map_buildcap(map, start, length, max_prot);
@@ -5922,14 +5922,14 @@ vm_map_reservation_create(vm_map_t map, vm_ptr_t *addr, vm_size_t length,
  * hint address.
  */
 int
-vm_map_reservation_create_fixed(vm_map_t map, vm_ptr_t *addr, vm_size_t length,
+vm_map_reservation_create_fixed(vm_map_t map, vm_pointer_t *addr, vm_size_t length,
     vm_offset_t alignment, vm_prot_t max_prot)
 {
 	int result;
 	vm_size_t padded_length;
 	vm_offset_t hint_addr = *addr;
 	vm_offset_t hint_offset = 0;
-	vm_ptr_t rounded_addr;
+	vm_pointer_t rounded_addr;
 	vm_offset_t hint_align;
 
 	if ((map->flags & MAP_RESERVATIONS) == 0) {

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -484,22 +484,22 @@ vm_map_entry_read_succ(void *token, struct vm_map_entry *const clone,
 #ifdef _KERNEL
 boolean_t vm_map_check_protection (vm_map_t, vm_offset_t, vm_offset_t, vm_prot_t);
 int vm_map_delete(vm_map_t, vm_offset_t, vm_offset_t, bool);
-int vm_map_find(vm_map_t, vm_object_t, vm_ooffset_t, vm_ptr_t *, vm_size_t,
+int vm_map_find(vm_map_t, vm_object_t, vm_ooffset_t, vm_pointer_t *, vm_size_t,
     vm_offset_t, int, vm_prot_t, vm_prot_t, int);
-int vm_map_find_min(vm_map_t, vm_object_t, vm_ooffset_t, vm_ptr_t *,
+int vm_map_find_min(vm_map_t, vm_object_t, vm_ooffset_t, vm_pointer_t *,
     vm_size_t, vm_offset_t, vm_offset_t, int, vm_prot_t, vm_prot_t, int);
 int vm_map_find_aligned(vm_map_t map, vm_offset_t *addr, vm_size_t length,
     vm_offset_t max_addr, vm_offset_t alignment);
-int vm_map_fixed(vm_map_t, vm_object_t, vm_ooffset_t, vm_ptr_t, vm_size_t,
+int vm_map_fixed(vm_map_t, vm_object_t, vm_ooffset_t, vm_pointer_t, vm_size_t,
     vm_prot_t, vm_prot_t, int);
 vm_offset_t vm_map_findspace(vm_map_t, vm_offset_t, vm_size_t);
 int vm_map_alignspace(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
     vm_offset_t *addr, vm_size_t length, vm_offset_t max_addr,
     vm_offset_t alignment);
 int vm_map_inherit (vm_map_t, vm_offset_t, vm_offset_t, vm_inherit_t);
-void vm_map_init(vm_map_t, pmap_t, vm_ptr_t, vm_ptr_t);
-int vm_map_insert (vm_map_t, vm_object_t, vm_ooffset_t, vm_ptr_t,
-    vm_ptr_t, vm_prot_t, vm_prot_t, int, vm_offset_t);
+void vm_map_init(vm_map_t, pmap_t, vm_pointer_t, vm_pointer_t);
+int vm_map_insert (vm_map_t, vm_object_t, vm_ooffset_t, vm_pointer_t,
+    vm_pointer_t, vm_prot_t, vm_prot_t, int, vm_offset_t);
 int vm_map_lookup (vm_map_t *, vm_offset_t, vm_prot_t, vm_map_entry_t *, vm_object_t *,
     vm_pindex_t *, vm_prot_t *, boolean_t *);
 int vm_map_lookup_locked(vm_map_t *, vm_offset_t, vm_prot_t, vm_map_entry_t *, vm_object_t *,
@@ -509,16 +509,16 @@ boolean_t vm_map_lookup_entry (vm_map_t, vm_offset_t, vm_map_entry_t *);
 bool vm_map_reservation_is_unmapped(vm_map_t, vm_offset_t);
 int vm_map_reservation_delete(vm_map_t, vm_offset_t);
 int vm_map_reservation_delete_locked(vm_map_t, vm_offset_t);
-int vm_map_reservation_create(vm_map_t, vm_ptr_t *, vm_size_t, vm_offset_t,
+int vm_map_reservation_create(vm_map_t, vm_pointer_t *, vm_size_t, vm_offset_t,
     vm_prot_t);
-int vm_map_reservation_create_fixed(vm_map_t, vm_ptr_t *, vm_size_t,
+int vm_map_reservation_create_fixed(vm_map_t, vm_pointer_t *, vm_size_t,
     vm_offset_t, vm_prot_t);
-int vm_map_reservation_create_locked(vm_map_t, vm_ptr_t *, vm_size_t, vm_prot_t);
+int vm_map_reservation_create_locked(vm_map_t, vm_pointer_t *, vm_size_t, vm_prot_t);
 #if __has_feature(capabilities)
 int vm_map_prot2perms(vm_prot_t prot);
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
-vm_ptr_t _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
+vm_pointer_t _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
     vm_prot_t prot);
 #define	vm_map_buildcap(map, addr, length, prot)	\
     _vm_map_buildcap(map, addr, length, prot)
@@ -559,11 +559,11 @@ int vm_map_clear(vm_map_t);
 void vm_map_try_merge_entries(vm_map_t map, vm_map_entry_t prev,
     vm_map_entry_t entry);
 void vm_map_startup (void);
-int vm_map_submap (vm_map_t, vm_ptr_t, vm_ptr_t, vm_map_t);
+int vm_map_submap (vm_map_t, vm_pointer_t, vm_pointer_t, vm_map_t);
 int vm_map_sync(vm_map_t, vm_offset_t, vm_offset_t, boolean_t, boolean_t,
     boolean_t);
 int vm_map_madvise (vm_map_t, vm_offset_t, vm_offset_t, int);
-int vm_map_stack (vm_map_t, vm_ptr_t, vm_size_t, vm_prot_t, vm_prot_t, int);
+int vm_map_stack (vm_map_t, vm_pointer_t, vm_size_t, vm_prot_t, vm_prot_t, int);
 int vm_map_unwire(vm_map_t map, vm_offset_t start, vm_offset_t end,
     int flags);
 int vm_map_wire(vm_map_t map, vm_offset_t start, vm_offset_t end, int flags);

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -150,7 +150,7 @@ cap_covers_pages(const void * __capability cap, size_t size)
 }
 
 static void * __capability
-mmap_retcap(struct thread *td, vm_ptr_t addr,
+mmap_retcap(struct thread *td, vm_pointer_t addr,
     const struct mmap_req *mrp)
 {
 	void * __capability newcap;
@@ -487,7 +487,7 @@ kern_mmap_req(struct thread *td, struct mmap_req *mrp)
 	struct proc *p;
 	off_t pos;
 	vm_offset_t addr_mask = PAGE_MASK;
-	vm_ptr_t addr, orig_addr;
+	vm_pointer_t addr, orig_addr;
 	vm_offset_t max_addr;
 	vm_size_t len, pageoff, size;
 	vm_prot_t cap_maxprot;
@@ -1927,7 +1927,7 @@ vm_mmap_cdev(struct thread *td, vm_size_t objsize, vm_prot_t *protp,
  * character device, or NULL for MAP_ANON.
  */
 int
-vm_mmap(vm_map_t map, vm_ptr_t *addr, vm_size_t size, vm_prot_t prot,
+vm_mmap(vm_map_t map, vm_pointer_t *addr, vm_size_t size, vm_prot_t prot,
 	vm_prot_t maxprot, int flags,
 	objtype_t handle_type, void *handle,
 	vm_ooffset_t foff)
@@ -2036,7 +2036,7 @@ kern_mmap_racct_check(struct thread *td, vm_map_t map, vm_size_t size)
  * map.  Called by mmap for MAP_ANON, vm_mmap, shm_mmap, and vn_mmap.
  */
 int
-vm_mmap_object(vm_map_t map, vm_ptr_t *addr, vm_offset_t max_addr,
+vm_mmap_object(vm_map_t map, vm_pointer_t *addr, vm_offset_t max_addr,
     vm_size_t size, vm_prot_t prot,
     vm_prot_t maxprot, int flags, vm_object_t object, vm_ooffset_t foff,
     boolean_t writecounted, struct thread *td)
@@ -2044,7 +2044,7 @@ vm_mmap_object(vm_map_t map, vm_ptr_t *addr, vm_offset_t max_addr,
 	int docow, error, findspace, rv;
 	bool curmap, fitit, new_reservation;
 	vm_size_t padded_size;
-	vm_ptr_t reservation;
+	vm_pointer_t reservation;
 
 	CHERI_ASSERT_PTRSIZE_BOUNDS(addr);
 

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -517,7 +517,7 @@ vm_page_init_page(vm_page_t m, vm_paddr_t pa, int segind)
 
 #ifndef PMAP_HAS_PAGE_ARRAY
 static vm_paddr_t
-vm_page_array_alloc(vm_ptr_t *vaddr, vm_paddr_t end, vm_paddr_t page_range)
+vm_page_array_alloc(vm_pointer_t *vaddr, vm_paddr_t end, vm_paddr_t page_range)
 {
 	vm_paddr_t new_end;
 
@@ -548,8 +548,8 @@ vm_page_array_alloc(vm_ptr_t *vaddr, vm_paddr_t end, vm_paddr_t page_range)
  *	physical pages.  Initializes these structures, and populates the free
  *	page queues.
  */
-vm_ptr_t
-vm_page_startup(vm_ptr_t vaddr)
+vm_pointer_t
+vm_page_startup(vm_pointer_t vaddr)
 {
 	struct vm_phys_seg *seg;
 	vm_page_t m;
@@ -563,7 +563,7 @@ vm_page_startup(vm_ptr_t vaddr)
 #endif
 	int biggestone, i, segind;
 #ifdef WITNESS
-	vm_ptr_t mapped;
+	vm_pointer_t mapped;
 	int witness_size;
 #endif
 #if defined(__i386__) && defined(VM_PHYSSEG_DENSE)

--- a/sys/vm/vm_page.h
+++ b/sys/vm/vm_page.h
@@ -676,7 +676,7 @@ vm_page_bits_t vm_page_set_dirty(vm_page_t m);
 void vm_page_set_valid_range(vm_page_t m, int base, int size);
 int vm_page_sleep_if_busy(vm_page_t m, const char *msg);
 int vm_page_sleep_if_xbusy(vm_page_t m, const char *msg);
-vm_ptr_t vm_page_startup(vm_ptr_t vaddr);
+vm_pointer_t vm_page_startup(vm_pointer_t vaddr);
 void vm_page_sunbusy(vm_page_t m);
 bool vm_page_try_remove_all(vm_page_t m);
 bool vm_page_try_remove_write(vm_page_t m);

--- a/sys/vm/vm_reserv.c
+++ b/sys/vm/vm_reserv.c
@@ -1427,7 +1427,7 @@ vm_reserv_size(int level)
  * management system's data structures, in particular, the reservation array.
  */
 vm_paddr_t
-vm_reserv_startup(vm_ptr_t *vaddr, vm_paddr_t end)
+vm_reserv_startup(vm_pointer_t *vaddr, vm_paddr_t end)
 {
 	vm_paddr_t new_end;
 	vm_pindex_t count;

--- a/sys/vm/vm_reserv.h
+++ b/sys/vm/vm_reserv.h
@@ -66,7 +66,7 @@ bool		vm_reserv_reclaim_inactive(int domain);
 void		vm_reserv_rename(vm_page_t m, vm_object_t new_object,
 		    vm_object_t old_object, vm_pindex_t old_object_offset);
 int		vm_reserv_size(int level);
-vm_paddr_t	vm_reserv_startup(vm_ptr_t *vaddr, vm_paddr_t end);
+vm_paddr_t	vm_reserv_startup(vm_pointer_t *vaddr, vm_paddr_t end);
 vm_page_t	vm_reserv_to_superpage(vm_page_t m);
 
 #endif	/* VM_NRESERVLEVEL > 0 */


### PR DESCRIPTION
As suggested by @jrtc27, this is a no-effort change that makes the type name mirror the spelling of `vm_offset_t`. Even though we will eventually try to upstream this as `uintptr_t` it is worth doing for consistency in the meantime.