### PR TITLE
less(1): Prevent bin_file() -> is_utf8_well_formed() buffer overrun

### DIFF
--- a/contrib/less/filename.c
+++ b/contrib/less/filename.c
@@ -477,7 +477,7 @@ bin_file(f)
 	edata = &data[n];
 	for (p = data;  p < edata;  )
 	{
-		if (utf_mode && !is_utf8_well_formed(p, edata-data))
+		if (utf_mode && !is_utf8_well_formed(p, edata-p))
 		{
 			bin_count++;
 			utf_skip_to_lead(&p, edata);


### PR DESCRIPTION
Apply upstream GNU less PR#271 commit 5ed5582e:
https://github.com/gwsw/less/pull/271

When supplied with a file of random data >256 bytes, read()
would return a full buffer of data[256] to bin_file().
That function loops through the buffer, but calls is_utf8_well_formed()
with the full length of the buffer.  When looping on the last byte of the
buffer, is_uft8_well_formed() reads past the end.

This commit fixes bin_file() to only inspect the remaining bytes in the
buffer.