### PR TITLE
syscallarg_t: remove layer of typedef indirection

### DIFF
--- a/sys/sys/types.h
+++ b/sys/sys/types.h
@@ -278,7 +278,7 @@ typedef __rman_res_t    rman_res_t;
 #if defined(_KERNEL) || defined(__CHERI_PURE_CAPABILITY__)
 typedef __intcap_t	syscallarg_t;
 #else
-typedef register_t	syscallarg_t;
+typedef __register_t	syscallarg_t;
 #endif
 
 #ifdef _KERNEL


### PR DESCRIPTION
I was thinking of pulling together a patch to upstream I noticed this line didn't really match the rest of the file.