### PR TITLE
Stub malloc_revoke

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -104,6 +104,7 @@ char	*getenv(const char *);
 long	 labs(long) __pure2;
 ldiv_t	 ldiv(long, long) __pure2;
 void	*malloc(size_t) __malloc_like __result_use_check __alloc_size(1);
+void	 malloc_revoke(void);
 int	 mblen(const char *, size_t);
 size_t	 mbstowcs(wchar_t * __restrict , const char * __restrict, size_t);
 int	 mbtowc(wchar_t * __restrict, const char * __restrict, size_t);

--- a/lib/libc/stdlib/Makefile.inc
+++ b/lib/libc/stdlib/Makefile.inc
@@ -37,7 +37,7 @@ MAN+=	a64l.3 abort.3 abs.3 alloca.3 atexit.3 atof.3 \
 	atoi.3 atol.3 at_quick_exit.3 bsearch.3 \
 	div.3 exit.3 getenv.3 getopt.3 getopt_long.3 getsubopt.3 \
 	hcreate.3 imaxabs.3 imaxdiv.3 insque.3 labs.3 ldiv.3 llabs.3 lldiv.3 \
-	lsearch.3 memory.3 ptsname.3 qsort.3 \
+	lsearch.3 malloc_revoke.3 memory.3 ptsname.3 qsort.3 \
 	quick_exit.3 \
 	radixsort.3 rand.3 random.3 reallocarray.3 reallocf.3 realpath.3 \
 	set_constraint_handler_s.3 \

--- a/lib/libc/stdlib/jemalloc/Makefile.inc
+++ b/lib/libc/stdlib/jemalloc/Makefile.inc
@@ -21,6 +21,7 @@ jemalloc_${src}: ${SRCTOP}/contrib/jemalloc/src/${src} .NOMETA
 CFLAGS.jemalloc_${src}+=	-Werror=cheri-bitwise-operations -Werror=cheri
 .endif
 .endfor
+MISRCS+=	malloc_revoke.c
 
 MAN+=jemalloc.3
 CLEANFILES+=jemalloc.3

--- a/lib/libc/stdlib/jemalloc/Symbol.map
+++ b/lib/libc/stdlib/jemalloc/Symbol.map
@@ -11,6 +11,7 @@ FBSD_1.0 {
 	realloc;
 	free;
 	malloc_usable_size;
+	malloc_revoke;
 };
 
 FBSD_1.3 {

--- a/lib/libc/stdlib/malloc_revoke.3
+++ b/lib/libc/stdlib/malloc_revoke.3
@@ -1,0 +1,66 @@
+.\"-
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
+.\" Copyright (c) 2021 SRI International
+.\"
+.\" This software was developed by SRI International and the University of
+.\" Cambridge Computer Laboratory (Department of Computer Science and
+.\" Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+.\" DARPA SSITH research programme.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.Dd May 14, 2021
+.Dt MALLOC_REVOKE 3
+.Os
+.Sh NAME
+.Nm malloc_revoke
+.Nd trigger a revocation pass
+.Sh LIBRARY
+.Lb libc
+.Sh SYNOPSIS
+.In stdlib.h
+.Ft void
+.Fn malloc_revoke "void"
+.Sh DESCRIPTION
+On systems supporting revocation,
+.Fn
+triggers a full revocation pass, returning when the pass is complete.
+This results in the revocation of all pointers staged for quarantine.
+Depending on their implementation, this may be a subset of pointers
+previous passed to
+.Xr free 3
+or
+.Xr realloc 3 .
+Individual implementations may provide stronger guarantees (e.g., an
+allocator might guarantee that all pointers to objects freed by the
+current thread will be revoked.
+.Sh SEE ALSO
+.Xr free 3 ,
+.Xr realloc 3
+.Sh AUTHORS
+This software and this manual page were
+developed by SRI International and the University of Cambridge Computer
+Laboratory (Department of Computer Science and Technology) under contract
+.Pq HR0011-18-C-0016
+.Pq Do ECATS Dc ,
+as part of the DARPA SSITH research programme.

--- a/lib/libc/stdlib/malloc_revoke.c
+++ b/lib/libc/stdlib/malloc_revoke.c
@@ -1,0 +1,42 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021 SRI International
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+/*
+ * Do-nothing stub for malloc implementations that don't support
+ * revocation.
+ */
+void
+malloc_revoke(void)
+{
+}


### PR DESCRIPTION
Add a stub version of `malloc_revoke()` for non-revoking mallocs. Also add a skeleton manpage.

The current `void` args and return match dlmalloc's implementation which is convenient for now.  We might want to expand the signature to return success (0/-1) and set errorno as appropriate.