### PR TITLE
Morello Modules

### DIFF
--- a/sys/arm64/arm64/exception_morello.S
+++ b/sys/arm64/arm64/exception_morello.S
@@ -38,7 +38,7 @@ __FBSDID("$FreeBSD$");
 	mov	x18, sp
 	sub	sp, sp, #128
 .endif
-	stp	c29, c30, [sp], #-32
+	stp	x29, x30, [sp, #-16]!
 	sub	sp, sp, #(TF_SIZE)
 	stp	c28, c29, [sp, #(TF_X + 28 * 16)]
 	stp	c26, c27, [sp, #(TF_X + 26 * 16)]
@@ -137,7 +137,7 @@ __FBSDID("$FreeBSD$");
 	ldr	     x29, [sp, #(TF_X + 29 * 16)]
 .endif
 .if \el == 0
-	add	sp, sp, #(TF_SIZE + 32)
+	add	sp, sp, #(TF_SIZE + 16)
 .else
 	mov	sp, x18
 	mrs	x18, tpidr_el1

--- a/sys/cam/scsi/scsi_cd.c
+++ b/sys/cam/scsi/scsi_cd.c
@@ -2024,8 +2024,7 @@ cdioctl(struct disk *dp, u_long cmd, void *addr, int flag, struct thread *td)
 				data->header.data_len[1] +
 				sizeof(struct cd_sub_channel_header)));
 			cam_periph_unlock(periph);
-			error = copyout(data, __USER_CAP_UNBOUND(args->data),
-			    len);
+			error = copyout(data, args->data, len);
 			free(data, M_SCSICD);
 		}
 		break;

--- a/sys/compat/linux/linux_errno.inc
+++ b/sys/compat/linux/linux_errno.inc
@@ -159,7 +159,7 @@ static const int linux_errtbl[ELAST + 1] = {
 	[EPROT] = -LINUX_EINVAL,	/* XXX */
 };
 
-_Static_assert(ELAST == 99,
+_Static_assert(ELAST == 98,
     "missing errno entries in linux_errtbl");
 
 static const int linux_to_bsd_errtbl[LINUX_ELAST + 1] = {

--- a/sys/dev/cxgbe/t4_ioctl.h
+++ b/sys/dev/cxgbe/t4_ioctl.h
@@ -76,19 +76,19 @@ struct t4_reg {
 struct t4_regdump {
 	uint32_t version;
 	uint32_t len; /* bytes */
-	uint32_t *data;
+	uint32_t * __kerncap data;
 };
 
 struct t4_data {
 	uint32_t len;
-	uint8_t *data;
+	uint8_t * __kerncap data;
 };
 
 struct t4_bootrom {
 	uint32_t pf_offset;
 	uint32_t pfidx_addr;
 	uint32_t len;
-	uint8_t *data;
+	uint8_t * __kerncap data;
 };
 
 struct t4_i2c_data {
@@ -337,7 +337,7 @@ struct t4_sge_context {
 struct t4_mem_range {
 	uint32_t addr;
 	uint32_t len;
-	uint32_t *data;
+	uint32_t * __kerncap data;
 };
 
 #define T4_TRACE_LEN 112
@@ -363,7 +363,7 @@ struct t4_cudbg_dump {
 	uint8_t wr_flash;
 	uint8_t	bitmap[16];
 	uint32_t len;
-	uint8_t *data;
+	uint8_t * __kerncap data;
 };
 
 enum {
@@ -401,7 +401,14 @@ struct offload_rule {
  */
 struct t4_offload_policy {
 	uint32_t nrules;
-	struct offload_rule *rule;
+#ifdef _KERNEL
+	union {
+		struct offload_rule * __capability user_rule;
+#endif
+		struct offload_rule *rule;
+#ifdef _KERNEL
+	};
+#endif
 };
 
 #define CHELSIO_T4_GETREG	_IOWR('f', T4_GETREG, struct t4_reg)

--- a/sys/dev/efidev/efidev.c
+++ b/sys/dev/efidev/efidev.c
@@ -53,14 +53,6 @@ efidev_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t addr,
 	int error;
 
 	switch (cmd) {
-	case EFIIOC_GET_TABLE:
-	{
-		struct efi_get_table_ioc *egtioc =
-		    (struct efi_get_table_ioc *)addr;
-
-		error = efi_get_table(&egtioc->uuid, &egtioc->ptr);
-		break;
-	}
 	case EFIIOC_GET_TIME:
 	{
 		struct efi_tm *tm = (struct efi_tm *)addr;

--- a/sys/dev/hwpmc/hwpmc_arm64_md.c
+++ b/sys/dev/hwpmc/hwpmc_arm64_md.c
@@ -111,7 +111,7 @@ int
 pmc_save_user_callchain(uintptr_t *cc, int maxsamples,
     struct trapframe *tf)
 {
-	uintptr_t pc, r, oldfp, fp;
+	uintcap_t pc, r, oldfp, fp;
 	struct thread *td;
 	int count;
 
@@ -120,7 +120,7 @@ pmc_save_user_callchain(uintptr_t *cc, int maxsamples,
 
 	td = curthread;
 	pc = PMC_TRAPFRAME_TO_PC(tf);
-	*cc++ = pc;
+	*cc++ = (uintptr_t)pc;
 
 	if (maxsamples <= 1)
 		return (1);
@@ -133,8 +133,8 @@ pmc_save_user_callchain(uintptr_t *cc, int maxsamples,
 
 	for (count = 1; count < maxsamples; count++) {
 		/* Use saved lr as pc. */
-		r = fp + sizeof(uintptr_t);
-		if (copyin((void *)r, &pc, sizeof(pc)) != 0)
+		r = fp + sizeof(uintcap_t);
+		if (copyin((void * __capability)r, &pc, sizeof(pc)) != 0)
 			break;
 		if (!PMC_IN_USERSPACE(pc))
 			break;
@@ -144,7 +144,7 @@ pmc_save_user_callchain(uintptr_t *cc, int maxsamples,
 		/* Switch to next frame up */
 		oldfp = fp;
 		r = fp;
-		if (copyin((void *)r, &fp, sizeof(fp)) != 0)
+		if (copyin((void * __capability)r, &fp, sizeof(fp)) != 0)
 			break;
 		if (fp < oldfp || !PMC_IN_USERSPACE(fp))
 			break;

--- a/sys/dev/mlx5/mlx5_core/mlx5_fwdump.c
+++ b/sys/dev/mlx5/mlx5_core/mlx5_fwdump.c
@@ -258,7 +258,7 @@ static int
 mlx5_fwdump_copyout(struct mlx5_core_dev *mdev, struct mlx5_fwdump_get *fwg)
 {
 	const struct mlx5_crspace_regmap *r;
-	struct mlx5_fwdump_reg rv, *urv;
+	struct mlx5_fwdump_reg rv, * __capability urv;
 	uint32_t i, ri;
 	int error;
 

--- a/sys/dev/mlx5/mlx5io.h
+++ b/sys/dev/mlx5/mlx5io.h
@@ -44,20 +44,20 @@ struct mlx5_tool_addr {
 
 struct mlx5_fwdump_get {
 	struct mlx5_tool_addr devaddr;
-	struct mlx5_fwdump_reg *buf;
+	struct mlx5_fwdump_reg * __kerncap buf;
 	size_t reg_cnt;
 	size_t reg_filled; /* out */
 };
 
 struct mlx5_fw_update {
 	struct mlx5_tool_addr devaddr;
-	void *img_fw_data;
+	void * __kerncap img_fw_data;
 	size_t img_fw_data_len;
 };
 
 struct mlx5_eeprom_get {
 	struct mlx5_tool_addr devaddr;
-	uint32_t *eeprom_info_buf;
+	uint32_t * __kerncap eeprom_info_buf;
 	uint8_t eeprom_info_page_valid;
 	size_t eeprom_info_out_len;
 };

--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -1926,7 +1926,7 @@ bf_insns_get_ptr(void *fpp)
 		    (struct bpf_insn *)(uintptr_t)fpup->fp64.bf_insns,
 		    fpup->fp64.bf_len * sizeof(struct bpf_insn)));
 #endif
-	return (fpup->fp.bf_insns);
+	return (fpup->fp.bf_user_insns);
 }
 
 /*
@@ -1964,7 +1964,7 @@ bpf_setf(struct bpf_d *d, struct bpf_program *fp, u_long cmd)
 	flen = fp->bf_len;
 	if (flen > bpf_maxinsns || (bf_insns_get_ptr(fp) == NULL && flen != 0))
 		return (EINVAL);
-	size = flen * sizeof(*fp->bf_insns);
+	size = flen * sizeof(*fp->bf_user_insns);
 	if (size > 0) {
 		/* We're setting up new filter. Copy and check actual data. */
 		fcode = bpf_program_buffer_alloc(size, M_WAITOK);

--- a/sys/net/bpf.h
+++ b/sys/net/bpf.h
@@ -70,7 +70,14 @@ typedef	u_int64_t bpf_u_int64;
  */
 struct bpf_program {
 	u_int bf_len;
-	struct bpf_insn * __kerncap bf_insns;
+#ifdef _KERNEL
+	union {
+		struct bpf_insn * __capability bf_user_insns;
+#endif
+		struct bpf_insn *bf_insns;
+#ifdef _KERNEL
+	};
+#endif
 };
 
 /*

--- a/sys/ofed/include/rdma/ib_verbs.h
+++ b/sys/ofed/include/rdma/ib_verbs.h
@@ -1394,8 +1394,8 @@ struct ib_uobject {
 };
 
 struct ib_udata {
-	const void __user *inbuf;
-	void __user *outbuf;
+	const void __user * __kerncap inbuf;
+	void __user * __kerncap outbuf;
 	size_t       inlen;
 	size_t       outlen;
 };
@@ -2180,7 +2180,8 @@ static inline bool ib_is_udata_cleared(struct ib_udata *udata,
 				       size_t offset,
 				       size_t len)
 {
-	const void __user *p = (const char __user *)udata->inbuf + offset;
+	const void __user * __kerncap p =
+	    (const char __user * __kerncap)udata->inbuf + offset;
 	bool ret;
 	u8 *buf;
 

--- a/sys/sys/cdio.h
+++ b/sys/sys/cdio.h
@@ -137,7 +137,7 @@ struct ioc_read_subchannel {
 #define CD_TRACK_INFO		3
 	u_char track;
 	int	data_len;
-	struct  cd_sub_channel_info *data;
+	struct  cd_sub_channel_info * __kerncap data;
 };
 #define CDIOCREADSUBCHANNEL _IOWR('c', 3 , struct ioc_read_subchannel )
 

--- a/sys/sys/efiio.h
+++ b/sys/sys/efiio.h
@@ -32,12 +32,6 @@
 #include <sys/uuid.h>
 #include <sys/efi.h>
 
-struct efi_get_table_ioc
-{
-	struct uuid uuid;	/* UUID to look up */
-	void *ptr;		/* Pointer to table in KVA space */
-};
-
 struct efi_var_ioc
 {
 	efi_char *name;		/* User pointer to name, in wide chars */
@@ -48,7 +42,6 @@ struct efi_var_ioc
 	size_t datasize;	/* Number of *bytes* in the data */
 };
 
-#define EFIIOC_GET_TABLE	_IOWR('E',  1, struct efi_get_table_ioc)
 #define EFIIOC_GET_TIME		_IOR('E',   2, struct efi_tm)
 #define EFIIOC_SET_TIME		_IOW('E',   3, struct efi_tm)
 #define EFIIOC_VAR_GET		_IOWR('E',  4, struct efi_var_ioc)

--- a/sys/sys/efiio.h
+++ b/sys/sys/efiio.h
@@ -34,12 +34,12 @@
 
 struct efi_var_ioc
 {
-	efi_char *name;		/* User pointer to name, in wide chars */
-	size_t namesize;	/* Number of wide characters in name */
-	struct uuid vendor;	/* Vendor's UUID for variable */
-	uint32_t attrib;	/* Attributes */
-	void *data;		/* User pointer to the data */
-	size_t datasize;	/* Number of *bytes* in the data */
+	efi_char * __kerncap name;	/* User pointer to name, in wide chars */
+	size_t namesize;		/* Number of wide characters in name */
+	struct uuid vendor;		/* Vendor's UUID for variable */
+	uint32_t attrib;		/* Attributes */
+	void * __kerncap data;		/* User pointer to the data */
+	size_t datasize;		/* Number of *bytes* in the data */
 };
 
 #define EFIIOC_GET_TIME		_IOR('E',   2, struct efi_tm)

--- a/sys/sys/errno.h
+++ b/sys/sys/errno.h
@@ -182,11 +182,10 @@ __END_DECLS
 #define	EOWNERDEAD	96		/* Previous owner died */
 #define	EINTEGRITY	97		/* Integrity check failed */
 #define	EPROT		98		/* Memory protection violation */
-#define	ENOMETHOD	99		/* Undefined object-capability method */
 #endif /* _POSIX_SOURCE */
 
 #ifndef _POSIX_SOURCE
-#define	ELAST		99		/* Must be equal largest errno */
+#define	ELAST		98		/* Must be equal largest errno */
 #endif /* _POSIX_SOURCE */
 
 #if defined(_KERNEL) || defined(_WANT_KERNEL_ERRNO) || defined(_STANDALONE)


### PR DESCRIPTION
This fixes all the modules enabled on arm64 but not mips64 or riscv, excluding the compat-related ones (i.e. cloudabi32/64 and the set of Linuxulator modules), and provides a tiny fix so the Linuxulator works again without panicking on load on INVARIANTS kernels (currently non-CHERI given Linuxulator needs changes to build for CHERI kernels).

It also bundles in a much-needed fix so stack unwinding works (or at least does the same thing as the baseline again; other than the deficiencies outlined in the commit, the implementation seems rather confused about when to use pre-unwind and post-unwind values in the printing). This ultimately should be ripped out and replaced with the RISC-V version with minor adaptation to be arm64-flavoured upstream.
