### PR TITLE
bcopy*() cleanup

### DIFF
--- a/sys/kern/sysv_sem.c
+++ b/sys/kern/sysv_sem.c
@@ -841,7 +841,7 @@ kern_semctl(struct thread *td, int semid, int semnum, int cmd,
 		if (error != 0)
 			goto done2;
 #endif
-		bcopy_c(&semakptr->u, arg->buf, sizeof(struct semid_ds));
+		bcopy_c(PTR2CAP(&semakptr->u), arg->buf, sizeof(struct semid_ds));
 		if (cred->cr_prison != semakptr->cred->cr_prison)
 			arg->buf->sem_perm.key = IPC_PRIVATE;
 		*rval = IXSEQ_TO_IPCID(semid, semakptr->u.sem_perm);
@@ -897,7 +897,7 @@ kern_semctl(struct thread *td, int semid, int semnum, int cmd,
 			goto done2;
 		if ((error = ipcperm(td, &semakptr->u.sem_perm, IPC_R)))
 			goto done2;
-		bcopy_c(&semakptr->u, arg->buf, sizeof(struct semid_ds));
+		bcopy_c(PTR2CAP(&semakptr->u), arg->buf, sizeof(struct semid_ds));
 		if (cred->cr_prison != semakptr->cred->cr_prison)
 			arg->buf->sem_perm.key = IPC_PRIVATE;
 

--- a/sys/libkern/bcopy.c
+++ b/sys/libkern/bcopy.c
@@ -181,12 +181,6 @@ memcpynocap(void *dst0, const void *src0, size_t length)
 }
 
 __strong_reference(memcpynocap, memmovenocap);
-
-void
-bcopynocap(const void *src0, void *dst0, size_t length)
-{
-	_memcpy(dst0, src0, length, false);
-}
 #endif
 // CHERI CHANGES START
 // {

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -139,25 +139,11 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 
 __strong_reference(memcpy_c, memmove_c);
 
-void
-bcopy_c(const void * __capability src, void * __capability dst, size_t len)
-{
-
-	memcpy_c(dst, src, len);
-}
-
 void * __capability
 memcpynocap_c(void * __capability dst, const void *  __capability src,
     size_t len)
 {
 	return (memcpy_c(dst, cheri_andperm(src, ~CHERI_PERM_LOAD_CAP), len));
-}
-
-void
-bcopynocap_c(const void * __capability src, void * __capability dst, size_t len)
-{
-
-	memcpy_c(dst, cheri_andperm(src, ~CHERI_PERM_LOAD_CAP), len);
 }
 
 __strong_reference(memcpynocap_c, memmovenocap_c);

--- a/sys/sys/sem.h
+++ b/sys/sys/sem.h
@@ -71,7 +71,7 @@ struct sembuf {
     defined(_WANT_SEMUN_OLD)
 union semun_old {
 	int		val;		/* value for SETVAL */
-	struct		semid_ds_old *buf; /* buffer for IPC_STAT & IPC_SET */
+	struct semid_ds_old * __kerncap buf; /* buffer for IPC_STAT & IPC_SET */
 	unsigned short * __kerncap array; /* array for GETALL & SETALL */
 };
 #endif

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -399,20 +399,6 @@ void	hexdump(const void *ptr, int length, const char *hdr, int flags);
 #define	HD_OMIT_CHARS	(1 << 18)
 
 #define ovbcopy(f, t, l) bcopy((f), (t), (l))
-#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
-void	bcopy_c(const void * _Nonnull __capability from,
-	    void * _Nonnull __capability to, size_t len);
-void	bcopynocap_c(const void * _Nonnull __capability from,
-	    void * _Nonnull __capability to, size_t len);
-#else
-#define	bcopy_c		bcopy
-#define	bcopynocap_c	bcopynocap
-#endif
-#if __has_feature(capabilities)
-void	bcopynocap(const void *src0, void *dst0, size_t length);
-#else
-#define	bcopynocap	bcopy
-#endif
 void	explicit_bzero(void * _Nonnull, size_t);
 
 void	*memset(void * _Nonnull buf, int c, size_t len);
@@ -475,6 +461,10 @@ int	SAN_INTERCEPTOR(memcmp)(const void *, const void *, size_t);
 #define memmove(dest, src, n)	__builtin_memmove((dest), (src), (n))
 #define memcmp(b1, b2, len)	__builtin_memcmp((b1), (b2), (len))
 #endif /* SAN_NEEDS_INTERCEPTORS */
+
+#define bcopy_c(from, to, len)		memmove_c((to), (from), (len))
+#define bcopynocap(from, to, len)	memmovenocap((to), (from), (len))
+#define bcopynocap_c(from, to, len)	memmovenocap_c((to), (from), (len))
 
 void	*memset_early(void * _Nonnull buf, int c, size_t len);
 #define bzero_early(buf, len) memset_early((buf), 0, (len))

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -448,12 +448,6 @@ void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
 #else
 #define	memmovenocap	memmove
 #endif
-
-struct copy_map {
-	size_t	len;
-	size_t	uoffset;
-	size_t	koffset;
-};
 void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
 int	memcmp(const void *b1, const void *b2, size_t len);
 

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -448,7 +448,6 @@ void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
 #else
 #define	memmovenocap	memmove
 #endif
-void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
 int	memcmp(const void *b1, const void *b2, size_t len);
 
 #ifdef SAN_NEEDS_INTERCEPTORS

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -403,38 +403,32 @@ void	explicit_bzero(void * _Nonnull, size_t);
 
 void	*memset(void * _Nonnull buf, int c, size_t len);
 void	*memcpy(void * _Nonnull to, const void * _Nonnull from, size_t len);
+void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
+int	memcmp(const void *b1, const void *b2, size_t len);
+#if __has_feature(capabilities)
+void	*memcpynocap(void * _Nonnull to, const void * _Nonnull from,
+    size_t len);
+void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
+    size_t n);
+#else
+#define	memcpynocap	memcpy
+#define	memmovenocap	memmove
+#endif
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void	* __capability memcpy_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
 void	* __capability memcpynocap_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
-#else
-#define	memcpy_c	memcpy
-#define	memcpynocap_c	memcpynocap
-#endif
-#if __has_feature(capabilities)
-void	*memcpynocap(void * _Nonnull to, const void * _Nonnull from,
-    size_t len);
-#else
-#define	memcpynocap	memcpy
-#endif
-void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
-#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void	* __capability memmove_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
 void	* __capability memmovenocap_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
 #else
+#define	memcpy_c	memcpy
+#define	memcpynocap_c	memcpynocap
 #define	memmove_c	memmove
 #define	memmovenocap_c	memmovenocap
 #endif
-#if __has_feature(capabilities)
-void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
-    size_t n);
-#else
-#define	memmovenocap	memmove
-#endif
-int	memcmp(const void *b1, const void *b2, size_t len);
 
 #ifdef SAN_NEEDS_INTERCEPTORS
 #define	SAN_INTERCEPTOR(func)	\


### PR DESCRIPTION
This reimplements CHERI-specific bcopy*() functions as macros around mem* in the kernel to be consistent with upstream FreeBSD which has done the same for bcopy() and bzero().