### PR TITLE
Improve uiomove tag preservation, including fix for #1045

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -11,6 +11,7 @@ SRCS+=	cheribsdtest_bounds_globals.c					\
 	cheribsdtest_fault.c						\
 	cheribsdtest_flag_captured.c					\
 	cheribsdtest_kbounce.c						\
+	cheribsdtest_ipc.c						\
 	cheribsdtest_local_global.c					\
 	cheribsdtest_longjmp.c						\
 	cheribsdtest_printf.c						\

--- a/bin/cheribsdtest/cheribsdtest_ipc.c
+++ b/bin/cheribsdtest/cheribsdtest_ipc.c
@@ -1,0 +1,90 @@
+/*-
+ * Copyright (c) 2021 Robert N. M. Watson
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#if !__has_feature(capabilities)
+#error "This code requires a CHERI-aware compiler"
+#endif
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/time.h>
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+
+#include <netinet/in.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+#include <unistd.h>
+
+#include "cheribsdtest.h"
+
+/*
+ * As a regression test, block the current thread in a pipe write using a
+ * large write of a buffer containing a capability, and trigger a timer signal
+ * to interrupt that write.
+ *
+ * This would previously panic the kernel with a fatal capability page fault as
+ * uiomove_fromphys called from pipe_clone_write_buffer would use a plain bcopy
+ * and so not strip tags, but the kernel buffer was allocated without
+ * VM_PROT_WRITE_CAP.
+ */
+
+#define	BUFFER_SIZE	8192
+
+CHERIBSDTEST(test_ipc_pipe_sleep_signal,
+    "check that direct write pipe IPC of a capability can be interrupted",
+    .ct_flags = CT_FLAG_SIGNAL,
+    .ct_signum = SIGALRM)
+{
+	void * __capability buffer[BUFFER_SIZE / sizeof(void * __capability)];
+	int fds[2];
+
+	memset(buffer, 0, sizeof(buffer));
+	buffer[0] = (__cheri_tocap void * __capability)buffer;
+
+	CHERIBSDTEST_CHECK_SYSCALL(pipe(fds));
+	CHERIBSDTEST_CHECK_SYSCALL(alarm(1));
+	CHERIBSDTEST_CHECK_SYSCALL(write(fds[0], buffer, sizeof(buffer)));
+	close(fds[0]);
+	close(fds[1]);
+	cheribsdtest_failure_errx("write didn't block");
+}

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -55,8 +55,9 @@ __FBSDID("$FreeBSD$");
  * Implement uiomove(9) from physical memory using the direct map to
  * avoid the creation and destruction of ephemeral mappings.
  */
