### PR TITLE
Workaround for compiler error in atsectl.c line 296

### DIFF
--- a/tools/tools/atsectl/atsectl.c
+++ b/tools/tools/atsectl/atsectl.c
@@ -290,7 +290,8 @@ set(char *eaddrstr)
 int
 main(int argc, char **argv)
 {
-	char ch, *s;
+	char *s;
+	int ch;
 
 	s = NULL;
 	while ((ch = getopt(argc, argv, "ghlus:")) != -1) {


### PR DESCRIPTION
The compiler error states that the comparison in line 296 is trivially true, which is caused by assigning
a value to a char type variable and then comparing it against "-1".