### PR TITLE
kldxref: Stub out R_MORELLO_CAPINIT on morello like R_AARCH64_ABS64

### DIFF
--- a/usr.sbin/kldxref/ef_aarch64.c
+++ b/usr.sbin/kldxref/ef_aarch64.c
@@ -79,6 +79,8 @@ ef_reloc(struct elf_file *ef, const void *reldata, int reltype, Elf_Off relbase,
 		*((void * __capability *)where) = cheri_fromint(fragment[0] +
 		    relbase + addend);
 		break;
+	case R_MORELLO_CAPINIT:
+		break;
 #endif
 	default:
 		warnx("unhandled relocation type %lu", rtype);


### PR DESCRIPTION
The current implementation of R_AARCH64_ABS64 doesn't do anything, which
is dodgy, but seems to not matter, so do the same for the equivalent
R_MORELLO_CAPINIT to silence the unhandled relocation warning.
