### PR TITLE
mmap: reject MAP_RESERVATION_CREATE from userspace

### DIFF
--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -83,7 +83,7 @@ struct mmap_req {
 	int			mr_prot;
 	int			mr_flags;
 	int			mr_fd;
-	int			_int_pad;
+	int			mr_kern_flags;
 	off_t			mr_pos;
 	mmap_check_fp_fn	mr_check_fp_fn;
 #if __has_feature(capabilities)

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -312,7 +312,7 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 		.mr_pos = uap->pos,
 	    }));
 #else
-	int flags = uap->flags;
+	int flags = uap->flags, kern_flags = 0;
 	void * __capability source_cap;
 	register_t perms, reqperms;
 	vm_offset_t hint;
@@ -358,7 +358,7 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 		 * When a capability is not provided, we implicitly
 		 * request the creation of a reservation.
 		 */
-		flags |= MAP_RESERVATION_CREATE;
+		kern_flags |= MAP_RESERVATION_CREATE;
 
 		if (flags & MAP_FIXED)
 			flags |= MAP_EXCL;
@@ -436,6 +436,7 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 		.mr_len = uap->len,
 		.mr_prot = uap->prot,
 		.mr_flags = flags,
+		.mr_kern_flags = kern_flags,
 		.mr_fd = uap->fd,
 		.mr_pos = uap->pos,
 		.mr_source_cap = source_cap,
@@ -561,7 +562,7 @@ kern_mmap(struct thread *td, struct mmap_req *mrp)
 	    (flags & ~(MAP_SHARED | MAP_PRIVATE | MAP_FIXED | MAP_HASSEMAPHORE |
 	    MAP_STACK | MAP_NOSYNC | MAP_ANON | MAP_EXCL | MAP_NOCORE |
 	    MAP_PREFAULT_READ | MAP_GUARD |
-	    MAP_CHERI_NOSETBOUNDS | MAP_RESERVATION_CREATE |
+	    MAP_CHERI_NOSETBOUNDS |
 #ifdef MAP_32BIT
 	    MAP_32BIT |
 #endif
@@ -571,6 +572,7 @@ kern_mmap(struct thread *td, struct mmap_req *mrp)
 		    extra_flags);
 		return (EINVAL);
 	}
+	flags |= mrp->mr_kern_flags;
 	if ((flags & (MAP_EXCL | MAP_FIXED)) == MAP_EXCL) {
 		SYSERRCAUSE("%s: MAP_EXCL without MAP_FIXED", __func__);
 		return (EINVAL);


### PR DESCRIPTION
Rather than smuggling the kernel-only MAP_RESERVATION_CREATE flag to
kern_mmap() via mr_flags, add a new mr_kern_flags and pass it there.
This allows us to remove MAP_RESERVATION_CREATE from the list of flags
allowed from userspace and reject it centrally.

There's a larger issue of kernel/userspace flags being mixed, but that's
a large, API-breaking change that should start upstream.