### PR TITLE
cheribsdbox: Use a few more shared libraries

### DIFF
--- a/lib/libpam/modules/modules.inc
+++ b/lib/libpam/modules/modules.inc
@@ -3,14 +3,8 @@
 .include <src.opts.mk>
 
 MODULES		 =
-# A few minimal modules that can be used by tools/cheribsdbox
-MODULES		+= pam_deny
-MODULES		+= pam_nologin
-MODULES		+= pam_permit
-MODULES		+= pam_rootok
-MODULES		+= pam_self
-.if !defined(PAM_MINIMAL)
 MODULES		+= pam_chroot
+MODULES		+= pam_deny
 MODULES		+= pam_echo
 MODULES		+= pam_exec
 MODULES		+= pam_ftpusers
@@ -22,17 +16,20 @@ MODULES		+= pam_ksu
 .endif
 MODULES		+= pam_lastlog
 MODULES		+= pam_login_access
+MODULES		+= pam_nologin
 MODULES		+= pam_opie
 MODULES		+= pam_opieaccess
 MODULES		+= pam_passwdqc
+MODULES		+= pam_permit
 .if ${MK_RADIUS_SUPPORT} != "no"
 MODULES		+= pam_radius
 .endif
 MODULES		+= pam_rhosts
+MODULES		+= pam_rootok
 MODULES		+= pam_securetty
+MODULES		+= pam_self
 .if ${MK_OPENSSH} != "no"
 MODULES		+= pam_ssh
 .endif
 MODULES		+= pam_tacplus
 MODULES		+= pam_unix
-.endif  # !defined(PAM_MINIMAL)

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -92,9 +92,8 @@ CRUNCH_LIBS+=	-llzma
 CRUNCH_LIBS+=	-larchive -lprivatezstd
 CRUNCH_SHLIBS+=	-pthread
 
-# ktrace:
+# ktrace/truss:
 CRUNCH_LIBS+=	-lsysdecode
-CRUNCH_LIBS+= -lprocstat -lelf
 
 # needed by ifconfig
 CRUNCH_LIBS+=	-l80211
@@ -110,7 +109,8 @@ CRUNCH_LIBS+= -lusb
 .endif
 
 # netstat needs libkvm (which needs libelf)
-CRUNCH_LIBS+= -lkvm -lelf -lmemstat
+CRUNCH_SHLIBS+=	-lkvm -lelf -lprocstat
+CRUNCH_LIBS+=	-lmemstat
 # avoid depending on -lnetgraph
 CRUNCH_BUILDOPTS_netstat+=MK_NETGRAPH_SUPPORT=no -j1
 
@@ -404,7 +404,6 @@ CRUNCH_PROGS_libexec+=	getty
 
 CRUNCH_SRCDIRS+= secure/usr.sbin
 CRUNCH_PROGS_secure/usr.sbin+=	sshd
-# TODO: should we link libssh static and use ${LIBSSH}?
 CRUNCH_SHLIBS+=	-lpam -lutil
 
 CRUNCH_SRCDIRS+= secure/usr.bin
@@ -505,9 +504,6 @@ CRUNCH_LIBS:=${CRUNCH_LIBS} ${CRUNCH_SHLIBS} -Wl,--verbose -v
 # TODO: CRUNCH_BUILDOPTS+=-DNO_SHARED
 .endif
 
-# Build PAM with only minimal modules support
-CRUNCH_CUSTOM_LIBS+=lib/libpam
-CRUNCH_BUILDOPTS_lib/libpam+=-DPAM_MINIMAL
 # Also build a version of libssh without optional deps
 CRUNCH_CUSTOM_LIBS+=secure/lib/libssh
 CRUNCH_BUILDOPTS_secure/lib/libssh+="SSHDIR=${SRCTOP}/crypto/openssh"


### PR DESCRIPTION
I am about to add those to the minimal disk images anyway since various
programs need them (e.g. CTest), so we might as well link them dynamically
to avoid duplicating the code.
This also drops the local diff to the libpam Makefile since we link pam
dynamically.