### PR TITLE
Simplify cpu_set_upcall().

### DIFF
--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -213,24 +213,19 @@ cpu_set_upcall(struct thread *td, void (* __capability entry)(void *),
 	struct trapframe *tf = td->td_frame;
 
 	/* 32bits processes use r13 for sp */
-	if (td->td_frame->tf_spsr & PSR_M_32) {
+	if (td->td_frame->tf_spsr & PSR_M_32)
 		tf->tf_x[13] = STACKALIGN((uintcap_t)stack->ss_sp + stack->ss_size);
-		tf->tf_elr = (uintcap_t)entry;
-	}
-#if __has_feature(capabilities)
-	else if (SV_PROC_FLAG(td->td_proc, SV_CHERI) == 0) {
+	else
 		tf->tf_sp = STACKALIGN((uintcap_t)stack->ss_sp + stack->ss_size);
-		hybridabi_thread_setregs(td, (__cheri_addr unsigned long)entry);
-	}
-#endif
-	else {
-		tf->tf_sp = STACKALIGN((uintcap_t)stack->ss_sp + stack->ss_size);
+
 #if __has_feature(capabilities)
+	if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
 		trapframe_set_elr(tf, (uintcap_t)entry);
+	else
+		hybridabi_thread_setregs(td, (__cheri_addr unsigned long)entry);
 #else
-		tf->tf_elr = (uintcap_t)entry;
+	tf->tf_elr = (uintcap_t)entry;
 #endif
-	}
 	tf->tf_x[0] = (uintcap_t)arg;
 }
 


### PR DESCRIPTION
This reduces the diff to dev and should also fix ELR (PCC) for 32-bit
processes running under Morello.