### PR TITLE
libmd: Add +crypto to -march for sha512c_arm64.c

### DIFF
--- a/lib/libmd/Makefile
+++ b/lib/libmd/Makefile
@@ -137,7 +137,7 @@ CFLAGS+= -DARM64_SHA2
 CFLAGS.sha256c_arm64.c+= ${CFLAGS_CRYPTO}
 .if ${COMPILER_FEATURES:Maarch64-sha512}
 SRCS+=	sha512c_arm64.c
-CFLAGS_SHA3:=	${CFLAGS:M-march=*:S/^$/-march=armv8.2-a/W:[-1]}+sha3
+CFLAGS_SHA3:=	${CFLAGS:M-march=*:S/^$/-march=armv8.2-a/W:[-1]}+crypto+sha3
 CFLAGS+= -DARM64_SHA512
 CFLAGS.sha512c_arm64.c+= ${CFLAGS_SHA3}
 .endif # aarch64-sha512


### PR DESCRIPTION
Versions of CHERI/Morello LLVM that include the April upstream merge but
not the September upstream merge have a snapshot in the middle of the 13
cycle that includes the SHA512 intrinsics but does not (bogusly) lump
them under __ARM_FEATURE_SHA3. Add +crypto to -march to support these
older compilers.