### PR TITLE
Small if ioctl cleanups

### DIFF
--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -113,9 +113,7 @@ __read_mostly epoch_t net_epoch_preempt;
 #ifdef COMPAT_FREEBSD32
 #include <sys/mount.h>
 #include <compat/freebsd32/freebsd32.h>
-#endif
 
-#ifdef COMPAT_FREEBSD32
 struct ifreq_buffer32 {
 	uint32_t	length;		/* (size_t) */
 	uint32_t	buffer;		/* (void *) */
@@ -156,6 +154,15 @@ CTASSERT(sizeof(struct ifreq64) == sizeof(struct ifreq32));
 CTASSERT(__offsetof(struct ifreq, ifr_ifru) ==
     __offsetof(struct ifreq32, ifr_ifru));
 
+struct ifconf32 {
+	int32_t	ifc_len;
+	union {
+		uint32_t	ifcu_buf;
+		uint32_t	ifcu_req;
+	} ifc_ifcu;
+};
+#define	SIOCGIFCONF32	_IOWR('i', 36, struct ifconf32)
+
 struct ifdrv32 {
 	char		ifd_name[IFNAMSIZ];
 	uint32_t	ifd_cmd;
@@ -192,6 +199,22 @@ struct ifmediareq32 {
 #endif /* COMPAT_FREEBSD32 */
 
 #ifdef COMPAT_FREEBSD64
+struct if_clonereq64 {
+	int	ifcr_total;
+	int	ifcr_count;
+	uint64_t ifcr_buffer;
+};
+#define	SIOCIFGCLONERS64 _IOC_NEWTYPE(SIOCIFGCLONERS, struct if_clonereq64)
+
+struct ifconf64 {
+	int	ifc_len;
+	union {
+		uint64_t	ifcu_buf;
+		uint64_t	ifcu_req;
+	} ifc_ifcu;
+};
+#define	SIOCGIFCONF64	_IOC_NEWTYPE(SIOCGIFCONF, struct ifconf64)
+
 struct ifdrv64 {
 	char		ifd_name[IFNAMSIZ];
 	uint64_t	ifd_cmd;
@@ -236,15 +259,6 @@ union ifreq_union {
 	struct ifreq64	ifr64;
 #endif
 };
-
-#ifdef COMPAT_FREEBSD64
-struct if_clonereq64 {
-	int	ifcr_total;
-	int	ifcr_count;
-	uint64_t ifcr_buffer;
-};
-#define	SIOCIFGCLONERS64 _IOC_NEWTYPE(SIOCIFGCLONERS, struct if_clonereq64)
-#endif
 
 SYSCTL_NODE(_net, PF_LINK, link, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
     "Link layers");
@@ -2995,27 +3009,6 @@ ifhwioctl(u_long cmd, struct ifnet *ifp, caddr_t data, struct thread *td)
 	}
 	return (error);
 }
-
-#ifdef COMPAT_FREEBSD32
-struct ifconf32 {
-	int32_t	ifc_len;
-	union {
-		uint32_t	ifcu_buf;
-		uint32_t	ifcu_req;
-	} ifc_ifcu;
-};
-#define	SIOCGIFCONF32	_IOWR('i', 36, struct ifconf32)
-#endif
-#ifdef COMPAT_FREEBSD64
-struct ifconf64 {
-	int	ifc_len;
-	union {
-		uint64_t	ifcu_buf;
-		uint64_t	ifcu_req;
-	} ifc_ifcu;
-};
-#define	SIOCGIFCONF64	_IOC_NEWTYPE(SIOCGIFCONF, struct ifconf64)
-#endif
 
 /*
  * Interface ioctls.

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -173,6 +173,10 @@ struct ifgroupreq32 {
 		uint32_t	ifgru_groups;
 	} ifgr_ifgru;
 };
+#define	SIOCAIFGROUP32	_IOC_NEWTYPE(SIOCAIFGROUP, struct ifgroupreq32)
+#define	SIOCGIFGROUP32	_IOC_NEWTYPE(SIOCGIFGROUP, struct ifgroupreq32)
+#define	SIOCDIFGROUP32	_IOC_NEWTYPE(SIOCDIFGROUP, struct ifgroupreq32)
+#define	SIOCGIFGMEMB32	_IOC_NEWTYPE(SIOCGIFGMEMB, struct ifgroupreq32)
 
 struct ifmediareq32 {
 	char		ifm_name[IFNAMSIZ];
@@ -185,12 +189,7 @@ struct ifmediareq32 {
 };
 #define	SIOCGIFMEDIA32	_IOC_NEWTYPE(SIOCGIFMEDIA, struct ifmediareq32)
 #define	SIOCGIFXMEDIA32	_IOC_NEWTYPE(SIOCGIFXMEDIA, struct ifmediareq32)
-
-#define	_CASE_IOC_IFGROUPREQ_32(cmd)				\
-    _IOC_NEWTYPE((cmd), struct ifgroupreq32): case
-#else /* !COMPAT_FREEBSD32 */
-#define _CASE_IOC_IFGROUPREQ_32(cmd)
-#endif /* !COMPAT_FREEBSD32 */
+#endif /* COMPAT_FREEBSD32 */
 
 #ifdef COMPAT_FREEBSD64
 struct ifdrv64 {
@@ -210,6 +209,10 @@ struct ifgroupreq64 {
 		uint64_t	ifgru_groups;
 	} ifgr_ifgru;
 };
+#define	SIOCAIFGROUP64	_IOC_NEWTYPE(SIOCAIFGROUP, struct ifgroupreq64)
+#define	SIOCGIFGROUP64	_IOC_NEWTYPE(SIOCGIFGROUP, struct ifgroupreq64)
+#define	SIOCDIFGROUP64	_IOC_NEWTYPE(SIOCDIFGROUP, struct ifgroupreq64)
+#define	SIOCGIFGMEMB64	_IOC_NEWTYPE(SIOCGIFGMEMB, struct ifgroupreq64)
 
 struct ifmediareq64 {
 	char		ifm_name[IFNAMSIZ];
@@ -222,17 +225,7 @@ struct ifmediareq64 {
 };
 #define	SIOCGIFMEDIA64	_IOC_NEWTYPE(SIOCGIFMEDIA, struct ifmediareq64)
 #define	SIOCGIFXMEDIA64	_IOC_NEWTYPE(SIOCGIFXMEDIA, struct ifmediareq64)
-
-#define	_CASE_IOC_IFGROUPREQ_64(cmd)				\
-    _IOC_NEWTYPE((cmd), struct ifgroupreq64): case
-#else /* !COMPAT_FREEBSD64 */
-#define _CASE_IOC_IFGROUPREQ_64(cmd)
-#endif /* !COMPAT_FREEBSD64 */
-
-#define CASE_IOC_IFGROUPREQ(cmd)	\
-    _CASE_IOC_IFGROUPREQ_32(cmd)	\
-    _CASE_IOC_IFGROUPREQ_64(cmd)	\
-    (cmd)
+#endif /* COMPAT_FREEBSD64 */
 
 union ifreq_union {
 	struct ifreq	ifr;
@@ -241,16 +234,6 @@ union ifreq_union {
 #endif
 #ifdef COMPAT_FREEBSD64
 	struct ifreq64	ifr64;
-#endif
-};
-
-union ifgroupreq_union {
-	struct ifgroupreq ifgr;
-#ifdef COMPAT_FREEBSD32
-	struct ifgroupreq32 ifgr32;
-#endif
-#ifdef COMPAT_FREEBSD64
-	struct ifgroupreq64 ifgr64;
 #endif
 };
 
@@ -1711,44 +1694,6 @@ if_delgroups(struct ifnet *ifp)
 	IFNET_WUNLOCK();
 }
 
-static char *
-ifgr_group_get(void *ifgrp)
-{
-	union ifgroupreq_union *ifgrup;
-
-	ifgrup = ifgrp;
-#ifdef COMPAT_FREEBSD32
-	if (SV_CURPROC_FLAG(SV_ILP32))
-		return (&ifgrup->ifgr32.ifgr_ifgru.ifgru_group[0]);
-#endif
-#ifdef COMPAT_FREEBSD64
-	if (!SV_CURPROC_FLAG(SV_CHERI))
-		return (&ifgrup->ifgr64.ifgr_ifgru.ifgru_group[0]);
-#endif
-	return (&ifgrup->ifgr.ifgr_ifgru.ifgru_group[0]);
-}
-
-static struct ifg_req * __capability
-ifgr_groups_get(void *ifgrp)
-{
-	union ifgroupreq_union *ifgrup;
-
-	ifgrup = ifgrp;
-#ifdef COMPAT_FREEBSD32
-	if (SV_CURPROC_FLAG(SV_ILP32))
-		return (__USER_CAP((struct ifg_req *)(uintptr_t)
-		    ifgrup->ifgr32.ifgr_ifgru.ifgru_groups,
-		    ifgrup->ifgr32.ifgr_len));
-#endif
-#ifdef COMPAT_FREEBSD64
-	if (!SV_CURPROC_FLAG(SV_CHERI))
-		return (__USER_CAP((struct ifg_req *)(uintptr_t)
-		    ifgrup->ifgr64.ifgr_ifgru.ifgru_groups,
-		    ifgrup->ifgr64.ifgr_len));
-#endif
-	return (ifgrup->ifgr.ifgr_ifgru.ifgru_groups);
-}
-
 /*
  * Stores all groups from an interface in memory pointed to by ifgr.
  */
@@ -1768,7 +1713,7 @@ if_getgroup(struct ifgroupreq *ifgr, struct ifnet *ifp)
 	}
 
 	len = ifgr->ifgr_len;
-	ifgp = ifgr_groups_get(ifgr);
+	ifgp = ifgr->ifgr_groups;
 	/* XXX: wire */
 	CK_STAILQ_FOREACH(ifgl, &ifp->if_groups, ifgl_next) {
 		if (len < sizeof(ifgrq))
@@ -1813,7 +1758,7 @@ if_getgroupmembers(struct ifgroupreq *ifgr)
 	}
 
 	len = ifgr->ifgr_len;
-	ifgp = ifgr_groups_get(ifgr);
+	ifgp = ifgr->ifgr_groups;
 	CK_STAILQ_FOREACH(ifgm, &ifg->ifg_members, ifgm_next) {
 		if (len < sizeof(ifgrq)) {
 			IFNET_RUNLOCK();
@@ -3010,16 +2955,19 @@ ifhwioctl(u_long cmd, struct ifnet *ifp, caddr_t data, struct thread *td)
 		error = if_gethwaddr(ifp, ifr);
 		break;
 
-	case CASE_IOC_IFGROUPREQ(SIOCAIFGROUP):
+	case SIOCAIFGROUP:
+	{
+		struct ifgroupreq *ifgr = (struct ifgroupreq *)data;
+
 		error = priv_check(td, PRIV_NET_ADDIFGROUP);
 		if (error)
 			return (error);
-		if ((error = if_addgroup(ifp,
-		    ifgr_group_get((struct ifgroupreq *)data))))
+		if ((error = if_addgroup(ifp, ifgr->ifgr_group)))
 			return (error);
 		break;
+	}
 
-	case CASE_IOC_IFGROUPREQ(SIOCGIFGROUP):
+	case SIOCGIFGROUP:
 	{
 		struct epoch_tracker et;
 
@@ -3029,14 +2977,17 @@ ifhwioctl(u_long cmd, struct ifnet *ifp, caddr_t data, struct thread *td)
 		break;
 	}
 
-	case CASE_IOC_IFGROUPREQ(SIOCDIFGROUP):
+	case SIOCDIFGROUP:
+	{
+		struct ifgroupreq *ifgr = (struct ifgroupreq *)data;
+
 		error = priv_check(td, PRIV_NET_DELIFGROUP);
 		if (error)
 			return (error);
-		if ((error = if_delgroup(ifp,
-		    ifgr_group_get((struct ifgroupreq *)data))))
+		if ((error = if_delgroup(ifp, ifgr->ifgr_group)))
 			return (error);
 		break;
+	}
 
 	default:
 		error = ENOIOCTL;
@@ -3077,6 +3028,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		struct if_clonereq ifcr;
 		struct ifconf ifc;
 		struct ifdrv ifd;
+		struct ifgroupreq ifgr;
 		struct ifmediareq ifmr;
 		struct ifreq ifr;
 	} thunk;
@@ -3085,12 +3037,14 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 #ifdef COMPAT_FREEBSD32
 	struct ifconf32 *ifc32;
 	struct ifdrv32 *ifd32;
+	struct ifgroupreq32 *ifgr32;
 	struct ifmediareq32 *ifmr32;
 #endif
 #ifdef COMPAT_FREEBSD64
 	struct if_clonereq64 *ifcr64;
 	struct ifconf64 *ifc64;
 	struct ifdrv64 *ifd64;
+	struct ifgroupreq64 *ifgr64;
 	struct ifmediareq64 *ifmr64;
 	struct ifreq64 *ifr64;
 #endif
@@ -3139,6 +3093,31 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		data = (caddr_t)&thunk.ifd;
 		cmd = _IOC_NEWTYPE(cmd, struct ifdrv);
 		break;
+	case SIOCAIFGROUP32:
+	case SIOCGIFGROUP32:
+	case SIOCDIFGROUP32:
+	case SIOCGIFGMEMB32:
+		ifgr32 = (struct ifgroupreq32 *)data;
+		memcpy(thunk.ifgr.ifgr_name, ifgr32->ifgr_name,
+		    sizeof(thunk.ifgr.ifgr_name));
+		thunk.ifgr.ifgr_len = ifgr32->ifgr_len;
+		switch (cmd) {
+		case SIOCAIFGROUP32:
+		case SIOCDIFGROUP32:
+			memcpy(thunk.ifgr.ifgr_group, ifgr32->ifgr_group,
+			    sizeof(thunk.ifgr.ifgr_group));
+			break;
+		case SIOCGIFGROUP32:
+		case SIOCGIFGMEMB32:
+			thunk.ifgr.ifgr_groups = __USER_CAP(ifgr32->ifgr_groups,
+			    ifgr32->ifgr_len);
+			break;
+		}
+		saved_cmd = cmd;
+		saved_data = data;
+		data = (caddr_t)&thunk.ifgr;
+		cmd = _IOC_NEWTYPE(cmd, struct ifgroupreq);
+		break;
 	case SIOCGIFMEDIA32:
 	case SIOCGIFXMEDIA32:
 		ifmr32 = (struct ifmediareq32 *)data;
@@ -3180,6 +3159,31 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		saved_data = data;
 		data = (caddr_t)&thunk.ifd;
 		cmd = _IOC_NEWTYPE(cmd, struct ifdrv);
+		break;
+	case SIOCAIFGROUP64:
+	case SIOCGIFGROUP64:
+	case SIOCDIFGROUP64:
+	case SIOCGIFGMEMB64:
+		ifgr64 = (struct ifgroupreq64 *)data;
+		memcpy(thunk.ifgr.ifgr_name, ifgr64->ifgr_name,
+		    sizeof(thunk.ifgr.ifgr_name));
+		thunk.ifgr.ifgr_len = ifgr64->ifgr_len;
+		switch (cmd) {
+		case SIOCAIFGROUP64:
+		case SIOCDIFGROUP64:
+			memcpy(thunk.ifgr.ifgr_group, ifgr64->ifgr_group,
+			    sizeof(thunk.ifgr.ifgr_group));
+			break;
+		case SIOCGIFGROUP64:
+		case SIOCGIFGMEMB64:
+			thunk.ifgr.ifgr_groups = __USER_CAP(ifgr64->ifgr_groups,
+			    ifgr64->ifgr_len);
+			break;
+		}
+		saved_cmd = cmd;
+		saved_data = data;
+		data = (caddr_t)&thunk.ifgr;
+		cmd = _IOC_NEWTYPE(cmd, struct ifgroupreq);
 		break;
 	case SIOCGIFMEDIA64:
 	case SIOCGIFXMEDIA64:
@@ -3340,7 +3344,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		error = if_clone_list((struct if_clonereq *)data);
 		goto out_noref;
 
-	case CASE_IOC_IFGROUPREQ(SIOCGIFGMEMB):
+	case SIOCGIFGMEMB:
 		error = if_getgroupmembers((struct ifgroupreq *)data);
 		goto out_noref;
 #if defined(INET) || defined(INET6)
@@ -3424,6 +3428,11 @@ out_noref:
 		    ("ifd_len was updated %u -> %zu", ifd32->ifd_len,
 			thunk.ifd.ifd_len));
 		break;
+	case SIOCGIFGROUP32:
+	case SIOCGIFGMEMB32:
+		ifgr32 = (struct ifgroupreq32 *)data;
+		ifgr32->ifgr_len = thunk.ifgr.ifgr_len;
+		break;
 	case SIOCGIFMEDIA32:
 	case SIOCGIFXMEDIA32:
 		ifmr32 = (struct ifmediareq32 *)saved_data;
@@ -3450,6 +3459,11 @@ out_noref:
 		KASSERT(thunk.ifd.ifd_len == ifd64->ifd_len,
 		    ("ifd_len was updated %lu -> %zu", ifd64->ifd_len,
 			thunk.ifd.ifd_len));
+		break;
+	case SIOCGIFGROUP64:
+	case SIOCGIFGMEMB64:
+		ifgr64 = (struct ifgroupreq64 *)data;
+		ifgr64->ifgr_len = thunk.ifgr.ifgr_len;
 		break;
 	case SIOCGIFMEDIA64:
 	case SIOCGIFXMEDIA64:

--- a/sys/net/if.h
+++ b/sys/net/if.h
@@ -530,10 +530,8 @@ struct ifgroupreq {
 		char	ifgru_group[IFNAMSIZ];
 		struct ifg_req * __kerncap ifgru_groups;
 	} ifgr_ifgru;
-#ifndef _KERNEL
 #define ifgr_group	ifgr_ifgru.ifgru_group
 #define ifgr_groups	ifgr_ifgru.ifgru_groups
-#endif
 };
 
 /*


### PR DESCRIPTION
These are a couple of additional cleanups in sys/net/if.c that I noticed while working on upstreaming some of the changes from the earlier series.  The groupreq one is mostly about being consistent with what is now the dominant style for compat shims (especially for freebsd32 compat shims in this file upstream).