### PR TITLE
Purecap ddb

### DIFF
--- a/sys/ddb/db_command.c
+++ b/sys/ddb/db_command.c
@@ -601,7 +601,7 @@ typedef db_expr_t __db_f(db_expr_t, db_expr_t, db_expr_t, db_expr_t,
 static __inline int
 db_fncall_generic(db_expr_t addr, db_expr_t *rv, int nargs, db_expr_t args[])
 {
-	__db_f *f = (__db_f *)addr;
+	__db_f *f = (__db_f *)DB_CODE_PTR(addr);
 
 	if (nargs > 10) {
 		db_printf("Too many arguments (max 10)\n");
@@ -901,7 +901,7 @@ db_stack_trace_all(db_expr_t dummy, bool dummy2, db_expr_t dummy3,
 db_expr_t
 db_hex2dec(db_expr_t expr)
 {
-	uintptr_t x, y;
+	uintmax_t x, y;
 	db_expr_t val;
 
 	y = 1;
@@ -916,3 +916,13 @@ db_hex2dec(db_expr_t expr)
 	}
 	return (val);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer",
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ddb/db_main.c
+++ b/sys/ddb/db_main.c
@@ -81,6 +81,11 @@ vm_size_t ksymtab_size;
 vm_offset_t ksymtab_relbase;
 static struct db_private ksymtab_private;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+void *db_code_cap;
+void *db_data_cap;
+#endif
+
 bool
 X_db_line_at_pc(db_symtab_t *symtab, c_db_sym_t sym, char **file, int *line,
     db_expr_t off)
@@ -241,6 +246,10 @@ db_init(void)
 		    (char *)(ksymtab + ksymtab_size), "elf", (char *)&ksymtab_private);
 	}
 	db_add_symbol_table(NULL, NULL, "kld", NULL);
+#ifdef __CHERI_PURE_CAPABILITY__
+	db_code_cap = cheri_andperm(kernel_root_cap, CHERI_PERMS_KERNEL_CODE);
+	db_data_cap = cheri_andperm(kernel_root_cap, CHERI_PERMS_KERNEL_DATA);
+#endif
 	return (1);	/* We're the default debugger. */
 }
 
@@ -310,6 +319,26 @@ db_trace_thread_wrapper(struct thread *td)
 		db_trace_thread(td, -1);
 	(void)kdb_jmpbuf(prev_jb);
 }
+
+#ifdef __CHERI_PURE_CAPABILITY__
+void *
+db_code_ptr(db_addr_t addr)
+{
+	return (cheri_setaddress(db_code_cap, addr));
+}
+
+void *
+db_data_ptr_unbound(db_addr_t addr)
+{
+	return (cheri_setaddress(db_data_cap, addr));
+}
+
+void *
+db_data_ptr(db_addr_t addr, size_t len)
+{
+	return (cheri_setbounds(db_data_ptr_unbound(addr), len));
+}
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20200706,

--- a/sys/ddb/db_thread.c
+++ b/sys/ddb/db_thread.c
@@ -119,7 +119,7 @@ db_lookup_thread(db_expr_t addr, bool check_pid)
 	 */
 	decaddr = db_hex2dec(addr);
 	if (decaddr == -1)
-		return ((struct thread *)addr);
+		return (DB_DATA_PTR(addr, struct thread));
 
 	td = kdb_thr_lookup(decaddr);
 	if (td != NULL)
@@ -130,7 +130,7 @@ db_lookup_thread(db_expr_t addr, bool check_pid)
 				return (FIRST_THREAD_IN_PROC(p));
 		}
 	}
-	return ((struct thread *)addr);
+	return (DB_DATA_PTR(addr, struct thread));
 }
 
 /*
@@ -152,5 +152,15 @@ db_lookup_proc(db_expr_t addr)
 				return (p);
 		}
 	}
-	return ((struct proc *)addr);
+	return (DB_DATA_PTR(addr, struct proc));
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer",
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ddb/ddb.h
+++ b/sys/ddb/ddb.h
@@ -83,7 +83,9 @@ int	DB_CALL(db_expr_t, db_expr_t *, int, db_expr_t[]);
  * Most users should use db_fetch_symtab in order to set them from the
  * boot loader provided values.
  */
-extern vm_offset_t ksymtab, kstrtab, ksymtab_size, ksymtab_relbase;
+extern vm_pointer_t ksymtab, kstrtab;
+extern vm_size_t ksymtab_size;
+extern vm_offset_t ksymtab_relbase;
 
 /*
  * There are three "command tables":
@@ -228,7 +230,7 @@ bool		db_value_of_name_vnet(const char *name, db_expr_t *valuep);
 int		db_write_bytes(vm_offset_t addr, size_t size, char *data);
 void		db_command_register(struct command_table *, struct command *);
 void		db_command_unregister(struct command_table *, struct command *);
-int		db_fetch_ksymtab(vm_offset_t ksym_start, vm_offset_t ksym_end,
+int		db_fetch_ksymtab(vm_pointer_t ksym_start, vm_pointer_t ksym_end,
 		    vm_offset_t relbase);
 
 db_cmdfcn_t	db_breakpoint_cmd;
@@ -297,3 +299,12 @@ extern int	textdump_pending;	/* Call textdump_dumpsys() instead. */
 void	textdump_dumpsys(struct dumperinfo *di);
 
 #endif /* !_DDB_DDB_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ddb/ddb.h
