### PR TITLE
Morello fixes

### DIFF
--- a/sys/arm64/arm64/exception_morello.S
+++ b/sys/arm64/arm64/exception_morello.S
@@ -134,7 +134,7 @@ __FBSDID("$FreeBSD$");
 	ldp	c26, c27, [sp, #(TF_X + 26 * 16)]
 	ldp	c28, c29, [sp, #(TF_X + 28 * 16)]
 .else
-	ldr	     x29, [sp, #(TF_X + 29 * 16)]
+	ldr	     c29, [sp, #(TF_X + 29 * 16)]
 .endif
 .if \el == 0
 	add	sp, sp, #(TF_SIZE + 16)

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -319,6 +319,15 @@ drop_to_el1:
 	/* Don't trap to EL2 for exceptions */
 	mov	x2, #CPTR_RES1
 	msr	cptr_el2, x2
+#if __has_feature(capabilities)
+	/*
+	 * Wait for the write to cptr_el2 to complete. It will enable the
+	 * use of capabilities at EL2 that we need below. When not using
+	 * capabilities this is unneeded as the eret instruction will
+	 * act as in place of this barrier.
+	 */
+	isb
+#endif
 
 	/* Don't trap to EL2 for CP15 traps */
 	msr	hstr_el2, xzr


### PR DESCRIPTION
Fix two issues I found in CheriBSD/Morello:
 * We restore `x29` in el1 exception exit when we should be restoring `c29`
 * Add an `isb` after setting `cptr_el2` so it it observable when we try to use capability registers later in `EL2`