### PR TITLE
release: Use full window size for installer over serial lines

### DIFF
--- a/release/rc.local
+++ b/release/rc.local
@@ -48,6 +48,9 @@ else
 fi
 export TERM
 
+# Query terminal size; useful for serial lines.
+resizewin -z
+
 if [ -f /etc/installerconfig ]; then
 	if bsdinstall script /etc/installerconfig; then
 		dialog --backtitle "FreeBSD Installer" --title "Complete" --no-cancel --ok-label "Reboot" --pause "Installation of FreeBSD complete! Rebooting in 10 seconds" 10 30 10


### PR DESCRIPTION
When running over a serial line we end up defaulting to 80x24, which is rather cramped for many dialog boxes and occupies very little screen space for most modern terminals. Thus, run resizewin -z to set the terminal size if not already known before starting the installer, just as we do for csh and sh login shells already in their default dotfiles.

https://reviews.freebsd.org/D34414 is the upstream review but that's been stalled for several months so applying it directly to CheriBSD.
