### PR TITLE
tip: Fix pointer-vs-integer confusion

### DIFF
--- a/usr.bin/tip/tip/tip.h
+++ b/usr.bin/tip/tip/tip.h
@@ -169,12 +169,10 @@ typedef
 #define	number(v)	((long)(v))
 #define	boolean(v)      ((short)(long)(v))
 #define	character(v)    ((char)(long)(v))
-#define	address(v)      ((long *)(v))
 
 #define	setnumber(v,n)		do { (v) = (char *)(intptr_t)(n); } while (0)
 #define	setboolean(v,n)		do { (v) = (char *)(intptr_t)(n); } while (0)
 #define	setcharacter(v,n)	do { (v) = (char *)(intptr_t)(n); } while (0)
-#define	setaddress(v,n)		do { (v) = (char *)(n); } while (0)
 
 /*
  * Escape command table definitions --

--- a/usr.bin/tip/tip/value.c
+++ b/usr.bin/tip/tip/value.c
@@ -69,8 +69,22 @@ vinit(void)
 		if (p->v_type&ENVIRON)
 			if ((cp = getenv(p->v_name)))
 				p->v_value = cp;
-		if (p->v_type&IREMOTE)
-			setnumber(p->v_value, *address(p->v_value));
+		if (p->v_type&IREMOTE) {
+			switch (p->v_type&TMASK) {
+			case STRING:
+				p->v_value = *(char **)p->v_value;
+				break;
+			case NUMBER:
+				setnumber(p->v_value, *(long *)p->v_value);
+				break;
+			case BOOL:
+				setboolean(p->v_value, *(short *)p->v_value);
+				break;
+			case CHAR:
+				setcharacter(p->v_value, *(char *)p->v_value);
+				break;
+			}
+		}
 	}
 	/*
 	 * Read the .tiprc file in the HOME directory


### PR DESCRIPTION
Currently IREMOTE assumes that every value is (initially) a pointer to a long. This is true for NUMBERs, but false for STRINGs, which are instead pointers to pointers, though on ILP32 and LP64 systems these happen to have the same representation, but this is still a strict aliasing violation, and of course breaks on systems where the representations are not the same, such as CHERI. We do not currently have any BOOLs (short, curiously) or CHARs used with IREMOTE, though the code should not be relying on that.
