### PR TITLE
morello: Zero the bss during startup 8 bytes at a time.

### DIFF
--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -268,7 +268,7 @@ virtdone:
 	/* Zero the BSS */
 	buildptr_range 15, 14, _bss_start, _end
 1:
-	stp	PTR(zr), PTR(zr), [PTR(15)], #(2 * PTR_WIDTH)
+	str	xzr, [PTR(15)], #8
 	cmp	PTR(15), PTR(14)
 	b.lo	1b
 


### PR DESCRIPTION
.bss is not guaranteed to be a multiple of 2 pointers in size.  If the
.bss's size was not divisible by 2 pointers (32 bytes for the purecap
kernel), then the start of the symbol table used by ddb was
overwritten with zeroes causing DDB to think it had no valid symbols
for the kernel.

While we could store a single pointer in the loop perhaps, this isn't
really a critical path and we still store a plain integer at a time on
RISC-V as well in the purecap kernel.