### PR TITLE
riscv: Support building with CHERI ISAv9 mnemonics for jumps

### DIFF
--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -255,7 +255,11 @@ __FBSDID("$FreeBSD$");
 	csetaddr ct1, ct1, t0
 	li	t0, 1
 	csetflags ct1, ct1, t0
+#ifdef __riscv_xcheri_mode_dependent_jumps
+	jr.cap	ct1
+#else
 	cjr	ct1
+#endif
 .option capmode
 1:
 	/*

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -85,7 +85,11 @@ _alt_start:
 	csetaddr ct1, ct1, t0
 	li	t0, 1
 	csetflags ct1, ct1, t0
+#ifdef __riscv_xcheri_mode_dependent_jumps
+	jr.cap	ct1
+#else
 	cjr	ct1
+#endif
 1:
 .option pop
 #endif

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -670,7 +670,11 @@ ENTRY(fork_trampoline)
 	csetaddr ct1, ct1, t0
 	li	t0, 1
 	csetflags ct1, ct1, t0
+#ifdef __riscv_xcheri_mode_dependent_jumps
+	jr.cap	ct1
+#else
 	cjr	ct1
+#endif
 .option push
 .option capmode
 1:


### PR DESCRIPTION
In ISAv9, JALR is mode-dependent, so CJALR (and aliases like CJR) are only available in capability mode, with JALR.CAP being the new mnemonic for the old ISAv8 CJALR (but the same encoding). To aid this transition, Clang defines a new (temporary) __riscv_xcheri_mode_dependent_jumps macro so we can build with both old and new toolchains.
