### PR TITLE
Morello IFUNC preparatory cleanups

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -46,39 +46,7 @@ SRCS+=	cheribsdtest_cheriabi_open.c
 #SRCS+=	cheribsdtest_vm_swap.c
 #CFLAGS.cheribsdtest_vm_swap.c+=-Wno-cheri-capability-misuse
 
-.if ${MACHINE} == mips
-.PATH: ${SRCTOP}/sys/mips/cheri
-SRCS+=	cheri_memcpy_c.S
-CFLAGS.cheri_memcpy_c.S=-D__KERN_FUNC_PREFIX -D_KERNEL -DINVARIANTS
-CFLAGS+=	-DKERNEL_MEMCPY_TESTS
-.endif
-
-.if ${MACHINE} == "mips"
-.ifdef CHERI_C_TESTS
-CHERI_C_TESTS_DIR=	${SRCTOP}/contrib/subrepo-cheri-c-tests
-.if exists(${CHERI_C_TESTS_DIR}/Makefile)
-.PATH: ${CHERI_C_TESTS_DIR} \
-		${CHERI_C_TESTS_DIR}/clang-hybrid \
-		${CHERI_C_TESTS_DIR}/clang-purecap \
-		${CHERI_C_TESTS_DIR}/libc
-CFLAGS+=	-DCHERI_C_TESTS \
-		-I${CHERI_C_TESTS_DIR}
-
-CFLAGS+=	-DTEST_CUSTOM_FRAMEWORK -I${CHERIBSDTEST_DIR} \
-		-DHAVE_MALLOC_USUABLE_SIZE
-TEST_SRCS!=	grep ^DECLARE_TEST ${CHERI_C_TESTS_DIR}/cheri_c_testdecls.h | \
-		    sed -e 's/.*(\([^,]*\),.*/\1.c/'
-SRCS+=	test_runtime.c	\
-	${TEST_SRCS}
-
-.for test in ${TEST_SRCS}
-# Avoid the need for extern declarations for variables/functions that are
-# declared global so that the compiler emits them
-CFLAGS.${test}+=-Wno-missing-prototypes -Wno-missing-variable-declarations
-.endfor
-.endif
-.endif
-.endif
+.sinclude "${CHERIBSDTEST_DIR}/${MACHINE}/Makefile.cheribsdtest"
 
 .ifdef CHERIBSD_THREAD_TESTS
 CFLAGS+=	-DCHERIBSD_THREAD_TESTS

--- a/bin/cheribsdtest/mips/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/mips/Makefile.cheribsdtest
@@ -1,0 +1,31 @@
+# $FreeBSD$
+
+.PATH: ${SRCTOP}/sys/mips/cheri
+SRCS+=	cheri_memcpy_c.S
+CFLAGS.cheri_memcpy_c.S=-D__KERN_FUNC_PREFIX -D_KERNEL -DINVARIANTS
+CFLAGS+=	-DKERNEL_MEMCPY_TESTS
+
+.ifdef CHERI_C_TESTS
+CHERI_C_TESTS_DIR=	${SRCTOP}/contrib/subrepo-cheri-c-tests
+.if exists(${CHERI_C_TESTS_DIR}/Makefile)
+.PATH: ${CHERI_C_TESTS_DIR} \
+		${CHERI_C_TESTS_DIR}/clang-hybrid \
+		${CHERI_C_TESTS_DIR}/clang-purecap \
+		${CHERI_C_TESTS_DIR}/libc
+CFLAGS+=	-DCHERI_C_TESTS \
+		-I${CHERI_C_TESTS_DIR}
+
+CFLAGS+=	-DTEST_CUSTOM_FRAMEWORK -I${CHERIBSDTEST_DIR} \
+		-DHAVE_MALLOC_USUABLE_SIZE
+TEST_SRCS!=	grep ^DECLARE_TEST ${CHERI_C_TESTS_DIR}/cheri_c_testdecls.h | \
+		    sed -e 's/.*(\([^,]*\),.*/\1.c/'
+SRCS+=	test_runtime.c	\
+	${TEST_SRCS}
+
+.for test in ${TEST_SRCS}
+# Avoid the need for extern declarations for variables/functions that are
+# declared global so that the compiler emits them
+CFLAGS.${test}+=-Wno-missing-prototypes -Wno-missing-variable-declarations
+.endfor
+.endif
+.endif

