### PR TITLE
Retire no-longer-used extensions to ps_strings for sandboxes.

### DIFF
--- a/lib/libprocstat/core.c
+++ b/lib/libprocstat/core.c
@@ -111,12 +111,6 @@ struct _cap128_ps_strings {
 	int		ps_nargvstr;
 	cap128_t	ps_envstr __aligned(16);
 	int		ps_nenvstr;
-	cap128_t	ps_sbclasses __aligned(16);
-	size_t		ps_sbclasseslen;
-	cap128_t	ps_sbmethods __aligned(16);
-	size_t		ps_sbmethodslen;
-	cap128_t	ps_sbobjects __aligned(16);
-	size_t		ps_sbobjectslen;
 };
 typedef struct _cap128_ps_strings cap128_ps_strings_t;
 

--- a/sys/compat/freebsd32/freebsd32_util.h
+++ b/sys/compat/freebsd32/freebsd32_util.h
@@ -48,12 +48,6 @@ struct freebsd32_ps_strings {
 	int	ps_nargvstr;	/* the number of argument strings */
 	u_int32_t ps_envstr;	/* first of 0 or more environment strings */
 	int	ps_nenvstr;	/* the number of environment strings */
-	u_int32_t ps_sbclasses;		/* pointer to sandbox class data */
-	u_int32_t ps_sbclasseslen;	/* length of sandbox class data */
-	u_int32_t ps_sbmethods;		/* pointer to sandbox method data */
-	u_int32_t ps_sbmethodslen;	/* length of sandbox method data */
-	u_int32_t ps_sbobjects;		/* pointer to sandbox object data */
-	u_int32_t ps_sbobjectslen;	/* length of sandbox method data */
 };
 
 #if defined(__amd64__)

--- a/sys/compat/freebsd64/freebsd64_util.h
+++ b/sys/compat/freebsd64/freebsd64_util.h
@@ -48,12 +48,6 @@ struct freebsd64_ps_strings {
 	int		ps_nargvstr;
 	uint64_t	ps_envstr;
 	int		ps_nenvstr;
-	uint64_t	ps_sbclasses;
-	size_t		ps_sbclasseslen;
-	uint64_t	ps_sbmethods;
-	size_t		ps_sbmethodslen;
-	uint64_t	ps_sbobjects;
-	size_t		ps_sbobjectslen;
 };
 
 typedef struct {	/* Auxiliary vector entry on initial stack */

--- a/sys/sys/exec.h
+++ b/sys/sys/exec.h
@@ -52,24 +52,12 @@
  * pointers in ps_strings.  The kern.proc.args sysctl first tries p_args.
  * If p_args is NULL, it then falls back to reading ps_strings and following
  * the pointers.
- *
- * XXXRW: It appears this is safely extensible by appending new fields without
- * damaging the ABI.  However, good to confirm before upstreaming this change.
- *
- * XXXRW: Although it is not strictly required for CHERI, I have made similar
- * changes to freebsd32_ps_strings.
  */
 struct ps_strings {
 	char * __kerncap * __kerncap ps_argvstr; /* first of 0 or more argument strings */
 	unsigned int ps_nargvstr; /* the number of argument strings */
 	char * __kerncap * __kerncap ps_envstr;	/* first of 0 or more environment strings */
 	unsigned int ps_nenvstr; /* the number of environment strings */
-	void * __kerncap ps_sbclasses;	/* pointer to sandbox class data */
-	size_t	 ps_sbclasseslen;	/* length of sandbox class data */
-	void * __kerncap ps_sbmethods;	/* pointer to sandbox method data */
-	size_t	 ps_sbmethodslen;	/* length of sandbox method data */
-	void * __kerncap ps_sbobjects;	/* pointer to sandbox object data */
-	size_t	 ps_sbobjectslen;	/* length of sandbox object data */
 };
 
 /* Coredump output parameters. */


### PR DESCRIPTION
Presumably we probably would not want to use ps_strings in the future
if we needed to resurrect this but would instead add new ELF auxiliary
vector entries.