### PR TITLE
libc: Diff-reduce locale code

### DIFF
--- a/lib/libc/locale/collate.c
+++ b/lib/libc/locale/collate.c
@@ -74,13 +74,11 @@ __collate_load_tables_l(const char *encoding, struct xlocale_collate *table);
 static void
 destruct_collate(void *t)
 {
-#ifndef FORCE_C_LOCALE
 	struct xlocale_collate *table = t;
 	if (table->map && (table->maplen > 0)) {
 		(void) munmap(table->map, table->maplen);
 	}
 	free(t);
-#endif
 }
 
 void *
@@ -114,7 +112,6 @@ __collate_load_tables(const char *encoding)
 static int
 __collate_load_tables_l(const char *encoding, struct xlocale_collate *table)
 {
-#ifndef FORCE_C_LOCALE
 	int i, chains, z;
 	char *buf;
 	char *TMP;
@@ -122,12 +119,8 @@ __collate_load_tables_l(const char *encoding, struct xlocale_collate *table)
 	collate_info_t *info;
 	struct stat sbuf;
 	int fd;
-#endif
 
 	table->__collate_load_error = 1;
-#ifdef FORCE_C_LOCALE
-	return (_LDP_CACHE);
-#else
 
 	/* 'encoding' must be already checked. */
 	if (strcmp(encoding, "C") == 0 || strcmp(encoding, "POSIX") == 0 ||
@@ -222,7 +215,6 @@ __collate_load_tables_l(const char *encoding, struct xlocale_collate *table)
 
 	table->__collate_load_error = 0;
 	return (_LDP_LOADED);
-#endif
 }
 
 static const int32_t *

--- a/lib/libc/locale/ldpart.c
+++ b/lib/libc/locale/ldpart.c
@@ -69,10 +69,6 @@ __part_load_locale(const char *name,
 		return (_LDP_CACHE);
 	}
 
-#ifdef FORCE_C_LOCALE
-	/* XXX-BD: or should we just return _LDP_CACHE? */
-	return (_LDP_ERROR);
-#else
 	/*
 	 * If the locale name is the same as our cache, use the cache.
 	 */
@@ -153,7 +149,6 @@ bad_locale:
 	errno = saverr;
 
 	return (_LDP_ERROR);
-#endif
 }
 
 static int

--- a/lib/libc/locale/rune.c
+++ b/lib/libc/locale/rune.c
@@ -74,9 +74,6 @@ _Read_RuneMagi(const char *fname)
 	int runetype_ext_len = 0;
 	int fd;
 
-#ifdef FORCE_C_LOCALE
-	return (NULL);
-#else
 	if ((fd = _open(fname, O_RDONLY | O_CLOEXEC)) < 0) {
 		errno = EINVAL;
 		return (NULL);
@@ -252,5 +249,4 @@ invalid:
 	munmap(fdata, sb.st_size);
 	errno = EINVAL;
 	return (NULL);
-#endif
 }

--- a/lib/libc/locale/setlocale.c
+++ b/lib/libc/locale/setlocale.c
@@ -102,7 +102,6 @@ const char *__get_locale_env(int);
 char *
 setlocale(int category, const char *locale)
 {
-#ifndef FORCE_C_LOCALE
 	int i, j, len, saverr;
 	const char *env, *r;
 
@@ -205,7 +204,6 @@ setlocale(int category, const char *locale)
 			return (NULL);
 		}
 	}
-#endif
 	return (currentlocale());
 }
 
@@ -289,9 +287,6 @@ __get_locale_env(int category)
 {
 	const char *env;
 
-#ifdef FORCE_C_LOCALE
-	env = "C";
-#else
 	/* 1. check LC_ALL. */
 	env = getenv(categories[0]);
 
@@ -306,7 +301,6 @@ __get_locale_env(int category)
 	/* 4. if none is set, fall to "C" */
 	if (env == NULL || !*env)
 		env = "C";
-#endif
 
 	return (env);
 }
@@ -317,11 +311,6 @@ __get_locale_env(int category)
 int
 __detect_path_locale(void)
 {
-
-#ifdef FORCE_C_LOCALE
-	_PathLocale = NULL;
-	return (EINVAL);
-#else
 	if (_PathLocale == NULL) {
 		char *p = getenv("PATH_LOCALE");
 
@@ -336,5 +325,4 @@ __detect_path_locale(void)
 			_PathLocale = _PATH_LOCALE;
 	}
 	return (0);
-#endif
 }

--- a/lib/libc/locale/xlocale.c
+++ b/lib/libc/locale/xlocale.c
@@ -240,7 +240,6 @@ static int dupcomponent(int type, locale_t base, locale_t new)
 
 locale_t newlocale(int mask, const char *locale, locale_t base)
 {
-#ifndef FORCE_C_LOCALE
 	locale_t orig_base;
 	int type;
 	const char *realLocale = locale;
@@ -294,14 +293,10 @@ locale_t newlocale(int mask, const char *locale, locale_t base)
 	}
 
 	return (new);
-#else
-	return (NULL);
-#endif
 }
 
 locale_t duplocale(locale_t base)
 {
-#ifndef FORCE_C_LOCALE
 	locale_t new = alloc_locale();
 	int type;
 
@@ -319,9 +314,6 @@ locale_t duplocale(locale_t base)
 	}
 
 	return (new);
-#else
-	return (NULL);
-#endif
 }
 
 /*
@@ -368,14 +360,10 @@ const char *querylocale(int mask, locale_t loc)
  */
 locale_t uselocale(locale_t loc)
 {
-#ifndef FORCE_C_LOCALE
 	locale_t old = get_thread_locale();
 	if (NULL != loc) {
 		set_thread_locale(loc);
 	}
 	return (old ? old : LC_GLOBAL_LOCALE);
-#else
-	return (LC_GLOBAL_LOCALE);
-#endif
 }
 

--- a/lib/libc/locale/xlocale_private.h
+++ b/lib/libc/locale/xlocale_private.h
@@ -213,14 +213,10 @@ extern _Thread_local locale_t __thread_locale;
 static inline locale_t __get_locale(void)
 {
 
-#ifdef FORCE_C_LOCALE
-	return (&__xlocale_C_locale);
-#else
 	if (!__has_thread_locale) {
 		return (&__xlocale_global_locale);
 	}
 	return (__thread_locale ? __thread_locale : &__xlocale_global_locale);
-#endif
 }
 
 /**

--- a/lib/libc/locale/xlocale_private.h
+++ b/lib/libc/locale/xlocale_private.h
@@ -30,18 +30,6 @@
  *
  * $FreeBSD$
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181114,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ],
- *   "change_comment": "is this still needed?"
- * }
- * CHERI CHANGES END
- */
 
 #ifndef _XLOCALE_PRIVATE__H_
 #define _XLOCALE_PRIVATE__H_
@@ -225,7 +213,7 @@ static inline locale_t __get_locale(void)
  */
 static inline locale_t get_real_locale(locale_t locale)
 {
-	switch ((size_t)locale) {
+	switch ((intptr_t)locale) {
 		case 0: return (&__xlocale_C_locale);
 		case -1: return (&__xlocale_global_locale);
 		default: return (locale);


### PR DESCRIPTION
The only diffs now are \_ThreadRuneLocale's emutls variable in Symbol.map and lib/libc/locale/gb18030.c's diff to fix an overread of the source by including an extra MIN(..., strlen) (which should be revisited and either dropped or upstreamed).
