### PR TITLE
jemalloc: make MALLOC_PRODUCTION obey WITH(OUT)

### DIFF
--- a/contrib/jemalloc/include/jemalloc/jemalloc_FreeBSD.h
+++ b/contrib/jemalloc/include/jemalloc/jemalloc_FreeBSD.h
@@ -16,13 +16,8 @@
 
 #undef JEMALLOC_OVERRIDE_VALLOC
 
-#if !defined(MALLOC_PRODUCTION) && !defined(MALLOC_DEBUG)
-#define	MALLOC_PRODUCTION
-#endif
-
 #ifndef MALLOC_PRODUCTION
 #define	JEMALLOC_DEBUG
-#pragma message("JEMALLOC_DEBUG enabled!")
 #endif
 
 #undef JEMALLOC_DSS

--- a/lib/libc/stdlib/jemalloc/Makefile.inc
+++ b/lib/libc/stdlib/jemalloc/Makefile.inc
@@ -50,7 +50,7 @@ MLINKS+= \
 	jemalloc.3 malloc.conf.5
 
 .if defined(MALLOC_DEBUG)
-CFLAGS+=	-DMALLOC_DEBUG
+CFLAGS+=	-DJEMALLOC_DEBUG
 .elif ${MK_MALLOC_PRODUCTION} != "no" || defined(MALLOC_PRODUCTION)
 CFLAGS+=	-DMALLOC_PRODUCTION
 .endif


### PR DESCRIPTION
This reverts 854818ce20b7d which forced MALLOC_PRODUCTION and partially
reverts b1f8ea91fd5bb which allowed enabling MALLOC_DEBUG.  Correct the
MALLOC_DEBUG option to define JEMALLOC_DEBUG since the define has
changed upstream.