### PR TITLE
DNM/WIP: Openmp purecap

### DIFF
--- a/contrib/llvm-project/openmp/runtime/src/kmp_csupport.cpp
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_csupport.cpp
@@ -3953,16 +3953,11 @@ void __kmpc_doacross_init(ident_t *loc, int gtid, int num_dims,
     __kmp_wait_4((volatile kmp_uint32 *)&sh_buf->doacross_buf_idx, idx,
                  __kmp_eq_4, NULL);
   }
-#if KMP_32_BIT_ARCH
   // Check if we are the first thread. After the CAS the first thread gets 0,
   // others get 1 if initialization is in progress, allocated pointer otherwise.
   // Treat pointer as volatile integer (value 0 or 1) until memory is allocated.
-  flags = (kmp_uint32 *)KMP_COMPARE_AND_STORE_RET32(
-      (volatile kmp_int32 *)&sh_buf->doacross_flags, NULL, 1);
-#else
-  flags = (kmp_uint32 *)KMP_COMPARE_AND_STORE_RET64(
-      (volatile kmp_int64 *)&sh_buf->doacross_flags, NULL, 1LL);
-#endif
+  flags = (kmp_uint32 *)KMP_COMPARE_AND_STORE_RETPTR(&sh_buf->doacross_flags, NULL,
+                                                     (kmp_uint32 *)1);
   if (flags == NULL) {
     // we are the first thread, allocate the array of flags
     size_t size =

--- a/contrib/llvm-project/openmp/runtime/src/kmp_gsupport.cpp
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_gsupport.cpp
@@ -1216,7 +1216,7 @@ void KMP_EXPAND_NAME(KMP_API_NAME_GOMP_TASK)(void (*func)(void *), void *data,
 
   if (arg_size > 0) {
     if (arg_align > 0) {
-      task->shareds = (void *)((((size_t)task->shareds) + arg_align - 1) /
+      task->shareds = (void *)((((kmp_uintptr_t)task->shareds) + arg_align - 1) /
                                arg_align * arg_align);
     }
     // else error??
@@ -1766,7 +1766,7 @@ void __GOMP_taskloop(void (*func)(void *), void *data,
 
   // re-align shareds if needed and setup firstprivate copy constructors
   // through the task_dup mechanism
-  task->shareds = (void *)((((size_t)task->shareds) + arg_align - 1) /
+  task->shareds = (void *)((((kmp_uintptr_t)task->shareds) + arg_align - 1) /
                            arg_align * arg_align);
   if (copy_func) {
     task_dup = __kmp_gomp_task_dup;

--- a/contrib/llvm-project/openmp/runtime/src/kmp_itt.inl
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_itt.inl
@@ -500,7 +500,7 @@ void *__kmp_itt_barrier_object(int gtid, int bt, int set_name,
     // different ids (for each barrier type).
     object = reinterpret_cast<void *>(
         (kmp_uintptr_t)(team) +
-        (kmp_uintptr_t)counter % (sizeof(kmp_team_t) / bs_last_barrier) *
+        (size_t)(kmp_uintptr_t)counter % (sizeof(kmp_team_t) / bs_last_barrier) *
             bs_last_barrier +
         bt);
     KMP_ITT_DEBUG_LOCK();

--- a/contrib/llvm-project/openmp/runtime/src/kmp_os.h
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_os.h
@@ -976,6 +976,12 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
 
 #endif /* KMP_ARCH_X86 */
 
+#define TCR_ADDR TCR_PTR
+#define TCW_ADDR TCW_PTR
+#define TCR_SYNC_ADDR TCR_SYNC_PTR
+#define TCW_SYNC_ADDR TCW_SYNC_PTR
+#define TCX_SYNC_ADDR TCX_SYNC_PTR
+
 /* If these FTN_{TRUE,FALSE} values change, may need to change several places
    where they are used to check that language is Fortran, not C. */
 

--- a/contrib/llvm-project/openmp/runtime/src/kmp_os.h
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_os.h
@@ -185,10 +185,17 @@ typedef double kmp_real64;
 
 #ifndef KMP_INTPTR
 #define KMP_INTPTR 1
+#ifdef __CHERI_PURE_CAPABILITY__
+typedef intptr_t kmp_intptr_t;
+typedef uintptr_t kmp_uintptr_t;
+#define KMP_INTPTR_SPEC "Pd"
+#define KMP_UINTPTR_SPEC "Pu"
+#else
 typedef long kmp_intptr_t;
 typedef unsigned long kmp_uintptr_t;
 #define KMP_INTPTR_SPEC "ld"
 #define KMP_UINTPTR_SPEC "lu"
+#endif
 #endif
 
 #ifdef BUILD_I8
@@ -958,6 +965,18 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
   KMP_COMPARE_AND_STORE_REL64((volatile kmp_int64 *)(volatile void *)&(a),     \
                               (kmp_int64)(b), (kmp_int64)(c))
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#define TCR_C(a) (a)
+#define TCW_C(a, b) (a) = (b)
+#define TCI_C(a) (++(a))
+#define TCD_C(a) (--(a))
+#define TCR_SYNC_C(a) (a)
+#define TCW_SYNC_C(a, b) (a) = (b)
+#define TCX_SYNC_C(a, b, c)                                                    \
+  KMP_COMPARE_AND_STORE_RELPTR((volatile void *)&(a),                          \
+                              (kmp_intptr_t)(b), (kmp_intptr_t)(c))
+#endif
+
 #if KMP_ARCH_X86 || KMP_ARCH_MIPS
 // What about ARM?
 #define TCR_PTR(a) ((void *)TCR_4(a))
@@ -965,6 +984,14 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
 #define TCR_SYNC_PTR(a) ((void *)TCR_SYNC_4(a))
 #define TCW_SYNC_PTR(a, b) TCW_SYNC_4((a), (b))
 #define TCX_SYNC_PTR(a, b, c) ((void *)TCX_SYNC_4((a), (b), (c)))
+
+#elif defined(__CHERI_PURE_CAPABILITY__)
+
+#define TCR_PTR(a) ((void *)TCR_C(a))
+#define TCW_PTR(a, b) TCW_C((a), (b))
+#define TCR_SYNC_PTR(a) ((void *)TCR_SYNC_C(a))
+#define TCW_SYNC_PTR(a, b) TCW_SYNC_C((a), (b))
+#define TCX_SYNC_PTR(a, b, c) ((void *)TCX_SYNC_C((a), (b), (c)))
 
 #else /* 64 bit pointers */
 
@@ -976,11 +1003,19 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
 
 #endif /* KMP_ARCH_X86 */
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#define TCR_ADDR TCR_8
+#define TCW_ADDR TCW_8
+#define TCR_SYNC_ADDR TCR_SYNC_8
+#define TCW_SYNC_ADDR TCW_SYNC_8
+#define TCX_SYNC_ADDR TCX_SYNC_8
+#else
 #define TCR_ADDR TCR_PTR
 #define TCW_ADDR TCW_PTR
 #define TCR_SYNC_ADDR TCR_SYNC_PTR
 #define TCW_SYNC_ADDR TCW_SYNC_PTR
 #define TCX_SYNC_ADDR TCX_SYNC_PTR
+#endif
 
 /* If these FTN_{TRUE,FALSE} values change, may need to change several places
    where they are used to check that language is Fortran, not C. */

--- a/contrib/llvm-project/openmp/runtime/src/kmp_os.h
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_os.h
@@ -546,10 +546,16 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
 #define KMP_COMPARE_AND_STORE_PTR(p, cv, sv)                                   \
   __kmp_compare_and_store32((volatile kmp_int32 *)(p), (kmp_int32)(cv),        \
                             (kmp_int32)(sv))
+#define KMP_COMPARE_AND_STORE_RETPTR(p, cv, sv)                                \
+  (void *)__kmp_compare_and_storeret32((volatile kmp_int32 *)(p), (kmp_int32)(cv), \
+                               (kmp_int32)(sv))
 #else /* 64 bit pointers */
 #define KMP_COMPARE_AND_STORE_PTR(p, cv, sv)                                   \
   __kmp_compare_and_store64((volatile kmp_int64 *)(p), (kmp_int64)(cv),        \
                             (kmp_int64)(sv))
+#define KMP_COMPARE_AND_STORE_RETPTR(p, cv, sv)                                \
+  (void *)__kmp_compare_and_storeret64((volatile kmp_int64 *)(p), (kmp_int64)(cv), \
+                               (kmp_int64)(sv))
 #endif /* KMP_ARCH_X86 */
 
 #define KMP_COMPARE_AND_STORE_RET8(p, cv, sv)                                  \
@@ -679,6 +685,9 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
 #define KMP_COMPARE_AND_STORE_RET32(p, cv, sv)                                 \
   __sync_val_compare_and_swap((volatile kmp_uint32 *)(p), (kmp_uint32)(cv),    \
                               (kmp_uint32)(sv))
+#define KMP_COMPARE_AND_STORE_RETPTR(p, cv, sv)                                \
+  __sync_val_compare_and_swap((void *volatile *)(p), (void *)(cv),             \
+                              (void *)(sv))
 #if KMP_ARCH_MIPS
 static inline bool mips_sync_bool_compare_and_swap(
   volatile kmp_uint64 *p, kmp_uint64 cv, kmp_uint64 sv) {
@@ -842,10 +851,16 @@ extern kmp_real64 __kmp_xchg_real64(volatile kmp_real64 *p, kmp_real64 v);
 #define KMP_COMPARE_AND_STORE_PTR(p, cv, sv)                                   \
   __kmp_compare_and_store32((volatile kmp_int32 *)(p), (kmp_int32)(cv),        \
                             (kmp_int32)(sv))
+#define KMP_COMPARE_AND_STORE_RETPTR(p, cv, sv)                                \
+  (void *)__kmp_compare_and_storeret32((volatile kmp_int32 *)(p), (kmp_int32)(cv), \
+                               (kmp_int32)(sv))
 #else /* 64 bit pointers */
 #define KMP_COMPARE_AND_STORE_PTR(p, cv, sv)                                   \
   __kmp_compare_and_store64((volatile kmp_int64 *)(p), (kmp_int64)(cv),        \
                             (kmp_int64)(sv))
+#define KMP_COMPARE_AND_STORE_RETPTR(p, cv, sv)                                \
+  (void *)__kmp_compare_and_storeret64((volatile kmp_int64 *)(p), (kmp_int64)(cv), \
+                               (kmp_int64)(sv))
 #endif /* KMP_ARCH_X86 */
 
 #define KMP_COMPARE_AND_STORE_RET8(p, cv, sv)                                  \

--- a/contrib/llvm-project/openmp/runtime/src/kmp_runtime.cpp
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_runtime.cpp
@@ -162,7 +162,7 @@ int __kmp_get_global_thread_id() {
     if (!thr)
       continue;
 
-    stack_size = (size_t)TCR_PTR(thr->th.th_info.ds.ds_stacksize);
+    stack_size = (size_t)TCR_ADDR(thr->th.th_info.ds.ds_stacksize);
     stack_base = (char *)TCR_PTR(thr->th.th_info.ds.ds_stackbase);
 
     /* stack grows down -- search through all of the active threads */
@@ -306,7 +306,7 @@ void __kmp_check_stack_overlap(kmp_info_t *th) {
         char *other_stack_end =
             (char *)TCR_PTR(f_th->th.th_info.ds.ds_stackbase);
         char *other_stack_beg =
-            other_stack_end - (size_t)TCR_PTR(f_th->th.th_info.ds.ds_stacksize);
+            other_stack_end - (size_t)TCR_ADDR(f_th->th.th_info.ds.ds_stacksize);
         if ((stack_beg > other_stack_beg && stack_beg < other_stack_end) ||
             (stack_end > other_stack_beg && stack_end < other_stack_end)) {
 
@@ -314,7 +314,7 @@ void __kmp_check_stack_overlap(kmp_info_t *th) {
           if (__kmp_storage_map)
             __kmp_print_storage_map_gtid(
                 -1, other_stack_beg, other_stack_end,
-                (size_t)TCR_PTR(f_th->th.th_info.ds.ds_stacksize),
+                (size_t)TCR_ADDR(f_th->th.th_info.ds.ds_stacksize),
                 "th_%d stack (overlapped)", __kmp_gtid_from_thread(f_th));
 
           __kmp_fatal(KMP_MSG(StackOverlap), KMP_HNT(ChangeStackLimit),

--- a/contrib/llvm-project/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/contrib/llvm-project/openmp/runtime/src/kmp_taskdeps.cpp
@@ -60,7 +60,7 @@ const size_t MAX_GEN = 8;
 static inline size_t __kmp_dephash_hash(kmp_intptr_t addr, size_t hsize) {
   // TODO alternate to try: set = (((Addr64)(addrUsefulBits * 9.618)) %
   // m_num_sets );
-  return ((addr >> 6) ^ (addr >> 2)) % hsize;
+  return (((size_t)addr >> 6) ^ ((size_t)addr >> 2)) % hsize;
 }
 
 static kmp_dephash_t *__kmp_dephash_extend(kmp_info_t *thread,

--- a/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify.h
+++ b/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify.h
@@ -1663,7 +1663,9 @@ ITT_STUBV(ITTAPI, void, heap_record, (unsigned int record_mask))
  */
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_domain
 {
@@ -1679,7 +1681,9 @@ typedef struct ___itt_domain
     struct ___itt_domain* next;
 } __itt_domain;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 /**
@@ -1754,14 +1758,18 @@ ITT_STUB(ITTAPI, __itt_domain*, domain_create,  (const char    *name))
  */
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_id
 {
     unsigned long long d1, d2, d3;
 } __itt_id;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 static const __itt_id __itt_null = { 0, 0, 0 };
@@ -1852,7 +1860,9 @@ ITT_STUBV(ITTAPI, void, id_destroy, (const __itt_domain *domain, __itt_id id))
  */
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_string_handle
 {
@@ -1867,7 +1877,9 @@ typedef struct ___itt_string_handle
     struct ___itt_string_handle* next;
 } __itt_string_handle;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 /**
@@ -2581,7 +2593,9 @@ ITT_STUBV(ITTAPI, void, relation_add,            (const __itt_domain *domain, __
 /** @} relations group */
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_clock_info
 {
@@ -2589,7 +2603,9 @@ typedef struct ___itt_clock_info
     unsigned long long clock_base; /*!< Clock domain base timestamp */
 } __itt_clock_info;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 /** @cond exclude_from_documentation */
@@ -2597,7 +2613,9 @@ typedef void (ITTAPI *__itt_get_clock_info_fn)(__itt_clock_info* clock_info, voi
 /** @endcond */
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_clock_domain
 {
@@ -2609,7 +2627,9 @@ typedef struct ___itt_clock_domain
     struct ___itt_clock_domain* next;
 } __itt_clock_domain;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 /**
@@ -3215,7 +3235,9 @@ typedef enum ___itt_track_group_type
 /** @endcond */
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_track_group
 {
@@ -3227,7 +3249,9 @@ typedef struct ___itt_track_group
     struct ___itt_track_group* next;
 } __itt_track_group;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 /**
@@ -3243,7 +3267,9 @@ typedef enum ___itt_track_type
 } __itt_track_type;
 
 /** @cond exclude_from_documentation */
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_track
 {
@@ -3255,7 +3281,9 @@ typedef struct ___itt_track
     struct ___itt_track* next;
 } __itt_track;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 /** @endcond */
 
 /**

--- a/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_config.h
+++ b/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_config.h
@@ -377,7 +377,9 @@ typedef enum {
     __itt_thread_ignored = 1
 } __itt_thread_state;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_thread_info
 {
@@ -460,7 +462,9 @@ typedef struct ___itt_global
     __itt_counter_info_t* counter_list;
 } __itt_global;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 
 #define NEW_THREAD_INFO_W(gptr,h,h_tail,t,s,n) { \
     h = (__itt_thread_info*)malloc(sizeof(__itt_thread_info)); \

--- a/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_static.cpp
+++ b/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_static.cpp
@@ -213,7 +213,7 @@ static __itt_api_info api_list[] = {
 /* Define functions with static implementation */
 #undef ITT_STUB
 #undef ITT_STUBV
-#define ITT_STUB(api,type,name,args,params,nameindll,group,format) { ITT_TO_STR(ITT_JOIN(__itt_,nameindll)), (void**)(void*)&ITTNOTIFY_NAME(name), (void*)(size_t)&ITT_VERSIONIZE(ITT_JOIN(_N_(name),_init)), (void*)(size_t)&ITT_VERSIONIZE(ITT_JOIN(_N_(name),_init)), (__itt_group_id)(group)},
+#define ITT_STUB(api,type,name,args,params,nameindll,group,format) { ITT_TO_STR(ITT_JOIN(__itt_,nameindll)), (void**)(void*)&ITTNOTIFY_NAME(name), (void*)(uintptr_t)&ITT_VERSIONIZE(ITT_JOIN(_N_(name),_init)), (void*)(uintptr_t)&ITT_VERSIONIZE(ITT_JOIN(_N_(name),_init)), (__itt_group_id)(group)},
 #define ITT_STUBV ITT_STUB
 #define __ITT_INTERNAL_INIT
 #include "ittnotify_static.h"
@@ -221,7 +221,7 @@ static __itt_api_info api_list[] = {
 /* Define functions without static implementation */
 #undef ITT_STUB
 #undef ITT_STUBV
-#define ITT_STUB(api,type,name,args,params,nameindll,group,format) {ITT_TO_STR(ITT_JOIN(__itt_,nameindll)), (void**)(void*)&ITTNOTIFY_NAME(name), (void*)(size_t)&ITT_VERSIONIZE(ITT_JOIN(_N_(name),_init)), NULL, (__itt_group_id)(group)},
+#define ITT_STUB(api,type,name,args,params,nameindll,group,format) {ITT_TO_STR(ITT_JOIN(__itt_,nameindll)), (void**)(void*)&ITTNOTIFY_NAME(name), (void*)(uintptr_t)&ITT_VERSIONIZE(ITT_JOIN(_N_(name),_init)), NULL, (__itt_group_id)(group)},
 #define ITT_STUBV ITT_STUB
 #include "ittnotify_static.h"
     {NULL, NULL, NULL, NULL, __itt_group_none}
@@ -277,7 +277,7 @@ static void __itt_report_error(unsigned code_arg, ...)
 
     if (_N_(_ittapi_global).error_handler != NULL)
     {
-        __itt_error_handler_t* handler = (__itt_error_handler_t*)(size_t)_N_(_ittapi_global).error_handler;
+        __itt_error_handler_t* handler = (__itt_error_handler_t*)(uintptr_t)_N_(_ittapi_global).error_handler;
         handler(code, args);
     }
 #ifdef ITT_NOTIFY_EXT_REPORT
@@ -1042,7 +1042,7 @@ ITT_EXTERN_C void _N_(fini_ittlib)(void)
                 if (PTHREAD_SYMBOLS) current_thread = __itt_thread_id();
                 if (_N_(_ittapi_global).lib != NULL)
                 {
-                    __itt_api_fini_ptr = (__itt_api_fini_t*)(size_t)__itt_get_proc(_N_(_ittapi_global).lib, "__itt_api_fini");
+                    __itt_api_fini_ptr = (__itt_api_fini_t*)(uintptr_t)__itt_get_proc(_N_(_ittapi_global).lib, "__itt_api_fini");
                 }
                 if (__itt_api_fini_ptr)
                 {
@@ -1146,7 +1146,7 @@ ITT_EXTERN_C int _N_(init_ittlib)(const char* lib_name, __itt_group_id init_grou
 #endif /* ITT_COMPLETE_GROUP */
                             break;
                         case 2:
-                            __itt_api_init_ptr = (__itt_api_init_t*)(size_t)__itt_get_proc(_N_(_ittapi_global).lib, "__itt_api_init");
+                            __itt_api_init_ptr = (__itt_api_init_t*)(uintptr_t)__itt_get_proc(_N_(_ittapi_global).lib, "__itt_api_init");
                             if (__itt_api_init_ptr)
                                 __itt_api_init_ptr(&_N_(_ittapi_global), init_groups);
                             break;
@@ -1195,8 +1195,8 @@ ITT_EXTERN_C int _N_(init_ittlib)(const char* lib_name, __itt_group_id init_grou
 
 ITT_EXTERN_C __itt_error_handler_t* _N_(set_error_handler)(__itt_error_handler_t* handler)
 {
-    __itt_error_handler_t* prev = (__itt_error_handler_t*)(size_t)_N_(_ittapi_global).error_handler;
-    _N_(_ittapi_global).error_handler = (void*)(size_t)handler;
+    __itt_error_handler_t* prev = (__itt_error_handler_t*)(uintptr_t)_N_(_ittapi_global).error_handler;
+    _N_(_ittapi_global).error_handler = (void*)(uintptr_t)handler;
     return prev;
 }
 

--- a/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_static.cpp
+++ b/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_static.cpp
@@ -183,7 +183,9 @@ ITT_EXTERN_C_BEGIN ITT_JOIN(_N_(name),_t)* ITTNOTIFY_NAME(name) = ITT_VERSIONIZE
 
 ITT_GROUP_LIST(group_list);
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_group_alias
 {
@@ -198,7 +200,9 @@ static __itt_group_alias group_alias[] = {
     { api_version,        (__itt_group_none) } /* !!! Just to avoid unused code elimination !!! */
 };
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 
 #if ITT_PLATFORM==ITT_PLATFORM_WIN && KMP_MSVC_COMPAT
 #pragma warning(push)

--- a/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_types.h
+++ b/contrib/llvm-project/openmp/runtime/src/thirdparty/ittnotify/ittnotify_types.h
@@ -34,7 +34,9 @@ typedef enum ___itt_group_id
     __itt_group_all       = -1
 } __itt_group_id;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(push, 8)
+#endif
 
 typedef struct ___itt_group_list
 {
@@ -42,7 +44,9 @@ typedef struct ___itt_group_list
     const char*    name;
 } __itt_group_list;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 #pragma pack(pop)
+#endif
 
 #define ITT_GROUP_LIST(varname) \
     static __itt_group_list varname[] = {       \

--- a/contrib/llvm-project/openmp/runtime/src/z_Linux_asm.S
+++ b/contrib/llvm-project/openmp/runtime/src/z_Linux_asm.S
@@ -1560,6 +1560,20 @@ __kmp_invoke_microtask:
 
 #if KMP_ARCH_RISCV64
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#define PTR_REG(x)  c ## x
+#define REG(x)      c ## x
+#define REG_SIZE    16
+#define LR          lc
+#define SR          sc
+#else
+#define PTR_REG(x)  x
+#define REG(x)      x
+#define REG_SIZE    8
+#define LR          ld
+#define SR          sd
+#endif
+	
 //------------------------------------------------------------------------
 //
 // typedef void (*microtask_t)(int *gtid, int *tid, ...);
@@ -1616,13 +1630,21 @@ __kmp_invoke_microtask:
 	.cfi_startproc
 
 	// First, save ra and fp
+#ifdef __CHERI_PURE_CAPABILITY__
+	cincoffset csp, csp, -32
+#else
 	addi	sp, sp, -16
-	sd	ra, 8(sp)
-	sd	fp, 0(sp)
+#endif
+	SR	REG(ra), 8(PTR_REG(sp))
+	SR	REG(fp), 0(PTR_REG(sp))
+#ifdef __CHERI_PURE_CAPABILITY__
+	cincoffset cfp, csp, 32
+#else
 	addi	fp, sp, 16
-	.cfi_def_cfa	fp, 0
-	.cfi_offset	ra, -8
-	.cfi_offset	fp, -16
+#endif
+	.cfi_def_cfa	REG(fp), 0
+	.cfi_offset	REG(ra), -(REG_SIZE)
+	.cfi_offset	REG(fp), -(REG_SIZE * 2)
 
 	// Compute the dynamic stack size:
 	//


### PR DESCRIPTION
This fixes most of the MI issues in libomp.  Each architecture needs some assembly ported as well.  I think there's also an issue in z_Linux_util.cpp where 'kve_start' is cast to a pointer (which may be hard to resolve).