### PR TITLE
Rename global root capabilities

### DIFF
--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -115,11 +115,7 @@ extern void * __capability swap_restore_cap;
 extern void * __capability kernel_root_sealcap;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-/*
- * Kernel root capability
- * has all permissions
- * This spans the whole address-space
- */
+/* Root kernel capability */
 extern void * __capability kernel_root_cap;
 #endif
 

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -123,7 +123,7 @@ extern void * __capability kernel_sealcap;
  * has all permissions
  * This spans the whole address-space
  */
-extern void * __capability cheri_kall_capability;
+extern void * __capability kernel_root_cap;
 #endif
 
 /*

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -94,14 +94,14 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 	    __func__, __LINE__)
 
 /* Root of all userspace capabilities. */
-extern void * __capability userspace_cap;
+extern void * __capability userspace_root_cap
 
 /*
  * Global capabilities used to construct other capabilities.
  */
 
 /* Root of all unsealed userspace capabilities. */
-extern void * __capability userspace_cap;
+extern void * __capability userspace_root_cap
 
 /* Root of all sealed userspace capabilities. */
 extern void * __capability userspace_sealcap;

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -93,18 +93,15 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 	_cheri_capability_build_user_rwx(perms, basep, length, off,	\
 	    __func__, __LINE__)
 
-/* Root of all userspace capabilities. */
-extern void * __capability userspace_root_cap
-
 /*
  * Global capabilities used to construct other capabilities.
  */
 
 /* Root of all unsealed userspace capabilities. */
-extern void * __capability userspace_root_cap
+extern void * __capability userspace_root_cap;
 
 /* Root of all sealed userspace capabilities. */
-extern void * __capability userspace_sealcap;
+extern void * __capability userspace_root_sealcap;
 
 /*
  * Omnipotent capability for restoring swapped capabilities.
@@ -115,7 +112,7 @@ extern void * __capability userspace_sealcap;
 extern void * __capability swap_restore_cap;
 
 /* Root of all sealed kernel capabilities. */
-extern void * __capability kernel_sealcap;
+extern void * __capability kernel_root_sealcap;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 /*

--- a/sys/cheri/cheri_otype.c
+++ b/sys/cheri/cheri_otype.c
@@ -43,7 +43,7 @@ __FBSDID("$FreeBSD$");
 static struct mtx cheri_otype_lock;
 static struct unrhdr *cheri_otypes;
 /* Initialized in _start() */
-void * __capability kernel_sealcap;
+void * __capability kernel_root_sealcap;
 
 static void
 cheri_otype_init(void *dummy __unused)
@@ -63,7 +63,7 @@ cheri_otype_alloc(void)
 	type = alloc_unr(cheri_otypes);
 	if (type == -1)
 		return (NULL);