+++ b/sys/ddb/ddb.h
@@ -232,6 +232,11 @@ void		db_command_register(struct command_table *, struct command *);
 void		db_command_unregister(struct command_table *, struct command *);
 int		db_fetch_ksymtab(vm_pointer_t ksym_start, vm_pointer_t ksym_end,
 		    vm_offset_t relbase);
+#ifdef __CHERI_PURE_CAPABILITY__
+void		*db_code_ptr(db_addr_t addr);
+void		*db_data_ptr_unbound(db_addr_t addr);
+void		*db_data_ptr(db_addr_t addr, size_t len);
+#endif
 
 db_cmdfcn_t	db_breakpoint_cmd;
 db_cmdfcn_t	db_capture_cmd;
@@ -298,13 +303,28 @@ int	textdump_writenextblock(struct dumperinfo *di, char *buffer);
 extern int	textdump_pending;	/* Call textdump_dumpsys() instead. */
 void	textdump_dumpsys(struct dumperinfo *di);
 
+/*
+ * Macros to construct valid pointers from addresses.
+ */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	DB_CODE_PTR(addr)			db_code_ptr((addr))
+#define	DB_DATA_PTR_LEN(addr, type, len)	((type *)db_data_ptr((addr), (len)))
+#define	DB_DATA_PTR_UNBOUND(addr, type)		((type *)db_data_ptr_unbound((addr)))
+#else
+#define	DB_CODE_PTR(addr)			((void *)(addr))
+#define	DB_DATA_PTR_LEN(addr, type, len)	((type *)(addr))
+#define	DB_DATA_PTR_UNBOUND(addr, type)		((type *)(addr))
+#endif
+#define	DB_DATA_PTR(addr, type)			DB_DATA_PTR_LEN(addr, type, sizeof(type))
+
 #endif /* !_DDB_DDB_H_ */
 // CHERI CHANGES START
 // {
 //   "updated": 20200803,
 //   "target_type": "kernel",
 //   "changes_purecap": [
-//     "pointer_as_integer"
+//     "pointer_as_integer",
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/geom/geom_subr.c
+++ b/sys/geom/geom_subr.c
@@ -1574,18 +1574,20 @@ DB_SHOW_COMMAND(geom, db_show_geom)
 				break;
 		}
 	} else {
-		switch (g_valid_obj((void *)addr)) {
+		switch (g_valid_obj((void *)(uintptr_t)addr)) {
 		case 1:
-			db_show_geom_class((struct g_class *)addr);
+			db_show_geom_class(DB_DATA_PTR(addr, struct g_class));
 			break;
 		case 2:
-			db_show_geom_geom(0, (struct g_geom *)addr);
+			db_show_geom_geom(0, DB_DATA_PTR(addr, struct g_geom));
 			break;
 		case 3:
-			db_show_geom_consumer(0, (struct g_consumer *)addr);
+			db_show_geom_consumer(0, DB_DATA_PTR(addr,
+			    struct g_consumer));
 			break;
 		case 4:
-			db_show_geom_provider(0, (struct g_provider *)addr);
+			db_show_geom_provider(0, DB_DATA_PTR(addr,
+			    struct g_provider));
 			break;
 		default:
 			db_printf("Not a GEOM object.\n");
@@ -1641,7 +1643,7 @@ DB_SHOW_COMMAND(bio, db_show_bio)
 	struct bio *bp;
 
 	if (have_addr) {
-		bp = (struct bio *)addr;
+		bp = DB_DATA_PTR(addr, struct bio);
 		db_printf("BIO %p\n", bp);
 		db_print_bio_cmd(bp);
 		db_print_bio_flags(bp);
@@ -1674,3 +1676,12 @@ DB_SHOW_COMMAND(bio, db_show_bio)
 #undef	ADDFLAG
 
 #endif	/* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/kern_conf.c
+++ b/sys/kern/kern_conf.c
@@ -1537,7 +1537,7 @@ DB_SHOW_COMMAND(cdev, db_show_cdev)
 		return;
 	}
 
-	dev = (struct cdev *)addr;
+	dev = DB_DATA_PTR(addr, struct cdev);
 	cdp = cdev2priv(dev);
 	db_printf("dev %s ref %d use %ld thr %ld inuse %u fdpriv %p\n",
 	    dev->si_name, dev->si_refcount, dev->si_usecount,
@@ -1577,3 +1577,12 @@ DB_SHOW_COMMAND(cdev, db_show_cdev)
 	db_printf("cdp_flags %s\n", buf);
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -4635,7 +4635,7 @@ DB_SHOW_COMMAND(file, db_show_file)
 		db_printf("usage: show file <addr>\n");
 		return;
 	}
-	fp = (struct file *)addr;
+	fp = DB_DATA_PTR(addr, struct file);
 	db_print_file(fp, 1);
 }
 
@@ -4918,6 +4918,9 @@ SYSINIT(fildescdev, SI_SUB_DRIVERS, SI_ORDER_MIDDLE, fildesc_drvinit, NULL);
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -4272,7 +4272,7 @@ DB_SHOW_COMMAND(prison, db_show_prison_command)
 					break;
 		if (pr == NULL)
 			/* Assume address points to a valid prison. */
-			pr = (struct prison *)addr;
+			pr = DB_DATA_PTR(addr, struct prison);
 	}
 	db_show_prison(pr);
 }
