### PR TITLE
release: Include debug distribution sets in disc1/memstick images

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -163,12 +163,12 @@ disc1: packagesystem
 	    -DDB_FROM_SRC
 # Copy distfiles
 	mkdir -p ${.TARGET}/usr/freebsd-dist
-	for dist in MANIFEST $$(ls *.txz | grep -vE -- '(base|lib32|lib64|lib64c)-dbg'); \
+	for dist in MANIFEST *.txz; \
 	    do cp $${dist} ${.TARGET}/usr/freebsd-dist; \
 	done
 .if defined(NO_ROOT)
 	echo "./usr/freebsd-dist type=dir uname=root gname=wheel mode=0755" >> ${.TARGET}/METALOG
-	for dist in MANIFEST $$(ls *.txz | grep -vE -- '(base|lib32|lib64|lib64c)-dbg'); \
+	for dist in MANIFEST *.txz; \
 	    do echo "./usr/freebsd-dist/$${dist} type=file uname=root gname=wheel mode=0644" >> ${.TARGET}/METALOG; \
 	done
 .endif
@@ -232,12 +232,12 @@ dvd: packagesystem
 		-DDB_FROM_SRC
 # Copy distfiles
 	mkdir -p ${.TARGET}/usr/freebsd-dist
-	for dist in MANIFEST $$(ls *.txz | grep -v -- '(base|lib32|lib64|lib64c)-dbg'); \
+	for dist in MANIFEST *.txz; \
 	    do cp $${dist} ${.TARGET}/usr/freebsd-dist; \
 	done
 .if defined(NO_ROOT)
 	echo "./usr/freebsd-dist type=dir uname=root gname=wheel mode=0755" >> ${.TARGET}/METALOG
-	for dist in MANIFEST $$(ls *.txz | grep -vE -- '(base|lib32|lib64|lib64c)-dbg'); \
+	for dist in MANIFEST *.txz; \
 	    do echo "./usr/freebsd-dist/$${dist} type=file uname=root gname=wheel mode=0644" >> ${.TARGET}/METALOG; \
 	done
 .endif


### PR DESCRIPTION
We don't currently build with separate debug files, and Jenkins does not
even enable debug info currently, but both of these will soon change for
the upcoming release and we want to provide debug distribution sets
without having to set up, and rely on, remote fetching for CheriBSD,
especially given we automatically install all listed distribution sets
with no way to opt out.

Also includes them in dvd for -DNO_ROOT builds, which (unintentionally)
already happens for root builds due to a missing -E in the grep call;
this can be traced back to 8834318685bc which turned grep -v '-dbg' into
grep -vE '(base|lib32)-dbg' for disc1/memstick but inadvertently changed it
to the nonsense grep -v '(base|lib32)-dbg' for dvd, forgetting the -E.