-	return (cheri_maketype(kernel_sealcap,
+	return (cheri_maketype(kernel_root_sealcap,
 	    type - CHERI_SEALCAP_KERNEL_BASE));
 }
 

--- a/sys/cheri/cheri_sealcap.c
+++ b/sys/cheri/cheri_sealcap.c
@@ -37,7 +37,7 @@
 #include <cheri/cheri.h>
 
 /* Set to -1 to prevent it from being zeroed with the rest of BSS */
-void * __capability userspace_sealcap = (void * __capability)(intcap_t)-1;
+void * __capability userspace_root_sealcap = (void * __capability)(intcap_t)-1;
 SYSCTL_OPAQUE(_security_cheri, OID_AUTO, sealcap, CTLFLAG_RD | CTLFLAG_PTROUT,
-    &userspace_sealcap, sizeof(userspace_sealcap), "",
+    &userspace_root_sealcap, sizeof(userspace_root_sealcap), "",
     "CHERI sealing root capability");

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -36,10 +36,10 @@
 #include <cheri/cheric.h>
 
 /* Set to -1 to prevent it from being zeroed with the rest of BSS */
-void * __capability userspace_cap = (void * __capability)(intcap_t)-1;
+void * __capability userspace_root_cap = (void * __capability)(intcap_t)-1;
 
 /*
- * Build a new userspace capability derived from userspace_cap.
+ * Build a new userspace capability derived from userspace_root_cap.
  * The resulting capability may include both read and execute permissions,
  * but not write, and will be a sentry capability. For architectures that use
  * flags, the flags for the resulting capability will be set based on what is
@@ -67,7 +67,7 @@ _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
 }
 
 /*
- * Build a new userspace capability derived from userspace_cap.
+ * Build a new userspace capability derived from userspace_root_cap.
  * The resulting capability may include read and write permissions, but
  * not execute.
  */
@@ -85,7 +85,7 @@ _cheri_capability_build_user_data(uint32_t perms, vaddr_t basep, size_t length,
 }
 
 /*
- * Build a new userspace capability derived from userspace_cap.
+ * Build a new userspace capability derived from userspace_root_cap.
  * The resulting capability may include read, write, and execute permissions.
  *
  * This function violates W^X and its use is discouraged and the reason for
@@ -98,7 +98,7 @@ _cheri_capability_build_user_rwx(uint32_t perms, vaddr_t basep, size_t length,
 	void * __capability tmpcap;
 
 	tmpcap = cheri_setoffset(cheri_andperm(cheri_setbounds(
-	    cheri_setoffset(userspace_cap, basep), length), perms), off);
+	    cheri_setoffset(userspace_root_cap, basep), length), perms), off);
 
 	KASSERT(cheri_getlen(tmpcap) == length,
 	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx: "

--- a/sys/ddb/db_main.c
+++ b/sys/ddb/db_main.c
@@ -249,9 +249,9 @@ db_init(void)
 	}
 	db_add_symbol_table(NULL, NULL, "kld", NULL);
 #ifdef __CHERI_PURE_CAPABILITY__
-	db_code_cap = cheri_andperm(cheri_kall_capability,
+	db_code_cap = cheri_andperm(kernel_root_cap,
 	    CHERI_PERMS_KERNEL_CODE);
-	db_data_cap = cheri_andperm(cheri_kall_capability,
+	db_data_cap = cheri_andperm(kernel_root_cap,
 	    CHERI_PERMS_KERNEL_DATA);
 #endif
 	return (1);	/* We're the default debugger. */

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -567,7 +567,7 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	reservation_cap = (void *)reservation;
 #else
 	reservation_cap = cheri_setbounds(
-	    cheri_setaddress(userspace_cap, reservation), end - start);
+	    cheri_setaddress(userspace_root_cap, reservation), end - start);
 #endif
 	*imgact_cap = cheri_andperm(reservation_cap, perm);
 

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -639,7 +639,7 @@ proc0_init(void *dummy __unused)
 	 * we strip all access permission because proc0 is not
 	 * expected to enter usermode.
 	 */
