### PR TITLE
Purecap kernel vmem changes

### DIFF
--- a/sys/amd64/amd64/pmap.c
+++ b/sys/amd64/amd64/pmap.c
@@ -2434,7 +2434,7 @@ pmap_init(void)
 		    lm_ents, (u_long)lm_ents * (NBPML4 / 1024 / 1024 / 1024));
 	if (lm_ents != 0) {
 		large_vmem = vmem_create("large", LARGEMAP_MIN_ADDRESS,
-		    (vmem_size_t)lm_ents * NBPML4, PAGE_SIZE, 0, M_WAITOK);
+		    (vmem_size_t)lm_ents * NBPML4, PAGE_SIZE, 0, M_WAITOK, 0);
 		if (large_vmem == NULL) {
 			printf("pmap: cannot create large map\n");
 			lm_ents = 0;

--- a/sys/amd64/sgx/sgx.c
+++ b/sys/amd64/sgx/sgx.c
@@ -1100,7 +1100,7 @@ sgx_get_epc_area(struct sgx_softc *sc)
 	}
 
 	sc->vmem_epc = vmem_create("SGX EPC", sc->epc_base, sc->epc_size,
-	    PAGE_SIZE, PAGE_SIZE, M_FIRSTFIT | M_WAITOK);
+	    PAGE_SIZE, PAGE_SIZE, M_FIRSTFIT | M_WAITOK, 0);
 	if (sc->vmem_epc == NULL) {
 		printf("%s: Can't create vmem arena.\n", __func__);
 		free(sc->epc_pages, M_SGX);

--- a/sys/arm/annapurna/alpine/alpine_pci_msix.c
+++ b/sys/arm/annapurna/alpine/alpine_pci_msix.c
@@ -217,7 +217,7 @@ al_msix_attach(device_t dev)
 	mtx_init(&sc->msi_mtx, "msi_mtx", NULL, MTX_DEF);
 
 	sc->irq_alloc = vmem_create("Alpine MSI-X IRQs", 0, sc->irq_count,
-	    1, 0, M_FIRSTFIT | M_WAITOK);
+	    1, 0, M_FIRSTFIT | M_WAITOK, 0);
 
 	device_printf(dev, "MSI-X SPI IRQ %d-%d\n", sc->irq_min, sc->irq_max);
 

--- a/sys/arm64/arm64/gicv3_its.c
+++ b/sys/arm64/arm64/gicv3_its.c
@@ -910,7 +910,7 @@ gicv3_its_attach(device_t dev)
 	 * system.
 	 */
 	sc->sc_irq_alloc = vmem_create(device_get_nameunit(dev), 0,
-	    gicv3_get_nirqs(dev), 1, 0, M_FIRSTFIT | M_WAITOK);
+	    gicv3_get_nirqs(dev), 1, 0, M_FIRSTFIT | M_WAITOK, 0);
 
 	sc->sc_irqs = malloc(sizeof(*sc->sc_irqs) * sc->sc_irq_length,
 	    M_GICV3_ITS, M_WAITOK | M_ZERO);

--- a/sys/arm64/intel/stratix10-svc.c
+++ b/sys/arm64/intel/stratix10-svc.c
@@ -178,7 +178,7 @@ s10_get_memory(struct s10_svc_softc *sc)
 		return (ENXIO);
 
 	vmem = vmem_create("stratix10 vmem", 0, 0, PAGE_SIZE,
-	    PAGE_SIZE, M_BESTFIT | M_WAITOK);
+	    PAGE_SIZE, M_BESTFIT | M_WAITOK, 0);
 	if (vmem == NULL)
 		return (ENXIO);
 

--- a/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c
@@ -17109,10 +17109,10 @@ dtrace_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	ASSERT(MUTEX_HELD(&cpu_lock));
 
 	dtrace_arena = vmem_create("dtrace", (void *)1, UINT32_MAX, 1,
-	    NULL, NULL, NULL, 0, VM_SLEEP | VMC_IDENTIFIER);
+	    NULL, NULL, NULL, 0, VM_SLEEP | VMC_IDENTIFIER, 0);
 	dtrace_minor = vmem_create("dtrace_minor", (void *)DTRACEMNRN_CLONE,
 	    UINT32_MAX - DTRACEMNRN_CLONE, 1, NULL, NULL, NULL, 0,
-	    VM_SLEEP | VMC_IDENTIFIER);
+	    VM_SLEEP | VMC_IDENTIFIER, 0);
 	dtrace_taskq = taskq_create("dtrace_taskq", 1, maxclsyspri,
 	    1, INT_MAX, 0);
 

--- a/sys/dev/cxgbe/iw_cxgbe/resource.c
+++ b/sys/dev/cxgbe/iw_cxgbe/resource.c
@@ -287,7 +287,7 @@ int c4iw_pblpool_create(struct c4iw_rdev *rdev)
 	rdev->pbl_arena = vmem_create("PBL_MEM_POOL",
 					rdev->adap->vres.pbl.start,
 					rdev->adap->vres.pbl.size,
-					1, 0, M_FIRSTFIT| M_NOWAIT);
+					1, 0, M_FIRSTFIT| M_NOWAIT, 0);
 	if (!rdev->pbl_arena)
 		return -ENOMEM;
 
