### PR TITLE
Clean up rtld ABI checking and enable for Morello

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -218,18 +218,11 @@ _rtld_validate_target_eflags(const char *path, Elf_Ehdr *hdr, const char *main_p
 #endif
 	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
 
-	/*
-	 * TODO: restore validation when the Morello toolchain correctly
-	 * identifies purecap libraries.
-	 */
-	(void)path; (void)main_path;
-#if 0
 	if (rtld_is_cheriabi != hdr_is_cheriabi) {
 		_rtld_error("%s: cannot load %s since it is%s CheriABI",
 		    main_path, path, hdr_is_cheriabi ? "" : " not");
 		return (false);
 	}
-#endif
 
 	return (true);
 }

--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -216,7 +216,7 @@ _rtld_validate_target_eflags(const char *path, Elf_Ehdr *hdr, const char *main_p
 #else
 	rtld_is_cheriabi = false;
 #endif
-	hdr_is_cheriabi = (hdr->e_entry & 0x1) != 0;
+	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
 
 	/*
 	 * TODO: restore validation when the Morello toolchain correctly

--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -204,29 +204,6 @@ extern void *__tls_get_addr(tls_index *ti);
 #define	TLS_VARIANT_I	1
 #define	TLS_DTV_OFFSET	0
 
-#define rtld_validate_target_eflags(path, hdr, main_path)	\
-	_rtld_validate_target_eflags(path, hdr, main_path)
-static inline bool
-_rtld_validate_target_eflags(const char *path, Elf_Ehdr *hdr, const char *main_path)
-{
-	bool rtld_is_cheriabi, hdr_is_cheriabi;
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	rtld_is_cheriabi = true;
-#else
-	rtld_is_cheriabi = false;
-#endif
-	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
-
-	if (rtld_is_cheriabi != hdr_is_cheriabi) {
-		_rtld_error("%s: cannot load %s since it is%s CheriABI",
-		    main_path, path, hdr_is_cheriabi ? "" : " not");
-		return (false);
-	}
-
-	return (true);
-}
-
 #ifdef __CHERI_PURE_CAPABILITY__
 static inline void
 fix_obj_mapping_cap_permissions(Obj_Entry *obj, const char *path __unused)

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -476,6 +476,23 @@ get_elf_header(int fd, const char *path, const struct stat *sbp,
 		goto error;
 	}
 
+#ifndef ELF_IS_CHERI
+#if __has_feature(capabilities)
+#error "Must have ELF_IS_CHERI for CHERI architectures"
+#endif
+#define ELF_IS_CHERI(hdr) false
+#endif
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (!ELF_IS_CHERI(hdr))
+#else
+	if (ELF_IS_CHERI(hdr))
+#endif
+	{
+		_rtld_error("%s: cannot load %s since it is%s CheriABI",
+		    main_path, path, ELF_IS_CHERI(hdr) ? "" : " not");
+		goto error;
+	}
+
 #ifndef rtld_validate_target_eflags
 #define rtld_validate_target_eflags(path, hdr, main_path) true
 	(void)main_path;

--- a/libexec/rtld-elf/mips/rtld_machdep.h
+++ b/libexec/rtld-elf/mips/rtld_machdep.h
@@ -367,29 +367,19 @@ static_assert(_MIPS_SZCAP == 128, "CHERI bits != 128?");
 static inline bool
 _rtld_validate_target_eflags(const char* path, Elf_Ehdr *hdr, const char* main_path)
 {
-	bool rtld_is_cheriabi, hdr_is_cheriabi;
 	size_t machine = (hdr->e_flags & EF_MIPS_MACH);
-	bool is_cheri = machine == EF_MIPS_MACH_CHERI256 || machine == EF_MIPS_MACH_CHERI128;
 
+	/* Catch bogus non-CHERI CheriABI and any CHERI-256 */
 #ifdef __CHERI_PURE_CAPABILITY__
-	rtld_is_cheriabi = true;
+	if (machine != EF_MIPS_MACH_CHERI128)
 #else
-	rtld_is_cheriabi = false;
+	if (machine == EF_MIPS_MACH_CHERI256)
 #endif
-	if (rtld_is_cheriabi || is_cheri) {
-		if (machine != EF_MIPS_MACH_CHERI128) {
-			_rtld_error("%s: cannot load %s since its capability "
-			    "size is not 128 bits (e_flags=0x%zx)",
-			    main_path, path, (size_t)hdr->e_flags);
-			return false;
-		}
-	}
-
-	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
-	if (rtld_is_cheriabi != hdr_is_cheriabi) {
-		_rtld_error("%s: cannot load %s since it is%s CheriABI",
-		    main_path, path, hdr_is_cheriabi ? "" : " not");
-		return (false);
+	{
+		_rtld_error("%s: cannot load %s since its capability "
+		    "size is not 128 bits (e_flags=0x%zx)",
+		    main_path, path, (size_t)hdr->e_flags);
+		return false;
 	}
 
 #ifdef __CHERI_PURE_CAPABILITY__

--- a/libexec/rtld-elf/mips/rtld_machdep.h
+++ b/libexec/rtld-elf/mips/rtld_machdep.h
@@ -385,7 +385,7 @@ _rtld_validate_target_eflags(const char* path, Elf_Ehdr *hdr, const char* main_p
 		}
 	}
 
-	hdr_is_cheriabi = (hdr->e_flags & EF_MIPS_ABI) == EF_MIPS_ABI_CHERIABI;
+	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
 	if (rtld_is_cheriabi != hdr_is_cheriabi) {
 		_rtld_error("%s: cannot load %s since it is%s CheriABI",
 		    main_path, path, hdr_is_cheriabi ? "" : " not");

--- a/libexec/rtld-elf/riscv/rtld_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_machdep.h
@@ -219,29 +219,6 @@ extern void *__tls_get_addr(tls_index* ti);
 
 #define	md_abi_variant_hook(x)
 
-#define rtld_validate_target_eflags(path, hdr, main_path)	\
-	_rtld_validate_target_eflags(path, hdr, main_path)
-static inline bool
-_rtld_validate_target_eflags(const char *path, Elf_Ehdr *hdr, const char *main_path)
-{
-	bool rtld_is_cheriabi, hdr_is_cheriabi;
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	rtld_is_cheriabi = true;
-#else
-	rtld_is_cheriabi = false;
-#endif
-	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
-
-	if (rtld_is_cheriabi != hdr_is_cheriabi) {
-		_rtld_error("%s: cannot load %s since it is%s CheriABI",
-		    main_path, path, hdr_is_cheriabi ? "" : " not");
-		return (false);
-	}
-
-	return (true);
-}
-
 #ifdef __CHERI_PURE_CAPABILITY__
 static inline void
 fix_obj_mapping_cap_permissions(Obj_Entry *obj, const char *path __unused)

--- a/libexec/rtld-elf/riscv/rtld_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_machdep.h
@@ -231,7 +231,7 @@ _rtld_validate_target_eflags(const char *path, Elf_Ehdr *hdr, const char *main_p
 #else
 	rtld_is_cheriabi = false;
 #endif
-	hdr_is_cheriabi = (hdr->e_flags & EF_RISCV_CHERIABI) != 0;
+	hdr_is_cheriabi = ELF_IS_CHERI(hdr);
 
 	if (rtld_is_cheriabi != hdr_is_cheriabi) {
 		_rtld_error("%s: cannot load %s since it is%s CheriABI",

--- a/sys/arm64/include/elf.h
+++ b/sys/arm64/include/elf.h
@@ -93,14 +93,7 @@ __ElfType(Auxinfo);
 
 #define	ELF_MACHINE_OK(x) ((x) == (ELF_ARCH))
 
-/*
- * TODO: Remove old e_entry check. This is deprecated, but needed to support
- * binaries built with a compiler and linker that predate setting the ELF flag
- * appropriately.
- */
-#define	ELF_IS_CHERI(hdr) \
-    ((((hdr)->e_flags & EF_AARCH64_CHERI_PURECAP) != 0) || \
-     (((hdr)->e_entry & 1) == 1))
+#define	ELF_IS_CHERI(hdr) (((hdr)->e_flags & EF_AARCH64_CHERI_PURECAP) != 0)
 
 /* Define "machine" characteristics */
 #if __ELF_WORD_SIZE == 64


### PR DESCRIPTION
ELF_IS_CHERI post-dates CheriABI rtld, hence why it wasn't used for mips, but for some reason I never thought to use it in rtld when cleaning the code up and adding CHERI-RISC-V...
