### PR TITLE
Making the clang-format check non-fatal

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,3 +31,10 @@ jobs:
         with:
           source-ref: "${{ github.event.pull_request.head.sha }}"
           target-ref: "${{ github.base_ref }}"
+      - name: Add comment
+        if: ${{ failure() }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Check the clang-format job for formatting suggestions.

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -2222,12 +2222,12 @@ core_output(char * __capability base_cap, size_t len, off_t offset,
 int
 sbuf_drain_core_output(void *arg, const char *data, int len)
 {
-	struct coredump_params *cp;
-	struct proc *p;
-	int error, locked;
+struct coredump_params *cp;
+struct proc *p;
+int error, locked;
 
-	cp = arg;
-	p = cp->td->td_proc;
+cp = arg;
+p = cp->td->td_proc;
 
 	/*
 	 * Some kern_proc out routines that print to this sbuf may


### PR DESCRIPTION
Repeat of #1409 but not from a fork