### PR TITLE
Fix pkg64 manpage build error

### DIFF
--- a/usr.sbin/pkg/Makefile
+++ b/usr.sbin/pkg/Makefile
@@ -11,7 +11,7 @@ CONFSDIR=	/etc/pkg${PKG_SUFFIX}
 CONFSMODE=	644
 PROG=	pkg${PKG_SUFFIX}
 SRCS=	pkg.c dns_utils.c config.c
-MAN=	pkg${PKG_SUFFIX}.7
+MAN?=	pkg${PKG_SUFFIX}.7
 
 CFLAGS+='-DPKG_SUFFIX="${PKG_SUFFIX}"'
 


### PR DESCRIPTION
The pkg64 Makefile attempts to disable manpages but that is overridden
by the pkg Makefile. This fixes the WITH_MAN build for me.