### PR TITLE
psci: Make the assembly code match the structure defined in C

### DIFF
--- a/sys/dev/psci/smccc_arm64.S
+++ b/sys/dev/psci/smccc_arm64.S
@@ -77,10 +77,10 @@ ENTRY(arm_smccc_hvc)
 #ifdef __CHERI_PURE_CAPABILITY__
 	restore_registers
 #endif
-	ldr	x4, [PTRN(sp)]
+	ldr	PTR(4), [PTRN(sp)]
 	cbz	x4, 1f
-	stp	x0, x1, [PTR(4), #16 * 0]
-	stp	x2, x3, [PTR(4), #16 * 1]
+	stp	PTR(0), PTR(1), [PTR(4), #__SIZEOF_POINTER__ * 0]
+	stp	PTR(2), PTR(3), [PTR(4), #__SIZEOF_POINTER__ * 2]
 1:	ret
 END(arm_smccc_hvc)
 
@@ -97,10 +97,10 @@ ENTRY(arm_smccc_smc)
 #ifdef __CHERI_PURE_CAPABILITY__
 	restore_registers
 #endif
-	ldr	x4, [PTRN(sp)]
+	ldr	PTR(4), [PTRN(sp)]
 	cbz	x4, 1f
-	stp	x0, x1, [PTR(4), #16 * 0]
-	stp	x2, x3, [PTR(4), #16 * 1]
+	stp	PTR(0), PTR(1), [PTR(4), #__SIZEOF_POINTER__ * 0]
+	stp	PTR(2), PTR(3), [PTR(4), #__SIZEOF_POINTER__ * 2]
 1:	ret
 END(arm_smccc_smc)
 // CHERI CHANGES START


### PR DESCRIPTION
The output argument is a struct containing uintptr_t, so we should be
storing capabilities there and not integers. Alternatively, the struct
should be changed to always use ptraddr_t.