### PR TITLE
Add fueptr and suptr.

### DIFF
--- a/sys/dev/usb/usb_generic.c
+++ b/sys/dev/usb/usb_generic.c
@@ -1084,7 +1084,7 @@ ugen_fs_getbuffer(void * __capability *uptrp, struct usb_fifo *f,
 	u.ppBuffer = buffer;
 	switch (f->fs_ep_sz) {
 	case sizeof(struct usb_fs_endpoint):
-		if (fuecap(u.ppBuffer + n, (uintcap_t *)uptrp) != 0)
+		if (fueptr(u.ppBuffer + n, (uintcap_t *)uptrp) != 0)
 			return (EFAULT);
 		return (0);
 #ifdef COMPAT_FREEBSD32

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1398,7 +1398,7 @@ get_argenv_ptr(void * __capability *arrayp, void * __capability *ptrp)
 	} else
 #endif
 	{
-		if (fuecap(array, &ptr) == -1)
+		if (fueptr(array, &ptr) == -1)
 			return (EFAULT);
 		array += sizeof(ptr);
 		*ptrp = (void * __capability)ptr;
@@ -1925,7 +1925,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 #else
 	imgp->argv = vectp;
 #endif
-	if (sucap(&arginfo->ps_argvstr, (intcap_t)imgp->argv) != 0 ||
+	if (suptr(&arginfo->ps_argvstr, (intcap_t)imgp->argv) != 0 ||
 	    suword32(&arginfo->ps_nargvstr, argc) != 0)
 		return (EFAULT);
 
@@ -1938,7 +1938,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		if (sucap(vectp++, cheri_setbounds(ustringp, len)) != 0)
 			return (EFAULT);
 #else
-		if (suword(vectp++, ustringp) != 0)
+		if (suptr(vectp++, ustringp) != 0)
 			return (EFAULT);
 #endif
 		stringp += len;
@@ -1954,7 +1954,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 #else
 	imgp->envv = vectp;
 #endif
-	if (sucap(&arginfo->ps_envstr, (intcap_t)imgp->envv) != 0 ||
+	if (suptr(&arginfo->ps_envstr, (intcap_t)imgp->envv) != 0 ||
 	    suword32(&arginfo->ps_nenvstr, envc) != 0)
 		return (EFAULT);
 
@@ -1967,7 +1967,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		if (sucap(vectp++, cheri_setbounds(ustringp, len)) != 0)
 			return (EFAULT);
 #else
-		if (suword(vectp++, ustringp) != 0)
+		if (suptr(vectp++, ustringp) != 0)
 			return (EFAULT);
 #endif
 		stringp += len;

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -5486,7 +5486,7 @@ umtx_read_uptr(struct thread *td, uintcap_t ptr, uintcap_t *res, bool compat32)
 	} else
 #endif
 	{
-		error = fuecap((void * __capability)ptr, &res1);
+		error = fueptr((void * __capability)ptr, &res1);
 	}
 	if (error == 0)
 		*res = res1;

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1483,7 +1483,7 @@ aiocb_store_kernelinfo(void * __capability ujobp, long jobref)
 	struct aiocb * __capability ujob;
 
 	ujob = ujobp;
-	return (sucap(&ujob->_aiocb_private.kernelinfo, jobref));
+	return (suptr(&ujob->_aiocb_private.kernelinfo, jobref));
 }
 
 static int
@@ -1491,7 +1491,7 @@ aiocb_store_aiocb(struct aiocb ** __capability ujobp,
     struct aiocb * __capability ujob)
 {
 
-	return (sucap(ujobp, (intcap_t)ujob));
+	return (suptr(ujobp, (intcap_t)ujob));
 }
 
 static size_t

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -530,8 +530,9 @@ int32_t	fuword32(volatile const void * __capability base);
 int64_t	fuword64(volatile const void * __capability base);
 #if __has_feature(capabilities)
 int	fuecap(volatile const void * __capability base, intcap_t *val);
+#define	fueptr			fuecap
 #else
-#define	fuecap(base, val)		fueword((base), (long *)(val))
+#define	fueptr(base, val)	fueword((base), (long *)(val))
 #endif
 int	fueword(volatile const void * __capability base, long *val);
 int	fueword32(volatile const void * __capability base, int32_t *val);
@@ -543,8 +544,9 @@ int	suword32(volatile void * __capability base, int32_t word);
 int	suword64(volatile void * __capability base, int64_t word);
 #if __has_feature(capabilities)
 int	sucap(volatile const void * __capability base, intcap_t val);
+#define	suptr			sucap
 #else
-#define	sucap		suword
+#define	suptr			suword
 #endif
 uint32_t casuword32(volatile uint32_t * __capability base, uint32_t oldval,
 	    uint32_t newval);


### PR DESCRIPTION
In places that work with user pointers and not specifically capabilities,
use fueptr and suptr instead of fuecap and sucap.  fuecap and sucap are
now only declared in CHERI kernels (hybrid or purecap).