### PR TITLE
Purecap dpcpu vnet

### DIFF
--- a/sys/contrib/ipfilter/netinet/mlfk_ipl.c
+++ b/sys/contrib/ipfilter/netinet/mlfk_ipl.c
@@ -367,77 +367,51 @@ sysctl_error:
 }
 
 /*
- * In the VIMAGE case kern_sysctl.c already adds the vnet base address given
- * we set CTLFLAG_VNET to get proper access checks.  Have to undo this.
- * Then we add the given offset to the specific malloced struct hanging off
- * virtualized ipmain struct.
+ * arg2 holds the offset of the relevant member in the virtualized
+ * ipfmain structure.
  */
 static int
 sysctl_ipf_int_nat ( SYSCTL_HANDLER_ARGS )
 {
+	ipf_nat_softc_t *nat_softc;
 
-	if (arg1) {
-		ipf_nat_softc_t *nat_softc;
+	nat_softc = V_ipfmain.ipf_nat_soft;
+	arg1 = (void *)((uintptr_t)nat_softc + arg2);
 
-		nat_softc = V_ipfmain.ipf_nat_soft;
-#ifdef VIMAGE
-		arg1 = (void *)((uintptr_t)arg1 - curvnet->vnet_data_base);
-#endif
-		arg1 = (void *)((uintptr_t)nat_softc + (uintptr_t)arg1);
-	}
-
-	return (sysctl_ipf_int(oidp, arg1, arg2, req));
+	return (sysctl_ipf_int(oidp, arg1, 0, req));
 }
 
 static int
 sysctl_ipf_int_state ( SYSCTL_HANDLER_ARGS )
 {
+	ipf_state_softc_t *state_softc;
 
-	if (arg1) {
-		ipf_state_softc_t *state_softc;
+	state_softc = V_ipfmain.ipf_state_soft;
+	arg1 = (void *)((uintptr_t)state_softc + arg2);
 
-		state_softc = V_ipfmain.ipf_state_soft;
-#ifdef VIMAGE
-		arg1 = (void *)((uintptr_t)arg1 - curvnet->vnet_data_base);
-#endif
-		arg1 = (void *)((uintptr_t)state_softc + (uintptr_t)arg1);
-	}
-
-	return (sysctl_ipf_int(oidp, arg1, arg2, req));
+	return (sysctl_ipf_int(oidp, arg1, 0, req));
 }
 
 static int
 sysctl_ipf_int_auth ( SYSCTL_HANDLER_ARGS )
 {
+	ipf_auth_softc_t *auth_softc;
 
-	if (arg1) {
-		ipf_auth_softc_t *auth_softc;
+	auth_softc = V_ipfmain.ipf_auth_soft;
+	arg1 = (void *)((uintptr_t)auth_softc + arg2);
 
-		auth_softc = V_ipfmain.ipf_auth_soft;
-#ifdef VIMAGE
-		arg1 = (void *)((uintptr_t)arg1 - curvnet->vnet_data_base);
-#endif
-		arg1 = (void *)((uintptr_t)auth_softc + (uintptr_t)arg1);
-	}
-
-	return (sysctl_ipf_int(oidp, arg1, arg2, req));
+	return (sysctl_ipf_int(oidp, arg1, 0, req));
 }
 
 static int
 sysctl_ipf_int_frag ( SYSCTL_HANDLER_ARGS )
 {
+	ipf_frag_softc_t *frag_softc;
 
-	if (arg1) {
-		ipf_frag_softc_t *frag_softc;
+	frag_softc = V_ipfmain.ipf_frag_soft;
+	arg1 = (void *)((uintptr_t)frag_softc + arg2);
 
-		frag_softc = V_ipfmain.ipf_frag_soft;
-#ifdef VIMAGE
-		arg1 = (void *)((uintptr_t)arg1 - curvnet->vnet_data_base);
-#endif
-		arg1 = (void *)((uintptr_t)frag_softc + (uintptr_t)arg1);
-	}
-
-	return (sysctl_ipf_int(oidp, arg1, arg2, req));
+	return (sysctl_ipf_int(oidp, arg1, 0, req));
 }
 #endif
 
