### PR TITLE
[UPSTREAM] libarchive: Fix UB in deconst() function

### DIFF
--- a/contrib/libarchive/libarchive/archive_read_support_format_warc.c
+++ b/contrib/libarchive/libarchive/archive_read_support_format_warc.c
@@ -427,7 +427,7 @@ _warc_skip(struct archive_read *a)
 static void*
 deconst(const void *c)
 {
-	return (char *)0x1 + (((const char *)c) - (const char *)0x1);
+	return (void *)(uintptr_t)c;
 }
 
 static char*


### PR DESCRIPTION
Creating a pointer by adding an offset to 0x1 is undefined behaviour and
results in an invalid pointer when running on CHERI systems. Use a
standards-compliant cast via uintptr_t instead.

This was found due to a crash while running the libarchive test suite on a
CHERI-RISC-V system.

Submitted upstream as https://github.com/libarchive/libarchive/pull/1465