### PR TITLE
Add a clang-format GitHub action

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,11 @@
+name: clang-format checks
+on: [pull_request]
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arichardson/clang-format-checker@v3
+        with:
+          target-ref: "${{ github.base_ref }}" # required, merge target
+          clang-version: 12     # optional, default: 12

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,11 +1,33 @@
-name: clang-format checks
+name: Check coding style with clang-format
 on: [pull_request]
+defaults:
+  run:
+    shell: bash
 jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: arichardson/clang-format-checker@v3
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Try to fetch required commits
+        run: |
+          set -xe
+          echo "base_ref=${{ github.base_ref }}"
+          echo "github.event.pull_request.head.sha=${{ github.event.pull_request.head.sha }}"
+          # Based on https://stackoverflow.com/questions/54181901/fetching-only-the-range-of-commits-not-present-in-base-branch
+          for ((depth = 8; depth <= 65536; depth *= 2)); do
+              echo "trying depth $depth ..."
+              git fetch "--depth=$depth" origin "${{ github.base_ref }}:${{ github.base_ref }}"
+              git fetch "--depth=$depth" origin "+${{ github.event.pull_request.head.sha }}"
+              if git merge-base "${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}"; then
+                  echo "found with depth=$depth"
+                  break
+              fi
+          done
+      - name: List commits
+        run: git log --oneline "${{ github.base_ref }}..${{ github.event.pull_request.head.sha }}"
+      - name: Run clang-format
+        uses: wolletd/clang-format-checker@v1
         with:
-          target-ref: "${{ github.base_ref }}" # required, merge target
-          clang-version: 12     # optional, default: 12
+          source-ref: "${{ github.event.pull_request.head.sha }}"
+          target-ref: "${{ github.base_ref }}"

--- a/sys/libkern/strlen.c
+++ b/sys/libkern/strlen.c
@@ -98,7 +98,7 @@ size_t
 		lp++;
 #else
 	va = (*lp - mask01);
-	vb = ((~*lp) & mask80);
+	vb = ((~*lp)&mask80);
 	lp++;
 	byte_check = (bool)(va & vb);
 #endif
@@ -124,8 +124,7 @@ size_t
 			testbyte(2);
 			testbyte(3);
 #if (LONG_BIT >= 64)
-			testbyte(4);
-			testbyte(5);
+			testbyte(4); testbyte(5);
 			testbyte(6);
 			testbyte(7);
 #endif

--- a/sys/libkern/strlen.c
+++ b/sys/libkern/strlen.c
@@ -98,7 +98,7 @@ size_t
 		lp++;
 #else
 	va = (*lp - mask01);
-	vb = ((~*lp)&mask80);
+	vb = ((~*lp) & mask80);
 	lp++;
 	byte_check = (bool)(va & vb);
 #endif
@@ -124,7 +124,8 @@ size_t
 			testbyte(2);
 			testbyte(3);
 #if (LONG_BIT >= 64)
-			testbyte(4); testbyte(5);
+			testbyte(4);
+			testbyte(5);
 			testbyte(6);
 			testbyte(7);
 #endif


### PR DESCRIPTION
This checks all the commits in the current PR using
my fork of WolleTD/clang-format-checker.
Ideally, it would also add inline comments but that
might be quite a lot of work.