### PR TITLE
sys/crypto/des: Fix out-of-bounds accesses to deslong

### DIFF
--- a/sys/crypto/des/des.h
+++ b/sys/crypto/des/des.h
@@ -67,7 +67,6 @@ typedef struct des_ks_struct
 	 * 8 byte longs */
 	DES_LONG deslong[2];
 	} ks;
-	int weak_key;
 } des_key_schedule[16];
 
 #define DES_KEY_SZ 	(sizeof(des_cblock))

--- a/sys/crypto/des/des_enc.c
+++ b/sys/crypto/des/des_enc.c
@@ -76,7 +76,6 @@ void des_encrypt1(DES_LONG *data, des_key_schedule ks, int enc)
 #ifndef DES_UNROLL
 	int i;
 #endif
-	DES_LONG *s;
 
 	r=data[0];
 	l=data[1];
@@ -93,7 +92,7 @@ void des_encrypt1(DES_LONG *data, des_key_schedule ks, int enc)
 	r=ROTATE(r,29)&0xffffffffL;
 	l=ROTATE(l,29)&0xffffffffL;
 
-	s=ks->ks.deslong;
+#define s(S)	ks[(S)>>1].ks.deslong[(S)&1]
 	/* I don't know if it is worth the effort of loop unrolling the
 	 * inner loop */
 	if (enc)
@@ -163,6 +162,7 @@ void des_encrypt1(DES_LONG *data, des_key_schedule ks, int enc)
 	data[0]=l;
 	data[1]=r;
 	l=r=t=u=0;
+#undef s
 }
 
 void des_encrypt2(DES_LONG *data, des_key_schedule ks, int enc)
@@ -174,7 +174,6 @@ void des_encrypt2(DES_LONG *data, des_key_schedule ks, int enc)
 #ifndef DES_UNROLL
 	int i;
 #endif
-	DES_LONG *s;
 
 	r=data[0];
 	l=data[1];
@@ -189,7 +188,7 @@ void des_encrypt2(DES_LONG *data, des_key_schedule ks, int enc)
 	r=ROTATE(r,29)&0xffffffffL;
 	l=ROTATE(l,29)&0xffffffffL;
 
-	s=ks->ks.deslong;
+#define s(S)	ks[(S)>>1].ks.deslong[(S)&1]
 	/* I don't know if it is worth the effort of loop unrolling the
 	 * inner loop */
 	if (enc)
@@ -254,6 +253,7 @@ void des_encrypt2(DES_LONG *data, des_key_schedule ks, int enc)
 	data[0]=ROTATE(l,3)&0xffffffffL;
 	data[1]=ROTATE(r,3)&0xffffffffL;
 	l=r=t=u=0;
+#undef s
 }
 
 void des_encrypt3(DES_LONG *data, des_key_schedule ks1, des_key_schedule ks2,

--- a/sys/crypto/des/des_locl.h
+++ b/sys/crypto/des/des_locl.h
@@ -125,8 +125,8 @@
 
 #define LOAD_DATA_tmp(a,b,c,d,e,f) LOAD_DATA(a,b,c,d,e,f,g)
 #define LOAD_DATA(R,S,u,t,E0,E1,tmp) \
-	u=R^s[S  ]; \
-	t=R^s[S+1]
+	u=R^s(S  ); \
+	t=R^s(S+1);
 
 /* The changes to this macro may help or hinder, depending on the
  * compiler and the achitecture.  gcc2 always seems to do well :-).

--- a/sys/crypto/des/des_setkey.c
+++ b/sys/crypto/des/des_setkey.c
@@ -174,10 +174,8 @@ void des_set_key_unchecked(const unsigned char *key, des_key_schedule schedule)
 	static int shifts2[16]={0,0,1,1,1,1,1,1,0,1,1,1,1,1,1,0};
 	DES_LONG c,d,t,s,t2;
 	const unsigned char *in;
-	DES_LONG *k;
 	int i;
 
-	k = schedule->ks.deslong;
 	in = key;
 
 	c2l(in,c);
@@ -218,10 +216,10 @@ void des_set_key_unchecked(const unsigned char *key, des_key_schedule schedule)
 
 		/* table contained 0213 4657 */
 		t2=((t<<16L)|(s&0x0000ffffL))&0xffffffffL;
-		*(k++)=ROTATE(t2,30)&0xffffffffL;
+		schedule[i].ks.deslong[0]=ROTATE(t2,30)&0xffffffffL;
 
 		t2=((s>>16L)|(t&0xffff0000L));
-		*(k++)=ROTATE(t2,26)&0xffffffffL;
+		schedule[i].ks.deslong[1]=ROTATE(t2,26)&0xffffffffL;
 	}
 }
 


### PR DESCRIPTION
The types are as follows:

    typedef unsigned char des_cblock[8];
    typedef struct des_ks_struct {
            union {
                    des_cblock cblock;
                    DES_LONG deslong[2];
            } ks;
            int weak_key;
    } des_key_schedule[16];

Currently des_encrypt1, des_encrypt2 and des_set_key_unchecked access
the first des_key_schedule's deslong and use that as an array of 32
elements. This is dubious and bad practice even if it has the same
underlying representation, but each des_key_schedule also has a weak_key
field, so we end up reading and writing some of those rather than the
final deslong's. To make matters worse, i386 has an assembly
implementation of des_enc (but not des_setkey) that also assumes there
is no weak_key field.

Firstly, remove the unused (or at least not intentionally) weak_key
field so the i386 assembly matches the layout of des_key_schedule.
Secondly, properly index the des_key_schedule and then its deslong; this
ensures we stay away from UB even if in practice this works on
traditional architectures (but not on CHERI if you enable the additional
optional subobject bounds hardening compiler flag). All the calls to
LOAD_DATA can be trivially proved by a compiler to be even (either
because they're constants if DES_UNROLL is defined, or because the
iterator is always even) and so the added complication should not hurt
optimisation (and since the iterator is only ever used for S, it can
just be transformed into a loop with half the upper bound and half the
step amount, removing the need to right shift or have a second
iterator).
