### PR TITLE
crossbuild: Don't declare vaddr_t

### DIFF
--- a/tools/build/stdint.h
+++ b/tools/build/stdint.h
@@ -39,13 +39,11 @@
 #pragma once
 #include_next <stdint.h>
 
-#ifndef _VADDR_T_DECLARED
+#ifndef _PTRADDR_T_DECLARED
 #ifndef __CHERI_PURE_CAPABILITY__
-typedef	uintptr_t		vaddr_t;
 typedef	uintptr_t		ptraddr_t;
 #else
-typedef	unsigned long		vaddr_t;
 typedef	unsigned long		ptraddr_t;
 #endif
-#define _VADDR_T_DECLARED
+#define _PTRADDR_T_DECLARED
 #endif


### PR DESCRIPTION
Also use _PTRADDR_T_DECLARED guards around ptraddr_t decleration.