### PR TITLE
Don't filter amu and gdb from INTERNALLIBS for /usr/lib64c.

### DIFF
--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -114,10 +114,7 @@ build${libcompat}: .PHONY
 	    ${LIBCOMPATWMAKE} -f Makefile.inc1 -DNO_FSCHG libraries
 .if ${MK_COMPAT_CHERIABI} == "yes" && ${MK_CHERI_PURE} == "yes"
 # To build a purecap world against /usr/lib64c, we need internal libs.
-# Skip amu because it needs unifdef which isn't available here and we
-# don't build amd (and it's going away).
-# We've locally removed gdb.
-.for _lib in ${_INTERNALLIBS:Namu:Ngdb}
+.for _lib in ${_INTERNALLIBS}
 	${_+_}cd ${.CURDIR}${LIB${_lib:tu}DIR:S|${_LIB_OBJTOP}||}; \
 	    ${LIBCOMPATWMAKE} all
 .endfor


### PR DESCRIPTION
These libraries have been removed upstream.