@@ -342,7 +342,7 @@ int c4iw_rqtpool_create(struct c4iw_rdev *rdev)
 	rdev->rqt_arena = vmem_create("RQT_MEM_POOL",
 					rdev->adap->vres.rq.start,
 					rdev->adap->vres.rq.size,
-					1, 0, M_FIRSTFIT| M_NOWAIT);
+					1, 0, M_FIRSTFIT| M_NOWAIT, 0);
 	if (!rdev->rqt_arena)
 		return -ENOMEM;
 

--- a/sys/dev/cxgbe/t4_main.c
+++ b/sys/dev/cxgbe/t4_main.c
@@ -1387,7 +1387,7 @@ t4_attach(device_t dev)
 #endif
 	if (sc->vres.key.size != 0)
 		sc->key_map = vmem_create("T4TLS key map", sc->vres.key.start,
-		    sc->vres.key.size, 32, 0, M_FIRSTFIT | M_WAITOK);
+		    sc->vres.key.size, 32, 0, M_FIRSTFIT | M_WAITOK, 0);
 
 	/*
 	 * Second pass over the ports.  This time we know the number of rx and

--- a/sys/dev/cxgbe/tom/t4_ddp.c
+++ b/sys/dev/cxgbe/tom/t4_ddp.c
@@ -1224,7 +1224,7 @@ t4_init_ppod_region(struct ppod_region *pr, struct t4_range *r, u_int psz,
 	pr->pr_invalid_bit = 1 << (pr->pr_alias_shift - 1);
 
 	pr->pr_arena = vmem_create(name, 0, pr->pr_len, PPOD_SIZE, 0,
-	    M_FIRSTFIT | M_NOWAIT);
+	    M_FIRSTFIT | M_NOWAIT, 0);
 	if (pr->pr_arena == NULL)
 		return (ENOMEM);
 

--- a/sys/dev/xdma/xdma.c
+++ b/sys/dev/xdma/xdma.c
@@ -422,7 +422,7 @@ xdma_get_memory(device_t dev)
 		return (NULL);
 
 	vmem = vmem_create("xDMA vmem", 0, 0, PAGE_SIZE,
-	    PAGE_SIZE, M_BESTFIT | M_WAITOK);
+	    PAGE_SIZE, M_BESTFIT | M_WAITOK, 0);
 	if (vmem == NULL)
 		return (NULL);
 

--- a/sys/dev/xdma/xdma_iommu.c
+++ b/sys/dev/xdma/xdma_iommu.c
@@ -142,7 +142,7 @@ xdma_iommu_init(struct xdma_iommu *xio)
 #endif
 
 	xio->vmem = vmem_create("xDMA vmem", 0, 0, PAGE_SIZE,
-	    PAGE_SIZE, M_FIRSTFIT | M_WAITOK);
+	    PAGE_SIZE, M_FIRSTFIT | M_WAITOK, 0);
 	if (xio->vmem == NULL)
 		return (ENXIO);
 

--- a/sys/i386/i386/pmap.c
+++ b/sys/i386/i386/pmap.c
@@ -5929,7 +5929,7 @@ pmap_init_trm(void)
 	TUNABLE_INT_FETCH("machdep.trm_guard", &trm_guard);
 	if ((trm_guard & PAGE_MASK) != 0)
 		trm_guard = 0;
-	pmap_trm_arena = vmem_create("i386trampoline", 0, 0, 1, 0, M_WAITOK);
+	pmap_trm_arena = vmem_create("i386trampoline", 0, 0, 1, 0, M_WAITOK, 0);
 	vmem_set_import(pmap_trm_arena, pmap_trm_import, NULL, NULL, PAGE_SIZE);
 	pd_m = vm_page_alloc(NULL, 0, VM_ALLOC_NOOBJ | VM_ALLOC_NOBUSY |
 	    VM_ALLOC_NORMAL | VM_ALLOC_WIRED | VM_ALLOC_WAITOK | VM_ALLOC_ZERO);

--- a/sys/kern/subr_vmem.c
+++ b/sys/kern/subr_vmem.c
@@ -61,6 +61,8 @@ __FBSDID("$FreeBSD$");
 #include <sys/vmem.h>
 #include <sys/vmmeter.h>
 
+#include <cheri/cheric.h>
+
 #include "opt_vm.h"
 
 #include <vm/uma.h>
@@ -169,6 +171,9 @@ struct vmem {
 
 	/* quantum cache */
 	qcache_t		vm_qcache[VMEM_QCACHE_IDX_MAX];
+
+	/* arena flags */
+	int			vm_flags;
 };
 
 #define	BT_TYPE_SPAN		1	/* Allocated from importfn */
