### PR TITLE
Morello libc and other user land bits

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -175,7 +175,8 @@ _libc_cheri=	libc_cheri
 _libcheri=	libcheri
 .endif
 
-.if ${MACHINE_CPUARCH} == "mips" || ${MACHINE_CPUARCH} == "riscv"
+.if ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "mips" || \
+    ${MACHINE_CPUARCH} == "riscv"
 .if !${MACHINE_ABI:Mptr32}
 SUBDIR+= libsimple_printf
 .endif

--- a/lib/csu/aarch64c/Makefile
+++ b/lib/csu/aarch64c/Makefile
@@ -1,0 +1,5 @@
+# $FreeBSD$
+
+.PATH:	${.CURDIR}/../common-cheri ${.CURDIR}/../common
+
+.include <bsd.lib.mk>

--- a/lib/csu/aarch64c/crt.h
+++ b/lib/csu/aarch64c/crt.h
@@ -1,0 +1,2 @@
+/* $FreeBSD$ */
+/* Empty so we can include this unconditionally */

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -1,0 +1,141 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2020 Alex Richardson
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+#include <machine/elf.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include "libc_private.h"
+#include "ignore_init.c"
+
+/*
+ * For -pie executables rtld will process the __cap_relocs, so we don't need
+ * to include the code here.
+ */
+#ifndef PIC
+#define DONT_EXPORT_CRT_INIT_GLOBALS
+#define CRT_INIT_GLOBALS_GDC_ONLY
+#include "crt_init_globals.c"
+#endif
+
+struct Struct_Obj_Entry;
+void _start(void *, void (*)(void), struct Struct_Obj_Entry *) __exported;
+
+#ifdef GCRT
+/* Profiling support. */
+#error "GCRT should not be defined for purecap"
+#endif
+
+Elf_Auxinfo *__auxargs;
+
+/*
+ * The entry function, C part. This performs the bulk of program initialisation
+ * before handing off to main().
+ *
+ * Note: If we want to support tight function bounds, it is important that
+ * function calls and global variable accesses are only be made after
+ * do_crt_init_globals() has completed (as this initializes the capabilities to
+ * globals and functions in the captable, which is used for all function calls).
+ * This restriction only applies to statically linked binaries since the dynamic
+ * linker takes care of initialization otherwise.
+ */
+void
+_start(void *auxv,
+	void (*cleanup)(void),			/* from shared loader */
+	struct Struct_Obj_Entry *obj)		/* from shared loader */
+{
+	int argc = 0;
+	char **argv = NULL;
+	char **env = NULL;
+	const bool has_dynamic_linker = obj != NULL && cleanup != NULL;
+#ifndef PIC
+	const Elf_Phdr *at_phdr = NULL;
+	long at_phnum = 0;
+#else
+	if (!has_dynamic_linker)
+		__builtin_trap(); /* RTLD missing? Wrong *crt1.o linked? */
+#endif
+
+	if (cheri_getdefault() != NULL)
+		__builtin_trap(); /* $ddc should be NULL */
+
+	/*
+	 * Digest the auxiliary vector for local use.
+	 *
+	 * Note: this file must be compile with -fno-jump-tables to avoid use
+	 * of the captable before do_crt_init_globals() has been called.
+	 */
+	for (Elf_Auxinfo *auxp = auxv; auxp->a_type != AT_NULL;  auxp++) {
+		if (auxp->a_type == AT_ARGV) {
+			argv = (char **)auxp->a_un.a_ptr;
+		} else if (auxp->a_type == AT_ENVV) {
+			env = (char **)auxp->a_un.a_ptr;
+		} else if (auxp->a_type == AT_ARGC) {
+			argc = auxp->a_un.a_val;
+#ifndef PIC
+		} else if (auxp->a_type == AT_PHDR) {
+			at_phdr = auxp->a_un.a_ptr;
+		} else if (auxp->a_type == AT_PHNUM) {
+			at_phnum = auxp->a_un.a_val;
+#endif
+		}
+	}
+
+	/* For -pie executables rtld will initialize the __cap_relocs */
+#ifndef PIC
+	/*
+	 * crt_init_globals_3 must be called before accessing any globals.
+	 *
+	 * Note: We parse the phdrs to ensure that the global data cap does
+	 * not span the readonly segment or text segment.
+	 */
+	if (!has_dynamic_linker)
+		do_crt_init_globals(at_phdr, at_phnum);
+#endif
+	/* We can access global variables/make function calls now. */
+
+	__auxargs = auxv; /* Store the global auxargs pointer */
+
+	handle_argv(argc, argv, env);
+
+	if (cleanup != NULL)
+		atexit(cleanup);
+	else
+		_init_tls();
+
+	handle_static_init(argc, argv, env);
+
+	exit(main(argc, argv, env));
+}

