### PR TITLE
mmap: Support page capability permissions

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -810,6 +810,25 @@ static const struct cheri_test cheri_tests[] = {
 	  .ct_desc = "check tags are stored for MAP_ANON pages",
 	  .ct_func = cheribsdtest_vm_tag_mmap_anon, },
 
+	{ .ct_name = "cheribsdtest_vm_tag_mmap_anon_cap_rw",
+	  .ct_desc = "check tags are stored for MAP_ANON pages with "
+	    "explicit page capability read/write perms",
+	  .ct_func = cheribsdtest_vm_tag_mmap_anon_cap_rw, },
+
+	{ .ct_name = "cheribsdtest_vm_tag_mmap_anon_cap_w",
+	  .ct_desc = "check that a load from MAP_ANON pages without "
+	    "PROT_CAP_READ strips tags",
+	  .ct_func = cheribsdtest_vm_tag_mmap_anon_cap_w, },
+
+	{ .ct_name = "cheribsdtest_vm_tag_mmap_anon_cap_none_store",
+	  .ct_desc = "check that a store to MAP_ANON pages without "
+	    "PROT_CAP_WRITE faults",
+	  .ct_func = cheribsdtest_vm_tag_mmap_anon_cap_none_store,
+	  .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+	  .ct_signum = SIGSEGV,
+	  .ct_si_code = SEGV_STORETAG,
+	  .ct_si_trapno = TRAPNO_STORE_CAP_PF, },
+
 	{ .ct_name = "cheribsdtest_vm_tag_shm_open_anon_shared",
 	  .ct_desc = "check tags are stored for SHM_ANON MAP_SHARED pages",
 	  .ct_func = cheribsdtest_vm_tag_shm_open_anon_shared, },

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -633,7 +633,7 @@ DECLARE_CHERIBSD_TEST(test_tls_align_ptr);
 DECLARE_CHERIBSD_TEST(test_tls_threads);
 
 /* cheribsdtest_vm.c */
-DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_mmap_anon);;
+DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_mmap_anon);
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_shm_open_anon_shared);
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_shm_open_anon_private);
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_shm_open_anon_shared2x);

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -634,6 +634,9 @@ DECLARE_CHERIBSD_TEST(test_tls_threads);
 
 /* cheribsdtest_vm.c */
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_mmap_anon);
+DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_mmap_anon_cap_rw);
+DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_mmap_anon_cap_w);
+DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_mmap_anon_cap_none_store);
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_shm_open_anon_shared);
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_shm_open_anon_private);
 DECLARE_CHERIBSD_TEST(cheribsdtest_vm_tag_shm_open_anon_shared2x);

--- a/lib/libc/sys/mmap.2
+++ b/lib/libc/sys/mmap.2
@@ -107,7 +107,7 @@ argument by
 .Em or Ns 'ing
 the following values:
 .Pp
-.Bl -tag -width PROT_WRITE -compact
+.Bl -tag -width PROT_CAP_WRITE -compact
 .It Dv PROT_NONE
 Pages may not be accessed.
 .It Dv PROT_READ
@@ -116,7 +116,34 @@ Pages may be read.
 Pages may be written.
 .It Dv PROT_EXEC
 Pages may be executed.
+.It Dv PROT_CAP_READ
+CHERI capabilities may be written to pages.
+.It Dv PROT_CAP_WRITE
+CHERI capabilities may be read from pages.
+.It Dv PROT_CAP_NONE
+CHERI capabilities may not be accessed in pages.
 .El
+.Pp
+When
+.Dv PROT_CAP_NONE
+is combined with
+.Dv PROT_CAP_READ
+or
+.Dv PROT_CAP_WRITE
+it has no effect.
+If no
+.Dv PROT_CAP_*
+flags are included in
+.Fa prot
+than
+.Dv PROT_CAP_READ
+and
+.Dv PROT_CAP_WRITE
+are implied by the presence of
+.Dv PROT_READ
+and
+.Dv PROT_WRITE
+respectively.
 .Pp
 In addition to these protection flags,
 .Fx

--- a/lib/libc/sys/mprotect.2
+++ b/lib/libc/sys/mprotect.2
@@ -47,35 +47,13 @@ system call
 changes the specified pages to have protection
 .Fa prot .
 .Pp