@@ -4285,6 +4285,9 @@ DB_SHOW_COMMAND(prison, db_show_prison_command)
 //   "changes": [
 //     "iovec-macros",
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -1459,7 +1459,7 @@ DB_SHOW_COMMAND(multizone_matches, db_show_multizone_matches)
 		db_printf("Usage: show multizone_matches <malloc type/addr>\n");
 		return;
 	}
-	mtp = (void *)addr;
+	mtp = DB_DATA_PTR(addr, struct malloc_type);
 	if (mtp->ks_version != M_VERSION) {
 		db_printf("Version %lx does not match expected %x\n",
 		    mtp->ks_version, M_VERSION);
@@ -1486,6 +1486,9 @@ DB_SHOW_COMMAND(multizone_matches, db_show_multizone_matches)
 //   "target_type": "kernel",
 //   "changes": [
 //     "integer_provenance"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_timeout.c
+++ b/sys/kern/kern_timeout.c
@@ -1476,7 +1476,7 @@ DB_SHOW_COMMAND(callout, db_show_callout)
 		return;
 	}
 
-	_show_callout((struct callout *)addr);
+	_show_callout(DB_DATA_PTR(addr, struct callout));
 }
 
 static void
@@ -1517,3 +1517,12 @@ DB_SHOW_COMMAND(callout_last, db_show_callout_last)
 	}
 }
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_bus.c
+++ b/sys/kern/subr_bus.c
@@ -6086,15 +6086,9 @@ _gone_in_dev(device_t dev, int major, const char *msg)
 }
 
 #ifdef DDB
-DB_SHOW_COMMAND(device, db_show_device)
+static void
+db_print_device(device_t dev)
 {
-	device_t dev;
-
-	if (!have_addr)
-		return;
-
-	dev = (device_t)addr;
-
 	db_printf("name:    %s\n", device_get_nameunit(dev));
 	db_printf("  driver:  %s\n", DRIVERNAME(dev->driver));
 	db_printf("  class:   %s\n", DEVCLANAME(dev->devclass));
@@ -6104,12 +6098,32 @@ DB_SHOW_COMMAND(device, db_show_device)
 	db_printf("  ivars:   %p\n", dev->ivars);
 }
 
+DB_SHOW_COMMAND(device, db_show_device)
+{
+	device_t dev;
+
+	if (!have_addr)
+		return;
+
+	dev = DB_DATA_PTR(addr, struct device);
+	db_print_device(dev);
+}
+
 DB_SHOW_ALL_COMMAND(devices, db_show_all_devices)
 {
 	device_t dev;
 
 	TAILQ_FOREACH(dev, &bus_data_devices, devlink) {
-		db_show_device((db_expr_t)dev, true, count, modif);
+		db_print_device(dev);
 	}
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_lock.c
+++ b/sys/kern/subr_lock.c
@@ -194,7 +194,12 @@ DB_SHOW_COMMAND(lock, db_show_lock)
 
 	if (!have_addr)
 		return;
-	lock = (struct lock_object *)addr;
+
+	/*
+	 * XXX: Can't narrow bounds as this is a base class and lc_ddb_show
+	 * can access members in the subclass.
+	 */
+	lock = DB_DATA_PTR_UNBOUND(addr, struct lock_object);
 	if (LO_CLASSINDEX(lock) > LOCK_CLASS_MAX) {
 		db_printf("Unknown lock class: %d\n", LO_CLASSINDEX(lock));
 		return;
@@ -749,3 +754,12 @@ SYSCTL_PROC(_debug_lock_prof, OID_AUTO, enable,
     "Enable lock profiling");
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_pctrie.c
+++ b/sys/kern/subr_pctrie.c
@@ -802,7 +802,7 @@ DB_SHOW_COMMAND(pctrienode, db_show_pctrienode)
 
         if (!have_addr)
                 return;
-	node = (struct pctrie_node *)addr;
+	node = DB_DATA_PTR(addr, struct pctrie_node);
 	db_printf("node %p, owner %jx, children count %u, level %u:\n",
 	    (void *)node, (uintmax_t)node->pn_owner, node->pn_count,
 	    node->pn_clev);
@@ -817,3 +817,12 @@ DB_SHOW_COMMAND(pctrienode, db_show_pctrienode)
 	}
 }
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200127,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_rangeset.c
+++ b/sys/kern/subr_rangeset.c
@@ -351,7 +351,7 @@ DB_SHOW_COMMAND(rangeset, rangeset_show_fn)
 		return;
 	}
 
-	rs = (struct rangeset *)addr;
+	rs = DB_DATA_PTR(addr, struct rangeset);
 	db_printf("rangeset %p\n", rs);
 	for (cursor = 0;; cursor = r->re_start + 1) {
 		r1 = pctrie_lookup_ge(&rs->rs_trie, cursor);
@@ -363,3 +363,12 @@ DB_SHOW_COMMAND(rangeset, rangeset_show_fn)
 	}
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_rman.c
+++ b/sys/kern/subr_rman.c
@@ -1111,10 +1111,12 @@ dump_rman(struct rman *rm)
 
 DB_SHOW_COMMAND(rman, db_show_rman)
 {
+	struct rman *rm;
 
 	if (have_addr) {
-		dump_rman_header((struct rman *)addr);
-		dump_rman((struct rman *)addr);
+		rm = DB_DATA_PTR(addr, struct rman);
+		dump_rman_header(rm);
+		dump_rman(rm);
 	}
 }
 
