### PR TITLE
localedef: Fix bootstrapping on Ubuntu 16.04

### DIFF
--- a/usr.bin/localedef/bootstrap/xlocale.h
+++ b/usr.bin/localedef/bootstrap/xlocale.h
@@ -35,8 +35,21 @@
  *
  * $FreeBSD$
  */
+
+#pragma once
+
 /*
- * This header only exists to avoid pulling in the host xlocale.h from
- * the libc-internal headers. This is required since newer Linux GLibc no
- * longer includes xlocale.h and older versions include an incompatible header.
+ * This header only exists to avoid pulling in the host xlocale.h from the
+ * libc-internal headers. New versions of glibc include bits/types/locale.h
+ * from stdlib.h and so get their own locale_t (and don't provide xlocale.h),
+ * but older versions include xlocale.h and expect to have a __locale_t. Thus
+ * we provide dummy definitions of both so the (unused) prototypes don't give
+ * errors.
  */
+
+#ifdef locale_t
+#error "Dummy xlocale.h included inside bootstrapping namespace context"
+#endif
+
+typedef	struct __dummy_host_locale	*__locale_t;
+typedef	__locale_t			locale_t;


### PR DESCRIPTION
Glibc's stdlib.h defines various prototypes for GNU extensions that take a locale_t. Newer versions use locale_t directly and include an internal bits/types/locale_t.h in order to get its definition, but older versions include xlocale.h for that, for which our bootstrap version is empty.  Moreover it expects to use the glibc-specific __locale_t type. Thus, provide dummy definitions of both types in order to ensure the prototypes don't give any errors, and guard against the header being inadvertently included between the bootstrapping namespace.h and un-namespace.h, where locale_t is #define'd.
