### PR TITLE
Revert "Add /fett/bin to the default path."

### DIFF
--- a/usr.bin/login/login.conf
+++ b/usr.bin/login/login.conf
@@ -28,7 +28,7 @@ default:\
 	:welcome=/var/run/motd:\
 	:setenv=BLOCKSIZE=K:\
 	:mail=/var/mail/$:\
-	:path=/fett/bin /sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin ~/bin:\
+	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin ~/bin:\
 	:nologin=/var/run/nologin:\
 	:cputime=unlimited:\
 	:datasize=unlimited:\


### PR DESCRIPTION
FETT is long over and we don't need to support it.

This reverts commit 5a54021a9ddf6030edd4cd7def602c17b1a33902.