### PR TITLE
Cheribsdtest tweaks

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -187,6 +187,7 @@ signal_handler(int signum, siginfo_t *info, void *vuap)
 	ccsp->ccs_signum = signum;
 	ccsp->ccs_si_code = info->si_code;
 	ccsp->ccs_si_trapno = info->si_trapno;
+	ccsp->ccs_si_addr = info->si_addr;
 #ifdef __mips__
 	ccsp->ccs_cp2_cause = cfp->cf_capcause;
 #endif
@@ -448,6 +449,12 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 		snprintf(reason, sizeof(reason),
 		    "Expected si_trapno %d, got %d", ctp->ct_si_trapno,
 		    ccsp->ccs_si_trapno);
+		goto fail;
+	}
+	if ((ctp->ct_flags & CT_FLAG_SI_ADDR) &&
+	    !cheri_ptr_equal_exact(ccsp->ccs_si_addr_expected, ccsp->ccs_si_addr)) {
+		snprintf(reason, sizeof(reason), "Expected si_addr %#p, got %#p",
+		    ccsp->ccs_si_addr_expected, ccsp->ccs_si_addr);
 		goto fail;
 	}
 

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 2012-2018, 2020 Robert N. M. Watson
  * Copyright (c) 2014-2016 SRI International
+ * Copyright (c) 2021 Microsoft Corp.
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -374,7 +375,25 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 	(void)waitpid(childpid, &status, 0);
 
 	/*
-	 * First, check for errors from the test framework: successful process
+	 * If the test explicitly signalled failure for some reason, report
+	 * this first rather than reporting an expected failure that has
+	 * not yet been triggered.
+	 */
+	if (ccsp->ccs_testresult == TESTRESULT_FAILURE) {
+		/*
+		 * Ensure string is nul-terminated, as we will print
+		 * it in due course, and a failed test might have left
+		 * a corrupted string.
+		 */
+		ccsp->ccs_testresult_str[sizeof(ccsp->ccs_testresult_str) - 1] =
+		    '\0';
+		memcpy(reason, ccsp->ccs_testresult_str,
+		    sizeof(ccsp->ccs_testresult_str));
+		goto fail;
+	}
+
+	/*
+	 * Check for errors from the test framework: successful process
 	 * termination, signal disposition/exception codes/etc.  Analyse
 	 * child's signal state returned via shared memory.
 	 */
@@ -443,18 +462,6 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 		if (ccsp->ccs_testresult == TESTRESULT_UNKNOWN) {
 			snprintf(reason, sizeof(reason),
 			    "Test failed to set a success/failure status");
-			goto fail;
-		}
-		if (ccsp->ccs_testresult == TESTRESULT_FAILURE) {
-			/*
-			 * Ensure string is nul-terminated, as we will print
-			 * it in due course, and a failed test might have left
-			 * a corrupted string.
-			 */
-			ccsp->ccs_testresult_str[
-			    sizeof(ccsp->ccs_testresult_str) - 1] = '\0';
-			memcpy(reason, ccsp->ccs_testresult_str,
-			    sizeof(ccsp->ccs_testresult_str));
 			goto fail;
 		}
 		if (ccsp->ccs_testresult != TESTRESULT_SUCCESS) {

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 2012-2018, 2020 Robert N. M. Watson
  * Copyright (c) 2014 SRI International
+ * Copyright (c) 2021 Microsoft Corp.
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -69,6 +70,12 @@
 } while (0)
 
 /*
+ * Convert a pointer to a null-derived void * with the same address. This is
+ * useful for getting the correct value for ccs_si_addr_expected.
+ */
+#define	NULL_DERIVED_VOIDP(x) ((void *)(uintptr_t)(ptraddr_t)(x))
+
+/*
  * Shared memory interface between tests and the test controller process.
  */
 #define	TESTRESULT_STR_LEN	1024
