### PR TITLE
Morello: Don't clobber c2 in TLS dynamic resolver

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -237,9 +237,9 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	cmp	x3, x4
 	b.ne	1f			/* dtv[0] != tlsdec->dtv_gen */
 
-	ldr	w2, [c1, #16]		/* tlsdesc->tls_index */
-	add	w2, w2, #1
-	ldr     c3, [c0, w2, sxtw #4]	/* dtv[tlsdesc->tls_index + 1] */
+	ldr	w3, [c1, #16]		/* tlsdesc->tls_index */
+	add	w3, w3, #1
+	ldr     c3, [c0, w3, sxtw #4]	/* dtv[tlsdesc->tls_index + 1] */
 	cbz	x3, 1f
 
 	/* Return (dtv[tlsdesc->tls_index + 1] + tlsdesc->tls_offs) */


### PR DESCRIPTION
Use w3 to scale the tls_index instead of w2.  The aarch64 version
saves x2 on the stack, but the Morello version only saves c3 and c4.