### PR TITLE
Widen procstat 'EMUL' field to make room for 'FreeBSD ELF64C’.

### DIFF
--- a/usr.bin/procstat/procstat_basic.c
+++ b/usr.bin/procstat/procstat_basic.c
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
- * Copyright (c) 2007 Robert N. M. Watson
+ * Copyright (c) 2007, 2022 Robert N. M. Watson
  * Copyright (c) 2015 Allan Jude <allanjude@freebsd.org>
  * All rights reserved.
  *
@@ -46,7 +46,7 @@ procstat_basic(struct procstat *procstat __unused, struct kinfo_proc *kipp)
 {
 
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0)
-		xo_emit("{T:/%5s %5s %5s %5s %5s %3s %-8s %-9s %-13s %-12s}\n",
+		xo_emit("{T:/%5s %5s %5s %5s %5s %3s %-8s %-9s %-14s %-12s}\n",
 		    "PID", "PPID", "PGID", "SID", "TSID", "THR", "LOGIN",
 		    "WCHAN", "EMUL", "COMM");
 
@@ -65,7 +65,7 @@ procstat_basic(struct procstat *procstat __unused, struct kinfo_proc *kipp)
 		xo_emit("{:wait_channel/%-9s/%s} ", strlen(kipp->ki_wmesg) ?
 		    kipp->ki_wmesg : "-");
 	}
-	xo_emit("{:emulation/%-13s/%s} ", strcmp(kipp->ki_emul, "null") ?
+	xo_emit("{:emulation/%-14s/%s} ", strcmp(kipp->ki_emul, "null") ?
 	    kipp->ki_emul : "-");
 	xo_emit("{:command/%-12s/%s}\n", kipp->ki_comm);
 }


### PR DESCRIPTION
‘FreeBSD ELF64C’ is one character longer than the previous longest ABI string supported by procstat(1), leading to a poorly aligned following column. Perhaps more ideally the field would be autosized, but for now just shift everything one character over.