### PR TITLE
Coproc fixes

### DIFF
--- a/sys/arm64/include/cpu.h
+++ b/sys/arm64/include/cpu.h
@@ -45,7 +45,7 @@
 #include <machine/frame.h>
 #include <machine/armreg.h>
 
-#define	TRAPF_PC(tfp)		((tfp)->tf_lr)
+#define	TRAPF_PC(tfp)		((tfp)->tf_elr)
 #define	TRAPF_USERMODE(tfp)	(((tfp)->tf_spsr & PSR_M_MASK) == PSR_M_EL0t)
 
 #define	cpu_getstack(td)	((td)->td_frame->tf_sp)

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -570,7 +570,7 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 		uprintf("Warning: Attempted to load position-dependent "
 		    "executable with non-representable base: %s\n",
 		    imgp->execpath);
-		return (KERN_FAILURE); /* XXX: EPRECISION or similar? */
+		return (EINVAL); /* XXX: EPRECISION or similar? */
 	}
 
 	/*
@@ -584,7 +584,7 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	result = vm_map_reservation_create(map, &reservation, end - start,
 	    PAGE_SIZE, VM_PROT_ALL);
 	if (result != KERN_SUCCESS)
-		return (result);
+		return (vm_mmap_to_errno(result));
 
 	*preferred_rbase = reservation - start;
 
@@ -596,7 +596,7 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 #endif
 	*imgact_cap = cheri_andperm(reservation_cap, perm);
 
-	return (KERN_SUCCESS);
+	return (0);
 }
 #endif
 

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1188,10 +1188,9 @@ exec_new_vmspace(struct image_params *imgp, struct sysentvec *sv)
 #if __has_feature(capabilities)
 	p->p_usrstack = CHERI_REPRESENTABLE_BASE(p->p_usrstack, ssiz);
 #endif
-	p->p_psstrings = p->p_usrstack - sv->sv_szpsstrings;
 
 	/* We reserve the whole max stack size with restricted permission */
-	stack_addr =  p->p_usrstack - ssiz;
+	stack_addr = p->p_usrstack - ssiz;
 	stack_prot = (obj != NULL && imgp->stack_prot != 0) ? imgp->stack_prot :
 	    sv->sv_stackprot;
 	imgp->stack_sz = ssiz;

--- a/sys/riscv/include/cpu.h
+++ b/sys/riscv/include/cpu.h
@@ -41,7 +41,7 @@
 #include <machine/cpufunc.h>
 #include <machine/frame.h>
 
-#define	TRAPF_PC(tfp)		((tfp)->tf_ra)
+#define	TRAPF_PC(tfp)		((tfp)->tf_sepc)
 #define	TRAPF_USERMODE(tfp)	(((tfp)->tf_sstatus & SSTATUS_SPP) == 0)
 
 #define	cpu_getstack(td)	((td)->td_frame->tf_sp)

--- a/sys/riscv/riscv/cpufunc_asm.S
+++ b/sys/riscv/riscv/cpufunc_asm.S
@@ -39,5 +39,5 @@ __FBSDID("$FreeBSD$");
 	.align	2
 
 ENTRY(riscv_nullop)
-	ret
+	RETURN
 END(riscv_nullop)

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -543,18 +543,21 @@ do_trap_user(struct trapframe *frame)
 	case SCAUSE_STORE_MISALIGNED:
 		call_trapsignal(td, SIGBUS, BUS_ADRALN,
 		    (uintcap_t)frame->tf_stval, exception, 0);
+		userret(td, frame);
 		break;
 	case SCAUSE_LOAD_CAP_PAGE_FAULT:
 		if (log_user_cheri_exceptions)
 			dump_cheri_exception(frame);
 		call_trapsignal(td, SIGSEGV, SEGV_LOADTAG,
 		    (uintcap_t)frame->tf_stval, exception, 0);
+		userret(td, frame);
 		break;
 	case SCAUSE_STORE_AMO_CAP_PAGE_FAULT:
 		if (log_user_cheri_exceptions)
 			dump_cheri_exception(frame);
 		call_trapsignal(td, SIGSEGV, SEGV_STORETAG,
 		    (uintcap_t)frame->tf_stval, exception, 0);
+		userret(td, frame);
 		break;
 	case SCAUSE_CHERI:
 		if (log_user_cheri_exceptions)

--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -244,6 +244,7 @@ SUBDIR.${MK_KERBEROS_SUPPORT}+=	compile_et
 SUBDIR.${MK_LDNS_UTILS}+=	drill
 SUBDIR.${MK_LDNS_UTILS}+=	host
 SUBDIR.${MK_LIB32}+=	ldd32
+SUBDIR.${MK_LIB64}+=	ktrdump64
 SUBDIR.${MK_LIB64}+=	ldd64
 SUBDIR.${MK_LOCATE}+=	locate
 # XXX msgs?

--- a/usr.bin/ktrdump/Makefile
+++ b/usr.bin/ktrdump/Makefile
@@ -1,8 +1,9 @@
 # $FreeBSD$
 
-PROG=	ktrdump
+PROG?=	ktrdump
+SRCS=	ktrdump.c
 LIBADD=	kvm
-MAN=	ktrdump.8
+MAN?=	ktrdump.8
 
 WARNS?=	2
 

--- a/usr.bin/ktrdump64/Makefile
+++ b/usr.bin/ktrdump64/Makefile
@@ -1,0 +1,9 @@
+NEED_COMPAT=	64
+.include <bsd.compat.mk>
+
+PROG=	ktrdump64
+MAN=
+MLINKS=	ktrdump.8 ktrdump64.8
+
+.PATH:	${SRCTOP}/usr.bin/ktrdump
+.include "${SRCTOP}/usr.bin/ktrdump/Makefile"


### PR DESCRIPTION
These are various small fixes I encountered while working on the merge of the coexcve branch.  The sys_kldsym() fix fixes the purecap ktrdump not being able to resolve symbols, though since I was using a hybrid kernel I ended up needing ktrdump64 instead to have the 'struct ktr_entry' type match the ABI.  ktrdump64 seemed simpler and less invasive given the nature of this tool than trying to teach ktrdump about different kernel ABIs.