@@ -1138,3 +1140,12 @@ DB_SHOW_ALL_COMMAND(rman, db_show_all_rman)
 }
 DB_SHOW_ALIAS(allrman, db_show_all_rman);
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_turnstile.c
+++ b/sys/kern/subr_turnstile.c
@@ -1314,7 +1314,7 @@ DB_SHOW_COMMAND(locktree, db_show_locktree)
 
 	if (!have_addr)
 		return;
-	lock = (struct lock_object *)addr;
+	lock = DB_DATA_PTR(addr, struct lock_object);
 	tc = TC_LOOKUP(lock);
 	LIST_FOREACH(ts, &tc->tc_turnstiles, ts_hash)
 		if (ts->ts_lockobj == lock)
@@ -1327,3 +1327,12 @@ DB_SHOW_COMMAND(locktree, db_show_locktree)
 		print_waiters(ts, 0);
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_vmem.c
+++ b/sys/kern/subr_vmem.c
@@ -1702,7 +1702,7 @@ DB_SHOW_COMMAND(vmemdump, vmemdump)
 		return;
 	}
 
-	vmem_dump((const vmem_t *)addr, db_printf);
+	vmem_dump(DB_DATA_PTR(addr, const vmem_t), db_printf);
 }
 
 DB_SHOW_ALL_COMMAND(vmemdump, vmemdumpall)
@@ -1715,7 +1715,7 @@ DB_SHOW_ALL_COMMAND(vmemdump, vmemdumpall)
 
 DB_SHOW_COMMAND(vmem, vmem_summ)
 {
-	const vmem_t *vm = (const void *)addr;
+	const vmem_t *vm;
 	const bt_t *bt;
 	size_t ft[VMEM_MAXORDER], ut[VMEM_MAXORDER];
 	size_t fs[VMEM_MAXORDER], us[VMEM_MAXORDER];
@@ -1726,6 +1726,7 @@ DB_SHOW_COMMAND(vmem, vmem_summ)
 		return;
 	}
 
+	vm = DB_DATA_PTR(addr, const vmem_t);
 	db_printf("vmem %p '%s'\n", vm, vm->vm_name);
 	db_printf("\tquantum:\t%zu\n", vm->vm_quantum_mask + 1);
 	db_printf("\tsize:\t%zu\n", vm->vm_size);
@@ -1826,3 +1827,12 @@ vmem_check(vmem_t *vm)
 }
 
 #endif /* defined(DIAGNOSTIC) */
+// CHERI CHANGES START
+// {
+//   "updated": 20200708,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -2349,7 +2349,7 @@ DB_SHOW_COMMAND(tty, db_show_tty)
 		db_printf("usage: show tty <addr>\n");
 		return;
 	}
-	tp = (struct tty *)addr;
+	tp = DB_DATA_PTR(addr, struct tty);
 
 	db_printf("%p: %s\n", tp, tty_devname(tp));
 	db_printf("\tmtx: %p\n", tp->t_mtx);
@@ -2442,3 +2442,12 @@ DB_SHOW_ALL_COMMAND(ttys, db_show_all_ttys)
 	}
 }
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/uipc_debug.c
+++ b/sys/kern/uipc_debug.c
@@ -494,7 +494,7 @@ DB_SHOW_COMMAND(socket, db_show_socket)
 		db_printf("usage: show socket <addr>\n");
 		return;
 	}
-	so = (struct socket *)addr;
+	so = DB_DATA_PTR(addr, struct socket);
 
 	db_print_socket(so, "socket", 0);
 }
@@ -507,7 +507,7 @@ DB_SHOW_COMMAND(sockbuf, db_show_sockbuf)
 		db_printf("usage: show sockbuf <addr>\n");
 		return;
 	}
-	sb = (struct sockbuf *)addr;
+	sb = DB_DATA_PTR(addr, struct sockbuf);
 
 	db_print_sockbuf(sb, "sockbuf", 0);
 }
@@ -520,7 +520,7 @@ DB_SHOW_COMMAND(protosw, db_show_protosw)
 		db_printf("usage: show protosw <addr>\n");
 		return;
 	}
-	pr = (struct protosw *)addr;
+	pr = DB_DATA_PTR(addr, struct protosw);
 
 	db_print_protosw(pr, "protosw", 0);
 }
@@ -533,8 +533,17 @@ DB_SHOW_COMMAND(domain, db_show_domain)
 		db_printf("usage: show protosw <addr>\n");
 		return;
 	}
-	d = (struct domain *)addr;
+	d = DB_DATA_PTR(addr, struct domain);
 
 	db_print_domain(d, "domain", 0);
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/uipc_usrreq.c
+++ b/sys/kern/uipc_usrreq.c
@@ -2964,7 +2964,7 @@ DB_SHOW_COMMAND(unpcb, db_show_unpcb)
                 db_printf("usage: show unpcb <addr>\n");
                 return;
         }
-        unp = (struct unpcb *)addr;
+	unp = DB_DATA_PTR(addr, struct unpcb);
 
 	db_printf("unp_socket: %p   unp_vnode: %p\n", unp->unp_socket,
 	    unp->unp_vnode);
@@ -2991,3 +2991,12 @@ DB_SHOW_COMMAND(unpcb, db_show_unpcb)
 	db_printf("unp_refcount: %u\n", unp->unp_refcount);
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/vfs_bio.c
+++ b/sys/kern/vfs_bio.c
@@ -5292,7 +5292,7 @@ end_pages:
 DB_SHOW_COMMAND(buffer, db_show_buffer)
 {
 	/* get args */
-	struct buf *bp = (struct buf *)addr;
+	struct buf *bp;
 #ifdef FULL_BUF_TRACKING
 	uint32_t i, j;
 #endif
@@ -5302,6 +5302,7 @@ DB_SHOW_COMMAND(buffer, db_show_buffer)
 		return;
 	}
 
