### PR TITLE
pkg utility explaining available package managers pkg64c and pkg64

### DIFF
--- a/bin/csh/dot.cshrc
+++ b/bin/csh/dot.cshrc
@@ -19,7 +19,7 @@ alias ll	ls -lAF
 # A righteous umask
 umask 22
 
-set path = (/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin $HOME/bin)
+set path = (/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin /usr/local64/sbin /usr/local64/bin $HOME/bin)
 
 setenv	EDITOR	vi
 setenv	PAGER	less

--- a/bin/sh/dot.profile
+++ b/bin/sh/dot.profile
@@ -2,7 +2,7 @@
 #
 HOME=/root
 export HOME
-PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:~/bin
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/local64/sbin:/usr/local64/bin:~/bin
 export PATH
 TERM=${TERM:-xterm}
 export TERM

--- a/share/skel/dot.cshrc
+++ b/share/skel/dot.cshrc
@@ -14,7 +14,7 @@ alias ll	ls -lAF
 
 # These are normally set through /etc/login.conf.  You may override them here
 # if wanted.
-# set path = (/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin $HOME/bin)
+# set path = (/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin /usr/local64/sbin /usr/local64/bin $HOME/bin)
 # A righteous umask
 # umask 22
 

--- a/share/skel/dot.profile
+++ b/share/skel/dot.profile
@@ -7,7 +7,7 @@
 
 # These are normally set through /etc/login.conf.  You may override them here
 # if wanted.
-# PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:$HOME/bin; export PATH
+# PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/local64/sbin:/usr/local64/bin:$HOME/bin; export PATH
 
 # Setting TERM is normally done through /etc/ttys.  Do only override
 # if you're sure that you'll never log in via telnet or xterm or a

--- a/usr.bin/login/login.conf
+++ b/usr.bin/login/login.conf
@@ -28,7 +28,7 @@ default:\
 	:welcome=/var/run/motd:\
 	:setenv=BLOCKSIZE=K:\
 	:mail=/var/mail/$:\
-	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin ~/bin:\
+	:path=/sbin /bin /usr/sbin /usr/bin /usr/local/sbin /usr/local/bin /usr/local64/sbin /usr/local64/bin ~/bin:\
 	:nologin=/var/run/nologin:\
 	:cputime=unlimited:\
 	:datasize=unlimited:\

--- a/usr.sbin/Makefile
+++ b/usr.sbin/Makefile
@@ -185,7 +185,7 @@ SUBDIR.${MK_OPENSSL_KTLS}+=	rpc.tlsclntd
 SUBDIR.${MK_OPENSSL_KTLS}+=	rpc.tlsservd
 SUBDIR.${MK_PF}+=	ftp-proxy
 .if ${MACHINE_ABI:Mpurecap}
-# Install pkg64 and pkg64c instead of pkg if world is purecap.
+# Install pkg64 and pkg64c with pkg.sh instead of pkg if world is purecap.
 SUBDIR.${MK_PKGBOOTSTRAP}.${MK_LIB64}+=	pkg64
 SUBDIR.${MK_PKGBOOTSTRAP}+=	pkg64c
 .else

--- a/usr.sbin/Makefile
+++ b/usr.sbin/Makefile
@@ -184,8 +184,13 @@ SUBDIR.${MK_OPENSSL}+=	keyserv
 SUBDIR.${MK_OPENSSL_KTLS}+=	rpc.tlsclntd
 SUBDIR.${MK_OPENSSL_KTLS}+=	rpc.tlsservd
 SUBDIR.${MK_PF}+=	ftp-proxy
-SUBDIR.${MK_PKGBOOTSTRAP}+=	pkg
+.if ${MACHINE_ABI:Mpurecap}
+# Install pkg64 and pkg64c instead of pkg if world is purecap.
 SUBDIR.${MK_PKGBOOTSTRAP}.${MK_LIB64}+=	pkg64
+SUBDIR.${MK_PKGBOOTSTRAP}+=	pkg64c
+.else
+SUBDIR.${MK_PKGBOOTSTRAP}+=	pkg
+.endif
 SUBDIR.${MK_PMC}+=	pmc pmcannotate pmccontrol pmcstat pmcstudy
 SUBDIR.${MK_PORTSNAP}+=	portsnap
 SUBDIR.${MK_PPP}+=	ppp

--- a/usr.sbin/pkg/Makefile
+++ b/usr.sbin/pkg/Makefile
@@ -9,7 +9,7 @@ CONFS=		${PKGCONF}
 CONFSNAME_${PKGCONF}=	${PKGCONF:C/\.conf.+$/.conf/}
 CONFSDIR=	/etc/pkg${PKG_SUFFIX}
 CONFSMODE=	644
-PROG=	pkg${PKG_SUFFIX}
+PROG?=	pkg${PKG_SUFFIX}
 SRCS=	pkg.c dns_utils.c config.c
 MAN?=	pkg${PKG_SUFFIX}.7
 

--- a/usr.sbin/pkg64c/Makefile
+++ b/usr.sbin/pkg64c/Makefile
@@ -1,0 +1,4 @@
+PROG=	pkg64c
+
+.PATH: ${.CURDIR}/../pkg
+.include "${.CURDIR}/../pkg/Makefile"

--- a/usr.sbin/pkg64c/Makefile
+++ b/usr.sbin/pkg64c/Makefile
@@ -1,4 +1,6 @@
 PROG=	pkg64c
 
+SCRIPTS=	pkg.sh
+
 .PATH: ${.CURDIR}/../pkg
 .include "${.CURDIR}/../pkg/Makefile"

--- a/usr.sbin/pkg64c/pkg.sh
+++ b/usr.sbin/pkg64c/pkg.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Copyright (c) 2022 Konrad Witaszczyk
+#
+# This software was developed by the University of Cambridge Department of
+# Computer Science and Technology with support from Innovate UK project 105694,
+# "Digital Security by Design (DSbD) Technology Platform Prototype".
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+cat >&2 <<EOF
+Please use the ABI-specific pkg variant:
+ * pkg64c for experimental software built for CheriABI;
+ * pkg64 for stable software built for the hybrid ABI.
+
+Replace pkg with pkg64c or pkg64 in your command and try again.
+EOF
+
+# Exit with an error to inform a user that pkg isn't a valid command.
+exit 1


### PR DESCRIPTION
Related issue: https://github.com/CTSRD-CHERI/cheribsd/issues/1346.

In order to make users aware of consequences of using experimental CheriABI packages:
* Rename the pkg program to pkg64c;
* Introduce the pkg utility that explains what package managers are available.

This PR also adds /usr/local64/{bin,sbin} to PATH.