@@ -208,10 +213,10 @@ static uma_zone_t vmem_zone;
 #define	VMEM_LOCK_DESTROY(vm)	mtx_destroy(&vm->vm_lock)
 #define	VMEM_ASSERT_LOCKED(vm)	mtx_assert(&vm->vm_lock, MA_OWNED);
 
-#define	VMEM_ALIGNUP(addr, align)	(-(-(addr) & -(align)))
+#define	VMEM_ALIGNUP(addr, align)	roundup2(addr, align)
 
 #define	VMEM_CROSS_P(addr1, addr2, boundary) \
-	((((addr1) ^ (addr2)) & -(boundary)) != 0)
+    ((((ptraddr_t)(addr1) ^ (ptraddr_t)(addr2)) & -(boundary)) != 0)
 
 #define	ORDER2SIZE(order)	((order) < VMEM_OPTVALUE ? ((order) + 1) : \
     (vmem_size_t)1 << ((order) - (VMEM_OPTVALUE - VMEM_OPTORDER - 1)))
@@ -248,6 +253,39 @@ vmem_t *transient_arena = &transient_arena_storage;
 static struct vmem memguard_arena_storage;
 vmem_t *memguard_arena = &memguard_arena_storage;
 #endif
+
+static vmem_addr_t
+vmem_buildcap(vmem_t *vm, vmem_addr_t addr, vmem_size_t size)
+{
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+		addr = cheri_setboundsexact(addr, size);
+	}
+#endif
+	return (addr);
+}
+
+/*
+ * Round up allocation alignment for the given requested size, if needed.
+ */
+static vmem_size_t
+vmem_roundup_align(vmem_t *vm, vmem_size_t align, vmem_size_t size)
+{
+
+	/* XXX-AM: Double check, may be redundant to verify these */
+	MPASS((align & vm->vm_quantum_mask) == 0);
+	MPASS((align & (align - 1)) == 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+	if ((vm->vm_flags & VMEM_CAPABILITY_ARENA) != 0 &&
+	    CHERI_REPRESENTABLE_ALIGNMENT(size) > align) {
+		MPASS((CHERI_REPRESENTABLE_ALIGNMENT(size) &
+		    vm->vm_quantum_mask) == 0);
+		align = CHERI_REPRESENTABLE_ALIGNMENT(size);
+	}
+#endif
+	return (align);
+}
 
 static bool
 bt_isbusy(bt_t *bt)
@@ -442,7 +480,7 @@ bt_freehead_toalloc(vmem_t *vm, vmem_size_t size, int strat)
 /* ---- boundary tag hash */
 
 static struct vmem_hashlist *
-bt_hashhead(vmem_t *vm, vmem_addr_t addr)
+bt_hashhead(vmem_t *vm, ptraddr_t addr)
 {
 	struct vmem_hashlist *list;
 	unsigned int hash;
@@ -845,10 +883,21 @@ vmem_add1(vmem_t *vm, vmem_addr_t addr, vmem_size_t size, int type)
 		 * the future to coalesce the new segment with an existing free
 		 * segment.
 		 */
-		btprev = TAILQ_LAST(&vm->vm_seglist, vmem_seglist);
-		if ((!bt_isbusy(btprev) && !bt_isfree(btprev)) ||
-		    btprev->bt_start + btprev->bt_size != addr)
+#ifdef __CHERI_PURE_CAPABILITY__
+		if ((vm->vm_flags & VMEM_CAPABILITY_ARENA) != 0) {
+			/*
+			 * With CHERI, it is not possible to merge across
+			 * segments.
+			 */
 			btprev = NULL;
+		} else
+#endif
+		{
+			btprev = TAILQ_LAST(&vm->vm_seglist, vmem_seglist);
+			if ((!bt_isbusy(btprev) && !bt_isfree(btprev)) ||
+			    btprev->bt_start + btprev->bt_size != addr)
+				btprev = NULL;
+		}
 	} else {
 		btprev = NULL;
 	}
@@ -934,6 +983,14 @@ vmem_import(vmem_t *vm, vmem_size_t size, vmem_size_t align, int flags)
 	bt_restore(vm);
 	if (error)
 		return (ENOMEM);
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+		KASSERT(cheri_getlen(addr) == size,
+		    ("Inexact bounds expected %zx found %zx",
+		    (size_t)size, cheri_getlen(addr)));
+	}
+#endif
 
 	vmem_add1(vm, addr, size, BT_TYPE_SPAN);
 
