### PR TITLE
ue: Add subobject annotation for struct ether_cfg_task subclass.

### DIFF
--- a/sys/dev/usb/net/usb_ethernet.h
+++ b/sys/dev/usb/net/usb_ethernet.h
@@ -70,7 +70,7 @@ struct usb_ether_methods {
 };
 
 struct usb_ether_cfg_task {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct usb_ether *ue;
 };
 


### PR DESCRIPTION
struct ether_cf_task extends struct usb_proc_msg and the driver needs
to downcast.