### PR TITLE
Lib64c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ TGTS=	all all-man buildenv buildenvvars buildkernel buildsysroot buildworld \
 	build64 distribute64 install64 \
 	buildsoft distributesoft installsoft \
 	build64c distribute64c \
+	libcheribuildenv libcheribuildenvvars \
 	lib64cbuildenv lib64cbuildenvvars \
 	lib64buildenv lib64buildenvvars lib32buildenv lib32buildenvvars \
 	builddtb xdev xdev-build xdev-install \

--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,8 @@ TGTS=	all all-man buildenv buildenvvars buildkernel buildsysroot buildworld \
 	build32 distribute32 install32 \
 	build64 distribute64 install64 \
 	buildsoft distributesoft installsoft \
-	buildcheri distributecheri \
-	libcheribuildenv libcheribuildenvvars \
+	build64c distribute64c \
+	lib64cbuildenv lib64cbuildenvvars \
 	lib64buildenv lib64buildenvvars lib32buildenv lib32buildenvvars \
 	builddtb xdev xdev-build xdev-install \
 	xdev-links native-xtools native-xtools-install stageworld stagekernel \

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -894,11 +894,11 @@ XCFLAGS+=	${BFLAGS}
 .endif
 
 .if ${MK_COMPAT_CHERIABI} == "yes"
-_LIBCOMPAT=CHERI
+_LIBCOMPAT= 64C
 .elif ${MK_LIB32} == "yes"
 _LIBCOMPAT= 32
 .elif ${MK_LIB64} == "yes"
-_LIBCOMPAT=64
+_LIBCOMPAT= 64
 .elif ${MK_LIBSOFT} == "yes"
 _LIBCOMPAT= SOFT
 .endif
@@ -1653,9 +1653,9 @@ restage reinstall reinstallsysroot: .MAKE .PHONY
 	@echo ">>> Adding symlinks for native ABI libdir: ${MACHINE_ABI}"
 	@echo "--------------------------------------------------------------"
 .if ${MACHINE_ABI:Mpurecap}
-	@echo "Purecap ABI: creating libcheri links"
-	ln -sfnv lib ${DESTDIR}/libcheri
-	ln -sfnv lib ${DESTDIR}/usr/libcheri
+	@echo "Purecap ABI: creating lib64c links"
+	ln -sfnv lib ${DESTDIR}/lib64c
+	ln -sfnv lib ${DESTDIR}/usr/lib64c
 .elif ${MACHINE_ABI:Mptr64}
 	@echo "64-bit ABI: creating lib64 links"
 	ln -sfnv lib ${DESTDIR}/lib64
@@ -1666,6 +1666,14 @@ restage reinstall reinstallsysroot: .MAKE .PHONY
 	ln -sfnv lib ${DESTDIR}/usr/lib32
 .else
 .error "MACHINE_ABI incorrect? ${MACHINE_ABI}"
+.endif
+.if ${MACHINE_ABI:Mpurecap}
+	@echo "Purecap ABI: creating libcheri links"
+	ln -sfnv lib ${DESTDIR}/libcheri
+	ln -sfnv lib ${DESTDIR}/usr/libcheri
+.elif ${MK_COMPAT_CHERIABI} == "yes"
+	@echo "Hybrid ABI: creating libcheri links"
+	ln -sfnv lib64c ${DESTDIR}/usr/libcheri
 .endif
 .if make(reinstallsysroot)
 	@echo "Removing $$(find ${DESTDIR} -type d -empty -print | wc -l) empty directories from ${DESTDIR}"

--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -91,6 +91,11 @@ build${libcompat}: .PHONY
 	${WORLDTMP_MTREE} -f ${.CURDIR}/etc/mtree/BSD.lib${libcompat}.dist \
 	    -p ${WORLDTMP}/usr/lib/debug/usr >/dev/null
 .endif
+# XXX: Remove this hack once morello-llvm supports lib64c
+.if ${libcompat} == "64c" && ${COMPAT_ARCH} == "aarch64"
+	@echo "Morello: creating libcheri link in WORLDTMP"
+	ln -sfnv lib64c ${WORLDTMP}/usr/libcheri
+.endif
 .for _dir in lib/ncurses/ncurses lib/ncurses/ncursesw ${_libmagic} ${_jevents}
 .for _t in ${_obj} build-tools
 	${_+_}cd ${.CURDIR}/${_dir}; \