@@ -960,6 +1017,8 @@ vmem_fit(const bt_t *bt, vmem_size_t size, vmem_size_t align,
 	/*
 	 * XXX assumption: vmem_addr_t and vmem_size_t are
 	 * unsigned integer of the same size.
+	 * CHERI breaks this assumption, but the virtual address
+	 * size is still the same as vmem_size_t.
 	 */
 
 	start = bt->bt_start;
@@ -969,6 +1028,7 @@ vmem_fit(const bt_t *bt, vmem_size_t size, vmem_size_t align,
 	end = BT_END(bt);
 	if (end > maxaddr)
 		end = maxaddr;
+
 	if (start > end) 
 		return (ENOMEM);
 
@@ -979,13 +1039,13 @@ vmem_fit(const bt_t *bt, vmem_size_t size, vmem_size_t align,
 		MPASS(align < nocross);
 		start = VMEM_ALIGNUP(start - phase, nocross) + phase;
 	}
-	if (start <= end && end - start >= size - 1) {
-		MPASS((start & (align - 1)) == phase);
+	if (start <= end && (ptraddr_t)end - (ptraddr_t)start >= size - 1) {
+		MPASS(((ptraddr_t)start & (align - 1)) == phase);
 		MPASS(!VMEM_CROSS_P(start, start + size - 1, nocross));
 		MPASS(minaddr <= start);
 		MPASS(maxaddr == 0 || start + size - 1 <= maxaddr);
 		MPASS(bt->bt_start <= start);
-		MPASS(BT_END(bt) - start >= size - 1);
+		MPASS((ptraddr_t)BT_END(bt) - (ptraddr_t)start >= size - 1);
 		*addrp = start;
 
 		return (0);
@@ -1010,7 +1070,7 @@ vmem_clip(vmem_t *vm, bt_t *bt, vmem_addr_t start, vmem_size_t size)
 		btprev = bt_alloc(vm);
 		btprev->bt_type = BT_TYPE_FREE;
 		btprev->bt_start = bt->bt_start;
-		btprev->bt_size = start - bt->bt_start;
+		btprev->bt_size = (ptraddr_t)start - (ptraddr_t)bt->bt_start;
 		bt->bt_start = start;
 		bt->bt_size -= btprev->bt_size;
 		bt_insfree(vm, btprev);
@@ -1114,13 +1174,24 @@ vmem_try_release(vmem_t *vm, struct vmem_btag *bt, const bool remfree)
 }
 
 static int
-vmem_xalloc_nextfit(vmem_t *vm, const vmem_size_t size, vmem_size_t align,
+vmem_xalloc_nextfit(vmem_t *vm, vmem_size_t size, vmem_size_t align,
     const vmem_size_t phase, const vmem_size_t nocross, int flags,
     vmem_addr_t *addrp)
 {
 	struct vmem_btag *bt, *cursor, *next, *prev;
 	int error;
+	vmem_addr_t addr;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	/*
+	 * Size and alignment have not been rounded up yet,
+	 * we do not round up the size to quantum size here.
+	 */
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		size = CHERI_REPRESENTABLE_LENGTH(size);
+		align = vmem_roundup_align(vm, align, size);
+	}
+#endif
 	error = ENOMEM;
 	VMEM_LOCK(vm);
 
@@ -1141,8 +1212,8 @@ retry:
 			bt = TAILQ_FIRST(&vm->vm_seglist);
 		if (bt->bt_type == BT_TYPE_FREE && bt->bt_size >= size &&
 		    (error = vmem_fit(bt, size, align, phase, nocross,
-		    VMEM_ADDR_MIN, VMEM_ADDR_MAX, addrp)) == 0) {
-			vmem_clip(vm, bt, *addrp, size);
+		    VMEM_ADDR_MIN, VMEM_ADDR_MAX, &addr)) == 0) {
+			vmem_clip(vm, bt, addr, size);
 			break;
 		}
 	}
@@ -1166,8 +1237,8 @@ retry:
 		 */
 		if (error == ENOMEM && prev->bt_size >= size &&
 		    (error = vmem_fit(prev, size, align, phase, nocross,
-		    VMEM_ADDR_MIN, VMEM_ADDR_MAX, addrp)) == 0) {
-			vmem_clip(vm, prev, *addrp, size);
+		    VMEM_ADDR_MIN, VMEM_ADDR_MAX, &addr)) == 0) {
+			vmem_clip(vm, prev, addr, size);
 			bt = prev;
 		} else
 			(void)vmem_try_release(vm, prev, true);
