### PR TITLE
procctl: Rework ABI compatiblity.

### DIFF
--- a/.mergify_pause_paths
+++ b/.mergify_pause_paths
@@ -1,1 +1,1 @@
-^(contrib/jemalloc|sys/kern/(capabilities.conf|syscalls.master|systrace_args.c)|usr.bin/truss|sys/arm64/conf/GENERIC|sys/.*/elf_machdep.c)
+^(contrib/jemalloc|sys/kern/(capabilities.conf|kern_procctl.c|syscalls.master|systrace_args.c)|usr.bin/truss|sys/arm64/conf/GENERIC|sys/.*/elf_machdep.c)

--- a/sys/sys/procctl.h
+++ b/sys/sys/procctl.h
@@ -106,7 +106,7 @@ struct procctl_reaper_pidinfo {
 struct procctl_reaper_pids {
 	u_int	rp_count;
 	u_int	rp_pad0[15];
-	struct procctl_reaper_pidinfo *rp_pids;
+	struct procctl_reaper_pidinfo * __kerncap rp_pids;
 };
 
 struct procctl_reaper_kill {

--- a/sys/sys/syscallsubr.h
+++ b/sys/sys/syscallsubr.h
@@ -636,8 +636,6 @@ int	user_ppoll(struct thread *td, struct pollfd *__capability fds,
 	    const sigset_t * __capability uset);
 int	user_preadv(struct thread *td, int fd, struct iovec * __capability iovp,
 	    u_int iovcnt, off_t offset, copyinuio_t *copyinuio_f);
-int	user_procctl(struct thread *td, enum idtype idtype, id_t id, int com,
-	    void * __capability data);
 int	user_pselect(struct thread *td, int nd, fd_set * __capability in,
 	    fd_set * __capability ou, fd_set * __capability ex,
 	    const struct timespec * __capability uts,


### PR DESCRIPTION
- Drop freebsd32 bits from sys/kern as freebsd32_procctl() is
  self-contained over in freebsd32_misc.c.

- Retire struct procctl_reaper_kill_c and instead add __kerncap to the
  real structure.

- Unwind user_procctl and instead make freebsd64_procctl more like
  freebsd32_procctl.  In particular, upstream changes are going to
  make supporting freebsd64 in this function more complicated and
  hacky.