### PR TITLE
bsd.compat.mk: Error if NEED_COMPAT is set but not HAS_COMPAT

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -236,7 +236,7 @@ LIBSOFT_MACHINE_ABI=	${MACHINE_ABI:Nhard-float} soft-float
 # In the program linking case, select LIBCOMPAT
 .if defined(NEED_COMPAT)
 .if !defined(HAS_COMPAT)
-.warning NEED_COMPAT defined, but no LIBCOMPAT is available (COMPAT_ARCH == ${COMPAT_ARCH})
+.error NEED_COMPAT defined, but no LIBCOMPAT is available (COMPAT_ARCH == ${COMPAT_ARCH})
 .elif !${HAS_COMPAT:M${NEED_COMPAT}} && ${NEED_COMPAT} != "any"
 .error NEED_COMPAT (${NEED_COMPAT}) defined, but not in HAS_COMPAT (${HAS_COMPAT})
 .elif ${NEED_COMPAT} == "any"


### PR DESCRIPTION
The motivation behind this is that, as Morello userspace is slowly merged in, we will have a period where only hybrid can be built, and we want to make sure that we never build NEED_COMPAT=CHERI programs as hybrid (such as cheribsdtest-purecap), which is something that accidentally ended up happing during the CHERI-RISC-V bring-up due to this bug. Instead we should make sure to add (MACHINE_ABI:Mpurecap || MK_COMPAT_CHERIABI) checks guarding such programs, not MACHINE_CPU:Mcheri.