-Currently these protection bits are known,
-which can be combined, OR'd together:
-.Pp
-.Bl -tag -width ".Dv PROT_WRITE" -compact
-.It Dv PROT_NONE
-No permissions at all.
-.It Dv PROT_READ
-The pages can be read.
-.It Dv PROT_WRITE
-The pages can be written.
-.It Dv PROT_EXEC
-The pages can be executed.
-.El
-.Pp
-In addition to these protection flags,
-.Fx
-provides the ability to set the maximum protection of a region
-(which prevents
+The set of protection bits is documented in
+.Xr mmap 2 .
+Like
+.Xr mmap 2 ,
 .Nm
-from upgrading the permissions).
-This is accomplished by
-.Em or Ns 'ing
-one or more
-.Dv PROT_
-values wrapped in the
-.Dv PROT_MAX()
-macro into the
-.Fa prot
-argument.
+can set the maximum protection of a region
+(which prevents upgrading the permissions).
 .Sh RETURN VALUES
 .Rv -std mprotect
 .Sh ERRORS

--- a/lib/libc/sys/mprotect.2
+++ b/lib/libc/sys/mprotect.2
@@ -28,7 +28,7 @@
 .\"	@(#)mprotect.2	8.1 (Berkeley) 6/9/93
 .\" $FreeBSD$
 .\"
-.Dd February 26, 2020
+.Dd January 14, 2021
 .Dt MPROTECT 2
 .Os
 .Sh NAME
@@ -46,11 +46,6 @@ The
 system call
 changes the specified pages to have protection
 .Fa prot .
-Not all implementations will guarantee protection on a page basis;
-the granularity of protection changes may be as large as an entire region.
-A region is the virtual address space defined by the start
-and end addresses of a
-.Vt "struct vm_map_entry" .
 .Pp
 Currently these protection bits are known,
 which can be combined, OR'd together:

--- a/sys/fs/devfs/devfs_vnops.c
+++ b/sys/fs/devfs/devfs_vnops.c
@@ -2007,6 +2007,7 @@ devfs_mmap_f(struct file *fp, vm_map_t map, vm_offset_t *addr,
 		else if ((prot & VM_PROT_WRITE) != 0)
 			return (EACCES);
 	}
+	maxprot = VM_PROT_ADD_CAP(maxprot);
 	maxprot &= cap_maxprot;
 
 	fpop = td->td_fpop;

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -2629,14 +2629,14 @@ vn_mmap(struct file *fp, vm_map_t map, vm_offset_t *addr,
 			maxprot |= VM_PROT_WRITE;
 		else if ((prot & VM_PROT_WRITE) != 0)
 			return (EACCES);
+
+		prot = VM_PROT_REMOVE_CAP(prot);
 	} else {
 		maxprot |= VM_PROT_WRITE;
 		cap_maxprot |= VM_PROT_WRITE;
 
 		/* Permit capability loads and stores for MAP_PRIVATE. */
-		prot = VM_PROT_ADD_CAP(prot);
 		maxprot = VM_PROT_ADD_CAP(maxprot);
-		cap_maxprot = VM_PROT_ADD_CAP(cap_maxprot);
 	}
 	maxprot &= cap_maxprot;
 

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -56,8 +56,26 @@
 #define	PROT_WRITE	0x02	/* pages can be written */
 #define	PROT_EXEC	0x04	/* pages can be executed */
 #if __BSD_VISIBLE
-#define	_PROT_ALL	(PROT_READ | PROT_WRITE | PROT_EXEC)
-#define	PROT_EXTRACT(prot)	((prot) & _PROT_ALL)
+/*
+ * For backwards capability load and store protections are implied by the
+ * values of PROT_READ and PROT_WRITE or-ed together unless any PROT_CAP_*
+ * value is included.
+ */
+#define	PROT_CAP_NONE	0x4000
+#define	PROT_CAP_READ	0x0008	/* capabilities can be loaded from pages */
+#define	PROT_CAP_WRITE	0x0010	/* capabilities can be stored in pages */
+#define	_PROT_CAP_ALL	(PROT_CAP_NONE | PROT_CAP_READ | PROT_CAP_WRITE)
+#define	PROT_CAP_IMPLIED(prot) __extension__ ({				\
+	int p = (prot);							\
+	if ((p & _PROT_CAP_ALL) == 0) {					\
+		p |= ((p & PROT_READ) != 0) ? PROT_CAP_READ : 0;	\
+		p |= ((p & PROT_WRITE) != 0) ? PROT_CAP_WRITE : 0;	\
+	}								\
+	p;								\
+})
+
+#define	_PROT_ALL	(PROT_READ | PROT_WRITE | PROT_EXEC | _PROT_CAP_ALL)
+#define	PROT_EXTRACT(prot) 	((prot) & _PROT_ALL)
 
 #define	_PROT_MAX_SHIFT	16
 #define	PROT_MAX(prot)		((prot) << _PROT_MAX_SHIFT)

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -62,6 +62,10 @@
 #define	_PROT_MAX_SHIFT	16
 #define	PROT_MAX(prot)		((prot) << _PROT_MAX_SHIFT)
 #define	PROT_MAX_EXTRACT(prot)	(((prot) >> _PROT_MAX_SHIFT) & _PROT_ALL)