--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -127,7 +127,7 @@ distribute${libcompat} install${libcompat}: .PHONY
 	${_+_}cd ${.CURDIR}; \
 	    ${LIBCOMPATIMAKE} -f Makefile.inc1 _lc_${.TARGET:S/${libcompat}$//}
 
-.if ${.TARGETS:Mlib${libcompat}buildenv}
+.if ${.TARGETS:Mlib${libcompat}buildenv} || ${.TARGETS:Mlibcheribuildenv}
 .if ${.MAKEFLAGS:M-j}
 .error The lib${libcompat}buildenv target is incompatible with -j
 .endif
@@ -145,6 +145,10 @@ lib${libcompat}buildenv: .PHONY
 	    INSTALL="${INSTALL_CMD} ${INSTALLFLAGS}" \
 	    MTREE_CMD="${MTREE_CMD} ${MTREEFLAGS}" \
 	    "MAKEFLAGS=${MAKEFLAGS:NTARGET*}" ${BUILDENV_SHELL} || true
+
+.if ${libcompat} == "64c"
+libcheribuildenv: lib64cbuildenv
+.endif
 .endif
 
 .endif # defined(_LIBCOMPAT)

--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -108,7 +108,7 @@ build${libcompat}: .PHONY
 	${_+_}cd ${.CURDIR}; \
 	    ${LIBCOMPATWMAKE} -f Makefile.inc1 -DNO_FSCHG libraries
 .if ${MK_COMPAT_CHERIABI} == "yes" && ${MK_CHERI_PURE} == "yes"
-# To build a purecap world against /usr/libcheri, we need internal libs.
+# To build a purecap world against /usr/lib64c, we need internal libs.
 # Skip amu because it needs unifdef which isn't available here and we
 # don't build amd (and it's going away).
 # We've locally removed gdb.

--- a/bin/cheribsdtest/cheribsdtest_sentries.c
+++ b/bin/cheribsdtest/cheribsdtest_sentries.c
@@ -80,7 +80,7 @@ CHERIBSDTEST(test_sentry_dlsym,
 	const char *libm_so;
 
 #if defined(COMPAT_CHERI)
-	libm_so = "/usr/libcheri/" LIBM_SONAME;
+	libm_so = "/usr/lib64c/" LIBM_SONAME;
 #else
 	libm_so = "/lib/" LIBM_SONAME;
 #endif

--- a/cddl/lib/libuutil/Makefile
+++ b/cddl/lib/libuutil/Makefile
@@ -29,7 +29,7 @@ LIBADD= avl spl
 # The aok vairable used by assert() is defined in
 # sys/cddl/contrib/opensolaris/common/nvpair/opensolaris_nvpair.c so we need
 # to link against nvpair in order to get size information for that file
-# (at least for libcheri)
+# (at least for purecap)
 LIBADD+=	nvpair
 
 .include <bsd.lib.mk>

--- a/contrib/openpam/lib/libpam/openpam_constants.c
+++ b/contrib/openpam/lib/libpam/openpam_constants.c
@@ -178,8 +178,8 @@ const char *openpam_module_path[] = {
 #ifdef OPENPAM_MODULES_DIRECTORY
 	OPENPAM_MODULES_DIRECTORY,
 #elif COMPAT_CHERI
-	"/usr/libcheri",
-	"/usr/local/libcheri",
+	"/usr/lib64c",
+	"/usr/local/lib64c",
 #elif COMPAT_32BIT
 	"/usr/lib32",
 	"/usr/local/lib32",

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -104,8 +104,8 @@ MTREES=		mtree/BSD.root.dist		/		\
 		mtree/BSD.include.dist		/usr/include	\
 		mtree/BSD.debug.dist		/usr/lib
 .if ${MK_COMPAT_CHERIABI} != "no"
-MTREES+=	mtree/BSD.libcheri.dist		/usr
-MTREES+=	mtree/BSD.libcheri.dist		/usr/lib/debug/usr
+MTREES+=	mtree/BSD.lib64c.dist		/usr
+MTREES+=	mtree/BSD.lib64c.dist		/usr/lib/debug/usr
 .endif
 .if ${MK_LIB32} != "no"
 MTREES+=	mtree/BSD.lib32.dist		/usr

--- a/etc/mtree/BSD.lib64c.dist
+++ b/etc/mtree/BSD.lib64c.dist
@@ -5,7 +5,7 @@
 
 /set type=dir uname=root gname=wheel mode=0755
 .
-    libcheri
+    lib64c
         dtrace
         ..
         engines

--- a/etc/mtree/Makefile
+++ b/etc/mtree/Makefile
@@ -9,7 +9,7 @@ FILES=	\
 	BSD.root.dist \
 	${_BSD.lib32.dist} \
 	${_BSD.lib64.dist} \
-	${_BSD.libcheri.dist} \
+	${_BSD.lib64c.dist} \
 	${_BSD.libsoft.dist} \
 	${_BSD.sendmail.dist} \
 	${_BSD.tests.dist} \
@@ -17,7 +17,7 @@ FILES=	\
 	BSD.var.dist
 
 .if ${MK_COMPAT_CHERIABI} != "no"
-_BSD.libcheri.dist=	BSD.libcheri.dist
+_BSD.lib64c.dist=	BSD.lib64c.dist
 .endif
 .if ${MK_LIB32} != "no"
 _BSD.lib32.dist=	BSD.lib32.dist

--- a/include/paths.h
+++ b/include/paths.h
@@ -68,7 +68,7 @@
 #define	_PATH_GELI	"/sbin/geli"
 #define	_PATH_HALT	"/sbin/halt"
 #if defined(COMPAT_CHERI)
-#define	_PATH_I18NMODULE	"/usr/libcheri/i18n"
+#define	_PATH_I18NMODULE	"/usr/lib64c/i18n"
 #elif defined(COMPAT_32BIT)
 #define	_PATH_I18NMODULE	"/usr/lib32/i18n"
 #elif defined(COMPAT_64BIT)

--- a/lib/geom/Makefile.classes
+++ b/lib/geom/Makefile.classes
@@ -5,7 +5,7 @@ GEOM_CLASS_DIR?=/usr/lib32/geom
 .elif defined(COMPAT_64BIT)
 GEOM_CLASS_DIR?=/usr/lib64/geom
 .elif defined(COMPAT_CHERI)
-GEOM_CLASS_DIR?=/usr/libcheri/geom
+GEOM_CLASS_DIR?=/usr/lib64c/geom
 .else
 GEOM_CLASS_DIR?=/lib/geom
 .endif

--- a/lib/libiconv_modules/Makefile.inc
+++ b/lib/libiconv_modules/Makefile.inc
@@ -12,7 +12,7 @@ SHLIBDIR= /usr/lib32/i18n
 .elif defined(COMPAT_64BIT)
 SHLIBDIR= /usr/lib64/i18n
 .elif defined(COMPAT_CHERI)
-SHLIBDIR= /usr/libcheri/i18n
+SHLIBDIR= /usr/lib64c/i18n
 .else
 SHLIBDIR= /usr/lib/i18n
 .endif

--- a/libexec/Makefile
+++ b/libexec/Makefile
@@ -86,14 +86,14 @@ _tftp-proxy=	tftp-proxy
 _rtld-elf=	rtld-elf rtld-elf-debug
 SUBDIR.${MK_LIB32}+=	rtld-elf32
 SUBDIR.${MK_LIB64}+=	rtld-elf64
-SUBDIR.${MK_COMPAT_CHERIABI}+=	rtld-cheri-elf rtld-cheri-elf-debug
+SUBDIR.${MK_COMPAT_CHERIABI}+=	rtld-elf64c rtld-elf64c-debug
 # rtld.1 needs to be installed before the cross-dir MLINKS can work.
 SUBDIR_INSTALL_USE_DEPENDS=
 SUBDIR_DEPEND_rtld-elf-debug=	rtld-elf
-SUBDIR_DEPEND_rtld-cheri-elf-debug=	rtld-elf
-SUBDIR_DEPEND_rtld-cheri-elf=	rtld-elf
 SUBDIR_DEPEND_rtld-elf32=	rtld-elf
 SUBDIR_DEPEND_rtld-elf64=	rtld-elf
+SUBDIR_DEPEND_rtld-elf64c=	rtld-elf
+SUBDIR_DEPEND_rtld-elf64c-debug=	rtld-elf
 .endif
 
 .if ${MK_RBOOTD} != "no"

--- a/libexec/rtld-elf/debug.h
+++ b/libexec/rtld-elf/debug.h
@@ -81,7 +81,7 @@ __END_DECLS
 #elif defined(COMPAT_64BIT)
 #define _MYNAME	"ld-elf64.so.1"
 #elif defined(COMPAT_CHERI)
-#define _MYNAME	"ld-cheri-elf.so.1"
+#define _MYNAME	"ld-elf64c.so.1"
 #else
 #define _MYNAME	"ld-elf.so.1"
 #endif

--- a/libexec/rtld-elf/paths.h
+++ b/libexec/rtld-elf/paths.h
@@ -32,14 +32,14 @@
 #undef _PATH_ELF_HINTS
 
 #define	_DEFAULT_BASENAME_RTLD		"ld-elf.so.1"
-#define	_CHERIABI_BASENAME_RTLD		"ld-cheri-elf.so.1"
+#define	_CHERIABI_BASENAME_RTLD		"ld-elf64c.so.1"
 #define	_COMPAT32_BASENAME_RTLD		"ld-elf32.so.1"
 #define	_COMPAT64_BASENAME_RTLD		"ld-elf64.so.1"
 
 
 #ifdef COMPAT_CHERI
-#define	_PATH_ELF_HINTS		"/var/run/ld-cheri-elf.so.hints"
-#define	_PATH_LIBMAP_CONF	"/etc/libmap-cheri.conf"
+#define	_PATH_ELF_HINTS		"/var/run/ld-elf64c.so.hints"
+#define	_PATH_LIBMAP_CONF	"/etc/libmap64c.conf"
 #define	_BASENAME_RTLD		_CHERIABI_BASENAME_RTLD
 #define	STANDARD_LIBRARY_PATH	"/lib64c:/usr/lib64c"
 #define	LD_			"LD_CHERI_"

--- a/libexec/rtld-elf/paths.h
+++ b/libexec/rtld-elf/paths.h
@@ -41,7 +41,7 @@
 #define	_PATH_ELF_HINTS		"/var/run/ld-cheri-elf.so.hints"
 #define	_PATH_LIBMAP_CONF	"/etc/libmap-cheri.conf"
 #define	_BASENAME_RTLD		_CHERIABI_BASENAME_RTLD
-#define	STANDARD_LIBRARY_PATH	"/libcheri:/usr/libcheri"
+#define	STANDARD_LIBRARY_PATH	"/lib64c:/usr/lib64c"
 #define	LD_			"LD_CHERI_"
 #endif
 

--- a/libexec/rtld-elf64c-debug/Makefile
+++ b/libexec/rtld-elf64c-debug/Makefile
@@ -3,9 +3,9 @@
 NEED_COMPAT=	CHERI
 .include <bsd.compat.mk>
 
-PROG=	ld-cheri-elf-debug.so.1
+PROG=	ld-elf64c-debug.so.1
 MAN=
-MLINKS=	rtld.1 ld-cheri-elf-debug.so.1.1
+MLINKS=	rtld.1 ld-elf64c-debug.so.1.1
 
 RTLD_DEBUG_VERBOSE?=	3
 BUILD_RTLD_DEBUG:=	yes

--- a/libexec/rtld-elf64c/Makefile
+++ b/libexec/rtld-elf64c/Makefile
@@ -3,9 +3,9 @@
 NEED_COMPAT=	CHERI
 .include <bsd.compat.mk>
 
-PROG=	ld-cheri-elf.so.1
+PROG=	ld-elf64c.so.1
 MAN=
-MLINKS=	rtld.1 ld-cheri-elf.so.1
+MLINKS=	rtld.1 ld-elf64c.so.1
 
 .PATH:  ${SRCTOP}/libexec/rtld-elf
 .include "${SRCTOP}/libexec/rtld-elf/Makefile"

--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -165,33 +165,33 @@ LIB64_MACHINE_ABI=	${MACHINE_ABI:Npurecap}
 .if ${MK_COMPAT_CHERIABI} != "no"
 .if ${COMPAT_ARCH} == "aarch64"
 HAS_COMPAT+=CHERI
-LIBCHERI_MACHINE=	arm64
-LIBCHERI_MACHINE_ARCH=	aarch64c
-LIBCHERICPUFLAGS=	-target aarch64-unknown-freebsd13.0
+LIB64C_MACHINE=	arm64
+LIB64C_MACHINE_ARCH=	aarch64c
+LIB64CCPUFLAGS=	-target aarch64-unknown-freebsd13.0
 # XXX: Drop -femulated-tls once bsd.cpu.mk no longer passes it
-LIBCHERICPUFLAGS+=	-march=morello+c64 -mabi=purecap -femulated-tls
+LIB64CCPUFLAGS+=	-march=morello+c64 -mabi=purecap -femulated-tls
 .elif ${COMPAT_ARCH:Mmips64*} && !${COMPAT_ARCH:Mmips64*c*}
 .if ${COMPAT_ARCH:Mmips*el*}
 .error No little endian CHERI
 .endif
 HAS_COMPAT+=CHERI
-LIBCHERICPUFLAGS=  -target mips64-unknown-freebsd13.0 -cheri -mabi=purecap
-LIBCHERICPUFLAGS+=	-fpic
-LIBCHERICPUFLAGS+=	-Werror=cheri-bitwise-operations
-LIBCHERI_MACHINE=	mips
-LIBCHERI_MACHINE_ARCH=	mips64c128
-LIBCHERILDFLAGS=	-fuse-ld=lld
+LIB64CCPUFLAGS=  -target mips64-unknown-freebsd13.0 -cheri -mabi=purecap
+LIB64CCPUFLAGS+=	-fpic
+LIB64CCPUFLAGS+=	-Werror=cheri-bitwise-operations
+LIB64C_MACHINE=	mips
+LIB64C_MACHINE_ARCH=	mips64c128
+LIB64CLDFLAGS=	-fuse-ld=lld
 .elif ${COMPAT_ARCH:Mriscv64*} && !${COMPAT_ARCH:Mriscv64*c*}
 HAS_COMPAT+=CHERI
-LIBCHERI_MACHINE=	riscv
-LIBCHERI_MACHINE_ARCH=	${COMPAT_ARCH}c
-LIBCHERIWMAKEFLAGS=	CPUTYPE=cheri
-LIBCHERICPUFLAGS=	-target riscv64-unknown-freebsd13.0
+LIB64C_MACHINE=	riscv
+LIB64C_MACHINE_ARCH=	${COMPAT_ARCH}c
+LIB64CWMAKEFLAGS=	CPUTYPE=cheri
+LIB64CCPUFLAGS=	-target riscv64-unknown-freebsd13.0
 COMPAT_RISCV_ABI=	l64pc128
 .if !${MACHINE_ARCH:Mriscv*sf}
 COMPAT_RISCV_ABI:=	${COMPAT_RISCV_ABI}d
 .endif
-LIBCHERICPUFLAGS+=	-march=${COMPAT_RISCV_MARCH} -mabi=${COMPAT_RISCV_ABI}
+LIB64CCPUFLAGS+=	-march=${COMPAT_RISCV_MARCH} -mabi=${COMPAT_RISCV_ABI}
 .endif	# ${COMPAT_ARCH:Mriscv64*}
 .endif # ${MK_COMPAT_CHERIABI} != "no"
 
@@ -209,31 +209,31 @@ COMPAT_RISCV_MARCH:=	${COMPAT_RISCV_MARCH}xcheri
 
 # Common CHERI flags
 .if defined(HAS_COMPAT) && ${HAS_COMPAT:MCHERI}
-LIBCHERICFLAGS+=	-DCOMPAT_CHERI
-LIBCHERIWMAKEFLAGS+=	COMPAT_CHERI=yes
-LIBCHERI_MACHINE_ABI=	${MACHINE_ABI} purecap
+LIB64CCFLAGS+=	-DCOMPAT_CHERI
+LIB64CWMAKEFLAGS+=	COMPAT_CHERI=yes
+LIB64C_MACHINE_ABI=	${MACHINE_ABI} purecap
 
 # This duplicates some logic in bsd.cpu.mk that is needed for the
 # WANT_COMPAT/NEED_COMPAT case.
-LIBCHERICFLAGS+=	-D__LP64__=1
+LIB64CCFLAGS+=	-D__LP64__=1
 
-LIBCHERICFLAGS+=	-Werror=implicit-function-declaration
+LIB64CCFLAGS+=	-Werror=implicit-function-declaration
 
 .ifdef CHERI_USE_CAP_TABLE
-LIBCHERICFLAGS+=	-cheri-cap-table-abi=${CHERI_USE_CAP_TABLE}
+LIB64CCFLAGS+=	-cheri-cap-table-abi=${CHERI_USE_CAP_TABLE}
 .endif
 
 .if defined(CHERI_SUBOBJECT_BOUNDS)
 # Allow per-subdirectory overrides if we know that there is maximum that works
 .if defined(CHERI_SUBOBJECT_BOUNDS_MAX)
-LIBCHERICFLAGS+=	-Xclang -cheri-bounds=${CHERI_SUBOBJECT_BOUNDS_MAX}
+LIB64CCFLAGS+=	-Xclang -cheri-bounds=${CHERI_SUBOBJECT_BOUNDS_MAX}
 .else
-LIBCHERICFLAGS+=	-Xclang -cheri-bounds=${CHERI_SUBOBJECT_BOUNDS}
+LIB64CCFLAGS+=	-Xclang -cheri-bounds=${CHERI_SUBOBJECT_BOUNDS}
 .endif # CHERI_SUBOBJECT_BOUNDS_MAX
 CHERI_SUBOBJECT_BOUNDS_DEBUG?=yes
 .if ${CHERI_SUBOBJECT_BOUNDS_DEBUG} == "yes"
 # If debugging is enabled, clear SW permission bit 2 when the bounds are reduced
-LIBCHERICFLAGS+=	-mllvm -cheri-subobject-bounds-clear-swperm=2
+LIB64CCFLAGS+=	-mllvm -cheri-subobject-bounds-clear-swperm=2
 .endif # CHERI_SUBOBJECT_BOUNDS_DEBUG
 .endif # CHERI_SUBOBJECT_BOUNDS
 .endif
@@ -268,12 +268,12 @@ WANT_COMPAT:=	${NEED_COMPAT}
 
 .if defined(HAS_COMPAT) && defined(WANT_COMPAT)
 .if ${WANT_COMPAT} == "any"
-_LIBCOMPAT:=	${HAS_COMPAT:[1]}
+_LIBCOMPAT:=	${HAS_COMPAT:[1]:S/CHERI/64C/}
 .elif !${HAS_COMPAT:M${WANT_COMPAT}}
 .warning WANT_COMPAT (${WANT_COMPAT}) defined, but not in HAS_COMPAT (${HAS_COMPAT})
 .undef WANT_COMPAT
 .else
-_LIBCOMPAT:=	${WANT_COMPAT}
+_LIBCOMPAT:=	${WANT_COMPAT:S/CHERI/64C/}
 .endif
 .else # defined(HAS_COMPAT) && defined(WANT_COMPAT)
 .undef WANT_COMPAT

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -112,7 +112,7 @@ static __ElfN(Brandinfo) freebsd_brand_info = {
 	.interp_path	= "/libexec/ld-elf.so.1",
 	.sysvec		= &elf64_freebsd_sysvec,
 #if __has_feature(capabilities)
-	.interp_newpath	= "/libexec/ld-cheri-elf.so.1",
+	.interp_newpath	= "/libexec/ld-elf64c.so.1",
 #else
 	.interp_newpath	= NULL,
 #endif

--- a/sys/mips/mips/elf_machdep.c
+++ b/sys/mips/mips/elf_machdep.c
@@ -152,7 +152,7 @@ static __ElfN(Brandinfo) freebsd_brand_info = {
 	.interp_path	= "/libexec/ld-elf.so.1",
 	.sysvec		= &elf_freebsd_sysvec,
 #if __has_feature(capabilities)
-	.interp_newpath	= "/libexec/ld-cheri-elf.so.1",
+	.interp_newpath	= "/libexec/ld-elf64c.so.1",
 	.header_supported = mips_elf_header_supported,
 #else
 	.interp_newpath	= NULL,

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -128,7 +128,7 @@ static __ElfN(Brandinfo) freebsd_brand_info = {
 	.interp_path	= "/libexec/ld-elf.so.1",
 	.sysvec		= &elf_freebsd_sysvec,
 #if __has_feature(capabilities)
-	.interp_newpath	= "/libexec/ld-cheri-elf.so.1",
+	.interp_newpath	= "/libexec/ld-elf64c.so.1",
 #else
 	.interp_newpath	= NULL,
 #endif

--- a/usr.bin/stdbuf/stdbuf.c
+++ b/usr.bin/stdbuf/stdbuf.c
@@ -36,7 +36,7 @@
 #define	LIBSTDBUF	"/usr/lib/libstdbuf.so"
 #define	LIBSTDBUF32	"/usr/lib32/libstdbuf.so"
 #define	LIBSTDBUF64	"/usr/lib64/libstdbuf.so"
-#define	LIBSTDBUFCHERI	"/usr/libcheri/libstdbuf.so"
+#define	LIBSTDBUFCHERI	"/usr/lib64c/libstdbuf.so"
 
 extern char *__progname;
 


### PR DESCRIPTION
This further breaks the libcheri build on MIPS, but that's already broken in several other ways at this point.

There are some other possible changes we could make such as:

MK_COMPAT_CHERIABI -> MK_LIB64C
LD_CHERI_* -> LD_64C_*
NEED_COMPAT: CHERI -> 64C.

The first one possibly makes sense.  The other two I am less sure of (and they'd certainly be disruptive).