### PR TITLE
Revert "Strip programs and shared libraries directly rather than via …

### DIFF
--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -256,11 +256,6 @@ DEBUGMKDIR=
 .else
 SHLIB_NAME_FULL=${SHLIB_NAME}
 .endif
-.if defined(STRIP) && !empty(STRIP)
-SHLIB_NAME_INSTALL=${SHLIB_NAME}.stripped
-.else
-SHLIB_NAME_INSTALL=${SHLIB_NAME}
-.endif
 .endif
 
 .include <bsd.symver.mk>
@@ -323,7 +318,7 @@ CLEANFILES+=	${SOBJS}
 .endif
 
 .if defined(SHLIB_NAME)
-_LIBS+=		${SHLIB_NAME_INSTALL}
+_LIBS+=		${SHLIB_NAME}
 
 SOLINKOPTS+=	-shared -Wl,-x
 .if !defined(ALLOW_SHARED_TEXTREL)
@@ -369,7 +364,7 @@ ${SHLIB_NAME_FULL}: ${SOBJS}
 .endif
 
 .if ${MK_DEBUG_FILES} != "no"
-CLEANFILES+=	${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug ${SHLIB_NAME}.stripped
+CLEANFILES+=	${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug
 ${SHLIB_NAME}: ${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug
 	${OBJCOPY} --strip-debug --add-gnu-debuglink=${SHLIB_NAME}.debug \
 	    ${SHLIB_NAME_FULL} ${.TARGET}
@@ -380,11 +375,6 @@ ${SHLIB_NAME}: ${SHLIB_NAME_FULL} ${SHLIB_NAME}.debug
 
 ${SHLIB_NAME}.debug: ${SHLIB_NAME_FULL}
 	${OBJCOPY} --only-keep-debug ${SHLIB_NAME_FULL} ${.TARGET}
-.endif
-
-.if ${SHLIB_NAME} != ${SHLIB_NAME_INSTALL}
-${SHLIB_NAME_INSTALL}: ${SHLIB_NAME}
-	${STRIPBIN} -o ${.TARGET} ${STRIP_FLAGS} ${SHLIB_NAME}
 .endif
 .endif #defined(SHLIB_NAME)
 
@@ -507,7 +497,7 @@ _libinstall:
 .if defined(SHLIB_NAME)
 	${INSTALL} ${TAG_ARGS} -o ${LIBOWN} -g ${LIBGRP} -m ${LIBMODE} \
 	    ${_INSTALLFLAGS} ${_SHLINSTALLFLAGS} \
-	    ${SHLIB_NAME_INSTALL} ${DESTDIR}${_SHLIBDIR}/${SHLIB_NAME}
+	    ${SHLIB_NAME} ${DESTDIR}${_SHLIBDIR}
 .if ${MK_DEBUG_FILES} != "no"
 .if defined(DEBUGMKDIR)
 	${INSTALL} ${TAG_ARGS:D${TAG_ARGS},dbg} -d ${DESTDIR}${DEBUGFILEDIR}/

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -155,12 +155,6 @@ DEBUGMKDIR=
 PROG_FULL=	${PROG}
 .endif
 
-.if defined(STRIP) && !empty(STRIP) && defined(PROG) && !defined(INTERNALPROG)
-PROG_INSTALL=	${PROG}.stripped
-.else
-PROG_INSTALL=	${PROG}
-.endif
-
 .if defined(PROG)
 PROGNAME?=	${PROG}
 
@@ -235,11 +229,6 @@ ${PROGNAME}.debug: ${PROG_FULL}
 	${OBJCOPY} --only-keep-debug ${PROG_FULL} ${.TARGET}
 .endif
 
-.if ${PROG_INSTALL} != ${PROG}
-${PROG_INSTALL}: ${PROG}
-	${STRIPBIN} -o ${.TARGET} ${STRIP_FLAGS} ${PROG}
-.endif
-
 .if defined(LLVM_LINK)
 ${PROG_FULL}.bc: ${BCOBJS}
 	${LLVM_LINK} -o ${.TARGET} ${BCOBJS}
@@ -263,10 +252,10 @@ MAN1=	${MAN}
 all:
 .else
 .if target(afterbuild)
-.ORDER: ${PROG_INSTALL} afterbuild
-all: ${PROG_INSTALL} ${SCRIPTS} afterbuild
+.ORDER: ${PROG} afterbuild
+all: ${PROG} ${SCRIPTS} afterbuild
 .else
-all: ${PROG_INSTALL} ${SCRIPTS}
+all: ${PROG} ${SCRIPTS}
 .endif
 .if ${MK_MAN} != "no"
 all: all-man
@@ -275,7 +264,6 @@ all: all-man
 
 .if defined(PROG)
 CLEANFILES+= ${PROG} ${PROG}.bc ${PROG}.ll
-CLEANFILES+= ${PROG}.stripped
 .if ${MK_DEBUG_FILES} != "no"
 CLEANFILES+= ${PROG_FULL} ${PROGNAME}.debug
 .endif


### PR DESCRIPTION
…install."

Due to a mis-merge, the stripped programs were not being installed, and
the primary effect of stripping libraries now that upstream uses separate
debug files was to remove the debuglink section used by debuggers to find
the separate debug file.

This reverts commit 305dc803d8a0788d4deed2fc82b1141e0db22711.