-	caddr_t minuser_cap = cheri_setaddress(userspace_cap,
+	caddr_t minuser_cap = cheri_setaddress(userspace_root_cap,
 	    p->p_sysent->sv_minuser);
 	minuser_cap = cheri_setbounds(minuser_cap,
 	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser);

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -464,7 +464,7 @@ link_elf_init(void* arg)
 	 * so we are forced to use a 0-based capability and rely on bounds
 	 * enforcement later.
 	 */
-	ef->address = cheri_andperm(cheri_kall_capability,
+	ef->address = cheri_andperm(kernel_root_cap,
 		(CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP));
 	linker_kernel_file->address = ef->address;
 #endif /* __CHERI_PURE_CAPABILITY__ */

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -365,7 +365,7 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	ef = (elf_file_t)lf;
 	ef->preloaded = 1;
 #ifdef __CHERI_PURE_CAPABILITY__
-	ef->address = cheri_setaddress(cheri_kall_capability,
+	ef->address = cheri_setaddress(kernel_root_cap,
 	    *(vaddr_t *)baseptr);
 	ef->address = cheri_setbounds(ef->address, *(size_t *)sizeptr);
 	ef->address = cheri_andperm(ef->address, CHERI_PERMS_KERNEL_CODE |

--- a/sys/mips/beri/beri_machdep.c
+++ b/sys/mips/beri/beri_machdep.c
@@ -112,7 +112,7 @@ beri_platform_ptr(vm_offset_t vaddr)
 	if (vaddr == 0)
 		return (NULL);
 
-	void *cap = cheri_setaddress(cheri_kall_capability, vaddr);
+	void *cap = cheri_setaddress(kernel_root_cap, vaddr);
 	cap = cheri_andperm(cap, CHERI_PERM_LOAD);
 
 	return (cap);

--- a/sys/mips/beri/beri_machdep.c
+++ b/sys/mips/beri/beri_machdep.c
@@ -274,7 +274,7 @@ platform_start(__register_t a0, __register_t a1,  __register_t a2,
 #ifdef __CHERI_PURE_CAPABILITY__
 	argv = beri_platform_ptr(a1);
 	envp = beri_platform_ptr(a2);
-	platform_clear_bss(cheri_kdata_capability);
+	platform_clear_bss(kernel_data_cap);
 #else
 	argv = (uint64_t *)a1;
 	envp = (uint64_t *)a2;

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -219,7 +219,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);
 	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS);
-	userspace_cap = ctemp;
+	userspace_root_cap = ctemp;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	/*
@@ -279,7 +279,7 @@ cheri_cpu_startup(void)
 {
 
 	/*
-	 * Documentary assertions for userspace_cap.  Default data and
+	 * Documentary assertions for userspace_root_cap. Default data and
 	 * code need to be identically sized or we'll need seperate caps.
 	 */
 	_Static_assert(CHERI_CAP_USER_DATA_BASE == CHERI_CAP_USER_CODE_BASE,

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -107,7 +107,7 @@ caddr_t cheri_kseg1_capability = (void *)(intcap_t)-1;
 caddr_t cheri_kseg2_capability = (void *)(intcap_t)-1;
 caddr_t cheri_kcode_capability = (void *)(intcap_t)-1;
 caddr_t cheri_kdata_capability = (void *)(intcap_t)-1;
-void *cheri_kall_capability = (void *)(intcap_t)-1;
+void *kernel_root_cap = (void *)(intcap_t)-1;
 
 /*
  * This is called from locore to initialise the cap table entries
@@ -265,7 +265,7 @@ cheri_init_capabilities(void * __capability kroot)
 	    ~(CHERI_PERM_EXECUTE | CHERI_PERM_CCALL | CHERI_PERM_SEAL |
 	      CHERI_PERM_SYSTEM_REGS));
 
-	cheri_kall_capability = kroot;
+	kernel_root_cap = kroot;
 #endif
 }
 

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -221,6 +221,11 @@ cheri_init_capabilities(void * __capability kroot)
 	    CHERI_CAP_USER_CODE_PERMS);
 	userspace_root_cap = ctemp;
 
+	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_KERNEL_BASE);
+	ctemp = cheri_setbounds(kroot, CHERI_SEALCAP_KERNEL_LENGTH);
+	ctemp = cheri_andperm(kroot, CHERI_SEALCAP_KERNEL_PERMS);
+	kernel_root_sealcap = ctemp;
+
 #ifdef __CHERI_PURE_CAPABILITY__
 	/*
 	 * Split kroot and generate a capability for each memory segment.
@@ -265,7 +270,8 @@ cheri_init_capabilities(void * __capability kroot)
 	    ~(CHERI_PERM_EXECUTE | CHERI_PERM_CCALL | CHERI_PERM_SEAL |
 	      CHERI_PERM_SYSTEM_REGS));
 
-	kernel_root_cap = kroot;
+	kernel_root_cap = cheri_andperm(kroot,
+	    ~(CHERI_PERM_SEAL | CHERI_PERM_UNSEAL));
 #endif
 }
 

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -100,13 +100,13 @@ extern char etext[], end[];
 /*
  * Global capabilities for various address-space segments.
  */
-caddr_t cheri_xkphys_capability = (void *)(intcap_t)-1;
-caddr_t cheri_xkseg_capability = (void *)(intcap_t)-1;
-caddr_t cheri_kseg0_capability = (void *)(intcap_t)-1;
-caddr_t cheri_kseg1_capability = (void *)(intcap_t)-1;
-caddr_t cheri_kseg2_capability = (void *)(intcap_t)-1;
-caddr_t cheri_kcode_capability = (void *)(intcap_t)-1;
-caddr_t cheri_kdata_capability = (void *)(intcap_t)-1;
+caddr_t mips_xkphys_cap = (void *)(intcap_t)-1;
+caddr_t mips_xkseg_cap = (void *)(intcap_t)-1;
+caddr_t mips_kseg0_cap = (void *)(intcap_t)-1;
+caddr_t mips_kseg1_cap = (void *)(intcap_t)-1;
+caddr_t mips_kseg2_cap = (void *)(intcap_t)-1;
+caddr_t kernel_code_cap = (void *)(intcap_t)-1;
+caddr_t kernel_data_cap = (void *)(intcap_t)-1;
 void *kernel_root_cap = (void *)(intcap_t)-1;
 
 /*
@@ -234,24 +234,24 @@ cheri_init_capabilities(void * __capability kroot)
 	 * KROOT that covers only kernel .data/.rodata/.bss etc.
 	 * Those should fall both into kseg0.
 	 */
-	cheri_xkphys_capability = cheri_ptrperm(
+	mips_xkphys_cap = cheri_ptrperm(
 	    cheri_setoffset(kroot, MIPS_XKPHYS_START),
 	    MIPS_XKPHYS_END - MIPS_XKPHYS_START,
 	    (CHERI_PERM_LOAD | CHERI_PERM_STORE | CHERI_PERM_LOAD_CAP |
 	     CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP));
-	cheri_xkseg_capability = cheri_ptrperm(
+	mips_xkseg_cap = cheri_ptrperm(
 	    cheri_setoffset(kroot, MIPS_XKSEG_START),
 	    MIPS_XKSEG_END - MIPS_XKSEG_START,
 	    CHERI_CAP_KERN_PERMS);
-	cheri_kseg0_capability = cheri_ptrperm(
+	mips_kseg0_cap = cheri_ptrperm(
 	    cheri_setoffset(kroot, MIPS_KSEG0_START),
 	    (vaddr_t)MIPS_KSEG0_END - (vaddr_t)MIPS_KSEG0_START,
 	    CHERI_CAP_KERN_PERMS);
-	cheri_kseg1_capability = cheri_ptrperm(
+	mips_kseg1_cap = cheri_ptrperm(
 	    cheri_setoffset(kroot, MIPS_KSEG1_START),
 	    (vaddr_t)MIPS_KSEG1_END - (vaddr_t)MIPS_KSEG1_START,
 	    CHERI_CAP_KERN_PERMS);
-	cheri_kseg2_capability = cheri_ptrperm(
+	mips_kseg2_cap = cheri_ptrperm(
 	    cheri_setoffset(kroot, MIPS_KSEG2_START),
 	    (vaddr_t)MIPS_KSEG2_END - (vaddr_t)MIPS_KSEG2_START,
 	    CHERI_CAP_KERN_PERMS);
@@ -259,14 +259,14 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setoffset(kroot, MIPS_KSEG0_START);
 	ctemp = cheri_setboundsexact(ctemp,
 	    (vaddr_t)&etext - (vaddr_t)MIPS_KSEG0_START);
-	cheri_kcode_capability = cheri_andperm(ctemp,
+	kernel_code_cap = cheri_andperm(ctemp,
 	    (CHERI_PERM_EXECUTE | CHERI_PERM_LOAD | CHERI_PERM_CCALL |
 	     CHERI_PERM_SYSTEM_REGS | CHERI_PERM_GLOBAL));
 
 	ctemp = cheri_setoffset(kroot, (vaddr_t)&etext);
 	ctemp = cheri_setboundsexact(ctemp,
 	    (vaddr_t)&end - (vaddr_t)&etext);
-	cheri_kdata_capability = cheri_andperm(ctemp,
+	kernel_data_cap = cheri_andperm(ctemp,
 	    ~(CHERI_PERM_EXECUTE | CHERI_PERM_CCALL | CHERI_PERM_SEAL |
 	      CHERI_PERM_SYSTEM_REGS));
 

--- a/sys/mips/cheri/cheri.c
+++ b/sys/mips/cheri/cheri.c
@@ -213,7 +213,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_USERSPACE_BASE);
 	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
 	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
-	userspace_sealcap = ctemp;
+	userspace_root_sealcap = ctemp;
 
 	ctemp = cheri_setaddress(kroot, CHERI_CAP_USER_DATA_BASE);
 	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);

--- a/sys/mips/cheri/cheri_stack_machdep.c
+++ b/sys/mips/cheri/cheri_stack_machdep.c
@@ -86,12 +86,11 @@ stack_fetch_ra(uintptr_t sp, u_register_t stack_pos)
 		 * XXX-AM: The exception handlers have base=0, this should
 		 * probably change.
 		 */
-		if (cheri_getbase(ra) < cheri_getbase(cheri_kcode_capability))
-			ra = cheri_setaddress(
-			    (uintptr_t)cheri_kcode_capability, ra);
+		if (cheri_getbase(ra) < cheri_getbase(kernel_code_cap))
+			ra = cheri_setaddress((uintptr_t)kernel_code_cap, ra);
 		else
 			ra = cheri_setaddress(cheri_setbounds(
-			    cheri_setaddress((uintptr_t)cheri_kcode_capability,
+			    cheri_setaddress((uintptr_t)kernel_code_cap,
 			    cheri_getbase(ra)), cheri_getlen(ra)), ra);
 	}
 

--- a/sys/mips/cheri/exception.S
+++ b/sys/mips/cheri/exception.S
@@ -1447,7 +1447,7 @@ LEAF_NOPROFILE(MipsTLBMissException)
 	 * the KERNEL_ADDRESS with MIPS_XKSEG() to automatically have it
 	 * derived as a capability everywhere. The implications are not obvious
 	 * to me so I'll leave it for now.
-	 * PTR_LA		k1, _C_LABEL(cheri_xkseg_capability)
+	 * PTR_LA		k1, _C_LABEL(mips_xkseg_cap)
 	*/
 	PTR_LI		k1, VM_MAX_KERNEL_ADDRESS	# check fault address against
 	sltu		k1, k1, k0			# upper bound of kernel_segmap
@@ -1528,7 +1528,7 @@ VECTOR(MipsCache, unknown)
 	CAPCALL_LOAD(CHERI_REG_KSCRATCH, _C_LABEL(MipsCacheException))
 	clc	CHERI_REG_KSCRATCH, zero, 0(CHERI_REG_KSCRATCH)
 	cgetaddr k0, CHERI_REG_KSCRATCH
-	CAPCALL_LOAD(CHERI_REG_KSCRATCH, _C_LABEL(cheri_kseg1_capability))
+	CAPCALL_LOAD(CHERI_REG_KSCRATCH, _C_LABEL(mips_kseg1_cap))
 	clc	CHERI_REG_KSCRATCH, zero, 0(CHERI_REG_KSCRATCH)
 	csetaddr CHERI_REG_KSCRATCH, CHERI_REG_KSCRATCH, k0
 	cjr	CHERI_REG_KSCRATCH

--- a/sys/mips/include/cpuregs.h
+++ b/sys/mips/include/cpuregs.h
@@ -108,11 +108,11 @@
 /*
  * Global capabilities for various address-space segments.
  */
-extern caddr_t cheri_xkphys_capability;
-extern caddr_t cheri_xkseg_capability;
-extern caddr_t cheri_kseg0_capability;
-extern caddr_t cheri_kseg1_capability;
-extern caddr_t cheri_kseg2_capability;
+extern caddr_t mips_xkphys_cap;
+extern caddr_t mips_xkseg_cap;
+extern caddr_t mips_kseg0_cap;
+extern caddr_t mips_kseg1_cap;
+extern caddr_t mips_kseg2_cap;
 /*
  * Global capabilities for specific kernel address space regions
  */
@@ -121,33 +121,33 @@ extern caddr_t cheri_kseg2_capability;
  * has PERM_LOAD PERM_EXECUTE PERM_CCALL PERM_SYSTEM_REGS
  * This spans the kernel .text section and exception vectors.
  */
-extern caddr_t cheri_kcode_capability;
+extern caddr_t kernel_code_cap;
 /*
  * Kernel global data capability
  * has PERM_LOAD PERM_STORE PERM_LOAD_CAP PERM_STORE_CAP PERM_STORE_LOCAL_CAP
  * This spans the kernel data sections, excluding debug sections
  */
-extern caddr_t cheri_kdata_capability;
+extern caddr_t kernel_data_cap;
 
 /*
  * Macros used to create a pointer for each address space segment
  */
 #define MIPS_XKPHYS(x)						\
-	(cheri_xkphys_capability + ((x) - MIPS_XKPHYS_START))
+	(mips_xkphys_cap + ((x) - MIPS_XKPHYS_START))
 #define MIPS_XKSEG(x)						\
-	(cheri_xkseg_capability + ((x) - MIPS_XKSEG_START))
+	(mips_xkseg_cap + ((x) - MIPS_XKSEG_START))
 #define MIPS_KSEG0(x)							\
-	(cheri_kseg0_capability + ((x) - (vm_offset_t)MIPS_KSEG0_START))
+	(mips_kseg0_cap + ((x) - (vm_offset_t)MIPS_KSEG0_START))
 #define MIPS_KSEG1(x)							\
-	(cheri_kseg1_capability + ((x) - (vm_offset_t)MIPS_KSEG1_START))
+	(mips_kseg1_cap + ((x) - (vm_offset_t)MIPS_KSEG1_START))
 #define MIPS_KSEG2(x)							\
-	(cheri_kseg2_capability + ((x) - (vm_offset_t)MIPS_KSEG2_START))
+	(mips_kseg2_cap + ((x) - (vm_offset_t)MIPS_KSEG2_START))
 /* Macros used to create pointers in specific kernel address space regions */
 #define MIPS_KCODE(x)							\
-	(cheri_kcode_capability + ((x) - (vm_offset_t)MIPS_KSEG0_START))
+	(kernel_code_cap + ((x) - (vm_offset_t)MIPS_KSEG0_START))
 #define MIPS_KDATA(x)							\
-	(cheri_kdata_capability +					\
-	((x) - __builtin_mips_cheri_get_cap_base(cheri_kdata_capability)))
+	(kernel_data_cap +					\
+	((x) - __builtin_mips_cheri_get_cap_base(kernel_data_cap)))
 #define MIPS_KALL(x) ((char *)kernel_root_cap + (x))
 #else /* ! __CHERI_PURE_CAPABILITY__ */
 #define MIPS_XKPHYS(x) ((char *)(x))

--- a/sys/mips/include/cpuregs.h
+++ b/sys/mips/include/cpuregs.h
@@ -148,7 +148,7 @@ extern caddr_t cheri_kdata_capability;
 #define MIPS_KDATA(x)							\
 	(cheri_kdata_capability +					\
 	((x) - __builtin_mips_cheri_get_cap_base(cheri_kdata_capability)))
-#define MIPS_KALL(x) ((char *)cheri_kall_capability + (x))
+#define MIPS_KALL(x) ((char *)kernel_root_cap + (x))
 #else /* ! __CHERI_PURE_CAPABILITY__ */
 #define MIPS_XKPHYS(x) ((char *)(x))
 #define MIPS_XKSEG(x) ((char *)(x))

--- a/sys/mips/malta/cheri_yamon.S
+++ b/sys/mips/malta/cheri_yamon.S
@@ -50,7 +50,7 @@ NESTED(_yamon_cheri_syscon_read, 32, $c17)
 	cincoffset	$c24, $c11, 0
 
 	/* Switch to an unbounded kernel PCC */
-	CAPTABLE_LOAD($c12, _C_LABEL(cheri_kall_capability))
+	CAPTABLE_LOAD($c12, _C_LABEL(kernel_root_cap))
 	clc	$c12, zero, 0($c12)
 	REG_LI	t0, CHERI_PERMS_KERNEL_CODE
 	candperm	$c12, $c12, t0

--- a/sys/mips/malta/malta_machdep.c
+++ b/sys/mips/malta/malta_machdep.c
@@ -374,7 +374,7 @@ platform_argv_ptr(int32_t argv)
 	 * do not try to get the precise string length.
 	 */
 	arg = cheri_ptrperm(
-	    cheri_setaddress(cheri_kseg0_capability, (vm_offset_t)(argv)),
+	    cheri_setaddress(mips_kseg0_cap, (vm_offset_t)(argv)),
 	    4096, CHERI_PERM_LOAD | CHERI_PERM_STORE);
 
 	return (arg);
@@ -411,11 +411,11 @@ platform_start(__register_t a0, __register_t a1,  __register_t a2,
 
 	/* Clear the BSS and SBSS segments */
 #ifdef __CHERI_PURE_CAPABILITY__
-	argv = cheri_ptrperm(cheri_setaddress(cheri_kseg0_capability, a1),
+	argv = cheri_ptrperm(cheri_setaddress(mips_kseg0_cap, a1),
 	    argc * sizeof(uint64_t), CHERI_PERM_LOAD);
-	envp = cheri_andperm(cheri_setaddress(cheri_kseg0_capability, a2),
+	envp = cheri_andperm(cheri_setaddress(mips_kseg0_cap, a2),
 	    CHERI_PERM_LOAD);
-	platform_clear_bss(cheri_kdata_capability);
+	platform_clear_bss(kernel_data_cap);
 #else
 	argv = (int32_t *)a1;
 	envp = (int32_t *)a2;

--- a/sys/mips/mips/busdma_machdep.c
+++ b/sys/mips/mips/busdma_machdep.c
@@ -1156,7 +1156,7 @@ bus_dmamap_sync_buf(vm_pointer_t buf, int len, bus_dmasync_op_t op, int aligned)
 			 * misalignment since buf_cl is aligned to cache line.
 			 */
 			buf_cl = (vm_pointer_t)cheri_ptrperm(
-			    cheri_setoffset(cheri_kall_capability, tmp_va),
+			    cheri_setoffset(kernel_root_cap, tmp_va),
 			    size_cl, CHERI_PERMS_KERNEL_DATA);
 			KASSERT(is_aligned(buf_cl, sizeof(void *)),
 			    ("dmamap cacheline head source buffer is not"
@@ -1171,7 +1171,7 @@ bus_dmamap_sync_buf(vm_pointer_t buf, int len, bus_dmasync_op_t op, int aligned)
 		    (tmp_va & cache_linesize_mask)) & cache_linesize_mask;
 		if (size_clend) {
 			buf_clend = (vm_pointer_t)cheri_ptrperm(
-			    cheri_setoffset(cheri_kall_capability, tmp_va),
+			    cheri_setoffset(kernel_root_cap, tmp_va),
 			    size_clend, CHERI_PERMS_KERNEL_DATA);
 			/* Enforce the same misalignment as in buf_clend */
 			tmp_clend += mips_dcache_max_linesize - size_clend;

--- a/sys/mips/mips/locore.S
+++ b/sys/mips/mips/locore.S
@@ -196,7 +196,7 @@ VECTOR(_locore, unknown)
 	csetbounds	CHERI_REG_C27, CHERI_REG_C27, t0
 	REG_LI	t0, CHERI_SEALCAP_USERSPACE_PERMS
 	candperm	CHERI_REG_C27, CHERI_REG_C27, t0
-	PTR_LA	t0, _C_LABEL(userspace_sealcap)
+	PTR_LA	t0, _C_LABEL(userspace_root_sealcap)
 	csc	CHERI_REG_C27, t0, 0($ddc)
 
 	/*

--- a/sys/mips/mips/locore.S
+++ b/sys/mips/mips/locore.S
@@ -163,7 +163,7 @@ VECTOR(_locore, unknown)
 	csetbounds	CHERI_REG_C27, CHERI_REG_C27, t0
 	REG_LI	t0, CHERI_SEALCAP_KERNEL_PERMS
 	candperm	CHERI_REG_C27, CHERI_REG_C27, t0
-	PTR_LA	t0, _C_LABEL(kernel_sealcap)
+	PTR_LA	t0, _C_LABEL(kernel_root_sealcap)
 	csc	CHERI_REG_C27, t0, 0($ddc)
 
 	/*

--- a/sys/mips/mips/locore.S
+++ b/sys/mips/mips/locore.S
@@ -183,7 +183,7 @@ VECTOR(_locore, unknown)
 	csetbounds	CHERI_REG_C27, CHERI_REG_C27, t0
 	REG_LI	t0, CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS
 	candperm	CHERI_REG_C27, CHERI_REG_C27, t0
-	PTR_LA	t0, _C_LABEL(userspace_cap)
+	PTR_LA	t0, _C_LABEL(userspace_root_cap)
 	csc	CHERI_REG_C27, t0, 0($ddc)
 
 	/*

--- a/sys/mips/mips/vm_machdep.c
+++ b/sys/mips/mips/vm_machdep.c
@@ -293,7 +293,7 @@ cpu_thread_free(struct thread *td)
 	 * and make sure that the kstack cache zone can rebuild the full capability.
 	 */
 	td->td_kstack = (vm_pointer_t)cheri_ptrperm(
-	    cheri_setaddress(cheri_kall_capability,
+	    cheri_setaddress(kernel_root_cap,
 	        cheri_getbase((void *)td->td_kstack)),
 	    td->td_kstack_pages * PAGE_SIZE, CHERI_PERMS_KERNEL_DATA);
 #endif

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -53,7 +53,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_KERNEL_BASE);
 	ctemp = cheri_setbounds(kroot, CHERI_SEALCAP_KERNEL_LENGTH);
 	ctemp = cheri_andperm(kroot, CHERI_SEALCAP_KERNEL_PERMS);
-	kernel_sealcap = ctemp;
+	kernel_root_sealcap = ctemp;
 
 	ctemp = cheri_setaddress(kroot, CHERI_CAP_USER_DATA_BASE);
 	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -59,7 +59,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);
 	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS);
-	userspace_cap = ctemp;
+	userspace_root_cap = ctemp;
 
 	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_USERSPACE_BASE);
 	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -64,7 +64,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_USERSPACE_BASE);
 	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
 	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
-	userspace_sealcap = ctemp;
+	userspace_root_sealcap = ctemp;
 
 	swap_restore_cap = kroot;
 

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -43,7 +43,7 @@
 #include <machine/riscvreg.h>
 #include <machine/vmparam.h>
 
-void *cheri_kall_capability = (void *)(intcap_t)-1;
+void *kernel_root_cap = (void *)(intcap_t)-1;
 
 void
 cheri_init_capabilities(void * __capability kroot)
@@ -74,7 +74,8 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_andperm(ctemp, CHERI_PERMS_KERNEL_DATA);
 	devmap_init_capability(ctemp);
 
-	cheri_kall_capability = kroot;
+	kernel_root_cap = cheri_andperm(kroot,
+	    ~(CHERI_PERM_SEAL | CHERI_PERM_UNSEAL));
 #endif
 }
 

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -978,7 +978,7 @@ try_load_dtb(caddr_t kmdp)
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (dtbp != (vm_pointer_t)NULL) {
 		dtbp = (vm_pointer_t)cheri_andperm(cheri_setaddress(
-		    cheri_kall_capability, dtbp), CHERI_PERMS_KERNEL_DATA);
+		    kernel_root_cap, dtbp), CHERI_PERMS_KERNEL_DATA);
 		dtbp = (vm_pointer_t)cheri_setbounds((void *)dtbp,
 		    fdt_totalsize((void *)dtbp));
 	}
@@ -1076,7 +1076,7 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(vm_offset_t));
 	PRELOAD_PUSH_VALUE(vm_offset_t, lastaddr);
 #ifdef __CHERI_PURE_CAPABILITY__
-	void *dtbp = cheri_setbounds(cheri_setaddress(cheri_kall_capability,
+	void *dtbp = cheri_setbounds(cheri_setaddress(kernel_root_cap,
 	    lastaddr), dtb_size);
 	memmove(dtbp, (const void *)rvbp->dtbp_virt, dtb_size);
 	lastaddr = roundup(lastaddr + cheri_getlen(dtbp), sizeof(int));

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -537,7 +537,7 @@ pmap_bootstrap_dmap(vm_pointer_t kern_l1, vm_paddr_t min_pa, vm_paddr_t max_pa)
 	dmap_phys_max = pa;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	dmap_capability = cheri_setaddress(cheri_kall_capability,
+	dmap_capability = cheri_setaddress(kernel_root_cap,
 	    DMAP_MIN_ADDRESS);
 	dmap_capability = cheri_setbounds(dmap_capability,
 	    dmap_phys_max - dmap_phys_base);
@@ -652,7 +652,7 @@ pmap_bootstrap(vm_pointer_t l1pt, vm_paddr_t kernstart, vm_size_t kernlen)
 
 	freemempos = roundup2(KERNBASE + kernlen, PAGE_SIZE);
 #ifdef __CHERI_PURE_CAPABILITY__
-	freemempos = (vm_pointer_t)cheri_setaddress(cheri_kall_capability,
+	freemempos = (vm_pointer_t)cheri_setaddress(kernel_root_cap,
 	    freemempos);
 #endif
 

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -455,7 +455,7 @@ kern_mmap(struct thread *td, uintptr_t addr0, size_t len, int prot, int flags,
 		.mr_pos = pos,
 #ifdef __CHERI_PURE_CAPABILITY__
 		/* Needed for fixed mappings */
-		.mr_source_cap = userspace_cap
+		.mr_source_cap = userspace_root_cap,
 #endif
 	};
 


### PR DESCRIPTION
Moved to {kernel,userspace}_*cap naming for capabilities.
I renamed the mips-specific ones by prefixing them with `mips_` as in `mips_xkseg_cap` instead of using the `kernel_*` prefix as I would not expect those to be used outside MD code.