### PR TITLE
Add cheribsdtest_vm_tag_mprotect_none_and_back

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -123,6 +123,32 @@ CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_private,
 	cheribsdtest_success();
 }
 
+CHERIBSDTEST(cheribsdtest_vm_tag_mprotect_none_and_back,
+    "check that mmap/mprotect(NONE)/mprotect(RW) still permits stores")
+{
+	size_t sz = getpagesize();
+	void * __capability volatile *arena;
+
+	arena = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, sz, PROT_READ|PROT_WRITE,
+	    MAP_ANON, -1, 0));
+
+	/* store cap, implicitly testing store permission */
+	arena[0] = cheri_ptr(&arena, sizeof(arena));
+
+	CHERIBSDTEST_CHECK_SYSCALL(mprotect(__DEVOLATILE(void *, arena), sz,
+	    PROT_NONE));
+	CHERIBSDTEST_CHECK_SYSCALL(mprotect(__DEVOLATILE(void *, arena), sz,
+	    PROT_READ|PROT_WRITE));
+
+	CHERIBSDTEST_VERIFY(cheri_gettag(arena[0]));
+
+	/* store cap, implicitly testing store permission */
+	arena[1] = cheri_ptr(&arena, sizeof(arena));
+	CHERIBSDTEST_VERIFY(cheri_gettag(arena[1]));
+
+	cheribsdtest_success();
+}
+
 /*
  * Test aliasing of SHM_ANON objects
  */


### PR DESCRIPTION
This probably shouldn't land until it passes, and that probably takes someone with an understanding of the VM digging into why it doesn't.