### PR TITLE
assorted build cleanups

### DIFF
--- a/libexec/Makefile
+++ b/libexec/Makefile
@@ -87,6 +87,13 @@ _rtld-elf=	rtld-elf rtld-elf-debug
 SUBDIR.${MK_LIB32}+=	rtld-elf32
 SUBDIR.${MK_LIB64}+=	rtld-elf64
 SUBDIR.${MK_COMPAT_CHERIABI}+=	rtld-cheri-elf rtld-cheri-elf-debug
+# rtld.1 needs to be installed before the cross-dir MLINKS can work.
+SUBDIR_INSTALL_USE_DEPENDS=
+SUBDIR_DEPEND_rtld-elf-debug=	rtld-elf
+SUBDIR_DEPEND_rtld-cheri-elf-debug=	rtld-elf
+SUBDIR_DEPEND_rtld-cheri-elf=	rtld-elf
+SUBDIR_DEPEND_rtld-elf32=	rtld-elf
+SUBDIR_DEPEND_rtld-elf64=	rtld-elf
 .endif
 
 .if ${MK_RBOOTD} != "no"

--- a/share/mk/bsd.subdir.mk
+++ b/share/mk/bsd.subdir.mk
@@ -58,7 +58,7 @@ STANDALONE_SUBDIR_TARGETS+= \
 		maninstall manlint obj objlink
 
 # It is safe to install in parallel when staging.
-.if defined(NO_ROOT) || !empty(SYSROOT)
+.if (defined(NO_ROOT) || !empty(SYSROOT)) && !defined(SUBDIR_INSTALL_USE_DEPENDS)
 STANDALONE_SUBDIR_TARGETS+= realinstall
 .endif
 


### PR DESCRIPTION
Fix manpage related issues in sh_static and rtld.  In the former case, just don't install one.  In the latter, don't perform installs in parallel in libexec so rtld.1 is installed before other rtld's start to link to it.

Remove an outdated local diff from libc's CFLAGS