@@ -645,29 +619,29 @@ ipf_fbsd_sysctl_create(void)
 	sysctl_ctx_init(&ipf_clist);
 
 	SYSCTL_DYN_IPF_NAT(_net_inet_ipf, OID_AUTO, "fr_defnatage", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_nat_softc_t, ipf_nat_defage), 0, "");
+	    NULL, offsetof(ipf_nat_softc_t, ipf_nat_defage), "");
 	SYSCTL_DYN_IPF_STATE(_net_inet_ipf, OID_AUTO, "fr_statesize", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_state_softc_t, ipf_state_size), 0, "");
+	    NULL, offsetof(ipf_state_softc_t, ipf_state_size), "");
 	SYSCTL_DYN_IPF_STATE(_net_inet_ipf, OID_AUTO, "fr_statemax", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_state_softc_t, ipf_state_max), 0, "");
+	    NULL, offsetof(ipf_state_softc_t, ipf_state_max), "");
 	SYSCTL_DYN_IPF_NAT(_net_inet_ipf, OID_AUTO, "ipf_nattable_max", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_nat_softc_t, ipf_nat_table_max), 0, "");
+	    NULL, offsetof(ipf_nat_softc_t, ipf_nat_table_max), "");
 	SYSCTL_DYN_IPF_NAT(_net_inet_ipf, OID_AUTO, "ipf_nattable_sz", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_nat_softc_t, ipf_nat_table_sz), 0, "");
+	    NULL, offsetof(ipf_nat_softc_t, ipf_nat_table_sz), "");
 	SYSCTL_DYN_IPF_NAT(_net_inet_ipf, OID_AUTO, "ipf_natrules_sz", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_nat_softc_t, ipf_nat_maprules_sz), 0, "");
+	    NULL, offsetof(ipf_nat_softc_t, ipf_nat_maprules_sz), "");
 	SYSCTL_DYN_IPF_NAT(_net_inet_ipf, OID_AUTO, "ipf_rdrrules_sz", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_nat_softc_t, ipf_nat_rdrrules_sz), 0, "");
+	    NULL, offsetof(ipf_nat_softc_t, ipf_nat_rdrrules_sz), "");
 	SYSCTL_DYN_IPF_NAT(_net_inet_ipf, OID_AUTO, "ipf_hostmap_sz", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_nat_softc_t, ipf_nat_hostmap_sz), 0, "");
+	    NULL, offsetof(ipf_nat_softc_t, ipf_nat_hostmap_sz), "");
 	SYSCTL_DYN_IPF_AUTH(_net_inet_ipf, OID_AUTO, "fr_authsize", CTLFLAG_RWO,
-	    (void *)offsetof(ipf_auth_softc_t, ipf_auth_size), 0, "");
+	    NULL, offsetof(ipf_auth_softc_t, ipf_auth_size), "");
 	SYSCTL_DYN_IPF_AUTH(_net_inet_ipf, OID_AUTO, "fr_authused", CTLFLAG_RD,
-	    (void *)offsetof(ipf_auth_softc_t, ipf_auth_used), 0, "");
+	    NULL, offsetof(ipf_auth_softc_t, ipf_auth_used), "");
 	SYSCTL_DYN_IPF_AUTH(_net_inet_ipf, OID_AUTO, "fr_defaultauthage", CTLFLAG_RW,
-	    (void *)offsetof(ipf_auth_softc_t, ipf_auth_defaultage), 0, "");
+	    NULL, offsetof(ipf_auth_softc_t, ipf_auth_defaultage), "");
 	SYSCTL_DYN_IPF_FRAG(_net_inet_ipf, OID_AUTO, "fr_ipfrttl", CTLFLAG_RW,
-	    (void *)offsetof(ipf_frag_softc_t, ipfr_ttl), 0, "");
+	    NULL, offsetof(ipf_frag_softc_t, ipfr_ttl), "");
 	return 0;
 }
 

