### PR TITLE
Purecap kldload

### DIFF
--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -136,6 +136,14 @@ extern u_int	security_cheri_debugger_on_sandbox_unwind;
 extern u_int	security_cheri_sandboxed_signals;
 extern u_int	security_cheri_syscall_violations;
 extern u_int	security_cheri_bound_legacy_capabilities;
+
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Used by the kernel linker to handle caprelocs in modules.
+ */
+void	init_linker_file_cap_relocs(void *start_relocs, void *stop_relocs,
+	    void *data_cap, void *pc_cap, unsigned long base_addr);
+#endif
 #endif /* !_KERNEL */
 
 /*

--- a/sys/cheri/cheri_cap_relocs.c
+++ b/sys/cheri/cheri_cap_relocs.c
@@ -40,3 +40,21 @@ init_cap_relocs(void *data_cap, void *code_cap)
 {
 	cheri_init_globals_3(data_cap, code_cap, data_cap);
 }
+
+/* Can't include <sys/cheri.h>. */
+void	init_linker_file_cap_relocs(void *start_relocs, void *stop_relocs,
+	    void *data_cap, void *pc_cap, unsigned long base_addr);
+
+void
+init_linker_file_cap_relocs(void *start_relocs, void *stop_relocs,
+    void *data_cap, void *pc_cap, unsigned long base_addr)
+{
+#if !defined(__CHERI_PURE_CAPABILITY__) || __CHERI_CAPABILITY_TABLE__ == 3
+	/* pc-relative or hybrid ABI -> need large bounds on $pcc */
+	bool can_set_code_bounds = false;
+#else
+	bool can_set_code_bounds = true; /* fn-desc/plt ABI -> tight bounds okay */
+#endif
+	cheri_init_globals_impl(start_relocs, stop_relocs, data_cap, pc_cap,
+	    data_cap, can_set_code_bounds, base_addr);
+}

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1119,27 +1119,27 @@ freebsd64_kldfind(struct thread *td, struct freebsd64_kldfind_args *uap)
 int
 freebsd64_kldstat(struct thread *td, struct freebsd64_kldstat_args *uap)
 {
-        struct kld_file_stat stat;
+	struct kld_file_stat stat;
 	struct kld_file_stat64 stat64, * __capability stat64p;
-        int error, version;
+	int error, version;
 
 	stat64p = __USER_CAP_OBJ(uap->stat);
 	error = copyin(&stat64p->version, &version, sizeof(version));
 	if (error != 0)
-                return (error);
-        if (version != sizeof(struct kld_file_stat64))
-                return (EINVAL);
+		return (error);
+	if (version != sizeof(struct kld_file_stat64))
+		return (EINVAL);
 
-        error = kern_kldstat(td, uap->fileid, &stat);
-        if (error != 0)
-                return (error);
+	error = kern_kldstat(td, uap->fileid, &stat);
+	if (error != 0)
+		return (error);
 
-        bcopy(&stat.name[0], &stat64.name[0], sizeof(stat.name));
-        CP(stat, stat64, refs);
-        CP(stat, stat64, id);
+	bcopy(&stat.name[0], &stat64.name[0], sizeof(stat.name));
+	CP(stat, stat64, refs);
+	CP(stat, stat64, id);
 	stat64.address = (__cheri_addr uint64_t)stat.address;
-        CP(stat, stat64, size);
-        bcopy(&stat.pathname[0], &stat64.pathname[0], sizeof(stat.pathname));
+	CP(stat, stat64, size);
+	bcopy(&stat.pathname[0], &stat64.pathname[0], sizeof(stat.pathname));
 	return (copyout(&stat64, __USER_CAP(uap->stat, version), version));
 }
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1120,11 +1120,11 @@ int
 freebsd64_kldstat(struct thread *td, struct freebsd64_kldstat_args *uap)
 {
         struct kld_file_stat stat;
-        struct kld_file_stat64 stat64;
+	struct kld_file_stat64 stat64, * __capability stat64p;
         int error, version;
 
-        error = copyin(__USER_CAP_OBJ(&uap->stat->version), &version,
-	    sizeof(version));
+	stat64p = __USER_CAP_OBJ(uap->stat);
+	error = copyin(&stat64p->version, &version, sizeof(version));
 	if (error != 0)
                 return (error);
         if (version != sizeof(struct kld_file_stat64))
@@ -1140,7 +1140,7 @@ freebsd64_kldstat(struct thread *td, struct freebsd64_kldstat_args *uap)
 	stat64.address = (__cheri_addr uint64_t)stat.address;
         CP(stat, stat64, size);
         bcopy(&stat.pathname[0], &stat64.pathname[0], sizeof(stat.pathname));
-        return (copyout(&stat64, __USER_CAP_OBJ(uap->stat), version));
+	return (copyout(&stat64, __USER_CAP(uap->stat, version), version));
 }
 
 int

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -1094,6 +1094,21 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 		error = ENOEXEC;
 		goto out;
 	}
