### PR TITLE
Add tests for C variable-length arrays on the stack.

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -104,7 +104,7 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 	cheribsdtest_success();
 }
 
-static void
+static __noinline void
 test_bounds_stack_alloca(size_t len)
 {
 	void * __capability c = (__cheri_tocap void * __capability)alloca(len);
@@ -112,7 +112,7 @@ test_bounds_stack_alloca(size_t len)
 	test_bounds_precise(c, len);
 }
 
-static void
+static __noinline void
 test_bounds_stack_vla(size_t len)
 {
 	char vla[len];

--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -116,7 +116,7 @@ static __noinline void
 test_bounds_stack_vla(size_t len)
 {
 	char vla[len];
-	void * __capability c = (__cheri_tocap void *__capability)&vla;
+	void * __capability c = (__cheri_tocap void * __capability)&vla;
 
 	test_bounds_precise(c, len);
 }


### PR DESCRIPTION
We already provided tests for stack allocations done statically, and via ```alloca()```, but not via the VLA syntax. The benefits of these tests are only very incremental, but I think a good idea to have them giving on going GNU toolchain work.