### PR TITLE
Use correct operator when comparing with `cheri_gettop` result

### DIFF
--- a/sys/arm64/arm64/unwind.c
+++ b/sys/arm64/arm64/unwind.c
@@ -46,7 +46,7 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	if ((ptraddr_t)fp < cheri_getbase(fp) ||
-	    (ptraddr_t)(fp + sizeof(uintptr_t) * 2) >= cheri_gettop(fp) ||
+	    (ptraddr_t)(fp + sizeof(fp) * 2) > cheri_gettop(fp) ||
 	    cheri_gettag(fp) == 0 ||
 	    (cheri_getperm(fp) & (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)) !=
 	    (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP))

--- a/sys/riscv/riscv/unwind.c
+++ b/sys/riscv/riscv/unwind.c
@@ -52,7 +52,7 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	if ((ptraddr_t)(fp - sizeof(fp) * 2) < cheri_getbase(fp) ||
-	    (ptraddr_t)fp >= cheri_gettop(fp) ||
+	    (ptraddr_t)fp > cheri_gettop(fp) ||
 	    cheri_gettag(fp) == 0 ||
 	    (cheri_getperm(fp) & (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)) !=
 	    (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP))


### PR DESCRIPTION
~This patch, suggested by @bsdjhb, fixes a kernel panic caused by a misaligned `fp` being accessed.~

Edit: This patch uses the correct operator to compare capability top bounds.