### PR TITLE
Remove PIE from DEFAULT_YES_OPTIONS.

### DIFF
--- a/share/mk/bsd.opts.mk
+++ b/share/mk/bsd.opts.mk
@@ -61,7 +61,6 @@ __DEFAULT_YES_OPTIONS = \
     NIS \
     NLS \
     OPENSSH \
-    PIE \
     SSP \
     TESTS \
     TOOLCHAIN \


### PR DESCRIPTION
This is a local diff and PIE is later enabled by default upstream on
all non-32-bit arches.