### PR TITLE
makesyscall tidying

### DIFF
--- a/sys/kern/init_sysent.c
+++ b/sys/kern/init_sysent.c
@@ -9,7 +9,6 @@
 #include <sys/sysent.h>
 #include <sys/sysproto.h>
 
-
 #define AS(name) (sizeof(struct name) / sizeof(syscallarg_t))
 
 #ifdef COMPAT_43

--- a/sys/tools/makesyscalls.lua
+++ b/sys/tools/makesyscalls.lua
@@ -624,8 +624,8 @@ local function process_args(args)
 	local changes_abi = false
 
 	for arg in args:gmatch("([^,]+)") do
-		local abi_change = not isptrtype(arg) or check_abi_changes(arg)
-		changes_abi = changes_abi or abi_change
+		local arg_abi_change = not isptrtype(arg) or check_abi_changes(arg)
+		changes_abi = changes_abi or arg_abi_change
 
 		arg = strip_arg_annotations(arg)
 
@@ -641,7 +641,7 @@ local function process_args(args)
 		argtype = argtype:gsub("intptr_t", config["abi_intptr_t"])
 
 		-- XX TODO: Forward declarations? See: sysstubfwd in CheriBSD
-		if abi_change then
+		if arg_abi_change then
 			local abi_type_suffix = config["abi_type_suffix"]
 			argtype = argtype:gsub("_native ", " ")
 			argtype = argtype:gsub("(struct [^ ]*)", "%1" ..

--- a/sys/tools/makesyscalls.lua
+++ b/sys/tools/makesyscalls.lua
@@ -483,8 +483,10 @@ local pattern_table = {
 		dump_prevline = true,
 		pattern = "%%ABI_HEADERS%%",
 		process = function()
-			line = config['abi_headers'] .. "\n"
-			write_line('sysinc', line)
+			if config['abi_headers'] ~= "" then
+				line = config['abi_headers'] .. "\n"
+				write_line('sysinc', line)
+			end
 		end,
 	},
 	{


### PR DESCRIPTION
Pull in a few changes from the recently upstreamed generation of freebsd32 from sys/kern/syscalls.master. These should hopefully reduce the risk of conflicts and mis-merges when we loop those changes back.