+	bp = DB_DATA_PTR(addr, struct buf);
 	db_printf("buf at %p\n", bp);
 	db_printf("b_flags = 0x%b, b_xflags=0x%b\n",
 	    (u_int)bp->b_flags, PRINT_BUF_FLAGS,
@@ -5439,7 +5440,7 @@ DB_SHOW_COMMAND(vnodebufs, db_show_vnodebufs)
 		db_printf("usage: show vnodebufs <addr>\n");
 		return;
 	}
-	vp = (struct vnode *)addr;
+	vp = DB_DATA_PTR(addr, struct vnode);
 	db_printf("Clean buffers:\n");
 	TAILQ_FOREACH(bp, &vp->v_bufobj.bo_clean.bv_hd, b_bobufs) {
 		db_show_buffer((uintptr_t)bp, 1, 0, NULL);
@@ -5475,3 +5476,12 @@ DB_COMMAND(countfreebufs, db_coundfreebufs)
 	db_printf("numfreebuffers is %d\n", numfreebuffers);
 }
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20190517,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -3551,7 +3551,7 @@ DB_SHOW_COMMAND(vpath, db_show_vpath)
 		return;
 	}
 
-	vp = (struct vnode *)addr;
+	vp = DB_DATA_PTR(addr, struct vnode);
 	db_print_vpath(vp);
 }
 
@@ -4773,6 +4773,9 @@ out:
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/vfs_subr.c
+++ b/sys/kern/vfs_subr.c
@@ -4161,7 +4161,7 @@ DB_SHOW_COMMAND(vnode, db_show_vnode)
 
 	if (!have_addr)
 		return;
-	vp = (struct vnode *)addr;
+	vp = DB_DATA_PTR(addr, struct vnode);
 	vn_printf(vp, "vnode ");
 }
 
@@ -4192,7 +4192,7 @@ DB_SHOW_COMMAND(mount, db_show_mount)
 		return;
 	}
 
-	mp = (struct mount *)addr;
+	mp = DB_DATA_PTR(addr, struct mount);
 	db_printf("%p %s on %s (%s)\n", mp, mp->mnt_stat.f_mntfromname,
 	    mp->mnt_stat.f_mntonname, mp->mnt_stat.f_fstypename);
 
@@ -6839,6 +6839,9 @@ vn_seqc_write_end(struct vnode *vp)
 //   "target_type": "kernel",
 //   "changes": [
 //     "sysctl"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/mips/mips/machdep.c
+++ b/sys/mips/mips/machdep.c
@@ -459,8 +459,8 @@ mips_postboot_fixup(void)
 #ifdef DDB
 	Elf_Size *trampoline_data = (Elf_Size*)kernel_kseg0_end;
 	Elf_Size symtabsize = 0;
-	vm_offset_t ksym_start;
-	vm_offset_t ksym_end;
+	vm_pointer_t ksym_start;
+	vm_pointer_t ksym_end;
 
 	if (trampoline_data[0] == SYMTAB_MAGIC) {
 		symtabsize = trampoline_data[1];
@@ -692,3 +692,12 @@ mips_exc_cntrs_sysctl_register(void *arg)
 
 SYSINIT(sysctl, SI_SUB_KMEM, SI_ORDER_ANY, mips_exc_cntrs_sysctl_register, 0);
 #endif /* defined((MIPS_EXC_CNTRS) */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -3108,7 +3108,7 @@ DB_SHOW_COMMAND(bpf_if, db_show_bpf_if)
 		return;
 	}
 
-	bpf_show_bpf_if((struct bpf_if *)addr);
+	bpf_show_bpf_if(DB_DATA_PTR(addr, struct bpf_if));
 }
 #endif
 // CHERI CHANGES START
@@ -3117,6 +3117,9 @@ DB_SHOW_COMMAND(bpf_if, db_show_bpf_if)
 //   "target_type": "kernel",
 //   "changes": [
 //     "ioctl:misc"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/net/if_debug.c
+++ b/sys/net/if_debug.c
@@ -110,7 +110,7 @@ DB_SHOW_COMMAND(ifnet, db_show_ifnet)
 		return;
 	}
 
-	if_show_ifnet((struct ifnet *)addr);
+	if_show_ifnet(DB_DATA_PTR(addr, struct ifnet));
 }
 
 DB_SHOW_ALL_COMMAND(ifnets, db_show_all_ifnets)
@@ -136,3 +136,12 @@ DB_SHOW_ALL_COMMAND(ifnets, db_show_all_ifnets)
 	}
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/if_llatbl.c
+++ b/sys/net/if_llatbl.c
@@ -860,7 +860,7 @@ DB_SHOW_COMMAND(llentry, db_show_llentry)
 		return;
 	}
 
-	llatbl_lle_show((struct llentry_sa *)addr);
+	llatbl_lle_show(DB_DATA_PTR(addr, struct llentry_sa));
 }
 
 static void
@@ -889,7 +889,7 @@ DB_SHOW_COMMAND(lltable, db_show_lltable)
 		return;
 	}
 
-	llatbl_llt_show((struct lltable *)addr);
+	llatbl_llt_show(DB_DATA_PTR(addr, struct lltable));
 }
 
 DB_SHOW_ALL_COMMAND(lltables, db_show_all_lltables)
