### PR TITLE
freebsd64_copyout_strings: Synch with exec_copyout_strings.

### DIFF
--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1922,7 +1922,8 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 #else
 		imgp->auxv = vectp;
 #endif
-		error = imgp->sysent->sv_copyout_auxargs(imgp, (uintcap_t)imgp->auxv);
+		error = imgp->sysent->sv_copyout_auxargs(imgp,
+		    (uintcap_t)imgp->auxv);
 		if (error != 0)
 			return (error);
 	}


### PR DESCRIPTION
- Use imgp->strings instead of re-deriving the user stack capability.

- Don't assume sv_szsigcode is non-NULL if sv_sigcodebase is set.

- Use exec_stackgap() instead of invoking sv_stackgap directly.

- Use strlen() on argv and environment strings.  (I didn't do this
  when originally splitting out freebsd64_copyout_strings to more
  closely match upstream, but I now think it is more important to
  match our exec_copyout_strings().)

- Set imgp->auxv (even though it is currently only used in MD code
  for SV_CHERI).