### PR TITLE
Changes needed to build with newer LLVM

### DIFF
--- a/contrib/libpng/pngpriv.h
+++ b/contrib/libpng/pngpriv.h
@@ -475,8 +475,7 @@
 
 /* This implicitly assumes alignment is always to a power of 2. */
 #ifdef png_alignof
-#  define png_isaligned(ptr, type)\
-   ((((const char*)ptr-(const char*)0) & (png_alignof(type)-1)) == 0)
+#  define png_isaligned(ptr, type) __is_aligned(ptr, png_alignof(type))
 #else
 #  define png_isaligned(ptr, type) 0
 #endif

--- a/contrib/libpng/pngrutil.c
+++ b/contrib/libpng/pngrutil.c
@@ -4152,11 +4152,11 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
       */
      {
         png_bytep temp = png_ptr->big_row_buf + 32;
-        int extra = (int)((temp - (png_bytep)0) & 0x0f);
+        int extra = (ptraddr_t)temp & 0x0f;
         png_ptr->row_buf = temp - extra - 1/*filter byte*/;
 
         temp = png_ptr->big_prev_row + 32;
-        extra = (int)((temp - (png_bytep)0) & 0x0f);
+        extra = (ptraddr_t)temp & 0x0f;
         png_ptr->prev_row = temp - extra - 1/*filter byte*/;
      }
 

--- a/lib/googletest/Makefile.inc
+++ b/lib/googletest/Makefile.inc
@@ -10,3 +10,6 @@ CXXFLAGS+=	${GTESTS_FLAGS}
 
 # Silence warnings about usage of deprecated std::auto_ptr
 CXXWARNFLAGS+=	-Wno-deprecated-declarations
+
+# Silence warnings about usage of deprecated implicit copy constructors
+CXXWARNFLAGS+=  -Wno-deprecated-copy

--- a/lib/libc/stdlib/merge.c
+++ b/lib/libc/stdlib/merge.c
@@ -143,12 +143,8 @@ mergesort(void *base, size_t nmemb, size_t size, cmp_t cmp)
 	if (nmemb == 0)
 		return (0);
 
-	/*
-	 * XXX
-	 * Stupid subtraction for the Cray.
-	 */
 	iflag = 0;
-	if (!(size % ISIZE) && !(((char *)base - (char *)0) % ISIZE))
+	if (__is_aligned(size, ISIZE) && __is_aligned(base, ISIZE))
 		iflag = 1;
 
 	if ((list2 = malloc(nmemb * size + PSIZE)) == NULL)

--- a/lib/libefivar/Makefile
+++ b/lib/libefivar/Makefile
@@ -43,8 +43,7 @@ MAN=		efivar.3
 
 CFLAGS+=	-I${EFIBOOT}/include
 CFLAGS+=	-I${.CURDIR} -I${EDK2INC}
-
-CFLAGS.efivar-dp-format.c=-Wno-unused-parameter
+CFLAGS+=	-fno-strict-aliasing
 
 MLINKS+=efivar.3 efi_set_variables_supported.3 \
 	efivar.3 efi_del_variable.3 \
@@ -65,4 +64,9 @@ WARNS?=		9
 
 .include <bsd.lib.mk>
 
-CFLAGS+= -fno-strict-aliasing -Wno-cast-align -Wno-unused-parameter
+CWARNFLAGS+=	-Wno-cast-align
+CWARNFLAGS+=	-Wno-unused-parameter
+
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
+CWARNFLAGS+=	-Wno-unused-but-set-variable
+.endif

--- a/lib/libefivar/Makefile
+++ b/lib/libefivar/Makefile
@@ -67,6 +67,6 @@ WARNS?=		9
 CWARNFLAGS+=	-Wno-cast-align
 CWARNFLAGS+=	-Wno-unused-parameter
 
-.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_FEATURES:MWunused-but-set-variable}
 CWARNFLAGS+=	-Wno-unused-but-set-variable
 .endif

--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -245,6 +245,19 @@ ${X_}COMPILER_FEATURES+=	c++17
 .endif
 .if ${${X_}COMPILER_TYPE} == "clang"
 ${X_}COMPILER_FEATURES+=	retpoline init-all
