### PR TITLE
Kernel mips cleanup

### DIFF
--- a/sys/cddl/dev/dtrace/mips/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/mips/dtrace_isa.c
@@ -81,16 +81,24 @@ dtrace_getpcstack(pc_t *pcstack, int pcstack_limit, int aframes,
 	int depth = 0;
 	vm_offset_t callpc;
 	pc_t caller = (pc_t) solaris_cpu[curcpu].cpu_dtrace_caller;
-	register_t pc, sp;
+	register_t sp, ra, pc;
 
 	if (intrpc != 0)
 		pcstack[depth++] = (pc_t) intrpc;
 
 	aframes++;
 
-	pc = (intptr_t)&&here;
 	sp = (register_t)(intptr_t)__builtin_frame_address(0);
-here:
+	ra = (register_t)(intptr_t)__builtin_return_address(0);
+
+       	__asm __volatile(
+		"jal 99f\n"
+		"nop\n"
+		"99:\n"
+		"move %0, $31\n" /* get ra */
+		"move $31, %1\n" /* restore ra */
+		: "=r" (pc)
+		: "r" (ra));
 
 	while (depth < pcstack_limit) {
 
@@ -210,14 +218,22 @@ uint64_t
 dtrace_getarg(int arg, int aframes)
 {
 	int i;
-	register_t pc, sp;
+	register_t sp, ra, pc;
 	/* XXX: Fix this ugly code */
 	register_t args[8];
 	int valid[8];
 
-	pc = (intptr_t)&&here;
 	sp = (register_t)(intptr_t)__builtin_frame_address(0);
-here:
+	ra = (register_t)(intptr_t)__builtin_return_address(0);
+
+       	__asm __volatile(
+		"jal 99f\n"
+		"nop\n"
+		"99:\n"
+		"move %0, $31\n" /* get ra */
+		"move $31, %1\n" /* restore ra */
+		: "=r" (pc)
+		: "r" (ra));
 
 	for (i = 0; i <= aframes + 1; i++) {
 		if (dtrace_next_frame(&pc, &sp, args, valid) < 0) {
@@ -239,12 +255,20 @@ here:
 int
 dtrace_getstackdepth(int aframes)
 {
-	register_t pc, sp;
+	register_t sp, ra, pc;
 	int depth = 0;
 
-	pc = (intptr_t)&&here;
 	sp = (register_t)(intptr_t)__builtin_frame_address(0);
-here:
+	ra = (register_t)(intptr_t)__builtin_return_address(0);
+
+       	__asm __volatile(
+		"jal 99f\n"
+		"nop\n"
+		"99:\n"
+		"move %0, $31\n" /* get ra */
+		"move $31, %1\n" /* restore ra */
+		: "=r" (pc)
+		: "r" (ra));
 
 	for (;;) {
 		if (dtrace_next_frame(&pc, &sp, NULL, NULL) < 0)

--- a/sys/cddl/dev/dtrace/mips/dtrace_subr.c
+++ b/sys/cddl/dev/dtrace/mips/dtrace_subr.c
@@ -221,7 +221,7 @@ dtrace_trap(struct trapframe *frame, u_int type)
 				    (intmax_t)frame->pc, (intmax_t)frame->badvaddr);
 			}
 			else
- 				TRAPF_PC_INCREMENT(frame, sizeof(int));
+				frame->pc += sizeof(int);
 			return (1);
 		default:
 			/* Handle all other traps in the usual way. */
@@ -250,7 +250,7 @@ dtrace_invop_start(struct trapframe *frame)
 	int16_t offs;
 	int invop;
 
-	invop = dtrace_invop(TRAPF_PC(frame), frame, TRAPF_PC(frame));
+	invop = dtrace_invop(frame->pc, frame, frame->pc);
 	if (invop == 0)
 		return (-1);
 
@@ -260,11 +260,11 @@ dtrace_invop_start(struct trapframe *frame)
 	switch (invop & LDSD_RA_SP_MASK) {
 	case LD_RA_SP:
 		frame->ra = *sp;
-		TRAPF_PC_INCREMENT(frame, INSN_SIZE);
+		frame->pc += INSN_SIZE;
 		break;
 	case SD_RA_SP:
 		*(sp) = frame->ra;
-		TRAPF_PC_INCREMENT(frame, INSN_SIZE);
+		frame->pc += INSN_SIZE;
 		break;
 	default:
 		printf("%s: 0x%x undefined\n", __func__, invop);

--- a/sys/conf/kern.post.mk
+++ b/sys/conf/kern.post.mk
@@ -191,17 +191,6 @@ gdbinit:
 .endif
 .endif
 
-CTFFLAGS_KERNEL=${CTFFLAGS}
-.if ${MACHINE_CPUARCH} == "mips"
-# For mips, the CTF section is generated from the symbols in `.dynsym`.
-# `.dymsym` only contains a subset of the `.symtab` symbols, needed for
-# dynamic linking. This flag is needed because the `.symtab` section is not
-# loaded at boot time, and its address is not available anywhere without a
-# proper bootloader.
-# The problem can be solved looking at |sys/mips/mips/elf_trampoline.c|.
-CTFFLAGS_KERNEL+=-s
-.endif
-
 ${FULLKERNEL}: ${SYSTEM_DEP} vers.o
 	@rm -f ${.TARGET}
 	@echo linking ${.TARGET}
@@ -210,8 +199,8 @@ ${FULLKERNEL}: ${SYSTEM_DEP} vers.o
 	@sh ${S}/tools/embed_mfs.sh ${.TARGET} ${MFS_IMAGE}
 .endif
 .if ${MK_CTF} != "no"
-	@echo ${CTFMERGE} ${CTFFLAGS_KERNEL} -o ${.TARGET} ...
-	@${CTFMERGE} ${CTFFLAGS_KERNEL} -o ${.TARGET} ${SYSTEM_OBJS} vers.o
+	@echo ${CTFMERGE} ${CTFFLAGS} -o ${.TARGET} ...
+	@${CTFMERGE} ${CTFFLAGS} -o ${.TARGET} ${SYSTEM_OBJS} vers.o
 .endif
 .if !defined(DEBUG)
 	${OBJCOPY} --strip-debug ${.TARGET}

--- a/sys/ddb/db_print.c
+++ b/sys/ddb/db_print.c
@@ -43,7 +43,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/proc.h>
 
 #include <machine/pcb.h>
-#include <machine/vmparam.h>
 
 #include <ddb/ddb.h>
 #include <ddb/db_variables.h>
@@ -81,23 +80,6 @@ db_show_regs(db_expr_t _1, bool _2, db_expr_t _3, char *modif)
 			continue;
 		db_printf("%-12s%#*lr", regp->name,
 		    (int)(sizeof(unsigned long) * 2 + 2), (unsigned long)value);
-#ifdef __mips__
-		if (value >= VM_MAXUSER_ADDRESS) {
-#if __has_feature(capabilities)
-			if ((value % sizeof(void * __capability)) == 0)
-				db_printf("\t(capability-aligned)");
-			else
-#endif
-			if ((value % 8) == 0)
-				db_printf("\t(dword-aligned)");
-			else if ((value % 4) == 0)
-				db_printf("\t(word-aligned)");
-			else if ((value % 2) == 0)
-				db_printf("\t(halfword-aligned)");
-			else
-				db_printf("\t(unaligned)");
-		}
-#endif
 		db_find_xtrn_sym_and_offset((db_addr_t)value, &name, &offset);
 		if (name != NULL && offset <= (unsigned long)db_maxoff &&
 		    offset != value) {


### PR DESCRIPTION
Removes remaining MIPS-specific local diffs outside of DTS files and sys/dev/altera.