### PR TITLE
Add a fingerprint for the pkg.CheriBSD.org repo.

### DIFF
--- a/share/keys/pkg/trusted/Makefile
+++ b/share/keys/pkg/trusted/Makefile
@@ -3,6 +3,7 @@
 PACKAGE=	pkg-bootstrap
 
 FILES=	pkg.freebsd.org.2013102301
+FILES+=	pkg.cheribsd.org.2022032901
 
 FILESDIR=	${SHAREDIR}/keys/pkg/trusted
 FILESMODE=	644

--- a/share/keys/pkg/trusted/pkg.cheribsd.org.2022032901
+++ b/share/keys/pkg/trusted/pkg.cheribsd.org.2022032901
@@ -1,0 +1,2 @@
+function: "sha256"
+fingerprint: "6d57c70a6cbc9716d21db10e2b2dcf71f5aa1da14b54e4f7ce2044a5e70257bf"


### PR DESCRIPTION
The signing key corresponding to the fingerprint was generated on a host separate from build hosts and pkg.CheriBSD.org. Packages will be signed with pkg-repo(8) and a signing command executed via SSH on the host where the signing key was generated.

The generating and the signing operations are implemented in [1].

[1] https://github.com/CTSRD-CHERI/poudriere-infrastructure/blob/master/key.sh

Example signing process:
```
# sha256 -q CheriBSD:20220314:aarch64c/Latest/pkg.pkg | ssh pkg-repo@zeno sh poudriere-infrastructure/key.sh sign >CheriBSD:20220314:aarch64c/Latest/pkg.pkg.sig
# pkg repo CheriBSD:20220314:aarch64c signing_command: ssh pkg-repo@zeno sh poudriere-infrastructure/key.sh sign
Creating repository in CheriBSD:20220314:aarch64c: 100%
Packing files for repository: 100%
# 
```

Example bootstrap and update commands' output:
```
# pkg
The package management tool is not yet installed on your system.
Do you want to fetch and install it now? [y/N]: y
Bootstrapping pkg from pkg+http://pkg.CheriBSD.org/CheriBSD:20220314:aarch64c.new, please wait...
Verifying signature with trusted certificate pkg.cheribsd.org.2022032901... done
[cheribsd-morello-purecap-main] Installing pkg-1.17.5_1...
[cheribsd-morello-purecap-main] Extracting pkg-1.17.5_1: 100%
pkg: not enough arguments
Usage: pkg [-v] [-d] [-l] [-N] [-j <jail name or id>|-c <chroot path>|-r <rootdir>] [-C <configuration file>] [-R <repo config dir>] [-o var=value] [-4|-6] <command> [<args>]

For more information on available commands and options see 'pkg help'.
# pkg update
Updating CheriBSD repository catalogue...
[cheribsd-morello-purecap-main] Fetching meta.conf: 100%    163 B   0.2kB/s    00:01    
[cheribsd-morello-purecap-main] Fetching packagesite.pkg: 100%    1 KiB   1.2kB/s    00:01    
Processing entries: 100%
CheriBSD repository update completed. 1 packages processed.
All repositories are up to date.
#
```