### PR TITLE
Remove duplicate code that clears `tpidr[ro]`

### DIFF
--- a/sys/arm64/arm64/exec_machdep.c
+++ b/sys/arm64/arm64/exec_machdep.c
@@ -500,11 +500,6 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 	WRITE_SPECIALREG_CAP(rctpidr_el0, 0);
 #endif
 
-	td->td_pcb->pcb_tpidr_el0 = 0;
-	td->td_pcb->pcb_tpidrro_el0 = 0;
-	WRITE_SPECIALREG(tpidrro_el0, 0);
-	WRITE_SPECIALREG(tpidr_el0, 0);
-
 #ifdef VFP
 	vfp_reset_state(td, pcb);
 #endif


### PR DESCRIPTION
The removed code duplicates the code starting at line 483.