### PR TITLE
[UPSTREAM] Also build programs with -Wl,--gdb-index

### DIFF
--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -27,6 +27,9 @@ NO_WERROR=
 .if defined(DEBUG_FLAGS)
 CFLAGS+=${DEBUG_FLAGS}
 CXXFLAGS+=${DEBUG_FLAGS}
+.if ${LINKER_FEATURES:Mgdb-index}
+LDFLAGS+=	-Wl,--gdb-index
+.endif
 
 .if ${MK_CTF} != "no" && ${DEBUG_FLAGS:M-g} != ""
 CTFFLAGS+= -g


### PR DESCRIPTION
Commit 9e55b67bd8be942c886994749568dcd1f93d984c added it for libraries but
not for programs. This requires a rather ugly workaround in bsd.crunchgen.mk,
but I think that is simpler than trying to modify the makefile that crunchgen
generates.