--- a/lib/libc/aarch64/gen/Makefile.inc
+++ b/lib/libc/aarch64/gen/Makefile.inc
@@ -15,3 +15,7 @@ SRCS+=	_ctx_start.S \
 	setjmp.S \
 	sigsetjmp.S \
 	trivial-getcontextx.c
+
+.if ${MACHINE_ABI:Mpurecap}
+SRCS+=	emutls.c
+.endif

--- a/lib/libc/aarch64/gen/_ctx_start.S
+++ b/lib/libc/aarch64/gen/_ctx_start.S
@@ -31,8 +31,8 @@
 __FBSDID("$FreeBSD$");
 
 ENTRY(_ctx_start)
-	blr	x19		/* Call func from makecontext */
-	mov	x0, x20		/* Load ucp saved in makecontext */
+	blr	REG(19)		/* Call func from makecontext */
+	mov	REG(0), REG(20)	/* Load ucp saved in makecontext */
 	bl	_C_LABEL(ctx_done)
 	bl	_C_LABEL(abort)
 END(_ctx_start)

--- a/lib/libc/aarch64/gen/_set_tp.c
+++ b/lib/libc/aarch64/gen/_set_tp.c
@@ -39,5 +39,9 @@ void
 _set_tp(void *tp)
 {
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	asm volatile("msr	ctpidr_el0, %0" : : "C"(tp));
+#else
 	asm volatile("msr	tpidr_el0, %0" : : "r"(tp));
+#endif
 }

--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -37,23 +37,23 @@ __FBSDID("$FreeBSD$");
 ENTRY(_setjmp)
 	/* Store the magic value and stack pointer */
 	ldr	x8, .Lmagic
-	mov	x9, sp
-	stp	x8, x9, [x0], #16
+	mov	REG(9), REGN(sp)
+	stp	REG(8), REG(9), [REG(0)], #(REG_WIDTH * 2)
 
 	/* Store the general purpose registers and lr */
-	stp	x19, x20, [x0], #16
-	stp	x21, x22, [x0], #16
-	stp	x23, x24, [x0], #16
-	stp	x25, x26, [x0], #16
-	stp	x27, x28, [x0], #16
-	stp	x29, lr, [x0], #16
+	stp	REG(19), REG(20), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(21), REG(22), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(23), REG(24), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(25), REG(26), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(27), REG(28), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(29), REGN(lr), [REG(0)], #(REG_WIDTH * 2)
 
 #ifndef _STANDALONE
 	/* Store the vfp registers */
-	stp	d8, d9, [x0], #16
-	stp	d10, d11, [x0], #16
-	stp	d12, d13, [x0], #16
-	stp	d14, d15, [x0]
+	stp	d8, d9, [REG(0)], #16
+	stp	d10, d11, [REG(0)], #16
+	stp	d12, d13, [REG(0)], #16
+	stp	d14, d15, [REG(0)]
 #endif
 
 	/* Return value */
@@ -66,29 +66,29 @@ END(_setjmp)
 
 ENTRY(_longjmp)
 	/* Check the magic value */
-	ldr	x8, [x0], #8
+	ldr	REG(8), [REG(0)], #(REG_WIDTH)
 	ldr	x9, .Lmagic
 	cmp	x8, x9
 	b.ne	botch
 
 	/* Restore the stack pointer */
-	ldr	x8, [x0], #8
-	mov	sp, x8
+	ldr	REG(8), [REG(0)], #(REG_WIDTH)
+	mov	REGN(sp), REG(8)
 
 	/* Restore the general purpose registers and lr */