+#if __has_feature(capabilities)
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (!ELF_IS_CHERI(hdr)) {
+		link_elf_error(filename, "Hybrid ABI");
+		error = ENOEXEC;
+		goto out;
+	}
+#else
+	if (ELF_IS_CHERI(hdr)) {
+		link_elf_error(filename, "Pure capability ABI");
+		error = ENOEXEC;
+		goto out;
+	}
+#endif
+#endif
 
 	/*
 	 * We rely on the program header being in the first page.

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -668,14 +668,11 @@ parse_dynamic(elf_file_t ef)
 	if (ef->strtab)
 		ef->strtab = cheri_kern_setbounds(ef->strtab, ef->strsz);
 	if (ef->rel)
-		ef->rel = cheri_kern_setbounds(ef->rel,
-		    ef->relsize * sizeof(*ef->rel));
+		ef->rel = cheri_kern_setbounds(ef->rel, ef->relsize);
 	if (ef->pltrel)
-		ef->pltrel = cheri_kern_setbounds(ef->pltrel,
-		    ef->pltrelsize * sizeof(*ef->pltrel));
+		ef->pltrel = cheri_kern_setbounds(ef->pltrel, ef->pltrelsize);
 	if (ef->rela)
-		ef->rela = cheri_kern_setbounds(ef->rela,
-		    ef->relasize * sizeof(*ef->rela));
+		ef->rela = cheri_kern_setbounds(ef->rela, ef->relasize);
 	if (ef->symtab)
 		ef->symtab = cheri_kern_setbounds(ef->symtab,
 		    ef->nchains * sizeof(Elf_Sym));

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -77,7 +77,7 @@ __FBSDID("$FreeBSD$");
 #define MAXSEGS 4
 
 typedef struct elf_file {
-	struct linker_file lf;		/* Common fields */
+	struct linker_file lf __subobject_member_used_for_c_inheritance; /* Common fields */
 	int		preloaded;	/* Was file pre-loaded */
 	caddr_t		address;	/* Relocation address */
 #ifdef SPARSE_MAPPING

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -462,24 +462,12 @@ link_elf_init(void* arg)
 	ef->address = 0;
 #else /* __CHERI_PURE_CAPABILITY__ */
 	/*
-	 * This is the top-level capability used to generate all pointers
-	 * to ELF structures in the kernel image.
-	 *
-	 * XXX-AM: Ideally this is derived from the kernel data capability
-	 * since it does not need access to anything else, the capability is
-	 * read-only on the assumption that we shouldn't ELF files do not
-	 * write to kernel ELF sections.
-	 * It is particularly sad that we have to use this capability to
-	 * load other things later, we may have some more luck if we link
-	 * the kernel at 0x00 and relocate it at boot using pcc/ddc...
-	 * This is incompatible with the way other kld are linked, they are
-	 * 0-based so the addresses in the ELF file can be used as offsets
-	 * relative to ef->address. This is not true for the kernel,
-	 * so we are forced to use a 0-based capability and rely on bounds
-	 * enforcement later.
+	 * It is particularly sad that we are not able to put bounds on
+	 * this capability.  At some point ef->address should become a
+	 * plain address and ef should grow capabilities for different
+	 * loadable segments instead.
 	 */
