### PR TITLE
Coexecve args

### DIFF
--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1512,16 +1512,6 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 	if (error != 0)
 		goto ret;
 
-#if 0
-	/*
-	 * XXX: For some reason imgp->start_addr is changed from ~0UL to 0 so due
-	 * to computing the minimum we were always getting a start_addr of 0.
-	 */
-	/* KASSERT(imgp->start_addr != 0,
-	 *   ("Should be ULONG_MAX and not 0x%lx", imgp->start_addr)); */
-	imgp->start_addr = ~0UL;
-#endif
-
 #if __has_feature(capabilities)
 	error = __elfN(build_imgact_capability)(imgp, &imgp->imgact_capability,
 	    hdr, phdr, &et_dyn_addr);

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1395,20 +1395,19 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 	sv = brand_info->sysvec;
 
 	/*
-	 * Check if colocation is allowed.  We can only do it after we know
-	 * if the binary is for CheriABI or not.  We also check the proccess
-	 * to colocate with.
+	 * Check if colocation is allowed.  We require both processes
+	 * to be CheriABI.
 	 */
 	if (imgp->cop != NULL) {
-		/* XXX-JHB: This check is equivalent to #ifndef ELF_CHERI. */
-		if ((sv->sv_flags & SV_CHERI) == 0) {
-			error = EPERM;
-			goto ret;
-		}
+#ifdef ELF_CHERI
 		if (SV_PROC_FLAG(imgp->cop, SV_CHERI) == 0) {
 			error = EPERM;
 			goto ret;
 		}
+#else
+		error = EPERM;
+		goto ret;
+#endif
 	}
 
 	et_dyn_addr = 0;

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -453,6 +453,7 @@ kern_execve(struct thread *td, struct image_args *args,
 		case ENOEXEC:
 		case ENOENT:
 		case ELOOP:
+			exec_free_args(args);
 			return (error);
 		default:
 			break;
@@ -1053,7 +1054,6 @@ exec_fail:
 	mac_execve_exit(imgp);
 	mac_execve_interpreter_exit(interpvplabel);
 #endif
-	exec_free_args(args);
 
 	/*
 	 * Handle deferred decrement of ref counts.
@@ -1080,6 +1080,8 @@ exec_fail:
 			if (error == EJUSTRETURN)
 				return (error);
 		}
+		exec_free_args(args);
+
 		/* sorry, no more process anymore. exit gracefully */
 		if (cop != NULL)
 			PRELE(cop);
@@ -1087,6 +1089,8 @@ exec_fail:
 		exit1(td, 0, SIGABRT);
 		/* NOT REACHED */
 	}
+	if (!opportunistic)
+		exec_free_args(args);
 
 #ifdef KTRACE
 	if (error == 0)

--- a/sys/riscv/riscv/cpufunc_asm.S
+++ b/sys/riscv/riscv/cpufunc_asm.S
@@ -39,5 +39,5 @@ __FBSDID("$FreeBSD$");
 	.align	2
 
 ENTRY(riscv_nullop)
-	ret
+	RETURN
 END(riscv_nullop)


### PR DESCRIPTION
The last commit is what I think is the fix for the length violation panics I've seen when leaving a system up overnight.  Probably what happens is that at some point the address space that cron lives in "fills up" with abandoned entries and every future execve falls back to non-opportunistic.  I might try a temporary hack to force the opportunistic case to fail always and verify it breaks quickly on the stock coexecve kernel and works with the fix.

The purecap changes are because cheribuild has recently changed to compile purecap kernels by default.  One is a cherry-pick, the second is a local fix.