### PR TITLE
Add __subobject_use_container_bounds to all struct radix_node[2] embeds

### DIFF
--- a/sys/kern/vfs_export.c
+++ b/sys/kern/vfs_export.c
@@ -81,7 +81,7 @@ static struct netcred *vfs_export_lookup(struct mount *, struct sockaddr *);
  * Network address lookup element
  */
 struct netcred {
-	struct	radix_node netc_rnodes[2];
+	struct	radix_node netc_rnodes[2] __subobject_use_container_bounds;
 	uint64_t netc_exflags;
 	struct	ucred *netc_anon;
 	int	netc_numsecflavors;

--- a/sys/net/pfvar.h
+++ b/sys/net/pfvar.h
@@ -1216,7 +1216,7 @@ struct pfr_kcounters {
 #ifdef _KERNEL
 SLIST_HEAD(pfr_kentryworkq, pfr_kentry);
 struct pfr_kentry {
-	struct radix_node	 pfrke_node[2];
+	struct radix_node	 pfrke_node[2] __subobject_use_container_bounds;
 	union sockaddr_union	 pfrke_sa;
 	SLIST_ENTRY(pfr_kentry)	 pfrke_workq;
 	struct pfr_kcounters	 pfrke_counters;

--- a/sys/netinet/in_fib_algo.c
+++ b/sys/netinet/in_fib_algo.c
@@ -509,7 +509,7 @@ struct fib_lookup_module flm_bsearch4= {
 #define KEY_LEN_INET	(offsetof(struct sockaddr_in, sin_addr) + sizeof(in_addr_t))
 #define OFF_LEN_INET	(8 * offsetof(struct sockaddr_in, sin_addr))
 struct radix4_addr_entry {
-	struct radix_node	rn[2];
+	struct radix_node	rn[2] __subobject_use_container_bounds;
 	struct sockaddr_in	addr;
 	struct nhop_object	*nhop;
 };

--- a/sys/netinet6/in6_fib_algo.c
+++ b/sys/netinet6/in6_fib_algo.c
@@ -80,7 +80,7 @@ struct sa_in6 {
 	struct in6_addr		sin6_addr;
 };
 struct radix6_addr_entry {
-	struct radix_node	rn[2];
+	struct radix_node	rn[2] __subobject_use_container_bounds;
 	struct sa_in6		addr;
 	struct nhop_object	*nhop;
 };

--- a/sys/netpfil/ipfw/ip_fw_table_algo.c
+++ b/sys/netpfil/ipfw/ip_fw_table_algo.c
@@ -324,7 +324,7 @@ static int bdel(const void *key, void *base, size_t nmemb, size_t size,
 #define OFF_LEN_INET6	(8 * offsetof(struct sa_in6, sin6_addr))
 
 struct radix_addr_entry {
-	struct radix_node	rn[2];
+	struct radix_node	rn[2] __subobject_use_container_bounds;
 	struct sockaddr_in	addr;
 	uint32_t		value;
 	uint8_t			masklen;
@@ -338,7 +338,7 @@ struct sa_in6 {
 };
 
 struct radix_addr_xentry {
-	struct radix_node	rn[2];
+	struct radix_node	rn[2] __subobject_use_container_bounds;
 	struct sa_in6		addr6;
 	uint32_t		value;
 	uint8_t			masklen;


### PR DESCRIPTION
A downcast idiom is used to retrieve the container from the node
pointer, so we cannot set bounds when passing these to rnh_addaddr /
rn_addroute. This repeats 3f0122c5f4b2 for all the other instances I
could find.
