### PR TITLE
Don't dereference anchoropt, even if non-NULL, if it is an empty string.

### DIFF
--- a/sbin/pfctl/pfctl.c
+++ b/sbin/pfctl/pfctl.c
@@ -2773,7 +2773,7 @@ main(int argc, char *argv[])
 	if (anchoropt != NULL) {
 		int len = strlen(anchoropt);
 
-		if (anchoropt[len - 1] == '*') {
+		if (len >= 1 && anchoropt[len - 1] == '*') {
 			if (len >= 2 && anchoropt[len - 2] == '/')
 				anchoropt[len - 2] = '\0';
 			else


### PR DESCRIPTION
This results a nightly crash due to a bounds violation in pfctl(8) when the
daily event runs. Requires further validation before considering a merge.

Fixes https://github.com/CTSRD-CHERI/cheribsd/issues/1385
Also fixes https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=264128