### PR TITLE
Purecap kernel pcpu headers

### DIFF
--- a/sys/riscv/include/pcpu.h
+++ b/sys/riscv/include/pcpu.h
@@ -60,7 +60,11 @@ get_pcpu(void)
 {
 	struct pcpu *pcpu;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("cmove %0, ctp" : "=&C"(pcpu));
+#else
 	__asm __volatile("mv %0, tp" : "=&r"(pcpu));
+#endif
 
 	return (pcpu);
 }
@@ -70,7 +74,11 @@ get_curthread(void)
 {
 	struct thread *td;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("clc %0, 0(ctp)" : "=&C"(td));
+#else
 	__asm __volatile("ld %0, 0(tp)" : "=&r"(td));
+#endif
 
 	return (td);
 }
@@ -86,3 +94,12 @@ get_curthread(void)
 #endif	/* _KERNEL */
 
 #endif	/* !_MACHINE_PCPU_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "support"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/riscv/include/pcpu.h
+++ b/sys/riscv/include/pcpu.h
@@ -44,11 +44,17 @@
 
 #define	ALT_STACK_SIZE	128
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	__PCPU_PAD	168
+#else
+#define	__PCPU_PAD	56
+#endif
+
 #define	PCPU_MD_FIELDS							\
 	struct pmap *pc_curpmap;	/* Currently active pmap */	\
 	uint32_t pc_pending_ipis;	/* IPIs pending to this CPU */	\
 	uint32_t pc_hart;		/* Hart ID */			\
-	char __pad[56]			/* Pad to factor of PAGE_SIZE */
+	char __pad[__PCPU_PAD]		/* Pad to factor of PAGE_SIZE */
 
 #ifdef _KERNEL
 

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -1089,7 +1089,11 @@ initriscv(struct riscv_bootparams *rvbp)
 	pcpu_init(pcpup, 0, sizeof(struct pcpu));
 
 	/* Set the pcpu pointer */
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("cmove ctp, %0" :: "C"(pcpup));
+#else
 	__asm __volatile("mv tp, %0" :: "r"(pcpup));
+#endif
 
 	PCPU_SET(curthread, &thread0);
 

--- a/sys/riscv/riscv/mp_machdep.c
+++ b/sys/riscv/riscv/mp_machdep.c
@@ -242,7 +242,11 @@ init_secondary(uint64_t hart)
 
 	/* Setup the pcpu pointer */
 	pcpup = &__pcpu[cpuid];
+#ifdef __CHERI_PURE_CAPABILITY__
+	__asm __volatile("cmove ctp, %0" :: "C"(pcpup));
+#else
 	__asm __volatile("mv tp, %0" :: "r"(pcpup));
+#endif
 
 	/* Workaround: make sure wfi doesn't halt the hart */
 	csr_set(sie, SIE_SSIE);
@@ -560,3 +564,12 @@ cpu_mp_setmaxid(void)
 	mp_ncpus = 1;
 	mp_maxid = 0;
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200803,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "support"
+//   ]
+// }
+// CHERI CHANGES END


### PR DESCRIPTION
- Bound pcpu pointer in MIPS macros
- Add purecap-only pcpu fields
- Adjust RISC-V padding and store pcpu pointer in kernel ctp