### PR TITLE
riscv: Implement non-stub __vdso_gettc and __vdso_gettimekeep

### DIFF
--- a/lib/libc/riscv/sys/Makefile.inc
+++ b/lib/libc/riscv/sys/Makefile.inc
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-SRCS+=	trivial-vdso_tc.c
+SRCS+=	__vdso_gettc.c
 
 MDASM=	cerror.S \
 	syscall.S \

--- a/lib/libc/riscv/sys/__vdso_gettc.c
+++ b/lib/libc/riscv/sys/__vdso_gettc.c
@@ -1,0 +1,56 @@
+/*-
+ * Copyright (c) 2021 Jessica Clarke
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+#include <sys/elf.h>
+#include <sys/time.h>
+#include <sys/vdso.h>
+
+#include <machine/riscvreg.h>
+
+#include <errno.h>
+
+#include "libc_private.h"
+
+#pragma weak __vdso_gettc
+int
+__vdso_gettc(const struct vdso_timehands *th, u_int *tc)
+{
+	if (th->th_algo != VDSO_TH_ALGO_RISCV_RDTIME)
+		return (ENOSYS);
+
+	*tc = csr_read(time);
+	return (0);
+}
+
+#pragma weak __vdso_gettimekeep
+int
+__vdso_gettimekeep(struct vdso_timekeep **tk)
+{
+	return (_elf_aux_info(AT_TIMEKEEP, tk, sizeof(*tk)));
+}

--- a/sys/riscv/include/vdso.h
+++ b/sys/riscv/include/vdso.h
@@ -31,4 +31,6 @@
 #define	VDSO_TIMEHANDS_MD			\
 	uint32_t	th_res[8];
 
+#define	VDSO_TH_ALGO_RISCV_RDTIME	VDSO_TH_ALGO_1
+
 #endif /* !_MACHINE_VDSO_H_ */

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -90,8 +90,8 @@ struct sysentvec elf_freebsd_sysvec = {
 	.sv_setregs	= exec_setregs,
 	.sv_fixlimit	= NULL,
 	.sv_maxssiz	= NULL,
-	.sv_flags	= SV_ABI_FREEBSD | SV_LP64 | SV_SHP | SV_ASLR |
-	    SV_RNG_SEED_VER |
+	.sv_flags	= SV_ABI_FREEBSD | SV_LP64 | SV_SHP | SV_TIMEKEEP |
+	    SV_ASLR | SV_RNG_SEED_VER |
 #if __has_feature(capabilities)
 	    SV_CHERI,
 #else


### PR DESCRIPTION
PR:	256905
Reviewed by:	arichardson, mhorne
MFC after:	1 week
Differential Revision:	https://reviews.freebsd.org/D30963

(cherry picked from commit 348c41d1815dc2e872a1deba1f4bf760caaa1094)