### PR TITLE
Set imply_prot_max to on by default

### DIFF
--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -118,7 +118,7 @@ SYSCTL_INT(_vm, OID_AUTO, old_mlock, CTLFLAG_RWTUN, &old_mlock, 0,
 static int mincore_mapped = 1;
 SYSCTL_INT(_vm, OID_AUTO, mincore_mapped, CTLFLAG_RWTUN, &mincore_mapped, 0,
     "mincore reports mappings, not residency");
-static int imply_prot_max = 0;
+static int imply_prot_max = 1;
 SYSCTL_INT(_vm, OID_AUTO, imply_prot_max, CTLFLAG_RWTUN, &imply_prot_max, 0,
     "Imply maximum page protections in mmap() when none are specified");
 static int log_wxrequests = 0;


### PR DESCRIPTION
Unlike upstream FreeBSD, we check max_prot in mmap(), so the implied RWX
max_prot for non-CHERI programs was causing mmap to fail with capsicum
errors for file descriptors that are read-only. This caused 13 test failures
happens in the usr.bin/tail tests. A better fix would be to clamp the
default max_prot value to whatever the capsicum rights permit, but that is
something that should be fixed upstream.