+# Detect certain supported warning flags to allow building with clang versions
+# built from git between releases. For example this affects all CHERI LLVM
+# versions that include the April 2021 upstream merge but not the September one.
+# Without this check we get the following build failure:
+# error: unknown warning option '-Werror=unused-but-set-variable'
+_check_flag=${${cc}:N${CCACHE_BIN}} -Werror=unknown-warning-option -fsyntax-only -xc /dev/null
+_warning_flags_to_check=unused-but-set-variable
+.for _flag in ${_warning_flags_to_check}
+_flag_supported!=	${_check_flag} -Werror=${_flag} 2>/dev/null && echo "yes" || echo "no"
+.if ${_flag_supported} == "yes"
+${X_}COMPILER_FEATURES+= W${_flag}
+.endif
+.endfor
 .endif
 
 .if ${${cc}:N${CCACHE_BIN}:[1]:M/*} && exists(${${cc}:N${CCACHE_BIN}:[1]})

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -80,6 +80,9 @@ CWARNFLAGS+=	-Wno-pointer-sign
 .if ${WARNS} <= 6
 CWARNFLAGS.clang+=	-Wno-empty-body -Wno-string-plus-int
 CWARNFLAGS.clang+=	-Wno-unused-const-variable
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
+CWARNFLAGS.clang+=	-Wno-error=unused-but-set-variable
+.endif
 .endif # WARNS <= 6
 .if ${WARNS} <= 3
 CWARNFLAGS.clang+=	-Wno-tautological-compare -Wno-unused-value\

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -242,8 +242,10 @@ CFLAGS+=-nobuiltininc -idirafter ${COMPILER_RESOURCE_DIR}/include
 .endif
 .endif
 
-CLANG_OPT_SMALL= -mstack-alignment=8 -mllvm -inline-threshold=3\
-		 -mllvm -simplifycfg-dup-ret
+CLANG_OPT_SMALL= -mstack-alignment=8 -mllvm -inline-threshold=3
+.if ${COMPILER_VERSION} < 130000
+CLANG_OPT_SMALL+= -mllvm -simplifycfg-dup-ret
+.endif
 CLANG_OPT_SMALL+= -mllvm -enable-load-pre=false
 CFLAGS.clang+=	 -Qunused-arguments
 # The libc++ headers use c++11 extensions.  These are normally silenced because

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -80,7 +80,7 @@ CWARNFLAGS+=	-Wno-pointer-sign
 .if ${WARNS} <= 6
 CWARNFLAGS.clang+=	-Wno-empty-body -Wno-string-plus-int
 CWARNFLAGS.clang+=	-Wno-unused-const-variable
-.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_FEATURES:MWunused-but-set-variable}
 CWARNFLAGS.clang+=	-Wno-error=unused-but-set-variable
 .endif
 .endif # WARNS <= 6

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -216,6 +216,11 @@ CWARNFLAGS+=	-Wno-error=pass-failed
 CXXWARNFLAGS+=	-Wno-error=non-c-typedef-for-linkage
 .endif
 
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
+# Work around c++/v1/__bit_reference warning until we update subrepocheri-libc++
+CXXWARNFLAGS+=  -Wno-error=deprecated-copy
+.endif
+
 # How to handle FreeBSD custom printf format specifiers.
 .if ${COMPILER_TYPE} == "clang"
 FORMAT_EXTENSIONS=	-D__printf__=__freebsd_kprintf__

--- a/stand/i386/loader/Makefile
+++ b/stand/i386/loader/Makefile
@@ -55,6 +55,12 @@ ORG=		0x0
 
 CFLAGS+=	-Wall
 LDFLAGS+=	-static ${LDFLAGS_ORG} -Wl,--gc-sections
+.if ${LINKER_TYPE} == "lld" && ${LINKER_VERSION} >= 130000
+# lld 13 and higher default to garbage collecting start/stop symbols,
+# completely ruining our linker sets. For now, work around it by
+# disabling this un-feature.
+LDFLAGS+=	-Wl,-z,nostart-stop-gc
+.endif
 
 # i386 standalone support library
 LIBI386=	${BOOTOBJ}/i386/libi386/libi386.a

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -25,6 +25,9 @@ NO_WUNNEEDED_INTERNAL_DECL=	-Wno-error=unneeded-internal-declaration
 NO_WSOMETIMES_UNINITIALIZED=	-Wno-error=sometimes-uninitialized
 NO_WCAST_QUAL=			-Wno-error=cast-qual
 NO_WTAUTOLOGICAL_POINTER_COMPARE= -Wno-tautological-pointer-compare
+.if ${COMPILER_VERSION} >= 100000
+NO_WMISLEADING_INDENTATION=	-Wno-misleading-indentation
+.endif
 # Several other warnings which might be useful in some cases, but not severe
 # enough to error out the whole kernel build.  Display them anyway, so there is
 # some incentive to fix them eventually.
@@ -33,8 +36,8 @@ CWARNEXTRA?=	-Wno-error=tautological-compare -Wno-error=empty-body \
 		-Wno-error=pointer-sign
 CWARNEXTRA+=	-Wno-error=shift-negative-value
 CWARNEXTRA+=	-Wno-address-of-packed-member
-.if ${COMPILER_VERSION} >= 100000
-NO_WMISLEADING_INDENTATION=	-Wno-misleading-indentation
+.if ${COMPILER_VERSION} >= 130000
+CWARNFLAGS+=	-Wno-error=unused-but-set-variable
 .endif
 .endif	# clang
 

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -36,7 +36,7 @@ CWARNEXTRA?=	-Wno-error=tautological-compare -Wno-error=empty-body \
 		-Wno-error=pointer-sign
 CWARNEXTRA+=	-Wno-error=shift-negative-value
 CWARNEXTRA+=	-Wno-address-of-packed-member
-.if ${COMPILER_VERSION} >= 130000
+.if ${COMPILER_FEATURES:MWunused-but-set-variable}
 CWARNFLAGS+=	-Wno-error=unused-but-set-variable
 .endif
 .endif	# clang

--- a/sys/contrib/dev/acpica/include/actypes.h
+++ b/sys/contrib/dev/acpica/include/actypes.h
@@ -662,8 +662,13 @@ typedef UINT64                          ACPI_INTEGER;
 /* Pointer/Integer type conversions */
 
 #define ACPI_TO_POINTER(i)              ACPI_CAST_PTR (void, (ACPI_SIZE) (i))
+#ifdef __FreeBSD__
+#define ACPI_TO_INTEGER(p)              ((ACPI_SIZE) (p))
+#define ACPI_OFFSET(d, f)               ((ACPI_SIZE) __offsetof(d, f))
+#else
 #define ACPI_TO_INTEGER(p)              ACPI_PTR_DIFF (p, (void *) 0)
 #define ACPI_OFFSET(d, f)               ACPI_PTR_DIFF (&(((d *) 0)->f), (void *) 0)
+#endif
 #define ACPI_PHYSADDR_TO_PTR(i)         ACPI_TO_POINTER(i)
 #define ACPI_PTR_TO_PHYSADDR(i)         ACPI_TO_INTEGER(i)
 

--- a/sys/x86/xen/pv.c
+++ b/sys/x86/xen/pv.c
@@ -335,7 +335,7 @@ hammer_time_xen(vm_paddr_t start_info_paddr)
 			HYPERVISOR_shutdown(SHUTDOWN_crash);
 		}
 		mod = (struct hvm_modlist_entry *)
