### PR TITLE
swap_pager: Use CSealEntry to seal restored sentries.

### DIFF
--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -2220,8 +2220,12 @@ cheri_restore_tag(void * __capability *cp)
 	newcap = cheri_incoffset(newcap, offset);
 
 	if (sealed) {
-		sealcap = cheri_setoffset(swap_restore_cap, type);
-		newcap = cheri_seal(newcap, sealcap);
+		if (type == CHERI_OTYPE_SENTRY) {
+			newcap = cheri_sealentry(newcap);
+		} else {
+			sealcap = cheri_setoffset(swap_restore_cap, type);
+			newcap = cheri_seal(newcap, sealcap);
+		}
 	}
 
 	/*


### PR DESCRIPTION
CSeal on at least RISC-V is not able to seal a sentry and raises an
exception instead.