### PR TITLE
vaddr_t -> ptraddr_t

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
@@ -220,7 +220,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_perm,
 
 CHERIBSDTEST(test_cheriabi_open_sealed, "Sealed path")
 {
-	char *path;
+	char *path, *sealed_path;
 	void *sealer;
 	size_t sealer_size;
 	int fd;
@@ -235,9 +235,9 @@ CHERIBSDTEST(test_cheriabi_open_sealed, "Sealed path")
 	if (path == NULL)
 		cheribsdtest_failure_err("calloc");
 	strcpy(path, "/dev/null");
-	path = cheri_seal(path, sealer);
+	sealed_path = cheri_seal(path, sealer);
 
-	fd = open(path, O_RDONLY);
+	fd = open(sealed_path, O_RDONLY);
 	free(path);
 	if (fd > 0)
 		cheribsdtest_failure_errx("open succeeded");

--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -216,7 +216,7 @@ CHERIBSDTEST(test_nofault_cfromptr, "Exercise CFromPtr success")
 	 * has an offset interpretation).
 	 * https://git.morello-project.org/morello/llvm-project/-/issues/16
 	 */
-	cd = __builtin_cheri_cap_from_pointer(cb, (vaddr_t)buf + 10);
+	cd = __builtin_cheri_cap_from_pointer(cb, (ptraddr_t)buf + 10);
 #else
 	/*
 	 * This pragma is require to allow compiling this file both with and

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -694,7 +694,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_reuse,
 	 * XXX-AM: is this checking the right thing?
 	 * We may be failing because the reservation length is not enough.
 	 */
-	map2 = mmap((void *)(uintptr_t)((vaddr_t)map + PAGE_SIZE),
+	map2 = mmap((void *)(uintptr_t)((ptraddr_t)map + PAGE_SIZE),
 	    PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0);
 	if (map2 == MAP_FAILED) {
 		CHERIBSDTEST_VERIFY2(errno == ENOMEM,
@@ -720,14 +720,14 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_align,
 	/* No alignment */
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
-	CHERIBSDTEST_VERIFY2(((vaddr_t)(map) & align_mask) == 0,
+	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
 	    "mmap failed to align representable region for %p", map);
 
 	/* Underaligned */
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_ALIGNED(align_shift - 1),
 	    -1, 0));
-	CHERIBSDTEST_VERIFY2(((vaddr_t)(map) & align_mask) == 0,
+	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
 	    "mmap failed to align representable region with requested "
 	    "alignment %lx for %p", align_shift - 1, map);
 
@@ -736,20 +736,20 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_align,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_ALIGNED(align_shift + 1),
 	    -1, 0));
 	CHERIBSDTEST_VERIFY2(
-	    ((vaddr_t)(map) & ((1 << (align_shift + 1)) - 1)) == 0,
+	    ((ptraddr_t)(map) & ((1 << (align_shift + 1)) - 1)) == 0,
 	    "mmap failed to align representable region with requested "
 	    "alignment %lx for %p", align_shift + 1, map);
 
 	/* Explicit cheri alignment */
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_ALIGNED_CHERI, -1, 0));
-	CHERIBSDTEST_VERIFY2(((vaddr_t)(map) & align_mask) == 0,
+	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
 	    "mmap failed to align representable region with requested "
 	    "cheri alignment for %p", map);
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_ALIGNED_CHERI_SEAL, -1, 0));
-	CHERIBSDTEST_VERIFY2(((vaddr_t)(map) & align_mask) == 0,
+	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
 	    "mmap failed to align representable region with requested "
 	    "cheri seal alignment for %p", map);
 
@@ -826,7 +826,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_shared,
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
 	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
 
-	CHERIBSDTEST_VERIFY2(((vaddr_t)(map) & align_mask) == 0,
+	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
 	    "mmap failed to align shared regiont for representability");
 	CHERIBSDTEST_VERIFY2(cheri_getlen(map) == expected_len,
 	    "mmap returned pointer with unrepresentable length");
@@ -967,7 +967,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_insert_null_derived,
 	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
 	    "mmap failed to return valid capability");
 
-	map = mmap((void *)(uintptr_t)(vaddr_t)map, PAGE_SIZE,
+	map = mmap((void *)(uintptr_t)(ptraddr_t)map, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0);
 	CHERIBSDTEST_VERIFY2(map == MAP_FAILED,
 	    "mmap fixed with NULL-derived hint succeded");

--- a/contrib/jemalloc/FREEBSD-upgrade
+++ b/contrib/jemalloc/FREEBSD-upgrade
@@ -94,7 +94,6 @@ do_extract_helper() {
   )
 }
 
-# XXX-CHERI: hack configure.ac to add 5 to LG_QUANTA
 do_autogen() {
   ./autogen.sh --enable-xmalloc --enable-utrace \
     --with-malloc-conf=abort_conf:false \

--- a/contrib/jemalloc/include/jemalloc/internal/arena_inlines_b.h
+++ b/contrib/jemalloc/include/jemalloc/internal/arena_inlines_b.h
@@ -200,7 +200,7 @@ arena_salloc(tsdn_t *tsdn, const void *ptr) {
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
 	szind_t szind = rtree_szind_read(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, true);
+	    (ptraddr_t)ptr, true);
 	assert(szind != SC_NSIZES);
 
 	return sz_index2size(szind);
@@ -223,7 +223,7 @@ arena_vsalloc(tsdn_t *tsdn, const void *ptr) {
 	extent_t *extent;
 	szind_t szind;
 	if (rtree_extent_szind_read(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, false, &extent, &szind)) {
+	    (ptraddr_t)ptr, false, &extent, &szind)) {
 		return 0;
 	}
 
@@ -258,12 +258,12 @@ arena_dalloc_no_tcache(tsdn_t *tsdn, void *ptr) {
 
 	szind_t szind;
 	bool slab;
-	rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx, (vaddr_t)ptr,
+	rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx, (ptraddr_t)ptr,
 	    true, &szind, &slab);
 
 	if (config_debug) {
 		extent_t *extent = rtree_extent_read(tsdn, &extents_rtree,
-		    rtree_ctx, (vaddr_t)ptr, true);
+		    rtree_ctx, (ptraddr_t)ptr, true);
 		assert(szind == extent_szind_get(extent));
 		assert(szind < SC_NSIZES);
 		assert(slab == extent_slab_get(extent));
@@ -314,13 +314,13 @@ arena_dalloc(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 	} else {
 		rtree_ctx = tsd_rtree_ctx(tsdn_tsd(tsdn));
 		rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-		    (vaddr_t)ptr, true, &szind, &slab);
+		    (ptraddr_t)ptr, true, &szind, &slab);
 	}
 
 	if (config_debug) {
 		rtree_ctx = tsd_rtree_ctx(tsdn_tsd(tsdn));
 		extent_t *extent = rtree_extent_read(tsdn, &extents_rtree,
-		    rtree_ctx, (vaddr_t)ptr, true);
+		    rtree_ctx, (ptraddr_t)ptr, true);
 		assert(szind == extent_szind_get(extent));
 		assert(szind < SC_NSIZES);
 		assert(slab == extent_slab_get(extent));
@@ -357,14 +357,14 @@ arena_sdalloc_no_tcache(tsdn_t *tsdn, void *ptr, size_t size) {
 		    &rtree_ctx_fallback);
 
 		rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-		    (vaddr_t)ptr, true, &szind, &slab);
+		    (ptraddr_t)ptr, true, &szind, &slab);
 
 		assert(szind == sz_size2index(size));
 		assert((config_prof && opt_prof) || slab == (szind < SC_NBINS));
 
 		if (config_debug) {
 			extent_t *extent = rtree_extent_read(tsdn,
-			    &extents_rtree, rtree_ctx, (vaddr_t)ptr, true);
+			    &extents_rtree, rtree_ctx, (ptraddr_t)ptr, true);
 			assert(szind == extent_szind_get(extent));
 			assert(slab == extent_slab_get(extent));
 		}
@@ -400,7 +400,7 @@ arena_sdalloc(tsdn_t *tsdn, void *ptr, size_t size, tcache_t *tcache,
 			rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn,
 			    &rtree_ctx_fallback);
 			rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-			    (vaddr_t)ptr, true, &local_ctx.szind,
+			    (ptraddr_t)ptr, true, &local_ctx.szind,
 			    &local_ctx.slab);
 			assert(local_ctx.szind == sz_size2index(size));
 			alloc_ctx = &local_ctx;
@@ -419,9 +419,9 @@ arena_sdalloc(tsdn_t *tsdn, void *ptr, size_t size, tcache_t *tcache,
 	if (config_debug) {
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsdn_tsd(tsdn));
 		rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-		    (vaddr_t)ptr, true, &szind, &slab);
+		    (ptraddr_t)ptr, true, &szind, &slab);
 		extent_t *extent = rtree_extent_read(tsdn,
-		    &extents_rtree, rtree_ctx, (vaddr_t)ptr, true);
+		    &extents_rtree, rtree_ctx, (ptraddr_t)ptr, true);
 		assert(szind == extent_szind_get(extent));
 		assert(slab == extent_slab_get(extent));
 	}

--- a/contrib/jemalloc/include/jemalloc/internal/arena_inlines_b.h
+++ b/contrib/jemalloc/include/jemalloc/internal/arena_inlines_b.h
@@ -1,16 +1,5 @@
 #ifndef JEMALLOC_INTERNAL_ARENA_INLINES_B_H
 #define JEMALLOC_INTERNAL_ARENA_INLINES_B_H
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181113,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 #include "jemalloc/internal/jemalloc_internal_types.h"
 #include "jemalloc/internal/mutex.h"
@@ -200,7 +189,7 @@ arena_salloc(tsdn_t *tsdn, const void *ptr) {
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
 	szind_t szind = rtree_szind_read(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, true);
+	    (uintptr_t)ptr, true);
 	assert(szind != SC_NSIZES);
 
 	return sz_index2size(szind);
@@ -223,7 +212,7 @@ arena_vsalloc(tsdn_t *tsdn, const void *ptr) {
 	extent_t *extent;
 	szind_t szind;
 	if (rtree_extent_szind_read(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, false, &extent, &szind)) {
+	    (uintptr_t)ptr, false, &extent, &szind)) {
 		return 0;
 	}
 
@@ -258,12 +247,12 @@ arena_dalloc_no_tcache(tsdn_t *tsdn, void *ptr) {
 
 	szind_t szind;
 	bool slab;
-	rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx, (ptraddr_t)ptr,
+	rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx, (uintptr_t)ptr,
 	    true, &szind, &slab);
 
 	if (config_debug) {
 		extent_t *extent = rtree_extent_read(tsdn, &extents_rtree,
-		    rtree_ctx, (ptraddr_t)ptr, true);
+		    rtree_ctx, (uintptr_t)ptr, true);
 		assert(szind == extent_szind_get(extent));
 		assert(szind < SC_NSIZES);
 		assert(slab == extent_slab_get(extent));
@@ -314,13 +303,13 @@ arena_dalloc(tsdn_t *tsdn, void *ptr, tcache_t *tcache,
 	} else {
 		rtree_ctx = tsd_rtree_ctx(tsdn_tsd(tsdn));
 		rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-		    (ptraddr_t)ptr, true, &szind, &slab);
+		    (uintptr_t)ptr, true, &szind, &slab);
 	}
 
 	if (config_debug) {
 		rtree_ctx = tsd_rtree_ctx(tsdn_tsd(tsdn));
 		extent_t *extent = rtree_extent_read(tsdn, &extents_rtree,
-		    rtree_ctx, (ptraddr_t)ptr, true);
+		    rtree_ctx, (uintptr_t)ptr, true);
 		assert(szind == extent_szind_get(extent));
 		assert(szind < SC_NSIZES);
 		assert(slab == extent_slab_get(extent));
@@ -357,14 +346,14 @@ arena_sdalloc_no_tcache(tsdn_t *tsdn, void *ptr, size_t size) {
 		    &rtree_ctx_fallback);
 
 		rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-		    (ptraddr_t)ptr, true, &szind, &slab);
+		    (uintptr_t)ptr, true, &szind, &slab);
 
 		assert(szind == sz_size2index(size));
 		assert((config_prof && opt_prof) || slab == (szind < SC_NBINS));
 
 		if (config_debug) {
 			extent_t *extent = rtree_extent_read(tsdn,
-			    &extents_rtree, rtree_ctx, (ptraddr_t)ptr, true);
+			    &extents_rtree, rtree_ctx, (uintptr_t)ptr, true);
 			assert(szind == extent_szind_get(extent));
 			assert(slab == extent_slab_get(extent));
 		}
@@ -400,7 +389,7 @@ arena_sdalloc(tsdn_t *tsdn, void *ptr, size_t size, tcache_t *tcache,
 			rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn,
 			    &rtree_ctx_fallback);
 			rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-			    (ptraddr_t)ptr, true, &local_ctx.szind,
+			    (uintptr_t)ptr, true, &local_ctx.szind,
 			    &local_ctx.slab);
 			assert(local_ctx.szind == sz_size2index(size));
 			alloc_ctx = &local_ctx;
@@ -419,9 +408,9 @@ arena_sdalloc(tsdn_t *tsdn, void *ptr, size_t size, tcache_t *tcache,
 	if (config_debug) {
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsdn_tsd(tsdn));
 		rtree_szind_slab_read(tsdn, &extents_rtree, rtree_ctx,
-		    (ptraddr_t)ptr, true, &szind, &slab);
+		    (uintptr_t)ptr, true, &szind, &slab);
 		extent_t *extent = rtree_extent_read(tsdn,
-		    &extents_rtree, rtree_ctx, (ptraddr_t)ptr, true);
+		    &extents_rtree, rtree_ctx, (uintptr_t)ptr, true);
 		assert(szind == extent_szind_get(extent));
 		assert(slab == extent_slab_get(extent));
 	}

--- a/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
+++ b/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
@@ -244,7 +244,7 @@ extent_addr_randomize(tsdn_t *tsdn, extent_t *extent, size_t alignment) {
 		extent->e_addr = (void *)((uintptr_t)extent->e_addr +
 		    random_offset);
 		assert(ALIGNMENT_ADDR2BASE(extent->e_addr, alignment) ==
-		    (ptraddr_t)extent->e_addr);
+		    extent->e_addr);
 	}
 }
 

--- a/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
+++ b/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
@@ -23,27 +23,27 @@
 static inline void
 extent_lock(tsdn_t *tsdn, extent_t *extent) {
 	assert(extent != NULL);
-	mutex_pool_lock(tsdn, &extent_mutex_pool, (ptraddr_t)extent);
+	mutex_pool_lock(tsdn, &extent_mutex_pool, (uintptr_t)extent);
 }
 
 static inline void
 extent_unlock(tsdn_t *tsdn, extent_t *extent) {
 	assert(extent != NULL);
-	mutex_pool_unlock(tsdn, &extent_mutex_pool, (ptraddr_t)extent);
+	mutex_pool_unlock(tsdn, &extent_mutex_pool, (uintptr_t)extent);
 }
 
 static inline void
 extent_lock2(tsdn_t *tsdn, extent_t *extent1, extent_t *extent2) {
 	assert(extent1 != NULL && extent2 != NULL);
-	mutex_pool_lock2(tsdn, &extent_mutex_pool, (ptraddr_t)extent1,
-	    (ptraddr_t)extent2);
+	mutex_pool_lock2(tsdn, &extent_mutex_pool, (uintptr_t)extent1,
+	    (uintptr_t)extent2);
 }
 
 static inline void
 extent_unlock2(tsdn_t *tsdn, extent_t *extent1, extent_t *extent2) {
 	assert(extent1 != NULL && extent2 != NULL);
-	mutex_pool_unlock2(tsdn, &extent_mutex_pool, (ptraddr_t)extent1,
-	    (ptraddr_t)extent2);
+	mutex_pool_unlock2(tsdn, &extent_mutex_pool, (uintptr_t)extent1,
+	    (uintptr_t)extent2);
 }
 
 static inline unsigned

--- a/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
+++ b/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
@@ -470,16 +470,16 @@ extent_esn_comp(const extent_t *a, const extent_t *b) {
 
 static inline int
 extent_ad_comp(const extent_t *a, const extent_t *b) {
-	ptraddr_t a_addr = (ptraddr_t)extent_addr_get(a);
-	ptraddr_t b_addr = (ptraddr_t)extent_addr_get(b);
+	uintptr_t a_addr = (uintptr_t)extent_addr_get(a);
+	uintptr_t b_addr = (uintptr_t)extent_addr_get(b);
 
 	return (a_addr > b_addr) - (a_addr < b_addr);
 }
 
 static inline int
 extent_ead_comp(const extent_t *a, const extent_t *b) {
-	ptraddr_t a_eaddr = (ptraddr_t)a;
-	ptraddr_t b_eaddr = (ptraddr_t)b;
+	uintptr_t a_eaddr = (uintptr_t)a;
+	uintptr_t b_eaddr = (uintptr_t)b;
 
 	return (a_eaddr > b_eaddr) - (a_eaddr < b_eaddr);
 }

--- a/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
+++ b/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
@@ -23,27 +23,27 @@
 static inline void
 extent_lock(tsdn_t *tsdn, extent_t *extent) {
 	assert(extent != NULL);
-	mutex_pool_lock(tsdn, &extent_mutex_pool, (vaddr_t)extent);
+	mutex_pool_lock(tsdn, &extent_mutex_pool, (ptraddr_t)extent);
 }
 
 static inline void
 extent_unlock(tsdn_t *tsdn, extent_t *extent) {
 	assert(extent != NULL);
-	mutex_pool_unlock(tsdn, &extent_mutex_pool, (vaddr_t)extent);
+	mutex_pool_unlock(tsdn, &extent_mutex_pool, (ptraddr_t)extent);
 }
 
 static inline void
 extent_lock2(tsdn_t *tsdn, extent_t *extent1, extent_t *extent2) {
 	assert(extent1 != NULL && extent2 != NULL);
-	mutex_pool_lock2(tsdn, &extent_mutex_pool, (vaddr_t)extent1,
-	    (vaddr_t)extent2);
+	mutex_pool_lock2(tsdn, &extent_mutex_pool, (ptraddr_t)extent1,
+	    (ptraddr_t)extent2);
 }
 
 static inline void
 extent_unlock2(tsdn_t *tsdn, extent_t *extent1, extent_t *extent2) {
 	assert(extent1 != NULL && extent2 != NULL);
-	mutex_pool_unlock2(tsdn, &extent_mutex_pool, (vaddr_t)extent1,
-	    (vaddr_t)extent2);
+	mutex_pool_unlock2(tsdn, &extent_mutex_pool, (ptraddr_t)extent1,
+	    (ptraddr_t)extent2);
 }
 
 static inline unsigned
@@ -244,7 +244,7 @@ extent_addr_randomize(tsdn_t *tsdn, extent_t *extent, size_t alignment) {
 		extent->e_addr = (void *)((uintptr_t)extent->e_addr +
 		    random_offset);
 		assert(ALIGNMENT_ADDR2BASE(extent->e_addr, alignment) ==
-		    (vaddr_t)extent->e_addr);
+		    (ptraddr_t)extent->e_addr);
 	}
 }
 