-		    (vm_paddr_t)start_info->modlist_paddr + KERNBASE;
+		    (start_info->modlist_paddr + KERNBASE);
 		if (mod[0].paddr >= physfree) {
 			xc_printf("ERROR: unexpected module memory address\n");
 			HYPERVISOR_shutdown(SHUTDOWN_crash);

--- a/tests/sys/fs/fusefs/Makefile
+++ b/tests/sys/fs/fusefs/Makefile
@@ -72,6 +72,8 @@ CXXWARNFLAGS.gcc+=	-Wno-placement-new -Wno-attributes
 .if ${COMPILER_TYPE} == "gcc" && ${COMPILER_VERSION} >= 80000
 CXXWARNFLAGS+=	-Wno-class-memaccess
 .endif
+# Supress warnings about deprecated implicit copy constructors in gtest.
+CXXWARNFLAGS+=  -Wno-deprecated-copy
 CXXFLAGS+=	-I${SRCTOP}/tests
 CXXFLAGS+=	-I${FUSEFS}
 CXXFLAGS+=	-I${MOUNT}

--- a/tools/build/cross-build/include/common/sys/cdefs.h
+++ b/tools/build/cross-build/include/common/sys/cdefs.h
@@ -255,3 +255,22 @@
 #define	__BSD_VISIBLE		1
 #define	__ISO_C_VISIBLE		2011
 #define	__EXT1_VISIBLE		1
+
+/* Alignment builtins for better type checking and improved code generation. */
+/* Provide fallback versions for other compilers (GCC/Clang < 10): */
+#if !__has_builtin(__builtin_is_aligned)
+#define __builtin_is_aligned(x, align)	\
+	(((__uintptr_t)x & ((align) - 1)) == 0)
+#endif
+#if !__has_builtin(__builtin_align_up)
+#define __builtin_align_up(x, align)	\
+	((__typeof__(x))(((__uintptr_t)(x)+((align)-1))&(~((align)-1))))
+#endif
+#if !__has_builtin(__builtin_align_down)
+#define __builtin_align_down(x, align)	\
+	((__typeof__(x))((x)&(~((align)-1))))
+#endif
+
+#define __align_up(x, y) __builtin_align_up(x, y)
+#define __align_down(x, y) __builtin_align_down(x, y)
+#define __is_aligned(x, y) __builtin_is_aligned(x, y)


### PR DESCRIPTION
Mostly cherry-picks from upstream. Only real change is the last commit that allows us to still use the old compiler which is > 13.0.0 but doesn't support -Wno-unused-but-set-variable yet.