### PR TITLE
test-includes: improve portability

### DIFF
--- a/tools/build/test-includes/Makefile
+++ b/tools/build/test-includes/Makefile
@@ -16,7 +16,7 @@
 LIB=	test-includes
 INTERNALLIB=	This is a compile-only test
 MAN=
-HDRS!=	(cd ${SRCTOP}/sys; ls sys/[^_]*.h | sort ; ls net*/[^_]*.h | sort)
+HDRS!=	(cd ${SRCTOP}/sys; ls sys/[!_]*.h | sort ; ls net*/[!_]*.h | sort)
 NO_PIC=	yes
 
 # Some files have to be clean for extra defines too...


### PR DESCRIPTION
FreeBSD's shell permits [^bar] to match characters not in [bar] like
common regular expressions. This is non-portable and '!' should be
used in place of '^' for portability.

Reported by:	Nathaniel Wesley Filardo
Issue:		https://github.com/CTSRD-CHERI/cheribsd/issues/1321
Reviewed by:	imp
Differential Revision:	https://reviews.freebsd.org/D34597