### PR TITLE
cheribsdtest: Stop marking compiler bounds tests as flaky on Morello

### DIFF
--- a/bin/cheribsdtest/arm64/cheribsdtest_md.h
+++ b/bin/cheribsdtest/arm64/cheribsdtest_md.h
@@ -46,8 +46,6 @@
 
 #define	SI_CODE_STORELOCAL	PROT_CHERI_PERM
 
-#define	FLAKY_COMPILER_BOUNDS	"Morello compiler pads excessively"
-
 #ifndef __CHERI_PURE_CAPABILITY__
 /* The Morello compiler currently sets bounds on globals. */
 #define	XFAIL_HYBRID_BOUNDS_GLOBALS	NULL

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -114,13 +114,9 @@ extern struct cheribsdtest_child_state *ccsp;
 
 /*
  * Macros defined in one or more cheribsdtest_md.h to indicate the
- * reason for failure or flaky behavior.  Define to NULL here to
+ * reason for failure or flaky behavior.  Provide defaults here to
  * reduce the size of MD headers.
  */
-#ifndef FLAKY_COMPILER_BOUNDS
-#define	FLAKY_COMPILER_BOUNDS	NULL
-#endif
-
 #ifndef	SI_CODE_STORELOCAL
 #define	SI_CODE_STORELOCAL	PROT_CHERI_STORELOCAL
 #endif

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -237,10 +237,8 @@ TEST_BOUNDS(global_static_uint8_array3, "global static uint8_t[3]")
 TEST_BOUNDS(global_uint8_array3, "global uint8_t[3]");
 TEST_BOUNDS(global_static_uint8_array17, "global static uint_t[17]");
 TEST_BOUNDS(global_uint8_array17, "global uint_t[17]");
-TEST_BOUNDS(global_static_uint8_array65537, "global static uint8_t[65537]",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS);
-TEST_BOUNDS(global_uint8_array65537, "global uint8_t[65537]",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS);
+TEST_BOUNDS(global_static_uint8_array65537, "global static uint8_t[65537]");
+TEST_BOUNDS(global_uint8_array65537, "global uint8_t[65537]");
 
 /*
  * Arrays of bytes with power-of-two sizes starting with size 32.
@@ -502,6 +500,5 @@ TEST_BOUNDS(extern_global_array65536, "extern global uint8_t[16] (C size)");
 TEST_DYNAMIC_BOUNDS(extern_global_uint16, uint16_t);
 TEST_DYNAMIC_BOUNDS(extern_global_uint64, uint64_t);
 TEST_DYNAMIC_BOUNDS(extern_global_array1, uint8_t[1]);
-TEST_DYNAMIC_BOUNDS(extern_global_array65537, uint8_t[65537],
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS);
+TEST_DYNAMIC_BOUNDS(extern_global_array65537, uint8_t[65537]);
 TEST_DYNAMIC_BOUNDS(extern_global_array256, uint8_t[256]);

--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -131,15 +131,13 @@ CHERIBSDTEST(test_bounds_stack_static_uint8,
 }
 
 CHERIBSDTEST(test_bounds_stack_alloca_uint8,
-    "Check bounds on 8-bit alloca stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds on 8-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint8_t));
 }
 
 CHERIBSDTEST(test_bounds_stack_vla_uint8,
-    "Check bounds on 8-bit VLA stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds on 8-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint8_t));
 }
@@ -154,15 +152,13 @@ CHERIBSDTEST(test_bounds_stack_static_uint16,
 }
 
 CHERIBSDTEST(test_bounds_stack_alloca_uint16,
-    "Check bounds on 16-bit alloca stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds on 16-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint16_t));
 }
 
 CHERIBSDTEST(test_bounds_stack_vla_uint16,
-    "Check bounds on 16-bit VLA stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds on 16-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint16_t));
 }
@@ -177,15 +173,13 @@ CHERIBSDTEST(test_bounds_stack_static_uint32,
 }
 
 CHERIBSDTEST(test_bounds_stack_alloca_uint32,
-    "Check bounds 32-bit alloca stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds 32-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint32_t));
 }
 
 CHERIBSDTEST(test_bounds_stack_vla_uint32,
-    "Check bounds 32-bit VLA stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds 32-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint32_t));
 }
@@ -200,15 +194,13 @@ CHERIBSDTEST(test_bounds_stack_static_uint64,
 }
 
 CHERIBSDTEST(test_bounds_stack_alloca_uint64,
-    "Check bounds on 64-bit alloca stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds on 64-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint64_t));
 }
 
 CHERIBSDTEST(test_bounds_stack_vla_uint64,
-    "Check bounds on 64-bit VLA stack allocation",
-    .ct_flaky_reason = FLAKY_COMPILER_BOUNDS)
+    "Check bounds on 64-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint64_t));
 }


### PR DESCRIPTION
My fixes for these were merged to Morello LLVM 6 months ago.
