### PR TITLE
link_elf: Fix link_elf_link_preload for purecap kernels

### DIFF
--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -981,7 +981,15 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	ef = (elf_file_t) lf;
 	ef->preloaded = 1;
 	ef->modptr = modptr;
+#ifdef __CHERI_PURE_CAPABILITY__
+	ef->address = cheri_setaddress(kernel_root_cap,
+	    *(ptraddr_t *)baseptr);
+	ef->address = cheri_setbounds(ef->address, *(size_t *)sizeptr);
+	ef->address = cheri_andperm(ef->address, CHERI_PERMS_KERNEL_CODE |
+	    CHERI_PERMS_KERNEL_DATA);
+#else
 	ef->address = *(caddr_t *)baseptr;
+#endif
 #ifdef SPARSE_MAPPING
 	ef->object = NULL;
 #endif


### PR DESCRIPTION
MODINFO_ADDR is an address not a pointer. link_elf_obj already handled
this, presumably for CHERI-MIPS, but link_elf did not, so copy the fix.
