### PR TITLE
Handle AT_RESOLVE_BENEATH in freebsd64

### DIFF
--- a/sys/compat/cloudabi/cloudabi_file.c
+++ b/sys/compat/cloudabi/cloudabi_file.c
@@ -187,7 +187,7 @@ cloudabi_sys_file_link(struct thread *td,
 	error = kern_linkat(td, uap->fd1.fd, uap->fd2, PTR2CAP(path1),
 	    PTR2CAP(path2),
 	    UIO_SYSSPACE, (uap->fd1.flags & CLOUDABI_LOOKUP_SYMLINK_FOLLOW) ?
-	    FOLLOW : NOFOLLOW);
+	    AT_SYMLINK_FOLLOW : 0);
 	cloudabi_freestr(path1);
 	cloudabi_freestr(path2);
 	return (error);

--- a/sys/compat/freebsd64/freebsd64_vfs.c
+++ b/sys/compat/freebsd64/freebsd64_vfs.c
@@ -923,9 +923,6 @@ int
 freebsd64_linkat(struct thread *td, struct freebsd64_linkat_args *uap)
 {
 
-	if (uap->flag & ~AT_SYMLINK_FOLLOW)
-		return (EINVAL);
-
 	return (kern_linkat(td, uap->fd1, uap->fd2, __USER_CAP_STR(uap->path1),
 	    __USER_CAP_STR(uap->path2), UIO_USERSPACE, uap->flag));
 }
@@ -1065,9 +1062,6 @@ int
 freebsd64_chflagsat(struct thread *td, struct freebsd64_chflagsat_args *uap)
 {
 
-	if (uap->atflag & ~AT_SYMLINK_NOFOLLOW)
-		return (EINVAL);
-
 	return (kern_chflagsat(td, uap->fd, __USER_CAP_STR(uap->path),
 	    UIO_USERSPACE, uap->flags, uap->atflag));
 }
@@ -1091,9 +1085,6 @@ freebsd64_chmod(struct thread *td, struct freebsd64_chmod_args *uap)
 int
 freebsd64_fchmodat(struct thread *td, struct freebsd64_fchmodat_args *uap)
 {
-
-	if (uap->flag & ~AT_SYMLINK_NOFOLLOW)
-		return (EINVAL);
 
 	return (kern_fchmodat(td, uap->fd, __USER_CAP_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->flag));
@@ -1284,8 +1275,6 @@ int
 freebsd64_getfhat(struct thread *td, struct freebsd64_getfhat_args *uap)
 {
 
-	if ((uap->flags & ~(AT_SYMLINK_NOFOLLOW)) != 0)
-		return (EINVAL);
 	return (kern_getfhat(td, uap->flags, uap->fd,
 	    __USER_CAP_STR(uap->path), UIO_SYSSPACE,
 	    __USER_CAP_OBJ(uap->fhp), UIO_USERSPACE));

--- a/sys/compat/freebsd64/freebsd64_vfs.c
+++ b/sys/compat/freebsd64/freebsd64_vfs.c
@@ -916,21 +916,18 @@ freebsd64_link(struct thread *td, struct freebsd64_link_args *uap)
 {
 
 	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    __USER_CAP_STR(uap->to), UIO_USERSPACE, FOLLOW));
+	    __USER_CAP_STR(uap->to), UIO_USERSPACE, AT_SYMLINK_FOLLOW));
 }
 
 int
 freebsd64_linkat(struct thread *td, struct freebsd64_linkat_args *uap)
 {
-	int flag;
 
-	flag = uap->flag;
-	if (flag & ~AT_SYMLINK_FOLLOW)
+	if (uap->flag & ~AT_SYMLINK_FOLLOW)
 		return (EINVAL);
 
 	return (kern_linkat(td, uap->fd1, uap->fd2, __USER_CAP_STR(uap->path1),
-	    __USER_CAP_STR(uap->path2), UIO_USERSPACE,
-	    (flag & AT_SYMLINK_FOLLOW) ? FOLLOW : NOFOLLOW));
+	    __USER_CAP_STR(uap->path2), UIO_USERSPACE, uap->flag));
 }
 
 int

