### PR TITLE
Jenkinsfile: Use normal qemu-cheri branch for Morello

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,8 +124,7 @@ def runTests(params, String suffix) {
     stage("Test setup") {
         // copy qemu archive and run directly on the host
         dir("qemu-${params.buildOS}") { deleteDir() }
-        def qemuProject = suffix.contains('morello') ? 'qemu/qemu-morello-merged' : 'qemu/qemu-cheri'
-        copyArtifacts projectName: qemuProject, filter: "qemu-${params.buildOS}/**", target: '.',
+        copyArtifacts projectName: 'qemu/qemu-cheri', filter: "qemu-${params.buildOS}/**", target: '.',
                       fingerprintArtifacts: false
         sh label: 'generate SSH key',
            script: 'test -e $WORKSPACE/id_ed25519 || ssh-keygen -t ed25519 -N \'\' -f $WORKSPACE/id_ed25519 < /dev/null'


### PR DESCRIPTION
Morello is now supported in the main qemu-cheri branch.