### PR TITLE
mips: Fix build of kernel.tramp.bin after upstream merge

### DIFF
--- a/sys/conf/Makefile.mips
+++ b/sys/conf/Makefile.mips
@@ -61,6 +61,8 @@ TRAMP_ARCH_FLAGS?=$(ARCH_FLAGS)
 TRAMP_EXTRA_FLAGS=${EXTRA_FLAGS} ${TRAMP_ARCH_FLAGS}
 # Kernel code is always compiled with soft-float on MIPS
 TRAMP_EXTRA_FLAGS+=-msoft-float
+# No standard library available
+TRAMP_EXTRA_FLAGS+=-ffreestanding
 .if ${MACHINE_ARCH:Mmips64*} != ""
 TRAMP_ELFSIZE=64
 .else


### PR DESCRIPTION
Since the upstream merge we end up with the compiler generating calls to memcpy (and it appears upstream LLVM does too, so this will probably also be a problem upstream when the LLVM 13 import is finished). Like the kernel we should just compile this file with -ffreestanding to avoid such surprises.

Note that elf_trampoline.c does actually provide a memcpy, but it's static. That's a bit weird, and means by the time the memcpy calls are generated by the compiler the explicit ones have already been inlined and the function itself GC'ed, but since using -ffreestanding is the right thing to do for this kind of code anyway, that doesn't actually matter.