### PR TITLE
GitHub Actions: Use oldest Ubuntu and newest macOS

### DIFF
--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -16,8 +16,8 @@ jobs:
         include:
           # TODO: both Ubuntu and macOS have bmake packages, we should try them instead of bootstrapping our own copy.
           - os: ubuntu-16.04
-            compiler: clang-10
-            cross-bindir: /usr/lib/llvm-10/bin
+            compiler: clang-9
+            cross-bindir: /usr/lib/llvm-9/bin
             pkgs: bmake libarchive-dev
           - os: macOS-11.0
             compiler: clang-11

--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -19,7 +19,7 @@ jobs:
             compiler: clang-9
             cross-bindir: /usr/lib/llvm-9/bin
             pkgs: bmake libarchive-dev
-          - os: macOS-11.0
+          - os: macos-11.0
             compiler: clang-11
             #cross-bindir: /usr/local/Cellar/llvm/11.0.0/bin  # script figures this out automatically
             pkgs: bmake libarchive llvm@11

--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         include:
           # TODO: both Ubuntu and macOS have bmake packages, we should try them instead of bootstrapping our own copy.
-          - os: ubuntu-20.04
+          - os: ubuntu-16.04
             compiler: clang-10
             cross-bindir: /usr/lib/llvm-10/bin
             pkgs: bmake libarchive-dev
-          - os: macOS-latest
+          - os: macOS-11.0
             compiler: clang-11
             #cross-bindir: /usr/local/Cellar/llvm/11.0.0/bin  # script figures this out automatically
             pkgs: bmake libarchive llvm@11


### PR DESCRIPTION
This ensures that we can build on macOS 11.0
and the oldest supported Ubuntu release
(both of which were previously broken).