### PR TITLE
aiocb64_copyin: Handle opcodes for lio_listio().

### DIFF
--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -3362,6 +3362,8 @@ aiocb64_copyin(void * __capability ujob, struct kaiocb *kjob, int type)
 	CP(job64, *kcb, aio_fildes);
 	CP(job64, *kcb, aio_offset);
 	CP(job64, *kcb, aio_lio_opcode);
+	if (type == LIO_NOP)
+		type = kcb->aio_lio_opcode;
 	if (type & LIO_VECTORED) {
 		CP(job64, *kcb, aio_iovcnt);
 		iov64 = __USER_CAP(job64.aio_iov, kcb->aio_iovcnt * sizeof(struct iovec64));


### PR DESCRIPTION
For lio_listio(), the request type to check for LIO_VECTORED must be
read from the aiocb rather than using the passed-in type.