-	ldp	x19, x20, [x0], #16
-	ldp	x21, x22, [x0], #16
-	ldp	x23, x24, [x0], #16
-	ldp	x25, x26, [x0], #16
-	ldp	x27, x28, [x0], #16
-	ldp	x29, lr, [x0], #16
+	ldp	REG(19), REG(20), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(21), REG(22), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(23), REG(24), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(25), REG(26), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(27), REG(28), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(29), REGN(lr), [REG(0)], #(REG_WIDTH * 2)
 
 #ifndef _STANDALONE
 	/* Restore the vfp registers */
-	ldp	d8, d9, [x0], #16
-	ldp	d10, d11, [x0], #16
-	ldp	d12, d13, [x0], #16
-	ldp	d14, d15, [x0]
+	ldp	d8, d9, [REG(0)], #16
+	ldp	d10, d11, [REG(0)], #16
+	ldp	d12, d13, [REG(0)], #16
+	ldp	d14, d15, [REG(0)]
 #endif
 
 	/* Load the return value */

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -35,36 +35,36 @@ __FBSDID("$FreeBSD$");
 #include <machine/setjmp.h>
 
 ENTRY(setjmp)
-	sub	sp, sp, #16
-	stp	x0, lr, [sp]
+	sub	REGN(sp), REGN(sp), #(REG_WIDTH * 2)
+	stp	REG(0), REGN(lr), [REGN(sp)]
 
 	/* Store the signal mask */
-	add	x2, x0, #(_JB_SIGMASK * 8)	/* oset */
+	add	REG(2), REG(0), #(_JB_SIGMASK * REG_WIDTH)	/* oset */
 	mov	x1, #0				/* set */
 	mov	x0, #1				/* SIG_BLOCK */
 	bl	sigprocmask
 
-	ldp	x0, lr, [sp]
-	add	sp, sp, #16
+	ldp	REG(0), REGN(lr), [REGN(sp)]
+	add	REGN(sp), REGN(sp), #(REG_WIDTH * 2)
 
 	/* Store the magic value and stack pointer */
 	ldr	x8, .Lmagic
-	mov	x9, sp
-	stp	x8, x9, [x0], #16
+	mov	REG(9), REGN(sp)
+	stp	REG(8), REG(9), [REG(0)], #(REG_WIDTH * 2)
 
 	/* Store the general purpose registers and lr */
-	stp	x19, x20, [x0], #16
-	stp	x21, x22, [x0], #16
-	stp	x23, x24, [x0], #16
-	stp	x25, x26, [x0], #16
-	stp	x27, x28, [x0], #16
-	stp	x29, lr, [x0], #16
+	stp	REG(19), REG(20), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(21), REG(22), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(23), REG(24), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(25), REG(26), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(27), REG(28), [REG(0)], #(REG_WIDTH * 2)
+	stp	REG(29), REGN(lr), [REG(0)], #(REG_WIDTH * 2)
 
 	/* Store the vfp registers */
-	stp	d8, d9, [x0], #16
-	stp	d10, d11, [x0], #16
-	stp	d12, d13, [x0], #16
-	stp	d14, d15, [x0]
+	stp	d8, d9, [REG(0)], #16
+	stp	d10, d11, [REG(0)], #16
+	stp	d12, d13, [REG(0)], #16
+	stp	d14, d15, [REG(0)]
 
 	/* Return value */
 	mov	x0, #0
@@ -75,43 +75,43 @@ ENTRY(setjmp)
 END(setjmp)
 
 ENTRY(longjmp)
