### PR TITLE
Always include debug info in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,12 +278,9 @@ selectedArchitectures.each { suffix ->
                 '--cheribsd/build-tests',
                 '--cheribsd/build-bench-kernels',
                 '--cheribsd/with-manpages',
+                '--cheribsd/debug-info',
+                '--cheribsd/debug-files',
         ]
-        if (GlobalVars.isTestSuiteJob) {
-            cheribuildArgs.add('--cheribsd/debug-info')
-        } else {
-            cheribuildArgs.add('--cheribsd/no-debug-info')
-        }
         if (GlobalVars.selectedPurecapKernelArchitectures.contains(suffix)) {
             cheribuildArgs.add('--cheribsd/build-alternate-abi-kernels')
         }


### PR DESCRIPTION
I believe I originally added the `--cheribsd/no-debug-info`
flag to reduce disk usage in Jenkins. However, this means that
the release images we are shipping do not include debug symbols,
which means userspace crashes are much more difficult to debug
than they should be.