@@ -918,3 +918,12 @@ DB_SHOW_ALL_COMMAND(lltables, db_show_all_lltables)
 	}
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/vnet.c
+++ b/sys/net/vnet.c
@@ -735,7 +735,7 @@ DB_SHOW_COMMAND(vnet, db_show_vnet)
 		return;
 	}
 
-	db_vnet_print((struct vnet *)addr);
+	db_vnet_print(DB_DATA_PTR(addr, struct vnet));
 }
 
 static void
@@ -806,3 +806,12 @@ DB_SHOW_COMMAND(vnetrcrs, db_show_vnetrcrs)
 }
 #endif
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net80211/ieee80211_ddb.c
+++ b/sys/net80211/ieee80211_ddb.c
@@ -95,7 +95,7 @@ DB_SHOW_COMMAND(sta, db_show_sta)
 		db_printf("usage: show sta <addr>\n");
 		return;
 	}
-	_db_show_sta((const struct ieee80211_node *) addr);
+	_db_show_sta(DB_DATA_PTR(addr, const struct ieee80211_node));
 }
 
 DB_SHOW_COMMAND(statab, db_show_statab)
@@ -104,7 +104,8 @@ DB_SHOW_COMMAND(statab, db_show_statab)
 		db_printf("usage: show statab <addr>\n");
 		return;
 	}
-	_db_show_node_table("", (const struct ieee80211_node_table *) addr);
+	_db_show_node_table("", DB_DATA_PTR(addr,
+	    const struct ieee80211_node_table));
 }
 
 DB_SHOW_COMMAND(vap, db_show_vap)
@@ -128,7 +129,8 @@ DB_SHOW_COMMAND(vap, db_show_vap)
 			showprocs = 1;
 			break;
 		}
-	_db_show_vap((const struct ieee80211vap *) addr, showmesh, showprocs);
+	_db_show_vap(DB_DATA_PTR(addr, const struct ieee80211vap), showmesh,
+	    showprocs);
 }
 
 DB_SHOW_COMMAND(com, db_show_com)
@@ -159,7 +161,7 @@ DB_SHOW_COMMAND(com, db_show_com)
 			break;
 		}
 
-	ic = (const struct ieee80211com *) addr;
+	ic = DB_DATA_PTR(addr, const struct ieee80211com);
 	_db_show_com(ic, showvaps, showsta, showmesh, showprocs);
 }
 
@@ -186,7 +188,7 @@ DB_SHOW_ALL_COMMAND(mesh, db_show_mesh)
 		db_printf("usage: show mesh <addr>\n");
 		return;
 	}
-	ms = (const struct ieee80211_mesh_state *) addr;
+	ms = DB_DATA_PTR(addr, const struct ieee80211_mesh_state);
 	_db_show_mesh(ms);
 }
 #endif /* IEEE80211_SUPPORT_MESH */
@@ -904,3 +906,12 @@ _db_show_mesh(const struct ieee80211_mesh_state *ms)
 }
 #endif /* IEEE80211_SUPPORT_MESH */
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20201217,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/igmp.c
+++ b/sys/netinet/igmp.c
@@ -3657,7 +3657,7 @@ DB_SHOW_COMMAND(igi_list, db_show_igi_list)
 		db_printf("usage: show igi_list <addr>\n");
 		return;
 	}
-	igi_head = (struct _igi_list *)addr;
+	igi_head = DB_DATA_PTR(addr, struct _igi_list);
 
 	LIST_FOREACH_SAFE(igi, igi_head, igi_link, tigi) {
 		db_printf("igmp_ifsoftc %p:\n", igi);
@@ -3707,3 +3707,12 @@ static moduledata_t igmp_mod = {
     0
 };
 DECLARE_MODULE(igmp, igmp_mod, SI_SUB_PROTO_MC, SI_ORDER_MIDDLE);
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/in_debug.c
+++ b/sys/netinet/in_debug.c
@@ -69,13 +69,13 @@ DB_SHOW_COMMAND(sin, db_show_sin)
 {
 	struct sockaddr_in *sin;
 
-	sin = (struct sockaddr_in *)addr;
-	if (sin == NULL) {
+	if (!have_addr) {
 		/* usage: No need to confess if you didn't sin. */
 		db_printf("usage: show sin <struct sockaddr_in *>\n");
 		return;
 	}
 
+	sin = DB_DATA_PTR(addr, struct sockaddr_in);
 	in_show_sockaddr_in(sin);
 }
 
@@ -106,12 +106,21 @@ DB_SHOW_COMMAND(in_ifaddr, db_show_in_ifaddr)
 {
 	struct in_ifaddr *ia;
 
-	ia = (struct in_ifaddr *)addr;
-	if (ia == NULL) {
+	if (!have_addr) {
 		db_printf("usage: show in_ifaddr <struct in_ifaddr *>\n");
 		return;
 	}
 
+	ia = DB_DATA_PTR(addr, struct in_ifaddr);
 	in_show_in_ifaddr(ia);
 }
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/in_pcb.c
+++ b/sys/netinet/in_pcb.c
@@ -3208,7 +3208,7 @@ DB_SHOW_COMMAND(inpcb, db_show_inpcb)
 		db_printf("usage: show inpcb <addr>\n");
 		return;
 	}
-	inp = (struct inpcb *)addr;
+	inp = DB_DATA_PTR(addr, struct inpcb);
 
 	db_print_inpcb(inp, "inpcb", 0);
 }
@@ -3519,3 +3519,12 @@ rl_init(void *st)
 SYSINIT(rl, SI_SUB_PROTO_DOMAININIT, SI_ORDER_ANY, rl_init, NULL);
 #endif
 #endif /* RATELIMIT */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/tcp_usrreq.c
+++ b/sys/netinet/tcp_usrreq.c
@@ -2954,7 +2954,7 @@ DB_SHOW_COMMAND(tcpcb, db_show_tcpcb)
 		db_printf("usage: show tcpcb <addr>\n");
 		return;
 	}