@@ -77,6 +84,7 @@ struct cheribsdtest_child_state {
 	int		ccs_signum;
 	int		ccs_si_code;
 	int		ccs_si_trapno;
+	void		*ccs_si_addr;
 #ifdef __mips__
 	register_t	ccs_cp2_cause;
 #endif
@@ -84,6 +92,7 @@ struct cheribsdtest_child_state {
 	/* Fields filled in by the test itself. */
 	int		ccs_testresult;
 	char		ccs_testresult_str[TESTRESULT_STR_LEN];
+	void		*ccs_si_addr_expected;
 };
 extern struct cheribsdtest_child_state *ccsp;
 
@@ -111,6 +120,7 @@ extern struct cheribsdtest_child_state *ccsp;
 #define	CT_FLAG_SI_CODE		0x00000200  /* Check signal si_code. */
 #define	CT_FLAG_SIGEXIT		0x00000400  /* Exits with uncaught signal;
 					       checks status signum. */
+#define	CT_FLAG_SI_ADDR		0x00000800  /* Check signal si_addr. */
 
 /*
  * Macros defined in one or more cheribsdtest_md.h to indicate the
@@ -192,6 +202,7 @@ void	cheribsdtest_failure_errc(int code, const char *msg, ...) __dead2
 void	cheribsdtest_failure_errx(const char *msg, ...) __dead2  __printflike(1, 2);
 void	cheribsdtest_success(void) __dead2;
 void	signal_handler_clear(int sig);
+void	cheribsdtest_set_expected_si_addr(void *addr);
 
 /**
  * Like CHERIBSDTEST_VERIFY but instead of printing condition details prints

--- a/bin/cheribsdtest/cheribsdtest_util.c
+++ b/bin/cheribsdtest/cheribsdtest_util.c
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2014 Robert N. M. Watson
+ * Copyright (c) 2021 Microsoft Corp.
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -118,4 +119,11 @@ cheribsdtest_success(void)
 
 	ccsp->ccs_testresult = TESTRESULT_SUCCESS;
 	exit(0);
+}
+
+void
+cheribsdtest_set_expected_si_addr(void *addr)
+{
+
+	ccsp->ccs_si_addr_expected = addr;
 }

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2014, 2016 Robert N. M. Watson
+ * Copyright (c) 2021 Microsoft Corp.
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -431,7 +432,7 @@ create_tempfile()
  */
 CHERIBSDTEST(cheribsdtest_vm_notag_tmpfile_shared,
     "check tags are not stored for tmpfile() MAP_SHARED pages",
-    .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+    .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO | CT_FLAG_SI_ADDR,
     .ct_signum = SIGSEGV,
     .ct_si_code = SEGV_STORETAG,
     .ct_si_trapno = TRAPNO_STORE_CAP_PF,
@@ -444,6 +445,7 @@ CHERIBSDTEST(cheribsdtest_vm_notag_tmpfile_shared,
 	fd = create_tempfile();
 	cp = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
 	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+	cheribsdtest_set_expected_si_addr(NULL_DERIVED_VOIDP(cp));
 	cp_value = cheri_ptr(&v, sizeof(v));
 	*cp = cp_value;
 	cheribsdtest_failure_errx("tagged store succeeded");

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2013-2016 Robert N. M. Watson
+ * Copyright (c) 2021 Microsoft Corp.
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -75,6 +76,29 @@
 
 #define	cheri_setbounds(x, y)	__builtin_cheri_bounds_set((x), (y))
 #define	cheri_setboundsexact(x, y)	__builtin_cheri_bounds_set_exact((x), (y))
+
+/* Compare capabilities including bounds and perms etc. */
+#define cheri_equal_exact(x, y) __builtin_cheri_equal_exact(x, y)
+
+/*
+ * Return whether the two pointers are equal, including capability metadata if
+ * in purecap mode.
+ */
+#ifdef __cplusplus
+static inline bool
+#else
+static inline _Bool
+#endif
+cheri_ptr_equal_exact(void *x, void *y)
+{
+#ifdef __CHERI_PURE_CAPABILITY__
+	/* For purecap compare the entire capability including metadata */
+	return (cheri_equal_exact(x, y));
+#else
+	/* In hybrid mode void * is just an address */
+	return (x == y);
+#endif
+}
 
 /*
  * Soft implementation of cheri_subset_test().


### PR DESCRIPTION
Here are a couple of tweaks to `cheribsdtest` I have locally that seem generally applicable:

1. Add an optional check for `si_addr` in tests that trigger a signal.
2. Move the check for `TESTRESULT_FAILURE` before other checks. This solves a problem with reporting the result when a test with `CT_FLAG_SIGNAL` calls `cheribsdtest_failure_*` before triggering the signal. In that case the check for signal would overwrite the error message provided by the test with `Unexpected signal 0 recieved` which is much less useful.