@@ -1178,7 +1249,7 @@ retry:
 	 */
 	if (error == 0) {
 		TAILQ_REMOVE(&vm->vm_seglist, cursor, bt_seglist);
-		for (; bt != NULL && bt->bt_start < *addrp + size;
+		for (; bt != NULL && bt->bt_start < addr + size;
 		    bt = TAILQ_NEXT(bt, bt_seglist))
 			;
 		if (bt != NULL)
@@ -1194,8 +1265,10 @@ retry:
 	if (error == ENOMEM && vmem_try_fetch(vm, size, align, flags))
 		goto retry;
 
+	*addrp = vmem_buildcap(vm, addr, size);
 out:
 	VMEM_UNLOCK(vm);
+
 	return (error);
 }
 
@@ -1238,7 +1311,8 @@ vmem_set_reclaim(vmem_t *vm, vmem_reclaim_t *reclaimfn)
  */
 vmem_t *
 vmem_init(vmem_t *vm, const char *name, vmem_addr_t base, vmem_size_t size,
-    vmem_size_t quantum, vmem_size_t qcache_max, int flags)
+    vmem_size_t quantum, vmem_size_t qcache_max, int flags,
+    int arena_flags)
 {
 	vmem_size_t i;
 
@@ -1258,6 +1332,7 @@ vmem_init(vmem_t *vm, const char *name, vmem_addr_t base, vmem_size_t size,
 	vm->vm_size = 0;
 	vm->vm_limit = 0;
 	vm->vm_inuse = 0;
+	vm->vm_flags = arena_flags;
 	qc_init(vm, qcache_max);
 
 	TAILQ_INIT(&vm->vm_seglist);
@@ -1291,7 +1366,8 @@ vmem_init(vmem_t *vm, const char *name, vmem_addr_t base, vmem_size_t size,
  */
 vmem_t *
 vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
-    vmem_size_t quantum, vmem_size_t qcache_max, int flags)
+    vmem_size_t quantum, vmem_size_t qcache_max, int flags,
+    int arena_flags)
 {
 
 	vmem_t *vm;
@@ -1299,8 +1375,8 @@ vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
 	vm = uma_zalloc(vmem_zone, flags & (M_WAITOK|M_NOWAIT));
 	if (vm == NULL)
 		return (NULL);
-	if (vmem_init(vm, name, base, size, quantum, qcache_max,
-	    flags) == NULL)
+	if (vmem_init(vm, name, base, size, quantum, qcache_max, flags,
+	    arena_flags) == NULL)
 		return (NULL);
 	return (vm);
 }
@@ -1320,17 +1396,41 @@ vmem_size_t
 vmem_roundup_size(vmem_t *vm, vmem_size_t size)
 {
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		size = CHERI_REPRESENTABLE_LENGTH(size);
+		/* if quantum <= representable size, we are done */
+		if ((size & vm->vm_quantum_mask) == 0)
+			return (size);
+		/*
+		 * If quantum > representable size, the size will be
+		 * rounded to quantum size, which will be representable
+		 * with some suitable alignment of the base,
+		 * because it must be a power of 2.
+		 */
+	}
+#endif
 	return (size + vm->vm_quantum_mask) & ~vm->vm_quantum_mask;
 }
 
 /*
  * vmem_alloc: allocate resource from the arena.
+ * Note: In the purecap kernel we need to be sure that the quantum
+ * taken from the cache is able to accommodate the representable
+ * size of the requested allocation and protect against loss of precision
+ * due to insufficient alignment of the quantum base.
+ * This is implicitly done by filling the quantum cache zones from
+ * vmem_xalloc(), which enforces those invariants.
+ * The quantum size may exceed the intended size, this
+ * is fine as the whole quantum is allocated and we do not have security
+ * implications.
  */
 int
 vmem_alloc(vmem_t *vm, vmem_size_t size, int flags, vmem_addr_t *addrp)
 {
 	const int strat __unused = flags & VMEM_FITMASK;
 	qcache_t *qc;
+	vmem_addr_t addr;
 
 	flags &= VMEM_FLAGS;
 	MPASS(size > 0);
@@ -1345,16 +1445,30 @@ vmem_alloc(vmem_t *vm, vmem_size_t size, int flags, vmem_addr_t *addrp)
 		 * to return 0.
 		 */
 		qc = &vm->vm_qcache[(size - 1) >> vm->vm_quantum_shift];
-		*addrp = (vmem_addr_t)uma_zalloc(qc->qc_cache,
+		addr = (vmem_addr_t)uma_zalloc(qc->qc_cache,
 		    (flags & ~M_WAITOK) | M_NOWAIT);
-		if (__predict_true(*addrp != 0))
+		if (__predict_true(addr != 0)) {
+			*addrp = vmem_buildcap(vm, *addrp, size);
 			return (0);
+		}
 	}
 
 	return (vmem_xalloc(vm, size, 0, 0, 0, VMEM_ADDR_MIN, VMEM_ADDR_MAX,
 	    flags, addrp));
 }
 
