### PR TITLE
Look for cross toolchains under /usr/local64

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -67,6 +67,8 @@ TIME_ENV ?= time env
 .if defined(CROSS_TOOLCHAIN)
 .if exists(${LOCALBASE}/share/toolchains/${CROSS_TOOLCHAIN}.mk)
 .include "${LOCALBASE}/share/toolchains/${CROSS_TOOLCHAIN}.mk"
+.elif exists(/usr/local64/share/toolchains/${CROSS_TOOLCHAIN}.mk)
+.include "/usr/local64/share/toolchains/${CROSS_TOOLCHAIN}.mk"
 .elif exists(/usr/share/toolchains/${CROSS_TOOLCHAIN}.mk)
 .include "/usr/share/toolchains/${CROSS_TOOLCHAIN}.mk"
 .elif exists(${CROSS_TOOLCHAIN})


### PR DESCRIPTION
For the time being, the llvm-morello and llvm-cheri toolchains are
installed under /usr/local64 on native CHERI systems.

Testing: Works on a Morello box