--- a/sys/ddb/db_sym.c
+++ b/sys/ddb/db_sym.c
@@ -246,7 +246,8 @@ db_value_of_name_pcpu(const char *name, db_expr_t *valuep)
 	db_symbol_values(sym, &name, &value);
 	if (value < DPCPU_START || value >= DPCPU_STOP)
 		return (false);
-	*valuep = (db_expr_t)((uintptr_t)value + dpcpu_off[cpu]);
+	*valuep = (db_expr_t)(dpcpu_off[cpu] - DPCPU_BIAS +
+	    ((ptraddr_t)value - (ptraddr_t)DPCPU_START));
 	return (true);
 }
 
@@ -481,3 +482,13 @@ db_sym_numargs(c_db_sym_t sym, int *nargp, char **argnames)
 {
 	return (X_db_sym_numargs(db_last_symtab, sym, nargp, argnames));
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20190830,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "kdb",
+//     "pointer_provenance"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ddb/db_sym.c
+++ b/sys/ddb/db_sym.c
@@ -271,7 +271,8 @@ db_value_of_name_vnet(const char *name, db_expr_t *valuep)
 	db_symbol_values(sym, &name, &value);
 	if (value < VNET_START || value >= VNET_STOP)
 		return (false);
-	*valuep = (db_expr_t)((uintptr_t)value + vnet->vnet_data_base);
+	*valuep = (db_expr_t)((uintptr_t)vnet->vnet_data_mem +
+	    ((ptraddr_t)value - (ptraddr_t)VNET_START));
 	return (true);
 #else
 	return (false);

--- a/sys/kern/kern_switch.c
+++ b/sys/kern/kern_switch.c
@@ -116,7 +116,7 @@ static int
 sysctl_stats_reset(SYSCTL_HANDLER_ARGS)
 {
 	struct sysctl_oid *p;
-	uintptr_t counter;
+	ptraddr_t counter;
         int error;
 	int val;
 	int i;
@@ -134,9 +134,9 @@ sysctl_stats_reset(SYSCTL_HANDLER_ARGS)
 	SLIST_FOREACH(p, oidp->oid_parent, oid_link) {
 		if (p == oidp || p->oid_arg1 == NULL)
 			continue;
-		counter = (uintptr_t)p->oid_arg1;
+		counter = ((ptraddr_t)p->oid_arg1 - (ptraddr_t)DPCPU_START);
 		CPU_FOREACH(i) {
-			*(long *)(dpcpu_off[i] + counter) = 0;
+			*(long *)(dpcpu_off[i] - DPCPU_BIAS + counter) = 0;
 		}
 	}
 	return (0);
@@ -542,3 +542,12 @@ runq_remove_idx(struct runq *rq, struct thread *td, u_char *idx)
 			*idx = (pri + 1) % RQ_NQS;
 	}
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "pointer_provenance"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -2245,8 +2245,10 @@ sysctl_root(SYSCTL_HANDLER_ARGS)
 		goto out;
 #endif
 #ifdef VIMAGE
-	if ((oid->oid_kind & CTLFLAG_VNET) && arg1 != NULL)
-		arg1 = (void *)(curvnet->vnet_data_base + (uintptr_t)arg1);
+	if ((oid->oid_kind & CTLFLAG_VNET) && arg1 != NULL) {
+		arg1 = (void *)(curvnet->vnet_data_base - VNET_BIAS +
+		    ((ptraddr_t)arg1 - (ptraddr_t)VNET_START));
+	}
 #endif
 	error = sysctl_root_handler_locked(oid, arg1, arg2, req, &tracker);
 
@@ -2999,6 +3001,9 @@ out:
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "pointer_provenance"
 //   ]
 // }
 // CHERI CHANGES END


### PR DESCRIPTION
Handle VNET and dynamic per-CPU variables in the purecap kernel.

Note that this is focused on the "consumer" side for the use of the variables.  There are additional changes in the kernel linker to support these special variable types, but I'm waiting to include that as part of a kernel linker patch series.