### PR TITLE
vm_map: relax assertions for hybrid processes

### DIFF
--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -6083,7 +6083,8 @@ _vm_map_assert_consistent(vm_map_t map, int check)
 		KASSERT(entry->start < entry->end,
 		    ("map %p start = %jx, end = %jx", map,
 		    (uintmax_t)entry->start, (uintmax_t)entry->end));
-		KASSERT(prev->reservation <= entry->reservation,
+		KASSERT((map->flags & MAP_RESERVATIONS) == 0 ||
+		    prev->reservation <= entry->reservation,
 		    ("map %p prev->reservation = %jx, reservation = %jx", map,
 		    (uintmax_t)prev->reservation,
 		    (uintmax_t)entry->reservation));


### PR DESCRIPTION
Don't check that reservations are non-overlapping for hybrid processes.
As reported in #1371, this invariant isn't maintained in processes
who's maps don't set the MAP_RESERVATIONS flag.

This is a workaround to allow a system with the DIAGNOSIC option enabled
to run hybrid processes.