### PR TITLE
Add four test cases relating to varargs:

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -8,6 +8,7 @@ SRCS+=	cheribsdtest_bounds_globals.c					\
 	cheribsdtest_bounds_globals_x.c					\
 	cheribsdtest_bounds_heap.c					\
 	cheribsdtest_bounds_stack.c					\
+	cheribsdtest_bounds_varargs.c					\
 	cheribsdtest_fault.c						\
 	cheribsdtest_flag_captured.c					\
 	cheribsdtest_kbounce.c						\

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2018 Robert N. M. Watson
+ * Copyright (c) 2012-2018, 2020 Robert N. M. Watson
  * Copyright (c) 2014-2016 SRI International
  * All rights reserved.
  *
@@ -945,9 +945,24 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "Check bounds on a 1,048,576-byte dynamic stack allocation",
 	  .ct_func = test_bounds_stack_dynamic_1048576, },
 
+#ifdef __CHERI_PURE_CAPABILITY__
 	/*
-	 * Test bounds on varargs.
+	 * Test bounds on varargs.  Bounds checking of varargs is supported
+	 * only in our pure-capability ABIs, so don't these tests on hybrid
+	 * code.
 	 */
+	{ .ct_name = "test_bounds_varargs_empty_pointer_null",
+	  .ct_desc = "check that empty varargs gives a tag violation on load",
+	  .ct_func = test_bounds_varargs_empty_pointer_null,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGPROT,
+	  .ct_si_code = PROT_CHERI_TAG,
+	  .ct_si_trapno = TRAPNO_CHERI,
+#if defined(__riscv) || defined(__aarch64__)
+	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
+#endif
+	},
+
 	{ .ct_name = "test_bounds_varargs_vaarg_overflow",
 	  .ct_desc = "check that va_arg() triggers a fault on overrun",
 	  .ct_func = test_bounds_varargs_vaarg_overflow,
@@ -955,8 +970,8 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_BOUNDS,
 	  .ct_si_trapno = TRAPNO_CHERI,
-#ifndef __CHERI_PURE_CAPABILITY__
-	  .ct_xfail_reason = "No varargs bounds in hybrid compilation",
+#if defined(__riscv) || defined(__aarch64__)
+	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
 #endif
 	  },
 
@@ -967,8 +982,8 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_BOUNDS,
 	  .ct_si_trapno = TRAPNO_CHERI,
-#ifndef __CHERI_PURE_CAPABILITY__
-	  .ct_xfail_reason = "No varargs bounds in hybrid compilation",
+#if defined(__riscv) || defined(__aarch64__)
+	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
 #endif
 	  },
 
@@ -979,10 +994,11 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_signum = SIGPROT,
 	  .ct_si_code = PROT_CHERI_BOUNDS,
 	  .ct_si_trapno = TRAPNO_CHERI,
-#ifndef __CHERI_PURE_CAPABILITY__
-	  .ct_xfail_reason = "No varargs bounds in hybrid compilation",
+#if defined(__riscv) || defined(__aarch64__)
+	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
 #endif
 	  },