-	ef->address = cheri_andperm(kernel_root_cap,
-		(CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP));
+	ef->address = cheri_setaddress(kernel_root_cap, 0);
 	linker_kernel_file->address = ef->address;
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #endif

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -381,6 +381,13 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	    hdr->e_ident[EI_VERSION] != EV_CURRENT ||
 	    hdr->e_version != EV_CURRENT ||
 	    hdr->e_type != ET_REL ||
+#if __has_feature(capabilities)
+#ifdef __CHERI_PURE_CAPABILITY__
+	    !ELF_IS_CHERI(hdr) ||
+#else
+	    ELF_IS_CHERI(hdr) ||
+#endif
+#endif
 	    hdr->e_machine != ELF_TARG_MACH) {
 		error = EFTYPE;
 		goto out;
@@ -748,6 +755,21 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 		error = ENOEXEC;
 		goto out;
 	}
+#if __has_feature(capabilities)
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (!ELF_IS_CHERI(hdr)) {
+		link_elf_error(filename, "Hybrid ABI");
+		error = ENOEXEC;
+		goto out;
+	}
+#else
+	if (ELF_IS_CHERI(hdr)) {
+		link_elf_error(filename, "Pure capability ABI");
+		error = ENOEXEC;
+		goto out;
+	}
+#endif
+#endif
 
 	lf = linker_make_file(filename, &link_elf_class);
 	if (!lf) {

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -91,7 +91,7 @@ typedef struct {
 } Elf_relaent;
 
 typedef struct elf_file {
-	struct linker_file lf;		/* Common fields */
+	struct linker_file lf __subobject_member_used_for_c_inheritance; /* Common fields */
 
 	int		preloaded;
 	caddr_t		address;	/* Relocation address */

--- a/sys/kern/linker_if.m
+++ b/sys/kern/linker_if.m
@@ -54,6 +54,40 @@ METHOD int search_symbol {
 };
 
 #
+# Lookup a symbol by index rather than name.  If the symbol is not
+# found then return ENOENT, otherwise zero.
+#
+# Useful for processing relocations.
+#
+METHOD int symidx_address {
+    linker_file_t	file;
+    unsigned long	index;
+    int			deps;
+    ptraddr_t		*address;
+};
+
+CODE {
+	#ifdef __CHERI_PURE_CAPABILITY__
+};
+HEADER {
+	#ifdef __CHERI_PURE_CAPABILITY__
+};
+
+METHOD int symidx_capability {
+    linker_file_t	file;
+    unsigned long	index;
+    int			deps;
+    uintcap_t		*cap;
+};
+
+CODE {
+	#endif
+};
+HEADER {
+	#endif
+};
+
+#
 # Call the callback with each specified function defined in the file.
 # Stop and return the error if the callback returns an error.
 #

--- a/sys/riscv/conf/std.CHERI-PURECAP
+++ b/sys/riscv/conf/std.CHERI-PURECAP
@@ -2,7 +2,6 @@ include "std.CHERI"
 
 machine		riscv	riscv64c
 
-makeoptions	NO_MODULES=yes
 makeoptions	CHERI_SUBOBJECT_BOUNDS=subobject-safe
 
 options 	CHERI_PURECAP_KERNEL


### PR DESCRIPTION
The first several changes are all generic purecap fixes that were only encountered when enabling module builds.  For some cases I disabled modules rather than trying to fix them.

The last few changes are the actual fixes for the kernel linker.

I know this will need updating to deal with vm_pointer_t fallout and some other changes, so this probably shouldn't be merged right away.  OTOH, since this is "close enough", we can probably just omit the bits about not building kernel modules from the first PR being merged to dev since I suspect this will all land in dev by the time we can actually turn CI on in dev.