+/*
+ * Note: In the purecap kernel we need to be sure that the allocation
+ * is representable by the capability we return.
+ * This requires:
+ * - Increasing allocation alignment to avoid truncation of the base
+ *  due to low precision.
+ * - Rounding up the requested size to a representable boundary.
+ * The requested size is always rounded up to a quantum size, we
+ * need to round to the representable length first in case we
+ * end up require one extra quantum. Increases in alignment are also
+ * rounded up to quantum sizes.
+ */
 int
 vmem_xalloc(vmem_t *vm, const vmem_size_t size0, vmem_size_t align,
     const vmem_size_t phase, const vmem_size_t nocross,
@@ -1368,6 +1482,7 @@ vmem_xalloc(vmem_t *vm, const vmem_size_t size0, vmem_size_t align,
 	bt_t *bt;
 	int error;
 	int strat;
+	vmem_addr_t addr = 0;
 
 	flags &= VMEM_FLAGS;
 	strat = flags & VMEM_FITMASK;
@@ -1386,6 +1501,14 @@ vmem_xalloc(vmem_t *vm, const vmem_size_t size0, vmem_size_t align,
 	MPASS(nocross == 0 || nocross >= size);
 	MPASS(minaddr <= maxaddr);
 	MPASS(!VMEM_CROSS_P(phase, phase + size - 1, nocross));
+
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA)
+		KASSERT(cheri_getlen(addrp) == sizeof(void *),
+		    ("Invalid bounds for pointer-sized object %zx",
+		    (size_t)cheri_getlen(addrp)));
+#endif
+
 	if (strat == M_NEXTFIT)
 		MPASS(minaddr == VMEM_ADDR_MIN && maxaddr == VMEM_ADDR_MAX);
 
@@ -1400,6 +1523,7 @@ vmem_xalloc(vmem_t *vm, const vmem_size_t size0, vmem_size_t align,
 		return (vmem_xalloc_nextfit(vm, size0, align, phase, nocross,
 		    flags, addrp));
 
+	align = vmem_roundup_align(vm, align, size);
 	end = &vm->vm_freelist[VMEM_MAXORDER];
 	/*
 	 * choose a free block from which we allocate.
@@ -1424,9 +1548,9 @@ vmem_xalloc(vmem_t *vm, const vmem_size_t size0, vmem_size_t align,
 			LIST_FOREACH(bt, list, bt_freelist) {
 				if (bt->bt_size >= size) {
 					error = vmem_fit(bt, size, align, phase,
-					    nocross, minaddr, maxaddr, addrp);
+					    nocross, minaddr, maxaddr, &addr);
 					if (error == 0) {
-						vmem_clip(vm, bt, *addrp, size);
+						vmem_clip(vm, bt, addr, size);
 						goto out;
 					}
 				}
@@ -1459,6 +1583,8 @@ out:
 	VMEM_UNLOCK(vm);
 	if (error != 0 && (flags & M_NOWAIT) == 0)
 		panic("failed to allocate waiting allocation\n");
+	if (error == 0)
+		*addrp = vmem_buildcap(vm, addr, size);
 
 	return (error);
 }
@@ -1471,6 +1597,14 @@ vmem_free(vmem_t *vm, vmem_addr_t addr, vmem_size_t size)
 {
 	qcache_t *qc;
 	MPASS(size > 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		if (!cheri_gettag(addr))
+			panic("Expected valid capability");
+		if (cheri_getsealed(addr))
+			panic("Expect unsealed capability");
+	}
+#endif
 
 	if (size <= vm->vm_qcache_max &&
 	    __predict_true(addr >= VMEM_ADDR_QCACHE_MIN)) {
@@ -1487,11 +1621,20 @@ vmem_xfree(vmem_t *vm, vmem_addr_t addr, vmem_size_t size __unused)
 	bt_t *t;
 
 	MPASS(size > 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		if (!cheri_gettag(addr))
+			panic("Expected valid capability");
+		if (cheri_getsealed(addr))
+			panic("Expect unsealed capability");
+	}
+#endif
 
 	VMEM_LOCK(vm);
 	bt = bt_lookupbusy(vm, addr);
 	MPASS(bt != NULL);
 	MPASS(bt->bt_start == addr);
+	/* XXX-AM: may be invalid when representablility is enforced */
 	MPASS(bt->bt_size == vmem_roundup_size(vm, size) ||
 	    bt->bt_size - vmem_roundup_size(vm, size) <= vm->vm_quantum_mask);
 	MPASS(bt->bt_type == BT_TYPE_BUSY);
@@ -1531,6 +1674,15 @@ vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size, int flags)
 {
 	int error;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (vm->vm_flags & VMEM_CAPABILITY_ARENA) {
+		KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+		KASSERT(!cheri_getsealed(addr), ("Expect unsealed capability"));
+		KASSERT(cheri_getlen(addr) == size,
+		    ("Inexact bounds expected %zx found %zx",
+		    (size_t)size, cheri_getlen(addr)));
+	}
+#endif
 	flags &= VMEM_FLAGS;
 
 	VMEM_LOCK(vm);
@@ -1671,7 +1823,8 @@ vmem_whatis(vmem_addr_t addr, int (*pr)(const char *, ...))
 		}
 		(*pr)("%p is %p+%zu in VMEM '%s' (%s)\n",
 		    (void *)addr, (void *)bt->bt_start,
-		    (vmem_size_t)(addr - bt->bt_start), vm->vm_name,
+		    (vmem_size_t)((ptraddr_t)addr - (ptraddr_t)bt->bt_start),
+		    vm->vm_name,
 		    (bt->bt_type == BT_TYPE_BUSY) ? "allocated" : "free");
 	}
 }
@@ -1832,6 +1985,10 @@ vmem_check(vmem_t *vm)
 //   "updated": 20200708,
 //   "target_type": "kernel",
 //   "changes_purecap": [
+//     "uintcap_arithmetic",
+//     "bounds_compression",
+//     "support",
+//     "pointer_alignment",
 //     "kdb"
 //   ]
 // }

--- a/sys/powerpc/aim/mmu_radix.c
+++ b/sys/powerpc/aim/mmu_radix.c
@@ -3646,7 +3646,7 @@ mmu_radix_init()
 	if (error != 0)
 		panic("qframe allocation failed");
 	asid_arena = vmem_create("ASID", isa3_base_pid + 1, (1<<isa3_pid_bits),
-	    1, 1, M_WAITOK);
+	    1, 1, M_WAITOK, 0);
 }
 
 static boolean_t

