### PR TITLE
vfs.ffs compat freebsd64

### DIFF
--- a/sbin/fsck_ffs/pass5.c
+++ b/sbin/fsck_ffs/pass5.c
@@ -392,7 +392,7 @@ pass5(void)
 		cmd.value = cstotal.cs_ndir - fs->fs_cstotal.cs_ndir;
 		if (cmd.value != 0) {
 			if (debug)
-				printf("adjndir by %+" PRIi64 "\n", cmd.value);
+				printf("adjndir by %+" PRIi64 "\n", (int64_t)cmd.value);
 			if (bkgrdsumadj == 0 || sysctl(adjndir, MIBSIZE, 0, 0,
 			    &cmd, sizeof cmd) == -1)
 				rwerror("ADJUST NUMBER OF DIRECTORIES", cmd.value);
@@ -401,7 +401,7 @@ pass5(void)
 		cmd.value = cstotal.cs_nbfree - fs->fs_cstotal.cs_nbfree;
 		if (cmd.value != 0) {
 			if (debug)
-				printf("adjnbfree by %+" PRIi64 "\n", cmd.value);
+				printf("adjnbfree by %+" PRIi64 "\n", (int64_t)cmd.value);
 			if (bkgrdsumadj == 0 || sysctl(adjnbfree, MIBSIZE, 0, 0,
 			    &cmd, sizeof cmd) == -1)
 				rwerror("ADJUST NUMBER OF FREE BLOCKS", cmd.value);
@@ -410,7 +410,7 @@ pass5(void)
 		cmd.value = cstotal.cs_nifree - fs->fs_cstotal.cs_nifree;
 		if (cmd.value != 0) {
 			if (debug)
-				printf("adjnifree by %+" PRIi64 "\n", cmd.value);
+				printf("adjnifree by %+" PRIi64 "\n", (int64_t)cmd.value);
 			if (bkgrdsumadj == 0 || sysctl(adjnifree, MIBSIZE, 0, 0,
 			    &cmd, sizeof cmd) == -1)
 				rwerror("ADJUST NUMBER OF FREE INODES", cmd.value);
@@ -419,7 +419,7 @@ pass5(void)
 		cmd.value = cstotal.cs_nffree - fs->fs_cstotal.cs_nffree;
 		if (cmd.value != 0) {
 			if (debug)
-				printf("adjnffree by %+" PRIi64 "\n", cmd.value);
+				printf("adjnffree by %+" PRIi64 "\n", (int64_t)cmd.value);
 			if (bkgrdsumadj == 0 || sysctl(adjnffree, MIBSIZE, 0, 0,
 			    &cmd, sizeof cmd) == -1)
 				rwerror("ADJUST NUMBER OF FREE FRAGS", cmd.value);
@@ -428,7 +428,7 @@ pass5(void)
 		cmd.value = cstotal.cs_numclusters - fs->fs_cstotal.cs_numclusters;
 		if (cmd.value != 0) {
 			if (debug)
-				printf("adjnumclusters by %+" PRIi64 "\n", cmd.value);
+				printf("adjnumclusters by %+" PRIi64 "\n", (int64_t)cmd.value);
 			if (bkgrdsumadj == 0 || sysctl(adjnumclusters, MIBSIZE, 0, 0,
 			    &cmd, sizeof cmd) == -1)
 				rwerror("ADJUST NUMBER OF FREE CLUSTERS", cmd.value);

--- a/sys/ufs/ffs/ffs_alloc.c
+++ b/sys/ufs/ffs/ffs_alloc.c
@@ -3492,7 +3492,8 @@ sysctl_ffs_fsck(SYSCTL_HANDLER_ARGS)
 		if (fsckcmds) {
 			char buf[32];
 
-			if (copyinstr((char *)(intptr_t)cmd.value, buf,32,NULL))
+			if (copyinstr((char * __capability)(intcap_t)cmd.value,
+			    buf, sizeof(buf), NULL))
 				strncpy(buf, "Name_too_long", 32);
 			printf("%s: unlink %s (inode %jd)\n",
 			    mp->mnt_stat.f_mntonname, buf, (intmax_t)cmd.size);
@@ -3506,7 +3507,7 @@ sysctl_ffs_fsck(SYSCTL_HANDLER_ARGS)
 		vn_finished_write(mp);
 		mp = NULL;
 		error = kern_funlinkat(td, AT_FDCWD,
-		    __USER_CAP_STR((char *)(intptr_t)cmd.value), FD_NONE,
+		    (char * __capability)(intcap_t)cmd.value, FD_NONE,
 		    UIO_USERSPACE, 0, (ino_t)cmd.size);
 		break;
 

--- a/sys/ufs/ffs/fs.h
+++ b/sys/ufs/ffs/fs.h
@@ -36,6 +36,7 @@
 #define	_UFS_FFS_FS_H_
 
 #include <sys/mount.h>
+#include <sys/stdint.h>
 #include <ufs/ufs/dinode.h>
 
 /*
@@ -249,6 +250,7 @@
 #define	FFS_SET_SIZE		17	/* set inode size */
 #define	FFS_MAXID		17	/* number of valid ffs ids */
 
+#ifndef MAKEFS
 /*
  * Command structure passed in to the filesystem to adjust filesystem values.
  */
@@ -256,10 +258,15 @@
 struct fsck_cmd {
 	int32_t	version;	/* version of command structure */
 	int32_t	handle;		/* reference to filesystem to be changed */
-	int64_t	value;		/* inode or block number to be affected */
+#ifdef __ILP32__
+	int64_t value;		/* inode or block number to be affected */
+#else
+	kintcap_t value;
+#endif
 	int64_t	size;		/* amount or range to be adjusted */
 	int64_t	spare;		/* reserved for future use */
 };
+#endif
 
 /*
  * A recovery structure placed at the end of the boot block area by newfs


### PR DESCRIPTION
Allow (in theory) 64-bit background fsck to work by altering struct ffs_cmd to fit a capability on CHERI systems and adding a thunk for freebsd64 calls. Compiles and the system boots, but complete untested.