### PR TITLE
Work around Jenkins build parameter behaviour

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,11 @@ ls -la "artifacts-${suffix}/"
         }
     }
 }
-def selectedArchitectures = params.architectures.split('\n')
+
+// Work around for https://issues.jenkins.io/browse/JENKINS-46941
+// Jenkins appears to use the last selected manual override for automatically triggered builds.
+// Therefore, only read the parameter value for manually-triggered builds.
+def selectedArchitectures = isManualBuild() ? params.architectures.split('\n') : allArchitectures
 echo("Selected architectures: ${selectedArchitectures}")
 selectedArchitectures.each { suffix ->
     String name = "cheribsd-${suffix}"


### PR DESCRIPTION
Jenkins appears to use the last selected manual override for
automatically triggered builds. This appears to use the last manual
selection across *all* branches for multi-branch pipelines.
This is causing some pull requests on the dev branch to be built using
a manual selection of morello-purecap and that does not work yet.
Therefore, ignore the parameter value except for manually-triggered builds.

This appears to be https://issues.jenkins.io/browse/JENKINS-46941