### PR TITLE
umtx: Fix UMTX_OP_NWAKE_PRIVATE for freebsd64 processes on a purecap kernel

### DIFF
--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -5044,16 +5044,15 @@ static int
 __umtx_op_nwake_private64(struct thread *td,
     struct freebsd64__umtx_op_args *uap)
 {
-	char *uaddrs[BATCH_SIZE], **upp;
+	uint64_t uaddrs[BATCH_SIZE], * __capability upp;
 	int count, error, i, pos, tocopy;
 
-	upp = (char **)uap->obj;
+	upp = __USER_CAP(uap->obj, uap->val * sizeof(uint64_t));
 	error = 0;
 	for (count = uap->val, pos = 0; count > 0; count -= tocopy,
 	    pos += tocopy) {
 		tocopy = MIN(count, BATCH_SIZE);
-		error = copyin(__USER_CAP_UNBOUND(upp + pos), uaddrs,
-		    tocopy * sizeof(char *));
+		error = copyin(upp + pos, uaddrs, tocopy * sizeof(uint64_t));
 		if (error != 0)
 			break;
 		for (i = 0; i < tocopy; ++i)


### PR DESCRIPTION
Using char * as the user address type only works in hybrid kernels; we
must use uint64_t instead. Whilst here, hoist the capability derivation
out of the loop and add appropriate bounds.

Without this, buildworld on a purecap kernel (which currently only has a
toolchain built as hybrid) eventually gets stuck during the everything
phase, with all jobs being lld processes performing relocatable links
which each have all their threads waiting in UMTX_OP_WAIT_UINT_PRIVATE
operations. It's unclear why this only affected relocatable links, or
even if that's always the case.
