### PR TITLE
Fix fib4_lookup tag fault panics

### DIFF
--- a/lib/libc/stdlib/qsort.c
+++ b/lib/libc/stdlib/qsort.c
@@ -53,11 +53,6 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include "libc_private.h"
 
-#if __has_feature(capabilities)
-typedef __uintcap_t big_primitive_type;
-#else
-typedef long big_primitive_type;
-#endif
 #if defined(I_AM_QSORT_R)
 typedef int		 cmp_t(void *, const void *, const void *);
 #elif defined(I_AM_QSORT_S)
@@ -89,10 +84,10 @@ static inline void	 swapfunc(char *, char *, size_t, int, int);
 	es % sizeof(TYPE) ? 2 : es == sizeof(TYPE) ? 0 : 1;
 
 static inline void
-swapfunc( char *a, char *b, size_t n, int swaptype_big_primitive_type, int swaptype_int)
+swapfunc(char *a, char *b, size_t n, int swaptype_intcap_t, int swaptype_int)
 {
-	if (swaptype_big_primitive_type <= 1)
-		swapcode(big_primitive_type, a, b, n)
+	if (swaptype_intcap_t <= 1)
+		swapcode(intcap_t, a, b, n)
 	else if (swaptype_int <= 1)
 		swapcode(int, a, b, n)
 	else
@@ -100,19 +95,19 @@ swapfunc( char *a, char *b, size_t n, int swaptype_big_primitive_type, int swapt
 }
 
 #define	swap(a, b)					\
-	if (swaptype_big_primitive_type == 0) {			\
-		big_primitive_type t = *(big_primitive_type *)(a);			\
-		*(big_primitive_type *)(a) = *(big_primitive_type *)(b);		\
-		*(big_primitive_type *)(b) = t;			\
+	if (swaptype_intcap_t == 0) {			\
+		intcap_t t = *(intcap_t *)(a);		\
+		*(intcap_t *)(a) = *(intcap_t *)(b);	\
+		*(intcap_t *)(b) = t;			\
 	} else if (swaptype_int == 0) {			\
 		int t = *(int *)(a);			\
 		*(int *)(a) = *(int *)(b);		\
 		*(int *)(b) = t;			\
 	} else						\
-		swapfunc(a, b, es, swaptype_big_primitive_type, swaptype_int)
+		swapfunc(a, b, es, swaptype_intcap_t, swaptype_int)
 
 #define	vecswap(a, b, n)				\
-	if ((n) > 0) swapfunc(a, b, n, swaptype_big_primitive_type, swaptype_int)
+	if ((n) > 0) swapfunc(a, b, n, swaptype_intcap_t, swaptype_int)
 
 #if defined(I_AM_QSORT_R)
 #define	CMP(t, x, y) (cmp((t), (x), (y)))
@@ -149,10 +144,10 @@ local_qsort(void *a, size_t n, size_t es, cmp_t *cmp, void *thunk)
 	char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
 	size_t d1, d2;
 	int cmp_result;
-	int swaptype_big_primitive_type, swaptype_int, swap_cnt;
+	int swaptype_intcap_t, swaptype_int, swap_cnt;
 
 loop:
-	SWAPINIT(big_primitive_type, a, es);
+	SWAPINIT(intcap_t, a, es);
 	SWAPINIT(int, a, es);
 	swap_cnt = 0;
 	if (n < 7) {

--- a/sys/libkern/qsort.c
+++ b/sys/libkern/qsort.c
@@ -28,6 +28,18 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+/*
+ * CHERI CHANGES START
+ * {
+ *   "updated": 20181121,
+ *   "target_type": "lib",
+ *   "changes": [
+ *     "integer_provenance"
+ *   ],
+ *   "change_comment": "memswap"
+ * }
+ * CHERI CHANGES END
+ */
 
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
@@ -62,10 +74,10 @@ static inline void	 swapfunc(char *, char *, size_t, int, int);
 	es % sizeof(TYPE) ? 2 : es == sizeof(TYPE) ? 0 : 1;
 
 static inline void
-swapfunc(char *a, char *b, size_t n, int swaptype_long, int swaptype_int)
+swapfunc(char *a, char *b, size_t n, int swaptype_intcap_t, int swaptype_int)
 {
-	if (swaptype_long <= 1)
-		swapcode(long, a, b, n)
+	if (swaptype_intcap_t <= 1)
+		swapcode(intcap_t, a, b, n)
 	else if (swaptype_int <= 1)
 		swapcode(int, a, b, n)
 	else
@@ -73,19 +85,19 @@ swapfunc(char *a, char *b, size_t n, int swaptype_long, int swaptype_int)
 }
 
 #define	swap(a, b)					\
-	if (swaptype_long == 0) {			\
-		long t = *(long *)(a);			\
-		*(long *)(a) = *(long *)(b);		\
-		*(long *)(b) = t;			\
+	if (swaptype_intcap_t == 0) {			\
+		intcap_t t = *(intcap_t *)(a);		\
+		*(intcap_t *)(a) = *(intcap_t *)(b);	\
+		*(intcap_t *)(b) = t;			\
 	} else if (swaptype_int == 0) {			\
 		int t = *(int *)(a);			\
 		*(int *)(a) = *(int *)(b);		\
 		*(int *)(b) = t;			\
 	} else						\
-		swapfunc(a, b, es, swaptype_long, swaptype_int)
+		swapfunc(a, b, es, swaptype_intcap_t, swaptype_int)
 
 #define	vecswap(a, b, n)				\
-	if ((n) > 0) swapfunc(a, b, n, swaptype_long, swaptype_int)
+	if ((n) > 0) swapfunc(a, b, n, swaptype_intcap_t, swaptype_int)
 
 #ifdef I_AM_QSORT_R
 #define	CMP(t, x, y) (cmp((t), (x), (y)))
@@ -117,9 +129,9 @@ qsort(void *a, size_t n, size_t es, cmp_t *cmp)
 	char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
 	size_t d1, d2;
 	int cmp_result;
-	int swaptype_long, swaptype_int, swap_cnt;
+	int swaptype_intcap_t, swaptype_int, swap_cnt;
 
-loop:	SWAPINIT(long, a, es);
+loop:	SWAPINIT(intcap_t, a, es);
 	SWAPINIT(int, a, es);
 	swap_cnt = 0;
 	if (n < 7) {


### PR DESCRIPTION
This fixes qsort for CHERI kernels in order to fix fib4_lookup tag faults that have been plaguing my Morello purecap kernels if they receive packets between the time re0 comes up and the time re0's routes are set up. At least I hope so...

Also includes a cleanup to libc's qsort to be less unnecessarily verbose yet opaque (and fix a whitespace issue introduced in the original CHERIfication commit).