+#endif
 
 	/*
 	 * Unsandboxed virtual-memory tests.

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -985,7 +985,7 @@ static const struct cheri_test cheri_tests[] = {
 #if defined(__riscv) || defined(__aarch64__)
 	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
 #endif
-	  },
+	},
 
 	{ .ct_name = "test_bounds_varargs_printf_store",
 	  .ct_desc = "check that store via printf varargs overflow faults",

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -997,7 +997,7 @@ static const struct cheri_test cheri_tests[] = {
 #if defined(__riscv) || defined(__aarch64__)
 	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
 #endif
-	  },
+	},
 #endif
 
 	/*

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -946,6 +946,45 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_func = test_bounds_stack_dynamic_1048576, },
 
 	/*
+	 * Test bounds on varargs.
+	 */
+	{ .ct_name = "test_bounds_varargs_vaarg_overflow",
+	  .ct_desc = "check that va_arg() triggers a fault on overrun",
+	  .ct_func = test_bounds_varargs_vaarg_overflow,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGPROT,
+	  .ct_si_code = PROT_CHERI_BOUNDS,
+	  .ct_si_trapno = TRAPNO_CHERI,
+#ifndef __CHERI_PURE_CAPABILITY__
+	  .ct_xfail_reason = "No varargs bounds in hybrid compilation",
+#endif
+	  },
+
+	{ .ct_name = "test_bounds_varargs_printf_load",
+	  .ct_desc = "check that load via printf varargs overflow faults",
+	  .ct_func = test_bounds_varargs_printf_load,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGPROT,
+	  .ct_si_code = PROT_CHERI_BOUNDS,
+	  .ct_si_trapno = TRAPNO_CHERI,
+#ifndef __CHERI_PURE_CAPABILITY__
+	  .ct_xfail_reason = "No varargs bounds in hybrid compilation",
+#endif
+	  },
+
+	{ .ct_name = "test_bounds_varargs_printf_store",
+	  .ct_desc = "check that store via printf varargs overflow faults",
+	  .ct_func = test_bounds_varargs_printf_store,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGPROT,
+	  .ct_si_code = PROT_CHERI_BOUNDS,
+	  .ct_si_trapno = TRAPNO_CHERI,
+#ifndef __CHERI_PURE_CAPABILITY__
+	  .ct_xfail_reason = "No varargs bounds in hybrid compilation",
+#endif
+	  },
+
+	/*
 	 * Unsandboxed virtual-memory tests.
 	 */
 	{ .ct_name = "cheribsdtest_vm_tag_mmap_anon",

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -973,7 +973,7 @@ static const struct cheri_test cheri_tests[] = {
 #if defined(__riscv) || defined(__aarch64__)
 	  .ct_xfail_reason = "varargs bounds broken on pure-capability RISC-V and Morello",
 #endif
-	  },
+	},
 
 	{ .ct_name = "test_bounds_varargs_printf_load",
 	  .ct_desc = "check that load via printf varargs overflow faults",

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -349,6 +349,7 @@ DECLARE_CHERIBSD_TEST(test_bounds_stack_dynamic_524288);
 DECLARE_CHERIBSD_TEST(test_bounds_stack_dynamic_1048576);
 
 /* cheribsdtest_bounds_varargs.c */
+DECLARE_CHERIBSD_TEST(test_bounds_varargs_empty_pointer_null);
 DECLARE_CHERIBSD_TEST(test_bounds_varargs_vaarg_overflow);
 DECLARE_CHERIBSD_TEST(test_bounds_varargs_printf_load);
 DECLARE_CHERIBSD_TEST(test_bounds_varargs_printf_store);

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2012-2018 Robert N. M. Watson
+ * Copyright (c) 2012-2018, 2020 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
  * All rights reserved.
  *
@@ -347,6 +347,11 @@ DECLARE_CHERIBSD_TEST(test_bounds_stack_dynamic_131072);
 DECLARE_CHERIBSD_TEST(test_bounds_stack_dynamic_262144);
 DECLARE_CHERIBSD_TEST(test_bounds_stack_dynamic_524288);
 DECLARE_CHERIBSD_TEST(test_bounds_stack_dynamic_1048576);
+
+/* cheribsdtest_bounds_varargs.c */
+DECLARE_CHERIBSD_TEST(test_bounds_varargs_vaarg_overflow);
+DECLARE_CHERIBSD_TEST(test_bounds_varargs_printf_load);
+DECLARE_CHERIBSD_TEST(test_bounds_varargs_printf_store);
 
 /* cheribsdtest_ccall.c */
 void	cheribsdtest_ccall_setup(void);

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -59,10 +59,10 @@
  * Directly overflow the varargs array by accessing off the end using
  * va_arg() one too many times.
  */
-static volatile int *p;
 static void
 varargs_test_onearg(const char *fmt, ...)
 {
+	int * volatile p;
 	va_list ap;
 
 	va_start(ap, fmt);

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -30,11 +30,6 @@
  */
 
 #include <sys/cdefs.h>
-
-#if !__has_feature(capabilities)
-#error "This code requires a CHERI-aware compiler"
-#endif
-
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
@@ -62,7 +57,7 @@
 static __noinline void
 varargs_test_onearg(const char *fmt, ...)
 {
-	int * volatile p;
+	int volatile i;
 	va_list ap;
 
 	va_start(ap, fmt);
@@ -71,7 +66,7 @@ varargs_test_onearg(const char *fmt, ...)
 	(void)va_arg(ap, void *);
 
 	/* Improperly access invalid second pointer argument. */
-	p = va_arg(ap, int *);
+	i = va_arg(ap, int);
 
 	cheribsdtest_failure_errx("va_arg() overran bounds without fault");
 }

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -57,7 +57,7 @@
 static __noinline void
 varargs_test_onearg(const char *fmt, ...)
 {
-	int volatile i;
+	volatile int i;
 	va_list ap;
 
 	va_start(ap, fmt);

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -65,7 +65,7 @@ varargs_test_onearg(const char *fmt, ...)
 	/* Ignore valid first pointer argument. */
 	(void)va_arg(ap, void *);
 
-	/* Improperly access invalid second pointer argument. */
+	/* Improperly access invalid second argument. */
 	i = va_arg(ap, int);
 
 	cheribsdtest_failure_errx("va_arg() overran bounds without fault");

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -59,7 +59,7 @@
  * Directly overflow the varargs array by accessing off the end using
  * va_arg() one too many times.
  */
-static void
+static __noinline void
 varargs_test_onearg(const char *fmt, ...)
 {
 	int * volatile p;


### PR DESCRIPTION
(1) Check that calling va_arg() one too many times generates a bounds
  violation.

(2) Check that printf() with an extra %p generates a bounds violation.

(3) Check that printf() with an extra %n generates a bounds violation.

Use an additional %c before the latter two in order to force allocation
of a varargs array.