### PR TITLE
Add hybrid ABI paths to man(1).

### DIFF
--- a/usr.bin/man/man.1
+++ b/usr.bin/man/man.1
@@ -365,6 +365,8 @@ is used.
 System configuration file.
 .It Pa /usr/local/etc/man.d/*.conf
 Local configuration files.
+.It Pa /usr/local64/etc/man.d/*.conf
+Local configuration files for the hybrid ABI.
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/usr.bin/man/man.conf.5
+++ b/usr.bin/man/man.conf.5
@@ -44,12 +44,15 @@ and its related utilities.
 During initialization,
 .Xr man 1
 reads the configuration files located at
-.Pa /usr/local/etc/man.d/*.conf
+.Pa /usr/local/etc/man.d/*.conf ,
+.Pa /usr/local64/etc/man.d/*.conf
 and
 .Pa /etc/man.conf .
 .Pp
 The files contained in
 .Pa /usr/local/etc/man.d/*.conf
+and
+.Pa /usr/local64/etc/man.d/*.conf
 are intended to be used by the
 .Xr ports 7
 system for extending the manual set to support additional paths and locales.
@@ -61,7 +64,9 @@ Currently supported configuration variables include:
 .It MANCONFIG
 Overrides the default location to import additional manual configuration files.
 Defaults to
-.Pa /usr/local/etc/man.d/*.conf .
+.Pa /usr/local/etc/man.d/*.conf
+and
+.Pa /usr/local64/etc/man.d/*.conf .
 .It MANPATH
 Adds the specified directory to the manual search path.
 .It MANLOCALE
@@ -88,11 +93,13 @@ section for how to use these variables.
 The parser used for this utility is very basic and only supports comment
 characters (#) at the beginning of a line.
 .Sh FILES
-.Bl -tag -width "Pa /usr/local/etc/man.d/*.conf" -compact
+.Bl -tag -width "Pa /usr/local64/etc/man.d/*.conf" -compact
 .It Pa /etc/man.conf
 System configuration file.
 .It Pa /usr/local/etc/man.d/*.conf
 Local configuration files.
+.It Pa /usr/local64/etc/man.d/*.conf
+Local configuration files for the hybrid ABI.
 .El
 .Sh EXAMPLES
 A perl port that needs to install additional manual pages outside of the

--- a/usr.bin/man/man.sh
+++ b/usr.bin/man/man.sh
@@ -1058,13 +1058,13 @@ SYSCTL=/sbin/sysctl
 
 debug=0
 man_default_sections='1:8:2:3:3lua:n:4:5:6:7:9:l'
-man_default_path='/usr/share/man:/usr/share/openssl/man:/usr/local/share/man:/usr/local/man'
+man_default_path='/usr/share/man:/usr/share/openssl/man:/usr/local/share/man:/usr/local/man:/usr/local64/share/man:/usr/local64/man'
 cattool='/usr/bin/zcat -f'
 
 config_global='/etc/man.conf'
 
 # This can be overridden via a setting in /etc/man.conf.
-config_local='/usr/local/etc/man.d/*.conf'
+config_local='/usr/local/etc/man.d/*.conf /usr/local64/etc/man.d/*.conf'
 
 # Set noglobbing for now. I don't want spurious globbing.
 set -f

--- a/usr.bin/man/manpath.1
+++ b/usr.bin/man/manpath.1
@@ -110,6 +110,8 @@ Influences the manual path as described in the
 System configuration file.
 .It Pa /usr/local/etc/man.d/*.conf
 Local configuration files.
+.It Pa /usr/local64/etc/man.d/*.conf
+Local configuration files for the hybrid ABI.
 .El
 .Sh SEE ALSO
 .Xr apropos 1 ,


### PR DESCRIPTION
At the moment, man(1) can find man pages in `/usr/local64/man` because it traverses paths in `PATH` to look for `man/` directories. However:
* It still cannot find configuration files in `/usr/local64/etc/man.d/` installed with packages;
* `/usr/local64/share/man` and `/usr/local64/man` should be considered by default and not just because `/usr/local64/*` is in `PATH`.