### PR TITLE
Fix loading vnet-using kernel modules

### DIFF
--- a/sys/ddb/db_sym.c
+++ b/sys/ddb/db_sym.c
@@ -271,7 +271,7 @@ db_value_of_name_vnet(const char *name, db_expr_t *valuep)
 	db_symbol_values(sym, &name, &value);
 	if (value < VNET_START || value >= VNET_STOP)
 		return (false);
-	*valuep = (db_expr_t)((uintptr_t)vnet->vnet_data_mem +
+	*valuep = (db_expr_t)((uintptr_t)vnet->vnet_data_base - VNET_BIAS +
 	    ((ptraddr_t)value - (ptraddr_t)VNET_START));
 	return (true);
 #else

--- a/sys/net/vnet.c
+++ b/sys/net/vnet.c
@@ -464,8 +464,8 @@ vnet_data_copy(void *start, int size)
 
 	VNET_LIST_RLOCK();
 	LIST_FOREACH(vnet, &vnet_head, vnet_le)
-		memcpy((void *)((uintptr_t)vnet->vnet_data_base +
-		    (ptraddr_t)start), start, size);
+		memcpy((void *)((uintptr_t)vnet->vnet_data_base - VNET_BIAS +
+		    ((ptraddr_t)start - (ptraddr_t)VNET_START)), start, size);
 	VNET_LIST_RUNLOCK();
 }
 


### PR DESCRIPTION
Also includes an NFC (I hope) change that I noticed that was an outlier in using the wrong variable (vnet_data_mem is otherwise only used for managing the actual allocation and initialising in vnet_alloc, never for accessing the data therein).