--- a/sys/powerpc/mpc85xx/pci_mpc85xx.c
+++ b/sys/powerpc/mpc85xx/pci_mpc85xx.c
@@ -894,7 +894,8 @@ fsl_msi_attach(device_t dev)
 	sc = device_get_softc(dev);
 
 	if (msi_vmem == NULL)
-		msi_vmem = vmem_create("MPIC MSI", 0, 0, 1, 0, M_BESTFIT | M_WAITOK);
+		msi_vmem = vmem_create("MPIC MSI", 0, 0, 1, 0,
+		    M_BESTFIT | M_WAITOK, 0);
 
 	/* Manually play with resource entries. */
 	sc->sc_base = bus_get_resource_start(dev, SYS_RES_MEMORY, 0);

--- a/sys/powerpc/powernv/opal_async.c
+++ b/sys/powerpc/powernv/opal_async.c
@@ -65,7 +65,7 @@ opal_init_async_tokens(int count)
 		return (EINVAL);
 
 	async_token_pool = vmem_create("OPAL Async", 0, count, 1, 1,
-	    M_WAITOK | M_FIRSTFIT);
+	    M_WAITOK | M_FIRSTFIT, 0);
 	completions = malloc(count * sizeof(struct async_completion),
 	    M_DEVBUF, M_WAITOK | M_ZERO);
 

--- a/sys/powerpc/powernv/opal_pci.c
+++ b/sys/powerpc/powernv/opal_pci.c
@@ -427,7 +427,7 @@ opalpci_attach(device_t dev)
 		sc->msi_base = msi_ranges[0];
 
 		sc->msi_vmem = vmem_create("OPAL MSI", msi_ranges[0],
-		    msi_ranges[1], 1, 0, M_BESTFIT | M_WAITOK);
+		    msi_ranges[1], 1, 0, M_BESTFIT | M_WAITOK, 0);
 
 		sc->base_msi_irq = powerpc_register_pic(dev,
 		    OF_xref_from_node(node),

--- a/sys/powerpc/pseries/phyp_vscsi.c
+++ b/sys/powerpc/pseries/phyp_vscsi.c
@@ -728,7 +728,7 @@ vscsi_crq_load_cb(void *xsc, bus_dma_segment_t *segs, int nsegs, int err)
 	sc->srp_iu_queue = (uint8_t *)(sc->crq_queue);
 	sc->srp_iu_phys = segs[0].ds_addr;
 	sc->srp_iu_arena = vmem_create("VSCSI SRP IU", PAGE_SIZE,
-	    segs[0].ds_len - PAGE_SIZE, 16, 0, M_BESTFIT | M_NOWAIT);
+	    segs[0].ds_len - PAGE_SIZE, 16, 0, M_BESTFIT | M_NOWAIT, 0);
 }
 
 static void

--- a/sys/powerpc/pseries/plpar_iommu.c
+++ b/sys/powerpc/pseries/plpar_iommu.c
@@ -140,7 +140,7 @@ phyp_iommu_set_dma_tag(device_t bus, device_t dev, bus_dma_tag_t tag)
 		 */
 		window->map->vmem = vmem_create("IOMMU mappings", PAGE_SIZE,
 		    trunc_page(VMEM_ADDR_MAX) - PAGE_SIZE, PAGE_SIZE, 0,
-		    M_BESTFIT | M_NOWAIT);
+		    M_BESTFIT | M_NOWAIT, 0);
 		SLIST_INSERT_HEAD(&iommu_map_head, window->map, entries);
 	}
 

--- a/sys/sys/vmem.h
+++ b/sys/sys/vmem.h
@@ -49,6 +49,9 @@ typedef int (vmem_import_t)(void *, vmem_size_t, int, vmem_addr_t *);
 typedef void (vmem_release_t)(void *, vmem_addr_t, vmem_size_t);
 typedef void (vmem_reclaim_t)(vmem_t *, int);
 
