### PR TITLE
rtld: Don't mprotect() the rtld RELO segment for purecap

### DIFF
--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -2669,7 +2669,8 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
     obj_rtld.path = xstrdup(ld_path_rtld);
 
     parse_rtld_phdr(&obj_rtld);
-    obj_enforce_relro(&obj_rtld);
+    if (obj_enforce_relro(&obj_rtld) == -1)
+	rtld_die();
 
     r_debug.r_brk = make_rtld_local_function_pointer(r_debug_state);
     r_debug.r_state = RT_CONSISTENT;

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -2669,8 +2669,15 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
     obj_rtld.path = xstrdup(ld_path_rtld);
 
     parse_rtld_phdr(&obj_rtld);
+#ifndef __CHERI_PURE_CAPABILITY__
+    /*
+     * We would need VMMAP permissions on AT_BASE to call mprotect(). Since
+     * this only marks one page as read-only and we have CHERI to enforce
+     * access, don't bother calling mprotect for RTLD.
+     */
     if (obj_enforce_relro(&obj_rtld) == -1)
 	rtld_die();
+#endif
 
     r_debug.r_brk = make_rtld_local_function_pointer(r_debug_state);
     r_debug.r_state = RT_CONSISTENT;


### PR DESCRIPTION
Currently the mprotect() call fails because of missing VMMAP permissions.
While we could add VMMAP to AT_BASE, I don't changing the page permissions
to read-only for one page in RTLD adds any security/debugging benefits
when we have CHERI capabilities.