### PR TITLE
arm64: Add MIDR_EL1 for Morello SoC

### DIFF
--- a/sys/arm64/arm64/identcpu.c
+++ b/sys/arm64/arm64/identcpu.c
@@ -174,6 +174,12 @@ struct cpu_implementers {
 /*
  * Per-implementer table of (PartNum, CPU Name) pairs.
  */
+/* Research */
+static const struct cpu_parts cpu_parts_research[] = {
+	{ CPU_PART_MORELLO, "Morello SoC" },
+	CPU_PART_NONE,
+};
+
 /* ARM Ltd. */
 static const struct cpu_parts cpu_parts_arm[] = {
 	{ CPU_PART_FOUNDATION, "Foundation-Model" },
@@ -214,6 +220,7 @@ static const struct cpu_parts cpu_parts_none[] = {
  * Implementers table.
  */
 const struct cpu_implementers cpu_implementers[] = {
+	{ CPU_IMPL_RESEARCH,	"Research",	cpu_parts_research },
 	{ CPU_IMPL_ARM,		"ARM",		cpu_parts_arm },
 	{ CPU_IMPL_BROADCOM,	"Broadcom",	cpu_parts_none },
 	{ CPU_IMPL_CAVIUM,	"Cavium",	cpu_parts_cavium },

--- a/sys/arm64/include/cpu.h
+++ b/sys/arm64/include/cpu.h
@@ -67,6 +67,7 @@
 
 #ifdef _KERNEL
 
+#define	CPU_IMPL_RESEARCH	0x3F
 #define	CPU_IMPL_ARM		0x41
 #define	CPU_IMPL_BROADCOM	0x42
 #define	CPU_IMPL_CAVIUM		0x43
@@ -78,6 +79,9 @@
 #define	CPU_IMPL_QUALCOMM	0x51
 #define	CPU_IMPL_MARVELL	0x56
 #define	CPU_IMPL_INTEL		0x69
+
+/* Research part numbers */
+#define	CPU_PART_MORELLO	0x412
 
 /* ARM Part numbers */
 #define	CPU_PART_FOUNDATION	0xD00


### PR DESCRIPTION
As documented in "Arm Morello System Development Platform (SDP) Preliminary Technical Reference Manual".
