### PR TITLE
arm64: Adjust ELR for ddb backtraces to include the C64 LSB

### DIFF
--- a/sys/arm64/arm64/db_trace.c
+++ b/sys/arm64/arm64/db_trace.c
@@ -123,6 +123,11 @@ db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 
 			frame->fp = tf->tf_x[29];
 			frame->pc = tf->tf_elr;
+#if __has_feature(capabilities)
+			/* Make ELR look like LR regarding the C64 LSB */
+			if ((tf->tf_spsr & PSR_C64) != 0)
+				frame->pc |= 0x1;
+#endif
 			if (!INKERNEL(frame->fp))
 				break;
 		} else {


### PR DESCRIPTION
BL(R) sets the LSB in LR, but for exceptions the LSB ends up in SPSR
instead with ELR's LSB always 0. Fix this up so exception frames look
like normal frames, otherwise ddb-computed function offsets show up as
off by one.
