### PR TITLE
Reorganise arm64 assembly code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,15 +28,15 @@ def jobProperties = [
         copyArtifactPermission('*'), // Downstream jobs (may) need the kernels/disk images
         rateLimit,
 ]
-// Don't archive sysroot/disk image/kernel images for pull requests and non-default branches:
+// Don't archive sysroot/disk image/kernel images for pull requests and non-default/releng branches:
 def archiveBranches = ['main', 'master', 'dev']
-if (!env.CHANGE_ID && archiveBranches.contains(env.BRANCH_NAME)) {
+if (!env.CHANGE_ID && (archiveBranches.contains(env.BRANCH_NAME) || env.BRANCH_NAME.startsWith('releng/'))) {
     if (!GlobalVars.isTestSuiteJob) {
         // Don't archive disk images for the test suite job
         GlobalVars.archiveArtifacts = true
     }
-    // For branches other than the master/main branch, only keep the last two artifacts to save disk space
-    if (env.BRANCH_NAME != 'main' && env.BRANCH_NAME != 'master') {
+    // For branches other than the master/main and releng branches, only keep the last two artifacts to save disk space
+    if (env.BRANCH_NAME != 'main' && env.BRANCH_NAME != 'master' && !env.BRANCH_NAME.startsWith('releng/')) {
         jobProperties.add(buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2')))
     }
 }

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -237,9 +237,9 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	cmp	x3, x4
 	b.ne	1f			/* dtv[0] != tlsdec->dtv_gen */
 
-	ldr	w2, [c1, #16]		/* tlsdesc->tls_index */
-	add	w2, w2, #1
-	ldr     c3, [c0, w2, sxtw #4]	/* dtv[tlsdesc->tls_index + 1] */
+	ldr	w3, [c1, #16]		/* tlsdesc->tls_index */
+	add	w3, w3, #1
+	ldr     c3, [c0, w3, sxtw #4]	/* dtv[tlsdesc->tls_index + 1] */
 	cbz	x3, 1f
 
 	/* Return (dtv[tlsdesc->tls_index + 1] + tlsdesc->tls_offs) */

--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -256,11 +256,6 @@ DEBUGMKDIR=
 .else
 SHLIB_NAME_FULL=${SHLIB_NAME}
 .endif
-.if defined(STRIP) && !empty(STRIP)
-SHLIB_NAME_INSTALL=${SHLIB_NAME}.stripped
-.else
-SHLIB_NAME_INSTALL=${SHLIB_NAME}
-.endif
 .endif
 
 .include <bsd.symver.mk>
@@ -323,7 +318,7 @@ CLEANFILES+=	${SOBJS}
 .endif
 
 .if defined(SHLIB_NAME)
-_LIBS+=		${SHLIB_NAME_INSTALL}
+_LIBS+=		${SHLIB_NAME}
 
 SOLINKOPTS+=	-shared -Wl,-x
 .if !defined(ALLOW_SHARED_TEXTREL)
@@ -369,7 +364,7 @@ ${SHLIB_NAME_FULL}: ${SOBJS}
 .endif
 
 .if ${MK_DEBUG_FILES} != "no"
-CLEANFILES+=	${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug ${SHLIB_NAME}.stripped
+CLEANFILES+=	${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug
 ${SHLIB_NAME}: ${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug
 	${OBJCOPY} --strip-debug --add-gnu-debuglink=${SHLIB_NAME}.debug \
 	    ${SHLIB_NAME_FULL} ${.TARGET}
@@ -380,11 +375,6 @@ ${SHLIB_NAME}: ${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug
 
 ${SHLIB_NAME}.debug: ${SHLIB_NAME_FULL}
 	${OBJCOPY} --only-keep-debug ${SHLIB_NAME_FULL} ${.TARGET}
-.endif
-
-.if ${SHLIB_NAME} != ${SHLIB_NAME_INSTALL}
-${SHLIB_NAME_INSTALL}: ${SHLIB_NAME}
-	${STRIPBIN} -o ${.TARGET} ${STRIP_FLAGS} ${SHLIB_NAME}
 .endif
 .endif #defined(SHLIB_NAME)
 
@@ -507,7 +497,7 @@ _libinstall:
 .if defined(SHLIB_NAME)
 	${INSTALL} ${TAG_ARGS} -o ${LIBOWN} -g ${LIBGRP} -m ${LIBMODE} \
 	    ${_INSTALLFLAGS} ${_SHLINSTALLFLAGS} \
-	    ${SHLIB_NAME_INSTALL} ${DESTDIR}${_SHLIBDIR}/${SHLIB_NAME}
+	    ${SHLIB_NAME} ${DESTDIR}${_SHLIBDIR}
 .if ${MK_DEBUG_FILES} != "no"
 .if defined(DEBUGMKDIR)
 	${INSTALL} ${TAG_ARGS:D${TAG_ARGS},dbg} -d ${DESTDIR}${DEBUGFILEDIR}/

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -155,12 +155,6 @@ DEBUGMKDIR=
 PROG_FULL=	${PROG}
 .endif
 
-.if defined(STRIP) && !empty(STRIP) && defined(PROG) && !defined(INTERNALPROG)
-PROG_INSTALL=	${PROG}.stripped
-.else
-PROG_INSTALL=	${PROG}
-.endif
-
 .if defined(PROG)
 PROGNAME?=	${PROG}
 
@@ -235,11 +229,6 @@ ${PROGNAME}.debug: ${PROG_FULL}
 	${OBJCOPY} --only-keep-debug ${PROG_FULL} ${.TARGET}
 .endif
 
-.if ${PROG_INSTALL} != ${PROG}
-${PROG_INSTALL}: ${PROG}
-	${STRIPBIN} -o ${.TARGET} ${STRIP_FLAGS} ${PROG}
-.endif
-
 .if defined(LLVM_LINK)
 ${PROG_FULL}.bc: ${BCOBJS}
 	${LLVM_LINK} -o ${.TARGET} ${BCOBJS}
@@ -263,10 +252,10 @@ MAN1=	${MAN}
 all:
 .else
 .if target(afterbuild)
-.ORDER: ${PROG_INSTALL} afterbuild
-all: ${PROG_INSTALL} ${SCRIPTS} afterbuild
+.ORDER: ${PROG} afterbuild
+all: ${PROG} ${SCRIPTS} afterbuild
 .else
-all: ${PROG_INSTALL} ${SCRIPTS}
+all: ${PROG} ${SCRIPTS}
 .endif
 .if ${MK_MAN} != "no"
 all: all-man
@@ -275,7 +264,6 @@ all: all-man
 
 .if defined(PROG)
 CLEANFILES+= ${PROG} ${PROG}.bc ${PROG}.ll
-CLEANFILES+= ${PROG}.stripped
 .if ${MK_DEBUG_FILES} != "no"
 CLEANFILES+= ${PROG_FULL} ${PROGNAME}.debug
 .endif

--- a/sys/arm64/arm64/exec_machdep.c
+++ b/sys/arm64/arm64/exec_machdep.c
@@ -571,10 +571,15 @@ get_mcontext(struct thread *td, mcontext_t *mcp, int clear_ret)
 	    sizeof(mcp->mc_capregs.cap_x[1]) *
 	    (nitems(mcp->mc_capregs.cap_x) - 1));
 
-	mcp->mc_capregs.cap_sp = tf->tf_sp;
+	if (cheri_getperm(tf->tf_elr) & CHERI_PERM_EXECUTIVE) {
+		mcp->mc_capregs.cap_sp = tf->tf_sp;
+		mcp->mc_capregs.cap_ddc = tf->tf_ddc;
+	} else {
+		mcp->mc_capregs.cap_sp = READ_SPECIALREG_CAP(rcsp_el0);
+		mcp->mc_capregs.cap_ddc = READ_SPECIALREG_CAP(rddc_el0);
+	}
 	mcp->mc_capregs.cap_lr = tf->tf_lr;
 	mcp->mc_capregs.cap_elr = tf->tf_elr;
-	mcp->mc_capregs.cap_ddc = tf->tf_ddc;
 	get_fpcontext(td, mcp);
 
 	return (0);
@@ -594,10 +599,15 @@ set_mcontext(struct thread *td, mcontext_t *mcp)
 
 	memcpy(tf->tf_x, mcp->mc_capregs.cap_x, sizeof(tf->tf_x));
 
-	tf->tf_sp = mcp->mc_capregs.cap_sp;
+	if (cheri_getperm(mcp->mc_capregs.cap_elr) & CHERI_PERM_EXECUTIVE) {
+		tf->tf_sp = mcp->mc_capregs.cap_sp;
+		tf->tf_ddc = mcp->mc_capregs.cap_ddc;
+	} else {
+		WRITE_SPECIALREG_CAP(rcsp_el0, mcp->mc_capregs.cap_sp);
+		WRITE_SPECIALREG_CAP(rddc_el0, mcp->mc_capregs.cap_ddc);
+	}
 	tf->tf_lr = mcp->mc_capregs.cap_lr;
 	tf->tf_elr = mcp->mc_capregs.cap_elr;
-	tf->tf_ddc = mcp->mc_capregs.cap_ddc;
 	tf->tf_spsr = mcp->mc_spsr;
 	set_fpcontext(td, mcp);
 
@@ -638,7 +648,7 @@ set_mcontext(struct thread *td, mcontext_t *mcp)
 	if ((spsr & PSR_M_MASK) != PSR_M_EL0t ||
 	    (spsr & PSR_AARCH32) != 0 ||
 	    (spsr & PSR_DAIF) != (td->td_frame->tf_spsr & PSR_DAIF))
-		return (EINVAL); 
+		return (EINVAL);
 
 	memcpy(tf->tf_x, mcp->mc_gpregs.gp_x, sizeof(tf->tf_x));
 

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -1012,7 +1012,7 @@ tcr:
 #else
 #define	TCR_MORELLO	0
 #endif
-	.quad (TCR_TxSZ(64 - VIRT_BITS) | TCR_TG1_4K | \
+	.quad (TCR_TxSZ(64 - VIRT_BITS) | TCR_TBI0 | TCR_TBI1 | TCR_TG1_4K | \
 	    TCR_CACHE_ATTRS | TCR_SMP_ATTRS | TCR_MORELLO)
 sctlr_set:
 	/* Bits to set */

--- a/sys/arm64/arm64/trap.c
+++ b/sys/arm64/arm64/trap.c
@@ -644,7 +644,7 @@ do_el0_sync(struct thread *td, struct trapframe *frame)
 	exception = ESR_ELx_EXCEPTION(esr);
 	switch (exception) {
 	case EXCP_INSN_ABORT_L:
-		far = READ_SPECIALREG(far_el1);
+		far = READ_SPECIALREG(far_el1) & 0xffffffffffff;
 
 		/*
 		 * Userspace may be trying to train the branch predictor to
@@ -661,7 +661,7 @@ do_el0_sync(struct thread *td, struct trapframe *frame)
 	case EXCP_DATA_ABORT_L:
 	case EXCP_DATA_ABORT:
 	case EXCP_WATCHPT_EL0:
-		far = READ_SPECIALREG(far_el1);
+		far = READ_SPECIALREG(far_el1) & 0xffffffffffff;
 		break;
 	}
 	intr_enable();
@@ -742,7 +742,7 @@ do_el0_sync(struct thread *td, struct trapframe *frame)
 		 */
 		if (!undef_insn(0, frame))
 			call_trapsignal(td, SIGILL, ILL_PRVOPC,
-			    (void * __capability)frame->tf_elr, exception); 
+			    (void * __capability)frame->tf_elr, exception);
 		userret(td, frame);
 		break;
 	case EXCP_SOFTSTP_EL0:

--- a/sys/arm64/cheri/cheri_machdep.c
+++ b/sys/arm64/cheri/cheri_machdep.c
@@ -43,6 +43,7 @@
 #include <machine/vmparam.h>
 
 void * __capability sentry_unsealcap;
+void * __capability smccc_ddc_el0;
 #ifdef __CHERI_PURE_CAPABILITY__
 void *kernel_root_cap = (void *)(intcap_t)-1;
 #endif
@@ -72,6 +73,8 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_setbounds(ctemp, 1);
 	ctemp = cheri_andperm(ctemp, CHERI_PERM_GLOBAL | CHERI_PERM_UNSEAL);
 	sentry_unsealcap = ctemp;
+
+	smccc_ddc_el0 = kroot;
 
 	swap_restore_cap = kroot;
 

--- a/sys/arm64/cheri/cheri_machdep.c
+++ b/sys/arm64/cheri/cheri_machdep.c
@@ -43,7 +43,9 @@
 #include <machine/vmparam.h>
 
 void * __capability sentry_unsealcap;
+#ifdef __CHERI_PURE_CAPABILITY__
 void *kernel_root_cap = (void *)(intcap_t)-1;
+#endif
 
 void
 cheri_init_capabilities(void * __capability kroot)

--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -56,6 +56,9 @@
 
 struct thread;
 
+/* Used to set DDC_EL0 in psci call functions. */
+extern void * __capability smccc_ddc_el0;
+
 /*
  * Morello specific kernel utility functions.
  */

--- a/sys/dev/psci/smccc_arm64.S
+++ b/sys/dev/psci/smccc_arm64.S
@@ -31,6 +31,7 @@
  */
 
 #include <machine/asm.h>
+#include <machine/armreg.h>
 __FBSDID("$FreeBSD$");
 
 /*
@@ -65,6 +66,33 @@ __FBSDID("$FreeBSD$");
 #endif
 
 /*
+ * XXX: TF-A in Morello firmware versions up to at least 1.4 do not
+ * initialize DDC_EL0 and depend on the caller setting it to almighty
+ * capability.
+ */
+#if __has_feature(capabilities)
+.macro	reset_ddc_el0
+	sub	PTRN(sp), PTRN(sp), #16 * 2
+	mrs	c9, ddc_el0
+	mrs	x10, daif
+	stp	c9, c10, [PTRN(sp)]
+	adrp	PTR(9), smccc_ddc_el0
+	ldr	c9, [PTR(9), :lo12:smccc_ddc_el0]
+
+	/* Mask interrupts while DDC_EL0 is set. */
+	msr	daifset, #(DAIF_INTR)
+	msr	ddc_el0, c9
+.endmacro
+
+.macro restore_ddc_el0
+	ldp	c9, c10, [PTRN(sp)]
+	msr	ddc_el0, c9
+	msr	daif, x10
+	add	PTRN(sp), PTRN(sp), #16 * 2
+.endmacro
+#endif
+
+/*
  * int arm_smccc_hvc(register_t, register_t, register_t, register_t,
  *     register_t, register_t, register_t, register_t,
  *     struct arm_smccc_res *res)
@@ -73,7 +101,13 @@ ENTRY(arm_smccc_hvc)
 #ifdef __CHERI_PURE_CAPABILITY__
 	save_registers
 #endif
+#if __has_feature(capabilities)
+	reset_ddc_el0
+#endif
 	hvc	#0
+#if __has_feature(capabilities)
+	restore_ddc_el0
+#endif
 #ifdef __CHERI_PURE_CAPABILITY__
 	restore_registers
 #endif
@@ -93,7 +127,13 @@ ENTRY(arm_smccc_smc)
 #ifdef __CHERI_PURE_CAPABILITY__
 	save_registers
 #endif
+#if __has_feature(capabilities)
+	reset_ddc_el0
+#endif
 	smc	#0
+#if __has_feature(capabilities)
+	restore_ddc_el0
+#endif
 #ifdef __CHERI_PURE_CAPABILITY__
 	restore_registers
 #endif

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -43,7 +43,9 @@
 #include <machine/riscvreg.h>
 #include <machine/vmparam.h>
 
+#ifdef __CHERI_PURE_CAPABILITY__
 void *kernel_root_cap = (void *)(intcap_t)-1;
+#endif
 
 void
 cheri_init_capabilities(void * __capability kroot)


### PR DESCRIPTION
This patch
* removes code that unnecessarily saves certain non-callee-saved registers (e.g. `r8`-`r18`) into the PCB, and
* reorganises the some arm64 assembly code to make them easier to modify for future extensions.