### PR TITLE
arm64: Fix inverted condition in busdma_bounce dma_preread_safe

### DIFF
--- a/sys/arm64/arm64/busdma_bounce.c
+++ b/sys/arm64/arm64/busdma_bounce.c
@@ -1047,9 +1047,9 @@ dma_preread_safe(vm_offset_t va, vm_size_t size)
 	 * Write back any partial cachelines immediately before and
 	 * after the DMA region.
 	 */
-	if (is_aligned(va, dcache_line_size))
+	if (!is_aligned(va, dcache_line_size))
 		cpu_dcache_wb_range(va, 1);
-	if (is_aligned(va + size, dcache_line_size))
+	if (!is_aligned(va + size, dcache_line_size))
 		cpu_dcache_wb_range(va + size, 1);
 
 	cpu_dcache_inv_range(va, size);


### PR DESCRIPTION
Commit 1d6cef536d96 accidentally inverted the condition of these when converting to using is_aligned.