### PR TITLE
Morello varargs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,6 @@ TGTS=	all all-man buildenv buildenvvars buildkernel buildsysroot buildworld \
 	build32 distribute32 install32 \
 	build64 distribute64 install64 \
 	build64c distribute64c \
-	libcheribuildenv libcheribuildenvvars \
 	lib64cbuildenv lib64cbuildenvvars \
 	lib64buildenv lib64buildenvvars lib32buildenv lib32buildenvvars \
 	builddtb xdev xdev-build xdev-install \

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -1669,14 +1669,6 @@ restage reinstall reinstallsysroot: .MAKE .PHONY
 .else
 .error MACHINE_ABI incorrect? ${MACHINE_ABI}
 .endif
-.if ${MACHINE_ABI:Mpurecap}
-	@echo "Purecap ABI: creating libcheri links"
-	ln -sfnv lib ${DESTDIR}/libcheri
-	ln -sfnv lib ${DESTDIR}/usr/libcheri
-.elif ${MK_COMPAT_CHERIABI} == "yes"
-	@echo "Hybrid ABI: creating libcheri links"
-	ln -sfnv lib64c ${DESTDIR}/usr/libcheri
-.endif
 .if make(reinstallsysroot)
 	@echo "Removing $$(find ${DESTDIR} -type d -empty -print | wc -l) empty directories from ${DESTDIR}"
 	find ${DESTDIR} -type d -empty -delete

--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -91,11 +91,6 @@ build${libcompat}: .PHONY
 	${WORLDTMP_MTREE} -f ${.CURDIR}/etc/mtree/BSD.lib${libcompat}.dist \
 	    -p ${WORLDTMP}/usr/lib/debug/usr >/dev/null
 .endif
-# XXX: Remove this hack once morello-llvm supports lib64c
-.if ${libcompat} == "64c" && ${COMPAT_ARCH} == "aarch64"
-	@echo "Morello: creating libcheri link in WORLDTMP"
-	ln -sfnv lib64c ${WORLDTMP}/usr/libcheri
-.endif
 .for _dir in lib/ncurses/tinfo ${_libmagic} ${_jevents}
 .for _t in ${_obj} build-tools
 	${_+_}cd ${.CURDIR}/${_dir}; \

--- a/Makefile.libcompat
+++ b/Makefile.libcompat
@@ -119,7 +119,7 @@ distribute${libcompat} install${libcompat}: .PHONY
 	${_+_}cd ${.CURDIR}; \
 	    ${LIBCOMPATIMAKE} -f Makefile.inc1 _lc_${.TARGET:S/${libcompat}$//}
 
-.if ${.TARGETS:Mlib${libcompat}buildenv} || ${.TARGETS:Mlibcheribuildenv}
+.if ${.TARGETS:Mlib${libcompat}buildenv}
 .if ${.MAKEFLAGS:M-j}
 .error The lib${libcompat}buildenv target is incompatible with -j
 .endif
@@ -137,10 +137,6 @@ lib${libcompat}buildenv: .PHONY
 	    INSTALL="${INSTALL_CMD} ${INSTALLFLAGS}" \
 	    MTREE_CMD="${MTREE_CMD} ${MTREEFLAGS}" \
 	    "MAKEFLAGS=${MAKEFLAGS:NTARGET*}" ${BUILDENV_SHELL} || true
-
-.if ${libcompat} == "64c"
-libcheribuildenv: lib64cbuildenv
-.endif
 .endif
 
 .endif # defined(_LIBCOMPAT)

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -115,7 +115,7 @@ ENTRY(_rtld_bind_start)
 	stp	CAP(2), CAP(3), [PTRN(sp), #-(CAP_WIDTH * 2)]!
 	stp	CAP(4), CAP(5), [PTRN(sp), #-(CAP_WIDTH * 2)]!
 	stp	CAP(6), CAP(7), [PTRN(sp), #-(CAP_WIDTH * 2)]!
-	stp	CAP(8), CAP(zr), [PTRN(sp), #-(CAP_WIDTH * 2)]!
+	stp	CAP(8), CAP(9), [PTRN(sp), #-(CAP_WIDTH * 2)]!
 
 	/* Save any floating-point arguments */
 	stp	q0, q1, [PTRN(sp), #-32]!
@@ -156,7 +156,7 @@ ENTRY(_rtld_bind_start)
 	ldp	q4, q5, [PTRN(sp)], #32
 	ldp	q2, q3, [PTRN(sp)], #32
 	ldp	q0, q1, [PTRN(sp)], #32
-	ldp	CAP(8), CAP(zr), [PTRN(sp)], #(CAP_WIDTH * 2)
+	ldp	CAP(8), CAP(9), [PTRN(sp)], #(CAP_WIDTH * 2)
 	ldp	CAP(6), CAP(7), [PTRN(sp)], #(CAP_WIDTH * 2)
 	ldp	CAP(4), CAP(5), [PTRN(sp)], #(CAP_WIDTH * 2)
 	ldp	CAP(2), CAP(3), [PTRN(sp)], #(CAP_WIDTH * 2)

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -308,9 +308,11 @@ MACHINE_CPU += riscv
 # CheriBSD implements the resolvers) or the Morello toolchain implements a
 # pure-capability traditional TLS like MIPS or RISC-V.
 CFLAGS+=	-march=morello+c64 -mabi=purecap -femulated-tls
+CFLAGS+=	-Xclang -morello-vararg=new
 LDFLAGS+=	-march=morello+c64 -mabi=purecap
 . elif defined(CPUTYPE) && ${CPUTYPE} == "morello"
 CFLAGS+=	-march=morello -mabi=aapcs
+CFLAGS+=	-Xclang -morello-vararg=new
 LDFLAGS+=	-march=morello -mabi=aapcs
 . endif
 .endif

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -142,6 +142,7 @@ CFLAGS+=	-march=morello+c64 -mabi=purecap
 .else
 CFLAGS+=	-march=morello
 .endif
+CFLAGS+=	-Xclang -morello-vararg=new
 .endif
 .endif
 


### PR DESCRIPTION
This also removes the old libcheri bits as support for lib64c was merged into Morello LLVM in commit 4f84c4ab99d06ac75a2f55441c8a317246b1b75c before the new varargs commit f1bea428c0f05baf716620cc7199e0c8854ff4b1.

I may need to push the remaining lib64 changes into cheribuild before landing this however?