-	tp = (struct tcpcb *)addr;
+	tp = DB_DATA_PTR(addr, struct tcpcb);
 
 	db_print_tcpcb(tp, "tcpcb", 0);
 }
@@ -2964,7 +2964,8 @@ DB_SHOW_COMMAND(tcpcb, db_show_tcpcb)
 //   "updated": 20191104,
 //   "target_type": "kernel",
 //   "changes": [
-//     "user_capabilities"
+//     "user_capabilities",
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/riscv/riscv/db_interface.c
+++ b/sys/riscv/riscv/db_interface.c
@@ -124,7 +124,7 @@ db_read_bytes(vm_offset_t addr, size_t size, char *data)
 	ret = setjmp(jb);
 
 	if (ret == 0) {
-		src = (const char *)addr;
+		src = DB_DATA_PTR_LEN(addr, const char, size);
 		while (size-- > 0)
 			*data++ = *src++;
 	}
@@ -147,7 +147,7 @@ db_write_bytes(vm_offset_t addr, size_t size, char *data)
 	prev_jb = kdb_jmpbuf(jb);
 	ret = setjmp(jb);
 	if (ret == 0) {
-		dst = (char *)addr;
+		dst = DB_DATA_PTR_LEN(addr, char, size);
 		while (size-- > 0)
 			*dst++ = *data++;
 
@@ -158,3 +158,12 @@ db_write_bytes(vm_offset_t addr, size_t size, char *data)
 
 	return (ret);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -1105,7 +1105,7 @@ parse_metadata(void)
 	caddr_t kmdp;
 	vm_offset_t lastaddr;
 #ifdef DDB
-	vm_offset_t ksym_start, ksym_end;
+	vm_pointer_t ksym_start, ksym_end;
 #endif
 	char *kern_envp;
 
@@ -1275,3 +1275,12 @@ bzero(void *buf, size_t len)
 	while(len-- > 0)
 		*p++ = 0;
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_as_integer"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ufs/ffs/ffs_softdep.c
+++ b/sys/ufs/ffs/ffs_softdep.c
@@ -14986,7 +14986,7 @@ DB_SHOW_COMMAND(sd_inodedep, db_show_sd_inodedep)
 		db_printf("inodedep address required\n");
 		return;
 	}
-	inodedep_print((struct inodedep*)addr, 1);
+	inodedep_print(DB_DATA_PTR(addr, struct inodedep), 1);
 }
 
 DB_SHOW_COMMAND(sd_allinodedeps, db_show_sd_allinodedeps)
@@ -15000,7 +15000,7 @@ DB_SHOW_COMMAND(sd_allinodedeps, db_show_sd_allinodedeps)
 		db_printf("ufsmount address required\n");
 		return;
 	}
-	ump = (struct ufsmount *)addr;
+	ump = DB_DATA_PTR(addr, struct ufsmount);
 	for (cnt = 0; cnt < ump->inodedep_hash_size; cnt++) {
 		inodedephd = &ump->inodedep_hashtbl[cnt];
 		LIST_FOREACH(inodedep, inodedephd, id_hash) {
@@ -15016,7 +15016,7 @@ DB_SHOW_COMMAND(sd_worklist, db_show_sd_worklist)
 		db_printf("worklist address required\n");
 		return;
 	}
-	worklist_print((struct worklist *)addr, 1);
+	worklist_print(DB_DATA_PTR(addr, struct worklist), 1);
 }
 
 DB_SHOW_COMMAND(sd_workhead, db_show_sd_workhead)
@@ -15038,7 +15038,7 @@ DB_SHOW_COMMAND(sd_workhead, db_show_sd_workhead)
 	 * a list we will still get the same result, so nothing
 	 * unexpected will result.
 	 */
-	wk = (struct worklist *)addr;
+	wk = DB_DATA_PTR(addr, struct worklist);
 	if (wk == NULL)
 		return;
 	wkhd = (struct workhead *)wk->wk_list.le_prev;
@@ -15069,7 +15069,7 @@ DB_SHOW_COMMAND(sd_mkdir, db_show_sd_mkdir)
 		db_printf("mkdir address required\n");
 		return;
 	}
-	mkdir_print((struct mkdir *)addr);
+	mkdir_print(DB_DATA_PTR(addr, struct mkdir));
 }
 
 DB_SHOW_COMMAND(sd_mkdir_list, db_show_sd_mkdir_list)
@@ -15081,7 +15081,7 @@ DB_SHOW_COMMAND(sd_mkdir_list, db_show_sd_mkdir_list)
 		db_printf("mkdir listhead address required\n");
 		return;
 	}
