### PR TITLE
Add a separate ELF note to indicate a binary is built for CheriBSD.

### DIFF
--- a/lib/csu/common/crtbrand.S
+++ b/lib/csu/common/crtbrand.S
@@ -47,3 +47,12 @@ __FBSDID("$FreeBSD$");
 2:	.p2align	2
 3:	.4byte		__FreeBSD_version
 4:
+	.section .note.tag,"aG",%note,.freebsd.noteG,comdat
+	.p2align	2
+	.4byte		6f-5f
+	.4byte		8f-7f
+	.4byte		NT_CHERIBSD_ABI_TAG
+5:	.asciz		NOTE_CHERIBSD_VENDOR
+6:	.p2align	2
+7:	.4byte		__CheriBSD_version
+8:

--- a/lib/csu/common/notes.h
+++ b/lib/csu/common/notes.h
@@ -28,6 +28,7 @@
 #define	CSU_COMMON_NOTES_H
 
 #define NOTE_FREEBSD_VENDOR	"FreeBSD"
+#define NOTE_CHERIBSD_VENDOR	"CheriBSD"
 
 #define NOTE_SECTION		".note.tag"
 

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -804,6 +804,9 @@ typedef struct {
 #define	NT_FREEBSD_ARCH_TAG	3
 #define	NT_FREEBSD_FEATURE_CTL	4
 
+/* Values for n_type used in CheriBSD executables. */
+#define	NT_CHERIBSD_ABI_TAG	1
+
 /* NT_FREEBSD_FEATURE_CTL desc[0] bits */
 #define	NT_FREEBSD_FCTL_ASLR_DISABLE	0x00000001
 #define	NT_FREEBSD_FCTL_PROTMAX_DISABLE	0x00000002


### PR DESCRIPTION
**This PR depends on `__CheriBSD_version` added by #1298 and should not be merged to `dev` before #1298 is merged.**

We would like to be able to distinguish CheriBSD binaries from FreeBSD binaries. Since the 3rd-party software doesn't recognise CheriBSD as a vendor, we must leave the NT_FREEBSD_ABI_TAG note intact as it would break their build systems.

Instead, let's introduce a new note NT_CHERIBSD_ABI_TAG that indicates a binary's vendor is CheriBSD and includes a CheriBSD ABI version in its description.

I considered two changes when working on this:
* Add a second NT_FREEBSD_ABI_TAG ELF note with CheriBSD as a vendor. I'm not sure if an ELF binary can have multiple notes with the same tag. Even if so, it makes sense not to reuse the same tag since a program might use a wrong one and fail because it wouldn't recognise CheriBSD;
* Add a separate assembly file with the new note. This could organise code better but I think there's more value in having it in one file in case some changes in the upstream brand would affect our additional brand. 

This idea was proposed by @bsdjhb.