+/* vmem arena flags for vmem_create() and vmem_init() */
+#define	VMEM_CAPABILITY_ARENA	0x1	/* The arena allocates virtual memory */
+
 /*
  * Create a vmem:
  *	name		- Name of the region
@@ -58,11 +61,14 @@ typedef void (vmem_reclaim_t)(vmem_t *, int);
  *	qcache_max	- Maximum size to quantum cache.  This creates a UMA
  *			  cache for each multiple of quantum up to qcache_max.
  *	flags		- M_* flags
+ *	arena_flags	- VMEM_*_ARENA flags
  */
 vmem_t *vmem_create(const char *name, vmem_addr_t base,
-    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags);
+    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags,
+    int arena_flags);
 vmem_t *vmem_init(vmem_t *vm, const char *name, vmem_addr_t base,
-    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags);
+    vmem_size_t size, vmem_size_t quantum, vmem_size_t qcache_max, int flags,
+    int arena_flags);
 void vmem_destroy(vmem_t *);
 
 /*

--- a/sys/vm/memguard.c
+++ b/sys/vm/memguard.c
@@ -212,7 +212,7 @@ memguard_init(vmem_t *parent)
 
 	vmem_alloc(parent, memguard_mapsize, M_BESTFIT | M_WAITOK, &base);
 	vmem_init(memguard_arena, "memguard arena", base, memguard_mapsize,
-	    PAGE_SIZE, 0, M_WAITOK);
+	    PAGE_SIZE, 0, M_WAITOK, VMEM_CAPABILITY_ARENA);
 	memguard_base = base;
 
 	printf("MEMGUARD DEBUGGING ALLOCATOR INITIALIZED:\n");
@@ -509,3 +509,12 @@ memguard_get_req_size(const void *addr)
 {
 	return (*v2sizep(trunc_page((uintptr_t)addr)));
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "bounds_compression"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/vm/vm_init.c
+++ b/sys/vm/vm_init.c
@@ -230,7 +230,8 @@ again:
 	kmi->buffer_sva = (vm_offset_t)firstaddr;
 	kmi->buffer_eva = kmi->buffer_sva + size;
 	vmem_init(buffer_arena, "buffer arena", firstaddr, size,
-	    PAGE_SIZE, (mp_ncpus > 4) ? BKVASIZE * 8 : 0, 0);
+	    PAGE_SIZE, (mp_ncpus > 4) ? BKVASIZE * 8 : 0, 0,
+	    VMEM_CAPABILITY_ARENA);
 
 	/*
 	 * And optionally transient bio space.
@@ -249,7 +250,7 @@ again:
 		kmi->transient_sva = (vm_offset_t)firstaddr;
 		kmi->transient_eva = kmi->transient_sva + size;
 		vmem_init(transient_arena, "transient arena",
-		    firstaddr, size, PAGE_SIZE, 0, 0);
+		    firstaddr, size, PAGE_SIZE, 0, 0, VMEM_CAPABILITY_ARENA);
 	}
 
 	/*
@@ -269,3 +270,12 @@ again:
 	kmem_subinit(pipe_map, kernel_map, &minaddr, &maxaddr, maxpipekva,
 	    false);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 2020706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "bounds_compression"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -876,7 +876,8 @@ kmem_init(vm_pointer_t start, vm_pointer_t end)
 	/*
 	 * Initialize the kernel_arena.  This can grow on demand.
 	 */
-	vmem_init(kernel_arena, "kernel arena", 0, 0, PAGE_SIZE, 0, 0);
+	vmem_init(kernel_arena, "kernel arena", 0, 0, PAGE_SIZE, 0, 0,
+	    VMEM_CAPABILITY_ARENA);
 	vmem_set_import(kernel_arena, kva_import, NULL, NULL, quantum);
 
 	for (domain = 0; domain < vm_ndomains; domain++) {
@@ -887,7 +888,8 @@ kmem_init(vm_pointer_t start, vm_pointer_t end)
 		 * maximizing the potential for superpage promotion.
 		 */
 		vm_dom[domain].vmd_kernel_arena = vmem_create(
-		    "kernel arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK);
+		    "kernel arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK,
+		    VMEM_CAPABILITY_ARENA);
 		vmem_set_import(vm_dom[domain].vmd_kernel_arena,
 		    kva_import_domain, NULL, kernel_arena, quantum);
 
@@ -901,7 +903,8 @@ kmem_init(vm_pointer_t start, vm_pointer_t end)
 		 */
 #if VM_NRESERVLEVEL > 0
 		vm_dom[domain].vmd_kernel_rwx_arena = vmem_create(
-		    "kernel rwx arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK);
+		    "kernel rwx arena domain", 0, 0, PAGE_SIZE, 0, M_WAITOK,
+		    VMEM_CAPABILITY_ARENA);
 		vmem_set_import(vm_dom[domain].vmd_kernel_rwx_arena,
 		    kva_import_domain, (vmem_release_t *)vmem_xfree,
 		    kernel_arena, KVA_QUANTUM);

--- a/sys/x86/iommu/intel_intrmap.c
+++ b/sys/x86/iommu/intel_intrmap.c
@@ -351,7 +351,7 @@ dmar_init_irt(struct dmar_unit *unit)
 		return (ENOMEM);
 	unit->irt_phys = pmap_kextract((vm_offset_t)unit->irt);
 	unit->irtids = vmem_create("dmarirt", 0, unit->irte_cnt, 1, 0,
-	    M_FIRSTFIT | M_NOWAIT);
+	    M_FIRSTFIT | M_NOWAIT, 0);
 	DMAR_LOCK(unit);
 	dmar_load_irt_ptr(unit);
 	dmar_qi_invalidate_iec_glob(unit);


### PR DESCRIPTION
- Add arena flags parameter to vmem_create() to control capability-specific operations
- Add assertions to check capabilities handled by vmem
- Enforce representable boundaries for vmem capability arenas