-	mkdirlisthd = (struct mkdirlist *)addr;
+	mkdirlisthd = DB_DATA_PTR(addr, struct mkdirlist);
 	LIST_FOREACH(mkdir, mkdirlisthd, md_mkdirs) {
 		mkdir_print(mkdir);
 		if (mkdir->md_diradd != NULL) {
@@ -15101,7 +15101,7 @@ DB_SHOW_COMMAND(sd_allocdirect, db_show_sd_allocdirect)
 		db_printf("allocdirect address required\n");
 		return;
 	}
-	allocdirect_print((struct allocdirect *)addr);
+	allocdirect_print(DB_DATA_PTR(addr, struct allocdirect));
 }
 
 DB_SHOW_COMMAND(sd_allocindir, db_show_sd_allocindir)
@@ -15110,9 +15110,18 @@ DB_SHOW_COMMAND(sd_allocindir, db_show_sd_allocindir)
 		db_printf("allocindir address required\n");
 		return;
 	}
-	allocindir_print((struct allocindir *)addr);
+	allocindir_print(DB_DATA_PTR(addr, struct allocindir));
 }
 
 #endif /* DDB */
 
 #endif /* SOFTUPDATES */
+// CHERI CHANGES START
+// {
+//   "updated": 20190628,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ufs/ffs/ffs_vfsops.c
+++ b/sys/ufs/ffs/ffs_vfsops.c
@@ -2673,7 +2673,8 @@ DB_SHOW_COMMAND(ffs, db_show_ffs)
 	struct ufsmount *ump;
 
 	if (have_addr) {
-		ump = VFSTOUFS((struct mount *)addr);
+		mp = DB_DATA_PTR(addr, struct mount);
+		ump = VFSTOUFS(mp);
 		db_print_ffs(ump);
 		return;
 	}
@@ -2691,7 +2692,8 @@ DB_SHOW_COMMAND(ffs, db_show_ffs)
 //   "updated": 20190628,
 //   "target_type": "kernel",
 //   "changes_purecap": [
-//     "pointer_shape"
+//     "pointer_shape",
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5622,7 +5622,7 @@ DB_SHOW_COMMAND(map, map)
 		db_printf("usage: show map <addr>\n");
 		return;
 	}
-	vm_map_print((vm_map_t)addr);
+	vm_map_print(DB_DATA_PTR(addr, struct vm_map));
 }
 
 DB_SHOW_COMMAND(procvm, procvm)
@@ -5649,6 +5649,9 @@ DB_SHOW_COMMAND(procvm, procvm)
 //   "target_type": "kernel",
 //   "changes": [
 //     "platform"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/vm/vm_object.c
+++ b/sys/vm/vm_object.c
@@ -2723,8 +2723,8 @@ DB_SHOW_COMMAND(vmochk, vm_object_check)
 DB_SHOW_COMMAND(object, vm_object_print_static)
 {
 	/* XXX convert args. */
-	vm_object_t object = (vm_object_t)addr;
-	boolean_t full = have_addr;
+	vm_object_t object;
+	boolean_t full = true; /* XXX */
 
 	vm_page_t p;
 
@@ -2733,9 +2733,10 @@ DB_SHOW_COMMAND(object, vm_object_print_static)
 
 	int count;
 
-	if (object == NULL)
+	if (!have_addr)
 		return;
 
+	object = DB_DATA_PTR(addr, struct vm_object);
 	db_iprintf(
 	    "Object %p: type=%d, size=0x%jx, res=%d, ref=%d, flags=0x%x ruid %d charge %jx\n",
 	    object, (int)object->type, (uintmax_t)object->size,
@@ -2866,6 +2867,9 @@ DB_SHOW_COMMAND(vmopag, vm_object_print_pages)
 //   "target_type": "kernel",
 //   "changes": [
 //     "support"
+//   ],
+//   "changes_purecap": [
+//     "kdb"
 //   ],
 //   "change_comment": ""
 // }

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -5523,7 +5523,7 @@ DB_SHOW_COMMAND(pginfo, vm_page_print_pginfo)
 	else if (phys)
 		m = PHYS_TO_VM_PAGE(addr);
 	else
-		m = (vm_page_t)addr;
+		m = DB_DATA_PTR(addr, struct vm_page);
 	db_printf(
     "page %p obj %p pidx 0x%jx phys 0x%jx q %d ref 0x%x\n"
     "  af 0x%x of 0x%x f 0x%x act %d busy %x valid 0x%x dirty 0x%x\n",
@@ -5532,3 +5532,12 @@ DB_SHOW_COMMAND(pginfo, vm_page_print_pginfo)
 	    m->flags, m->a.act_count, m->busy_lock, m->valid, m->dirty);
 }
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/vm/vm_radix.c
+++ b/sys/vm/vm_radix.c
@@ -894,7 +894,7 @@ DB_SHOW_COMMAND(radixnode, db_show_radixnode)
 
         if (!have_addr)
                 return;
-	rnode = (struct vm_radix_node *)addr;
+	rnode = DB_DATA_PTR(addr, struct vm_radix_node);
 	db_printf("radixnode %p, owner %jx, children count %u, level %u:\n",
 	    (void *)rnode, (uintmax_t)rnode->rn_owner, rnode->rn_count,
 	    rnode->rn_clev);
@@ -908,3 +908,12 @@ DB_SHOW_COMMAND(radixnode, db_show_radixnode)
 	}
 }
 #endif /* DDB */
+// CHERI CHANGES START
+// {
+//   "updated": 20200127,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb"
+//   ]
+// }
+// CHERI CHANGES END


### PR DESCRIPTION
These are MI changes for DDB support.  Mostly it consists of helpers for DDB commands that accept user-supplied addresses.  This takes a conservative approach and does not try to bound symbol addresses based on the symbol information.