### PR TITLE
bsd.compiler.mk: Detect distribution-provided GCC when executed as cc

### DIFF
--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -202,7 +202,16 @@ ${X_}COMPILER_TYPE:=	gcc
 . elif ${_v:Mclang} || ${_v:M(clang-*.*.*)}
 ${X_}COMPILER_TYPE:=	clang
 . else
+# With GCC, cc --version prints "cc $VERSION ($PKGVERSION)", so if a
+# distribution overrides the default GCC PKGVERSION it is not identified.
+# However, its -v output always says "gcc version" in it, so fall back on that.
+_gcc_version!=	${${cc}:N${CCACHE_BIN}} -v 2>&1 | grep "gcc version"
+.  if !empty(_gcc_version)
+${X_}COMPILER_TYPE:=	gcc
+.  else
 .error Unable to determine compiler type for ${cc}=${${cc}}.  Consider setting ${X_}COMPILER_TYPE.
+.  endif
+.undef _gcc_version
 . endif
 .endif
 .if !defined(${X_}COMPILER_VERSION)


### PR DESCRIPTION
Clang always prints "clang $VERSION" regardless of the name used to execute it, whereas GCC prints "$progname $VERSION", meaning if CC is set to cc and cc is GCC it will print "cc $VERSION". We are able to detect some of those cases since it then prints "($PKGVERSION)", where the default is "GCC", but many distributions override that to print their name and the package version number (e.g. "Debian 10.2.1-6"), so nothing tells us it's GCC other than the fact that it's not Clang (and that there's an FSF copyright disclaimer).

However, GCC's -v option will always print "gcc version $VERSION", so fall back on using that to detect GCC. Whilst Clang also supports this option, we should never get here, so Clang handling is not added.
