### PR TITLE
libc: Remove references to ENOMETHOD.

### DIFF
--- a/lib/libc/gen/errlst.c
+++ b/lib/libc/gen/errlst.c
@@ -36,7 +36,7 @@
  *   "changes": [
  *     "support"
  *   ],
- *   "change_comment": "EPROT, ENOMETHOD"
+ *   "change_comment": "EPROT"
  * }
  * CHERI CHANGES END
  */
@@ -172,13 +172,13 @@ const char *const sys_errlist[] = {
 	"Previous owner died",			/* 96 - EOWNERDEAD */
 	"Integrity check failed",		/* 97 - EINTEGRITY */
 	"Memory protection violation",		/* 98 - EPROT */
-	"Object-capability method not defined",	/* 99 - ENOMETHOD */
 
 #ifndef __CHERI_PURE_CAPABILITY__
 /*
  * Reserved space in sys_errlist, take the next slot for a next error code.
  * Reserve prevents the array size from changing for some time.
  */
+	__uprefix,				/* 99 */
 	__uprefix,				/* 100 */
 	__uprefix,				/* 101 */
 	__uprefix,				/* 102 */

--- a/lib/libc/nls/C.msg
+++ b/lib/libc/nls/C.msg
@@ -211,8 +211,6 @@ $ EINTEGRITY
 97 Integrity check failed
 $ EPROT
 98 Memory protection violation
-$ ENOMETHOD
-99 Object-capability method not defined
 $
 $ strsignal() support catalog
 $

--- a/lib/libc/sys/intro.2
+++ b/lib/libc/sys/intro.2
@@ -488,8 +488,6 @@ command to return a different exit value to automate the running of
 during a system boot.
 .It Er 98 EPROT Em "Memory protection violation" .
 A memory protection error occurred.
-.It Er 99 ENOMETHOD Em "Object-capability method not defined" .
-A method invoked on an object capability was undefined.
 .El
 .Sh DEFINITIONS
 .Bl -tag -width Ds


### PR DESCRIPTION
The actual errno value was removed from errno.h almost a year ago in
commit da841970cf37590751542906ccfcaf28d2237fde.