--- a/sys/compat/linux/linux_file.c
+++ b/sys/compat/linux/linux_file.c
@@ -1119,7 +1119,7 @@ linux_link(struct thread *td, struct linux_link_args *args)
 
 	if (!LUSECONVPATH(td)) {
 		return (kern_linkat(td, AT_FDCWD, AT_FDCWD, args->path, args->to,
-		    UIO_USERSPACE, FOLLOW));
+		    UIO_USERSPACE, AT_SYMLINK_FOLLOW));
 	}
 	LCONVPATHEXIST(td, args->path, &path);
 	/* Expand LCONVPATHCREATE so that `path' can be freed on errors */
@@ -1129,7 +1129,7 @@ linux_link(struct thread *td, struct linux_link_args *args)
 		return (error);
 	}
 	error = kern_linkat(td, AT_FDCWD, AT_FDCWD, PTR2CAP(path), PTR2CAP(to),
-	    UIO_SYSSPACE, FOLLOW);
+	    UIO_SYSSPACE, AT_SYMLINK_FOLLOW);
 	LFREEPATH(path);
 	LFREEPATH(to);
 	return (error);
@@ -1140,18 +1140,18 @@ int
 linux_linkat(struct thread *td, struct linux_linkat_args *args)
 {
 	char *path, *to;
-	int error, olddfd, newdfd, follow;
+	int error, olddfd, newdfd, flag;
 
 	if (args->flag & ~LINUX_AT_SYMLINK_FOLLOW)
 		return (EINVAL);
 
 	olddfd = (args->olddfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->olddfd;
 	newdfd = (args->newdfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->newdfd;
-	follow = (args->flag & LINUX_AT_SYMLINK_FOLLOW) == 0 ? NOFOLLOW :
-	    FOLLOW;
+	flag = (args->flag & LINUX_AT_SYMLINK_FOLLOW) == 0 ? 0 :
+	    AT_SYMLINK_FOLLOW;
 	if (!LUSECONVPATH(td)) {
 		return (kern_linkat(td, olddfd, newdfd, args->oldname,
-		    args->newname, UIO_USERSPACE, follow));
+		    args->newname, UIO_USERSPACE, flag));
 	}
 	LCONVPATHEXIST_AT(td, args->oldname, &path, olddfd);
 	/* Expand LCONVPATHCREATE so that `path' can be freed on errors */
@@ -1161,7 +1161,7 @@ linux_linkat(struct thread *td, struct linux_linkat_args *args)
 		return (error);
 	}
 	error = kern_linkat(td, olddfd, newdfd, PTR2CAP(path), PTR2CAP(to),
-	    UIO_SYSSPACE, follow);
+	    UIO_SYSSPACE, flag);
 	LFREEPATH(path);
 	LFREEPATH(to);
 	return (error);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -1534,9 +1534,6 @@ int
 sys_linkat(struct thread *td, struct linkat_args *uap)
 {
 
-	if ((uap->flag & ~(AT_SYMLINK_FOLLOW | AT_RESOLVE_BENEATH)) != 0)
-		return (EINVAL);
-
 	return (kern_linkat(td, uap->fd1, uap->fd2, uap->path1, uap->path2,
 	    UIO_USERSPACE, uap->flag));
 }
