### PR TITLE
Add missing MII_PHY_ENDs to avoid buffer overreads on probe

### DIFF
--- a/sys/dev/mii/dp83822phy.c
+++ b/sys/dev/mii/dp83822phy.c
@@ -86,7 +86,8 @@ struct dp83822_softc {
 };
 
 static const struct mii_phydesc dpphys[] = {
-	MII_PHY_DESC(xxTI, DP83822)
+	MII_PHY_DESC(xxTI, DP83822),
+	MII_PHY_END
 };
 
 static const struct mii_phy_funcs dpphy_funcs = {

--- a/sys/dev/mii/dp83867phy.c
+++ b/sys/dev/mii/dp83867phy.c
@@ -101,7 +101,8 @@ struct dp83867_softc {
 };
 
 static const struct mii_phydesc dpphys[] = {
-	MII_PHY_DESC(xxTI, DP83867)
+	MII_PHY_DESC(xxTI, DP83867),
+	MII_PHY_END
 };
 
 static const struct mii_phy_funcs dpphy_funcs = {


### PR DESCRIPTION
Doesn't show in CI since vtnet isn't a real MAC with a PHY. This shows up on any hardware with a real MAC+PHY combo regardless of the PHY since every probe gets its turn, including both broken ones (and since more than one is broken, at least one won't match and thus try and walk off the end).
