### PR TITLE
Explicitly clear a pointer to the next free block.

### DIFF
--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -263,6 +263,20 @@ __tls_malloc(size_t nbytes)
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;
 	TLS_MALLOC_UNLOCK;
+	/*
+	 * XXXKW: Set an ov_next capability to a NULL capability without any
+	 * permissions.
+	 *
+	 * Based on a tag and permissions of ov_next, find_overhead() determines
+	 * if an allocation is aligned. The QEMU user mode for CheriABI doesn't
+	 * implement tagged memory and find_overhead() might incorrectly assume
+	 * the allocation is aligned because of a non-cleared tag. Having the
+	 * permissions cleared, find_overhead() behaves as expected under the
+	 * user mode.
+	 *
+	 * This is a workaround and should be reverted once the user mode
+	 * implements tagged memory.
+	 */
 	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -264,7 +264,7 @@ __tls_malloc(size_t nbytes)
 	nextf[bucket] = op->ov_next;
 	TLS_MALLOC_UNLOCK;
 	/*
-	 * XXXKW: Set an ov_next capability to a NULL capability without any
+	 * XXXQEMU: Set an ov_next capability to a NULL capability, clearing any
 	 * permissions.
 	 *
 	 * Based on a tag and permissions of ov_next, find_overhead() determines

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -263,6 +263,7 @@ __tls_malloc(size_t nbytes)
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;
 	TLS_MALLOC_UNLOCK;
+	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
 	return (op + 1);

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -173,6 +173,7 @@ __simple_malloc_unaligned(size_t nbytes)
 	}
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;
+	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
 	return (op + 1);

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -173,6 +173,20 @@ __simple_malloc_unaligned(size_t nbytes)
 	}
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;
+	/*
+	 * XXXKW: Set an ov_next capability to a NULL capability without any
+	 * permissions.
+	 *
+	 * Based on a tag and permissions of ov_next, find_overhead() determines
+	 * if an allocation is aligned. The QEMU user mode for CheriABI doesn't
+	 * implement tagged memory and find_overhead() might incorrectly assume
+	 * the allocation is aligned because of a non-cleared tag. Having the
+	 * permissions cleared, find_overhead() behaves as expected under the
+	 * user mode.
+	 *
+	 * This is a workaround and should be reverted once the user mode
+	 * implements tagged memory.
+	 */
 	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -174,7 +174,7 @@ __simple_malloc_unaligned(size_t nbytes)
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;
 	/*
-	 * XXXKW: Set an ov_next capability to a NULL capability without any
+	 * XXXQEMU: Set an ov_next capability to a NULL capability, clearing any
 	 * permissions.
 	 *
 	 * Based on a tag and permissions of ov_next, find_overhead() determines

--- a/libexec/rtld-elf/rtld_malloc.c
+++ b/libexec/rtld-elf/rtld_malloc.c
@@ -145,6 +145,20 @@ __crt_malloc(size_t nbytes)
 	}
 	/* remove from linked list */
   	nextf[bucket] = op->ov_next;
+	/*
+	 * XXXKW: Set an ov_next capability to a NULL capability without any
+	 * permissions.
+	 *
+	 * Based on a tag and permissions of ov_next, find_overhead() determines
+	 * if an allocation is aligned. The QEMU user mode for CheriABI doesn't
+	 * implement tagged memory and find_overhead() might incorrectly assume
+	 * the allocation is aligned because of a non-cleared tag. Having the
+	 * permissions cleared, find_overhead() behaves as expected under the
+	 * user mode.
+	 *
+	 * This is a workaround and should be reverted once the user mode
+	 * implements tagged memory.
+	 */
 	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;

--- a/libexec/rtld-elf/rtld_malloc.c
+++ b/libexec/rtld-elf/rtld_malloc.c
@@ -146,7 +146,7 @@ __crt_malloc(size_t nbytes)
 	/* remove from linked list */
   	nextf[bucket] = op->ov_next;
 	/*
-	 * XXXKW: Set an ov_next capability to a NULL capability without any
+	 * XXXKW: Set an ov_next capability to a NULL capability, clearing any
 	 * permissions.
 	 *
 	 * Based on a tag and permissions of ov_next, find_overhead() determines

--- a/libexec/rtld-elf/rtld_malloc.c
+++ b/libexec/rtld-elf/rtld_malloc.c
@@ -146,7 +146,7 @@ __crt_malloc(size_t nbytes)
 	/* remove from linked list */
   	nextf[bucket] = op->ov_next;
 	/*
-	 * XXXKW: Set an ov_next capability to a NULL capability, clearing any
+	 * XXXQEMU: Set an ov_next capability to a NULL capability, clearing any
 	 * permissions.
 	 *
 	 * Based on a tag and permissions of ov_next, find_overhead() determines

--- a/libexec/rtld-elf/rtld_malloc.c
+++ b/libexec/rtld-elf/rtld_malloc.c
@@ -145,6 +145,7 @@ __crt_malloc(size_t nbytes)
 	}
 	/* remove from linked list */
   	nextf[bucket] = op->ov_next;
+	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
   	return ((char *)(op + 1));


### PR DESCRIPTION
find_overhead() checks if overhead.ov_next is tagged and stores an
internal allocator pointer (has the CHERI_PERM_CHERIABI_VMMAP
permission). In malloc(), a tag of overhead.ov_next should be cleared
with an integer store to overhead.ovu.ovu_magic and find_overhead()
shouldn't consider overhead.ov_next to find an overhead of an aligned
allocation.

Currently, we don't implement tagged memory in the QEMU user mode
leaving tags valid. This behaviour breaks the above logic as
overhead.ov_next remains valid after malloc().

In order to make the user mode work, set overhead.ov_next to NULL.
While it doesn't change a tag of the pointer in the user mode,
it also clears permissions of it, making find_overhead() work as
expected.

Note that this is a workaround for the real issue: we must implement
tagged memory in the user mode.