### PR TITLE
Add a pkg repository configuration for CheriBSD.

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -79,6 +79,20 @@
 #define __FreeBSD_version 1400053
 
 /*
+ * __CheriBSD_version numbers describe CheriBSD ABIs.
+ *
+ * Encoding:	<YYYY><MM><DD>
+ *
+ * __CheriBSD_version is bumped with every ABI change. This includes the
+ * kernel's KBI and the base system's ABI, similarly to __FreeBSD_version.
+ * The separate __CheriBSD_version counter was introduced to allow external
+ * software still use __FreeBSD_version which is independently incremented in
+ * FreeBSD.
+ */
+#undef __CheriBSD_version
+#define __CheriBSD_version 20220314
+
+/*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,
  * which by definition is always true on FreeBSD. This macro is also defined
  * on other systems that use the kernel of FreeBSD, such as GNU/kFreeBSD.

--- a/usr.sbin/pkg/CheriBSD.conf
+++ b/usr.sbin/pkg/CheriBSD.conf
@@ -1,0 +1,15 @@
+#
+# To disable this repository, instead of modifying or removing this file,
+# create a /usr/local/etc/pkg/repos/CheriBSD.conf file:
+#
+#   mkdir -p /usr/local/etc/pkg/repos
+#   echo "CheriBSD: { enabled: no }" > /usr/local/etc/pkg/repos/CheriBSD.conf
+#
+
+CheriBSD: {
+  url: "pkg+http://pkg.CheriBSD.org/${ABI}",
+  mirror_type: "srv",
+  signature_type: "fingerprints",
+  fingerprints: "/usr/share/keys/pkg",
+  enabled: yes
+}

--- a/usr.sbin/pkg/Makefile
+++ b/usr.sbin/pkg/Makefile
@@ -1,23 +1,10 @@
 # $FreeBSD$
 
+.include <src.opts.mk>
+
 PACKAGE=	pkg-bootstrap
 
-_BRANCH!=	${MAKE} -C ${SRCTOP}/release -V BRANCH
-BRANCH?=	${_BRANCH}
-.if ${BRANCH:MCURRENT} != ""
-PKGCONFBRANCH?=	latest
-.else
-. if ${BRANCH:MBETA*} || ${BRANCH:MRC*} || ${BRANCH:MRELEASE*}
-PKGCONFBRANCH?=	quarterly
-. else
-.  if ${MACHINE} != "amd64" && ${MACHINE} != "i386"
-PKGCONFBRANCH?=	quarterly
-.  else
-PKGCONFBRANCH?=	latest
-.  endif
-. endif
-.endif
-PKGCONF?=	FreeBSD.conf.${PKGCONFBRANCH}
+PKGCONF?=	CheriBSD.conf
 CONFS=		${PKGCONF}
 CONFSNAME_${PKGCONF}=	${PKGCONF:C/\.conf.+$/.conf/}
 CONFSDIR=	/etc/pkg${PKG_SUFFIX}

--- a/usr.sbin/pkg/config.c
+++ b/usr.sbin/pkg/config.c
@@ -66,7 +66,7 @@ static struct config_entry c[] = {
 	[PACKAGESITE] = {
 		PKG_CONFIG_STRING,
 		"PACKAGESITE",
-		URL_SCHEME_PREFIX "http://pkg.FreeBSD.org/${ABI}/latest",
+		URL_SCHEME_PREFIX "http://pkg.CheriBSD.org/${ABI}",
 		NULL,
 		NULL,
 		false,
@@ -149,14 +149,9 @@ static struct config_entry c[] = {
 static int
 pkg_get_myabi(char *dest, size_t sz)
 {
-	struct utsname uts;
 	char machine_arch[255];
 	size_t len;
 	int error;
-
-	error = uname(&uts);
-	if (error)
-		return (errno);
 
 	len = sizeof(machine_arch);
 	error = sysctlbyname("hw.machine_arch", machine_arch, &len, NULL, 0);
@@ -164,12 +159,7 @@ pkg_get_myabi(char *dest, size_t sz)
 		return (errno);
 	machine_arch[len] = '\0';
 
-	/*
-	 * Use __FreeBSD_version rather than kernel version (uts.release) for
-	 * use in jails. This is equivalent to the value of uname -U.
-	 */
-	snprintf(dest, sz, "%s:%d:%s", uts.sysname, __FreeBSD_version/100000,
-	    machine_arch);
+	snprintf(dest, sz, "CheriBSD:%d:%s", __CheriBSD_version, machine_arch);
 
 	return (error);
 }


### PR DESCRIPTION
pkg for CheriABI can detect aarch64c and riscv64c ABIs [0] and the ports-mgmt/pkg port includes this change [1] now. Since pkg should be ready to bootstrap itself, it's a good moment to add a repository configuration for CheriBSD packages. They're not available on pkg.CheriBSD.org yet but we should be able to host them in the following days. Fingerprints should be added the the repository by @gvnn3 as they must be generated on the host the packages are built, in a secure way.

[0] https://github.com/CTSRD-CHERI/pkg/commit/386a364fc65aa3d2285318b9dbdaa6da0a6d78fc
[1] https://github.com/CTSRD-CHERI/cheribsd-ports/commit/4c64703ac643132e5ff052a30b2203ed13ac176c