### PR TITLE
libprocstat: Guard ZFS code with MK_ZFS not MK_CDDL

### DIFF
--- a/lib/libprocstat/Makefile
+++ b/lib/libprocstat/Makefile
@@ -55,7 +55,7 @@ MLINKS+=libprocstat.3 procstat_close.3 \
 		libprocstat.3 procstat_open_sysctl.3
 
 # XXX This is a hack.
-.if ${MK_CDDL} != "no" && ${MACHINE} != "mips"
+.if ${MK_ZFS} != "no"
 CFLAGS+=	-DLIBPROCSTAT_ZFS
 SRCS+=	zfs.c
 OBJS+=	zfs/zfs_defs.o


### PR DESCRIPTION
This is more correct, even if we currently disable CDDL for CHERI so it doesn't matter.

Whilst here, drop the MIPS check; it's not needed and should be done via src.opts.mk, especially now we use the right variable.