-	sub	sp, sp, #32
-	stp	x0, lr, [sp]
-	str	x1, [sp, #16]
+	sub	REGN(sp), REGN(sp), #(REG_WIDTH * 4)
+	stp	REG(0), REGN(lr), [REGN(sp)]
+	str	REG(1), [REGN(sp), #(REG_WIDTH * 2)]
 
 	/* Restore the signal mask */
 	mov	x2, #0				/* oset */
-	add	x1, x0, #(_JB_SIGMASK * 8)	/* set */
+	add	REG(1), REG(0), #(_JB_SIGMASK * REG_WIDTH)	/* set */
 	mov	x0, #3				/* SIG_SETMASK */
 	bl	sigprocmask
 
-	ldr	x1, [sp, #16]
-	ldp	x0, lr, [sp]
-	add	sp, sp, #32
+	ldr	REG(1), [REGN(sp), #(REG_WIDTH * 2)]
+	ldp	REG(0), REGN(lr), [REGN(sp)]
+	add	REGN(sp), REGN(sp), #(REG_WIDTH * 4)
 
 	/* Check the magic value */
-	ldr	x8, [x0], #8
+	ldr	REG(8), [REG(0)], #(REG_WIDTH)
 	ldr	x9, .Lmagic
 	cmp	x8, x9
 	b.ne	botch
 
 	/* Restore the stack pointer */
-	ldr	x8, [x0], #8
-	mov	sp, x8
+	ldr	REG(8), [REG(0)], #(REG_WIDTH)
+	mov	REGN(sp), REG(8)
 
 	/* Restore the general purpose registers and lr */
-	ldp	x19, x20, [x0], #16
-	ldp	x21, x22, [x0], #16
-	ldp	x23, x24, [x0], #16
-	ldp	x25, x26, [x0], #16
-	ldp	x27, x28, [x0], #16
-	ldp	x29, lr, [x0], #16
+	ldp	REG(19), REG(20), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(21), REG(22), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(23), REG(24), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(25), REG(26), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(27), REG(28), [REG(0)], #(REG_WIDTH * 2)
+	ldp	REG(29), REGN(lr), [REG(0)], #(REG_WIDTH * 2)
 
 	/* Restore the vfp registers */
-	ldp	d8, d9, [x0], #16
-	ldp	d10, d11, [x0], #16
-	ldp	d12, d13, [x0], #16
-	ldp	d14, d15, [x0]
+	ldp	d8, d9, [REG(0)], #16
+	ldp	d10, d11, [REG(0)], #16
+	ldp	d12, d13, [REG(0)], #16
+	ldp	d14, d15, [REG(0)]
 
 	/* Load the return value */
 	mov	x0, x1

--- a/lib/libc/aarch64/gen/sigsetjmp.S
+++ b/lib/libc/aarch64/gen/sigsetjmp.S
@@ -43,7 +43,7 @@ END(sigsetjmp)
 ENTRY(siglongjmp)
 	/* Load the _setjmp magic */
 	ldr	x2, .Lmagic
-	ldr	x3, [x0]
+	ldr	x3, [REG(0)]
 
 	/* Check the magic */
 	cmp	x2, x3

--- a/lib/libc/aarch64/static_tls.h
+++ b/lib/libc/aarch64/static_tls.h
@@ -38,7 +38,11 @@ _libc_get_static_tls_base(size_t offset)
 {
 	uintptr_t tlsbase;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("mrs	%0, ctpidr_el0" : "=C" (tlsbase));
+#else
 	__asm __volatile("mrs	%x0, tpidr_el0" : "=r" (tlsbase));
+#endif
 	tlsbase += offset;
 	return (tlsbase);
 }

--- a/lib/libc/aarch64/string/Makefile.inc
+++ b/lib/libc/aarch64/string/Makefile.inc
@@ -4,6 +4,7 @@
 # https://git.linaro.org/toolchain/cortex-strings.git
 #
 
+.if !${MACHINE_ABI:Mpurecap}
 .PATH: ${SRCTOP}/contrib/cortex-strings/src/aarch64
 
 MDSRCS+= \
@@ -22,4 +23,5 @@ MDSRCS+= \
 MDSRCS+= \
 	memcpy.S \
 	memmove.S
+.endif
 .endif

--- a/lib/libc/aarch64/sys/cerror.S
+++ b/lib/libc/aarch64/sys/cerror.S
@@ -30,13 +30,13 @@ __FBSDID("$FreeBSD$");
 
 ENTRY(cerror)
 	.hidden	cerror
-	sub	sp, sp, #16
-	stp	x0, lr, [sp]
+	sub	REGN(sp), REGN(sp), #(REG_WIDTH * 2)
+	stp	REG(0), REGN(lr), [REGN(sp)]
 	bl	_C_LABEL(__error)
-	ldp	x1, lr, [sp]
-	str	w1, [x0]
+	ldp	REG(1), REGN(lr), [REGN(sp)]
+	str	w1, [REG(0)]
 	movn	x0, #0
 	movn	x1, #0
-	add	sp, sp, #16
+	add	REGN(sp), REGN(sp), #(REG_WIDTH * 2)
 	ret
 END(cerror)

--- a/lib/libc/aarch64/sys/vfork.S
+++ b/lib/libc/aarch64/sys/vfork.S
@@ -32,11 +32,11 @@ __FBSDID("$FreeBSD$");
 ENTRY(__sys_vfork)
 	WEAK_REFERENCE(__sys_vfork, vfork)
 	WEAK_REFERENCE(__sys_vfork, _vfork)
-	mov	x2, lr
+	mov	REG(2), REGN(lr)
 	_SYSCALL(vfork)
 	b.cs	cerror
 	sub	x1, x1, #1
 	and	x0, x0, x1
-	mov	lr, x2
+	mov	REGN(lr), REG(2)
 	ret
 END(__sys_vfork)

--- a/lib/libc/gen/Symbol.map
+++ b/lib/libc/gen/Symbol.map
@@ -522,6 +522,7 @@ FBSDprivate_1.0 {
 	_sleep;
 	_rtld_allocate_tls;
 	_rtld_free_tls;
+	__emutls_get_address;
 #if defined(i386)
 	___libc_tls_get_addr;	/* x86 only */
 #endif

--- a/lib/libc/gen/emutls.c
+++ b/lib/libc/gen/emutls.c
@@ -1,0 +1,230 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2019 Andrew Turner
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract FA8750-10-C-0237
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+
+#include <machine/cpu.h>
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "static_tls.h"
+#include "libc_private.h"
+
+struct emutls_control {
+	uint64_t size;
+	uint64_t align;
+	union {
+		_Atomic size_t index;
+		void *unused; /* Ensure this is pointer sized */
+	};
+	void *value_addr;
+};
+
+_Static_assert(sizeof(struct emutls_control) == (sizeof(uint64_t) * 2 +
+    sizeof(void *) * 2), "emutls_control is the wrong size");
+
+struct emutls_array {
+	size_t size;
+	void *data[];
+};
+
+/*
+ * This cannot use pthread keys to store the per-thread emutls_array
+ * since libthr depends on TLS.  Instead, emutls_head points to a
+ * singly-linked list of emutls_array_list structures.  The static TLS
+ * base of each thread is used as the key to identify which
+ * emutls_array_list entry corresponds to each thread.
+ */
+struct emutls_array_list {
+	struct emutls_array_list *next;
+	struct emutls_array *array;
+	uintptr_t handle;
+};
+
+static _Atomic uintptr_t emutls_head;
+
+static _Atomic size_t emutls_next_index = 1;
+
+static void *
+emutls_alloc(size_t len)
+{
+
+	return (tls_calloc(len, 1));
+}
+
+static void *
+emutls_memalign(size_t len, size_t align)
+{
+
+	if (align < sizeof(void *))
+		align = sizeof(void *);
+	return (tls_malloc_aligned(len, align));
+}
+
+static void
+emutls_free(void *ptr)
+{
+
+	tls_free(ptr);
+}
+
+static void
+emutls_setspecific(void *specific)
+{
+	struct emutls_array_list *cur;
+
+	cur = (struct emutls_array_list *)atomic_load(&emutls_head);
+	while (cur != NULL) {
+		if (cur->handle == _libc_get_static_tls_base(0)) {
+			cur->array = specific;
+			return;
+		}
+		cur = cur->next;
+	}
+
+	cur = emutls_alloc(sizeof(*cur));
+	if (cur == NULL)
+		abort();
+	cur->handle = _libc_get_static_tls_base(0);
+	cur->array = specific;
+
+	cur->next = (struct emutls_array_list *)atomic_load(&emutls_head);
+	while (!atomic_compare_exchange_weak(&emutls_head,
+	    (uintptr_t *)&cur->next, (uintptr_t)cur))
+		cpu_spinwait();
+}
+
+static void *
+emutls_getspecific(void)
+{
+	struct emutls_array_list *cur;
+
+	cur = (struct emutls_array_list *)atomic_load(&emutls_head);
+	while (cur != NULL) {
+		if (cur->handle == _libc_get_static_tls_base(0))
+			return (cur->array);
+		cur = cur->next;
+	}
+
+	return (NULL);
+}
+
+/*
+ * Get the array struct for this thread, ensuring it is large enough to
+ * hold at least 'index' items
+ */
+static struct emutls_array *
+emutls_get_array(size_t index)
+{
+	struct emutls_array *array, *new_array;
+	size_t new_size;
+
+	array = emutls_getspecific();
+	if (array == NULL || index > array->size) {
+		/*
+		 * Allocate space for 16 values at a time to reduce
+		 * the overhead of calling malloc + memcpy
+		 */
+		new_size = roundup2(index, 16);
+
+		new_array = emutls_alloc(sizeof(struct emutls_array) +
+		    sizeof(void *) * new_size);
+		/* If this malloc fails there's not much we can do */
+		if (new_array == NULL)
+			abort();
+		new_array->size = new_size;
+		if (array != NULL) {
+			/* Copy the old array to the new array */
+			memcpy(&new_array->data, &array->data,
+			    sizeof(void *) * array->size);
+			emutls_free(array);
+		}
+		array = new_array;
+		emutls_setspecific(array);
+	}
+
+	return (array);
+}
+
+/*
+ * Allocate an index for this tsl value. The index is 1 based as 0 is special
+ * under emutls to indicate the index is unallocated.
+ */
+static inline size_t
+emutls_index(struct emutls_control* control)
+{
+	size_t index;
+
+	index = atomic_load_explicit(&control->index, memory_order_acquire);
+	if (index <= 0) {
+		do {
+			if (index > 0)
+				return (index);
+			/* If index < 0 another thread is allocating it */
+			if (index < 0)
+				cpu_spinwait();
+			else if (atomic_compare_exchange_weak(&control->index,
+			    &index, -1))
+				break;
+		} while (true);
+
+		index = atomic_fetch_add(&emutls_next_index, 1);
+		atomic_store_explicit(&control->index, index,
+		    memory_order_release);
+	}
+
+	return (index);
+}
+
+void *
+__emutls_get_address(struct emutls_control* control)
+{
+	struct emutls_array *array;
+	size_t index;
+
+	index = emutls_index(control);
+	array = emutls_get_array(index);
+	if (array->data[index - 1] == NULL) {
+		array->data[index - 1] = emutls_memalign(control->size,
+		    control->align);
+		if (control->value_addr != 0)
+			memcpy(array->data[index - 1],
+			    control->value_addr, control->size);
+	}
+
+	return (array->data[index - 1]);
+}

--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -117,7 +117,7 @@ void __libc_free_tls(void *tls, size_t tcbsize, size_t tcbalign);
 
 static size_t tls_static_space;
 static size_t tls_init_size;
-static size_t tls_init_align;
+static size_t tls_init_align = 1;
 static void *tls_init;
 #endif
 

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -204,8 +204,10 @@ __rederive_pointer(void *ptr)
 	TLS_MALLOC_LOCK;
 	for (i = 0; i < n_pagepools; i++) {
 		char *pool = pagepool_list[i];
-		if (cheri_is_address_inbounds(pool, addr))
+		if (cheri_is_address_inbounds(pool, addr)) {
+			TLS_MALLOC_UNLOCK;
 			return (cheri_setaddress(pool, addr));
+		}
 	}
 	TLS_MALLOC_UNLOCK;
 
@@ -253,8 +255,10 @@ __tls_malloc(size_t nbytes)
 	TLS_MALLOC_LOCK;
 	if ((op = nextf[bucket]) == NULL) {
 		morecore(bucket);
-		if ((op = nextf[bucket]) == NULL)
+		if ((op = nextf[bucket]) == NULL) {
+			TLS_MALLOC_UNLOCK;
 			return (NULL);
+		}
 	}
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -80,8 +80,8 @@
 #endif
 
 static spinlock_t tls_malloc_lock = _SPINLOCK_INITIALIZER;
-#define	TLS_MALLOC_LOCK		_SPINLOCK(&tls_malloc_lock)
-#define	TLS_MALLOC_UNLOCK	_SPINUNLOCK(&tls_malloc_lock)
+#define	TLS_MALLOC_LOCK		if (__isthreaded) _SPINLOCK(&tls_malloc_lock)
+#define	TLS_MALLOC_UNLOCK	if (__isthreaded) _SPINUNLOCK(&tls_malloc_lock)
 union overhead;
 static void morecore(int);
 static void *__tls_malloc_aligned(size_t size, size_t align);

--- a/lib/libc/locale/Symbol.map
+++ b/lib/libc/locale/Symbol.map
@@ -199,6 +199,7 @@ FBSD_1.3 {
 	__istype_l;
 	__runes_for_locale;
 	_ThreadRuneLocale;
+	__emutls_v._ThreadRuneLocale;
 	c16rtomb;
 	c16rtomb_l;
 	c32rtomb;

--- a/lib/libpmc/pmu-events/list.h
+++ b/lib/libpmc/pmu-events/list.h
@@ -49,7 +49,7 @@
 
 #ifndef LIST_HEAD_DEF
 #define	LIST_HEAD_DEF
-__subobject_use_container_bounds struct list_head {
+struct __subobject_use_container_bounds list_head {
 	struct list_head *next;
 	struct list_head *prev;
 };

--- a/lib/libsimple_printf/aarch64/write.S
+++ b/lib/libsimple_printf/aarch64/write.S
@@ -1,0 +1,11 @@
+#include "SYS.h"
+#include <sys/cdefs.h>
+/*
+ * We want to avoid any dependency on libc here so just do the syscall directly.
+ * We also don't care about errors here to avoid any dependency on errno
+ */
+ENTRY(SIMPLE_PRINTF_WRITE_FUNC)
+	.hidden _C_LABEL(SIMPLE_PRINTF_WRITE_FUNC)
+	_SYSCALL(write);
+	ret;
+END(SIMPLE_PRINTF_WRITE_FUNC)

--- a/lib/libthr/arch/aarch64/include/pthread_md.h
+++ b/lib/libthr/arch/aarch64/include/pthread_md.h
@@ -57,7 +57,11 @@ static __inline void
 _tcb_set(struct tcb *tcb)
 {
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("msr	ctpidr_el0, %0" :: "C" (tcb));
+#else
 	__asm __volatile("msr	tpidr_el0, %x0" :: "r" (tcb));
+#endif
 }
 
 /*
@@ -68,7 +72,11 @@ _tcb_get(void)
 {
 	struct tcb *tcb;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("mrs	%0, ctpidr_el0" : "=C" (tcb));
+#else
 	__asm __volatile("mrs	%x0, tpidr_el0" : "=r" (tcb));
+#endif
 	return (tcb);
 }
 

--- a/secure/lib/libcrypto/Makefile.inc
+++ b/secure/lib/libcrypto/Makefile.inc
@@ -23,7 +23,9 @@ CFLAGS+=	-DB_ENDIAN
 
 .if ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "amd64" || \
     ${MACHINE_CPUARCH} == "arm" || ${MACHINE_CPUARCH} == "i386"
+.if !${MACHINE_ARCH:Maarch64*c*}
 ASM_${MACHINE_CPUARCH}=
+.endif
 .endif
 
 .if defined(ASM_${MACHINE_CPUARCH})

--- a/sys/arm64/include/asm.h
+++ b/sys/arm64/include/asm.h
@@ -58,7 +58,17 @@
 #endif
 
 /* Alias for link register x30 */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	REG_WIDTH	16
+#define	REGN(n)		c ## n
+#define	REG(n)		c ## n
+#define	clr		c30
+#else
+#define	REG_WIDTH	8
+#define	REGN(n)		n
+#define	REG(n)		x ## n
 #define	lr		x30
+#endif
 
 /*
  * Switch into C64 mode to use instructions only available in Morello.

--- a/usr.bin/gh-bc/Makefile
+++ b/usr.bin/gh-bc/Makefile
@@ -54,8 +54,8 @@ MAN_SRC_BC=	bc/A.1
 MAN_SRC_DC=	dc/A.1
 
 # prevent floating point incompatibilities caused by -flto on some architectures
-.if !${MACHINE_ARCH:Mmips*} && ${MACHINE_ARCH:Mpowerpc64*} && \
-    !${MACHINE_ARCH:Mriscv64*}
+.if !${MACHINE_ARCH:Maarch64*} && !${MACHINE_ARCH:Mmips*} && \
+    !${MACHINE_ARCH:Mpowerpc64*} && !${MACHINE_ARCH:Mriscv64*}
 CFLAGS+=	-flto
 .endif
 


### PR DESCRIPTION
This is most of the userland changes from morello-dev (including the non-Morello-specific jevents fix) with the exception of compiler-rt (needs to loop back through LLVM), libunwind (needs to loop back and has some fixes in flight), and rtld.