### PR TITLE
Add more VM fast-out mechanism

### DIFF
--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -1522,7 +1522,7 @@ RetryFault:
 			if (fs.first_object == fs.object)
 				fault_page_free(&fs.first_m);
 			unlock_and_deallocate(&fs);
-			return (KERN_OUT_OF_BOUNDS);
+			return (KERN_NOT_RECEIVER);
 		}
 		VM_OBJECT_WUNLOCK(fs.object);
 		vm_fault_zerofill(&fs);

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -4623,7 +4623,7 @@ retrylookup:
 			*mp = NULL;
 			return (VM_PAGER_FAIL);
 		}
-	} else if ((allocflags & VM_ALLOC_NOCREAT) != 0) {
+	} else if ((allocflags & (VM_ALLOC_NOZERO | VM_ALLOC_NOCREAT)) != 0) {
 		*mp = NULL;
 		return (VM_PAGER_FAIL);
 	} else if ((m = vm_page_alloc(object, pindex, pflags)) == NULL) {

--- a/sys/vm/vm_page.h
+++ b/sys/vm/vm_page.h
@@ -537,6 +537,7 @@ vm_page_t PHYS_TO_VM_PAGE(vm_paddr_t pa);
 #define VM_ALLOC_INTERRUPT	1
 #define VM_ALLOC_SYSTEM		2
 #define	VM_ALLOC_CLASS_MASK	3
+#define	VM_ALLOC_NOZERO		0x0004	/* (g) Don't load a zero page */
 #define	VM_ALLOC_WAITOK		0x0008	/* (acf) Sleep and retry */
 #define	VM_ALLOC_WAITFAIL	0x0010	/* (acf) Sleep and return error */
 #define	VM_ALLOC_WIRED		0x0020	/* (acfgp) Allocate a wired page */


### PR DESCRIPTION
The revoker needs to touch every real page in an address space.  However, there isn't an extant mechanism to ask, in the general case, for the page at an address other than try `vm_page_grab_valid`, and, failing that, to have `vm_fault` do its thing.  (In some cases we can use `vm_page_find_least` to jump over holes in objects and avoid filling them with zero mappings, but that doesn't work for, e.g., CoW mappings.)

`vm_page_grab_valid` has a `VM_ALLOC_NOCREAT` (there's that missing e again) which is almost the right behaviour but we'd like a slightly weaker flag that doesn't create *new* pages but does fully reconstitute pages currently only partially valid.

`vm_fault`, because it's designed to do what it says on the tin, will, left to its own devices, allocate and map zero pages.  We'd like to signal to `vm_fault` that it doesn't need to do that, and we need its response to unambiguously signal whether it would have allocated a zero page but for our request vs. a true error that needs response.  