@@ -1587,6 +1584,9 @@ kern_linkat(struct thread *td, int fd1, int fd2,
 {
 	struct nameidata nd;
 	int error;
+
+	if ((flag & ~(AT_SYMLINK_FOLLOW | AT_RESOLVE_BENEATH)) != 0)
+		return (EINVAL);
 
 	do {
 		bwillwrite();
@@ -2764,9 +2764,6 @@ int
 sys_chflagsat(struct thread *td, struct chflagsat_args *uap)
 {
 
-	if ((uap->atflag & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
-		return (EINVAL);
-
 	return (kern_chflagsat(td, uap->fd, uap->path, UIO_USERSPACE,
 	    uap->flags, uap->atflag));
 }
@@ -2794,6 +2791,9 @@ kern_chflagsat(struct thread *td, int fd, const char * __capability path,
 {
 	struct nameidata nd;
 	int error;
+
+	if ((atflag & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
+		return (EINVAL);
 
 	AUDIT_ARG_FFLAGS(flags);
 	NDINIT_ATRIGHTS(&nd, LOOKUP, at2cnpflags(atflag, AT_SYMLINK_NOFOLLOW |
@@ -2892,9 +2892,6 @@ int
 sys_fchmodat(struct thread *td, struct fchmodat_args *uap)
 {
 
-	if ((uap->flag & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
-		return (EINVAL);
-
 	return (kern_fchmodat(td, uap->fd, uap->path, UIO_USERSPACE,
 	    uap->mode, uap->flag));
 }
@@ -2922,6 +2919,9 @@ kern_fchmodat(struct thread *td, int fd, const char * __capability path,
 {
 	struct nameidata nd;
 	int error;
+
+	if ((flag & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
+		return (EINVAL);
 
 	AUDIT_ARG_MODE(mode);
 	NDINIT_ATRIGHTS(&nd, LOOKUP, at2cnpflags(flag, AT_SYMLINK_NOFOLLOW |
@@ -3020,9 +3020,6 @@ int
 sys_fchownat(struct thread *td, struct fchownat_args *uap)
 {
 
-	if ((uap->flag & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
-		return (EINVAL);
-
 	return (kern_fchownat(td, uap->fd, uap->path, UIO_USERSPACE, uap->uid,
 	    uap->gid, uap->flag));
 }
@@ -3033,6 +3030,9 @@ kern_fchownat(struct thread *td, int fd, const char * __capability path,
 {
 	struct nameidata nd;
 	int error;
+
+	if ((flag & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
+		return (EINVAL);
 
 	AUDIT_ARG_OWNER(uid, gid);
 	NDINIT_ATRIGHTS(&nd, LOOKUP, at2cnpflags(flag, AT_SYMLINK_NOFOLLOW |
@@ -4388,8 +4388,6 @@ int
 sys_getfhat(struct thread *td, struct getfhat_args *uap)
 {
 
-	if ((uap->flags & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
-		return (EINVAL);
 	return (kern_getfhat(td, uap->flags, uap->fd, uap->path, UIO_USERSPACE,
 	    uap->fhp, UIO_USERSPACE));
 }
@@ -4404,6 +4402,8 @@ kern_getfhat(struct thread *td, int flags, int fd,
 	struct vnode *vp;
 	int error;
 
+	if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
+		return (EINVAL);
 	error = priv_check(td, PRIV_VFS_GETFH);
 	if (error != 0)
 		return (error);

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -311,7 +311,7 @@ int	kern_ktrace(struct thread *td, const char * __capability fname,
 	    int uops, int ufacs, int pid);
 int	kern_linkat(struct thread *td, int fd1, int fd2,
 	    const char * __capability path1, const char * __capability path2,
-	    enum uio_seg segflg, int follow);
+	    enum uio_seg segflg, int flag);
 int	kern_listen(struct thread *td, int s, int backlog);
 int	kern_lseek(struct thread *td, int fd, off_t offset, int whence);
 int	kern_lutimes(struct thread *td,
@@ -551,7 +551,7 @@ int	kern_utimesat(struct thread *td, int fd, const char * __capability path,
 	    enum uio_seg tptrseg);
 int	kern_utimensat(struct thread *td, int fd, const char * __capability path,
 	    enum uio_seg pathseg, const struct timespec * __capability tptr,
-	    enum uio_seg tptrseg, int follow);
+	    enum uio_seg tptrseg, int flag);
 int	kern_utrace(struct thread *td, const void * __capability addr,
 	    size_t len);
 int	kern_wait(struct thread *td, pid_t pid, int *status, int options,


### PR DESCRIPTION
The first commit avoids having to expose at2cnpflags() from sys/kern/vfs_syscalls.c to freebsd64.  I will try to merge the first commit upstream.