### PR TITLE
Purecap kernel subobject bounds annotations.

### DIFF
--- a/sys/cam/cam_ccb.h
+++ b/sys/cam/cam_ccb.h
@@ -343,7 +343,8 @@ typedef struct {
 } ccb_qos_area;
 
 struct ccb_hdr {
-	cam_pinfo	pinfo;		/* Info for priority scheduling */
+	/* Info for priority scheduling */
+	cam_pinfo	pinfo __no_subobject_bounds;
 	camq_entry	xpt_links;	/* For chaining in the XPT layer */
 	camq_entry	sim_links;	/* For chaining in the SIM layer */
 	camq_entry	periph_links;	/* For chaining in the type driver */
@@ -1403,7 +1404,8 @@ struct ccb_async {
  * and the argument to xpt_ccb_free.
  */
 union ccb {
-	struct	ccb_hdr			ccb_h;	/* For convenience */
+	/* For convenience */
+	struct	ccb_hdr			ccb_h __subobject_use_container_bounds;
 	struct	ccb_scsiio		csio;
 	struct	ccb_getdev		cgd;
 	struct	ccb_getdevlist		cgdl;
@@ -1653,3 +1655,12 @@ cam_fill_nvmeadmin(struct ccb_nvmeio *nvmeio, u_int32_t retries,
 __END_DECLS
 
 #endif /* _CAM_CAM_CCB_H */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/cam/cam_xpt_internal.h
+++ b/sys/cam/cam_xpt_internal.h
@@ -98,7 +98,7 @@ SET_DECLARE(cam_xpt_proto_set, struct xpt_proto);
  * cam_ed structure for each device on the bus.
  */
 struct cam_ed {
-	cam_pinfo	 devq_entry;
+	cam_pinfo	 devq_entry __subobject_use_container_bounds;
 	TAILQ_ENTRY(cam_ed) links;
 	struct	cam_et	 *target;
 	struct	cam_sim  *sim;
@@ -216,3 +216,12 @@ void			xpt_stop_tags(struct cam_path *path);
 MALLOC_DECLARE(M_CAMXPT);
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/contrib/ck/include/ck_queue.h
+++ b/sys/contrib/ck/include/ck_queue.h
@@ -125,8 +125,8 @@
  */
 #define	CK_SLIST_HEAD(name, type)						\
 struct name {									\
-	struct type *cslh_first;	/* first element */				\
-}
+	struct type *cslh_first;	/* first element */			\
+} __no_subobject_bounds
 
 #define	CK_SLIST_HEAD_INITIALIZER(head)						\
 	{ NULL }
@@ -134,7 +134,7 @@ struct name {									\
 #define	CK_SLIST_ENTRY(type)							\
 struct {									\
 	struct type *csle_next;	/* next element */				\
-}
+} __no_subobject_bounds
 
 /*
  * Singly-linked List functions.
@@ -231,7 +231,7 @@ struct {									\
 struct name {								\
 	struct type *cstqh_first;/* first element */			\
 	struct type **cstqh_last;/* addr of last next element */		\
-}
+} __no_subobject_bounds
 
 #define	CK_STAILQ_HEAD_INITIALIZER(head)				\
 	{ NULL, &(head).cstqh_first }
@@ -239,7 +239,7 @@ struct name {								\
 #define	CK_STAILQ_ENTRY(type)						\
 struct {								\
 	struct type *cstqe_next;	/* next element */			\
-}
+} __no_subobject_bounds
 
 /*
  * Singly-linked Tail queue functions.
@@ -354,7 +354,7 @@ struct {								\
 #define	CK_LIST_HEAD(name, type)						\
 struct name {									\
 	struct type *clh_first;	/* first element */				\
-}
+} __no_subobject_bounds
 
 #define	CK_LIST_HEAD_INITIALIZER(head)						\
 	{ NULL }
@@ -363,7 +363,7 @@ struct name {									\
 struct {									\
 	struct type *cle_next;	/* next element */				\
 	struct type **cle_prev;	/* address of previous next element */		\
-}
+} __no_subobject_bounds
 
 #define	CK_LIST_FIRST(head)		ck_pr_load_ptr(&(head)->clh_first)
 #define	CK_LIST_EMPTY(head)		(CK_LIST_FIRST(head) == NULL)
@@ -436,3 +436,12 @@ struct {									\
 } while (0)
 
 #endif /* CK_QUEUE_H */
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/contrib/ck/include/ck_stack.h
+++ b/sys/contrib/ck/include/ck_stack.h
@@ -34,7 +34,7 @@
 
 struct ck_stack_entry {
 	struct ck_stack_entry *next;
-};
+} __subobject_use_container_bounds;
 typedef struct ck_stack_entry ck_stack_entry_t;
 
 struct ck_stack {
@@ -360,7 +360,8 @@ ck_stack_init(struct ck_stack *stack)
 //   "updated": 20190812,
 //   "target_type": "header",
 //   "changes_purecap": [
-//     "pointer_shape"
+//     "pointer_shape",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/crypto/des/des_setkey.c
+++ b/sys/crypto/des/des_setkey.c
@@ -177,7 +177,7 @@ void des_set_key_unchecked(const unsigned char *key, des_key_schedule schedule)
 	DES_LONG *k;
 	int i;
 
-	k = &schedule->ks.deslong[0];
+	k = schedule->ks.deslong;
 	in = key;
 
 	c2l(in,c);
@@ -234,3 +234,12 @@ void des_fixup_key_parity(unsigned char *key)
 {
 	des_set_odd_parity(key);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20210401,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/dev/le/am79900var.h
+++ b/sys/dev/le/am79900var.h
@@ -48,10 +48,19 @@
  */
 struct am79900_softc {
 	struct lance_softc lsc;
-};
+} __no_subobject_bounds;
 
 int	am79900_config(struct am79900_softc *, const char*, int);
 void	am79900_detach(struct am79900_softc *);
 void	am79900_intr(void *);
 
 #endif /* _DEV_LE_AM79900VAR_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/dev/le/am7990var.h
+++ b/sys/dev/le/am7990var.h
@@ -48,10 +48,19 @@
  */
 struct am7990_softc {
 	struct lance_softc lsc;
-};
+} __no_subobject_bounds;
 
 int	am7990_config(struct am7990_softc *, const char*, int);
 void	am7990_detach(struct am7990_softc *);
 void	am7990_intr(void *);
 
 #endif /* !_DEV_LE_AM7990VAR_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/dev/le/if_le_isa.c
