### PR TITLE
usr.bin/dtc: Add another missing <limits> include

### DIFF
--- a/usr.bin/dtc/fdt.cc
+++ b/usr.bin/dtc/fdt.cc
@@ -38,6 +38,7 @@
 #include "dtb.hh"
 
 #include <algorithm>
+#include <limits>
 #include <sstream>
 
 #include <ctype.h>


### PR DESCRIPTION
It seems that recent libcstdc++ pulls in fewer headers implicitly, so this
is needed to get std::numeric_limits<>.