### PR TITLE
Jenkinsfile: Build benchmarking normal and MFS_ROOT kernels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ def buildImageAndRunTests(params, String suffix) {
     if (!GlobalVars.isTestSuiteJob && (suffix.startsWith('mips64') || suffix.startsWith('riscv64'))) {
         stage("Building MFS_ROOT kernels") {
             sh label: "Building MFS_ROOT disk image", script: "./cheribuild/jenkins-cheri-build.py --build disk-image-mfs-root-${suffix} ${params.extraArgs}"
-            sh label: "Building MFS_ROOT kernels", script: "./cheribuild/jenkins-cheri-build.py --build cheribsd-mfs-root-kernel-${suffix} --cheribsd-mfs-root-kernel-${suffix}/build-fpga-kernels ${params.extraArgs}"
+            sh label: "Building MFS_ROOT kernels", script: "./cheribuild/jenkins-cheri-build.py --build cheribsd-mfs-root-kernel-${suffix} --cheribsd/build-bench-kernels --cheribsd/build-fpga-kernels ${params.extraArgs}"
             // Move MFS_ROOT kernels into tarball/ so they aren't deleted
             sh "mv -fv kernel-${suffix}* tarball/"
         }
@@ -174,7 +174,8 @@ selectedArchitectures.each { suffix ->
         def cheribuildArgs = ["'--cheribsd/build-options=${extraBuildOptions}'",
                               '--keep-install-dir',
                               '--install-prefix=/rootfs',
-                              '--cheribsd/build-tests',]
+                              '--cheribsd/build-tests',
+                              '--cheribsd/build-bench-kernels']
         if (GlobalVars.isTestSuiteJob) {
             cheribuildArgs.add('--cheribsd/debug-info')
         } else {


### PR DESCRIPTION
The former have never been built in CI, but are useful for architectures using EFI as this way there is a NODEBUG kernel in the image. The latter used to be built by default but are no longer after the cleanup of kernel config code in cheribuild.

Whilst here, switch to the shorter form for cheribsd-mfs-root-kernel cheribuild options that is now supported (cheribsd-mfs-root-kernel falls back on cheribsd's configuration for kernel config options if not specified).