--- a/lib/csu/aarch64/crt1_c.c
+++ b/lib/csu/aarch64/crt1_c.c
@@ -95,7 +95,7 @@ __start(int argc, char *argv[], char *env[], void (*cleanup)(void))
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			crt_init_globals(phdr, phnum);
+			crt_init_globals(phdr, phnum, NULL, NULL, NULL);
 		}
 	}
 #endif

--- a/lib/csu/aarch64/crt1_c.c
+++ b/lib/csu/aarch64/crt1_c.c
@@ -59,8 +59,6 @@ extern long * _end;
 #endif
 
 #ifdef SHOULD_PROCESS_CAP_RELOCS
-#define DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_GDC_ONLY
 #include "crt_init_globals.c"
 #endif
 
@@ -97,7 +95,7 @@ __start(int argc, char *argv[], char *env[], void (*cleanup)(void))
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			do_crt_init_globals(phdr, phnum);
+			crt_init_globals(phdr, phnum);
 		}
 	}
 #endif

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -120,7 +120,7 @@ _start(void *auxv,
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		crt_init_globals(at_phdr, at_phnum);
+		crt_init_globals(at_phdr, at_phnum, NULL, NULL, NULL);
 #endif
 	/* We can access global variables/make function calls now. */
 

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -45,8 +45,6 @@ __FBSDID("$FreeBSD$");
  * to include the code here.
  */
 #ifndef PIC
-#define DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_GDC_ONLY
 #include "crt_init_globals.c"
 #endif
 
@@ -66,7 +64,7 @@ Elf_Auxinfo *__auxargs;
  *
  * Note: If we want to support tight function bounds, it is important that
  * function calls and global variable accesses are only be made after
- * do_crt_init_globals() has completed (as this initializes the capabilities to
+ * crt_init_globals() has completed (as this initializes the capabilities to
  * globals and functions in the captable, which is used for all function calls).
  * This restriction only applies to statically linked binaries since the dynamic
  * linker takes care of initialization otherwise.
@@ -95,7 +93,7 @@ _start(void *auxv,
 	 * Digest the auxiliary vector for local use.
 	 *
 	 * Note: this file must be compile with -fno-jump-tables to avoid use
-	 * of the captable before do_crt_init_globals() has been called.
+	 * of the captable before crt_init_globals() has been called.
 	 */
 	for (Elf_Auxinfo *auxp = auxv; auxp->a_type != AT_NULL;  auxp++) {
 		if (auxp->a_type == AT_ARGV) {
@@ -116,13 +114,13 @@ _start(void *auxv,
 	/* For -pie executables rtld will initialize the __cap_relocs */
 #ifndef PIC
 	/*
-	 * crt_init_globals_3 must be called before accessing any globals.
+	 * crt_init_globals must be called before accessing any globals.
 	 *
 	 * Note: We parse the phdrs to ensure that the global data cap does
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		do_crt_init_globals(at_phdr, at_phnum);
+		crt_init_globals(at_phdr, at_phnum);
 #endif
 	/* We can access global variables/make function calls now. */
 

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -32,53 +32,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef PIC
+#error "PIEs never need to initialise their own globals"
+#endif
+
 #define CHERI_INIT_GLOBALS_GDC_ONLY
 #include <cheri_init_globals.h>
 #if !defined(CHERI_INIT_GLOBALS_VERSION) || CHERI_INIT_GLOBALS_VERSION < 4
 #error "cheri_init_globals.h is outdated. Please update LLVM"
 #endif
 
-/*
- * Avoid adding an unnecessary crt_init_globals() export from crt1.o for a
- * function that the compiler will inline anyway:
- */
-#ifndef DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_STATIC
-#else
-#define CRT_INIT_GLOBALS_STATIC static __always_inline
-#endif
-
-#ifndef CRT_INIT_GLOBALS_GDC_ONLY
-CRT_INIT_GLOBALS_STATIC void crt_init_globals(void) __hidden;
-#endif
-CRT_INIT_GLOBALS_STATIC void crt_init_globals_3(void * __capability,
-    const void * __capability, const void * __capability) __hidden;
-
-__attribute__((weak)) extern int _DYNAMIC __no_subobject_bounds;
-
-CRT_INIT_GLOBALS_STATIC void
-crt_init_globals_3(void * __capability data_cap,
-    const void * __capability code_cap, const void * __capability rodata_cap)
-{
-	/* Otherwise we need to initialize globals manually */
-	cheri_init_globals_3(data_cap, code_cap, rodata_cap);
-}
-
-#ifndef CRT_INIT_GLOBALS_GDC_ONLY
-CRT_INIT_GLOBALS_STATIC void
-crt_init_globals(void)
-{
-
-	crt_init_globals_3(__builtin_cheri_global_data_get(),
-	    __builtin_cheri_program_counter_get(),
-	    __builtin_cheri_global_data_get());
-}
-#endif /* !CRT_INIT_GLOBALS_GDC_ONLY */
-
-#ifndef PIC
 /* This is __always_inline since it is called before globals have been set up */
 static __always_inline void
-do_crt_init_globals(const Elf_Phdr *phdr, long phnum)
+crt_init_globals(const Elf_Phdr *phdr, long phnum)
 {
 	const Elf_Phdr *phlimit = phdr + phnum;
 	Elf_Addr text_start = (Elf_Addr)-1l;
@@ -199,6 +165,5 @@ do_crt_init_globals(const Elf_Phdr *phdr, long phnum)
 		if (!cheri_gettag(code_cap))
 			__builtin_trap();
 	}
-	crt_init_globals_3(data_cap, code_cap, rodata_cap);
+	cheri_init_globals_3(data_cap, code_cap, rodata_cap);
 }
-#endif /* !defined(PIC) */

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -44,7 +44,10 @@
 
 /* This is __always_inline since it is called before globals have been set up */
 static __always_inline void
-crt_init_globals(const Elf_Phdr *phdr, long phnum)
+crt_init_globals(const Elf_Phdr *phdr, long phnum,
+    void * __capability *data_cap_out,
+    const void * __capability *code_cap_out,
+    const void * __capability *rodata_cap_out)
 {
 	const Elf_Phdr *phlimit = phdr + phnum;
 	Elf_Addr text_start = (Elf_Addr)-1l;
@@ -166,4 +169,10 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum)
 			__builtin_trap();
 	}
 	cheri_init_globals_3(data_cap, code_cap, rodata_cap);
+	if (data_cap_out)
+		*data_cap_out = data_cap;
+	if (code_cap_out)
+		*code_cap_out = code_cap;
+	if (rodata_cap_out)
+		*rodata_cap_out = rodata_cap;
 }

--- a/lib/csu/mips/crt1_c.c
+++ b/lib/csu/mips/crt1_c.c
@@ -106,7 +106,7 @@ __start(char **ap,
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			crt_init_globals(phdr, phnum);
+			crt_init_globals(phdr, phnum, NULL, NULL, NULL);
 		}
 	}
 #endif

--- a/lib/csu/mips/crt1_c.c
+++ b/lib/csu/mips/crt1_c.c
@@ -61,8 +61,6 @@ extern int etext;
 #endif
 
 #ifdef SHOULD_PROCESS_CAP_RELOCS
-#define DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_GDC_ONLY
 #include "crt_init_globals.c"
 #endif
 
@@ -108,7 +106,7 @@ __start(char **ap,
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			do_crt_init_globals(phdr, phnum);
+			crt_init_globals(phdr, phnum);
 		}
 	}
 #endif

--- a/lib/csu/mips64c128/crt1_c.c
+++ b/lib/csu/mips64c128/crt1_c.c
@@ -153,7 +153,7 @@ _start(void *auxv,
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		crt_init_globals(at_phdr, at_phnum);
+		crt_init_globals(at_phdr, at_phnum, NULL, NULL, NULL);
 #endif
 	/* We can access global variables/make function calls now. */
 

--- a/lib/csu/mips64c128/crt1_c.c
+++ b/lib/csu/mips64c128/crt1_c.c
@@ -53,8 +53,6 @@ __FBSDID("$FreeBSD$");
  * to include the code here.
  */
 #ifndef PIC
-#define DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_GDC_ONLY
 #include "crt_init_globals.c"
 #endif
 
@@ -97,7 +95,7 @@ asm(
  * before handing off to main().
  *
  * It is important to note that function calls and global variable accesses
- * can only be made after do_crt_init_globals() has completed (as this
+ * can only be made after crt_init_globals() has completed (as this
  * initializes the capabilities to globals and functions in the captable, which
  * is used for all function calls). This restriction only applies to statically
  * linked binaries since the dynamic linker takes care of initialization
@@ -128,7 +126,7 @@ _start(void *auxv,
 	 * Digest the auxiliary vector for local use.
 	 *
 	 * Note: this file must be compile with -fno-jump-tables to avoid use
-	 * of the captable before do_crt_init_globals() has been called.
+	 * of the captable before crt_init_globals() has been called.
 	 */
 	for (Elf_Auxinfo *auxp = auxv; auxp->a_type != AT_NULL;  auxp++) {
 		if (auxp->a_type == AT_ARGV) {
@@ -149,13 +147,13 @@ _start(void *auxv,
 	/* For -pie executables rtld will initialize the __cap_relocs */
 #ifndef PIC
 	/*
-	 * crt_init_globals_3 must be called before accessing any globals.
+	 * crt_init_globals must be called before accessing any globals.
 	 *
 	 * Note: We parse the phdrs to ensure that the global data cap does
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		do_crt_init_globals(at_phdr, at_phnum);
+		crt_init_globals(at_phdr, at_phnum);
 #endif
 	/* We can access global variables/make function calls now. */
 

--- a/lib/csu/riscv/crt1_c.c
+++ b/lib/csu/riscv/crt1_c.c
@@ -57,8 +57,6 @@ extern int etext;
 #endif
 
 #ifdef SHOULD_PROCESS_CAP_RELOCS
-#define DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_GDC_ONLY
 #include "crt_init_globals.c"
 #endif
 
@@ -93,7 +91,7 @@ __start(int argc, char **argv, char **env, void (*cleanup)(void))
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			do_crt_init_globals(phdr, phnum);
+			crt_init_globals(phdr, phnum);
 		}
 	}
 #endif

--- a/lib/csu/riscv/crt1_c.c
+++ b/lib/csu/riscv/crt1_c.c
@@ -91,7 +91,7 @@ __start(int argc, char **argv, char **env, void (*cleanup)(void))
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			crt_init_globals(phdr, phnum);
+			crt_init_globals(phdr, phnum, NULL, NULL, NULL);
 		}
 	}
 #endif

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -120,7 +120,7 @@ _start(void *auxv,
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		crt_init_globals(at_phdr, at_phnum);
+		crt_init_globals(at_phdr, at_phnum, NULL, NULL, NULL);
 #endif
 	/* We can access global variables/make function calls now. */
 

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -45,8 +45,6 @@ __FBSDID("$FreeBSD$");
  * to include the code here.
  */
 #ifndef PIC
-#define DONT_EXPORT_CRT_INIT_GLOBALS
-#define CRT_INIT_GLOBALS_GDC_ONLY
 #include "crt_init_globals.c"
 #endif
 
@@ -66,7 +64,7 @@ Elf_Auxinfo *__auxargs;
  *
  * Note: If we want to support tight function bounds, it is important that
  * function calls and global variable accesses are only be made after
- * do_crt_init_globals() has completed (as this initializes the capabilities to
+ * crt_init_globals() has completed (as this initializes the capabilities to
  * globals and functions in the captable, which is used for all function calls).
  * This restriction only applies to statically linked binaries since the dynamic
  * linker takes care of initialization otherwise.
@@ -95,7 +93,7 @@ _start(void *auxv,
 	 * Digest the auxiliary vector for local use.
 	 *
 	 * Note: this file must be compile with -fno-jump-tables to avoid use
-	 * of the captable before do_crt_init_globals() has been called.
+	 * of the captable before crt_init_globals() has been called.
 	 */
 	for (Elf_Auxinfo *auxp = auxv; auxp->a_type != AT_NULL;  auxp++) {
 		if (auxp->a_type == AT_ARGV) {
@@ -116,13 +114,13 @@ _start(void *auxv,
 	/* For -pie executables rtld will initialize the __cap_relocs */
 #ifndef PIC
 	/*
-	 * crt_init_globals_3 must be called before accessing any globals.
+	 * crt_init_globals must be called before accessing any globals.
 	 *
 	 * Note: We parse the phdrs to ensure that the global data cap does
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		do_crt_init_globals(at_phdr, at_phnum);
+		crt_init_globals(at_phdr, at_phnum);
 #endif
 	/* We can access global variables/make function calls now. */
 


### PR DESCRIPTION
Since Morello LLVM is a complete mess with regards to the IFUNC ABI at the moment, having just merged a totally ABI-breaking change in the past few weeks with no concern for a transition path, this pulls out some cheribsdtest and csu cleanups/refactorings I made along the way from #1234 so we can at least get those in whilst we figure out what to do with Arm's mess. Once again they're not actually properly testing purecap things, we're the only ones to do so (including them running CheriBSD in that category since they just run our scripts), and so any holes in our testing (in this case, because we hadn't implemented support for it yet) are holes in their testing and that's where the breakage happens for us to later discover.