### PR TITLE
bpf: Fix wrong free in bpf_setf

### DIFF
--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -2065,7 +2065,7 @@ bpf_setf(struct bpf_d *d, struct bpf_program *fp, u_long cmd)
 	BPFD_UNLOCK(d);
 
 	if (old_fcode != NULL)
-		NET_EPOCH_CALL(bpf_program_buffer_free, &fcode->epoch_ctx);
+		NET_EPOCH_CALL(bpf_program_buffer_free, &old_fcode->epoch_ctx);
 
 	if (track_event)
 		EVENTHANDLER_INVOKE(bpf_track,


### PR DESCRIPTION
Commit ab4fc2f7ba47 missed one instance of fcode that should have been
changd to the new old_fcode. This results in immediate use-after-free,
and eventually panics in bpfd_free with a double free detected when it
tries to free its own program buffer.