@@ -470,16 +470,16 @@ extent_esn_comp(const extent_t *a, const extent_t *b) {
 
 static inline int
 extent_ad_comp(const extent_t *a, const extent_t *b) {
-	vaddr_t a_addr = (vaddr_t)extent_addr_get(a);
-	vaddr_t b_addr = (vaddr_t)extent_addr_get(b);
+	ptraddr_t a_addr = (ptraddr_t)extent_addr_get(a);
+	ptraddr_t b_addr = (ptraddr_t)extent_addr_get(b);
 
 	return (a_addr > b_addr) - (a_addr < b_addr);
 }
 
 static inline int
 extent_ead_comp(const extent_t *a, const extent_t *b) {
-	vaddr_t a_eaddr = (vaddr_t)a;
-	vaddr_t b_eaddr = (vaddr_t)b;
+	ptraddr_t a_eaddr = (ptraddr_t)a;
+	ptraddr_t b_eaddr = (ptraddr_t)b;
 
 	return (a_eaddr > b_eaddr) - (a_eaddr < b_eaddr);
 }

--- a/contrib/jemalloc/include/jemalloc/internal/hash.h
+++ b/contrib/jemalloc/include/jemalloc/internal/hash.h
@@ -1,16 +1,5 @@
 #ifndef JEMALLOC_INTERNAL_HASH_H
 #define JEMALLOC_INTERNAL_HASH_H
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181113,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 #include "jemalloc/internal/assert.h"
 
@@ -35,7 +24,7 @@ hash_rotl_64(uint64_t x, int8_t r) {
 static inline uint32_t
 hash_get_block_32(const uint32_t *p, int i) {
 	/* Handle unaligned read. */
-	if (unlikely((ptraddr_t)p & (sizeof(uint32_t)-1)) != 0) {
+	if (unlikely((uintptr_t)p & (sizeof(uint32_t)-1)) != 0) {
 		uint32_t ret;
 
 		memcpy(&ret, (uint8_t *)(p + i), sizeof(uint32_t));
@@ -48,7 +37,7 @@ hash_get_block_32(const uint32_t *p, int i) {
 static inline uint64_t
 hash_get_block_64(const uint64_t *p, int i) {
 	/* Handle unaligned read. */
-	if (unlikely((ptraddr_t)p & (sizeof(uint64_t)-1)) != 0) {
+	if (unlikely((uintptr_t)p & (sizeof(uint64_t)-1)) != 0) {
 		uint64_t ret;
 
 		memcpy(&ret, (uint8_t *)(p + i), sizeof(uint64_t));

--- a/contrib/jemalloc/include/jemalloc/internal/hash.h
+++ b/contrib/jemalloc/include/jemalloc/internal/hash.h
@@ -35,7 +35,7 @@ hash_rotl_64(uint64_t x, int8_t r) {
 static inline uint32_t
 hash_get_block_32(const uint32_t *p, int i) {
 	/* Handle unaligned read. */
-	if (unlikely((vaddr_t)p & (sizeof(uint32_t)-1)) != 0) {
+	if (unlikely((ptraddr_t)p & (sizeof(uint32_t)-1)) != 0) {
 		uint32_t ret;
 
 		memcpy(&ret, (uint8_t *)(p + i), sizeof(uint32_t));
@@ -48,7 +48,7 @@ hash_get_block_32(const uint32_t *p, int i) {
 static inline uint64_t
 hash_get_block_64(const uint64_t *p, int i) {
 	/* Handle unaligned read. */
-	if (unlikely((vaddr_t)p & (sizeof(uint64_t)-1)) != 0) {
+	if (unlikely((ptraddr_t)p & (sizeof(uint64_t)-1)) != 0) {
 		uint64_t ret;
 
 		memcpy(&ret, (uint8_t *)(p + i), sizeof(uint64_t));

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -92,7 +92,7 @@ iealloc(tsdn_t *tsdn, const void *ptr) {
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
 	return rtree_extent_read(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, true);
+	    (ptraddr_t)ptr, true);
 }
 
 #endif /* JEMALLOC_INTERNAL_INLINES_B_H */

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_b.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_b.h
@@ -1,16 +1,5 @@
 #ifndef JEMALLOC_INTERNAL_INLINES_B_H
 #define JEMALLOC_INTERNAL_INLINES_B_H
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20180629,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 #include "jemalloc/internal/rtree.h"
 
@@ -92,7 +81,7 @@ iealloc(tsdn_t *tsdn, const void *ptr) {
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
 	return rtree_extent_read(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, true);
+	    (uintptr_t)ptr, true);
 }
 
 #endif /* JEMALLOC_INTERNAL_INLINES_B_H */

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -141,7 +141,7 @@ ipallocztm(tsdn_t *tsdn, size_t usize, size_t alignment, bool zero,
 	    WITNESS_RANK_CORE, 0);
 
 	ret = arena_palloc(tsdn, arena, usize, alignment, zero, tcache);
-	assert(ALIGNMENT_ADDR2BASE(ret, alignment) == (ptraddr_t)ret);
+	assert(ALIGNMENT_ADDR2BASE(ret, alignment) == ret);
 	if (config_stats && is_internal && likely(ret != NULL)) {
 		arena_internal_add(iaalloc(tsdn, ret), isalloc(tsdn, ret));
 	}

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -53,10 +53,10 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 
 	rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 	extent = rtree_extent_read(tsdn, &extents_rtree,
-	    rtree_ctx, (vaddr_t)ptr, true);
+	    rtree_ctx, (ptraddr_t)ptr, true);
 	assert(extent != NULL);
-	ubptr = cheri_setaddress(extent->e_addr, (vaddr_t)ptr);
-	assert((vaddr_t)ptr == (vaddr_t)ubptr);
+	ubptr = cheri_setaddress(extent->e_addr, (ptraddr_t)ptr);
+	assert((ptraddr_t)ptr == (ptraddr_t)ubptr);
 	assert(cheri_getbase(ubptr) == cheri_getbase(extent->e_addr));
 	assert(cheri_getlen(ubptr) == cheri_getlen(extent->e_addr));
 #endif
@@ -133,7 +133,7 @@ ipallocztm(tsdn_t *tsdn, size_t usize, size_t alignment, bool zero,
 	    WITNESS_RANK_CORE, 0);
 
 	ret = arena_palloc(tsdn, arena, usize, alignment, zero, tcache);
-	assert(ALIGNMENT_ADDR2BASE(ret, alignment) == (vaddr_t)ret);
+	assert(ALIGNMENT_ADDR2BASE(ret, alignment) == (ptraddr_t)ret);
 	if (config_stats && is_internal && likely(ret != NULL)) {
 		arena_internal_add(iaalloc(tsdn, ret), isalloc(tsdn, ret));
 	}
@@ -237,7 +237,7 @@ iralloct(tsdn_t *tsdn, void *ptr, size_t oldsize, size_t size, size_t alignment,
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
-	if (alignment != 0 && ((vaddr_t)ptr & ((vaddr_t)alignment-1))
+	if (alignment != 0 && ((ptraddr_t)ptr & ((ptraddr_t)alignment-1))
 	    != 0) {
 		/*
 		 * Existing object alignment is inadequate; allocate new space
@@ -266,7 +266,7 @@ ixalloc(tsdn_t *tsdn, void *ptr, size_t oldsize, size_t size, size_t extra,
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
-	if (alignment != 0 && ((vaddr_t)ptr & ((vaddr_t)alignment-1))
+	if (alignment != 0 && ((ptraddr_t)ptr & ((ptraddr_t)alignment-1))
 	    != 0) {
 		/* Existing object alignment is inadequate. */
 		*newsize = oldsize;

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -50,6 +50,10 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 		    "non-zero offset\n");
 		abort();
 	}
+	if (unlikely(cheri_getsealed(ptr))) {
+		malloc_write("<jemalloc>: refusing to unbound sealed cap\n");
+		abort();
+	}
 
 	rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 	extent = rtree_extent_read(tsdn, &extents_rtree,

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -53,7 +53,7 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 
 	rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 	extent = rtree_extent_read(tsdn, &extents_rtree,
-	    rtree_ctx, (ptraddr_t)ptr, true);
+	    rtree_ctx, (uintptr_t)ptr, true);
 	assert(extent != NULL);
 	ubptr = cheri_setaddress(extent->e_addr, (ptraddr_t)ptr);
 	assert((ptraddr_t)ptr == (ptraddr_t)ubptr);

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -237,7 +237,7 @@ iralloct(tsdn_t *tsdn, void *ptr, size_t oldsize, size_t size, size_t alignment,
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
-	if (alignment != 0 && ((ptraddr_t)ptr & ((ptraddr_t)alignment-1))
+	if (alignment != 0 && ((uintptr_t)ptr & (alignment-1))
 	    != 0) {
 		/*
 		 * Existing object alignment is inadequate; allocate new space
@@ -266,7 +266,7 @@ ixalloc(tsdn_t *tsdn, void *ptr, size_t oldsize, size_t size, size_t extra,
 	witness_assert_depth_to_rank(tsdn_witness_tsdp_get(tsdn),
 	    WITNESS_RANK_CORE, 0);
 
-	if (alignment != 0 && ((ptraddr_t)ptr & ((ptraddr_t)alignment-1))
+	if (alignment != 0 && ((uintptr_t)ptr & (alignment-1))
 	    != 0) {
 		/* Existing object alignment is inadequate. */
 		*newsize = oldsize;

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -56,6 +56,14 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 	    rtree_ctx, (uintptr_t)ptr, true);
 	assert(extent != NULL);
 	ubptr = cheri_setaddress(extent->e_addr, (ptraddr_t)ptr);
+	/*
+	 * Compare pointer addresses to work around an issue where
+	 * LLVM's GVN pass replaces ubptr with ptr in the assert
+	 * about equal bases on riscv64.
+	 *
+	 * This works around:
+	 * https://github.com/CTSRD-CHERI/llvm-project/issues/619
+	 */
 	assert((ptraddr_t)ptr == (ptraddr_t)ubptr);
 	assert(cheri_getbase(ubptr) == cheri_getbase(extent->e_addr));
 	assert(cheri_getlen(ubptr) == cheri_getlen(extent->e_addr));

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_types.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_types.h
@@ -96,7 +96,7 @@ typedef int malloc_cpuid_t;
 
 /* Return the nearest aligned address at or below a. */
 #define ALIGNMENT_ADDR2BASE(a, alignment)				\
-	((ptraddr_t)(a) & (ptraddr_t)((~(alignment)) + 1))
+	((void *)((uintptr_t)(a) & ((~(alignment)) + 1)))
 
 /* Return the offset between a and the nearest aligned address at or below a. */
 #if __has_builtin(__builtin_align_down)

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_types.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_types.h
@@ -96,7 +96,7 @@ typedef int malloc_cpuid_t;
 
 /* Return the nearest aligned address at or below a. */
 #define ALIGNMENT_ADDR2BASE(a, alignment)				\
-	((vaddr_t)(a) & (vaddr_t)((~(alignment)) + 1))
+	((ptraddr_t)(a) & (ptraddr_t)((~(alignment)) + 1))
 
 /* Return the offset between a and the nearest aligned address at or below a. */
 #if __has_builtin(__builtin_align_down)

--- a/contrib/jemalloc/include/jemalloc/internal/mutex_pool.h
+++ b/contrib/jemalloc/include/jemalloc/internal/mutex_pool.h
@@ -29,9 +29,10 @@ bool mutex_pool_init(mutex_pool_t *pool, const char *name, witness_rank_t rank);
 
 /* Internal helper - not meant to be called outside this module. */
 static inline malloc_mutex_t *
-mutex_pool_mutex(mutex_pool_t *pool, ptraddr_t key) {
+mutex_pool_mutex(mutex_pool_t *pool, uintptr_t key) {
+	ptraddr_t hashkey = key;
 	size_t hash_result[2];
-	hash(&key, sizeof(key), 0xd50dcc1b, hash_result);
+	hash(&hashkey, sizeof(hashkey), 0xd50dcc1b, hash_result);
 	return &pool->mutexes[hash_result[0] % MUTEX_POOL_SIZE];
 }
 
@@ -50,7 +51,7 @@ mutex_pool_assert_not_held(tsdn_t *tsdn, mutex_pool_t *pool) {
  */
 
 static inline void
-mutex_pool_lock(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
+mutex_pool_lock(tsdn_t *tsdn, mutex_pool_t *pool, uintptr_t key) {
 	mutex_pool_assert_not_held(tsdn, pool);
 
 	malloc_mutex_t *mutex = mutex_pool_mutex(pool, key);
@@ -58,7 +59,7 @@ mutex_pool_lock(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
 }
 
 static inline void
-mutex_pool_unlock(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
+mutex_pool_unlock(tsdn_t *tsdn, mutex_pool_t *pool, uintptr_t key) {
 	malloc_mutex_t *mutex = mutex_pool_mutex(pool, key);
 	malloc_mutex_unlock(tsdn, mutex);
 
@@ -66,16 +67,16 @@ mutex_pool_unlock(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
 }
 
 static inline void
-mutex_pool_lock2(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key1,
-    ptraddr_t key2) {
+mutex_pool_lock2(tsdn_t *tsdn, mutex_pool_t *pool, uintptr_t key1,
+    uintptr_t key2) {
 	mutex_pool_assert_not_held(tsdn, pool);
 
 	malloc_mutex_t *mutex1 = mutex_pool_mutex(pool, key1);
 	malloc_mutex_t *mutex2 = mutex_pool_mutex(pool, key2);
-	if ((ptraddr_t)mutex1 < (ptraddr_t)mutex2) {
+	if ((uintptr_t)mutex1 < (uintptr_t)mutex2) {
 		malloc_mutex_lock(tsdn, mutex1);
 		malloc_mutex_lock(tsdn, mutex2);
-	} else if ((ptraddr_t)mutex1 == (ptraddr_t)mutex2) {
+	} else if ((uintptr_t)mutex1 == (uintptr_t)mutex2) {
 		malloc_mutex_lock(tsdn, mutex1);
 	} else {
 		malloc_mutex_lock(tsdn, mutex2);
@@ -84,8 +85,8 @@ mutex_pool_lock2(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key1,
 }
 
 static inline void
-mutex_pool_unlock2(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key1,
-    ptraddr_t key2) {
+mutex_pool_unlock2(tsdn_t *tsdn, mutex_pool_t *pool, uintptr_t key1,
+    uintptr_t key2) {
 	malloc_mutex_t *mutex1 = mutex_pool_mutex(pool, key1);
 	malloc_mutex_t *mutex2 = mutex_pool_mutex(pool, key2);
 	if (mutex1 == mutex2) {
@@ -99,7 +100,7 @@ mutex_pool_unlock2(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key1,
 }
 
 static inline void
-mutex_pool_assert_owner(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
+mutex_pool_assert_owner(tsdn_t *tsdn, mutex_pool_t *pool, uintptr_t key) {
 	malloc_mutex_assert_owner(tsdn, mutex_pool_mutex(pool, key));
 }
 

--- a/contrib/jemalloc/include/jemalloc/internal/mutex_pool.h
+++ b/contrib/jemalloc/include/jemalloc/internal/mutex_pool.h
@@ -29,7 +29,7 @@ bool mutex_pool_init(mutex_pool_t *pool, const char *name, witness_rank_t rank);
 
 /* Internal helper - not meant to be called outside this module. */
 static inline malloc_mutex_t *
-mutex_pool_mutex(mutex_pool_t *pool, vaddr_t key) {
+mutex_pool_mutex(mutex_pool_t *pool, ptraddr_t key) {
 	size_t hash_result[2];
 	hash(&key, sizeof(key), 0xd50dcc1b, hash_result);
 	return &pool->mutexes[hash_result[0] % MUTEX_POOL_SIZE];
@@ -50,7 +50,7 @@ mutex_pool_assert_not_held(tsdn_t *tsdn, mutex_pool_t *pool) {
  */
 
 static inline void
-mutex_pool_lock(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key) {
+mutex_pool_lock(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
 	mutex_pool_assert_not_held(tsdn, pool);
 
 	malloc_mutex_t *mutex = mutex_pool_mutex(pool, key);
@@ -58,7 +58,7 @@ mutex_pool_lock(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key) {
 }
 
 static inline void
-mutex_pool_unlock(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key) {
+mutex_pool_unlock(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
 	malloc_mutex_t *mutex = mutex_pool_mutex(pool, key);
 	malloc_mutex_unlock(tsdn, mutex);
 
@@ -66,16 +66,16 @@ mutex_pool_unlock(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key) {
 }
 
 static inline void
-mutex_pool_lock2(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key1,
-    vaddr_t key2) {
+mutex_pool_lock2(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key1,
+    ptraddr_t key2) {
 	mutex_pool_assert_not_held(tsdn, pool);
 
 	malloc_mutex_t *mutex1 = mutex_pool_mutex(pool, key1);
 	malloc_mutex_t *mutex2 = mutex_pool_mutex(pool, key2);
-	if ((vaddr_t)mutex1 < (vaddr_t)mutex2) {
+	if ((ptraddr_t)mutex1 < (ptraddr_t)mutex2) {
 		malloc_mutex_lock(tsdn, mutex1);
 		malloc_mutex_lock(tsdn, mutex2);
-	} else if ((vaddr_t)mutex1 == (vaddr_t)mutex2) {
+	} else if ((ptraddr_t)mutex1 == (ptraddr_t)mutex2) {
 		malloc_mutex_lock(tsdn, mutex1);
 	} else {
 		malloc_mutex_lock(tsdn, mutex2);
@@ -84,8 +84,8 @@ mutex_pool_lock2(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key1,
 }
 
 static inline void
-mutex_pool_unlock2(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key1,
-    vaddr_t key2) {
+mutex_pool_unlock2(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key1,
+    ptraddr_t key2) {
 	malloc_mutex_t *mutex1 = mutex_pool_mutex(pool, key1);
 	malloc_mutex_t *mutex2 = mutex_pool_mutex(pool, key2);
 	if (mutex1 == mutex2) {
@@ -99,7 +99,7 @@ mutex_pool_unlock2(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key1,
 }
 
 static inline void
-mutex_pool_assert_owner(tsdn_t *tsdn, mutex_pool_t *pool, vaddr_t key) {
+mutex_pool_assert_owner(tsdn_t *tsdn, mutex_pool_t *pool, ptraddr_t key) {
 	malloc_mutex_assert_owner(tsdn, mutex_pool_mutex(pool, key));
 }
 

--- a/contrib/jemalloc/include/jemalloc/internal/rb.h
+++ b/contrib/jemalloc/include/jemalloc/internal/rb.h
@@ -490,7 +490,7 @@ a_prefix##insert(a_rbt_type *rbtree, a_type *node) {			\
     struct {								\
 	a_type *node;							\
 	int cmp;							\
-    } path[sizeof(vaddr_t) << 4], *pathp;				\
+    } path[sizeof(ptraddr_t) << 4], *pathp;				\
     rbt_node_new(a_type, a_field, rbtree, node);			\
     /* Wind. */								\
     path->node = rbtree->rbt_root;					\
@@ -507,7 +507,7 @@ a_prefix##insert(a_rbt_type *rbtree, a_type *node) {			\
     }									\
     pathp->node = node;							\
     /* Unwind. */							\
-    for (pathp--; (vaddr_t)pathp >= (vaddr_t)path; pathp--) {		\
+    for (pathp--; (ptraddr_t)pathp >= (ptraddr_t)path; pathp--) {	\
 	a_type *cnode = pathp->node;					\
 	if (pathp->cmp < 0) {						\
 	    a_type *left = pathp[1].node;				\
@@ -651,7 +651,7 @@ a_prefix##remove(a_rbt_type *rbtree, a_type *node) {			\
     /* The node to be pruned is black, so unwind until balance is     */\
     /* restored.                                                      */\
     pathp->node = NULL;							\
-    for (pathp--; (vaddr_t)pathp >= (vaddr_t)path; pathp--) {		\
+    for (pathp--; (ptraddr_t)pathp >= (ptraddr_t)path; pathp--) {	\
 	assert(pathp->cmp != 0);					\
 	if (pathp->cmp < 0) {						\
 	    rbtn_left_set(a_type, a_field, pathp->node,			\
@@ -692,7 +692,7 @@ a_prefix##remove(a_rbt_type *rbtree, a_type *node) {			\
 		}							\
 		/* Balance restored, but rotation modified subtree    */\
 		/* root.                                              */\
-		assert((vaddr_t)pathp > (vaddr_t)path);			\
+		assert((ptraddr_t)pathp > (ptraddr_t)path);		\
 		if (pathp[-1].cmp < 0) {				\
 		    rbtn_left_set(a_type, a_field, pathp[-1].node,	\
 		      tnode);						\
@@ -827,7 +827,7 @@ a_prefix##remove(a_rbt_type *rbtree, a_type *node) {			\
 		      tnode);						\
 		    /* Balance restored, but rotation modified        */\
 		    /* subtree root.                                  */\
-		    assert((vaddr_t)pathp > (vaddr_t)path);		\
+		    assert((ptraddr_t)pathp > (ptraddr_t)path);		\
 		    if (pathp[-1].cmp < 0) {				\
 			rbtn_left_set(a_type, a_field, pathp[-1].node,	\
 			  tnode);					\

--- a/contrib/jemalloc/include/jemalloc/internal/rb.h
+++ b/contrib/jemalloc/include/jemalloc/internal/rb.h
@@ -507,7 +507,7 @@ a_prefix##insert(a_rbt_type *rbtree, a_type *node) {			\
     }									\
     pathp->node = node;							\
     /* Unwind. */							\
-    for (pathp--; (ptraddr_t)pathp >= (ptraddr_t)path; pathp--) {	\
+    for (pathp--; (uintptr_t)pathp >= (uintptr_t)path; pathp--) {	\
 	a_type *cnode = pathp->node;					\
 	if (pathp->cmp < 0) {						\
 	    a_type *left = pathp[1].node;				\
@@ -651,7 +651,7 @@ a_prefix##remove(a_rbt_type *rbtree, a_type *node) {			\
     /* The node to be pruned is black, so unwind until balance is     */\
     /* restored.                                                      */\
     pathp->node = NULL;							\
-    for (pathp--; (ptraddr_t)pathp >= (ptraddr_t)path; pathp--) {	\
+    for (pathp--; (uintptr_t)pathp >= (uintptr_t)path; pathp--) {	\
 	assert(pathp->cmp != 0);					\
 	if (pathp->cmp < 0) {						\
 	    rbtn_left_set(a_type, a_field, pathp->node,			\
@@ -692,7 +692,7 @@ a_prefix##remove(a_rbt_type *rbtree, a_type *node) {			\
 		}							\
 		/* Balance restored, but rotation modified subtree    */\
 		/* root.                                              */\
-		assert((ptraddr_t)pathp > (ptraddr_t)path);		\
+		assert((uintptr_t)pathp > (uintptr_t)path);		\
 		if (pathp[-1].cmp < 0) {				\
 		    rbtn_left_set(a_type, a_field, pathp[-1].node,	\
 		      tnode);						\
@@ -827,7 +827,7 @@ a_prefix##remove(a_rbt_type *rbtree, a_type *node) {			\
 		      tnode);						\
 		    /* Balance restored, but rotation modified        */\
 		    /* subtree root.                                  */\
-		    assert((ptraddr_t)pathp > (ptraddr_t)path);		\
+		    assert((uintptr_t)pathp > (uintptr_t)path);		\
 		    if (pathp[-1].cmp < 0) {				\
 			rbtn_left_set(a_type, a_field, pathp[-1].node,	\
 			  tnode);					\

--- a/contrib/jemalloc/include/jemalloc/internal/rtree.h
+++ b/contrib/jemalloc/include/jemalloc/internal/rtree.h
@@ -221,7 +221,7 @@ rtree_leaf_elm_bits_extent_get(uintptr_t bits) {
 	return (extent_t *)(bits & mask);
 #    else
 	/* Restore sign-extended high bits, mask slab bit. */
-	return (extent_t *)((uintptr_t)((uintptr_t)(bits << RTREE_NHIB) >>
+	return (extent_t *)((uintptr_t)((intptr_t)(bits << RTREE_NHIB) >>
 	    RTREE_NHIB) & ~((uintptr_t)0x1));
 #    endif
 }

--- a/contrib/jemalloc/include/jemalloc/internal/rtree.h
+++ b/contrib/jemalloc/include/jemalloc/internal/rtree.h
@@ -49,7 +49,7 @@
 #endif
 
 /* Needed for initialization only. */
-#define RTREE_LEAFKEY_INVALID ((ptraddr_t)1)
+#define RTREE_LEAFKEY_INVALID ((uintptr_t)1)
 
 typedef struct rtree_node_elm_s rtree_node_elm_t;
 struct rtree_node_elm_s {
@@ -152,10 +152,10 @@ extern rtree_leaf_dalloc_t *JET_MUTABLE rtree_leaf_dalloc;
 void rtree_delete(tsdn_t *tsdn, rtree_t *rtree);
 #endif
 rtree_leaf_elm_t *rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree,
-    rtree_ctx_t *rtree_ctx, ptraddr_t key, bool dependent, bool init_missing);
+    rtree_ctx_t *rtree_ctx, uintptr_t key, bool dependent, bool init_missing);
 
-JEMALLOC_ALWAYS_INLINE ptraddr_t
-rtree_leafkey(ptraddr_t key) {
+JEMALLOC_ALWAYS_INLINE uintptr_t
+rtree_leafkey(uintptr_t key) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
 	unsigned cumbits = (rtree_levels[RTREE_HEIGHT-1].cumbits -
 	    rtree_levels[RTREE_HEIGHT-1].bits);
@@ -165,7 +165,7 @@ rtree_leafkey(ptraddr_t key) {
 }
 
 JEMALLOC_ALWAYS_INLINE size_t
-rtree_cache_direct_map(ptraddr_t key) {
+rtree_cache_direct_map(uintptr_t key) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
 	unsigned cumbits = (rtree_levels[RTREE_HEIGHT-1].cumbits -
 	    rtree_levels[RTREE_HEIGHT-1].bits);
@@ -173,8 +173,8 @@ rtree_cache_direct_map(ptraddr_t key) {
 	return (size_t)((key >> maskbits) & (RTREE_CTX_NCACHE - 1));
 }
 
-JEMALLOC_ALWAYS_INLINE ptraddr_t
-rtree_subkey(ptraddr_t key, unsigned level) {
+JEMALLOC_ALWAYS_INLINE uintptr_t
+rtree_subkey(uintptr_t key, unsigned level) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
 	unsigned cumbits = rtree_levels[level].cumbits;
 	unsigned shiftbits = ptrbits - cumbits;
@@ -206,7 +206,7 @@ JEMALLOC_ALWAYS_INLINE extent_t *
 rtree_leaf_elm_bits_extent_get(uintptr_t bits) {
 #    ifdef __CHERI_PURE_CAPABILITY__
 	/* We use the offset to store the other bits -> set offset to zero */
-	assert((ptraddr_t)cheri_getoffset(bits) < (1 << 10) &&
+	assert(cheri_getoffset(bits) < (1 << 10) &&
 	    "Should store at most 9 bits in the offset field!");
 	return (extent_t *)cheri_setoffset(bits, 0);
 #    elif defined(__aarch64__)
@@ -230,7 +230,7 @@ JEMALLOC_ALWAYS_INLINE szind_t
 rtree_leaf_elm_bits_szind_get(uintptr_t bits) {
 #    ifdef __CHERI_PURE_CAPABILITY__
 	/* Lowest bit of offset is the boolean flag -> shift by one for szind */
-	ptraddr_t szind_raw = (ptraddr_t)cheri_getoffset((void*)bits) >> 1;
+	uintptr_t szind_raw = cheri_getoffset((void*)bits) >> 1;
 	assert((szind_raw >> 8) == 0 && "All offset bits above szind should be zero!");
 	return (szind_t)szind_raw;
 #    else
@@ -244,7 +244,7 @@ rtree_leaf_elm_bits_slab_get(uintptr_t bits) {
 	/* Lowest bit of offset is the boolean flag */
 	return (bool)(cheri_getoffset((void*)bits) & 0x1);
 #    else
-	return (bool)(bits & (ptraddr_t)0x1);
+	return (bool)(bits & (uintptr_t)0x1);
 #    endif
 }
 
@@ -302,7 +302,7 @@ rtree_leaf_elm_extent_write(tsdn_t *tsdn, rtree_t *rtree,
 	    cheri_getoffset((void*)old_bits));
 #else
 	uintptr_t bits = ((uintptr_t)rtree_leaf_elm_bits_szind_get(old_bits) <<
-	    LG_VADDR) | ((uintptr_t)extent & (((ptraddr_t)0x1 << LG_VADDR) - 1))
+	    LG_VADDR) | ((uintptr_t)extent & (((uintptr_t)0x1 << LG_VADDR) - 1))
 	    | ((uintptr_t)rtree_leaf_elm_bits_slab_get(old_bits));
 #endif
 	atomic_store_p(&elm->le_bits, (void *)bits, ATOMIC_RELEASE);
@@ -321,7 +321,7 @@ rtree_leaf_elm_szind_write(tsdn_t *tsdn, rtree_t *rtree,
 	    true);
 #ifdef __CHERI_PURE_CAPABILITY__
 	uintptr_t bits = (uintptr_t)cheri_setoffset((void*)old_bits,
-	    (ptraddr_t)szind << 1 | (ptraddr_t)rtree_leaf_elm_bits_slab_get(old_bits));
+	    (uintptr_t)szind << 1 | (uintptr_t)rtree_leaf_elm_bits_slab_get(old_bits));
 #else
 	uintptr_t bits = ((uintptr_t)szind << LG_VADDR) |
 	    ((uintptr_t)rtree_leaf_elm_bits_extent_get(old_bits) &
@@ -342,7 +342,7 @@ rtree_leaf_elm_slab_write(tsdn_t *tsdn, rtree_t *rtree,
 	    true);
 #ifdef __CHERI_PURE_CAPABILITY__
 	uintptr_t bits = (uintptr_t)cheri_setoffset((void*)old_bits,
-	    (ptraddr_t)rtree_leaf_elm_bits_szind_get(old_bits) << 1 | (ptraddr_t)slab);
+	    (uintptr_t)rtree_leaf_elm_bits_szind_get(old_bits) << 1 | (uintptr_t)slab);
 #else
 	uintptr_t bits = ((uintptr_t)rtree_leaf_elm_bits_szind_get(old_bits) <<
 	    LG_VADDR) | ((uintptr_t)rtree_leaf_elm_bits_extent_get(old_bits) &
@@ -361,7 +361,7 @@ rtree_leaf_elm_write(tsdn_t *tsdn, rtree_t *rtree,
 #ifdef __CHERI_PURE_CAPABILITY__
 	assert(cheri_getoffset(extent) == 0 && "Offset must be zero for packing");
 	uintptr_t bits = (uintptr_t)cheri_setoffset((void*)extent,
-	    szind << 1 | (ptraddr_t)slab);
+	    szind << 1 | (uintptr_t)slab);
 #else
 	uintptr_t bits = ((uintptr_t)szind << LG_VADDR) |
 	    ((uintptr_t)extent & (((uintptr_t)0x1 << LG_VADDR) - 1)) |
@@ -412,19 +412,19 @@ rtree_leaf_elm_szind_slab_update(tsdn_t *tsdn, rtree_t *rtree,
 
 JEMALLOC_ALWAYS_INLINE rtree_leaf_elm_t *
 rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, bool dependent, bool init_missing) {
+    uintptr_t key, bool dependent, bool init_missing) {
 	assert(key != 0);
 	assert(!dependent || !init_missing);
 
 	size_t slot = rtree_cache_direct_map(key);
-	ptraddr_t leafkey = rtree_leafkey(key);
+	uintptr_t leafkey = rtree_leafkey(key);
 	assert(leafkey != RTREE_LEAFKEY_INVALID);
 
 	/* Fast path: L1 direct mapped cache. */
 	if (likely(rtree_ctx->cache[slot].leafkey == leafkey)) {
 		rtree_leaf_elm_t *leaf = rtree_ctx->cache[slot].leaf;
 		assert(leaf != NULL);
-		ptraddr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
+		uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
 		return &leaf[subkey];
 	}
 	/*
@@ -455,7 +455,7 @@ rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		}							\
 		rtree_ctx->cache[slot].leafkey = leafkey;		\
 		rtree_ctx->cache[slot].leaf = leaf;			\
-		ptraddr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);	\
+		uintptr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);	\
 		return &leaf[subkey];					\
 	}								\
 } while (0)
@@ -472,7 +472,7 @@ rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 }
 
 static inline bool
-rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, ptraddr_t key,
+rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, uintptr_t key,
     extent_t *extent, szind_t szind, bool slab) {
 	/* Use rtree_clear() to set the extent to NULL. */
 	assert(extent != NULL);
@@ -490,7 +490,7 @@ rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, ptraddr_t key,
 }
 
 JEMALLOC_ALWAYS_INLINE rtree_leaf_elm_t *
-rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, ptraddr_t key,
+rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, uintptr_t key,
     bool dependent) {
 	rtree_leaf_elm_t *elm = rtree_leaf_elm_lookup(tsdn, rtree, rtree_ctx,
 	    key, dependent, false);
@@ -503,7 +503,7 @@ rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, ptraddr_t key,
 
 JEMALLOC_ALWAYS_INLINE extent_t *
 rtree_extent_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, bool dependent) {
+    uintptr_t key, bool dependent) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -514,7 +514,7 @@ rtree_extent_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 JEMALLOC_ALWAYS_INLINE szind_t
 rtree_szind_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, bool dependent) {
+    uintptr_t key, bool dependent) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -530,7 +530,7 @@ rtree_szind_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 JEMALLOC_ALWAYS_INLINE bool
 rtree_extent_szind_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, bool dependent, extent_t **r_extent, szind_t *r_szind) {
+    uintptr_t key, bool dependent, extent_t **r_extent, szind_t *r_szind) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -579,7 +579,7 @@ rtree_szind_slab_read_fast(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 }
 JEMALLOC_ALWAYS_INLINE bool
 rtree_szind_slab_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, bool dependent, szind_t *r_szind, bool *r_slab) {
+    uintptr_t key, bool dependent, szind_t *r_szind, bool *r_slab) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -598,7 +598,7 @@ rtree_szind_slab_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 static inline void
 rtree_szind_slab_update(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, szind_t szind, bool slab) {
+    uintptr_t key, szind_t szind, bool slab) {
 	assert(!slab || szind < SC_NBINS);
 
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key, true);
@@ -607,7 +607,7 @@ rtree_szind_slab_update(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 static inline void
 rtree_clear(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key) {
+    uintptr_t key) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key, true);
 	assert(rtree_leaf_elm_extent_read(tsdn, rtree, elm, false) !=
 	    NULL);

--- a/contrib/jemalloc/include/jemalloc/internal/rtree.h
+++ b/contrib/jemalloc/include/jemalloc/internal/rtree.h
@@ -49,7 +49,7 @@
 #endif
 
 /* Needed for initialization only. */
-#define RTREE_LEAFKEY_INVALID ((vaddr_t)1)
+#define RTREE_LEAFKEY_INVALID ((ptraddr_t)1)
 
 typedef struct rtree_node_elm_s rtree_node_elm_t;
 struct rtree_node_elm_s {
@@ -152,20 +152,20 @@ extern rtree_leaf_dalloc_t *JET_MUTABLE rtree_leaf_dalloc;
 void rtree_delete(tsdn_t *tsdn, rtree_t *rtree);
 #endif
 rtree_leaf_elm_t *rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree,
-    rtree_ctx_t *rtree_ctx, vaddr_t key, bool dependent, bool init_missing);
+    rtree_ctx_t *rtree_ctx, ptraddr_t key, bool dependent, bool init_missing);
 
-JEMALLOC_ALWAYS_INLINE vaddr_t
-rtree_leafkey(vaddr_t key) {
+JEMALLOC_ALWAYS_INLINE ptraddr_t
+rtree_leafkey(ptraddr_t key) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
 	unsigned cumbits = (rtree_levels[RTREE_HEIGHT-1].cumbits -
 	    rtree_levels[RTREE_HEIGHT-1].bits);
 	unsigned maskbits = ptrbits - cumbits;
-	vaddr_t mask = ~((ZU(1) << maskbits) - 1);
+	ptraddr_t mask = ~((ZU(1) << maskbits) - 1);
 	return (key & mask);
 }
 
 JEMALLOC_ALWAYS_INLINE size_t
-rtree_cache_direct_map(vaddr_t key) {
+rtree_cache_direct_map(ptraddr_t key) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
 	unsigned cumbits = (rtree_levels[RTREE_HEIGHT-1].cumbits -
 	    rtree_levels[RTREE_HEIGHT-1].bits);
@@ -173,13 +173,13 @@ rtree_cache_direct_map(vaddr_t key) {
 	return (size_t)((key >> maskbits) & (RTREE_CTX_NCACHE - 1));
 }
 
-JEMALLOC_ALWAYS_INLINE vaddr_t
-rtree_subkey(vaddr_t key, unsigned level) {
+JEMALLOC_ALWAYS_INLINE ptraddr_t
+rtree_subkey(ptraddr_t key, unsigned level) {
 	unsigned ptrbits = ZU(1) << (LG_SIZEOF_PTR+3);
 	unsigned cumbits = rtree_levels[level].cumbits;
 	unsigned shiftbits = ptrbits - cumbits;
 	unsigned maskbits = rtree_levels[level].bits;
-	vaddr_t mask = (ZU(1) << maskbits) - 1;
+	ptraddr_t mask = (ZU(1) << maskbits) - 1;
 	return ((key >> shiftbits) & mask);
 }
 
@@ -206,9 +206,9 @@ JEMALLOC_ALWAYS_INLINE extent_t *
 rtree_leaf_elm_bits_extent_get(uintptr_t bits) {
 #    ifdef __CHERI_PURE_CAPABILITY__
 	/* We use the offset to store the other bits -> set offset to zero */
-	assert((vaddr_t)cheri_getoffset((void*)bits) < (1 << 10) &&
+	assert((ptraddr_t)cheri_getoffset(bits) < (1 << 10) &&
 	    "Should store at most 9 bits in the offset field!");
-	return (extent_t *)cheri_setoffset((void*)bits, 0);
+	return (extent_t *)cheri_setoffset(bits, 0);
 #    elif defined(__aarch64__)
 	/*
 	 * aarch64 doesn't sign extend the highest virtual address bit to set
@@ -230,7 +230,7 @@ JEMALLOC_ALWAYS_INLINE szind_t
 rtree_leaf_elm_bits_szind_get(uintptr_t bits) {
 #    ifdef __CHERI_PURE_CAPABILITY__
 	/* Lowest bit of offset is the boolean flag -> shift by one for szind */
-	vaddr_t szind_raw = (vaddr_t)cheri_getoffset((void*)bits) >> 1;
+	ptraddr_t szind_raw = (ptraddr_t)cheri_getoffset((void*)bits) >> 1;
 	assert((szind_raw >> 8) == 0 && "All offset bits above szind should be zero!");
 	return (szind_t)szind_raw;
 #    else
@@ -244,7 +244,7 @@ rtree_leaf_elm_bits_slab_get(uintptr_t bits) {
 	/* Lowest bit of offset is the boolean flag */
 	return (bool)(cheri_getoffset((void*)bits) & 0x1);
 #    else
-	return (bool)(bits & (vaddr_t)0x1);
+	return (bool)(bits & (ptraddr_t)0x1);
 #    endif
 }
 
@@ -302,7 +302,7 @@ rtree_leaf_elm_extent_write(tsdn_t *tsdn, rtree_t *rtree,
 	    cheri_getoffset((void*)old_bits));
 #else
 	uintptr_t bits = ((uintptr_t)rtree_leaf_elm_bits_szind_get(old_bits) <<
-	    LG_VADDR) | ((uintptr_t)extent & (((vaddr_t)0x1 << LG_VADDR) - 1))
+	    LG_VADDR) | ((uintptr_t)extent & (((ptraddr_t)0x1 << LG_VADDR) - 1))
 	    | ((uintptr_t)rtree_leaf_elm_bits_slab_get(old_bits));
 #endif
 	atomic_store_p(&elm->le_bits, (void *)bits, ATOMIC_RELEASE);
@@ -321,7 +321,7 @@ rtree_leaf_elm_szind_write(tsdn_t *tsdn, rtree_t *rtree,
 	    true);
 #ifdef __CHERI_PURE_CAPABILITY__
 	uintptr_t bits = (uintptr_t)cheri_setoffset((void*)old_bits,
-	    (vaddr_t)szind << 1 | (vaddr_t)rtree_leaf_elm_bits_slab_get(old_bits));
+	    (ptraddr_t)szind << 1 | (ptraddr_t)rtree_leaf_elm_bits_slab_get(old_bits));
 #else
 	uintptr_t bits = ((uintptr_t)szind << LG_VADDR) |
 	    ((uintptr_t)rtree_leaf_elm_bits_extent_get(old_bits) &
@@ -342,7 +342,7 @@ rtree_leaf_elm_slab_write(tsdn_t *tsdn, rtree_t *rtree,
 	    true);
 #ifdef __CHERI_PURE_CAPABILITY__
 	uintptr_t bits = (uintptr_t)cheri_setoffset((void*)old_bits,
-	    (vaddr_t)rtree_leaf_elm_bits_szind_get(old_bits) << 1 | (vaddr_t)slab);
+	    (ptraddr_t)rtree_leaf_elm_bits_szind_get(old_bits) << 1 | (ptraddr_t)slab);
 #else
 	uintptr_t bits = ((uintptr_t)rtree_leaf_elm_bits_szind_get(old_bits) <<
 	    LG_VADDR) | ((uintptr_t)rtree_leaf_elm_bits_extent_get(old_bits) &
@@ -361,7 +361,7 @@ rtree_leaf_elm_write(tsdn_t *tsdn, rtree_t *rtree,
 #ifdef __CHERI_PURE_CAPABILITY__
 	assert(cheri_getoffset(extent) == 0 && "Offset must be zero for packing");
 	uintptr_t bits = (uintptr_t)cheri_setoffset((void*)extent,
-	    szind << 1 | (vaddr_t)slab);
+	    szind << 1 | (ptraddr_t)slab);
 #else
 	uintptr_t bits = ((uintptr_t)szind << LG_VADDR) |
 	    ((uintptr_t)extent & (((uintptr_t)0x1 << LG_VADDR) - 1)) |
@@ -412,19 +412,19 @@ rtree_leaf_elm_szind_slab_update(tsdn_t *tsdn, rtree_t *rtree,
 
 JEMALLOC_ALWAYS_INLINE rtree_leaf_elm_t *
 rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, bool dependent, bool init_missing) {
+    ptraddr_t key, bool dependent, bool init_missing) {
 	assert(key != 0);
 	assert(!dependent || !init_missing);
 
 	size_t slot = rtree_cache_direct_map(key);
-	vaddr_t leafkey = rtree_leafkey(key);
+	ptraddr_t leafkey = rtree_leafkey(key);
 	assert(leafkey != RTREE_LEAFKEY_INVALID);
 
 	/* Fast path: L1 direct mapped cache. */
 	if (likely(rtree_ctx->cache[slot].leafkey == leafkey)) {
 		rtree_leaf_elm_t *leaf = rtree_ctx->cache[slot].leaf;
 		assert(leaf != NULL);
-		vaddr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
+		ptraddr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);
 		return &leaf[subkey];
 	}
 	/*
@@ -455,7 +455,7 @@ rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		}							\
 		rtree_ctx->cache[slot].leafkey = leafkey;		\
 		rtree_ctx->cache[slot].leaf = leaf;			\
-		vaddr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);	\
+		ptraddr_t subkey = rtree_subkey(key, RTREE_HEIGHT-1);	\
 		return &leaf[subkey];					\
 	}								\
 } while (0)
@@ -472,7 +472,7 @@ rtree_leaf_elm_lookup(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 }
 
 static inline bool
-rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, vaddr_t key,
+rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, ptraddr_t key,
     extent_t *extent, szind_t szind, bool slab) {
 	/* Use rtree_clear() to set the extent to NULL. */
 	assert(extent != NULL);
@@ -490,7 +490,7 @@ rtree_write(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, vaddr_t key,
 }
 
 JEMALLOC_ALWAYS_INLINE rtree_leaf_elm_t *
-rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, vaddr_t key,
+rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, ptraddr_t key,
     bool dependent) {
 	rtree_leaf_elm_t *elm = rtree_leaf_elm_lookup(tsdn, rtree, rtree_ctx,
 	    key, dependent, false);
@@ -503,7 +503,7 @@ rtree_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx, vaddr_t key,
 
 JEMALLOC_ALWAYS_INLINE extent_t *
 rtree_extent_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, bool dependent) {
+    ptraddr_t key, bool dependent) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -514,7 +514,7 @@ rtree_extent_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 JEMALLOC_ALWAYS_INLINE szind_t
 rtree_szind_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, bool dependent) {
+    ptraddr_t key, bool dependent) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -530,7 +530,7 @@ rtree_szind_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 JEMALLOC_ALWAYS_INLINE bool
 rtree_extent_szind_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, bool dependent, extent_t **r_extent, szind_t *r_szind) {
+    ptraddr_t key, bool dependent, extent_t **r_extent, szind_t *r_szind) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -579,7 +579,7 @@ rtree_szind_slab_read_fast(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 }
 JEMALLOC_ALWAYS_INLINE bool
 rtree_szind_slab_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, bool dependent, szind_t *r_szind, bool *r_slab) {
+    ptraddr_t key, bool dependent, szind_t *r_szind, bool *r_slab) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key,
 	    dependent);
 	if (!dependent && elm == NULL) {
@@ -598,7 +598,7 @@ rtree_szind_slab_read(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 static inline void
 rtree_szind_slab_update(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, szind_t szind, bool slab) {
+    ptraddr_t key, szind_t szind, bool slab) {
 	assert(!slab || szind < SC_NBINS);
 
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key, true);
@@ -607,7 +607,7 @@ rtree_szind_slab_update(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 
 static inline void
 rtree_clear(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key) {
+    ptraddr_t key) {
 	rtree_leaf_elm_t *elm = rtree_read(tsdn, rtree, rtree_ctx, key, true);
 	assert(rtree_leaf_elm_extent_read(tsdn, rtree, elm, false) !=
 	    NULL);

--- a/contrib/jemalloc/include/jemalloc/internal/rtree_tsd.h
+++ b/contrib/jemalloc/include/jemalloc/internal/rtree_tsd.h
@@ -44,7 +44,7 @@ typedef struct rtree_leaf_elm_s rtree_leaf_elm_t;
 
 typedef struct rtree_ctx_cache_elm_s rtree_ctx_cache_elm_t;
 struct rtree_ctx_cache_elm_s {
-	vaddr_t			leafkey;
+	ptraddr_t		leafkey;
 	rtree_leaf_elm_t	*leaf;
 };
 

--- a/contrib/jemalloc/src/arena.c
+++ b/contrib/jemalloc/src/arena.c
@@ -351,13 +351,13 @@ arena_slab_regind(extent_t *slab, szind_t binind, const void *ptr) {
 	size_t diff, regind;
 
 	/* Freeing a pointer outside the slab can cause assertion failure. */
-	assert((ptraddr_t)ptr >= (ptraddr_t)extent_addr_get(slab));
-	assert((ptraddr_t)ptr < (ptraddr_t)extent_past_get(slab));
+	assert((uintptr_t)ptr >= (uintptr_t)extent_addr_get(slab));
+	assert((uintptr_t)ptr < (uintptr_t)extent_past_get(slab));
 	/* Freeing an interior pointer can cause assertion failure. */
-	assert(((ptraddr_t)ptr - (ptraddr_t)extent_addr_get(slab)) %
-	    (ptraddr_t)bin_infos[binind].reg_size == 0);
+	assert(((uintptr_t)ptr - (uintptr_t)extent_addr_get(slab)) %
+	    (uintptr_t)bin_infos[binind].reg_size == 0);
 
-	diff = (size_t)((ptraddr_t)ptr - (ptraddr_t)extent_addr_get(slab));
+	diff = (size_t)((uintptr_t)ptr - (uintptr_t)extent_addr_get(slab));
 
 	/* Avoid doing division with a variable divisor. */
 	regind = div_compute(&arena_binind_div_info[binind], diff);

--- a/contrib/jemalloc/src/arena.c
+++ b/contrib/jemalloc/src/arena.c
@@ -685,7 +685,7 @@ arena_decay_reinit(arena_decay_t *decay, ssize_t decay_ms) {
 
 	nstime_init(&decay->epoch, 0);
 	nstime_update(&decay->epoch);
-	decay->jitter_state = (uint64_t)(ptraddr_t)decay;
+	decay->jitter_state = (uint64_t)(uintptr_t)decay;
 	arena_decay_deadline_init(decay);
 	decay->nunpurged = 0;
 	memset(decay->backlog, 0, SMOOTHSTEP_NSTEPS * sizeof(size_t));
@@ -2015,7 +2015,7 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 		 * deterministic seed.
 		 */
 		atomic_store_zu(&arena->offset_state, config_debug ? ind :
-		    (size_t)(ptraddr_t)arena, ATOMIC_RELAXED);
+		    (size_t)(uintptr_t)arena, ATOMIC_RELAXED);
 	}
 
 	atomic_store_zu(&arena->extent_sn_next, 0, ATOMIC_RELAXED);

--- a/contrib/jemalloc/src/arena.c
+++ b/contrib/jemalloc/src/arena.c
@@ -1135,7 +1135,7 @@ arena_reset(tsd_t *tsd, arena_t *arena) {
 		alloc_ctx_t alloc_ctx;
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-		    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+		    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 		assert(alloc_ctx.szind != SC_NSIZES);
 
 		if (config_stats || (config_prof && opt_prof)) {
@@ -1579,12 +1579,12 @@ arena_prof_promote(tsdn_t *tsdn, void *ptr, size_t usize) {
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
 	extent_t *extent = rtree_extent_read(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, true);
+	    (uintptr_t)ptr, true);
 	arena_t *arena = extent_arena_get(extent);
 
 	szind_t szind = sz_size2index(usize);
 	extent_szind_set(extent, szind);
-	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (ptraddr_t)ptr,
+	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (uintptr_t)ptr,
 	    szind, false);
 
 	prof_accum_cancel(tsdn, &arena->prof_accum, usize);
@@ -1600,7 +1600,7 @@ arena_prof_demote(tsdn_t *tsdn, extent_t *extent, const void *ptr) {
 	extent_szind_set(extent, SC_NBINS);
 	rtree_ctx_t rtree_ctx_fallback;
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
-	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (ptraddr_t)ptr,
+	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (uintptr_t)ptr,
 	    SC_NBINS, false);
 
 	assert(isalloc(tsdn, ptr) == SC_LARGE_MINCLASS);

--- a/contrib/jemalloc/src/arena.c
+++ b/contrib/jemalloc/src/arena.c
@@ -351,13 +351,13 @@ arena_slab_regind(extent_t *slab, szind_t binind, const void *ptr) {
 	size_t diff, regind;
 
 	/* Freeing a pointer outside the slab can cause assertion failure. */
-	assert((vaddr_t)ptr >= (vaddr_t)extent_addr_get(slab));
-	assert((vaddr_t)ptr < (vaddr_t)extent_past_get(slab));
+	assert((ptraddr_t)ptr >= (ptraddr_t)extent_addr_get(slab));
+	assert((ptraddr_t)ptr < (ptraddr_t)extent_past_get(slab));
 	/* Freeing an interior pointer can cause assertion failure. */
-	assert(((vaddr_t)ptr - (vaddr_t)extent_addr_get(slab)) %
-	    (vaddr_t)bin_infos[binind].reg_size == 0);
+	assert(((ptraddr_t)ptr - (ptraddr_t)extent_addr_get(slab)) %
+	    (ptraddr_t)bin_infos[binind].reg_size == 0);
 
-	diff = (size_t)((vaddr_t)ptr - (vaddr_t)extent_addr_get(slab));
+	diff = (size_t)((ptraddr_t)ptr - (ptraddr_t)extent_addr_get(slab));
 
 	/* Avoid doing division with a variable divisor. */
 	regind = div_compute(&arena_binind_div_info[binind], diff);
@@ -685,7 +685,7 @@ arena_decay_reinit(arena_decay_t *decay, ssize_t decay_ms) {
 
 	nstime_init(&decay->epoch, 0);
 	nstime_update(&decay->epoch);
-	decay->jitter_state = (uint64_t)(vaddr_t)decay;
+	decay->jitter_state = (uint64_t)(ptraddr_t)decay;
 	arena_decay_deadline_init(decay);
 	decay->nunpurged = 0;
 	memset(decay->backlog, 0, SMOOTHSTEP_NSTEPS * sizeof(size_t));
@@ -1135,7 +1135,7 @@ arena_reset(tsd_t *tsd, arena_t *arena) {
 		alloc_ctx_t alloc_ctx;
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-		    (vaddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+		    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 		assert(alloc_ctx.szind != SC_NSIZES);
 
 		if (config_stats || (config_prof && opt_prof)) {
@@ -1579,12 +1579,12 @@ arena_prof_promote(tsdn_t *tsdn, void *ptr, size_t usize) {
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
 
 	extent_t *extent = rtree_extent_read(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, true);
+	    (ptraddr_t)ptr, true);
 	arena_t *arena = extent_arena_get(extent);
 
 	szind_t szind = sz_size2index(usize);
 	extent_szind_set(extent, szind);
-	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (vaddr_t)ptr,
+	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (ptraddr_t)ptr,
 	    szind, false);
 
 	prof_accum_cancel(tsdn, &arena->prof_accum, usize);
@@ -1600,7 +1600,7 @@ arena_prof_demote(tsdn_t *tsdn, extent_t *extent, const void *ptr) {
 	extent_szind_set(extent, SC_NBINS);
 	rtree_ctx_t rtree_ctx_fallback;
 	rtree_ctx_t *rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
-	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (vaddr_t)ptr,
+	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx, (ptraddr_t)ptr,
 	    SC_NBINS, false);
 
 	assert(isalloc(tsdn, ptr) == SC_LARGE_MINCLASS);
@@ -2015,7 +2015,7 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 		 * deterministic seed.
 		 */
 		atomic_store_zu(&arena->offset_state, config_debug ? ind :
-		    (size_t)(vaddr_t)arena, ATOMIC_RELAXED);
+		    (size_t)(ptraddr_t)arena, ATOMIC_RELAXED);
 	}
 
 	atomic_store_zu(&arena->extent_sn_next, 0, ATOMIC_RELAXED);

--- a/contrib/jemalloc/src/base.c
+++ b/contrib/jemalloc/src/base.c
@@ -121,7 +121,7 @@ base_unmap(tsdn_t *tsdn, extent_hooks_t *extent_hooks, unsigned ind, void *addr,
 label_done:
 	if (metadata_thp_madvise()) {
 		/* Set NOHUGEPAGE after unmap to avoid kernel defrag. */
-		assert(__builtin_is_aligned(addr, HUGEPAGE) &&
+		assert(((uintptr_t)addr & HUGEPAGE_MASK) == 0 &&
 		    (size & HUGEPAGE_MASK) == 0);
 		pages_nohuge(addr, size);
 	}
@@ -196,8 +196,8 @@ base_extent_bump_alloc_helper(extent_t *extent, size_t *gap_size, size_t size,
 	assert(alignment == ALIGNMENT_CEILING(alignment, QUANTUM));
 	assert(size == ALIGNMENT_CEILING(size, alignment));
 
-	*gap_size = ALIGNMENT_CEILING((ptraddr_t)extent_addr_get(extent),
-	    alignment) - (ptraddr_t)extent_addr_get(extent);
+	*gap_size = ALIGNMENT_CEILING((uintptr_t)extent_addr_get(extent),
+	    alignment) - (uintptr_t)extent_addr_get(extent);
 	ret = (void *)((uintptr_t)extent_addr_get(extent) + *gap_size);
 	assert(extent_bsize_get(extent) >= *gap_size + size);
 	extent_binit(extent, (void *)((uintptr_t)extent_addr_get(extent) +
@@ -226,14 +226,14 @@ base_extent_bump_alloc_post(base_t *base, extent_t *extent, size_t gap_size,
 		 * crossed by the new allocation. Adjust n_thp similarly when
 		 * metadata_thp is enabled.
 		 */
-		base->resident += PAGE_CEILING((ptraddr_t)addr + size) -
-		    PAGE_CEILING((ptraddr_t)addr - gap_size);
+		base->resident += PAGE_CEILING((uintptr_t)addr + size) -
+		    PAGE_CEILING((uintptr_t)addr - gap_size);
 		assert(base->allocated <= base->resident);
 		assert(base->resident <= base->mapped);
 		if (metadata_thp_madvise() && (opt_metadata_thp ==
 		    metadata_thp_always || base->auto_thp_switched)) {
-			base->n_thp += (HUGEPAGE_CEILING((ptraddr_t)addr + size)
-			    - HUGEPAGE_CEILING((ptraddr_t)addr - gap_size)) >>
+			base->n_thp += (HUGEPAGE_CEILING((uintptr_t)addr + size)
+			    - HUGEPAGE_CEILING((uintptr_t)addr - gap_size)) >>
 			    LG_HUGEPAGE;
 			assert(base->mapped >= base->n_thp << LG_HUGEPAGE);
 		}

--- a/contrib/jemalloc/src/base.c
+++ b/contrib/jemalloc/src/base.c
@@ -196,8 +196,8 @@ base_extent_bump_alloc_helper(extent_t *extent, size_t *gap_size, size_t size,
 	assert(alignment == ALIGNMENT_CEILING(alignment, QUANTUM));
 	assert(size == ALIGNMENT_CEILING(size, alignment));
 
-	*gap_size = ALIGNMENT_CEILING((vaddr_t)extent_addr_get(extent),
-	    alignment) - (vaddr_t)extent_addr_get(extent);
+	*gap_size = ALIGNMENT_CEILING((ptraddr_t)extent_addr_get(extent),
+	    alignment) - (ptraddr_t)extent_addr_get(extent);
 	ret = (void *)((uintptr_t)extent_addr_get(extent) + *gap_size);
 	assert(extent_bsize_get(extent) >= *gap_size + size);
 	extent_binit(extent, (void *)((uintptr_t)extent_addr_get(extent) +
@@ -226,14 +226,14 @@ base_extent_bump_alloc_post(base_t *base, extent_t *extent, size_t gap_size,
 		 * crossed by the new allocation. Adjust n_thp similarly when
 		 * metadata_thp is enabled.
 		 */
-		base->resident += PAGE_CEILING((vaddr_t)addr + size) -
-		    PAGE_CEILING((vaddr_t)addr - gap_size);
+		base->resident += PAGE_CEILING((ptraddr_t)addr + size) -
+		    PAGE_CEILING((ptraddr_t)addr - gap_size);
 		assert(base->allocated <= base->resident);
 		assert(base->resident <= base->mapped);
 		if (metadata_thp_madvise() && (opt_metadata_thp ==
 		    metadata_thp_always || base->auto_thp_switched)) {
-			base->n_thp += (HUGEPAGE_CEILING((vaddr_t)addr + size)
-			    - HUGEPAGE_CEILING((vaddr_t)addr - gap_size)) >>
+			base->n_thp += (HUGEPAGE_CEILING((ptraddr_t)addr + size)
+			    - HUGEPAGE_CEILING((ptraddr_t)addr - gap_size)) >>
 			    LG_HUGEPAGE;
 			assert(base->mapped >= base->n_thp << LG_HUGEPAGE);
 		}

--- a/contrib/jemalloc/src/ctl.c
+++ b/contrib/jemalloc/src/ctl.c
@@ -1214,7 +1214,7 @@ ctl_lookup(tsdn_t *tsdn, const char *name, ctl_node_t const **nodesp,
 	elm = name;
 	/* Equivalent to strchrnul(). */
 	dot = ((tdot = strchr(elm, '.')) != NULL) ? tdot : strchr(elm, '\0');
-	elen = (size_t)((const char*)dot - (const char*)elm);
+	elen = (size_t)((uintptr_t)dot - (uintptr_t)elm);
 	if (elen == 0) {
 		ret = ENOENT;
 		goto label_return;
@@ -1293,7 +1293,7 @@ ctl_lookup(tsdn_t *tsdn, const char *name, ctl_node_t const **nodesp,
 		elm = &dot[1];
 		dot = ((tdot = strchr(elm, '.')) != NULL) ? tdot :
 		    strchr(elm, '\0');
-		elen = (size_t)((const char*)dot - (const char*)elm);
+		elen = (size_t)((uintptr_t)dot - (uintptr_t)elm);
 	}
 
 	ret = 0;

--- a/contrib/jemalloc/src/extent.c
+++ b/contrib/jemalloc/src/extent.c
@@ -430,11 +430,11 @@ extents_fit_alignment(extents_t *extents, size_t min_size, size_t max_size,
 		assert(i < SC_NPSIZES);
 		assert(!extent_heap_empty(&extents->heaps[i]));
 		extent_t *extent = extent_heap_first(&extents->heaps[i]);
-		ptraddr_t base = (ptraddr_t)extent_base_get(extent);
+		uintptr_t base = (uintptr_t)extent_base_get(extent);
 		size_t candidate_size = extent_size_get(extent);
 		assert(candidate_size >= min_size);
 
-		ptraddr_t next_align = ALIGNMENT_CEILING(base,
+		uintptr_t next_align = ALIGNMENT_CEILING((uintptr_t)base,
 		    PAGE_CEILING(alignment));
 		if (base > next_align || base + candidate_size <= next_align) {
 			/* Overflow or not crossing the next alignment. */
@@ -1006,8 +1006,8 @@ extent_split_interior(tsdn_t *tsdn, arena_t *arena,
     void *new_addr, size_t size, size_t pad, size_t alignment, bool slab,
     szind_t szind, bool growing_retained) {
 	size_t esize = size + pad;
-	size_t leadsize = ALIGNMENT_CEILING((ptraddr_t)extent_base_get(*extent),
-	    PAGE_CEILING(alignment)) - (ptraddr_t)extent_base_get(*extent);
+	size_t leadsize = ALIGNMENT_CEILING((uintptr_t)extent_base_get(*extent),
+	    PAGE_CEILING(alignment)) - (uintptr_t)extent_base_get(*extent);
 	assert(new_addr == NULL || leadsize == 0);
 	if (extent_size_get(*extent) < leadsize + esize) {
 		return extent_split_interior_cant_alloc;
@@ -1935,7 +1935,7 @@ extent_destroy_wrapper(tsdn_t *tsdn, arena_t *arena,
 static bool
 extent_commit_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
     size_t offset, size_t length, unsigned arena_ind) {
-	return pages_commit((void *)((uintptr_t)addr + (ptraddr_t)offset),
+	return pages_commit((void *)((uintptr_t)addr + (uintptr_t)offset),
 	    length);
 }
 
@@ -1971,7 +1971,7 @@ extent_commit_wrapper(tsdn_t *tsdn, arena_t *arena,
 static bool
 extent_decommit_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
     size_t offset, size_t length, unsigned arena_ind) {
-	return pages_decommit((void *)((uintptr_t)addr + (ptraddr_t)offset),
+	return pages_decommit((void *)((uintptr_t)addr + (uintptr_t)offset),
 	    length);
 }
 
@@ -2007,7 +2007,7 @@ extent_purge_lazy_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
 	assert(length != 0);
 	assert((length & PAGE_MASK) == 0);
 
-	return pages_purge_lazy((void *)((uintptr_t)addr + (ptraddr_t)offset),
+	return pages_purge_lazy((void *)((uintptr_t)addr + (uintptr_t)offset),
 	    length);
 }
 #endif

--- a/contrib/jemalloc/src/extent.c
+++ b/contrib/jemalloc/src/extent.c
@@ -175,7 +175,7 @@ extent_lock_from_addr(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx, void *addr,
     bool inactive_only) {
 	extent_t *ret = NULL;
 	rtree_leaf_elm_t *elm = rtree_leaf_elm_lookup(tsdn, &extents_rtree,
-	    rtree_ctx, (ptraddr_t)addr, false, false);
+	    rtree_ctx, (uintptr_t)addr, false, false);
 	if (elm == NULL) {
 		return NULL;
 	}
@@ -721,14 +721,14 @@ extent_rtree_leaf_elms_lookup(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx,
     const extent_t *extent, bool dependent, bool init_missing,
     rtree_leaf_elm_t **r_elm_a, rtree_leaf_elm_t **r_elm_b) {
 	*r_elm_a = rtree_leaf_elm_lookup(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)extent_base_get(extent), dependent, init_missing);
+	    (uintptr_t)extent_base_get(extent), dependent, init_missing);
 	if (!dependent && *r_elm_a == NULL) {
 		return true;
 	}
 	assert(*r_elm_a != NULL);
 
 	*r_elm_b = rtree_leaf_elm_lookup(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)extent_last_get(extent), dependent, init_missing);
+	    (uintptr_t)extent_last_get(extent), dependent, init_missing);
 	if (!dependent && *r_elm_b == NULL) {
 		return true;
 	}
@@ -755,7 +755,7 @@ extent_interior_register(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx, extent_t *extent,
 	/* Register interior. */
 	for (size_t i = 1; i < (extent_size_get(extent) >> LG_PAGE) - 1; i++) {
 		rtree_write(tsdn, &extents_rtree, rtree_ctx,
-		    (ptraddr_t)extent_base_get(extent) + (ptraddr_t)(i <<
+		    (uintptr_t)extent_base_get(extent) + (uintptr_t)(i <<
 		    LG_PAGE), extent, szind, true);
 	}
 }
@@ -863,7 +863,7 @@ extent_interior_deregister(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx,
 
 	for (i = 1; i < (extent_size_get(extent) >> LG_PAGE) - 1; i++) {
 		rtree_clear(tsdn, &extents_rtree, rtree_ctx,
-		    (ptraddr_t)extent_base_get(extent) + (ptraddr_t)(i <<
+		    (uintptr_t)extent_base_get(extent) + (uintptr_t)(i <<
 		    LG_PAGE));
 	}
 }
@@ -1054,12 +1054,12 @@ extent_split_interior(tsdn_t *tsdn, arena_t *arena,
 		extent_szind_set(*extent, szind);
 		if (szind != SC_NSIZES) {
 			rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx,
-			    (ptraddr_t)extent_addr_get(*extent), szind, slab);
+			    (uintptr_t)extent_addr_get(*extent), szind, slab);
 			if (slab && extent_size_get(*extent) > PAGE) {
 				rtree_szind_slab_update(tsdn, &extents_rtree,
 				    rtree_ctx,
-				    (ptraddr_t)extent_past_get(*extent) -
-				    (ptraddr_t)PAGE, szind, slab);
+				    (uintptr_t)extent_past_get(*extent) -
+				    (uintptr_t)PAGE, szind, slab);
 			}
 		}
 	}
@@ -1736,7 +1736,7 @@ extent_record(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
 	}
 
 	assert(rtree_extent_read(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)extent_base_get(extent), true) == extent);
+	    (uintptr_t)extent_base_get(extent), true) == extent);
 
 	if (!extents->delay_coalesce) {
 		extent = extent_try_coalesce(tsdn, arena, r_extent_hooks,

--- a/contrib/jemalloc/src/extent.c
+++ b/contrib/jemalloc/src/extent.c
@@ -175,7 +175,7 @@ extent_lock_from_addr(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx, void *addr,
     bool inactive_only) {
 	extent_t *ret = NULL;
 	rtree_leaf_elm_t *elm = rtree_leaf_elm_lookup(tsdn, &extents_rtree,
-	    rtree_ctx, (vaddr_t)addr, false, false);
+	    rtree_ctx, (ptraddr_t)addr, false, false);
 	if (elm == NULL) {
 		return NULL;
 	}
@@ -430,11 +430,11 @@ extents_fit_alignment(extents_t *extents, size_t min_size, size_t max_size,
 		assert(i < SC_NPSIZES);
 		assert(!extent_heap_empty(&extents->heaps[i]));
 		extent_t *extent = extent_heap_first(&extents->heaps[i]);
-		vaddr_t base = (vaddr_t)extent_base_get(extent);
+		ptraddr_t base = (ptraddr_t)extent_base_get(extent);
 		size_t candidate_size = extent_size_get(extent);
 		assert(candidate_size >= min_size);
 
-		vaddr_t next_align = ALIGNMENT_CEILING(base,
+		ptraddr_t next_align = ALIGNMENT_CEILING(base,
 		    PAGE_CEILING(alignment));
 		if (base > next_align || base + candidate_size <= next_align) {
 			/* Overflow or not crossing the next alignment. */
@@ -721,14 +721,14 @@ extent_rtree_leaf_elms_lookup(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx,
     const extent_t *extent, bool dependent, bool init_missing,
     rtree_leaf_elm_t **r_elm_a, rtree_leaf_elm_t **r_elm_b) {
 	*r_elm_a = rtree_leaf_elm_lookup(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)extent_base_get(extent), dependent, init_missing);
+	    (ptraddr_t)extent_base_get(extent), dependent, init_missing);
 	if (!dependent && *r_elm_a == NULL) {
 		return true;
 	}
 	assert(*r_elm_a != NULL);
 
 	*r_elm_b = rtree_leaf_elm_lookup(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)extent_last_get(extent), dependent, init_missing);
+	    (ptraddr_t)extent_last_get(extent), dependent, init_missing);
 	if (!dependent && *r_elm_b == NULL) {
 		return true;
 	}
@@ -755,7 +755,7 @@ extent_interior_register(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx, extent_t *extent,
 	/* Register interior. */
 	for (size_t i = 1; i < (extent_size_get(extent) >> LG_PAGE) - 1; i++) {
 		rtree_write(tsdn, &extents_rtree, rtree_ctx,
-		    (vaddr_t)extent_base_get(extent) + (vaddr_t)(i <<
+		    (ptraddr_t)extent_base_get(extent) + (ptraddr_t)(i <<
 		    LG_PAGE), extent, szind, true);
 	}
 }
@@ -863,7 +863,7 @@ extent_interior_deregister(tsdn_t *tsdn, rtree_ctx_t *rtree_ctx,
 
 	for (i = 1; i < (extent_size_get(extent) >> LG_PAGE) - 1; i++) {
 		rtree_clear(tsdn, &extents_rtree, rtree_ctx,
-		    (vaddr_t)extent_base_get(extent) + (vaddr_t)(i <<
+		    (ptraddr_t)extent_base_get(extent) + (ptraddr_t)(i <<
 		    LG_PAGE));
 	}
 }
@@ -1006,8 +1006,8 @@ extent_split_interior(tsdn_t *tsdn, arena_t *arena,
     void *new_addr, size_t size, size_t pad, size_t alignment, bool slab,
     szind_t szind, bool growing_retained) {
 	size_t esize = size + pad;
-	size_t leadsize = ALIGNMENT_CEILING((vaddr_t)extent_base_get(*extent),
-	    PAGE_CEILING(alignment)) - (vaddr_t)extent_base_get(*extent);
+	size_t leadsize = ALIGNMENT_CEILING((ptraddr_t)extent_base_get(*extent),
+	    PAGE_CEILING(alignment)) - (ptraddr_t)extent_base_get(*extent);
 	assert(new_addr == NULL || leadsize == 0);
 	if (extent_size_get(*extent) < leadsize + esize) {
 		return extent_split_interior_cant_alloc;
@@ -1054,12 +1054,12 @@ extent_split_interior(tsdn_t *tsdn, arena_t *arena,
 		extent_szind_set(*extent, szind);
 		if (szind != SC_NSIZES) {
 			rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx,
-			    (vaddr_t)extent_addr_get(*extent), szind, slab);
+			    (ptraddr_t)extent_addr_get(*extent), szind, slab);
 			if (slab && extent_size_get(*extent) > PAGE) {
 				rtree_szind_slab_update(tsdn, &extents_rtree,
 				    rtree_ctx,
-				    (vaddr_t)extent_past_get(*extent) -
-				    (vaddr_t)PAGE, szind, slab);
+				    (ptraddr_t)extent_past_get(*extent) -
+				    (ptraddr_t)PAGE, szind, slab);
 			}
 		}
 	}
@@ -1736,7 +1736,7 @@ extent_record(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
 	}
 
 	assert(rtree_extent_read(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)extent_base_get(extent), true) == extent);
+	    (ptraddr_t)extent_base_get(extent), true) == extent);
 
 	if (!extents->delay_coalesce) {
 		extent = extent_try_coalesce(tsdn, arena, r_extent_hooks,
@@ -1935,7 +1935,7 @@ extent_destroy_wrapper(tsdn_t *tsdn, arena_t *arena,
 static bool
 extent_commit_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
     size_t offset, size_t length, unsigned arena_ind) {
-	return pages_commit((void *)((uintptr_t)addr + (vaddr_t)offset),
+	return pages_commit((void *)((uintptr_t)addr + (ptraddr_t)offset),
 	    length);
 }
 
@@ -1971,7 +1971,7 @@ extent_commit_wrapper(tsdn_t *tsdn, arena_t *arena,
 static bool
 extent_decommit_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
     size_t offset, size_t length, unsigned arena_ind) {
-	return pages_decommit((void *)((uintptr_t)addr + (vaddr_t)offset),
+	return pages_decommit((void *)((uintptr_t)addr + (ptraddr_t)offset),
 	    length);
 }
 
@@ -2007,7 +2007,7 @@ extent_purge_lazy_default(extent_hooks_t *extent_hooks, void *addr, size_t size,
 	assert(length != 0);
 	assert((length & PAGE_MASK) == 0);
 
-	return pages_purge_lazy((void *)((uintptr_t)addr + (vaddr_t)offset),
+	return pages_purge_lazy((void *)((uintptr_t)addr + (ptraddr_t)offset),
 	    length);
 }
 #endif
@@ -2054,8 +2054,7 @@ extent_purge_forced_default(extent_hooks_t *extent_hooks, void *addr,
 	assert(length != 0);
 	assert((length & PAGE_MASK) == 0);
 
-	return pages_purge_forced((void *)((vaddr_t)addr +
-	    (vaddr_t)offset), length);
+	return pages_purge_forced((void *)((uintptr_t)addr + offset), length);
 }
 #endif
 

--- a/contrib/jemalloc/src/extent_dss.c
+++ b/contrib/jemalloc/src/extent_dss.c
@@ -150,8 +150,8 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 			    (uintptr_t)max_cur));
 			void *ret = (void *)ALIGNMENT_CEILING(
 			    (uintptr_t)gap_addr_page, alignment);
-			size_t gap_size_page = (const char*)ret -
-			    (const char*)gap_addr_page;
+			size_t gap_size_page = (uintptr_t)ret -
+			    (uintptr_t)gap_addr_page;
 			if (gap_size_page != 0) {
 				extent_init(gap, arena, gap_addr_page,
 				    gap_size_page, false, SC_NSIZES,
@@ -170,8 +170,8 @@ extent_alloc_dss(tsdn_t *tsdn, arena_t *arena, void *new_addr, size_t size,
 			}
 			/* Compute the increment, including subpage bytes. */
 			void *gap_addr_subpage = max_cur;
-			size_t gap_size_subpage = (const char*)ret -
-			    (const char*)gap_addr_subpage;
+			size_t gap_size_subpage = (uintptr_t)ret -
+			    (uintptr_t)gap_addr_subpage;
 			size_t incr = gap_size_subpage + size;
 
 			assert((uintptr_t)max_cur + incr == (uintptr_t)ret +

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -809,11 +809,6 @@ init_opt_stats_print_opts(const char *v, size_t vlen) {
 	assert(opts_len == strlen(opt_stats_print_opts));
 }
 
-static inline ptrdiff_t
-pointer_distance(const void* end, const void* start) {
-	return (const uint8_t*)end - (const uint8_t*)start;
-}
-
 /* Reads the next size pair in a multi-sized option. */
 static bool
 malloc_conf_multi_sizes_next(const char **slab_size_segment_cur,
@@ -885,7 +880,7 @@ malloc_conf_next(char const **opts_p, char const **k_p, size_t *klen_p,
 			break;
 		case ':':
 			opts++;
-			*klen_p = pointer_distance(opts, *k_p) - 1;
+			*klen_p = (uintptr_t)opts - 1 - (uintptr_t)*k_p;
 			*v_p = opts;
 			accept = true;
 			break;
@@ -916,11 +911,11 @@ malloc_conf_next(char const **opts_p, char const **k_p, size_t *klen_p,
 				malloc_write("<jemalloc>: Conf string ends "
 				    "with comma\n");
 			}
-			*vlen_p = pointer_distance(opts, *v_p) - 1;
+			*vlen_p = (uintptr_t)opts - 1 - (uintptr_t)*v_p;
 			accept = true;
 			break;
 		case '\0':
-			*vlen_p = pointer_distance(opts, *v_p);
+			*vlen_p = (uintptr_t)opts - (uintptr_t)*v_p;
 			accept = true;
 			break;
 		default:
@@ -1141,8 +1136,8 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 									\
 				set_errno(0);				\
 				um = malloc_strtoumax(v, &end, 0);	\
-				if (get_errno() != 0 || 		\
-				    pointer_distance(end, v) != vlen) {	\
+				if (get_errno() != 0 || (uintptr_t)end -\
+				    (uintptr_t)v != vlen) {	\
 					CONF_ERROR("Invalid conf value",\
 					    k, klen, v, vlen);		\
 				} else if (clip) {			\
@@ -1181,8 +1176,8 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 									\
 				set_errno(0);				\
 				l = strtol(v, &end, 0);			\
-				if (get_errno() != 0 || 		\
-				    pointer_distance(end, v) != vlen) {	\
+				if (get_errno() != 0 || (uintptr_t)end -\
+				    (uintptr_t)v != vlen) {		\
 					CONF_ERROR("Invalid conf value",\
 					    k, klen, v, vlen);		\
 				} else if (l < (ssize_t)(min) || l >	\

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -2199,7 +2199,7 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 	 * post-allocation work to do though.
 	 */
 	assert(dopts->alignment == 0
-	    || ((ptraddr_t)allocation & (dopts->alignment - 1)) == ZU(0));
+	    || ((uintptr_t)allocation & (dopts->alignment - 1)) == ZU(0));
 
 	if (config_stats) {
 		assert(usize == isalloc(tsd_tsdn(tsd), allocation));
@@ -3339,7 +3339,7 @@ je_rallocx(void *ptr, size_t size, int flags) {
 			usize = isalloc(tsd_tsdn(tsd), p);
 		}
 	}
-	assert(alignment == 0 || ((ptraddr_t)p & (alignment - 1)) == ZU(0));
+	assert(alignment == 0 || ((uintptr_t)p & (alignment - 1)) == ZU(0));
 
 	if (config_stats) {
 		*tsd_thread_allocatedp_get(tsd) += usize;

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -2638,7 +2638,7 @@ ifree(tsd_t *tsd, void *ptr, tcache_t *tcache, bool slow_path) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 
 	size_t usize;
@@ -2696,7 +2696,7 @@ isfree(tsd_t *tsd, void *ptr, size_t usize, tcache_t *tcache, bool slow_path) {
 	} else if (config_prof && opt_prof) {
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-		    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+		    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 		assert(alloc_ctx.szind == sz_size2index(usize));
 		ctx = &alloc_ctx;
 	} else {
@@ -2747,7 +2747,7 @@ je_realloc(void *ptr, size_t arg_size) {
 		alloc_ctx_t alloc_ctx;
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-		    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+		    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 		assert(alloc_ctx.szind != SC_NSIZES);
 		old_usize = sz_index2size(alloc_ctx.szind);
 		assert(old_usize == isalloc(tsd_tsdn(tsd), ptr));
@@ -3310,7 +3310,7 @@ je_rallocx(void *ptr, size_t size, int flags) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 	old_usize = sz_index2size(alloc_ctx.szind);
 	assert(old_usize == isalloc(tsd_tsdn(tsd), ptr));
@@ -3460,7 +3460,7 @@ je_xallocx(void *ptr, size_t size, size_t extra, int flags) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 	old_usize = sz_index2size(alloc_ctx.szind);
 	assert(old_usize == isalloc(tsd_tsdn(tsd), ptr));

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -2199,7 +2199,7 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 	 * post-allocation work to do though.
 	 */
 	assert(dopts->alignment == 0
-	    || ((vaddr_t)allocation & (dopts->alignment - 1)) == ZU(0));
+	    || ((ptraddr_t)allocation & (dopts->alignment - 1)) == ZU(0));
 
 	if (config_stats) {
 		assert(usize == isalloc(tsd_tsdn(tsd), allocation));
@@ -2638,7 +2638,7 @@ ifree(tsd_t *tsd, void *ptr, tcache_t *tcache, bool slow_path) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 
 	size_t usize;
@@ -2696,7 +2696,7 @@ isfree(tsd_t *tsd, void *ptr, size_t usize, tcache_t *tcache, bool slow_path) {
 	} else if (config_prof && opt_prof) {
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-		    (vaddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+		    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 		assert(alloc_ctx.szind == sz_size2index(usize));
 		ctx = &alloc_ctx;
 	} else {
@@ -2747,7 +2747,7 @@ je_realloc(void *ptr, size_t arg_size) {
 		alloc_ctx_t alloc_ctx;
 		rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 		rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-		    (vaddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+		    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 		assert(alloc_ctx.szind != SC_NSIZES);
 		old_usize = sz_index2size(alloc_ctx.szind);
 		assert(old_usize == isalloc(tsd_tsdn(tsd), ptr));
@@ -3310,7 +3310,7 @@ je_rallocx(void *ptr, size_t size, int flags) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 	old_usize = sz_index2size(alloc_ctx.szind);
 	assert(old_usize == isalloc(tsd_tsdn(tsd), ptr));
@@ -3339,7 +3339,7 @@ je_rallocx(void *ptr, size_t size, int flags) {
 			usize = isalloc(tsd_tsdn(tsd), p);
 		}
 	}
-	assert(alignment == 0 || ((vaddr_t)p & (alignment - 1)) == ZU(0));
+	assert(alignment == 0 || ((ptraddr_t)p & (alignment - 1)) == ZU(0));
 
 	if (config_stats) {
 		*tsd_thread_allocatedp_get(tsd) += usize;
@@ -3460,7 +3460,7 @@ je_xallocx(void *ptr, size_t size, size_t extra, int flags) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (vaddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 	old_usize = sz_index2size(alloc_ctx.szind);
 	assert(old_usize == isalloc(tsd_tsdn(tsd), ptr));

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -2633,7 +2633,7 @@ ifree(tsd_t *tsd, void *ptr, tcache_t *tcache, bool slow_path) {
 	alloc_ctx_t alloc_ctx;
 	rtree_ctx_t *rtree_ctx = tsd_rtree_ctx(tsd);
 	rtree_szind_slab_read(tsd_tsdn(tsd), &extents_rtree, rtree_ctx,
-	    (uintptr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
+	    (uintptr_t)(ptraddr_t)ptr, true, &alloc_ctx.szind, &alloc_ctx.slab);
 	assert(alloc_ctx.szind != SC_NSIZES);
 
 	size_t usize;

--- a/contrib/jemalloc/src/large.c
+++ b/contrib/jemalloc/src/large.c
@@ -197,7 +197,7 @@ large_ralloc_no_move_expand(tsdn_t *tsdn, extent_t *extent, size_t usize,
 	szind_t szind = sz_size2index(usize);
 	extent_szind_set(extent, szind);
 	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx,
-	    (ptraddr_t)extent_addr_get(extent), szind, false);
+	    (uintptr_t)extent_addr_get(extent), szind, false);
 
 	if (config_stats && new_mapping) {
 		arena_stats_mapped_add(tsdn, &arena->stats, trailsize);

--- a/contrib/jemalloc/src/large.c
+++ b/contrib/jemalloc/src/large.c
@@ -197,7 +197,7 @@ large_ralloc_no_move_expand(tsdn_t *tsdn, extent_t *extent, size_t usize,
 	szind_t szind = sz_size2index(usize);
 	extent_szind_set(extent, szind);
 	rtree_szind_slab_update(tsdn, &extents_rtree, rtree_ctx,
-	    (vaddr_t)extent_addr_get(extent), szind, false);
+	    (ptraddr_t)extent_addr_get(extent), szind, false);
 
 	if (config_stats && new_mapping) {
 		arena_stats_mapped_add(tsdn, &arena->stats, trailsize);

--- a/contrib/jemalloc/src/mutex.c
+++ b/contrib/jemalloc/src/mutex.c
@@ -1,14 +1,3 @@
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181113,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ]
- * }
- * CHERI CHANGES END
- */
 #define JEMALLOC_MUTEX_C_
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
@@ -142,8 +131,8 @@ mutex_addr_comp(const witness_t *witness1, void *mutex1,
     const witness_t *witness2, void *mutex2) {
 	assert(mutex1 != NULL);
 	assert(mutex2 != NULL);
-	ptraddr_t mu1int = (ptraddr_t)mutex1;
-	ptraddr_t mu2int = (ptraddr_t)mutex2;
+	uintptr_t mu1int = (uintptr_t)mutex1;
+	uintptr_t mu2int = (uintptr_t)mutex2;
 	if (mu1int < mu2int) {
 		return -1;
 	} else if (mu1int == mu2int) {

--- a/contrib/jemalloc/src/mutex.c
+++ b/contrib/jemalloc/src/mutex.c
@@ -142,8 +142,8 @@ mutex_addr_comp(const witness_t *witness1, void *mutex1,
     const witness_t *witness2, void *mutex2) {
 	assert(mutex1 != NULL);
 	assert(mutex2 != NULL);
-	vaddr_t mu1int = (vaddr_t)mutex1;
-	vaddr_t mu2int = (vaddr_t)mutex2;
+	ptraddr_t mu1int = (ptraddr_t)mutex1;
+	ptraddr_t mu2int = (ptraddr_t)mutex2;
 	if (mu1int < mu2int) {
 		return -1;
 	} else if (mu1int == mu2int) {

--- a/contrib/jemalloc/src/pages.c
+++ b/contrib/jemalloc/src/pages.c
@@ -70,7 +70,7 @@ static void os_pages_unmap(void *addr, size_t size);
 
 static void *
 os_pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (ptraddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
 	assert(ALIGNMENT_CEILING(size, os_page) == size);
 	assert(size != 0);
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -149,7 +149,7 @@ os_pages_trim(void *addr, size_t alloc_size, size_t leadsize, size_t size,
 
 static void
 os_pages_unmap(void *addr, size_t size) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (ptraddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
 	assert(ALIGNMENT_CEILING(size, os_page) == size);
 
 #ifdef _WIN32
@@ -201,7 +201,7 @@ pages_map_slow(size_t size, size_t alignment, bool *commit) {
 void *
 pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	assert(alignment >= PAGE);
-	assert(ALIGNMENT_ADDR2BASE(addr, alignment) == (ptraddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, alignment) == addr);
 
 #if defined(__FreeBSD__) && defined(MAP_EXCL)
 	/*
@@ -318,7 +318,7 @@ pages_decommit(void *addr, size_t size) {
 
 bool
 pages_purge_lazy(void *addr, size_t size) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (ptraddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == addr);
 	assert(PAGE_CEILING(size) == size);
 
 	if (!pages_can_purge_lazy) {

--- a/contrib/jemalloc/src/pages.c
+++ b/contrib/jemalloc/src/pages.c
@@ -70,7 +70,7 @@ static void os_pages_unmap(void *addr, size_t size);
 
 static void *
 os_pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (vaddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (ptraddr_t)addr);
 	assert(ALIGNMENT_CEILING(size, os_page) == size);
 	assert(size != 0);
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -149,7 +149,7 @@ os_pages_trim(void *addr, size_t alloc_size, size_t leadsize, size_t size,
 
 static void
 os_pages_unmap(void *addr, size_t size) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (vaddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (ptraddr_t)addr);
 	assert(ALIGNMENT_CEILING(size, os_page) == size);
 
 #ifdef _WIN32
@@ -188,8 +188,8 @@ pages_map_slow(size_t size, size_t alignment, bool *commit) {
 		if (pages == NULL) {
 			return NULL;
 		}
-		size_t leadsize = ALIGNMENT_CEILING((vaddr_t)pages, alignment)
-		    - (vaddr_t)pages;
+		size_t leadsize = ALIGNMENT_CEILING((ptraddr_t)pages, alignment)
+		    - (ptraddr_t)pages;
 		ret = os_pages_trim(pages, alloc_size, leadsize, size, commit);
 	} while (ret == NULL);
 
@@ -201,7 +201,7 @@ pages_map_slow(size_t size, size_t alignment, bool *commit) {
 void *
 pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	assert(alignment >= PAGE);
-	assert(ALIGNMENT_ADDR2BASE(addr, alignment) == (vaddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, alignment) == (ptraddr_t)addr);
 
 #if defined(__FreeBSD__) && defined(MAP_EXCL)
 	/*
@@ -256,7 +256,7 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 		return ret;
 	}
 	assert(addr == NULL);
-	if (ALIGNMENT_ADDR2OFFSET((vaddr_t)ret, alignment) != 0) {
+	if (ALIGNMENT_ADDR2OFFSET((ptraddr_t)ret, alignment) != 0) {
 		os_pages_unmap(ret, size);
 		return pages_map_slow(size, alignment, commit);
 	}
@@ -318,7 +318,7 @@ pages_decommit(void *addr, size_t size) {
 
 bool
 pages_purge_lazy(void *addr, size_t size) {
-	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (vaddr_t)addr);
+	assert(ALIGNMENT_ADDR2BASE(addr, os_page) == (ptraddr_t)addr);
 	assert(PAGE_CEILING(size) == size);
 
 	if (!pages_can_purge_lazy) {

--- a/contrib/jemalloc/src/pages.c
+++ b/contrib/jemalloc/src/pages.c
@@ -188,8 +188,8 @@ pages_map_slow(size_t size, size_t alignment, bool *commit) {
 		if (pages == NULL) {
 			return NULL;
 		}
-		size_t leadsize = ALIGNMENT_CEILING((ptraddr_t)pages, alignment)
-		    - (ptraddr_t)pages;
+		size_t leadsize = ALIGNMENT_CEILING((uintptr_t)pages, alignment)
+		    - (uintptr_t)pages;
 		ret = os_pages_trim(pages, alloc_size, leadsize, size, commit);
 	} while (ret == NULL);
 
@@ -256,7 +256,7 @@ pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 		return ret;
 	}
 	assert(addr == NULL);
-	if (ALIGNMENT_ADDR2OFFSET((ptraddr_t)ret, alignment) != 0) {
+	if (ALIGNMENT_ADDR2OFFSET(ret, alignment) != 0) {
 		os_pages_unmap(ret, size);
 		return pages_map_slow(size, alignment, commit);
 	}

--- a/contrib/jemalloc/src/prof.c
+++ b/contrib/jemalloc/src/prof.c
@@ -1,14 +1,3 @@
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181113,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ]
- * }
- * CHERI CHANGES END
- */
 #define JEMALLOC_PROF_C_
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
@@ -2237,7 +2226,7 @@ prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid, uint64_t thr_discrim,
 		return NULL;
 	}
 
-	tdata->prng_state = (uint64_t)(ptraddr_t)tdata;
+	tdata->prng_state = (uint64_t)(uintptr_t)tdata;
 	prof_sample_threshold_update(tdata);
 
 	tdata->enq = false;

--- a/contrib/jemalloc/src/prof.c
+++ b/contrib/jemalloc/src/prof.c
@@ -2237,7 +2237,7 @@ prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid, uint64_t thr_discrim,
 		return NULL;
 	}
 
-	tdata->prng_state = (uint64_t)(vaddr_t)tdata;
+	tdata->prng_state = (uint64_t)(ptraddr_t)tdata;
 	prof_sample_threshold_update(tdata);
 
 	tdata->enq = false;

--- a/contrib/jemalloc/src/rtree.c
+++ b/contrib/jemalloc/src/rtree.c
@@ -1,14 +1,3 @@
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20180629,
- *   "target_type": "lib",
- *   "changes": [
- *     "virtual_address"
- *   ]
- * }
- * CHERI CHANGES END
- */
 #define JEMALLOC_RTREE_C_
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/jemalloc_internal_includes.h"
@@ -164,12 +153,12 @@ rtree_leaf_init(tsdn_t *tsdn, rtree_t *rtree, atomic_p_t *elmp) {
 
 static bool
 rtree_node_valid(rtree_node_elm_t *node) {
-	return ((ptraddr_t)node != (ptraddr_t)0);
+	return ((uintptr_t)node != (uintptr_t)0);
 }
 
 static bool
 rtree_leaf_valid(rtree_leaf_elm_t *leaf) {
-	return ((ptraddr_t)leaf != (ptraddr_t)0);
+	return ((uintptr_t)leaf != (uintptr_t)0);
 }
 
 static rtree_node_elm_t *
@@ -232,7 +221,7 @@ rtree_child_leaf_read(tsdn_t *tsdn, rtree_t *rtree, rtree_node_elm_t *elm,
 
 rtree_leaf_elm_t *
 rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    ptraddr_t key, bool dependent, bool init_missing) {
+    uintptr_t key, bool dependent, bool init_missing) {
 	rtree_node_elm_t *node;
 	rtree_leaf_elm_t *leaf;
 #if RTREE_HEIGHT > 1
@@ -242,7 +231,7 @@ rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 #endif
 
 	if (config_debug) {
-		ptraddr_t leafkey = rtree_leafkey(key);
+		uintptr_t leafkey = rtree_leafkey(key);
 		for (unsigned i = 0; i < RTREE_CTX_NCACHE; i++) {
 			assert(rtree_ctx->cache[i].leafkey != leafkey);
 		}
@@ -257,7 +246,7 @@ rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		    unlikely(!rtree_node_valid(node))) {		\
 			return NULL;					\
 		}							\
-		ptraddr_t subkey = rtree_subkey(key, level);		\
+		uintptr_t subkey = rtree_subkey(key, level);		\
 		if (level + 2 < RTREE_HEIGHT) {				\
 			node = init_missing ?				\
 			    rtree_child_node_read(tsdn, rtree,		\
@@ -293,10 +282,10 @@ rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		    rtree_ctx->cache[slot].leafkey;			\
 		rtree_ctx->l2_cache[0].leaf =				\
 		    rtree_ctx->cache[slot].leaf;			\
-		ptraddr_t leafkey = rtree_leafkey(key);			\
+		uintptr_t leafkey = rtree_leafkey(key);			\
 		rtree_ctx->cache[slot].leafkey = leafkey;		\
 		rtree_ctx->cache[slot].leaf = leaf;			\
-		ptraddr_t subkey = rtree_subkey(key, level);		\
+		uintptr_t subkey = rtree_subkey(key, level);		\
 		return &leaf[subkey];					\
 	}
 	if (RTREE_HEIGHT > 1) {

--- a/contrib/jemalloc/src/rtree.c
+++ b/contrib/jemalloc/src/rtree.c
@@ -164,12 +164,12 @@ rtree_leaf_init(tsdn_t *tsdn, rtree_t *rtree, atomic_p_t *elmp) {
 
 static bool
 rtree_node_valid(rtree_node_elm_t *node) {
-	return ((vaddr_t)node != (vaddr_t)0);
+	return ((ptraddr_t)node != (ptraddr_t)0);
 }
 
 static bool
 rtree_leaf_valid(rtree_leaf_elm_t *leaf) {
-	return ((vaddr_t)leaf != (vaddr_t)0);
+	return ((ptraddr_t)leaf != (ptraddr_t)0);
 }
 
 static rtree_node_elm_t *
@@ -232,7 +232,7 @@ rtree_child_leaf_read(tsdn_t *tsdn, rtree_t *rtree, rtree_node_elm_t *elm,
 
 rtree_leaf_elm_t *
 rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
-    vaddr_t key, bool dependent, bool init_missing) {
+    ptraddr_t key, bool dependent, bool init_missing) {
 	rtree_node_elm_t *node;
 	rtree_leaf_elm_t *leaf;
 #if RTREE_HEIGHT > 1
@@ -242,7 +242,7 @@ rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 #endif
 
 	if (config_debug) {
-		vaddr_t leafkey = rtree_leafkey(key);
+		ptraddr_t leafkey = rtree_leafkey(key);
 		for (unsigned i = 0; i < RTREE_CTX_NCACHE; i++) {
 			assert(rtree_ctx->cache[i].leafkey != leafkey);
 		}
@@ -257,7 +257,7 @@ rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		    unlikely(!rtree_node_valid(node))) {		\
 			return NULL;					\
 		}							\
-		vaddr_t subkey = rtree_subkey(key, level);		\
+		ptraddr_t subkey = rtree_subkey(key, level);		\
 		if (level + 2 < RTREE_HEIGHT) {				\
 			node = init_missing ?				\
 			    rtree_child_node_read(tsdn, rtree,		\
@@ -293,10 +293,10 @@ rtree_leaf_elm_lookup_hard(tsdn_t *tsdn, rtree_t *rtree, rtree_ctx_t *rtree_ctx,
 		    rtree_ctx->cache[slot].leafkey;			\
 		rtree_ctx->l2_cache[0].leaf =				\
 		    rtree_ctx->cache[slot].leaf;			\
-		vaddr_t leafkey = rtree_leafkey(key);			\
+		ptraddr_t leafkey = rtree_leafkey(key);			\
 		rtree_ctx->cache[slot].leafkey = leafkey;		\
 		rtree_ctx->cache[slot].leaf = leaf;			\
-		vaddr_t subkey = rtree_subkey(key, level);		\
+		ptraddr_t subkey = rtree_subkey(key, level);		\
 		return &leaf[subkey];					\
 	}
 	if (RTREE_HEIGHT > 1) {

--- a/contrib/libarchive/libarchive/archive_rb.c
+++ b/contrib/libarchive/libarchive/archive_rb.c
@@ -114,14 +114,14 @@
 static inline void
 RB_COPY_PROPERTIES(struct archive_rb_node * const dst, struct archive_rb_node * const src)
 {
-	vaddr_t src_bits = __get_bits(src->rb_info, RB_FLAG_MASK);
+	ptraddr_t src_bits = __get_bits(src->rb_info, RB_FLAG_MASK);
 	dst->rb_info = __clear_bits(dst->rb_info, RB_FLAG_MASK) | src_bits;
 }
 static inline void
 RB_SWAP_PROPERTIES(struct archive_rb_node * const a, struct archive_rb_node * const b)
 {
-	vaddr_t a_bits = __get_bits(a->rb_info, RB_FLAG_MASK);
-	vaddr_t b_bits = __get_bits(b->rb_info, RB_FLAG_MASK);
+	ptraddr_t a_bits = __get_bits(a->rb_info, RB_FLAG_MASK);
+	ptraddr_t b_bits = __get_bits(b->rb_info, RB_FLAG_MASK);
 	a->rb_info = __clear_bits(a->rb_info, RB_FLAG_MASK) | b_bits;
 	b->rb_info = __clear_bits(b->rb_info, RB_FLAG_MASK) | a_bits;
 }

--- a/contrib/netbsd-tests/lib/libc/stdlib/t_posix_memalign.c
+++ b/contrib/netbsd-tests/lib/libc/stdlib/t_posix_memalign.c
@@ -85,7 +85,7 @@ ATF_TC_BODY(posix_memalign_basic, tc)
 		else {
 			ATF_REQUIRE_EQ_MSG(ret, 0,
 			    "posix_memalign: %s", strerror(ret));
-			ATF_REQUIRE_EQ_MSG(((vaddr_t)p) & (align[i] - 1), 0,
+			ATF_REQUIRE_EQ_MSG(((ptraddr_t)p) & (align[i] - 1), 0,
 			    "p = %p", p);
 			free(p);
 		}
@@ -145,7 +145,7 @@ ATF_TC_BODY(aligned_alloc_basic, tc)
 			    "aligned_alloc: success when size was not an "
 			    "integer multiple of alignment");
 #endif
-			ATF_REQUIRE_EQ_MSG(((vaddr_t)p) & (vaddr_t)(align[i] - 1), 0,
+			ATF_REQUIRE_EQ_MSG(((ptraddr_t)p) & (ptraddr_t)(align[i] - 1), 0,
 			    "p = %p", p);
 			free(p);
 		}

--- a/contrib/ntp/sntp/libopts/enum.c
+++ b/contrib/ntp/sntp/libopts/enum.c
@@ -63,7 +63,7 @@ static void
 set_memb_names(tOptions * opts, tOptDesc * od, char const * const * nm_list,
                unsigned int nm_ct);
 
-static vaddr_t
+static ptraddr_t
 check_membership_start(tOptDesc * od, char const ** argp, bool * invert);
 
 static uintptr_t
@@ -361,11 +361,11 @@ set_memb_shell(tOptions * pOpts, tOptDesc * pOD, char const * const * paz_names,
      *  print the name string.
      */
     unsigned int ix =  0;
-    vaddr_t  bits = (vaddr_t)pOD->optCookie;
+    ptraddr_t  bits = (ptraddr_t)pOD->optCookie;
     size_t     len  = 0;
 
     (void)pOpts;
-    bits &= ((vaddr_t)1 << (vaddr_t)name_ct) - (vaddr_t)1;
+    bits &= ((ptraddr_t)1 << (ptraddr_t)name_ct) - (ptraddr_t)1;
 
     while (bits != 0) {
         if (bits & 1) {
@@ -382,8 +382,8 @@ set_memb_names(tOptions * opts, tOptDesc * od, char const * const * nm_list,
                unsigned int nm_ct)
 {
     char *     pz;
-    vaddr_t  mask = (1UL << (vaddr_t)nm_ct) - 1UL;
-    vaddr_t  bits = (vaddr_t)od->optCookie & mask;
+    ptraddr_t  mask = (1UL << (ptraddr_t)nm_ct) - 1UL;
+    ptraddr_t  bits = (ptraddr_t)od->optCookie & mask;
     unsigned int ix = 0;
     size_t     len  = 1;
 
@@ -399,7 +399,7 @@ set_memb_names(tOptions * opts, tOptDesc * od, char const * const * nm_list,
     }
 
     od->optArg.argString = pz = AGALOC(len, "enum");
-    bits = (vaddr_t)od->optCookie & mask;
+    bits = (ptraddr_t)od->optCookie & mask;
     if (bits == 0) {
         *pz = NUL;
         return;
@@ -439,10 +439,10 @@ set_memb_names(tOptions * opts, tOptDesc * od, char const * const * nm_list,
  *
  * @returns either zero or the original value for the optCookie.
  */
-static vaddr_t
+static ptraddr_t
 check_membership_start(tOptDesc * od, char const ** argp, bool * invert)
 {
-    vaddr_t      res = (vaddr_t)od->optCookie;
+    ptraddr_t      res = (ptraddr_t)od->optCookie;
     char const * arg = SPN_WHITESPACE_CHARS(od->optArg.argString);
     if ((arg == NULL) || (*arg == NUL))
         goto member_start_fail;
@@ -513,7 +513,7 @@ find_member_bit(tOptions * opts, tOptDesc * od, char const * pz, int len,
         if (shift_ct >= nm_ct)
             return 0UL;
 
-        return (vaddr_t)1U << shift_ct;
+        return (ptraddr_t)1U << shift_ct;
     }
 }
 
@@ -586,7 +586,7 @@ optionSetMembers(tOptions * opts, tOptDesc * od,
     {
         char const * arg;
         bool         invert;
-        vaddr_t    res = check_membership_start(od, &arg, &invert);
+        ptraddr_t    res = check_membership_start(od, &arg, &invert);
         if (arg == NULL)
             goto fail_return;
 

--- a/contrib/ntp/sntp/libopts/putshell.c
+++ b/contrib/ntp/sntp/libopts/putshell.c
@@ -303,7 +303,7 @@ print_membership(tOptions * pOpts, tOptDesc * pOD)
 {
     char const * svstr = pOD->optArg.argString;
     char const * pz;
-    vaddr_t val = 1;
+    ptraddr_t val = 1;
     printf(zOptNumFmt, pOpts->pzPROGNAME, pOD->pz_NAME,
            (int)(uintptr_t)(pOD->optCookie));
     pOD->optCookie = VOIDP(~0UL);

--- a/contrib/ofed/libmlx4/qp.c
+++ b/contrib/ofed/libmlx4/qp.c
@@ -375,7 +375,7 @@ int mlx4_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 
 			seg = wqe;
 			wqe += sizeof *seg;
-			off = ((ptraddr_t) wqe) & (MLX4_INLINE_ALIGN - 1);
+			off = ((uintptr_t) wqe) & (MLX4_INLINE_ALIGN - 1);
 			num_seg = 0;
 			seg_len = 0;
 
@@ -774,11 +774,3 @@ void mlx4_clear_qp(struct mlx4_context *ctx, uint32_t qpn)
 	else
 		ctx->qp_table[tind].table[qpn & ctx->qp_table_mask] = NULL;
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20180907,
-//   "changes": [
-//     "pointer_alignment"
-//   ]
-// }
-// CHERI CHANGES END

--- a/contrib/ofed/libmlx4/qp.c
+++ b/contrib/ofed/libmlx4/qp.c
@@ -375,7 +375,7 @@ int mlx4_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 
 			seg = wqe;
 			wqe += sizeof *seg;
-			off = ((vaddr_t) wqe) & (MLX4_INLINE_ALIGN - 1);
+			off = ((ptraddr_t) wqe) & (MLX4_INLINE_ALIGN - 1);
 			num_seg = 0;
 			seg_len = 0;
 

--- a/contrib/one-true-awk/parse.c
+++ b/contrib/one-true-awk/parse.c
@@ -302,7 +302,7 @@ int isarg(const char *s)		/* is s in argument list for current function? */
 
 int ptoi(void *p)	/* convert pointer to integer */
 {
-	return (int) (vaddr_t) p;	/* swearing that p fits, of course */
+	return (int) (ptraddr_t) p;	/* swearing that p fits, of course */
 }
 
 Node *itonp(int i)	/* and vice versa */

--- a/contrib/one-true-awk/parse.c
+++ b/contrib/one-true-awk/parse.c
@@ -302,10 +302,10 @@ int isarg(const char *s)		/* is s in argument list for current function? */
 
 int ptoi(void *p)	/* convert pointer to integer */
 {
-	return (int) (ptraddr_t) p;	/* swearing that p fits, of course */
+	return (int) (intptr_t) p;	/* swearing that p fits, of course */
 }
 
 Node *itonp(int i)	/* and vice versa */
 {
-	return (Node *) (uintptr_t) i;
+	return (Node *) (intptr_t) i;
 }

--- a/contrib/tcpdump/in_cksum.c
+++ b/contrib/tcpdump/in_cksum.c
@@ -103,7 +103,7 @@ in_cksum(const struct cksum_vec *vec, int veclen)
 		/*
 		 * Force to even boundary.
 		 */
-		if ((1 & (vaddr_t) w) && (mlen > 0)) {
+		if ((1 & (ptraddr_t) w) && (mlen > 0)) {
 			REDUCE;
 			sum <<= 8;
 			s_util.c[0] = *(const uint8_t *)w;

--- a/contrib/tcpdump/in_cksum.c
+++ b/contrib/tcpdump/in_cksum.c
@@ -34,17 +34,6 @@
  *
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/10/93
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20180629,
- *   "target_type": "prog",
- *   "changes": [
- *     "pointer_alignment"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"
@@ -103,7 +92,7 @@ in_cksum(const struct cksum_vec *vec, int veclen)
 		/*
 		 * Force to even boundary.
 		 */
-		if ((1 & (ptraddr_t) w) && (mlen > 0)) {
+		if ((1 & (uintptr_t) w) && (mlen > 0)) {
 			REDUCE;
 			sum <<= 8;
 			s_util.c[0] = *(const uint8_t *)w;

--- a/crypto/heimdal/base/baselocl.h
+++ b/crypto/heimdal/base/baselocl.h
@@ -134,9 +134,9 @@ heim_base_atomic_dec(heim_base_atomic_type *x)
 #define heim_base_is_tagged_object(x) (__get_bits((x), 0x3) == 1)
 /* XXXAR: I hope x is never a valid pointer... */
 #define heim_base_make_tagged_object(x, tid) \
-    ((heim_object_t)(intptr_t)((((vaddr_t)(x)) << 5) | ((tid) << 2) | 0x1))
-#define heim_base_tagged_object_tid(x) ((((vaddr_t)(x)) & 0x1f) >> 2)
-#define heim_base_tagged_object_value(x) (((vaddr_t)(x)) >> 5)
+    ((heim_object_t)(intptr_t)((((ptraddr_t)(x)) << 5) | ((tid) << 2) | 0x1))
+#define heim_base_tagged_object_tid(x) ((((ptraddr_t)(x)) & 0x1f) >> 2)
+#define heim_base_tagged_object_value(x) (((ptraddr_t)(x)) >> 5)
 
 /*
  *

--- a/crypto/openssl/crypto/bn/bn_nist.c
+++ b/crypto/openssl/crypto/bn/bn_nist.c
@@ -340,7 +340,7 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_192_TOP], *res;
-    vaddr_t mask;
+    ptraddr_t mask;
     static const BIGNUM _bignum_nist_p_192_sqr = {
         (BN_ULONG *)_nist_p_192_sqr,
         OSSL_NELEM(_nist_p_192_sqr),
@@ -444,7 +444,7 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     mask =
         0 - (PTR_SIZE_INT) bn_sub_words(c_d, r_d, _nist_p_192[0],
                                         BN_NIST_192_TOP);
-    mask &= 0 - (vaddr_t) carry;
+    mask &= 0 - (ptraddr_t) carry;
 #ifndef __CHERI_PURE_CAPABILITY__
     res = c_d;
     res = (BN_ULONG *)
@@ -485,7 +485,7 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_224_TOP], *res;
-    vaddr_t mask;
+    ptraddr_t mask;
     union {
         bn_addsub_f f;
         PTR_SIZE_INT p;
@@ -635,7 +635,7 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     /* otherwise it's effectively same as in BN_nist_mod_192... */
     mask =
         0 - (PTR_SIZE_INT) (*u.f) (c_d, r_d, _nist_p_224[0], BN_NIST_224_TOP);
-    mask &= 0 - (vaddr_t) carry;
+    mask &= 0 - (ptraddr_t) carry;
 #ifndef __CHERI_PURE_CAPABILITY__
     res = c_d;
     res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |
@@ -674,7 +674,7 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_256_TOP], *res;
-    vaddr_t mask;
+    ptraddr_t mask;
     union {
         bn_addsub_f f;
         PTR_SIZE_INT p;
@@ -885,7 +885,7 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 
     mask =
         0 - (PTR_SIZE_INT) (*u.f) (c_d, r_d, _nist_p_256[0], BN_NIST_256_TOP);
-    mask &= 0 - (vaddr_t) carry;
+    mask &= 0 - (ptraddr_t) carry;
 #ifndef __CHERI_PURE_CAPABILITY__
     res = c_d;
     res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |
@@ -928,7 +928,7 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_384_TOP], *res;
-    vaddr_t mask;
+    ptraddr_t mask;
     union {
         bn_addsub_f f;
         PTR_SIZE_INT p;
@@ -1174,7 +1174,7 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 
     mask =
         0 - (PTR_SIZE_INT) (*u.f) (c_d, r_d, _nist_p_384[0], BN_NIST_384_TOP);
-    mask &= 0 - (vaddr_t) carry;
+    mask &= 0 - (ptraddr_t) carry;
 #ifndef __CHERI_PURE_CAPABILITY__
     res = c_d;
     res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |

--- a/lib/libc/gen/getgrent.c
+++ b/lib/libc/gen/getgrent.c
@@ -366,16 +366,16 @@ grp_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 	memcpy(&p, buffer + sizeof(struct group), sizeof(char *));
 
 	if (orig_buf_size + sizeof(struct group) + sizeof(char *) +
-	    (_ALIGN(p) - p) < buffer_size) {
+	    ((char *)_ALIGN(p) - p) < buffer_size) {
 		*ret_errno = ERANGE;
 		return (NS_RETURN);
 	}
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct group) + sizeof(char *) +
-	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
+	    ((char *)_ALIGN(p) - p),
 	    buffer_size - sizeof(struct group) - sizeof(char *) -
-	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
+	    ((char *)_ALIGN(p) - p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(grp->gr_name, orig_buf, p, char *);

--- a/lib/libc/gen/getgrent.c
+++ b/lib/libc/gen/getgrent.c
@@ -373,9 +373,9 @@ grp_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct group) + sizeof(char *) +
-	    (vaddr_t)_ALIGN(p) - (vaddr_t)p,
+	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
 	    buffer_size - sizeof(struct group) - sizeof(char *) -
-	    (vaddr_t)_ALIGN(p) + (vaddr_t)p);
+	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(grp->gr_name, orig_buf, p, char *);

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -383,7 +383,7 @@ find_overhead(void * cp)
 	 */
 	if (cheri_gettag(op->ov_next) &&
 	    (cheri_getperm(op->ov_next) & CHERI_PERM_SW_VMEM) != 0) {
-		vaddr_t base, pp_base;
+		ptraddr_t base, pp_base;
 
 		pp_base = cheri_getbase(op);
 		base = cheri_getbase(op->ov_next);
@@ -439,13 +439,14 @@ tls_free(void *cp)
 static void *
 __tls_malloc_aligned(size_t size, size_t align)
 {
-	vaddr_t memshift;
+	ptraddr_t memshift;
 	void *mem, *res;
 	if (align < sizeof(void *))
 		align = sizeof(void *);
 
 	mem = __tls_malloc(size + sizeof(void *) + align - 1);
-	memshift = roundup2((vaddr_t)mem + sizeof(void *), align) - (vaddr_t)mem;
+	memshift = roundup2((ptraddr_t)mem + sizeof(void *), align) -
+	    (ptraddr_t)mem;
 	res = (void *)((uintptr_t)mem + memshift);
 	*(void **)((uintptr_t)res - sizeof(void *)) = mem;
 	return (res);

--- a/lib/libc/net/gethostnamadr.c
+++ b/lib/libc/net/gethostnamadr.c
@@ -409,9 +409,9 @@ host_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct hostent) + sizeof(char *) +
-	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
+	    ((char *)_ALIGN(p) - p),
 	    buffer_size - sizeof(struct hostent) - sizeof(char *) -
-	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
+	    ((char *)_ALIGN(p) - p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(ht->h_name, orig_buf, p, char *);

--- a/lib/libc/net/gethostnamadr.c
+++ b/lib/libc/net/gethostnamadr.c
@@ -409,9 +409,9 @@ host_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct hostent) + sizeof(char *) +
-	    (vaddr_t)_ALIGN(p) - (vaddr_t)p,
+	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
 	    buffer_size - sizeof(struct hostent) - sizeof(char *) -
-	    (vaddr_t)_ALIGN(p) + (vaddr_t)p);
+	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(ht->h_name, orig_buf, p, char *);

--- a/lib/libc/net/getnetnamadr.c
+++ b/lib/libc/net/getnetnamadr.c
@@ -256,9 +256,9 @@ net_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct netent) + sizeof(char *) +
-	    (vaddr_t)_ALIGN(p) - (vaddr_t)p,
+	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
 	    buffer_size - sizeof(struct netent) - sizeof(char *) -
-	    (vaddr_t)_ALIGN(p) + (vaddr_t)p);
+	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(ne->n_name, orig_buf, p, char *);

--- a/lib/libc/net/getnetnamadr.c
+++ b/lib/libc/net/getnetnamadr.c
@@ -256,9 +256,9 @@ net_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct netent) + sizeof(char *) +
-	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
+	    ((char *)_ALIGN(p) - p),
 	    buffer_size - sizeof(struct netent) - sizeof(char *) -
-	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
+	    ((char *)_ALIGN(p) - p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(ne->n_name, orig_buf, p, char *);

--- a/lib/libc/net/getprotoent.c
+++ b/lib/libc/net/getprotoent.c
@@ -275,9 +275,9 @@ __proto_unmarshal_func(char *buffer, size_t buffer_size, void *retval,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct protoent) + sizeof(char *) +
-	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
+	    ((char *)_ALIGN(p) - p),
 	    buffer_size - sizeof(struct protoent) - sizeof(char *) -
-	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
+	    ((char *)_ALIGN(p) - p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(proto->p_name, orig_buf, p, char *);

--- a/lib/libc/net/getprotoent.c
+++ b/lib/libc/net/getprotoent.c
@@ -275,9 +275,9 @@ __proto_unmarshal_func(char *buffer, size_t buffer_size, void *retval,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct protoent) + sizeof(char *) +
-	    (vaddr_t)_ALIGN(p) - (vaddr_t)p,
+	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
 	    buffer_size - sizeof(struct protoent) - sizeof(char *) -
-	    (vaddr_t)_ALIGN(p) + (vaddr_t)p);
+	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(proto->p_name, orig_buf, p, char *);

--- a/lib/libc/net/getservent.c
+++ b/lib/libc/net/getservent.c
@@ -1105,9 +1105,9 @@ serv_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct servent) + sizeof(char *) +
-	    ((ptraddr_t)_ALIGN(p) - (ptraddr_t)p),
+	    ((char *)_ALIGN(p) - p),
 	    buffer_size - sizeof(struct servent) - sizeof(char *) -
-	    ((ptraddr_t)_ALIGN(p) - (ptraddr_t)p));
+	    ((char *)_ALIGN(p) - p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(serv->s_name, orig_buf, p, char *);

--- a/lib/libc/net/getservent.c
+++ b/lib/libc/net/getservent.c
@@ -1105,9 +1105,9 @@ serv_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct servent) + sizeof(char *) +
-	    ((vaddr_t)_ALIGN(p) - (vaddr_t)p),
+	    ((ptraddr_t)_ALIGN(p) - (ptraddr_t)p),
 	    buffer_size - sizeof(struct servent) - sizeof(char *) -
-	    ((vaddr_t)_ALIGN(p) - (vaddr_t)p));
+	    ((ptraddr_t)_ALIGN(p) - (ptraddr_t)p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(serv->s_name, orig_buf, p, char *);

--- a/lib/libc/rpc/getrpcent.c
+++ b/lib/libc/rpc/getrpcent.c
@@ -788,9 +788,9 @@ rpc_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct rpcent) + sizeof(char *) +
-	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
+	    ((char *)_ALIGN(p) - p),
 	    buffer_size - sizeof(struct rpcent) - sizeof(char *) -
-	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
+	    ((char *)_ALIGN(p) - p));
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(rpc->r_name, orig_buf, p, char *);

--- a/lib/libc/rpc/getrpcent.c
+++ b/lib/libc/rpc/getrpcent.c
@@ -788,9 +788,9 @@ rpc_unmarshal_func(char *buffer, size_t buffer_size, void *retval, va_list ap,
 
 	orig_buf = (char *)_ALIGN(orig_buf);
 	memcpy(orig_buf, buffer + sizeof(struct rpcent) + sizeof(char *) +
-	    (vaddr_t)_ALIGN(p) - (vaddr_t)p,
+	    (ptraddr_t)_ALIGN(p) - (ptraddr_t)p,
 	    buffer_size - sizeof(struct rpcent) - sizeof(char *) -
-	    (vaddr_t)_ALIGN(p) + (vaddr_t)p);
+	    (ptraddr_t)_ALIGN(p) + (ptraddr_t)p);
 	p = (char *)_ALIGN(p);
 
 	NS_APPLY_OFFSET(rpc->r_name, orig_buf, p, char *);

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -196,14 +196,14 @@ __simple_malloc_unaligned(size_t nbytes)
 static void *
 __simple_malloc_aligned(size_t nbytes, size_t align)
 {
-	vaddr_t memshift;
+	ptraddr_t memshift;
 	void *mem, *res;
 	if (align < sizeof(void *))
 		align = sizeof(void *);
 
 	mem = __simple_malloc_unaligned(nbytes + sizeof(void *) + align - 1);
-	memshift = roundup2((vaddr_t)mem + sizeof(void *), align) -
-	    (vaddr_t)mem;
+	memshift = roundup2((ptraddr_t)mem + sizeof(void *), align) -
+	    (ptraddr_t)mem;
 
 	res = (void *)((uintptr_t)mem + memshift);
 	*(void **)((uintptr_t)res - sizeof(void *)) = mem;
@@ -317,7 +317,7 @@ find_overhead(void * cp)
 	 */
 	if (cheri_gettag(op->ov_next) &&
 	    (cheri_getperm(op->ov_next) & CHERI_PERM_SW_VMEM) != 0) {
-		vaddr_t base, pp_base;
+		ptraddr_t base, pp_base;
 
 		pp_base = cheri_getbase(op);
 		base = cheri_getbase(op->ov_next);

--- a/lib/librt/sigev_thread.c
+++ b/lib/librt/sigev_thread.c
@@ -59,7 +59,7 @@
 
 LIST_HEAD(sigev_list_head, sigev_node);
 #define HASH_QUEUES		17
-#define	HASH(t, id)		((((vaddr_t)(id) << 3) + (t)) % HASH_QUEUES)
+#define	HASH(t, id)		((((ptraddr_t)(id) << 3) + (t)) % HASH_QUEUES)
 
 static struct sigev_list_head	sigev_hash[HASH_QUEUES];
 static struct sigev_list_head	sigev_all;

--- a/lib/librtld_db/rtld_db.c
+++ b/lib/librtld_db/rtld_db.c
@@ -373,7 +373,7 @@ rd_reset(rd_agent_t *rdap)
 	base = 0;
 	for (i = 0; i < count; i++) {
 		if (auxv[i].a_type == AT_BASE) {
-			base = (vaddr_t)auxv[i].a_un.a_ptr;
+			base = (ptraddr_t)auxv[i].a_un.a_ptr;
 			break;
 		}
 	}

--- a/lib/libthr/thread/thr_exit.c
+++ b/lib/libthr/thread/thr_exit.c
@@ -162,13 +162,6 @@ _Unwind_GetCFA(struct _Unwind_Context *context)
 #pragma weak _Unwind_ForcedUnwind
 #endif /* PIC */
 
-#ifndef __CHERI_PURE_CAPABILITY__
-#define WEAK_SYMBOL_NONNULL(sym) ((sym) != NULL)
-#else
-/* Work around https://github.com/CTSRD-CHERI/llvm/issues/167 */
-#define WEAK_SYMBOL_NONNULL(sym) ((vaddr_t)(sym) != (vaddr_t)0)
-#endif
-
 static void
 thread_unwind_cleanup(_Unwind_Reason_Code code __unused,
     struct _Unwind_Exception *e __unused)
@@ -307,7 +300,7 @@ _pthread_exit_mask(void *status, sigset_t *mask)
 	thread_uw_init();
 	if (get_uwl_forcedunwind() != NULL) {
 #else
-	if (WEAK_SYMBOL_NONNULL(_Unwind_ForcedUnwind)) {
+	if (_Unwind_ForcedUnwind != NULL) {
 #endif
 		if (curthread->unwind_disabled) {
 			if (message_printed == 0) {

--- a/lib/libthr/thread/thr_init.c
+++ b/lib/libthr/thread/thr_init.c
@@ -81,7 +81,7 @@ __FBSDID("$FreeBSD$");
  * and add guard pages on CHERIABI. In CHERIABI _usrstack is only used to
  * initialize stackaddr_attr for the main thread.
  */
-vaddr_t		_usrstack;
+ptraddr_t	_usrstack;
 struct pthread	*_thr_initial;
 int		_libthr_debug;
 int		_thread_event_mask;
@@ -511,7 +511,7 @@ init_private(void)
 		mib[0] = CTL_KERN;
 		mib[1] = KERN_USRSTACK;
 		/*
-		 * The sysctl returns a vaddr_t and not a pointer so _usrstack
+		 * The sysctl returns a ptraddr_t and not a pointer so _usrstack
 		 * must not be a pointer on CHERIABI
 		 */
 		len = sizeof (_usrstack);

--- a/lib/libthr/thread/thr_printf.c
+++ b/lib/libthr/thread/thr_printf.c
@@ -77,7 +77,7 @@ void
 _thread_vfdprintf(int fd, const char *fmt, va_list ap)
 {
 	static const char digits[16] = "0123456789abcdef";
-	/* XXX_AR: we should print capabilities not vaddr_t -> increase size */
+	/* XXX_AR: we should print capabilities not ptraddr_t -> increase size */
 	char buf[40];
 	char *s;
 	uint64_t r, u;
@@ -131,7 +131,7 @@ next:			c = *fmt++;
 				} else {
 					if (isptr) {
 						pointer = va_arg(ap, void*);
-						u = (vaddr_t)pointer;
+						u = (ptraddr_t)pointer;
 					} else if (islong) {
 						u = va_arg(ap, uint64_t);
 					} else {

--- a/lib/libthr/thread/thr_private.h
+++ b/lib/libthr/thread/thr_private.h
@@ -740,7 +740,7 @@ extern int __isthreaded;
  * Global variables for the pthread kernel.
  */
 
-extern vaddr_t		_usrstack __hidden;
+extern ptraddr_t	_usrstack __hidden;
 
 /* For debugger */
 extern int		_libthr_debug;

--- a/lib/libufs/block.c
+++ b/lib/libufs/block.c
@@ -27,17 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20180711,
- *   "target_type": "lib",
- *   "changes": [
- *     "pointer_alignment"
- *   ]
- * }
- * CHERI CHANGES END
- */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -77,7 +66,7 @@ bread(struct uufsd *disk, ufs2_daddr_t blockno, void *data, size_t size)
 	 * XXX: Bounce the buffer if not 64 byte aligned.
 	 * XXX: this can be removed if/when the kernel is fixed
 	 */
-	if (((ptraddr_t)data) & 0x3f) {
+	if (((intptr_t)data) & 0x3f) {
 		p2 = malloc(size);
 		if (p2 == NULL) {
 			ERROR(disk, "allocate bounce buffer");
@@ -130,7 +119,7 @@ bwrite(struct uufsd *disk, ufs2_daddr_t blockno, const void *data, size_t size)
 	 * XXX: Bounce the buffer if not 64 byte aligned.
 	 * XXX: this can be removed if/when the kernel is fixed
 	 */
-	if (((ptraddr_t)data) & 0x3f) {
+	if (((intptr_t)data) & 0x3f) {
 		p2 = malloc(size);
 		if (p2 == NULL) {
 			ERROR(disk, "allocate bounce buffer");

--- a/lib/libufs/block.c
+++ b/lib/libufs/block.c
@@ -77,7 +77,7 @@ bread(struct uufsd *disk, ufs2_daddr_t blockno, void *data, size_t size)
 	 * XXX: Bounce the buffer if not 64 byte aligned.
 	 * XXX: this can be removed if/when the kernel is fixed
 	 */
-	if (((vaddr_t)data) & 0x3f) {
+	if (((ptraddr_t)data) & 0x3f) {
 		p2 = malloc(size);
 		if (p2 == NULL) {
 			ERROR(disk, "allocate bounce buffer");
@@ -130,7 +130,7 @@ bwrite(struct uufsd *disk, ufs2_daddr_t blockno, const void *data, size_t size)
 	 * XXX: Bounce the buffer if not 64 byte aligned.
 	 * XXX: this can be removed if/when the kernel is fixed
 	 */
-	if (((vaddr_t)data) & 0x3f) {
+	if (((ptraddr_t)data) & 0x3f) {
 		p2 = malloc(size);
 		if (p2 == NULL) {
 			ERROR(disk, "allocate bounce buffer");

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -48,7 +48,7 @@ __unused static void cheri_init_globals(void);
 static __attribute__((always_inline))
 void _do___caprelocs(const struct capreloc *start_relocs,
     const struct capreloc *stop_relocs, void * __capability gdc,
-    const void * __capability pcc, vaddr_t base_addr, bool tight_pcc_bounds)
+    const void * __capability pcc, ptraddr_t base_addr, bool tight_pcc_bounds)
 {
 	cheri_init_globals_impl(start_relocs, stop_relocs, /*data_cap=*/gdc,
 	    /*code_cap=*/pcc, /*rodata_cap=*/pcc,

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -270,7 +270,7 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	  path, rtld_strerror(errno));
 	goto error;
     }
-    if (base_addr != NULL && (vaddr_t)mapbase != (vaddr_t)base_addr) {
+    if (base_addr != NULL && (ptraddr_t)mapbase != (ptraddr_t)base_addr) {
 #ifdef __CHERI_PURE_CAPABILITY__
 	_rtld_error("%s: mmap returned wrong address: wanted %#p, got %#p",
 	  path, base_addr, mapbase);

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -270,7 +270,7 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	  path, rtld_strerror(errno));
 	goto error;
     }
-    if (base_addr != NULL && (ptraddr_t)mapbase != (ptraddr_t)base_addr) {
+    if (base_addr != NULL && mapbase != base_addr) {
 #ifdef __CHERI_PURE_CAPABILITY__
 	_rtld_error("%s: mmap returned wrong address: wanted %#p, got %#p",
 	  path, base_addr, mapbase);

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -637,7 +637,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 
     /* Initialize and relocate ourselves. */
     assert(aux_info[AT_BASE] != NULL);
-    assert((vaddr_t)aux_info[AT_BASE]->a_un.a_ptr != 0 && "rtld cannot be mapped at address zero!");
+    assert((ptraddr_t)aux_info[AT_BASE]->a_un.a_ptr != 0 && "rtld cannot be mapped at address zero!");
     init_rtld((caddr_t) aux_info[AT_BASE]->a_un.a_ptr, aux_info);
 
     dlerror_dflt_init();
@@ -927,7 +927,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     /* Initialize a fake symbol for resolving undefined weak references. */
     sym_zero.st_info = ELF_ST_INFO(STB_GLOBAL, STT_NOTYPE);
     sym_zero.st_shndx = SHN_UNDEF;
-    sym_zero.st_value = -(vaddr_t)obj_main->relocbase;
+    sym_zero.st_value = -(ptraddr_t)obj_main->relocbase;
 
     if (!libmap_disable)
         libmap_disable = (bool)lm_init(libmap_override);
@@ -2637,7 +2637,7 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	    objtmp.cap_relocs, &__start___cap_relocs, cap_relocs_size,
 	    objtmp.cap_relocs_size);
 #endif
-	assert((vaddr_t)objtmp.cap_relocs == (vaddr_t)&__start___cap_relocs);
+	assert((ptraddr_t)objtmp.cap_relocs == (ptraddr_t)&__start___cap_relocs);
 	assert(objtmp.cap_relocs_size == cap_relocs_size);
     }
 #endif
@@ -4382,7 +4382,7 @@ dladdr(const void *addr, Dl_info *info)
         /* Clear all permissions from the symbol_addr */
         symbol_addr = cheri_andperm(symbol_addr, 0);
 #endif
-        if ((vaddr_t)symbol_addr > (vaddr_t)addr || (vaddr_t)symbol_addr < (vaddr_t)info->dli_saddr)
+        if ((ptraddr_t)symbol_addr > (ptraddr_t)addr || (ptraddr_t)symbol_addr < (ptraddr_t)info->dli_saddr)
             continue;
 
         dbg_cat(SYMLOOKUP, "%s: Found partial match for %s (" PTR_FMT ")\n", __func__,
@@ -4392,7 +4392,7 @@ dladdr(const void *addr, Dl_info *info)
         info->dli_saddr = symbol_addr;
 
         /* Exact match? */
-        if ((vaddr_t)info->dli_saddr == (vaddr_t)addr) {
+        if ((ptraddr_t)info->dli_saddr == (ptraddr_t)addr) {
             dbg_cat(SYMLOOKUP, "%s: Found exact match for %s (" PTR_FMT ")\n", __func__,
                 obj->strtab + def->st_name, symbol_addr);
             break;

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -637,7 +637,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 
     /* Initialize and relocate ourselves. */
     assert(aux_info[AT_BASE] != NULL);
-    assert((ptraddr_t)aux_info[AT_BASE]->a_un.a_ptr != 0 && "rtld cannot be mapped at address zero!");
+    assert(aux_info[AT_BASE]->a_un.a_ptr != NULL && "rtld cannot be mapped at address zero!");
     init_rtld((caddr_t) aux_info[AT_BASE]->a_un.a_ptr, aux_info);
 
     dlerror_dflt_init();
@@ -2637,7 +2637,7 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	    objtmp.cap_relocs, &__start___cap_relocs, cap_relocs_size,
 	    objtmp.cap_relocs_size);
 #endif
-	assert((ptraddr_t)objtmp.cap_relocs == (ptraddr_t)&__start___cap_relocs);
+	assert(objtmp.cap_relocs == &__start___cap_relocs);
 	assert(objtmp.cap_relocs_size == cap_relocs_size);
     }
 #endif
@@ -4382,7 +4382,7 @@ dladdr(const void *addr, Dl_info *info)
         /* Clear all permissions from the symbol_addr */
         symbol_addr = cheri_andperm(symbol_addr, 0);
 #endif
-        if ((ptraddr_t)symbol_addr > (ptraddr_t)addr || (ptraddr_t)symbol_addr < (ptraddr_t)info->dli_saddr)
+        if (symbol_addr > addr || symbol_addr < info->dli_saddr)
             continue;
 
         dbg_cat(SYMLOOKUP, "%s: Found partial match for %s (" PTR_FMT ")\n", __func__,
@@ -4392,7 +4392,7 @@ dladdr(const void *addr, Dl_info *info)
         info->dli_saddr = symbol_addr;
 
         /* Exact match? */
-        if ((ptraddr_t)info->dli_saddr == (ptraddr_t)addr) {
+        if (info->dli_saddr == addr) {
             dbg_cat(SYMLOOKUP, "%s: Found exact match for %s (" PTR_FMT ")\n", __func__,
                 obj->strtab + def->st_name, symbol_addr);
             break;

--- a/sbin/init/init.c
+++ b/sbin/init/init.c
@@ -355,15 +355,6 @@ invalid:
 	close(1);
 	close(2);
 
-#ifdef __DEBUG_CHERI_TRAP_DURING_INIT__
-	warning("RAISING a CHERI violation:\n");
-	void * __capability cap = __builtin_cheri_global_data_get();
-	cap = __builtin_cheri_offset_set(cap, (vaddr_t)&Reboot);
-	cap = __builtin_cheri_perms_and(cap, ~__CHERI_CAP_PERMISSION_PERMIT_LOAD__);
-	Reboot = *((int * __capability)cap);
-	__builtin_trap();
-#endif
-
 	if (kenv(KENV_GET, "init_exec", kenv_value, sizeof(kenv_value)) > 0) {
 		replace_init(kenv_value);
 		_exit(0); /* reboot */

--- a/sbin/kldstat/kldstat.c
+++ b/sbin/kldstat/kldstat.c
@@ -53,7 +53,7 @@ __FBSDID("$FreeBSD$");
 #include <strings.h>
 #include <unistd.h>
 
-#define	PTR_WIDTH ((int)(sizeof(vaddr_t) * 2 + 2))
+#define	PTR_WIDTH ((int)(sizeof(ptraddr_t) * 2 + 2))
 
 static void printmod(int);
 static void printfile(int, int, int);

--- a/share/man/man9/cheric.9
+++ b/share/man/man9/cheric.9
@@ -69,12 +69,12 @@
 .Ft void * __capability
 .Fn cheri_setbounds "void * __capability c" "size_t length"
 .Ft void * __capability
-.Fn cheri_fromint "vaddr_t"
+.Fn cheri_fromint "ptraddr_t"
 .Ft size_t
 .Fn cheri_get_low_ptr_bits "void * __capability c" "size_t mask"
-.Ft vaddr_t
+.Ft ptraddr_t
 .Fn cheri_getaddress "void * __capability c"
-.Ft vaddr_t
+.Ft ptraddr_t
 .Fn cheri_getbase "void * __capability c"
 .Ft void * __capability
 .Fn cheri_getdefault "void"
@@ -90,11 +90,11 @@
 .Fn cheri_getsealed "void * __capability c"
 .Ft void * __capability
 .Fn cheri_getstack "void"
-.Ft vaddr_t
+.Ft ptraddr_t
 .Fn cheri_gettop "void * __capability c"
 .Ft _Bool
 .Fn cheri_gettag "void * __capability c"
-.Ft vaddr_t
+.Ft ptraddr_t
 .Fn cheri_gettype "void * __capability c"
 .Ft void * __capability
 .Fn cheri_clearperm "void * __capability c" "size_t mask"
@@ -107,7 +107,7 @@
 .Ft void * __capability
 .Fn cheri_set_low_ptr_bits "void * __capability c" "size_t mask"
 .Ft void * __capability
-.Fn cheri_setaddress "void * __capability c" "vaddr_t address"
+.Fn cheri_setaddress "void * __capability c" "ptraddr_t address"
 .Ft void * __capability
 .Fn cheri_setoffset "void * __capability c" "size_t offset"
 .Ft void * __capability

--- a/sys/arm64/arm64/freebsd64_machdep.c
+++ b/sys/arm64/arm64/freebsd64_machdep.c
@@ -247,15 +247,15 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	onstack = sigonstack(tf->tf_sp);
 
 	CTR4(KTR_SIG, "sendsig: td=%p (%s) catcher=%p sig=%d", td, p->p_comm,
-	    (__cheri_addr vaddr_t) catcher, sig);
+	    (__cheri_addr ptraddr_t) catcher, sig);
 
 	/* Allocate and validate space for the signal handler context. */
 	if ((td->td_pflags & TDP_ALTSTACK) != 0 && !onstack &&
 	    SIGISMEMBER(psp->ps_sigonstack, sig)) {
-		sp = ((__cheri_addr vaddr_t)td->td_sigstk.ss_sp +
+		sp = ((__cheri_addr ptraddr_t)td->td_sigstk.ss_sp +
 		    td->td_sigstk.ss_size);
 	} else {
-		sp = (__cheri_addr vaddr_t)td->td_frame->tf_sp;
+		sp = (__cheri_addr ptraddr_t)td->td_frame->tf_sp;
 	}
 
 	/* Allocate room for the capability register context. */
@@ -276,7 +276,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	frame.sf_uc.uc_mcontext.mc_capregs = capregs;
 	siginfo_to_siginfo64(&ksi->ksi_info, &frame.sf_si);
 	frame.sf_uc.uc_sigmask = *mask;
-	frame.sf_uc.uc_stack.ss_sp = (__cheri_addr vaddr_t)td->td_sigstk.ss_sp;
+	frame.sf_uc.uc_stack.ss_sp = (__cheri_addr ptraddr_t)td->td_sigstk.ss_sp;
 	frame.sf_uc.uc_stack.ss_size = td->td_sigstk.ss_size;
 	frame.sf_uc.uc_stack.ss_flags = (td->td_pflags & TDP_ALTSTACK) != 0 ?
 	    (onstack ? SS_ONSTACK : 0) : SS_DISABLE;

--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -261,7 +261,7 @@ cpu_set_user_tls(struct thread *td, void * __capability tls_base)
 {
 	struct pcb *pcb;
 
-	if ((__cheri_addr vaddr_t)tls_base >= VM_MAXUSER_ADDRESS)
+	if ((__cheri_addr ptraddr_t)tls_base >= VM_MAXUSER_ADDRESS)
 		return (EINVAL);
 
 	pcb = td->td_pcb;

--- a/sys/cddl/contrib/opensolaris/uts/common/sys/avl_impl.h
+++ b/sys/cddl/contrib/opensolaris/uts/common/sys/avl_impl.h
@@ -115,7 +115,7 @@ struct avl_node {
  * index of this node in its parent's avl_child[]: bit #2
  */
 #ifndef __CHERI_PURE_CAPABILITY__
-#define	AVL_XCHILD(n)	(((vaddr_t)(n)->avl_pcb >> 2) & 1)
+#define	AVL_XCHILD(n)	(((ptraddr_t)(n)->avl_pcb >> 2) & 1)
 #define	AVL_SETCHILD(n, c)						\
 	((n)->avl_pcb = (uintptr_t)(((n)->avl_pcb & (uintptr_t)~4) | (uintptr_t)((c) << 2)))
 #else
@@ -129,7 +129,7 @@ struct avl_node {
  * -1, 0, or +1, and is encoded by adding 1 to the value to get the
  * unsigned values of 0, 1, 2.
  */
-#define	AVL_XBALANCE(n)		((int)(((vaddr_t)(n)->avl_pcb & 3) - 1))
+#define	AVL_XBALANCE(n)		((int)(((ptraddr_t)(n)->avl_pcb & 3) - 1))
 #ifndef __CHERI_PURE_CAPABILITY__
 #define	AVL_SETBALANCE(n, b)						\
 	((n)->avl_pcb = (uintptr_t)((((n)->avl_pcb & (uintptr_t)~3) | (uintptr_t)((b) + 1))))

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -59,13 +59,13 @@ struct cheri_object {
  * Functions to construct userspace capabilities.
  */
 void * __capability	_cheri_capability_build_user_code(struct thread *td,
-			    uint32_t perms, vaddr_t basep, size_t length,
+			    uint32_t perms, ptraddr_t basep, size_t length,
 			    off_t off, const char* func, int line);
 void * __capability	_cheri_capability_build_user_data(uint32_t perms,
-			    vaddr_t basep, size_t length, off_t off,
+			    ptraddr_t basep, size_t length, off_t off,
 			    const char* func, int line, bool exact);
 void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
-			    vaddr_t basep, size_t length, off_t off,
+			    ptraddr_t basep, size_t length, off_t off,
 			    const char* func, int line, bool exact);
 #define cheri_capability_build_user_code(td, perms, basep, length, off)	\
 	_cheri_capability_build_user_code(td, perms, basep, length, off,\

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -47,7 +47,7 @@ void * __capability userspace_root_cap = (void * __capability)(intcap_t)-1;
  */
 void * __capability
 _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
-    vaddr_t basep, size_t length, off_t off, const char* func, int line)
+    ptraddr_t basep, size_t length, off_t off, const char* func, int line)
 {
 	void * __capability tmpcap;
 
@@ -71,8 +71,8 @@ _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
  * not execute.
  */
 void * __capability
-_cheri_capability_build_user_data(uint32_t perms, vaddr_t basep, size_t length,
-    off_t off, const char* func, int line, bool exact)
+_cheri_capability_build_user_data(uint32_t perms, ptraddr_t basep,
+    size_t length, off_t off, const char* func, int line, bool exact)
 {
 
 	KASSERT((perms & ~CHERI_CAP_USER_DATA_PERMS) == 0,
@@ -92,7 +92,7 @@ _cheri_capability_build_user_data(uint32_t perms, vaddr_t basep, size_t length,
  * use should be documented in a comment when it is used.
  */
 void * __capability
-_cheri_capability_build_user_rwx(uint32_t perms, vaddr_t basep, size_t length,
+_cheri_capability_build_user_rwx(uint32_t perms, ptraddr_t basep, size_t length,
     off_t off, const char* func __unused, int line __unused, bool exact)
 {
 	void * __capability tmpcap;

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -133,7 +133,7 @@ static inline bool
 #else
 static inline _Bool
 #endif
-cheri_is_address_inbounds(const void * __capability cap, vaddr_t addr)
+cheri_is_address_inbounds(const void * __capability cap, ptraddr_t addr)
 {
 	return (addr >= cheri_getbase(cap) && addr < cheri_gettop(cap));
 }

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -109,7 +109,7 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 	error = kern_sigaction(td, uap->sig, actp, oactp, 0);
 	if (oactp && !error) {
 		memset(&oact64, 0, sizeof(oact64));
-		oact64.sa_u = (__cheri_addr vaddr_t)oactp->sa_handler;
+		oact64.sa_u = (__cheri_addr ptraddr_t)oactp->sa_handler;
 		oact64.sa_flags = oactp->sa_flags;
 		oact64.sa_mask = oactp->sa_mask;
 		error = copyout(&oact64, __USER_CAP_OBJ(uap->oact),

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -947,7 +947,7 @@ linux_dev_fdopen(struct cdev *dev, int fflags, struct thread *td,
 static inline int
 linux_remap_address(void * __capability *uaddr, size_t len)
 {
-	vaddr_t uaddr_val = (__cheri_addr vaddr_t)(*uaddr);
+	ptraddr_t uaddr_val = (__cheri_addr ptraddr_t)(*uaddr);
 
 	if (unlikely(uaddr_val >= LINUX_IOCTL_MIN_PTR &&
 	    uaddr_val < LINUX_IOCTL_MAX_PTR)) {
@@ -1040,12 +1040,12 @@ linux_clear_user(void * __capability _uaddr, size_t _len)
 int
 linux_access_ok(const void * __capability uaddr, size_t len)
 {
-	vaddr_t saddr;
-	vaddr_t eaddr;
+	ptraddr_t saddr;
+	ptraddr_t eaddr;
 
 	/* get start and end address */
-	saddr = (__cheri_addr vaddr_t)uaddr;
-	eaddr = (__cheri_addr vaddr_t)uaddr + len;
+	saddr = (__cheri_addr ptraddr_t)uaddr;
+	eaddr = (__cheri_addr ptraddr_t)uaddr + len;
 
 	/* verify addresses are valid for userspace */
 	return ((saddr == eaddr) ||

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -1917,7 +1917,7 @@ mdctlioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 			return (EINVAL);
 		MD_IOCTL2REQ(mdio, &mdr);
 		/* If the file is adjacent to the md_ioctl it's in kernel. */
-		if ((__cheri_addr vaddr_t)mdio->md_file == (vaddr_t)(mdio + 1))
+		if ((__cheri_addr ptraddr_t)mdio->md_file == (ptraddr_t)(mdio + 1))
 			mdr.md_file_seg = UIO_SYSSPACE;
 		else
 			mdr.md_file_seg = UIO_USERSPACE;

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -3481,7 +3481,7 @@ sysctl_kern_proc_sigfastblk(SYSCTL_HANDLER_ARGS)
 	 * meantime.
 	 */
 	if ((td1->td_pflags & TDP_SIGFASTBLOCK) != 0)
-		addr = (uintptr_t)(__cheri_addr vaddr_t)td1->td_sigblock_ptr;
+		addr = (uintptr_t)(__cheri_addr ptraddr_t)td1->td_sigblock_ptr;
 	else
 		error = ENOTTY;
 

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -411,7 +411,7 @@ umtxq_hash(struct umtx_key *key)
 {
 	unsigned n;
 
-	n = (vaddr_t)key->info.both.a + (vaddr_t)key->info.both.b;
+	n = (ptraddr_t)key->info.both.a + (ptraddr_t)key->info.both.b;
 	key->hash = ((n * GOLDEN_RATIO_PRIME) >> UMTX_SHIFTS) % UMTX_CHAINS;
 }
 
@@ -881,7 +881,7 @@ umtx_key_get(const void * __capability addr, int type, int share,
 	if (share == THREAD_SHARE) {
 		key->shared = 0;
 		key->info.private.vs = td->td_proc->p_vmspace;
-		key->info.private.addr = (__cheri_addr vaddr_t)addr;
+		key->info.private.addr = (__cheri_addr ptraddr_t)addr;
 	} else {
 		MPASS(share == PROCESS_SHARE || share == AUTO_SHARE);
 		map = &td->td_proc->p_vmspace->vm_map;
@@ -901,7 +901,7 @@ umtx_key_get(const void * __capability addr, int type, int share,
 		} else {
 			key->shared = 0;
 			key->info.private.vs = td->td_proc->p_vmspace;
-			key->info.private.addr = (__cheri_addr vaddr_t)addr;
+			key->info.private.addr = (__cheri_addr ptraddr_t)addr;
 		}
 		vm_map_lookup_done(map, entry);
 	}
@@ -4504,7 +4504,7 @@ umtx_shm_alive(struct thread *td, void * __capability addr)
 	boolean_t wired;
 
 	map = &td->td_proc->p_vmspace->vm_map;
-	res = vm_map_lookup(&map, (__cheri_addr vaddr_t)addr, VM_PROT_READ, &entry,
+	res = vm_map_lookup(&map, (__cheri_addr ptraddr_t)addr, VM_PROT_READ, &entry,
 	    &object, &pindex, &prot, &wired);
 	if (res != KERN_SUCCESS)
 		return (EFAULT);

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -521,7 +521,7 @@ copyin_implicit_cap(const void *uaddr, void *kaddr, size_t len)
 {
 
 	return (copyin(cheri_capability_build_user_data(
-	    CHERI_CAP_USER_DATA_PERMS, (vaddr_t)uaddr, len, 0), kaddr, len));
+	    CHERI_CAP_USER_DATA_PERMS, (ptraddr_t)uaddr, len, 0), kaddr, len));
 }
 
 int
@@ -530,7 +530,7 @@ copyout_implicit_cap(const void *kaddr, void *uaddr, size_t len)
 
 	return (copyout(kaddr,
 	    cheri_capability_build_user_data(CHERI_CAP_USER_DATA_PERMS,
-	    (vaddr_t)uaddr, len, 0), len));
+	    (ptraddr_t)uaddr, len, 0), len));
 }
 #else
 int

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1689,7 +1689,7 @@ aio_aqueue(struct thread *td, struct aiocb * __capability ujob,
 	}
 	kqfd = job->uaiocb.aio_sigevent.sigev_notify_kqueue;
 	memset(&kev, 0, sizeof(kev));
-	kev.ident = (__cheri_addr vaddr_t)job->ujob;
+	kev.ident = (__cheri_addr ptraddr_t)job->ujob;
 	kev.filter = EVFILT_AIO;
 	kev.flags = EV_ADD | EV_ENABLE | EV_FLAG1 | evflags;
 	kev.udata = job->uaiocb.aio_sigevent.sigev_value.sival_ptr;
@@ -1956,7 +1956,7 @@ kern_aio_return(struct thread *td, void * __capability ujob,
 		return (EINVAL);
 	AIO_LOCK(ki);
 	TAILQ_FOREACH(job, &ki->kaio_done, plist) {
-		if ((__cheri_addr vaddr_t)job->ujob == (__cheri_addr vaddr_t)ujob)
+		if ((__cheri_addr ptraddr_t)job->ujob == (__cheri_addr ptraddr_t)ujob)
 			break;
 	}
 	if (job != NULL) {
@@ -2116,7 +2116,7 @@ kern_aio_cancel(struct thread *td, int fd, void * __capability ujob,
 	TAILQ_FOREACH_SAFE(job, &ki->kaio_jobqueue, plist, jobn) {
 		if ((fd == job->uaiocb.aio_fildes) &&
 		    ((ujob == NULL) ||
-		     ((__cheri_addr vaddr_t)ujob == (__cheri_addr vaddr_t)job->ujob))) {
+		     ((__cheri_addr ptraddr_t)ujob == (__cheri_addr ptraddr_t)job->ujob))) {
 			if (aio_cancel_job(p, ki, job)) {
 				cancelled++;
 			} else {
@@ -2186,7 +2186,7 @@ kern_aio_error(struct thread *td, struct aiocb * __capability ujob,
 	}
 	AIO_LOCK(ki);
 	TAILQ_FOREACH(job, &ki->kaio_all, allist) {
-		if ((__cheri_addr vaddr_t)job->ujob == (__cheri_addr vaddr_t)ujob) {
+		if ((__cheri_addr ptraddr_t)job->ujob == (__cheri_addr ptraddr_t)ujob) {
 			if (job->jobflags & KAIOCB_FINISHED)
 				td->td_retval[0] =
 					job->uaiocb._aiocb_private.error;
@@ -2961,7 +2961,7 @@ aiocb32_store_aiocb(struct aiocb ** __capability ujobp,
     struct aiocb * __capability ujob)
 {
 
-	return (suword32(ujobp, (__cheri_addr vaddr_t)ujob));
+	return (suword32(ujobp, (__cheri_addr ptraddr_t)ujob));
 }
 
 static size_t
@@ -3432,7 +3432,7 @@ aiocb64_store_aiocb(struct aiocb ** __capability ujobp,
     struct aiocb * __capability ujob)
 {
 
-	return (suword(ujobp, (__cheri_addr vaddr_t)ujob));
+	return (suword(ujobp, (__cheri_addr ptraddr_t)ujob));
 }
 
 static size_t

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -633,7 +633,7 @@ vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base, int len, off_t offset,
 	if (segflg == UIO_USERSPACE)
 		IOVEC_INIT_C(&aiov,
 		    cheri_capability_build_user_data(CHERI_CAP_USER_DATA_PERMS,
-			(vaddr_t)base, len, 0), len);
+			(ptraddr_t)base, len, 0), len);
 	else
 #endif
 		IOVEC_INIT(&aiov, base, len);

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -40,7 +40,7 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 {
 	const char * __capability src;
 	char * __capability dst;
-	vaddr_t dst_addr, src_addr;
+	ptraddr_t dst_addr, src_addr;
 	int tocopy;
 
 	dst = dst0;
@@ -49,8 +49,8 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 	if (len == 0 || dst == src)
 		return (dst);
 
-	dst_addr = (__cheri_addr vaddr_t)dst;
-	src_addr = (__cheri_addr vaddr_t)src;
+	dst_addr = (__cheri_addr ptraddr_t)dst;
+	src_addr = (__cheri_addr ptraddr_t)src;
 	if (dst_addr < src_addr) {
 		/* Forwards. */
 
@@ -68,10 +68,10 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 				} while (--tocopy != 0);
 			}
 
-			KASSERT((__cheri_addr vaddr_t)dst % sizeof(uintcap_t) == 0,
+			KASSERT((__cheri_addr ptraddr_t)dst % sizeof(uintcap_t) == 0,
 			    ("dst %p not aligned",
 			    (void *)(__cheri_addr uintptr_t)dst));
-			KASSERT((__cheri_addr vaddr_t)src % sizeof(uintcap_t) == 0,
+			KASSERT((__cheri_addr ptraddr_t)src % sizeof(uintcap_t) == 0,
 			    ("src %p not aligned",
 			    (void *)(__cheri_addr uintptr_t)src));
 
@@ -96,8 +96,8 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 
 		src += len;
 		dst += len;
-		dst_addr = (__cheri_addr vaddr_t)dst;
-		src_addr = (__cheri_addr vaddr_t)src;
+		dst_addr = (__cheri_addr ptraddr_t)dst;
+		src_addr = (__cheri_addr ptraddr_t)src;
 		
 		/* Do both buffers have the same relative alignment? */
 		if ((dst_addr ^ src_addr) % sizeof(uintcap_t) == 0 &&
@@ -112,9 +112,9 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 				} while (--tocopy != 0);
 			}
 
-			KASSERT((__cheri_addr vaddr_t)dst % sizeof(uintcap_t) == 0,
+			KASSERT((__cheri_addr ptraddr_t)dst % sizeof(uintcap_t) == 0,
 			    ("dst %p not aligned", (void *)(__cheri_addr uintptr_t)dst));
-			KASSERT((__cheri_addr vaddr_t)src % sizeof(uintcap_t) == 0,
+			KASSERT((__cheri_addr ptraddr_t)src % sizeof(uintcap_t) == 0,
 			    ("src %p not aligned", (void *)(__cheri_addr uintptr_t)src));
 
 			/* Copy capabilities. */

--- a/sys/libkern/gsb_crc32.c
+++ b/sys/libkern/gsb_crc32.c
@@ -747,7 +747,7 @@ multitable_crc32c(uint32_t crc32c,
 	if (length == 0) {
 		return (crc32c);
 	}
-	to_even_word = (4 - (((vaddr_t) buffer) & 0x3));
+	to_even_word = (4 - (((ptraddr_t) buffer) & 0x3));
 	return (crc32c_sb8_64_bit(crc32c, buffer, length, to_even_word));
 }
 

--- a/sys/libkern/gsb_crc32.c
+++ b/sys/libkern/gsb_crc32.c
@@ -747,7 +747,7 @@ multitable_crc32c(uint32_t crc32c,
 	if (length == 0) {
 		return (crc32c);
 	}
-	to_even_word = (4 - (((ptraddr_t) buffer) & 0x3));
+	to_even_word = (4 - (((uintptr_t) buffer) & 0x3));
 	return (crc32c_sb8_64_bit(crc32c, buffer, length, to_even_word));
 }
 
@@ -800,12 +800,3 @@ calculate_crc32c(uint32_t crc32c, const unsigned char *buffer, unsigned int leng
 	return (singletable_crc32c(crc32c, buffer, length));
 }
 #endif
-// CHERI CHANGES START
-// {
-//   "updated": 20180629,
-//   "target_type": "kernel",
-//   "changes": [
-//     "pointer_alignment"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/netinet/tcp_log_buf.c
+++ b/sys/netinet/tcp_log_buf.c
@@ -2129,7 +2129,7 @@ tcp_log_expandlogbuf(struct tcp_log_dev_queue *param)
 	memset(hdr, 0, sizeof(struct tcp_log_header));
 	hdr->tlh_version = TCP_LOG_BUF_VER;
 	hdr->tlh_type = TCP_LOG_DEV_TYPE_BBR;
-	hdr->tlh_length = (vaddr_t)end - (vaddr_t)hdr;
+	hdr->tlh_length = (ptraddr_t)end - (ptraddr_t)hdr;
 	hdr->tlh_ie = entry->tldl_ie;
 	hdr->tlh_af = entry->tldl_af;
 	getboottime(&hdr->tlh_offset);

--- a/sys/netinet/tcp_log_buf.c
+++ b/sys/netinet/tcp_log_buf.c
@@ -2129,7 +2129,7 @@ tcp_log_expandlogbuf(struct tcp_log_dev_queue *param)
 	memset(hdr, 0, sizeof(struct tcp_log_header));
 	hdr->tlh_version = TCP_LOG_BUF_VER;
 	hdr->tlh_type = TCP_LOG_DEV_TYPE_BBR;
-	hdr->tlh_length = (ptraddr_t)end - (ptraddr_t)hdr;
+	hdr->tlh_length = end - (uint8_t *)hdr;
 	hdr->tlh_ie = entry->tldl_ie;
 	hdr->tlh_af = entry->tldl_af;
 	getboottime(&hdr->tlh_offset);

--- a/sys/riscv/riscv/exec_machdep.c
+++ b/sys/riscv/riscv/exec_machdep.c
@@ -275,8 +275,8 @@ exec_setregs(struct thread *td, struct image_params *imgp, uintcap_t stack)
 	} else
 #endif
 	{
-		tf->tf_a[0] = (__cheri_addr vaddr_t)stack;
-		tf->tf_sp = STACKALIGN((__cheri_addr vaddr_t)stack);
+		tf->tf_a[0] = (__cheri_addr ptraddr_t)stack;
+		tf->tf_sp = STACKALIGN((__cheri_addr ptraddr_t)stack);
 #if __has_feature(capabilities)
 		hybridabi_thread_setregs(td, imgp->entry_addr);
 #else
@@ -520,7 +520,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	onstack = sigonstack(tf->tf_sp);
 
 	CTR4(KTR_SIG, "sendsig: td=%p (%s) catcher=%p sig=%d", td, p->p_comm,
-	    (__cheri_addr vaddr_t)catcher, sig);
+	    (__cheri_addr ptraddr_t)catcher, sig);
 
 	/* Allocate and validate space for the signal handler context. */
 	if ((td->td_pflags & TDP_ALTSTACK) != 0 && !onstack &&
@@ -550,7 +550,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	if (copyoutcap(&frame, fp, sizeof(*fp)) != 0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td,
-				(__cheri_addr vaddr_t)fp);
+				(__cheri_addr ptraddr_t)fp);
 		PROC_LOCK(p);
 		sigexit(td, SIGILL);
 	}

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -258,15 +258,15 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	onstack = sigonstack(tf->tf_sp);
 
 	CTR4(KTR_SIG, "sendsig: td=%p (%s) catcher=%p sig=%d", td, p->p_comm,
-	    (__cheri_addr vaddr_t)catcher, sig);
+	    (__cheri_addr ptraddr_t)catcher, sig);
 
 	/* Allocate and validate space for the signal handler context. */
 	if ((td->td_pflags & TDP_ALTSTACK) != 0 && !onstack &&
 	    SIGISMEMBER(psp->ps_sigonstack, sig)) {
-		sp = ((__cheri_addr vaddr_t)td->td_sigstk.ss_sp +
+		sp = ((__cheri_addr ptraddr_t)td->td_sigstk.ss_sp +
 		    td->td_sigstk.ss_size);
 	} else {
-		sp = (__cheri_addr vaddr_t)td->td_frame->tf_sp;
+		sp = (__cheri_addr ptraddr_t)td->td_frame->tf_sp;
 	}
 
 	/* Allocate room for the capability register context. */
@@ -287,7 +287,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	frame.sf_uc.uc_mcontext.mc_capregs = capregs;
 	siginfo_to_siginfo64(&ksi->ksi_info, &frame.sf_si);
 	frame.sf_uc.uc_sigmask = *mask;
-	frame.sf_uc.uc_stack.ss_sp = (__cheri_addr vaddr_t)td->td_sigstk.ss_sp;
+	frame.sf_uc.uc_stack.ss_sp = (__cheri_addr ptraddr_t)td->td_sigstk.ss_sp;
 	frame.sf_uc.uc_stack.ss_size = td->td_sigstk.ss_size;
 	frame.sf_uc.uc_stack.ss_flags = (td->td_pflags & TDP_ALTSTACK) != 0 ?
 	    (onstack ? SS_ONSTACK : 0) : SS_DISABLE;

--- a/sys/riscv/riscv/vm_machdep.c
+++ b/sys/riscv/riscv/vm_machdep.c
@@ -210,7 +210,7 @@ cpu_set_upcall(struct thread *td, void (* __capability entry)(void *),
 	tf->tf_sp = STACKALIGN((uintcap_t)stack->ss_sp + stack->ss_size);
 #if __has_feature(capabilities)
 	if (SV_PROC_FLAG(td->td_proc, SV_CHERI) == 0) {
-		tf->tf_sp = (uintcap_t)(__cheri_addr vaddr_t)tf->tf_sp;
+		tf->tf_sp = (uintcap_t)(__cheri_addr ptraddr_t)tf->tf_sp;
 		hybridabi_thread_setregs(td, (__cheri_addr unsigned long)entry);
 	} else
 #endif
@@ -222,7 +222,7 @@ int
 cpu_set_user_tls(struct thread *td, void * __capability tls_base)
 {
 
-	if ((__cheri_addr vaddr_t)tls_base >= VM_MAXUSER_ADDRESS)
+	if ((__cheri_addr ptraddr_t)tls_base >= VM_MAXUSER_ADDRESS)
 		return (EINVAL);
 
 	/*
@@ -231,7 +231,7 @@ cpu_set_user_tls(struct thread *td, void * __capability tls_base)
 	 */
 #ifdef COMPAT_FREEBSD64
 	if (SV_PROC_FLAG(td->td_proc, SV_CHERI | SV_LP64) == SV_LP64)
-		td->td_frame->tf_tp = (__cheri_addr vaddr_t)tls_base +
+		td->td_frame->tf_tp = (__cheri_addr ptraddr_t)tls_base +
 		    TP_OFFSET64;
 	else
 #endif

--- a/sys/sys/_atomic_subword.h
+++ b/sys/sys/_atomic_subword.h
@@ -54,16 +54,16 @@
 
 #if _BYTE_ORDER == _BIG_ENDIAN
 #define	_ATOMIC_BYTE_SHIFT(p)		\
-    ((3 - ((__cheri_addr vaddr_t)(p) % 4)) * NBBY)
+    ((3 - ((__cheri_addr ptraddr_t)(p) % 4)) * NBBY)
 
 #define	_ATOMIC_HWORD_SHIFT(p)		\
-    ((2 - ((__cheri_addr vaddr_t)(p) % 4)) * NBBY)
+    ((2 - ((__cheri_addr ptraddr_t)(p) % 4)) * NBBY)
 #else
 #define	_ATOMIC_BYTE_SHIFT(p)		\
-    ((((__cheri_addr vaddr_t)(p) % 4)) * NBBY)
+    ((((__cheri_addr ptraddr_t)(p) % 4)) * NBBY)
 
 #define	_ATOMIC_HWORD_SHIFT(p)		\
-    ((((__cheri_addr vaddr_t)(p) % 4)) * NBBY)
+    ((((__cheri_addr ptraddr_t)(p) % 4)) * NBBY)
 #endif
 
 #ifndef	_atomic_cmpset_masked_word

--- a/sys/sys/imgact_elf.h
+++ b/sys/sys/imgact_elf.h
@@ -42,7 +42,7 @@
 #if (__has_feature(capabilities) && !defined(__ELF_CHERI)) || \
     (defined(__LP64__) && __ELF_WORD_SIZE == 32)
 #define	AUXARGS_ENTRY_PTR(pos, id, ptr) \
-    {(pos)->a_type = (id); (pos)->a_un.a_val = (__cheri_addr vaddr_t)(ptr); (pos)++;}
+    {(pos)->a_type = (id); (pos)->a_un.a_val = (__cheri_addr ptraddr_t)(ptr); (pos)++;}
 #else
 #define	AUXARGS_ENTRY_PTR(pos, id, ptr) \
     {(pos)->a_type = (id); (pos)->a_un.a_ptr = (ptr); (pos)++;}

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -427,8 +427,8 @@ __END_DECLS
  * capability.  NB: For purecap kernels this is a no-op.
  */
 #define	PTR2CAP(p)	({					\
-	KASSERT((vaddr_t)((p)) == 0 ||				\
-	    (vaddr_t)((p)) >= VM_MAXUSER_ADDRESS,		\
+	KASSERT((ptraddr_t)((p)) == 0 ||			\
+	    (ptraddr_t)((p)) >= VM_MAXUSER_ADDRESS,		\
 	    ("PTR2CAP on user address: %p", (p)));		\
 	(__cheri_tocap __typeof__((*p)) * __capability)(p);	\
 	})

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -595,7 +595,7 @@ __END_DECLS
 
 #if defined(_KERNEL) && defined(COMPAT_FREEBSD64)
 static inline bool
-is_magic_sighandler_constant(vaddr_t handler) {
+is_magic_sighandler_constant(ptraddr_t handler) {
 	/*
 	 * Instead of enumerating all the SIG_* constants, just check if
 	 * it is a small (positive or negative) integer so that this doesn't

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -126,8 +126,8 @@ struct ucred;
     ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
-	__builtin_cheri_offset_set(NULL, (vaddr_t)(ptr)) :		\
-	__builtin_cheri_offset_set((cap), (vaddr_t)(ptr)))
+	__builtin_cheri_offset_set(NULL, (ptraddr_t)(ptr)) :		\
+	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)))
 
 #define	__USER_CAP_UNBOUND(ptr)						\
 	___USER_CFROMPTR((ptr), __USER_DDC)

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -141,7 +141,7 @@ cap_covers_pages(const void * __capability cap, size_t size)
 	size_t pageoff;
 
 	addr = cap;
-	pageoff = ((__cheri_addr vaddr_t)addr & PAGE_MASK);
+	pageoff = ((__cheri_addr ptraddr_t)addr & PAGE_MASK);
 	addr -= pageoff;
 	size += pageoff;
 	size = (vm_size_t)round_page(size);

--- a/tools/build/Makefile
+++ b/tools/build/Makefile
@@ -78,7 +78,7 @@ _WITH_NO_SUBOBJECT_BOUNDS!= grep -c __no_subobject_bounds ${HOST_INCLUDE_ROOT}/s
 .if ${_WITH_NO_SUBOBJECT_BOUNDS} == 0
 SYSINCS+=	cdefs.h
 .endif
-# Define vaddr_t for bootstrapping
+# Define ptraddr_t for bootstrapping
 INCS+=	stdint.h
 
 _WITH_EXPLICIT_BZERO!= grep -c explicit_bzero ${HOST_INCLUDE_ROOT}/strings.h || true


### PR DESCRIPTION
This PR switches the tree from using the deprecated `vaddr_t` to `ptraddr_t`. It includes most changes, but doesn't include submodules.