### PR TITLE
Kernel subobject bounds

### DIFF
--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -178,12 +178,11 @@ freebsd64_copyout_control(struct msghdr *msg, struct mbuf *control)
 	socklen_t clen, datalen, oldclen;
 	int error;
 	char * __capability ctlbuf;
-	int len, maxlen, copylen;
+	int len, copylen;
 	struct mbuf *m;
 	error = 0;
 
 	len    = msg->msg_controllen;
-	maxlen = msg->msg_controllen;
 	msg->msg_controllen = 0;
 
 	ctlbuf = msg->msg_control;

--- a/sys/kern/subr_epoch.c
+++ b/sys/kern/subr_epoch.c
@@ -67,7 +67,7 @@ __FBSDID("$FreeBSD$");
 TAILQ_HEAD (epoch_tdlist, epoch_tracker);
 typedef struct epoch_record {
 	ck_epoch_record_t er_record __subobject_use_container_bounds;
-	struct epoch_context er_drain_ctx __subobject_use_container_bounds;
+	struct epoch_context er_drain_ctx;
 	struct epoch *er_parent;
 	volatile struct epoch_tdlist er_tdlist;
 	volatile uint32_t er_gen;

--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -115,13 +115,13 @@ struct bpf_if {
 	struct ifnet	*bif_ifp;	/* corresponding interface */
 	struct bpf_if	**bif_bpf;	/* Pointer to pointer to us */
 	volatile u_int	bif_refcnt;
-	struct epoch_context epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context epoch_ctx;
 };
 
 CTASSERT(offsetof(struct bpf_if, bif_ext) == 0);
 
 struct bpf_program_buffer {
-	struct epoch_context	epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context	epoch_ctx;
 #ifdef BPF_JITTER
 	bpf_jit_filter		*func;
 #endif

--- a/sys/net/bpfdesc.h
+++ b/sys/net/bpfdesc.h
@@ -108,7 +108,7 @@ struct bpf_d {
 	u_char		bd_compat32;	/* 32-bit stream on LP64 system */
 
 	volatile u_int	bd_refcnt;
-	struct epoch_context epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context epoch_ctx;
 };
 
 /* Values for bd_state */

--- a/sys/net/if_llatbl.h
+++ b/sys/net/if_llatbl.h
@@ -83,7 +83,7 @@ struct llentry {
 	struct callout		lle_timer;
 	struct rwlock		 lle_lock;
 	struct mtx		req_mtx;
-	struct epoch_context lle_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context lle_epoch_ctx;
 };
 
 #define	LLE_WLOCK(lle)		rw_wlock(&(lle)->lle_lock)

--- a/sys/net/if_var.h
+++ b/sys/net/if_var.h
@@ -434,7 +434,7 @@ struct ifnet {
 	 * Debugnet (Netdump) hooks to be called while in db/panic.
 	 */
 	struct debugnet_methods *if_debugnet_methods;
-	struct epoch_context	if_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context	if_epoch_ctx;
 
 	/*
 	 * Spare fields to be added before branching a stable branch, so
@@ -571,7 +571,7 @@ struct ifaddr {
 	counter_u64_t	ifa_opackets;
 	counter_u64_t	ifa_ibytes;
 	counter_u64_t	ifa_obytes;
-	struct	epoch_context	ifa_epoch_ctx __subobject_use_container_bounds;
+	struct	epoch_context	ifa_epoch_ctx;
 };
 
 struct ifaddr *	ifa_alloc(size_t size, int flags);
@@ -593,7 +593,7 @@ struct ifmultiaddr {
 	int	ifma_flags;
 	void	*ifma_protospec;	/* protocol-specific state, if any */
 	struct	ifmultiaddr *ifma_llifma; /* pointer to ifma for ifma_lladdr */
-	struct	epoch_context	ifma_epoch_ctx __subobject_use_container_bounds;
+	struct	epoch_context	ifma_epoch_ctx;
 };
 
 extern	struct sx ifnet_sxlock;

--- a/sys/net/if_vlan.c
+++ b/sys/net/if_vlan.c
@@ -178,7 +178,7 @@ mst_to_vst(struct m_snd_tag *mst)
 struct vlan_mc_entry {
 	struct sockaddr_dl		mc_addr;
 	CK_SLIST_ENTRY(vlan_mc_entry)	mc_entries;
-	struct epoch_context		mc_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context		mc_epoch_ctx;
 };
 
 struct ifvlan {

--- a/sys/net/pfil.c
+++ b/sys/net/pfil.c
@@ -86,7 +86,7 @@ struct pfil_link {
 	void			*link_ruleset;
 	int			 link_flags;
 	struct pfil_hook	*link_hook;
-	struct epoch_context	 link_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context	 link_epoch_ctx;
 };
 
 typedef CK_STAILQ_HEAD(pfil_chain, pfil_link)	pfil_chain_t;

--- a/sys/net/route/fib_algo.c
+++ b/sys/net/route/fib_algo.c
@@ -186,7 +186,7 @@ struct fib_data {
 	struct rib_subscription	*fd_rs;		/* storing table subscription */
 	struct fib_dp		fd_dp;		/* fib datapath data */
 	struct vnet		*fd_vnet;	/* vnet fib belongs to */
-	struct epoch_context	fd_epoch_ctx __subobject_use_container_bounds;	/* epoch context for deletion */
+	struct epoch_context	fd_epoch_ctx;	/* epoch context for deletion */
 	struct fib_lookup_module	*fd_flm;/* pointer to the lookup module */
 	struct fib_sync_status	fd_ss;		/* State relevant to the rib sync  */
 	uint32_t		fd_num_changes;	/* number of changes since last callout */
@@ -294,7 +294,7 @@ VNET_DEFINE_STATIC(TAILQ_HEAD(fib_error_head, fib_error), fib_error_list);
 
 /* Per-family array of fibnum -> {func, arg} mappings used in datapath */
 struct fib_dp_header {
-	struct epoch_context	fdh_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context	fdh_epoch_ctx;
 	uint32_t		fdh_num_tables;
 	struct fib_dp		fdh_idx[0] __subobject_use_container_bounds;
 };
@@ -1809,7 +1809,7 @@ fib_ref_nhop(struct fib_data *fd, struct nhop_object *nh)
 
 struct nhop_release_data {
 	struct nhop_object	*nh;
-	struct epoch_context	ctx __subobject_use_container_bounds;
+	struct epoch_context	ctx;
 };
 
 static void

--- a/sys/net/route/nhgrp_var.h
+++ b/sys/net/route/nhgrp_var.h
@@ -54,7 +54,7 @@ struct nhgrp_priv {
 	struct nh_control	*nh_control;	/* parent control structure */
 	struct nhgrp_priv	*nhg_priv_next;
 	struct nhgrp_object	*nhg;
-	struct epoch_context	nhg_epoch_ctx __subobject_use_container_bounds;	/* epoch data for nhop */
+	struct epoch_context	nhg_epoch_ctx;	/* epoch data for nhop */
 	struct weightened_nhop	nhg_nh_weights[0];
 };
 

--- a/sys/net/route/nhop_var.h
+++ b/sys/net/route/nhop_var.h
@@ -60,7 +60,7 @@ struct nh_control {
 	struct bitmask_head	gr_idx_head;	/* nhgrp index head */
 	struct rwlock		ctl_lock;	/* overall ctl lock */
 	struct rib_head		*ctl_rh;	/* pointer back to rnh */
-	struct epoch_context	ctl_epoch_ctx __subobject_use_container_bounds;	/* epoch ctl helper */
+	struct epoch_context	ctl_epoch_ctx;	/* epoch ctl helper */
 };
 
 #define	NHOPS_WLOCK(ctl)	rw_wlock(&(ctl)->ctl_lock)
@@ -88,7 +88,7 @@ struct nhop_priv {
 	struct nh_control	*nh_control;	/* backreference to the rnh */
 	struct nhop_priv	*nh_next;	/* hash table membership */
 	struct vnet		*nh_vnet;	/* vnet nhop belongs to */
-	struct epoch_context	nh_epoch_ctx __subobject_use_container_bounds;	/* epoch data for nhop */
+	struct epoch_context	nh_epoch_ctx;	/* epoch data for nhop */
 };
 
 #define	NH_PRIV_END_CMP	(__offsetof(struct nhop_priv, nh_idx))

--- a/sys/net/route/route_ctl.c
+++ b/sys/net/route/route_ctl.c
@@ -69,7 +69,7 @@ struct rib_subscription {
 	void					*arg;
 	struct rib_head				*rnh;
 	enum rib_subscription_type		type;
-	struct epoch_context			epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context			epoch_ctx;
 };
 
 static int add_route(struct rib_head *rnh, struct rt_addrinfo *info,

--- a/sys/net/route/route_var.h
+++ b/sys/net/route/route_var.h
@@ -187,7 +187,7 @@ struct rtentry {
 	u_long		rt_expire;	/* lifetime for route, e.g. redirect */
 	struct rtentry	*rt_chain;	/* pointer to next rtentry to delete */
 	/* net epoch tracker */
-	struct epoch_context	rt_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context	rt_epoch_ctx;
 };
 
 /*

--- a/sys/netinet/in_pcb.h
+++ b/sys/netinet/in_pcb.h
@@ -325,7 +325,7 @@ struct inpcb {
 	CK_LIST_ENTRY(inpcb) inp_list;	/* (p/l) list for all PCBs for proto */
 	                                /* (e[r]) for list iteration */
 	                                /* (p[w]/l) for addition/removal */
-	struct epoch_context inp_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context inp_epoch_ctx;
 };
 #endif	/* _KERNEL */
 
@@ -399,7 +399,7 @@ void	in_pcbtoxinpcb(const struct inpcb *, struct xinpcb *);
 #endif /* _SYS_SOCKETVAR_H_ */
 
 struct inpcbport {
-	struct epoch_context phd_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context phd_epoch_ctx;
 	CK_LIST_ENTRY(inpcbport) phd_hash;
 	struct inpcbhead phd_pcblist;
 	u_short phd_port;
@@ -407,7 +407,7 @@ struct inpcbport {
 
 struct in_pcblist {
 	int il_count;
-	struct epoch_context il_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context il_epoch_ctx;
 	struct inpcbinfo *il_pcbinfo;
 	struct inpcb *il_inp_list[0];
 };
@@ -562,7 +562,7 @@ struct inpcbgroup {
  */
 struct inpcblbgroup {
 	CK_LIST_ENTRY(inpcblbgroup) il_list;
-	struct epoch_context il_epoch_ctx __subobject_use_container_bounds;
+	struct epoch_context il_epoch_ctx;
 	uint16_t	il_lport;			/* (c) */
 	u_char		il_vflag;			/* (c) */
 	u_int8_t		il_numa_domain;

--- a/sys/sys/_mutex.h
+++ b/sys/sys/_mutex.h
@@ -45,9 +45,9 @@
  * be modified appropriately.
  */
 struct mtx {
-	struct lock_object	lock_object;	/* Common lock properties. */
-	volatile uintptr_t	mtx_lock;	/* Owner and flags. */
-} __no_subobject_bounds;
+	struct lock_object	lock_object __subobject_member_used_for_c_inheritance;	/* Common lock properties. */
+	volatile uintptr_t	mtx_lock __subobject_use_container_bounds;	/* Owner and flags. */
+};
 
 /*
  * Members of struct mtx_padalign must mirror members of struct mtx.
@@ -59,9 +59,9 @@ struct mtx {
  * the mutex.
  */
 struct mtx_padalign {
-	struct lock_object	lock_object;	/* Common lock properties. */
-	volatile uintptr_t	mtx_lock;	/* Owner and flags. */
-} __aligned(CACHE_LINE_SIZE) __no_subobject_bounds;
+	struct lock_object	lock_object __subobject_member_used_for_c_inheritance;	/* Common lock properties. */
+	volatile uintptr_t	mtx_lock __subobject_use_container_bounds;	/* Owner and flags. */
+} __aligned(CACHE_LINE_SIZE);
 
 #endif /* !_SYS__MUTEX_H_ */
 // CHERI CHANGES START

--- a/sys/sys/_rwlock.h
+++ b/sys/sys/_rwlock.h
@@ -42,9 +42,9 @@
  * implementation must be modified appropriately.
  */
 struct rwlock {
-	struct lock_object	lock_object;
-	volatile uintptr_t	rw_lock;
-} __no_subobject_bounds;
+	struct lock_object	lock_object __subobject_member_used_for_c_inheritance;
+	volatile uintptr_t	rw_lock __subobject_use_container_bounds;
+};
 
 /*
  * Members of struct rwlock_padalign must mirror members of struct rwlock.
@@ -56,9 +56,9 @@ struct rwlock {
  * the rwlock.
  */
 struct rwlock_padalign {
-	struct lock_object	lock_object;
-	volatile uintptr_t	rw_lock;
-} __aligned(CACHE_LINE_SIZE) __no_subobject_bounds;
+	struct lock_object	lock_object __subobject_member_used_for_c_inheritance;
+	volatile uintptr_t	rw_lock __subobject_use_container_bounds;
+} __aligned(CACHE_LINE_SIZE);
 
 #endif /* !_SYS__RWLOCK_H_ */
 // CHERI CHANGES START

--- a/sys/sys/_sx.h
+++ b/sys/sys/_sx.h
@@ -37,7 +37,7 @@
  * Shared/exclusive lock main structure definition.
  */
 struct sx {
-	struct lock_object	lock_object __subobject_use_container_bounds;
+	struct lock_object	lock_object __subobject_member_used_for_c_inheritance;
 	volatile uintptr_t	sx_lock;
 };
 

--- a/sys/sys/epoch.h
+++ b/sys/sys/epoch.h
@@ -32,7 +32,7 @@
 
 struct epoch_context {
 	void   *data[2];
-} __aligned(sizeof(void *));
+} __aligned(sizeof(void *)) __subobject_use_container_bounds;
 
 typedef struct epoch_context *epoch_context_t;
 typedef	void epoch_callback_t(epoch_context_t);


### PR DESCRIPTION
The last commit is just a warning fix for CheriBSD specific code I snuck in.

The second commit is perhaps debatable though technically more accurate perhaps?

If we had a working "__subobject_type_used_for_c_inheritance" we could tag "lock_object" with that and remove most of the locking annotations.