### PR TITLE
Fix cross-build support for Ubuntu 16.04

### DIFF
--- a/tools/build/cross-build/include/linux/unistd.h
+++ b/tools/build/cross-build/include/linux/unistd.h
@@ -41,9 +41,17 @@
 /* Ensure that unistd.h pulls in getopt */
 #define __USE_POSIX2
 #endif
+/*
+ * Before version 2.25, glibc's unistd.h would define the POSIX subset of
+ * getopt.h by defining __need_getopt,  including getopt.h (which would
+ * disable the header guard) and then undefining it so later including
+ * getopt.h explicitly would define the extensions. However, we wrap getopt,
+ * and so the wrapper's #pragma once breaks that. Thus getopt.h must be
+ * included before the real unistd.h to ensure we get all the extensions.
+ */
+#include <getopt.h>
 #include_next <unistd.h>
 #include <fcntl.h>
-#include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
Older glibc headers did some very nasty things that have since been sanitised. We could also fix this by adding a linux/getopt.h wrapper alongside the existing common/getopt.h that #undef's __need_getopt, but that seems a little more hacky and complicated.
