### PR TITLE
Export _mmap and __sys_mmap from libc.so

### DIFF
--- a/lib/libc/sys/Symbol.map
+++ b/lib/libc/sys/Symbol.map
@@ -760,6 +760,8 @@ FBSDprivate_1.0 {
 	__sys_mlock;
 	_mlockall;
 	__sys_mlockall;
+	_mmap;
+	__sys_mmap;
 	_modfind;
 	__sys_modfind;
 	_modfnext;


### PR DESCRIPTION
Unlike the other syscalls these two symbols were missing from the
version script. I noticed this while looking into purecap compiler-rt
runtime libraries.