+++ b/sys/dev/le/if_le_isa.c
@@ -99,7 +99,8 @@ __FBSDID("$FreeBSD$");
 #define	PCNET_RAP	0x12
 
 struct le_isa_softc {
-	struct am7990_softc	sc_am7990;	/* glue to MI code */
+	/* glue to MI code */
+	struct am7990_softc	sc_am7990 __subobject_use_container_bounds;
 
 	bus_size_t		sc_rap;		/* offsets to LANCE... */
 	bus_size_t		sc_rdp;		/* ...registers */
@@ -497,3 +498,12 @@ DEFINE_CLASS_0(le, le_isa_driver, le_isa_methods, sizeof(struct le_isa_softc));
 DRIVER_MODULE(le, isa, le_isa_driver, le_devclass, 0, 0);
 MODULE_DEPEND(le, ether, 1, 1, 1);
 ISA_PNP_INFO(le_isa_ids);
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/dev/le/if_le_pci.c
+++ b/sys/dev/le/if_le_pci.c
@@ -104,7 +104,8 @@ __FBSDID("$FreeBSD$");
 #define	PCNET_PCI_BDP	0x16
 
 struct le_pci_softc {
-	struct am79900_softc	sc_am79900;	/* glue to MI code */
+	/* glue to MI code */
+	struct am79900_softc	sc_am79900 __subobject_use_container_bounds;
 
 	struct resource		*sc_rres;
 
@@ -501,3 +502,12 @@ le_pci_resume(device_t dev)
 
 	return (0);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/fs/devfs/devfs_int.h
+++ b/sys/fs/devfs/devfs_int.h
@@ -43,7 +43,7 @@ struct devfs_dirent;
 struct devfs_mount;
 
 struct cdev_privdata {
-	struct file		*cdpd_fp;
+	struct file		*cdpd_fp __subobject_use_container_bounds;
 	void			*cdpd_data;
 	void			(*cdpd_dtr)(void *);
 	LIST_ENTRY(cdev_privdata) cdpd_list;
@@ -101,3 +101,12 @@ extern TAILQ_HEAD(cdev_priv_list, cdev_priv) cdevp_list;
 #endif /* _KERNEL */
 
 #endif /* !_FS_DEVFS_DEVFS_INT_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -2076,7 +2076,7 @@ fdinit(struct filedesc *fdp, bool prepfiles, int *lastfile)
 		MPASS(lastfile == NULL);
 
 	newfdp0 = uma_zalloc(filedesc0_zone, M_WAITOK | M_ZERO);
-	newfdp = &newfdp0->fd_fd;
+	newfdp = __unbounded_addressof(newfdp0->fd_fd);
 
 	/* Create the file descriptor table. */
 	FILEDESC_LOCK_INIT(newfdp);
@@ -4914,12 +4914,13 @@ fildesc_drvinit(void *unused)
 SYSINIT(fildescdev, SI_SUB_DRIVERS, SI_ORDER_MIDDLE, fildesc_drvinit, NULL);
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20200706,
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
 //   ],
 //   "changes_purecap": [
+//     "subobject_bounds",
 //     "kdb"
 //   ]
 // }

--- a/sys/kern/kern_fork.c
+++ b/sys/kern/kern_fork.c
@@ -249,10 +249,10 @@ SYSCTL_PROC(_kern, OID_AUTO, randompid,
     sysctl_kern_randompid, "I",
     "Random PID modulus. Special values: 0: disable, 1: choose random value");
 
-extern bitstr_t proc_id_pidmap;
-extern bitstr_t proc_id_grpidmap;
-extern bitstr_t proc_id_sessidmap;
-extern bitstr_t proc_id_reapmap;
+extern bitstr_t proc_id_pidmap __no_subobject_bounds;
+extern bitstr_t proc_id_grpidmap __no_subobject_bounds;
+extern bitstr_t proc_id_sessidmap __no_subobject_bounds;
+extern bitstr_t proc_id_reapmap __no_subobject_bounds;
 
 /*
  * Find an unused process ID
@@ -380,12 +380,14 @@ do_fork(struct thread *td, struct fork_req *fr, struct proc *p2, struct thread *
 	p1 = td->td_proc;
 
 	PROC_LOCK(p1);
-	bcopy(&p1->p_startcopy, &p2->p_startcopy,
+
+	bcopy(__unbounded_addressof(p1->p_startcopy),
+	    __unbounded_addressof(p2->p_startcopy),
 	    __rangeof(struct proc, p_startcopy, p_endcopy));
 	pargs_hold(p2->p_args);
 	PROC_UNLOCK(p1);
 
-	bzero(&p2->p_startzero,
+	bzero(__unbounded_addressof(p2->p_startzero),
 	    __rangeof(struct proc, p_startzero, p_endzero));
 
 	/* Tell the prison that we exist. */
@@ -464,10 +466,11 @@ do_fork(struct thread *td, struct fork_req *fr, struct proc *p2, struct thread *
 	PROC_LOCK(p2);
 	PROC_LOCK(p1);
 
-	bzero(&td2->td_startzero,
+	bzero(__unbounded_addressof(td2->td_startzero),
 	    __rangeof(struct thread, td_startzero, td_endzero));
 
-	bcopy(&td->td_startcopy, &td2->td_startcopy,
+	bcopy(__unbounded_addressof(td->td_startcopy),
+	    __unbounded_addressof(td2->td_startcopy),
 	    __rangeof(struct thread, td_startcopy, td_endcopy));
 
 	bcopy(&p2->p_comm, &td2->td_name, sizeof(td2->td_name));
@@ -1143,10 +1146,13 @@ fork_return(struct thread *td, struct trapframe *frame)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20190812,
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_resource.c
+++ b/sys/kern/kern_resource.c
@@ -1113,8 +1113,8 @@ rucollect(struct rusage *ru, struct rusage *ru2)
 
 	if (ru->ru_maxrss < ru2->ru_maxrss)
 		ru->ru_maxrss = ru2->ru_maxrss;
-	ip = &ru->ru_first;
-	ip2 = &ru2->ru_first;
+	ip = __unbounded_addressof(ru->ru_first);
+	ip2 = __unbounded_addressof(ru2->ru_first);
 	for (i = &ru->ru_last - &ru->ru_first; i >= 0; i--)
 		*ip++ += *ip2++;
 }
@@ -1574,10 +1574,13 @@ chgumtxcnt(struct uidinfo *uip, int diff, rlim_t max)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20200706,
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/kern_rmlock.c
+++ b/sys/kern/kern_rmlock.c
@@ -1102,7 +1102,7 @@ rms_runlock(struct rmslock *rms)
 
 struct rmslock_ipi {
 	struct rmslock *rms;
-	struct smp_rendezvous_cpus_retry_arg srcra;
+	struct smp_rendezvous_cpus_retry_arg srcra __subobject_use_container_bounds;
 };
 
 static void
@@ -1246,3 +1246,12 @@ rms_unlock(struct rmslock *rms)
 	else
 		rms_runlock(rms);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -807,7 +807,7 @@ static inline void
 abs_timeout_update(struct abs_timeout *timo)
 {
 
-	kern_clock_gettime(curthread, timo->clockid, &timo->cur);
+	kern_clock_gettime(curthread, timo->clockid, __unbounded_addressof(timo->cur));
 }
 
 static int
@@ -5185,10 +5185,13 @@ umtx_thread_cleanup(struct thread *td)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20200708,
 //   "target_type": "kernel",
 //   "changes": [
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -79,7 +79,7 @@ __FBSDID("$FreeBSD$");
 #define MAXSEGS 4
 
 typedef struct elf_file {
-	struct linker_file lf;		/* Common fields */
+	struct linker_file lf __subobject_member_used_for_c_inheritance; /* Common fields */
 	int		preloaded;	/* Was file pre-loaded */
 	caddr_t		address;	/* Relocation address */
 #ifdef SPARSE_MAPPING
@@ -2144,6 +2144,7 @@ link_elf_late_ireloc(void)
 //   "changes_purecap": [
 //     "pointer_provenance",
 //     "support",
+//     "subobject_bounds",
 //     "kdb",
 //     "pointer_as_integer"
 //   ]

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -91,7 +91,7 @@ typedef struct {
 } Elf_relaent;
 
 typedef struct elf_file {
-	struct linker_file lf;		/* Common fields */
+	struct linker_file lf __subobject_member_used_for_c_inheritance; /* Common fields */
 
 	int		preloaded;
 	caddr_t		address;	/* Relocation address */
@@ -1815,7 +1815,8 @@ link_elf_strtab_get(linker_file_t lf, caddr_t *strtab)
 //   "changes_purecap": [
 //     "pointer_as_integer",
 //     "kdb",
-//     "support"
+//     "support",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/subr_epoch.c
+++ b/sys/kern/subr_epoch.c
@@ -66,8 +66,8 @@ __FBSDID("$FreeBSD$");
 
 TAILQ_HEAD (epoch_tdlist, epoch_tracker);
 typedef struct epoch_record {
-	ck_epoch_record_t er_record;
-	struct epoch_context er_drain_ctx;
+	ck_epoch_record_t er_record __subobject_use_container_bounds;
+	struct epoch_context er_drain_ctx __subobject_use_container_bounds;
 	struct epoch *er_parent;
 	volatile struct epoch_tdlist er_tdlist;
 	volatile uint32_t er_gen;
@@ -991,3 +991,12 @@ epoch_drain_callbacks(epoch_t epoch)
 
 	PICKUP_GIANT();
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/subr_eventhandler.c
+++ b/sys/kern/subr_eventhandler.c
@@ -48,7 +48,7 @@ static struct mtx			eventhandler_mutex;
 
 struct eventhandler_entry_generic 
 {
-    struct eventhandler_entry	ee;
+    struct eventhandler_entry	ee __subobject_use_container_bounds;
     void			(* func)(void);
 };
 
@@ -317,3 +317,12 @@ eventhandler_create_list(const char *name)
 
 	return (list);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/kern/vfs_cache.c
+++ b/sys/kern/vfs_cache.c
@@ -164,7 +164,7 @@ struct	namecache_ts {
 	struct	timespec nc_dotdottime;	/* dotdot timespec provided by fs */
 	int	nc_ticks;		/* ticks value when entry was added */
 	int	nc_pad;
-	struct namecache nc_nc;
+	struct namecache nc_nc __subobject_use_container_bounds;
 };
 
 TAILQ_HEAD(cache_freebatch, namecache);
@@ -4779,7 +4779,8 @@ out:
 //   ],
 //   "changes_purecap": [
 //     "kdb",
-//     "pointer_shape"
+//     "pointer_shape",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -1591,7 +1591,7 @@ vfs_op_exit(struct mount *mp)
 
 struct vfs_op_barrier_ipi {
 	struct mount *mp;
-	struct smp_rendezvous_cpus_retry_arg srcra;
+	struct smp_rendezvous_cpus_retry_arg srcra __subobject_use_container_bounds;
 };
 
 static void
@@ -2611,11 +2611,14 @@ resume_all_fs(void)
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20191025,
+//   "updated": 20200708,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/mips/beri/beri_pic.c
+++ b/sys/mips/beri/beri_pic.c
@@ -81,7 +81,7 @@ enum {
 struct beripic_softc;
 
 struct beri_pic_isrc {
-	struct intr_irqsrc	isrc;
+	struct intr_irqsrc	isrc __subobject_use_container_bounds;
 	u_int			irq;
 	uint32_t		mips_hard_irq;
 };
@@ -368,3 +368,12 @@ static driver_t beripic_driver = {
 
 EARLY_DRIVER_MODULE(beripic, ofwbus, beripic_driver, beripic_devclass, 0, 0,
     BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
+// CHERI CHANGES START
+// {
+//   "updated": 20200513,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/include/pmap.h
+++ b/sys/mips/include/pmap.h
@@ -145,9 +145,9 @@ typedef struct pv_entry {
 struct pv_chunk {
 	pmap_t			pc_pmap;
 	TAILQ_ENTRY(pv_chunk)	pc_list;
-	u_long			pc_map[_NPCM];	/* bitmap; 1 = free */
 	TAILQ_ENTRY(pv_chunk)	pc_lru;
-	struct pv_entry		pc_pventry[_NPCPV];
+	u_long			pc_map[_NPCM];	/* bitmap; 1 = free */
+	struct pv_entry		pc_pventry[_NPCPV] __subobject_use_container_bounds;
 };
 
 /*

--- a/sys/mips/mips/freebsd64_machdep.c
+++ b/sys/mips/mips/freebsd64_machdep.c
@@ -352,7 +352,8 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	sf.sf_uc.uc_mcontext.mulhi = regs->mulhi;
 	sf.sf_uc.uc_mcontext.mc_tls = (__cheri_addr uint64_t)td->td_md.md_tls;
 	sf.sf_uc.uc_mcontext.mc_regs[0] = UCONTEXT_MAGIC;  /* magic number */
-	bcopy((void *)&regs->ast, (void *)&sf.sf_uc.uc_mcontext.mc_regs[1],
+	bcopy(__unbounded_addressof(regs->ast),
+	    (void *)&sf.sf_uc.uc_mcontext.mc_regs[1],
 	    sizeof(sf.sf_uc.uc_mcontext.mc_regs) - sizeof(register_t));
 	sf.sf_uc.uc_mcontext.mc_fpused = td->td_md.md_flags & MDTD_FPUSED;
 #if defined(CPU_HAVEFPU)
@@ -360,7 +361,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 		/* if FPU has current state, save it first */
 		if (td == PCPU_GET(fpcurthread))
 			MipsSaveCurFPState(td);
-		bcopy((void *)&td->td_frame->f0,
+		bcopy(__unbounded_addressof(td->td_frame->f0),
 		    (void *)sf.sf_uc.uc_mcontext.mc_fpregs,
 		    sizeof(sf.sf_uc.uc_mcontext.mc_fpregs));
 	}
@@ -549,3 +550,12 @@ elf64_dump_thread(struct thread *td __unused, void *dst __unused,
     size_t *off __unused)
 {
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/mips/mips/mips_pic.c
+++ b/sys/mips/mips/mips_pic.c
@@ -84,7 +84,7 @@ static void			 cpu_establish_intr(struct mips_pic_softc *sc,
 #define	INTR_MAP_DATA_MIPS	INTR_MAP_DATA_PLAT_1
 
 struct intr_map_data_mips_pic {
-	struct intr_map_data	hdr;
+	struct intr_map_data	hdr __subobject_use_container_bounds;
 	u_int			irq;
 };
 
@@ -113,7 +113,7 @@ struct mtx mips_pic_mtx;
 MTX_SYSINIT(mips_pic_mtx, &mips_pic_mtx, "mips intr controller mutex", MTX_DEF);
 
 struct mips_pic_irqsrc {
-	struct intr_irqsrc	isrc;
+	struct intr_irqsrc	isrc __subobject_use_container_bounds;
 	u_int			irq;
 };
 
@@ -710,3 +710,12 @@ cpu_establish_softintr(const char *name, driver_filter_t *filt,
 	cpu_establish_intr(pic_sc, name, filt, handler, arg, irq, flags,
 	    cookiep);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200517,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -115,17 +115,17 @@ struct bpf_if {
 	struct ifnet	*bif_ifp;	/* corresponding interface */
 	struct bpf_if	**bif_bpf;	/* Pointer to pointer to us */
 	volatile u_int	bif_refcnt;
-	struct epoch_context epoch_ctx;
+	struct epoch_context epoch_ctx __subobject_use_container_bounds;
 };
 
 CTASSERT(offsetof(struct bpf_if, bif_ext) == 0);
 
 struct bpf_program_buffer {
-	struct epoch_context	epoch_ctx;
+	struct epoch_context	epoch_ctx __subobject_use_container_bounds;
 #ifdef BPF_JITTER
 	bpf_jit_filter		*func;
 #endif
-	void			*buffer[0];
+	void			*buffer[];
 };
 
 #if defined(DEV_BPF) || defined(NETGRAPH_BPF)
@@ -3113,12 +3113,13 @@ DB_SHOW_COMMAND(bpf_if, db_show_bpf_if)
 #endif
 // CHERI CHANGES START
 // {
-//   "updated": 20181114,
+//   "updated": 20200706,
 //   "target_type": "kernel",
 //   "changes": [
 //     "ioctl:misc"
 //   ],
 //   "changes_purecap": [
+//     "subobject_bounds",
 //     "kdb"
 //   ]
 // }

--- a/sys/net/bpfdesc.h
+++ b/sys/net/bpfdesc.h
@@ -107,7 +107,7 @@ struct bpf_d {
 	u_char		bd_compat32;	/* 32-bit stream on LP64 system */
 
 	volatile u_int	bd_refcnt;
-	struct epoch_context epoch_ctx;
+	struct epoch_context epoch_ctx __subobject_use_container_bounds;
 };
 
 /* Values for bd_state */
@@ -159,3 +159,12 @@ struct xbpf_d {
 #define BPFIF_FLAG_DYING	1	/* Reject new bpf consumers */
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/if_dl.h
+++ b/sys/net/if_dl.h
@@ -64,8 +64,8 @@ struct sockaddr_dl {
 	u_char	sdl_nlen;	/* interface name length, no trailing 0 reqd. */
 	u_char	sdl_alen;	/* link level address length */
 	u_char	sdl_slen;	/* link layer selector length */
-	char	sdl_data[46];	/* minimum work area, can be larger;
-				   contains both if name and ll address */
+	/* minimum work area, can be larger; contains both if name and ll address */
+	char	sdl_data[46] __subobject_variable_length;
 };
 
 #define LLADDR(s) ((caddr_t)((s)->sdl_data + (s)->sdl_nlen))
@@ -89,3 +89,12 @@ __END_DECLS
 #endif /* !_KERNEL */
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/if_llatbl.h
+++ b/sys/net/if_llatbl.h
@@ -83,7 +83,7 @@ struct llentry {
 	struct callout		lle_timer;
 	struct rwlock		 lle_lock;
 	struct mtx		req_mtx;
-	struct epoch_context lle_epoch_ctx;
+	struct epoch_context lle_epoch_ctx __subobject_use_container_bounds;
 };
 
 #define	LLE_WLOCK(lle)		rw_wlock(&(lle)->lle_lock)
@@ -274,3 +274,12 @@ enum {
 typedef void (*lle_event_fn)(void *, struct llentry *, int);
 EVENTHANDLER_DECLARE(lle_event, lle_event_fn);
 #endif  /* _NET_IF_LLATBL_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/if_var.h
+++ b/sys/net/if_var.h
@@ -432,7 +432,7 @@ struct ifnet {
 	 * Debugnet (Netdump) hooks to be called while in db/panic.
 	 */
 	struct debugnet_methods *if_debugnet_methods;
-	struct epoch_context	if_epoch_ctx;
+	struct epoch_context	if_epoch_ctx __subobject_use_container_bounds;
 
 	/*
 	 * Spare fields to be added before branching a stable branch, so
@@ -569,7 +569,7 @@ struct ifaddr {
 	counter_u64_t	ifa_opackets;
 	counter_u64_t	ifa_ibytes;
 	counter_u64_t	ifa_obytes;
-	struct	epoch_context	ifa_epoch_ctx;
+	struct	epoch_context	ifa_epoch_ctx __subobject_use_container_bounds;
 };
 
 struct ifaddr *	ifa_alloc(size_t size, int flags);
@@ -590,7 +590,7 @@ struct ifmultiaddr {
 	int	ifma_flags;
 	void	*ifma_protospec;	/* protocol-specific state, if any */
 	struct	ifmultiaddr *ifma_llifma; /* pointer to ifma for ifma_lladdr */
-	struct	epoch_context	ifma_epoch_ctx;
+	struct	epoch_context	ifma_epoch_ctx __subobject_use_container_bounds;
 };
 
 extern	struct sx ifnet_sxlock;
@@ -839,10 +839,13 @@ int    ether_poll_deregister(if_t ifp);
 #endif /* !_NET_IF_VAR_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20181127,
+//   "updated": 20200706,
 //   "target_type": "header",
 //   "changes": [
 //     "ioctl:net"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/net/if_vlan.c
+++ b/sys/net/if_vlan.c
@@ -178,7 +178,7 @@ mst_to_vst(struct m_snd_tag *mst)
 struct vlan_mc_entry {
 	struct sockaddr_dl		mc_addr;
 	CK_SLIST_ENTRY(vlan_mc_entry)	mc_entries;
-	struct epoch_context		mc_epoch_ctx;
+	struct epoch_context		mc_epoch_ctx __subobject_use_container_bounds;
 };
 
 struct ifvlan {
@@ -2112,6 +2112,9 @@ vlan_snd_tag_free(struct m_snd_tag *mst)
 //   "changes": [
 //     "ioctl:net",
 //     "user_capabilities"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/net/pfil.c
+++ b/sys/net/pfil.c
@@ -86,7 +86,7 @@ struct pfil_link {
 	void			*link_ruleset;
 	int			 link_flags;
 	struct pfil_hook	*link_hook;
-	struct epoch_context	 link_epoch_ctx;
+	struct epoch_context	 link_epoch_ctx __subobject_use_container_bounds;
 };
 
 typedef CK_STAILQ_HEAD(pfil_chain, pfil_link)	pfil_chain_t;
@@ -673,3 +673,12 @@ pfilioc_link(struct pfilioc_link *req)
 
 	return (pfil_link(&args));
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/route/nhop_var.h
+++ b/sys/net/route/nhop_var.h
@@ -60,7 +60,7 @@ struct nh_control {
 	struct bitmask_head	gr_idx_head;	/* nhgrp index head */
 	struct rwlock		ctl_lock;	/* overall ctl lock */
 	struct rib_head		*ctl_rh;	/* pointer back to rnh */
-	struct epoch_context	ctl_epoch_ctx;	/* epoch ctl helper */
+	struct epoch_context	ctl_epoch_ctx __subobject_use_container_bounds;	/* epoch ctl helper */
 };
 
 #define	NHOPS_WLOCK(ctl)	rw_wlock(&(ctl)->ctl_lock)
@@ -88,7 +88,7 @@ struct nhop_priv {
 	struct nh_control	*nh_control;	/* backreference to the rnh */
 	struct nhop_priv	*nh_next;	/* hash table membership */
 	struct vnet		*nh_vnet;	/* vnet nhop belongs to */
-	struct epoch_context	nh_epoch_ctx;	/* epoch data for nhop */
+	struct epoch_context	nh_epoch_ctx __subobject_use_container_bounds;	/* epoch data for nhop */
 };
 
 #define	NH_PRIV_END_CMP	(__offsetof(struct nhop_priv, nh_idx))
@@ -106,3 +106,12 @@ struct nhop_priv *unlink_nhop(struct nh_control *ctl, struct nhop_priv *nh_priv)
 int cmp_priv(const struct nhop_priv *_one, const struct nhop_priv *_two);
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/route/route_ctl.c
+++ b/sys/net/route/route_ctl.c
@@ -71,7 +71,7 @@ struct rib_subscription {
 	rib_subscription_cb_t			*func;
 	void					*arg;
 	enum rib_subscription_type		type;
-	struct epoch_context			epoch_ctx;
+	struct epoch_context			epoch_ctx __subobject_use_container_bounds;
 };
 
 static int add_route(struct rib_head *rnh, struct rt_addrinfo *info,
@@ -1348,3 +1348,12 @@ rib_destroy_subscriptions(struct rib_head *rnh)
 	RIB_WUNLOCK(rnh);
 	NET_EPOCH_EXIT(et);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20210401,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/net/route/route_var.h
+++ b/sys/net/route/route_var.h
@@ -135,7 +135,8 @@ VNET_PCPUSTAT_DECLARE(struct rtstat, rtstat);
 #define RNTORT(p)	((struct rtentry *)(p))
 
 struct rtentry {
-	struct	radix_node rt_nodes[2];	/* tree glue, and other values */
+	/* tree glue, and other values */
+	struct	radix_node rt_nodes[2] __subobject_use_container_bounds;
 	/*
 	 * XXX struct rtentry must begin with a struct radix_node (or two!)
 	 * because the code does some casts of a 'struct radix_node *'
@@ -170,7 +171,8 @@ struct rtentry {
 	u_long		rt_weight;	/* absolute weight */ 
 	u_long		rt_expire;	/* lifetime for route, e.g. redirect */
 	struct rtentry	*rt_chain;	/* pointer to next rtentry to delete */
-	struct epoch_context	rt_epoch_ctx;	/* net epoch tracker */
+	/* net epoch tracker */
+	struct epoch_context	rt_epoch_ctx __subobject_use_container_bounds;
 };
 
 /*
@@ -312,3 +314,12 @@ void nhgrp_free(struct nhgrp_object *nhg);
 extern uint8_t mpath_entropy_key[MPATH_ENTROPY_KEY_LEN];
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/in.c
+++ b/sys/netinet/in.c
@@ -1101,7 +1101,7 @@ in_purgemaddrs(struct ifnet *ifp)
 }
 
 struct in_llentry {
-	struct llentry		base;
+	struct llentry base __subobject_use_container_bounds;
 };
 
 #define	IN_LLTBL_DEFAULT_HSIZE	32
@@ -1567,3 +1567,12 @@ in_domifdetach(struct ifnet *ifp, void *aux)
 	lltable_free(ii->ii_llt);
 	free(ii, M_IFADDR);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/in_pcb.h
+++ b/sys/netinet/in_pcb.h
@@ -325,7 +325,7 @@ struct inpcb {
 	CK_LIST_ENTRY(inpcb) inp_list;	/* (p/l) list for all PCBs for proto */
 	                                /* (e[r]) for list iteration */
 	                                /* (p[w]/l) for addition/removal */
-	struct epoch_context inp_epoch_ctx;
+	struct epoch_context inp_epoch_ctx __subobject_use_container_bounds;
 };
 #endif	/* _KERNEL */
 
@@ -399,7 +399,7 @@ void	in_pcbtoxinpcb(const struct inpcb *, struct xinpcb *);
 #endif /* _SYS_SOCKETVAR_H_ */
 
 struct inpcbport {
-	struct epoch_context phd_epoch_ctx;
+	struct epoch_context phd_epoch_ctx __subobject_use_container_bounds;
 	CK_LIST_ENTRY(inpcbport) phd_hash;
 	struct inpcbhead phd_pcblist;
 	u_short phd_port;
@@ -407,7 +407,7 @@ struct inpcbport {
 
 struct in_pcblist {
 	int il_count;
-	struct epoch_context il_epoch_ctx;
+	struct epoch_context il_epoch_ctx __subobject_use_container_bounds;
 	struct inpcbinfo *il_pcbinfo;
 	struct inpcb *il_inp_list[0];
 };
@@ -562,7 +562,7 @@ struct inpcbgroup {
  */
 struct inpcblbgroup {
 	CK_LIST_ENTRY(inpcblbgroup) il_list;
-	struct epoch_context il_epoch_ctx;
+	struct epoch_context il_epoch_ctx __subobject_use_container_bounds;
 	uint16_t	il_lport;			/* (c) */
 	u_char		il_vflag;			/* (c) */
 	u_char		il_pad;
@@ -896,10 +896,13 @@ void	in_pcboutput_eagain(struct inpcb *);
 #endif /* !_NETINET_IN_PCB_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20181121,
+//   "updated": 20200706,
 //   "target_type": "header",
 //   "changes": [
 //     "integer_provenance"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/netinet/in_var.h
+++ b/sys/netinet/in_var.h
@@ -73,7 +73,8 @@ struct in_ifinfo {
  * of the structure and is assumed to be first.
  */
 struct in_ifaddr {
-	struct	ifaddr ia_ifa;		/* protocol-independent info */
+	struct	ifaddr ia_ifa __subobject_use_container_bounds;
+					/* protocol-independent info */
 #define	ia_ifp		ia_ifa.ifa_ifp
 #define ia_flags	ia_ifa.ifa_flags
 					/* ia_subnet{,mask} in host order */
@@ -481,3 +482,12 @@ void	in_detachhead(struct rib_head *rh);
 #include <netinet6/in6_var.h>
 
 #endif /* _NETINET_IN_VAR_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190822,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/ip_gre.c
+++ b/sys/netinet/ip_gre.c
@@ -80,7 +80,7 @@ SYSCTL_INT(_net_inet_ip, OID_AUTO, grettl, CTLFLAG_VNET | CTLFLAG_RW,
     &VNET_NAME(ip_gre_ttl), 0, "Default TTL value for encapsulated packets");
 
 struct in_gre_socket {
-	struct gre_socket		base;
+	struct gre_socket		base __subobject_use_container_bounds;
 	in_addr_t			addr;
 };
 VNET_DEFINE_STATIC(struct gre_sockets *, ipv4_sockets) = NULL;
@@ -592,3 +592,12 @@ in_gre_uninit(void)
 		gre_hashdestroy((struct gre_list *)V_ipv4_sockets);
 	}
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/ip_icmp.c
+++ b/sys/netinet/ip_icmp.c
@@ -362,7 +362,7 @@ stdreply:	icmpelen = max(8, min(V_icmp_quotelen, ntohs(oip->ip_len) -
 	 * Copy the quotation into ICMP message and
 	 * convert quoted IP header back to network representation.
 	 */
-	m_copydata(n, 0, icmplen, (caddr_t)&icp->icmp_ip);
+	m_copydata(n, 0, icmplen, (caddr_t)__unbounded_addressof(icp->icmp_ip));
 	nip = &icp->icmp_ip;
 
 	/*
@@ -569,7 +569,7 @@ icmp_input(struct mbuf **mp, int *offp, int proto)
 		ctlfunc = inetsw[ip_protox[icp->icmp_ip.ip_p]].pr_ctlinput;
 		if (ctlfunc)
 			(*ctlfunc)(code, (struct sockaddr *)&icmpsrc,
-				   (void *)&icp->icmp_ip);
+				   (void *)__unbounded_addressof(icp->icmp_ip));
 		break;
 
 	badcode:
@@ -1135,3 +1135,12 @@ badport_bandlim(int which)
 			V_icmp_rates[which].descr, (intmax_t )pps, V_icmplim);
 	return (0);
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/tcp_input.c
+++ b/sys/netinet/tcp_input.c
@@ -603,7 +603,7 @@ tcp_input(struct mbuf **mp, int *offp, int proto)
 {
 	struct mbuf *m = *mp;
 	struct tcphdr *th = NULL;
-	struct ip *ip = NULL;
+	struct ip *ip __no_subobject_bounds = NULL;
 	struct inpcb *inp = NULL;
 	struct tcpcb *tp = NULL;
 	struct socket *so = NULL;
@@ -621,7 +621,7 @@ tcp_input(struct mbuf **mp, int *offp, int proto)
 	uint8_t iptos;
 	struct m_tag *fwd_tag = NULL;
 #ifdef INET6
-	struct ip6_hdr *ip6 = NULL;
+	struct ip6_hdr *ip6 __no_subobject_bounds = NULL;
 	int isipv6;
 #else
 	const void *ip6 = NULL;
@@ -837,7 +837,7 @@ findpcb:
 			 * any hardware-generated hash is ignored.
 			 */
 			inp = in6_pcblookup(&V_tcbinfo, &ip6->ip6_src,
-			    th->th_sport, &next_hop6->sin6_addr,
+			    th->th_sport, __unbounded_addressof(next_hop6->sin6_addr),
 			    next_hop6->sin6_port ? ntohs(next_hop6->sin6_port) :
 			    th->th_dport, INPLOOKUP_WILDCARD |
 			    INPLOOKUP_WLOCKPCB, m->m_pkthdr.rcvif);
@@ -3912,3 +3912,12 @@ tcp_compute_initwnd(uint32_t maxseg)
 			return (4 * maxseg);
 	}
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet/tcp_subr.c
+++ b/sys/netinet/tcp_subr.c
@@ -771,7 +771,7 @@ tcp_default_fb_fini(struct tcpcb *tp, int tcb_is_purged)
  * parsing purposes, which do not know about callouts.
  */
 struct tcpcb_mem {
-	struct	tcpcb		tcb;
+	struct	tcpcb		tcb __subobject_use_container_bounds;
 	struct	tcp_timer	tt;
 	struct	cc_var		ccv;
 #ifdef TCP_HHOOK
@@ -3505,3 +3505,12 @@ tcp_log_end_status(struct tcpcb *tp, uint8_t status)
 		}
 	}
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet6/in6.c
+++ b/sys/netinet6/in6.c
@@ -2025,7 +2025,7 @@ in6_if2idlen(struct ifnet *ifp)
 }
 
 struct in6_llentry {
-	struct llentry		base;
+	struct llentry base __subobject_use_container_bounds;
 };
 
 #define	IN6_LLTBL_DEFAULT_HSIZE	32
@@ -2545,3 +2545,12 @@ in6_sin_2_v4mapsin6_in_sock(struct sockaddr **nam)
 	free(*nam, M_SONAME);
 	*nam = (struct sockaddr *)sin6_p;
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet6/in6_var.h
+++ b/sys/netinet6/in6_var.h
@@ -119,7 +119,8 @@ SLIST_HEAD(in6_multi_head, in6_multi);
 MALLOC_DECLARE(M_IP6MADDR);
 
 struct	in6_ifaddr {
-	struct	ifaddr ia_ifa;		/* protocol-independent info */
+	struct	ifaddr ia_ifa __subobject_use_container_bounds;
+					/* protocol-independent info */
 #define	ia_ifp		ia_ifa.ifa_ifp
 #define ia_flags	ia_ifa.ifa_flags
 	struct	sockaddr_in6 ia_addr;	/* interface address */
@@ -921,3 +922,13 @@ struct mbuf *ip6_tryforward(struct mbuf *);
 #endif /* _KERNEL */
 
 #endif /* _NETINET6_IN6_VAR_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20191205,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "user_capabilities",
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet6/ip6_gre.c
+++ b/sys/netinet6/ip6_gre.c
@@ -71,7 +71,7 @@ SYSCTL_INT(_net_inet6_ip6, OID_AUTO, grehlim, CTLFLAG_VNET | CTLFLAG_RW,
     &VNET_NAME(ip6_gre_hlim), 0, "Default hop limit for encapsulated packets");
 
 struct in6_gre_socket {
-	struct gre_socket	base;
+	struct gre_socket	base __subobject_use_container_bounds;
 	struct in6_addr		addr; /* scope zone id is embedded */
 };
 VNET_DEFINE_STATIC(struct gre_sockets *, ipv6_sockets) = NULL;
@@ -592,3 +592,12 @@ in6_gre_uninit(void)
 		gre_hashdestroy((struct gre_list *)V_ipv6_sockets);
 	}
 }
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netinet6/mld6.c
+++ b/sys/netinet6/mld6.c
@@ -3293,7 +3293,7 @@ mld_init(void *unused __unused)
 
 	ip6_initpktopts(&mld_po);
 	mld_po.ip6po_hlim = 1;
-	mld_po.ip6po_hbh = &mld_ra.hbh;
+	mld_po.ip6po_hbh = __bounded_addressof(mld_ra.hbh, sizeof(mld_ra));
 	mld_po.ip6po_prefer_tempaddr = IP6PO_TEMPADDR_NOTPREFER;
 	mld_po.ip6po_flags = IP6PO_DONTFRAG;
 }
@@ -3349,3 +3349,12 @@ static moduledata_t mld_mod = {
     0
 };
 DECLARE_MODULE(mld, mld_mod, SI_SUB_PROTO_MC, SI_ORDER_ANY);
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netsmb/smb_conn.h
+++ b/sys/netsmb/smb_conn.h
@@ -306,10 +306,10 @@ struct smb_share {
 #define	ss_flags	obj.co_flags
 
 #define CPTOVC(cp)	((struct smb_vc*)(cp))
-#define VCTOCP(vcp)	(&(vcp)->obj)
+#define VCTOCP(vcp)	(__unbounded_addressof((vcp)->obj))
 #define CPTOSS(cp)	((struct smb_share*)(cp))
 #define	SSTOVC(ssp)	CPTOVC(((ssp)->obj.co_parent))
-#define SSTOCP(ssp)	(&(ssp)->obj)
+#define SSTOCP(ssp)	(__unbounded_addressof((ssp)->obj))
 
 struct smb_vcspec {
 	char *		srvname;
@@ -465,3 +465,12 @@ int  smb_iod_waitrq(struct smb_rq *rqp);
 int  smb_iod_removerq(struct smb_rq *rqp);
 
 #endif /* _KERNEL */
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -330,6 +330,7 @@ static void
 smbioc_ossn32_to_ossn(struct smbioc_ossn *ossn, const void *data)
 {
 	const struct smbioc_ossn32 *ossn32;
+	size_t copysize;
 
 	ossn32 = data;
 	ossn->ioc_opt = ossn32->ioc_opt;
@@ -339,8 +340,12 @@ smbioc_ossn32_to_ossn(struct smbioc_ossn *ossn, const void *data)
 	ossn->ioc_lolen = ossn32->ioc_lolen;
 	ossn->ioc_local = __USER_CAP((void *)(uintptr_t)ossn32->ioc_local,
 	    ossn32->ioc_lolen);
-	memcpy(&ossn->ioc_srvname, &ossn32->ioc_srvname,
-	    sizeof(*ossn) - offsetof(struct smbioc_ossn, ioc_srvname));
+	/* Do not include padding */
+	copysize = min(
+	    sizeof(*ossn) - offsetof(struct smbioc_ossn, ioc_srvname),
+	    sizeof(*ossn32) - offsetof(struct smbioc_ossn32, ioc_srvname));
+	memcpy(__unbounded_addressof(ossn->ioc_srvname),
+	    __unbounded_addressof(ossn32->ioc_srvname), copysize);
 }
 
 static void
@@ -462,6 +467,7 @@ static void
 smbioc_ossn64_to_ossn(struct smbioc_ossn *ossn, const void *data)
 {
 	const struct smbioc_ossn64 *ossn64;
+	size_t copysize;
 
 	ossn64 = data;
 	ossn->ioc_opt = ossn64->ioc_opt;
@@ -471,8 +477,12 @@ smbioc_ossn64_to_ossn(struct smbioc_ossn *ossn, const void *data)
 	ossn->ioc_lolen = ossn64->ioc_lolen;
 	ossn->ioc_local = __USER_CAP((void *)(uintptr_t)ossn64->ioc_local,
 	    ossn64->ioc_lolen);
-	memcpy(&ossn->ioc_srvname, &ossn64->ioc_srvname,
-	    sizeof(*ossn) - offsetof(struct smbioc_ossn, ioc_srvname));
+	/* Do not include padding */
+	copysize = min(
+	    sizeof(*ossn) - offsetof(struct smbioc_ossn, ioc_srvname),
+	    sizeof(*ossn64) - offsetof(struct smbioc_ossn64, ioc_srvname));
+	memcpy(__unbounded_addressof(ossn->ioc_srvname),
+	    __unbounded_addressof(ossn64->ioc_srvname), copysize);
 }
 
 static void
@@ -960,11 +970,14 @@ smb_dev2share(int fd, int mode, struct smb_cred *scred,
 }
 // CHERI CHANGES START
 // {
-//   "updated": 20191025,
+//   "updated": 20200706,
 //   "target_type": "kernel",
 //   "changes": [
 //     "ioctl:misc",
 //     "iovec-macros"
+//   ],
+//   "changes_purecap": [
+//      "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/riscv/include/pmap.h
+++ b/sys/riscv/include/pmap.h
@@ -109,7 +109,7 @@ struct pv_chunk {
 	TAILQ_ENTRY(pv_chunk)	pc_list;
 	uint64_t		pc_map[_NPCM];  /* bitmap; 1 = free */
 	TAILQ_ENTRY(pv_chunk)	pc_lru;
-	struct pv_entry		pc_pventry[_NPCPV];
+	struct pv_entry		pc_pventry[_NPCPV] __subobject_use_container_bounds;
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Ensure pv_chunk is a page. */
 	char			pc_pad[16];
@@ -189,7 +189,8 @@ pmap_vmspace_copy(pmap_t dst_pmap __unused, pmap_t src_pmap __unused)
 //   "target_type": "kernel",
 //   "changes_purecap": [
 //     "pointer_as_integer",
-//     "pointer_shape"
+//     "pointer_shape",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/riscv/riscv/intr_machdep.c
+++ b/sys/riscv/riscv/intr_machdep.c
@@ -64,7 +64,7 @@ __FBSDID("$FreeBSD$");
 void intr_irq_handler(struct trapframe *tf);
 
 struct intc_irqsrc {
-	struct intr_irqsrc	isrc;
+	struct intr_irqsrc	isrc __subobject_use_container_bounds;
 	u_int			irq;
 };
 
@@ -272,3 +272,13 @@ intc_init(void *dummy __unused)
 }
 
 SYSINIT(intc_init, SI_SUB_INTR, SI_ORDER_MIDDLE, intc_init, NULL);
+
+// CHERI CHANGES START
+// {
+//   "updated": 20200804,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/riscv/riscv/plic.c
+++ b/sys/riscv/riscv/plic.c
@@ -83,7 +83,7 @@ static pic_pre_ithread_t	plic_pre_ithread;
 static pic_bind_intr_t		plic_bind_intr;
 
 struct plic_irqsrc {
-	struct intr_irqsrc	isrc;
+	struct intr_irqsrc	isrc __subobject_use_container_bounds;
 	u_int			irq;
 };
 
@@ -477,3 +477,13 @@ static devclass_t plic_devclass;
 
 EARLY_DRIVER_MODULE(plic, simplebus, plic_driver, plic_devclass,
     0, 0, BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
+
+// CHERI CHANGES START
+// {
+//   "updated": 20200804,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/_eventhandler.h
+++ b/sys/sys/_eventhandler.h
@@ -64,9 +64,18 @@ extern struct eventhandler_list *_eventhandler_list_ ## name		\
 #define EVENTHANDLER_DECLARE(name, type)				\
 struct eventhandler_entry_ ## name 					\
 {									\
-	struct eventhandler_entry	ee;				\
+	struct eventhandler_entry	ee __subobject_use_container_bounds; \
 	type				eh_func;			\
 };									\
 struct __hack
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/_mutex.h
+++ b/sys/sys/_mutex.h
@@ -47,7 +47,7 @@
 struct mtx {
 	struct lock_object	lock_object;	/* Common lock properties. */
 	volatile uintptr_t	mtx_lock;	/* Owner and flags. */
-};
+} __no_subobject_bounds;
 
 /*
  * Members of struct mtx_padalign must mirror members of struct mtx.
@@ -61,6 +61,15 @@ struct mtx {
 struct mtx_padalign {
 	struct lock_object	lock_object;	/* Common lock properties. */
 	volatile uintptr_t	mtx_lock;	/* Owner and flags. */
-} __aligned(CACHE_LINE_SIZE);
+} __aligned(CACHE_LINE_SIZE) __no_subobject_bounds;
 
 #endif /* !_SYS__MUTEX_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/_rangeset.h
+++ b/sys/sys/_rangeset.h
@@ -40,7 +40,7 @@ typedef void *(*rs_dup_data_t)(void *ctx, void *data);
 typedef void (*rs_free_data_t)(void *ctx, void *data);
 
 struct rangeset {
-	struct pctrie	rs_trie;
+	struct pctrie	rs_trie __subobject_use_container_bounds;
 	rs_dup_data_t	rs_dup_data;
 	rs_free_data_t	rs_free_data;
 	void		*rs_data_ctx;
@@ -48,3 +48,12 @@ struct rangeset {
 };
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/_rmlock.h
+++ b/sys/sys/_rmlock.h
@@ -61,7 +61,8 @@ struct rmlock {
 #define	rm_lock_sx	_rm_lock._rm_lock_sx
 
 struct rm_priotracker {
-	struct rm_queue rmp_cpuQueue; /* Must be first */
+	/* Must be first */
+	struct rm_queue rmp_cpuQueue __subobject_use_container_bounds;
 	struct rmlock *rmp_rmlock;
 	struct thread *rmp_thread;
 	int rmp_flags;
@@ -82,3 +83,12 @@ struct rmslock {
 };
 
 #endif /* !_SYS__RMLOCK_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/_rwlock.h
+++ b/sys/sys/_rwlock.h
@@ -44,7 +44,7 @@
 struct rwlock {
 	struct lock_object	lock_object;
 	volatile uintptr_t	rw_lock;
-};
+} __no_subobject_bounds;
 
 /*
  * Members of struct rwlock_padalign must mirror members of struct rwlock.
@@ -58,6 +58,15 @@ struct rwlock {
 struct rwlock_padalign {
 	struct lock_object	lock_object;
 	volatile uintptr_t	rw_lock;
-} __aligned(CACHE_LINE_SIZE);
+} __aligned(CACHE_LINE_SIZE) __no_subobject_bounds;
 
 #endif /* !_SYS__RWLOCK_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/_sx.h
+++ b/sys/sys/_sx.h
@@ -37,8 +37,17 @@
  * Shared/exclusive lock main structure definition.
  */
 struct sx {
-	struct lock_object	lock_object;
+	struct lock_object	lock_object __subobject_use_container_bounds;
 	volatile uintptr_t	sx_lock;
 };
 
 #endif	/* !_SYS__SX_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/filedesc.h
+++ b/sys/sys/filedesc.h
@@ -69,7 +69,7 @@ struct filedescent {
 
 struct fdescenttbl {
 	int	fdt_nfiles;		/* number of open files allocated */
-	struct	filedescent fdt_ofiles[0];	/* open files */
+	struct	filedescent fdt_ofiles[0] __subobject_variable_length; /* open files */
 };
 #define	fd_seqc(fdt, fd)	(&(fdt)->fdt_ofiles[(fd)].fde_seqc)
 
@@ -334,3 +334,12 @@ struct pwd *pwd_get_smr(void);
 #endif /* _KERNEL */
 
 #endif /* !_SYS_FILEDESC_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -267,8 +267,8 @@ struct m_ext {
 		 * and its arguments.  They aren't copied into shadows in
 		 * mb_dupcl() to avoid dereferencing next cachelines.
 		 */
-		volatile u_int	 ext_count;
-		volatile u_int	*ext_cnt;
+		volatile u_int	 ext_count __no_subobject_bounds;
+		volatile u_int	*ext_cnt __no_subobject_bounds;
 	};
 	uint32_t	 ext_size;	/* size of buffer, for ext_free */
 	uint32_t	 ext_type:8,	/* type of external storage */
@@ -401,7 +401,7 @@ struct mbuf {
 				char		m_pktdat[0];
 			};
 		};
-		char	m_dat[0];			/* !M_PKTHDR, !M_EXT */
+		char	m_dat[0] __no_subobject_bounds;	/* !M_PKTHDR, !M_EXT */
 	};
 };
 
@@ -1639,7 +1639,8 @@ mbuf_has_tls_session(struct mbuf *m)
 //   "target_type": "header",
 //   "changes_purecap": [
 //     "support",
-//     "pointer_shape"
+//     "pointer_shape",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/sys/pctrie.h
+++ b/sys/sys/pctrie.h
@@ -72,7 +72,7 @@ static __inline uint64_t *						\
 name##_PCTRIE_PTR2VAL(struct type *ptr)					\
 {									\
 									\
-	return &ptr->field;						\
+	return __unbounded_addressof(ptr->field);			\
 }									\
 									\
 static __inline int							\
@@ -164,3 +164,12 @@ pctrie_is_empty(struct pctrie *ptree)
 
 #endif /* _KERNEL */
 #endif /* !_SYS_PCTRIE_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -385,7 +385,7 @@ struct thread {
 struct thread0_storage {
 	struct thread t0st_thread;
 	uint64_t t0st_sched[10];
-};
+} __no_subobject_bounds;
 
 struct mtx *thread_lock_block(struct thread *);
 void thread_lock_block_wait(struct thread *);
@@ -1260,7 +1260,8 @@ EVENTHANDLER_LIST_DECLARE(thread_init);
 //     "user_capabilities"
 //   ],
 //   "changes_purecap": [
-//     "pointer_as_integer"
+//     "pointer_as_integer",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/sys/queue.h
+++ b/sys/sys/queue.h
@@ -188,12 +188,12 @@ struct qm_trace {
  * Singly-linked List declarations.
  */
 #define	SLIST_HEAD(name, type)						\
-struct name {				\
-	struct type *slh_first;	/* first element */			\
+struct __no_subobject_bounds name {					\
+	struct type *slh_first __no_subobject_bounds_fp; /* first element */ \
 }
 
 #define	SLIST_CLASS_HEAD(name, type)					\
-struct name {				\
+struct __no_subobject_bounds name {					\
 	class type *slh_first;	/* first element */			\
 }
 
@@ -201,13 +201,13 @@ struct name {				\
 	{ NULL }
 
 #define	SLIST_ENTRY(type)						\
-struct {				\
-	struct type *sle_next;	/* next element */	\
+struct __no_subobject_bounds {						\
+	struct type *sle_next __no_subobject_bounds_fp;	/* next element */ \
 }
 
-#define	SLIST_CLASS_ENTRY(type)						\
-struct {								\
-	class type *sle_next;	/* next element */			\
+#define SLIST_CLASS_ENTRY(type)						\
+struct __no_subobject_bounds {						\
+	class type *sle_next __no_subobject_bounds_fp;	/* next element */ \
 }
 
 /*
@@ -457,13 +457,13 @@ struct __no_subobject_bounds {				\
  * List declarations.
  */
 #define	LIST_HEAD(name, type)						\
-struct __no_subobject_bounds name {				\
-	struct type *lh_first;	/* first element */			\
+struct __no_subobject_bounds name {					\
+	struct type *lh_first __no_subobject_bounds_fp;	/* first element */\
 }
 
 #define	LIST_CLASS_HEAD(name, type)					\
-struct __no_subobject_bounds name {				\
-	class type *lh_first;	/* first element */			\
+struct __no_subobject_bounds name {					\
+	class type *lh_first __no_subobject_bounds_fp;	/* first element */\
 }
 
 #define	LIST_HEAD_INITIALIZER(head)					\
@@ -888,3 +888,12 @@ struct __no_subobject_bounds {				\
 #define	TAILQ_END(head)		NULL
 
 #endif /* !_SYS_QUEUE_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/rangeset.h
+++ b/sys/sys/rangeset.h
@@ -44,7 +44,7 @@ typedef bool (*rs_pred_t)(void *ctx, void *r);
  * This structure must be embedded at the start of the rangeset element.
  */
 struct rs_el {
-	uint64_t	re_start;	/* pctrie key */
+	uint64_t	re_start __subobject_use_container_bounds; /* pctrie key */
 	uint64_t	re_end;
 };
 
@@ -86,3 +86,12 @@ int	rangeset_copy(struct rangeset *dst_rs, struct rangeset *src_rs);
 #endif
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/sys/socket.h
+++ b/sys/sys/socket.h
@@ -328,7 +328,7 @@ struct accept_filter_arg {
 struct sockaddr {
 	unsigned char	sa_len;		/* total length */
 	sa_family_t	sa_family;	/* address family */
-	char		sa_data[14];	/* actually longer; address value */
+	char		sa_data[14] __subobject_variable_length;	/* actually longer; address value */
 };
 #if __BSD_VISIBLE
 #define	SOCK_MAXADDRLEN	255		/* longest possible addresses */
@@ -791,10 +791,13 @@ void so_unlock(struct socket *so);
 #endif /* !_SYS_SOCKET_H_ */
 // CHERI CHANGES START
 // {
-//   "updated": 20191025,
+//   "updated": 20200706,
 //   "target_type": "header",
 //   "changes": [
 //     "pointer_alignment"
+//   ],
+//   "changes_purecap": [
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END

--- a/sys/sys/vnode.h
+++ b/sys/sys/vnode.h
@@ -152,7 +152,8 @@ struct vnode {
 	 */
 	TAILQ_ENTRY(vnode) v_vnodelist;		/* l vnode lists */
 	TAILQ_ENTRY(vnode) v_lazylist;		/* l vnode lazy list */
-	struct bufobj	v_bufobj;		/* * Buffer cache object */
+	/* * Buffer cache object */
+	struct bufobj	v_bufobj __subobject_use_container_bounds;
 
 	/*
 	 * Hooks for various subsystems and features.
@@ -1097,3 +1098,12 @@ int vn_dir_check_exec(struct vnode *vp, struct componentname *cnp);
 #endif /* _KERNEL */
 
 #endif /* !_SYS_VNODE_H_ */
+// CHERI CHANGES START
+// {
+//   "updated": 20190812,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ufs/ffs/softdep.h
+++ b/sys/ufs/ffs/softdep.h
@@ -218,7 +218,7 @@ struct worklist {
 	int			wk_line;	/* line where added / removed */
 	LIST_ENTRY(worklist)	wk_all;		/* list of deps of this type */
 #endif
-};
+} __no_subobject_bounds;
 #define	WK_DATA(wk) ((void *)(wk))
 #define	WK_PAGEDEP(wk) ((struct pagedep *)(wk))
 #define	WK_INODEDEP(wk) ((struct inodedep *)(wk))
@@ -465,7 +465,7 @@ struct newblk {
  * and inodedep->id_pendinghd lists.
  */
 struct allocdirect {
-	struct	newblk ad_block;	/* Common block logic */
+	struct	newblk ad_block __subobject_use_container_bounds;	/* Common block logic */
 #	define	ad_list ad_block.nb_list /* block pointer worklist */
 #	define	ad_state ad_list.wk_state /* block pointer state */
 	TAILQ_ENTRY(allocdirect) ad_next; /* inodedep's list of allocdirect's */
@@ -525,7 +525,7 @@ struct indirdep {
  * can then be freed as it is no longer applicable.
  */
 struct allocindir {
-	struct	newblk ai_block;	/* Common block area */
+	struct	newblk ai_block __subobject_use_container_bounds;	/* Common block area */
 #	define	ai_state ai_block.nb_list.wk_state /* indirect pointer state */
 	LIST_ENTRY(allocindir) ai_next;	/* indirdep's list of allocindir's */
 	struct	indirdep *ai_indirdep;	/* address of associated indirdep */
@@ -1119,3 +1119,12 @@ struct mount_softdeps {
 #define	softdep_flushtd			um_softdep->sd_flushtd
 #define	softdep_curdeps			um_softdep->sd_curdeps
 #define	softdep_alldeps			um_softdep->sd_alldeps
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "header",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/ufs/ufs/ufs_lookup.c
+++ b/sys/ufs/ufs/ufs_lookup.c
@@ -1365,6 +1365,7 @@ ufs_dirempty(ip, parentino, cred)
 	struct direct *dp = (struct direct *)&dbuf;
 	int error, namlen;
 	ssize_t count;
+	char *dp_name;
 #define	MINDIRSIZ (sizeof (struct dirtemplate) / 2)
 
 	for (off = 0; off < ip->i_size; off += dp->d_reclen) {
@@ -1394,7 +1395,8 @@ ufs_dirempty(ip, parentino, cred)
 #		endif
 		if (namlen > 2)
 			return (0);
-		if (dp->d_name[0] != '.')
+		dp_name = (char *)__bounded_addressof(dp->d_name, 4);
+		if (dp_name[0] != '.')
 			return (0);
 		/*
 		 * At this point namlen must be 1 or 2.
@@ -1403,7 +1405,7 @@ ufs_dirempty(ip, parentino, cred)
 		 */
 		if (namlen == 1 && dp->d_ino == ip->i_number)
 			continue;
-		if (dp->d_name[1] == '.' && dp->d_ino == parentino)
+		if (dp_name[1] == '.' && dp->d_ino == parentino)
 			continue;
 		return (0);
 	}
@@ -1623,3 +1625,12 @@ ufs_set_i_endoff(struct inode *ip, doff_t off, const char *file, int line)
 }
 
 #endif
+// CHERI CHANGES START
+// {
+//   "updated": 20200706,
+//   "target_type": "kernel",
+//   "changes_purecap": [
+//     "subobject_bounds"
+//   ]
+// }
+// CHERI CHANGES END

--- a/sys/vm/vm_page.h
+++ b/sys/vm/vm_page.h
@@ -241,7 +241,7 @@ struct vm_page {
 	vm_object_t object;		/* which object am I in (O) */
 	vm_pindex_t pindex;		/* offset into object (O,P) */
 	vm_paddr_t phys_addr;		/* physical address of page (C) */
-	struct md_page md;		/* machine dependent stuff */
+	struct md_page md __subobject_use_container_bounds; 	/* machine dependent stuff */
 	u_int ref_count;		/* page references (A) */
 	u_int busy_lock;		/* busy owners lock (A) */
 	union vm_page_astate a;		/* state accessed atomically (A) */
@@ -842,7 +842,7 @@ vm_page_aflag_clear(vm_page_t m, uint16_t bits)
 	 * atomic update.  Parallel non-atomic updates to the other fields
 	 * within this word are handled properly by the atomic update.
 	 */
-	addr = (void *)&m->a;
+	addr = (void *)__bounded_addressof(m->a, sizeof(uint32_t));
 	val = bits << VM_PAGE_AFLAG_SHIFT;
 	atomic_clear_32(addr, val);
 }
@@ -862,7 +862,7 @@ vm_page_aflag_set(vm_page_t m, uint16_t bits)
 	 * atomic update.  Parallel non-atomic updates to the other fields
 	 * within this word are handled properly by the atomic update.
 	 */
-	addr = (void *)&m->a;
+	addr = (void *)__bounded_addressof(m->a, sizeof(uint32_t));
 	val = bits << VM_PAGE_AFLAG_SHIFT;
 	atomic_set_32(addr, val);
 }
@@ -1019,7 +1019,8 @@ vm_page_domain(vm_page_t m)
 //   "updated": 20200706,
 //   "target_type": "header",
 //   "changes_purecap": [
-//     "pointer_as_integer"
+//     "pointer_as_integer",
+//     "subobject_bounds"
 //   ]
 // }
 // CHERI CHANGES END


### PR DESCRIPTION
I think there are some missing annotations in net/if.c due to diff removing the `ifr_addr_get_sa()` helper, I have yet to sync the purecap kernel to test that.