+#define PROT_MAX_IMPLIED(prot) __extension__ ({				\
+	int p = (prot);							\
+	PROT_MAX_EXTRACT(p) == 0 ? PROT_EXTRACT(prot) : PROT_MAX_EXTRACT(p); \
+})
 #endif
 
 /*

--- a/sys/vm/vm.h
+++ b/sys/vm/vm.h
@@ -96,6 +96,8 @@ typedef u_char vm_prot_t;	/* protection codes */
 #define	VM_PROT_ADD_CAP(prot)						\
 	((prot) | (((prot) & VM_PROT_READ) != 0 ? VM_PROT_READ_CAP : 0) | \
 	    (((prot) & VM_PROT_WRITE) != 0 ? VM_PROT_WRITE_CAP : 0))
+#define	VM_PROT_REMOVE_CAP(prot)					\
+	((prot) & ~(VM_PROT_READ_CAP | VM_PROT_WRITE_CAP));
 
 enum obj_type { OBJT_DEFAULT, OBJT_SWAP, OBJT_VNODE, OBJT_DEVICE, OBJT_PHYS,
 		OBJT_DEAD, OBJT_SG, OBJT_MGTDEVICE };

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -2865,7 +2865,6 @@ again:
 	/*
 	 * Make a first pass to check for protection violations.
 	 */
-restart_checks:
 	for (entry = first_entry; entry->start < end;
 	    entry = vm_map_entry_succ(entry)) {
 		if ((entry->eflags &
@@ -2874,27 +2873,6 @@ restart_checks:
 		if ((entry->eflags & MAP_ENTRY_IS_SUB_MAP) != 0) {
 			vm_map_unlock(map);
 			return (KERN_INVALID_ARGUMENT);
-		}
-
-		/*
-		 * When keep_cap is used (for mprotect()), upgrade
-		 * new_prot to include the associated VM_PROT_CAP bits
-		 * and retry the the scan.  This means that the
-		 * mprotect will fail if it spans map entries with and
-		 * without VM_PROT_CAP set.
-		 *
-		 * Alternatively, keep_cap could be applied to
-		 * individual map entries.  The current approach gives
-		 * more conservative semantics at the cost of
-		 * potential compatibility breakage.  The alternative
-		 * would maximize compatibility.
-		 */
-		if (keep_cap &&
-		    ((set_max && (entry->max_protection & VM_PROT_CAP) != 0) ||
-		    (!set_max && (entry->protection & VM_PROT_CAP) != 0))) {
-			new_prot = VM_PROT_ADD_CAP(new_prot);
-			keep_cap = FALSE;
-			goto restart_checks;
 		}
 
 		if ((new_prot & entry->max_protection) != new_prot) {

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -791,8 +791,7 @@ kern_mmap_req(struct thread *td, struct mmap_req *mrp)
 			return (error);
 		flags &= ~MAP_EXCL;
 		flags |= MAP_FIXED;
-		mrp->mr_source_cap = mmap_retcap(td,
-		    addr + pageoff, mrp);
+		mrp->mr_source_cap = mmap_retcap(td, addr + pageoff, mrp);
 		mrp->mr_flags = flags;
 	}
 #endif	/* __has_feature(capabilities) */

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -630,12 +630,6 @@ kern_mmap_req(struct thread *td, struct mmap_req *mrp)
 		SYSERRCAUSE("%s: both MAP_SHARED and MAP_PRIVATE", __func__);
 		return (EINVAL);
 	}
-	if (prot != PROT_NONE &&
-	    (prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC)) != 0) {
-		SYSERRCAUSE("%s: Unexpected protections 0x%x", __func__,
-		    (prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC)));
-		return (EINVAL);
-	}
 	if ((flags & MAP_GUARD) != 0 && (prot != PROT_NONE || fd != -1 ||
 	    pos != 0 || (flags & ~(MAP_FIXED | MAP_GUARD | MAP_EXCL |
 	    MAP_CHERI_NOSETBOUNDS |


### PR DESCRIPTION
Add PROT_CAP_NONE, PROT_CAP_READ, and PROT_CAP_WRITE to manage capablity
permissions.  To avoid the need to audit every mmap call (modifying
most), imply PROT_CAP_READ and PROT_CAP_WRITE if PROT_READ or PROT_WRITE
(respectively) are set unless at least one of PROT_CAP_* is set.

To permit expected or-ing behavior, PROT_CAP_NONE is overidden by
PROT_CAP_READ and PROT_CAP_WRITE when present.  It must be stripped
when converting an mmap protection to a vm_prot_t.