-int
-uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+static int
+uiomove_fromphys_flags(vm_page_t ma[], vm_offset_t offset, int n,
+    struct uio *uio, bool preserve_tags)
 {
 	struct thread *td = curthread;
 	struct iovec *iov;
@@ -94,7 +95,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					error = copyoutcap(cp, iov->iov_base,
+					    cnt);
+				else
+					error = copyincap(iov->iov_base, cp,
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
 				error = copyout(cp, iov->iov_base, cnt);
 			else
 				error = copyin(iov->iov_base, cp, cnt);
@@ -102,10 +110,17 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
-				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					bcopy_c(PTR2CAP(cp), iov->iov_base,
+					    cnt);
+				else
+					bcopy_c(iov->iov_base, PTR2CAP(cp),
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
+				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;
@@ -131,6 +146,20 @@ out:
 		td->td_pflags &= ~TDP_DEADLKTREAT;
 	return (error);
 }
+
+int
+uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+{
+	return (uiomove_fromphys_flags(ma, offset, n, uio, false));
+}
+
+#if __has_feature(capabilities)
+int
+uiomove_fromphys_cap(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+{
+	return (uiomove_fromphys_flags(ma, offset, n, uio, true));
+}
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20191025,

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -103,11 +103,9 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			if (uio->uio_rw == UIO_READ)
-				bcopy(cp, (__cheri_fromcap void *)iov->iov_base,
-				    cnt);
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy((__cheri_fromcap void *)iov->iov_base, cp,
-				    cnt);
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -288,10 +288,17 @@ uiomove_flags(void *cp, int n, struct uio *uio, bool nofault,
 			break;
 
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
-				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					bcopy_c(PTR2CAP(cp), iov->iov_base,
+					    cnt);
+				else
+					bcopy_c(iov->iov_base, PTR2CAP(cp),
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
+				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -289,12 +289,9 @@ uiomove_flags(void *cp, int n, struct uio *uio, bool nofault,
 
 		case UIO_SYSSPACE:
 			if (uio->uio_rw == UIO_READ)
-				bcopy(cp,
-				    (__cheri_fromcap void *)iov->iov_base,
-				    cnt);
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy((__cheri_fromcap void *)iov->iov_base,
-				    cp, cnt);
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -229,7 +229,7 @@ uiomove_object_page(vm_object_t obj, size_t len, struct uio *uio)
 	VM_OBJECT_WUNLOCK(obj);
 
 found:
-	error = uiomove_fromphys(&m, offset, tlen, uio);
+	error = uiomove_fromphys_cap(&m, offset, tlen, uio);
 	if (uio->uio_rw == UIO_WRITE && error == 0)
 		vm_page_set_dirty(m);
 	vm_page_activate(m);

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -153,4 +153,11 @@ memcpynocap_c(void * __capability dst, const void *  __capability src,
 	return (memcpy_c(dst, cheri_andperm(src, ~CHERI_PERM_LOAD_CAP), len));
 }
 
+void
+bcopynocap_c(const void * __capability src, void * __capability dst, size_t len)
+{
+
+	memcpy_c(dst, cheri_andperm(src, ~CHERI_PERM_LOAD_CAP), len);
+}
+
 __strong_reference(memcpynocap_c, memmovenocap_c);

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -126,12 +126,9 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			if (uio->uio_rw == UIO_READ)
-				bcopy(cp,
-				    (__cheri_fromcap void *)iov->iov_base,
-				    cnt);
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy((__cheri_fromcap void *)iov->iov_base,
-				    cp, cnt);
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/mips/mips/uio_machdep.c
+++ b/sys/mips/mips/uio_machdep.c
@@ -64,8 +64,9 @@ __FBSDID("$FreeBSD$");
  * of the direct mapping and sf_bufs to reduce the creation and
  * destruction of ephemeral mappings.  
  */
-int
-uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+static int
+uiomove_fromphys_flags(vm_page_t ma[], vm_offset_t offset, int n,
+    struct uio *uio, bool preserve_tags)
 {
 	struct sf_buf *sf;
 	struct thread *td = curthread;
@@ -114,7 +115,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					error = copyoutcap(cp, iov->iov_base,
+					    cnt);
+				else
+					error = copyincap(iov->iov_base, cp,
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
 				error = copyout(cp, iov->iov_base, cnt);
 			else
 				error = copyin(iov->iov_base, cp, cnt);
@@ -125,10 +133,17 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			}
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
-				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					bcopy_c(PTR2CAP(cp), iov->iov_base,
+					    cnt);
+				else
+					bcopy_c(iov->iov_base, PTR2CAP(cp),
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
+				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;
@@ -148,6 +163,20 @@ out:
 		td->td_pflags &= ~TDP_DEADLKTREAT;
 	return (error);
 }
+
+int
+uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+{
+	return (uiomove_fromphys_flags(ma, offset, n, uio, false));
+}
+
+#if __has_feature(capabilities)
+int
+uiomove_fromphys_cap(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+{
+	return (uiomove_fromphys_flags(ma, offset, n, uio, true));
+}
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20191025,

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -104,11 +104,9 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			if (uio->uio_rw == UIO_READ)
-				bcopy(cp, (__cheri_fromcap void *)iov->iov_base,
-				    cnt);
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy((__cheri_fromcap void *)iov->iov_base, cp,
-				    cnt);
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -55,8 +55,9 @@ __FBSDID("$FreeBSD$");
  * Implement uiomove(9) from physical memory using the direct map to
  * avoid the creation and destruction of ephemeral mappings.
  */
-int
-uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+static int
+uiomove_fromphys_flags(vm_page_t ma[], vm_offset_t offset, int n,
+    struct uio *uio, bool preserve_tags)
 {
 	struct thread *td = curthread;
 	struct iovec *iov;
@@ -95,7 +96,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					error = copyoutcap(cp, iov->iov_base,
+					    cnt);
+				else
+					error = copyincap(iov->iov_base, cp,
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
 				error = copyout(cp, iov->iov_base, cnt);
 			else
 				error = copyin(iov->iov_base, cp, cnt);
@@ -103,10 +111,17 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
-				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+			if (preserve_tags) {
+				if (uio->uio_rw == UIO_READ)
+					bcopy_c(PTR2CAP(cp), iov->iov_base,
+					    cnt);
+				else
+					bcopy_c(iov->iov_base, PTR2CAP(cp),
+					    cnt);
+			} else if (uio->uio_rw == UIO_READ)
+				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 			else
-				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
 			break;
 		case UIO_NOCOPY:
 			break;
@@ -132,6 +147,20 @@ out:
 		td->td_pflags &= ~TDP_DEADLKTREAT;
 	return (error);
 }
+
+int
+uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+{
+	return (uiomove_fromphys_flags(ma, offset, n, uio, false));
+}
+
+#if __has_feature(capabilities)
+int
+uiomove_fromphys_cap(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
+{
+	return (uiomove_fromphys_flags(ma, offset, n, uio, true));
+}
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20191025,

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -97,6 +97,12 @@ int	uiomove_cap(void *cp, int n, struct uio *uio);
 int	uiomove_frombuf(void *buf, int buflen, struct uio *uio);
 int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 	    struct uio *uio);
+#if __has_feature(capabilities)
+int	uiomove_fromphys_cap(struct vm_page *ma[], vm_offset_t offset, int n,
+	    struct uio *uio);
+#else
+#define	uiomove_fromphys_cap	uiomove_fromphys
+#endif
 int	uiomove_nofault(void *cp, int n, struct uio *uio);
 int	uiomove_object(struct vm_object *obj, off_t obj_size, struct uio *uio);
 int	updateiov(const struct uio *uiop, struct iovec * __capability iovp);


### PR DESCRIPTION
Currently we only have a cap version of uiomove itself, and preserve_tags is unconditional for UIO_SYSSPACE. This fixes that, plus adds a uiomove_fromphys_cap and makes uiomove_fromphys not tag preserving, as is needed in almost all cases (namely, other than SHM copying) and fixes the issue seen in #1045 where we tried to do a tag-preserving copy from a tag-bearing page (and capability, in the case of the purecap kernel) to a non-tag-bearing page (and capability, in the case of the purecap kernel, I assume) and thus faulted if the userspace buffer ever happened to contain capabilities (which, when stack-allocated, tends to be the case for large chunks of uninitialised memory).
