### PR TITLE
purecap-kernel: MFS_ROOT fixes

### DIFF
--- a/sys/dev/md/embedfs.S
+++ b/sys/dev/md/embedfs.S
@@ -34,7 +34,7 @@
 
 #include <sys/cdefs.h>
 
-	.section mfs, "a", %progbits
+	.section mfs, "aw", %progbits
 	.globl	mfs_root
 	.type	mfs_root, %object
 mfs_root:


### PR DESCRIPTION
This boots provided you patch cheribuild's minimal rc to bring up lo0 before vtnet0. I assume a normal purecap kernel is similarly broken if you bring vtnet0 up first. The current order in cheribuild for minimal images is a bit silly/unusual, but in this case it's useful as it finds a bug.
