### PR TITLE
Use CheriBSD instead of FreeBSD in /etc/os-release

### DIFF
--- a/libexec/rc/rc.d/os-release
+++ b/libexec/rc/rc.d/os-release
@@ -26,15 +26,16 @@ osrelease_start()
 	_version_id=${_version%%[^0-9.]*}
 	t=$(mktemp -t os-release)
 	cat > "$t" <<-__EOF__
-		NAME=FreeBSD
+		NAME=CheriBSD
 		VERSION="$_version"
 		VERSION_ID="$_version_id"
-		ID=freebsd
+		ID=cheribsd
+		ID_LIKE=freebsd
 		ANSI_COLOR="0;31"
-		PRETTY_NAME="FreeBSD $_version"
+		PRETTY_NAME="CheriBSD $_version"
 		CPE_NAME="cpe:/o:freebsd:freebsd:$_version_id"
-		HOME_URL="https://FreeBSD.org/"
-		BUG_REPORT_URL="https://bugs.FreeBSD.org/"
+		HOME_URL="https://www.cheribsd.org/"
+		BUG_REPORT_URL="https://github.com/CTSRD-CHERI/cheribsd/issues"
 __EOF__
 	install -C -o root -g wheel -m ${osrelease_perms} "$t" "${osrelease_file}"
 	rm -f "$t"


### PR DESCRIPTION
I haven't updated the version number since I'm not sure where we want to
store this information. The CPE_NAME also still uses the FreeBSD one,
but the homepage and bug report URL have been updated.

My motivation here is that we can easily distinguish CheriBSD from FreeBSD
hosts, but another alternative could be the VARIANT/VARIANT_ID field in
/etc/os-release to avoid introducing a new name that configure scripts
might not understand (not sure how many check for ID_LIKE).