### PR TITLE
ZFS work in progress

### DIFF
--- a/lib/libthr/thread/thr_attr.c
+++ b/lib/libthr/thread/thr_attr.c
@@ -460,7 +460,7 @@ __weak_reference(_thr_attr_setguardsize, pthread_attr_setguardsize);
 __weak_reference(_thr_attr_setguardsize, _pthread_attr_setguardsize);
 
 int
-_thr_attr_setguardsize(pthread_attr_t *attr, size_t guardsize)
+_thr_attr_setguardsize(pthread_attr_t *attr, size_t guardsize __unused)
 {
 	int	ret;
 
@@ -469,7 +469,9 @@ _thr_attr_setguardsize(pthread_attr_t *attr, size_t guardsize)
 		ret = EINVAL;
 	else {
 		/* Save the stack size. */
+#ifndef __CHERI_PURE_CAPABILITY__
 		(*attr)->guardsize_attr = guardsize;
+#endif
 		ret = 0;
 	}
 	return (ret);

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -333,8 +333,7 @@ BROKEN_OPTIONS+=OFED
 
 .if ${__C} == "cheri" || ${__C} == "morello" || \
     ${__T:Maarch64*c*} || ${__T:Mriscv*c*}
-# Broken post OpenZFS import
-BROKEN_OPTIONS+=CDDL ZFS
+BROKEN_OPTIONS+=DTRACE
 .endif
 
 # EFI doesn't exist on powerpc (well, officially)

--- a/sys/cddl/boot/zfs/zfsimpl.h
+++ b/sys/cddl/boot/zfs/zfsimpl.h
@@ -1108,7 +1108,7 @@ typedef struct dnode_phys {
 			blkptr_t __dn_ignore2;
 			uint8_t __dn_ignore3[DN_OLD_MAX_BONUSLEN -
 			    sizeof (blkptr_t)];
-			blkptr_t dn_spill;
+			blkptr_t dn_spill __subobject_use_remaining_size;
 		};
 	};
 } dnode_phys_t;

--- a/sys/conf/kern.opts.mk
+++ b/sys/conf/kern.opts.mk
@@ -188,6 +188,7 @@ MK_${var}_SUPPORT:= yes
 .if ${MK_CDDL} == "no"
 # ctfconvert may not exist if MK_CDDL=false
 MK_CTF:=	no
+MK_DTRACE:=	no
 .endif
 
 # FIXME: duplicated from bsd.own.mk since the value of MK_CTF may have changed

--- a/sys/conf/kern.opts.mk
+++ b/sys/conf/kern.opts.mk
@@ -112,7 +112,7 @@ __DEFAULT_YES_OPTIONS += FDT
 
 # Broken post OpenZFS import
 .if ${MACHINE_CPU:Mcheri}
-BROKEN_OPTIONS+= CDDL ZFS
+BROKEN_OPTIONS+=CDDL
 .endif
 
 # expanded inline from bsd.mkopt.mk to avoid share/mk dependency

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -265,8 +265,8 @@ ZFS_CFLAGS+= -DBITS_PER_LONG=64
 
 
 ZFS_ASM_CFLAGS= -x assembler-with-cpp -DLOCORE ${ZFS_CFLAGS}
-ZFS_C=		${CC} -c ${ZFS_CFLAGS} ${WERROR} ${.IMPSRC}
-ZFS_RPC_C=	${CC} -c ${ZFS_CFLAGS} -DHAVE_RPC_TYPES ${WERROR} ${.IMPSRC}
+ZFS_C=		${CC} -c ${ZFS_CFLAGS} -Xclang -cheri-bounds=conservative ${WERROR} ${.IMPSRC}
+ZFS_RPC_C=	${CC} -c ${ZFS_CFLAGS} -DHAVE_RPC_TYPES -Xclang -cheri-bounds=conservative ${WERROR} ${.IMPSRC}
 ZFS_S=		${CC} -c ${ZFS_ASM_CFLAGS} ${WERROR} ${.IMPSRC}
 
 # ATH driver

--- a/sys/contrib/openzfs/cmd/zstream/zstream_decompress.c
+++ b/sys/contrib/openzfs/cmd/zstream/zstream_decompress.c
@@ -144,7 +144,7 @@ zstream_do_decompress(int argc, char *argv[])
 		p = hsearch(e, ENTER);
 		if (p == NULL)
 			errx(1, "hsearch");
-		p->data = (void*)type;
+		p->data = (void*)(uintptr_t)type;
 	}
 
 	if (isatty(STDIN_FILENO)) {

--- a/sys/contrib/openzfs/include/libuutil_impl.h
+++ b/sys/contrib/openzfs/include/libuutil_impl.h
@@ -52,10 +52,14 @@ void uu_panic(const char *format, ...) __attribute__((format(printf, 1, 2)));
  * storing them with swapped endianness;  this is not perfect, but it's about
  * the best we can do without wasting a lot of space.
  */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	UU_PTR_ENCODE(ptr)		(uintptr_t)(ptr)
+#else
 #ifdef _LP64
 #define	UU_PTR_ENCODE(ptr)		BSWAP_64((uintptr_t)(void *)(ptr))
 #else
 #define	UU_PTR_ENCODE(ptr)		BSWAP_32((uintptr_t)(void *)(ptr))
+#endif
 #endif
 
 #define	UU_PTR_DECODE(ptr)		((void *)UU_PTR_ENCODE(ptr))

--- a/sys/contrib/openzfs/include/os/freebsd/spl/acl/acl_common.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/acl/acl_common.h
@@ -47,7 +47,7 @@ extern int acltrivial(const char *);
 extern void adjust_ace_pair(ace_t *pair, mode_t mode);
 extern void adjust_ace_pair_common(void *, size_t, size_t, mode_t);
 extern int ace_trivial_common(void *, int,
-    uint64_t (*walk)(void *, uint64_t, int aclcnt, uint16_t *, uint16_t *,
+    uintptr_t (*walk)(void *, uintptr_t, int aclcnt, uint16_t *, uint16_t *,
     uint32_t *mask));
 #if !defined(_KERNEL)
 extern acl_t *acl_alloc(acl_type_t);

--- a/sys/contrib/openzfs/include/os/freebsd/spl/sys/ccompile.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/sys/ccompile.h
@@ -144,7 +144,7 @@ typedef int enum_t;
 #define	P2PHASE(x, align)		((x) & ((align) - 1))
 #define	P2NPHASE(x, align)		(-(x) & ((align) - 1))
 #define	ISP2(x)			(((x) & ((x) - 1)) == 0)
-#define	IS_P2ALIGNED(v, a)	((((uintptr_t)(v)) & ((uintptr_t)(a) - 1)) == 0)
+#define	IS_P2ALIGNED(v, a)	((((ptraddr_t)(v)) & ((ptraddr_t)(a) - 1)) == 0)
 #define	P2BOUNDARY(off, len, align) \
 	(((off) ^ ((off) + (len) - 1)) > (align) - 1)
 

--- a/sys/contrib/openzfs/include/os/freebsd/spl/sys/sunddi.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/sys/sunddi.h
@@ -52,8 +52,8 @@ extern int ddi_strtol(const char *, char **, int, long *);
 extern int ddi_strtoull(const char *, char **, int, unsigned long long *);
 extern int ddi_strtoll(const char *, char **, int, long long *);
 
-extern int ddi_copyin(const void *from, void *to, size_t len, int flags);
-extern int ddi_copyout(const void *from, void *to, size_t len, int flags);
+extern int ddi_copyin(const void * __capability from, void *to, size_t len, int flags);
+extern int ddi_copyout(const void *from, void * __capability to, size_t len, int flags);
 extern void ddi_sysevent_init(void);
 
 

--- a/sys/contrib/openzfs/include/os/freebsd/spl/sys/sysmacros.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/sys/sysmacros.h
@@ -166,7 +166,7 @@ extern unsigned char bcd_to_byte[256];
 /*
  * Macro for checking power of 2 address alignment.
  */
-#define	IS_P2ALIGNED(v, a) ((((uintptr_t)(v)) & ((uintptr_t)(a) - 1)) == 0)
+#define	IS_P2ALIGNED(v, a) ((((ptraddr_t)(v)) & ((ptraddr_t)(a) - 1)) == 0)
 
 /*
  * Macros for counting and rounding.

--- a/sys/contrib/openzfs/include/os/freebsd/spl/sys/taskq.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/sys/taskq.h
@@ -44,7 +44,7 @@ typedef struct taskq {
 	struct taskqueue	*tq_queue;
 } taskq_t;
 
-typedef uintptr_t taskqid_t;
+typedef ptraddr_t taskqid_t;
 typedef void (task_func_t)(void *);
 
 typedef struct taskq_ent {

--- a/sys/contrib/openzfs/include/os/freebsd/spl/sys/uio.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/sys/uio.h
@@ -49,7 +49,7 @@ typedef struct zfs_uio {
 #define	zfs_uio_resid(u)	GET_UIO_STRUCT(u)->uio_resid
 #define	zfs_uio_iovcnt(u)	GET_UIO_STRUCT(u)->uio_iovcnt
 #define	zfs_uio_iovlen(u, idx)	GET_UIO_STRUCT(u)->uio_iov[(idx)].iov_len
-#define	zfs_uio_iovbase(u, idx)	GET_UIO_STRUCT(u)->uio_iov[(idx)].iov_base
+#define	zfs_uio_iovbase(u, idx)	(__cheri_fromcap void *)GET_UIO_STRUCT(u)->uio_iov[(idx)].iov_base
 #define	zfs_uio_td(u)		GET_UIO_STRUCT(u)->uio_td
 #define	zfs_uio_rw(u)		GET_UIO_STRUCT(u)->uio_rw
 #define	zfs_uio_fault_disable(u, set)

--- a/sys/contrib/openzfs/include/os/freebsd/spl/sys/vnode.h
+++ b/sys/contrib/openzfs/include/os/freebsd/spl/sys/vnode.h
@@ -203,15 +203,6 @@ vattr_init_mask(vattr_t *vap)
 
 #define		RLIM64_INFINITY 0
 
-static __inline int
-vn_rename(char *from, char *to, enum uio_seg seg)
-{
-
-	ASSERT(seg == UIO_SYSSPACE);
-
-	return (kern_renameat(curthread, AT_FDCWD, from, AT_FDCWD, to, seg));
-}
-
 #include <sys/vfs.h>
 
 #endif	/* _OPENSOLARIS_SYS_VNODE_H_ */

--- a/sys/contrib/openzfs/include/os/freebsd/zfs/sys/zfs_ioctl_compat.h
+++ b/sys/contrib/openzfs/include/os/freebsd/zfs/sys/zfs_ioctl_compat.h
@@ -81,7 +81,7 @@ extern "C" {
 
 typedef struct zfs_iocparm {
 	uint32_t	zfs_ioctl_version;
-	uint64_t	zfs_cmd;
+	kuint64cap_t	zfs_cmd;
 	uint64_t	zfs_cmd_size;
 } zfs_iocparm_t;
 

--- a/sys/contrib/openzfs/include/os/freebsd/zfs/sys/zfs_ioctl_compat.h
+++ b/sys/contrib/openzfs/include/os/freebsd/zfs/sys/zfs_ioctl_compat.h
@@ -37,6 +37,10 @@
 #include <sys/nvpair.h>
 #endif  /* _KERNEL */
 
+#if !__has_feature(capabilities)
+#define	ZFS_LEGACY_SUPPORT
+#endif
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
@@ -82,6 +86,7 @@ typedef struct zfs_iocparm {
 } zfs_iocparm_t;
 
 
+#ifdef ZFS_LEGACY_SUPPORT
 #define	LEGACY_MAXPATHLEN 1024
 #define	LEGACY_MAXNAMELEN 256
 
@@ -135,6 +140,7 @@ typedef struct zfs_cmd_legacy {
 	uint64_t	zc_createtxg;
 	zfs_stat_t	zc_stat;
 } zfs_cmd_legacy_t;
+#endif
 
 
 #ifdef _KERNEL
@@ -145,10 +151,12 @@ nvlist_t *zfs_ioctl_compat_innvl(zfs_cmd_t *, nvlist_t *, const int,
 nvlist_t *zfs_ioctl_compat_outnvl(zfs_cmd_t *, nvlist_t *, const int,
     const int);
 #endif	/* _KERNEL */
+#ifdef ZFS_LEGACY_SUPPORT
 int zfs_ioctl_legacy_to_ozfs(int request);
 int zfs_ioctl_ozfs_to_legacy(int request);
 void zfs_cmd_legacy_to_ozfs(zfs_cmd_legacy_t *src, zfs_cmd_t *dst);
 void zfs_cmd_ozfs_to_legacy(zfs_cmd_t *src, zfs_cmd_legacy_t *dst);
+#endif
 
 void zfs_cmd_compat_put(zfs_cmd_t *, caddr_t, const int, const int);
 

--- a/sys/contrib/openzfs/include/sys/avl_impl.h
+++ b/sys/contrib/openzfs/include/sys/avl_impl.h
@@ -55,7 +55,7 @@ extern "C" {
  * bottom bits of the parent pointer on 64 bit machines to save on space.
  */
 
-#ifndef _LP64
+#if !defined(_LP64) && !defined(__CHERI_PURE_CAPABILITY__)
 
 struct avl_node {
 	struct avl_node *avl_child[2];	/* left/right children */

--- a/sys/contrib/openzfs/include/sys/avl_impl.h
+++ b/sys/contrib/openzfs/include/sys/avl_impl.h
@@ -98,12 +98,12 @@ struct avl_node {
  */
 #define	AVL_XPARENT(n)		((struct avl_node *)((n)->avl_pcb & ~7))
 #define	AVL_SETPARENT(n, p)						\
-	((n)->avl_pcb = (((n)->avl_pcb & 7) | (uintptr_t)(p)))
+	((n)->avl_pcb = (((ptraddr_t)(n)->avl_pcb & 7) | (uintptr_t)(p)))
 
 /*
  * index of this node in its parent's avl_child[]: bit #2
  */
-#define	AVL_XCHILD(n)		(((n)->avl_pcb >> 2) & 1)
+#define	AVL_XCHILD(n)		(((ptraddr_t)(n)->avl_pcb >> 2) & 1)
 #define	AVL_SETCHILD(n, c)						\
 	((n)->avl_pcb = (uintptr_t)(((n)->avl_pcb & ~4) | ((c) << 2)))
 

--- a/sys/contrib/openzfs/include/sys/dbuf.h
+++ b/sys/contrib/openzfs/include/sys/dbuf.h
@@ -202,7 +202,7 @@ typedef struct dmu_buf_impl {
 	 */
 
 	/* the publicly visible structure */
-	dmu_buf_t db;
+	dmu_buf_t db __subobject_use_container_bounds;
 
 	/* the objset we belong to */
 	struct objset *db_objset;

--- a/sys/contrib/openzfs/include/sys/dmu.h
+++ b/sys/contrib/openzfs/include/sys/dmu.h
@@ -658,7 +658,7 @@ typedef struct dmu_buf_user {
 	 */
 	dmu_buf_t **dbu_clear_on_evict_dbufp;
 #endif
-} dmu_buf_user_t;
+} __subobject_use_container_bounds dmu_buf_user_t;
 
 /*
  * Initialize the given dmu_buf_user_t instance with the eviction function

--- a/sys/contrib/openzfs/include/sys/nvpair.h
+++ b/sys/contrib/openzfs/include/sys/nvpair.h
@@ -85,7 +85,7 @@ typedef struct nvpair {
 typedef struct nvlist {
 	int32_t		nvl_version;
 	uint32_t	nvl_nvflag;	/* persistent flags */
-	uint64_t	nvl_priv;	/* ptr to private data if not packed */
+	uint64ptr_t	nvl_priv;	/* ptr to private data if not packed */
 	uint32_t	nvl_flag;
 	int32_t		nvl_pad;	/* currently not used, for alignment */
 } nvlist_t;
@@ -105,7 +105,11 @@ typedef struct nvlist {
 #define	NV_FLAG_NOENTOK		0x1
 
 /* convenience macros */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	NV_ALIGN(x)		(((ulong_t)(x) + 15ul) & ~15ul)
+#else
 #define	NV_ALIGN(x)		(((ulong_t)(x) + 7ul) & ~7ul)
+#endif
 #define	NV_ALIGN4(x)		(((x) + 3) & ~3)
 
 #define	NVP_SIZE(nvp)		((nvp)->nvp_size)

--- a/sys/contrib/openzfs/include/sys/nvpair_impl.h
+++ b/sys/contrib/openzfs/include/sys/nvpair_impl.h
@@ -50,7 +50,7 @@ typedef struct i_nvp i_nvp_t;
 struct i_nvp {
 	union {
 		/* ensure alignment */
-		uint64_t	_nvi_align;
+		kuint64cap_t	_nvi_align;
 
 		struct {
 			/* pointer to next nvpair */

--- a/sys/contrib/openzfs/include/sys/nvpair_impl.h
+++ b/sys/contrib/openzfs/include/sys/nvpair_impl.h
@@ -65,7 +65,7 @@ struct i_nvp {
 	} _nvi_un;
 
 	/* nvpair */
-	nvpair_t nvi_nvp;
+	nvpair_t nvi_nvp __subobject_use_container_bounds;
 };
 #define	nvi_next	_nvi_un._nvi._nvi_next
 #define	nvi_prev	_nvi_un._nvi._nvi_prev

--- a/sys/contrib/openzfs/include/sys/nvpair_impl.h
+++ b/sys/contrib/openzfs/include/sys/nvpair_impl.h
@@ -50,7 +50,7 @@ typedef struct i_nvp i_nvp_t;
 struct i_nvp {
 	union {
 		/* ensure alignment */
-		kuint64cap_t	_nvi_align;
+		uint64_t	_nvi_align;
 
 		struct {
 			/* pointer to next nvpair */

--- a/sys/contrib/openzfs/include/sys/sa_impl.h
+++ b/sys/contrib/openzfs/include/sys/sa_impl.h
@@ -177,7 +177,7 @@ typedef struct sa_hdr_phys {
 	 *
 	 */
 	uint16_t sa_layout_info;
-	uint16_t sa_lengths[1];	/* optional sizes for variable length attrs */
+	uint16_t sa_lengths[1] __subobject_use_remaining_size;	/* optional sizes for variable length attrs */
 	/* ... Data follows the lengths.  */
 } sa_hdr_phys_t;
 

--- a/sys/contrib/openzfs/include/sys/spa.h
+++ b/sys/contrib/openzfs/include/sys/spa.h
@@ -1146,7 +1146,7 @@ extern void zfs_post_remove(spa_t *spa, vdev_t *vd);
 extern void zfs_post_state_change(spa_t *spa, vdev_t *vd, uint64_t laststate);
 extern void zfs_post_autoreplace(spa_t *spa, vdev_t *vd);
 extern uint64_t spa_get_errlog_size(spa_t *spa);
-extern int spa_get_errlog(spa_t *spa, void *uaddr, uint64_t *count);
+extern int spa_get_errlog(spa_t *spa, void * __capability uaddr, uint64_t *count);
 extern void spa_errlog_rotate(spa_t *spa);
 extern void spa_errlog_drain(spa_t *spa);
 extern void spa_errlog_sync(spa_t *spa, uint64_t txg);

--- a/sys/contrib/openzfs/include/sys/zfs_ioctl.h
+++ b/sys/contrib/openzfs/include/sys/zfs_ioctl.h
@@ -477,9 +477,9 @@ typedef enum zfs_case {
  */
 typedef struct zfs_cmd {
 	char		zc_name[MAXPATHLEN];	/* name of pool or dataset */
-	uint64_t	zc_nvlist_src;		/* really (char *) */
+	kuint64cap_t	zc_nvlist_src;		/* really (char *) */
 	uint64_t	zc_nvlist_src_size;
-	uint64_t	zc_nvlist_dst;		/* really (char *) */
+	kuint64cap_t	zc_nvlist_dst;		/* really (char *) */
 	uint64_t	zc_nvlist_dst_size;
 	boolean_t	zc_nvlist_dst_filled;	/* put an nvlist in dst? */
 	int		zc_pad2;
@@ -488,11 +488,11 @@ typedef struct zfs_cmd {
 	 * The following members are for legacy ioctls which haven't been
 	 * converted to the new method.
 	 */
-	uint64_t	zc_history;		/* really (char *) */
+	kuint64cap_t	zc_history;		/* really (char *) */
 	char		zc_value[MAXPATHLEN * 2];
 	char		zc_string[MAXNAMELEN];
 	uint64_t	zc_guid;
-	uint64_t	zc_nvlist_conf;		/* really (char *) */
+	kuint64cap_t	zc_nvlist_conf;		/* really (char *) */
 	uint64_t	zc_nvlist_conf_size;
 	uint64_t	zc_cookie;
 	uint64_t	zc_objset_type;

--- a/sys/contrib/openzfs/include/sys/zfs_onexit.h
+++ b/sys/contrib/openzfs/include/sys/zfs_onexit.h
@@ -54,7 +54,7 @@ extern void zfs_onexit_destroy(zfs_onexit_t *zo);
 extern zfs_file_t *zfs_onexit_fd_hold(int fd, minor_t *minorp);
 extern void zfs_onexit_fd_rele(zfs_file_t *);
 extern int zfs_onexit_add_cb(minor_t minor, void (*func)(void *), void *data,
-    uint64_t *action_handle);
+    uintptr_t *action_handle);
 
 #ifdef	__cplusplus
 }

--- a/sys/contrib/openzfs/lib/libspl/include/sys/isa_defs.h
+++ b/sys/contrib/openzfs/lib/libspl/include/sys/isa_defs.h
@@ -227,8 +227,12 @@ extern "C" {
  * RISC-V arch specific defines
  * only RV64G (including atomic) LP64 is supported yet
  */
-#elif defined(__riscv) && defined(_LP64) && _LP64 && \
-	defined(__riscv_atomic) && __riscv_atomic
+#elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64 \
+	&& defined(__riscv_atomic) && __riscv_atomic
+
+#if !defined(_LP64)
+#define _LP64 1
+#endif
 
 #ifndef	__riscv__
 #define	__riscv__

--- a/sys/contrib/openzfs/lib/libzfs/libzfs_dataset.c
+++ b/sys/contrib/openzfs/lib/libzfs/libzfs_dataset.c
@@ -2085,16 +2085,16 @@ zfs_is_recvd_props_mode(zfs_handle_t *zhp)
 }
 
 static void
-zfs_set_recvd_props_mode(zfs_handle_t *zhp, uint64_t *cookie)
+zfs_set_recvd_props_mode(zfs_handle_t *zhp, uintptr_t *cookie)
 {
-	*cookie = (uint64_t)(uintptr_t)zhp->zfs_props;
+	*cookie = (uintptr_t)zhp->zfs_props;
 	zhp->zfs_props = zhp->zfs_recvd_props;
 }
 
 static void
-zfs_unset_recvd_props_mode(zfs_handle_t *zhp, uint64_t *cookie)
+zfs_unset_recvd_props_mode(zfs_handle_t *zhp, uintptr_t *cookie)
 {
-	zhp->zfs_props = (nvlist_t *)(uintptr_t)*cookie;
+	zhp->zfs_props = (nvlist_t *)*cookie;
 	*cookie = 0;
 }
 
@@ -2358,7 +2358,7 @@ zfs_prop_get_recvd(zfs_handle_t *zhp, const char *propname, char *propbuf,
 	prop = zfs_name_to_prop(propname);
 
 	if (prop != ZPROP_USERPROP) {
-		uint64_t cookie;
+		uintptr_t cookie;
 		if (!nvlist_exists(zhp->zfs_recvd_props, propname))
 			return (-1);
 		zfs_set_recvd_props_mode(zhp, &cookie);

--- a/sys/contrib/openzfs/lib/libzfs/libzfs_dataset.c
+++ b/sys/contrib/openzfs/lib/libzfs/libzfs_dataset.c
@@ -5181,12 +5181,12 @@ zfs_set_fsacl(zfs_handle_t *zhp, boolean_t un, nvlist_t *nvl)
 	assert(zhp->zfs_type == ZFS_TYPE_VOLUME ||
 	    zhp->zfs_type == ZFS_TYPE_FILESYSTEM);
 
-	err = nvlist_size(nvl, &nvsz, NV_ENCODE_NATIVE);
+	err = nvlist_size(nvl, &nvsz, NV_ENCODE_XDR);
 	assert(err == 0);
 
 	nvbuf = malloc(nvsz);
 
-	err = nvlist_pack(nvl, &nvbuf, &nvsz, NV_ENCODE_NATIVE, 0);
+	err = nvlist_pack(nvl, &nvbuf, &nvsz, NV_ENCODE_XDR, 0);
 	assert(err == 0);
 
 	zc.zc_nvlist_src_size = nvsz;

--- a/sys/contrib/openzfs/lib/libzfs/libzfs_pool.c
+++ b/sys/contrib/openzfs/lib/libzfs/libzfs_pool.c
@@ -1550,7 +1550,7 @@ zpool_destroy(zpool_handle_t *zhp, const char *log_str)
 		return (-1);
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
-	zc.zc_history = (uint64_t)(uintptr_t)log_str;
+	zc.zc_history = (uintptr_t)log_str;
 
 	if (zfs_ioctl(hdl, ZFS_IOC_POOL_DESTROY, &zc) != 0) {
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
@@ -1741,7 +1741,7 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 	zc.zc_cookie = force;
 	zc.zc_guid = hardforce;
-	zc.zc_history = (uint64_t)(uintptr_t)log_str;
+	zc.zc_history = (uintptr_t)log_str;
 
 	if (zfs_ioctl(zhp->zpool_hdl, ZFS_IOC_POOL_EXPORT, &zc) != 0) {
 		switch (errno) {
@@ -4398,7 +4398,7 @@ get_history(zpool_handle_t *zhp, char *buf, uint64_t *off, uint64_t *len)
 
 	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
 
-	zc.zc_history = (uint64_t)(uintptr_t)buf;
+	zc.zc_history = (uintptr_t)buf;
 	zc.zc_history_len = *len;
 	zc.zc_history_offset = *off;
 

--- a/sys/contrib/openzfs/lib/libzfs/libzfs_util.c
+++ b/sys/contrib/openzfs/lib/libzfs/libzfs_util.c
@@ -1198,7 +1198,7 @@ zcmd_write_nvlist_com(libzfs_handle_t *hdl, uintptr_t *outnv, uint64_t *outlen,
 	size_t len = fnvlist_size(nvl);
 	packed = zfs_alloc(hdl, len);
 
-	verify(nvlist_pack(nvl, &packed, &len, NV_ENCODE_NATIVE, 0) == 0);
+	verify(nvlist_pack(nvl, &packed, &len, NV_ENCODE_XDR, 0) == 0);
 
 	*outnv = (uintptr_t)packed;
 	*outlen = len;

--- a/sys/contrib/openzfs/lib/libzfs/libzfs_util.c
+++ b/sys/contrib/openzfs/lib/libzfs/libzfs_util.c
@@ -1159,7 +1159,7 @@ zcmd_alloc_dst_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, size_t len)
 		len = 256 * 1024;
 	zc->zc_nvlist_dst_size = len;
 	zc->zc_nvlist_dst =
-	    (uint64_t)(uintptr_t)zfs_alloc(hdl, zc->zc_nvlist_dst_size);
+	    (uintptr_t)zfs_alloc(hdl, zc->zc_nvlist_dst_size);
 }
 
 /*
@@ -1172,7 +1172,7 @@ zcmd_expand_dst_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc)
 {
 	free((void *)(uintptr_t)zc->zc_nvlist_dst);
 	zc->zc_nvlist_dst =
-	    (uint64_t)(uintptr_t)zfs_alloc(hdl, zc->zc_nvlist_dst_size);
+	    (uintptr_t)zfs_alloc(hdl, zc->zc_nvlist_dst_size);
 }
 
 /*
@@ -1190,7 +1190,7 @@ zcmd_free_nvlists(zfs_cmd_t *zc)
 }
 
 static void
-zcmd_write_nvlist_com(libzfs_handle_t *hdl, uint64_t *outnv, uint64_t *outlen,
+zcmd_write_nvlist_com(libzfs_handle_t *hdl, uintptr_t *outnv, uint64_t *outlen,
     nvlist_t *nvl)
 {
 	char *packed;
@@ -1200,7 +1200,7 @@ zcmd_write_nvlist_com(libzfs_handle_t *hdl, uint64_t *outnv, uint64_t *outlen,
 
 	verify(nvlist_pack(nvl, &packed, &len, NV_ENCODE_NATIVE, 0) == 0);
 
-	*outnv = (uint64_t)(uintptr_t)packed;
+	*outnv = (uintptr_t)packed;
 	*outlen = len;
 }
 
@@ -1224,7 +1224,7 @@ zcmd_write_src_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, nvlist_t *nvl)
 int
 zcmd_read_dst_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, nvlist_t **nvlp)
 {
-	if (nvlist_unpack((void *)(uintptr_t)zc->zc_nvlist_dst,
+	if (nvlist_unpack((void *)zc->zc_nvlist_dst,
 	    zc->zc_nvlist_dst_size, nvlp, 0) != 0)
 		return (no_memory(hdl));
 

--- a/sys/contrib/openzfs/lib/libzfs_core/libzfs_core.c
+++ b/sys/contrib/openzfs/lib/libzfs_core/libzfs_core.c
@@ -192,7 +192,7 @@ lzc_ioctl(zfs_ioc_t ioc, const char *name,
 
 	if (source != NULL) {
 		packed = fnvlist_pack(source, &size);
-		zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
+		zc.zc_nvlist_src = (uintptr_t)packed;
 		zc.zc_nvlist_src_size = size;
 	}
 
@@ -204,9 +204,8 @@ lzc_ioctl(zfs_ioc_t ioc, const char *name,
 		} else {
 			zc.zc_nvlist_dst_size = MAX(size * 2, 128 * 1024);
 		}
-		zc.zc_nvlist_dst = (uint64_t)(uintptr_t)
-		    malloc(zc.zc_nvlist_dst_size);
-		if (zc.zc_nvlist_dst == (uint64_t)0) {
+		zc.zc_nvlist_dst = (uintptr_t)malloc(zc.zc_nvlist_dst_size);
+		if (zc.zc_nvlist_dst == (uintptr_t)0) {
 			error = ENOMEM;
 			goto out;
 		}
@@ -224,9 +223,9 @@ lzc_ioctl(zfs_ioc_t ioc, const char *name,
 		    ioc != ZFS_IOC_CHANNEL_PROGRAM) {
 			free((void *)(uintptr_t)zc.zc_nvlist_dst);
 			zc.zc_nvlist_dst_size *= 2;
-			zc.zc_nvlist_dst = (uint64_t)(uintptr_t)
+			zc.zc_nvlist_dst = (uintptr_t)
 			    malloc(zc.zc_nvlist_dst_size);
-			if (zc.zc_nvlist_dst == (uint64_t)0) {
+			if (zc.zc_nvlist_dst == (uintptr_t)0) {
 				error = ENOMEM;
 				goto out;
 			}
@@ -1113,13 +1112,13 @@ recv_impl(const char *snapname, nvlist_t *recvdprops, nvlist_t *localprops,
 
 		if (recvdprops != NULL) {
 			packed = fnvlist_pack(recvdprops, &size);
-			zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
+			zc.zc_nvlist_src = (uintptr_t)packed;
 			zc.zc_nvlist_src_size = size;
 		}
 
 		if (localprops != NULL) {
 			packed = fnvlist_pack(localprops, &size);
-			zc.zc_nvlist_conf = (uint64_t)(uintptr_t)packed;
+			zc.zc_nvlist_conf = (uintptr_t)packed;
 			zc.zc_nvlist_conf_size = size;
 		}
 
@@ -1135,7 +1134,7 @@ recv_impl(const char *snapname, nvlist_t *recvdprops, nvlist_t *localprops,
 		zc.zc_action_handle = 0;
 
 		zc.zc_nvlist_dst_size = 128 * 1024;
-		zc.zc_nvlist_dst = (uint64_t)(uintptr_t)
+		zc.zc_nvlist_dst = (uintptr_t)
 		    malloc(zc.zc_nvlist_dst_size);
 
 		error = lzc_ioctl_fd(g_fd, ZFS_IOC_RECV, &zc);

--- a/sys/contrib/openzfs/lib/libzfs_core/os/freebsd/libzfs_core_ioctl.c
+++ b/sys/contrib/openzfs/lib/libzfs_core/os/freebsd/libzfs_core_ioctl.c
@@ -57,7 +57,7 @@ zcmd_ioctl_compat(int fd, int request, zfs_cmd_t *zc, const int cflag)
 	switch (cflag) {
 	case ZFS_CMD_COMPAT_NONE:
 		ncmd = _IOWR('Z', request, zfs_iocparm_t);
-		zp.zfs_cmd = (uint64_t)(uintptr_t)zc;
+		zp.zfs_cmd = (uintptr_t)zc;
 		zp.zfs_cmd_size = sizeof (zfs_cmd_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_OZFS;
 		break;
@@ -67,7 +67,7 @@ zcmd_ioctl_compat(int fd, int request, zfs_cmd_t *zc, const int cflag)
 		ncmd = _IOWR('Z', newrequest, zfs_iocparm_t);
 		zc_c = malloc(sizeof (zfs_cmd_legacy_t));
 		zfs_cmd_ozfs_to_legacy(zc, zc_c);
-		zp.zfs_cmd = (uint64_t)(uintptr_t)zc_c;
+		zp.zfs_cmd = (uintptr_t)zc_c;
 		zp.zfs_cmd_size = sizeof (zfs_cmd_legacy_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_LEGACY;
 		break;

--- a/sys/contrib/openzfs/lib/libzpool/kernel.c
+++ b/sys/contrib/openzfs/lib/libzpool/kernel.c
@@ -972,7 +972,7 @@ zfs_onexit_fd_rele(zfs_file_t *fp)
 
 int
 zfs_onexit_add_cb(minor_t minor, void (*func)(void *), void *data,
-    uint64_t *action_handle)
+    uintptr_t *action_handle)
 {
 	(void) minor, (void) func, (void) data, (void) action_handle;
 	return (0);

--- a/sys/contrib/openzfs/lib/libzpool/util.c
+++ b/sys/contrib/openzfs/lib/libzpool/util.c
@@ -259,7 +259,9 @@ pool_active(void *unused, const char *name, uint64_t guid, boolean_t *isactive)
 	(void) unused, (void) guid;
 	zfs_iocparm_t zp;
 	zfs_cmd_t *zc = NULL;
+#ifdef ZFS_LEGACY_SUPPORT
 	zfs_cmd_legacy_t *zcl = NULL;
+#endif
 	unsigned long request;
 	int ret;
 
@@ -294,6 +296,7 @@ pool_active(void *unused, const char *name, uint64_t guid, boolean_t *isactive)
 		umem_free(zc, sizeof (zfs_cmd_t));
 
 		break;
+#ifdef ZFS_LEGACY_SUPPORT
 	case ZFS_IOCVER_LEGACY:
 		zcl = umem_zalloc(sizeof (zfs_cmd_legacy_t), UMEM_NOFAIL);
 
@@ -309,6 +312,7 @@ pool_active(void *unused, const char *name, uint64_t guid, boolean_t *isactive)
 		umem_free(zcl, sizeof (zfs_cmd_legacy_t));
 
 		break;
+#endif
 	default:
 		fprintf(stderr, "unrecognized zfs ioctl version %d", ver);
 		exit(1);

--- a/sys/contrib/openzfs/lib/libzpool/util.c
+++ b/sys/contrib/openzfs/lib/libzpool/util.c
@@ -285,7 +285,7 @@ pool_active(void *unused, const char *name, uint64_t guid, boolean_t *isactive)
 		zc = umem_zalloc(sizeof (zfs_cmd_t), UMEM_NOFAIL);
 
 		(void) strlcpy(zc->zc_name, name, sizeof (zc->zc_name));
-		zp.zfs_cmd = (uint64_t)(uintptr_t)zc;
+		zp.zfs_cmd = (uintptr_t)zc;
 		zp.zfs_cmd_size = sizeof (zfs_cmd_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_OZFS;
 
@@ -301,7 +301,7 @@ pool_active(void *unused, const char *name, uint64_t guid, boolean_t *isactive)
 		zcl = umem_zalloc(sizeof (zfs_cmd_legacy_t), UMEM_NOFAIL);
 
 		(void) strlcpy(zcl->zc_name, name, sizeof (zcl->zc_name));
-		zp.zfs_cmd = (uint64_t)(uintptr_t)zcl;
+		zp.zfs_cmd = (uintptr_t)zcl;
 		zp.zfs_cmd_size = sizeof (zfs_cmd_legacy_t);
 		zp.zfs_ioctl_version = ZFS_IOCVER_LEGACY;
 

--- a/sys/contrib/openzfs/module/icp/algs/blake3/blake3_impl.c
+++ b/sys/contrib/openzfs/module/icp/algs/blake3/blake3_impl.c
@@ -30,12 +30,12 @@
 
 static const blake3_impl_ops_t *const blake3_impls[] = {
 	&blake3_generic_impl,
-#if defined(__aarch64__) || \
+#if (defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)) || \
 	(defined(__x86_64) && defined(HAVE_SSE2)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
 	&blake3_sse2_impl,
 #endif
-#if defined(__aarch64__) || \
+#if (defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)) || \
 	(defined(__x86_64) && defined(HAVE_SSE4_1)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
 	&blake3_sse41_impl,

--- a/sys/contrib/openzfs/module/icp/algs/blake3/blake3_impl.h
+++ b/sys/contrib/openzfs/module/icp/algs/blake3/blake3_impl.h
@@ -69,13 +69,13 @@ extern const blake3_impl_ops_t *blake3_impl_get_ops(void);
 
 extern const blake3_impl_ops_t blake3_generic_impl;
 
-#if defined(__aarch64__) || \
+#if (defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)) || \
 	(defined(__x86_64) && defined(HAVE_SSE2)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
 extern const blake3_impl_ops_t blake3_sse2_impl;
 #endif
 
-#if defined(__aarch64__) || \
+#if (defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)) || \
 	(defined(__x86_64) && defined(HAVE_SSE4_1)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
 extern const blake3_impl_ops_t blake3_sse41_impl;

--- a/sys/contrib/openzfs/module/icp/algs/blake3/blake3_x86-64.c
+++ b/sys/contrib/openzfs/module/icp/algs/blake3/blake3_x86-64.c
@@ -25,7 +25,7 @@
 
 #include "blake3_impl.h"
 
-#if defined(__aarch64__) || \
+#if (defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)) || \
 	(defined(__x86_64) && defined(HAVE_SSE2)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
 
@@ -92,7 +92,7 @@ const blake3_impl_ops_t blake3_sse2_impl = {
 };
 #endif
 
-#if defined(__aarch64__) || \
+#if (defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)) || \
 	(defined(__x86_64) && defined(HAVE_SSE2)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
 

--- a/sys/contrib/openzfs/module/icp/asm-aarch64/blake3/b3_aarch64_sse2.S
+++ b/sys/contrib/openzfs/module/icp/asm-aarch64/blake3/b3_aarch64_sse2.S
@@ -28,7 +28,7 @@
  * Used tools: SIMDe https://github.com/simd-everywhere/simde
  */
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)
 	.text
 	.section	.rodata.cst16,"aM",@progbits,16
 	.p2align	4

--- a/sys/contrib/openzfs/module/icp/asm-aarch64/blake3/b3_aarch64_sse41.S
+++ b/sys/contrib/openzfs/module/icp/asm-aarch64/blake3/b3_aarch64_sse41.S
@@ -28,7 +28,7 @@
  * Used tools: SIMDe https://github.com/simd-everywhere/simde
  */
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !defined(__CHERI_PURE_CAPABILITY__)
 	.text
 	.section	.rodata.cst16,"aM",@progbits,16
 	.p2align	4

--- a/sys/contrib/openzfs/module/icp/include/aes/aes_impl.h
+++ b/sys/contrib/openzfs/module/icp/include/aes/aes_impl.h
@@ -39,7 +39,7 @@ extern "C" {
 
 /* Similar to sysmacros.h IS_P2ALIGNED, but checks two pointers: */
 #define	IS_P2ALIGNED2(v, w, a) \
-	((((uintptr_t)(v) | (uintptr_t)(w)) & ((uintptr_t)(a) - 1)) == 0)
+	((((ptraddr_t)(v) | (ptraddr_t)(w)) & ((ptraddr_t)(a) - 1)) == 0)
 
 #define	AES_BLOCK_LEN	16	/* bytes */
 /* Round constant length, in number of 32-bit elements: */

--- a/sys/contrib/openzfs/module/lua/lapi.c
+++ b/sys/contrib/openzfs/module/lua/lapi.c
@@ -442,7 +442,7 @@ LUA_API const void *lua_topointer (lua_State *L, int idx) {
     case LUA_TTABLE: return hvalue(o);
     case LUA_TLCL: return clLvalue(o);
     case LUA_TCCL: return clCvalue(o);
-    case LUA_TLCF: return cast(void *, cast(size_t, fvalue(o)));
+    case LUA_TLCF: return cast(void *, cast(uintptr_t, fvalue(o)));
     case LUA_TTHREAD: return thvalue(o);
     case LUA_TUSERDATA:
     case LUA_TLIGHTUSERDATA:

--- a/sys/contrib/openzfs/module/nvpair/fnvpair.c
+++ b/sys/contrib/openzfs/module/nvpair/fnvpair.c
@@ -40,7 +40,7 @@
  * functions, which can return the requested value (rather than filling in
  * a pointer).
  *
- * These functions use NV_UNIQUE_NAME, encoding NV_ENCODE_NATIVE, and allocate
+ * These functions use NV_UNIQUE_NAME, encoding NV_ENCODE_XDR, and allocate
  * with KM_SLEEP.
  *
  * More wrappers should be added as needed -- for example
@@ -65,7 +65,7 @@ size_t
 fnvlist_size(nvlist_t *nvl)
 {
 	size_t size;
-	VERIFY0(nvlist_size(nvl, &size, NV_ENCODE_NATIVE));
+	VERIFY0(nvlist_size(nvl, &size, NV_ENCODE_XDR));
 	return (size);
 }
 
@@ -77,7 +77,7 @@ char *
 fnvlist_pack(nvlist_t *nvl, size_t *sizep)
 {
 	char *packed = 0;
-	VERIFY3U(nvlist_pack(nvl, &packed, sizep, NV_ENCODE_NATIVE,
+	VERIFY3U(nvlist_pack(nvl, &packed, sizep, NV_ENCODE_XDR,
 	    KM_SLEEP), ==, 0);
 	return (packed);
 }

--- a/sys/contrib/openzfs/module/nvpair/nvpair.c
+++ b/sys/contrib/openzfs/module/nvpair/nvpair.c
@@ -143,7 +143,7 @@ static int nvlist_add_common(nvlist_t *nvl, const char *name, data_type_t type,
 
 #define	NVP_VALOFF(nvp)	(NV_ALIGN(sizeof (nvpair_t) + (nvp)->nvp_name_sz))
 #define	NVPAIR2I_NVP(nvp) \
-	((i_nvp_t *)((size_t)(nvp) - offsetof(i_nvp_t, nvi_nvp)))
+	((i_nvp_t *)((uintptr_t)(nvp) - offsetof(i_nvp_t, nvi_nvp)))
 
 #ifdef _KERNEL
 static const int nvpair_max_recursion = 20;
@@ -552,7 +552,7 @@ nvlist_init(nvlist_t *nvl, uint32_t nvflag, nvpriv_t *priv)
 {
 	nvl->nvl_version = NV_VERSION;
 	nvl->nvl_nvflag = nvflag & (NV_UNIQUE_NAME|NV_UNIQUE_NAME_TYPE);
-	nvl->nvl_priv = (uint64_t)(uintptr_t)priv;
+	nvl->nvl_priv = (uintptr_t)priv;
 	nvl->nvl_flag = 0;
 	nvl->nvl_pad = 0;
 }

--- a/sys/contrib/openzfs/module/nvpair/nvpair.c
+++ b/sys/contrib/openzfs/module/nvpair/nvpair.c
@@ -2753,8 +2753,7 @@ nvlist_xunpack(char *buf, size_t buflen, nvlist_t **nvlp, nv_alloc_t *nva)
 	if ((err = nvlist_xalloc(&nvl, 0, nva)) != 0)
 		return (err);
 
-	if ((err = nvlist_common(nvl, buf, &buflen, NV_ENCODE_NATIVE,
-	    NVS_OP_DECODE)) != 0)
+	if ((err = nvlist_common(nvl, buf, &buflen, -1, NVS_OP_DECODE)) != 0)
 		nvlist_free(nvl);
 	else
 		*nvlp = nvl;

--- a/sys/contrib/openzfs/module/nvpair/nvpair.c
+++ b/sys/contrib/openzfs/module/nvpair/nvpair.c
@@ -55,6 +55,10 @@
 
 #define	skip_whitespace(p)	while ((*(p) == ' ') || (*(p) == '\t')) (p)++
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#define NVPAIR_OVER_ALLOCATE_DECODE
+#endif
+
 /*
  * nvpair.c - Provides kernel & userland interfaces for manipulating
  *	name-value pairs.
@@ -809,8 +813,14 @@ i_validate_nvpair(nvpair_t *nvp)
 	 * verify string values and get the value size.
 	 */
 	size2 = i_get_value_size(type, NVP_VALUE(nvp), NVP_NELEM(nvp));
+	if (size2 < 0)
+		return (EFAULT);
 	size1 = nvp->nvp_size - NVP_VALOFF(nvp);
-	if (size2 < 0 || size1 != NV_ALIGN(size2))
+#ifdef NVPAIR_OVER_ALLOCATE_DECODE
+	if (size1 < NV_ALIGN(size2))
+#else
+	if (size1 != NV_ALIGN(size2))
+#endif
 		return (EFAULT);
 
 	return (0);
@@ -1086,7 +1096,7 @@ i_get_value_size(data_type_t type, const void *data, uint_t nelem)
 		value_sz = (uint64_t)nelem * sizeof (uint64_t);
 		break;
 	case DATA_TYPE_STRING_ARRAY:
-		value_sz = (uint64_t)nelem * sizeof (uint64_t);
+		value_sz = (uint64_t)nelem * sizeof (uint64ptr_t);
 
 		if (data != NULL) {
 			char *const *strs = data;
@@ -1107,7 +1117,7 @@ i_get_value_size(data_type_t type, const void *data, uint_t nelem)
 		value_sz = NV_ALIGN(sizeof (nvlist_t));
 		break;
 	case DATA_TYPE_NVLIST_ARRAY:
-		value_sz = (uint64_t)nelem * sizeof (uint64_t) +
+		value_sz = (uint64_t)nelem * sizeof (uint64ptr_t) +
 		    (uint64_t)nelem * NV_ALIGN(sizeof (nvlist_t));
 		break;
 	default:
@@ -1214,7 +1224,7 @@ nvlist_add_common(nvlist_t *nvl, const char *name,
 		char **cstrs = (void *)buf;
 
 		/* skip pre-allocated space for pointer array */
-		buf += nelem * sizeof (uint64_t);
+		buf += nelem * sizeof (uint64ptr_t);
 		for (i = 0; i < nelem; i++) {
 			int slen = strlen(strs[i]) + 1;
 			memcpy(buf, strs[i], slen);
@@ -1237,7 +1247,7 @@ nvlist_add_common(nvlist_t *nvl, const char *name,
 		nvlist_t **onvlp = (nvlist_t **)data;
 		nvlist_t **nvlp = EMBEDDED_NVL_ARRAY(nvp);
 		nvlist_t *embedded = (nvlist_t *)
-		    ((uintptr_t)nvlp + nelem * sizeof (uint64_t));
+		    ((uintptr_t)nvlp + nelem * sizeof (uint64ptr_t));
 
 		for (i = 0; i < nelem; i++) {
 			if ((err = nvlist_copy_embedded(nvl,
@@ -2537,7 +2547,7 @@ nvs_embedded_nvl_array(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 		break;
 
 	case NVS_OP_DECODE: {
-		size_t len = nelem * sizeof (uint64_t);
+		size_t len = nelem * sizeof (uint64ptr_t);
 		nvlist_t *embedded = (nvlist_t *)((uintptr_t)nvlp + len);
 
 		memset(nvlp, 0, len);	/* don't trust packed data */
@@ -2914,7 +2924,7 @@ nvpair_native_embedded(nvstream_t *nvs, nvpair_t *nvp)
 		 * to use memset.
 		 */
 		memset((char *)packed + offsetof(nvlist_t, nvl_priv),
-		    0, sizeof (uint64_t));
+		    0, sizeof (uint64ptr_t));
 	}
 
 	return (nvs_embedded(nvs, EMBEDDED_NVL(nvp)));
@@ -2926,7 +2936,7 @@ nvpair_native_embedded_array(nvstream_t *nvs, nvpair_t *nvp)
 	if (nvs->nvs_op == NVS_OP_ENCODE) {
 		nvs_native_t *native = (nvs_native_t *)nvs->nvs_private;
 		char *value = native->n_curr - nvp->nvp_size + NVP_VALOFF(nvp);
-		size_t len = NVP_NELEM(nvp) * sizeof (uint64_t);
+		size_t len = NVP_NELEM(nvp) * sizeof (uint64ptr_t);
 		nvlist_t *packed = (nvlist_t *)((uintptr_t)value + len);
 		int i;
 		/*
@@ -2943,7 +2953,7 @@ nvpair_native_embedded_array(nvstream_t *nvs, nvpair_t *nvp)
 			 * so we have to use memset.
 			 */
 			memset((char *)packed + offsetof(nvlist_t, nvl_priv),
-			    0, sizeof (uint64_t));
+			    0, sizeof (uint64ptr_t));
 	}
 
 	return (nvs_embedded_nvl_array(nvs, nvp, NULL));
@@ -2955,19 +2965,19 @@ nvpair_native_string_array(nvstream_t *nvs, nvpair_t *nvp)
 	switch (nvs->nvs_op) {
 	case NVS_OP_ENCODE: {
 		nvs_native_t *native = (nvs_native_t *)nvs->nvs_private;
-		uint64_t *strp = (void *)
+		uint64ptr_t *strp = (void *)
 		    (native->n_curr - nvp->nvp_size + NVP_VALOFF(nvp));
 		/*
 		 * Null out pointers that are meaningless in the packed
 		 * structure. The addresses may not be aligned, so we have
 		 * to use memset.
 		 */
-		memset(strp, 0, NVP_NELEM(nvp) * sizeof (uint64_t));
+		memset(strp, 0, NVP_NELEM(nvp) * sizeof (uint64ptr_t));
 		break;
 	}
 	case NVS_OP_DECODE: {
 		char **strp = (void *)NVP_VALUE(nvp);
-		char *buf = ((char *)strp + NVP_NELEM(nvp) * sizeof (uint64_t));
+		char *buf = ((char *)strp + NVP_NELEM(nvp) * sizeof (uint64ptr_t));
 		int i;
 
 		for (i = 0; i < NVP_NELEM(nvp); i++) {
@@ -3249,6 +3259,15 @@ nvs_xdr_nvp_##type(XDR *xdrs, void *ptr)	\
 	return (xdr_##type(xdrs, ptr));		\
 }
 
+#elif !defined(_KERNEL) && defined(__FreeBSD__)
+
+#define	NVS_BUILD_XDRPROC_T(type)				\
+static int							\
+nvs_xdr_nvp_##type(struct XDR *xdrs, void *ptr, unsigned int i __unused) \
+{								\
+	return (xdr_##type(xdrs, ptr));				\
+}
+
 #elif !defined(_KERNEL) && defined(XDR_CONTROL) /* tirpc */
 
 #define	NVS_BUILD_XDRPROC_T(type)		\
@@ -3445,7 +3464,7 @@ nvs_xdr_nvp_op(nvstream_t *nvs, nvpair_t *nvp)
 		break;
 
 	case DATA_TYPE_STRING_ARRAY: {
-		size_t len = nelem * sizeof (uint64_t);
+		size_t len = nelem * sizeof (uint64ptr_t);
 		char **strp = (void *)buf;
 		int i;
 
@@ -3603,6 +3622,112 @@ nvs_xdr_nvp_size(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 					(NVS_XDR_DATA_LEN(x) * 2) + \
 					NV_ALIGN4((NVS_XDR_DATA_LEN(x) / 4)))
 
+static int32_t
+nvpair_nominal_decode_size(nvpair_t *nvp)
+{
+#ifdef __CHERI_PURE_CAPABILITY__
+	int32_t size = nvp->nvp_size;
+	int32_t unpadded_size;
+
+	/* Remove over-alignment of the value due to padding of the name */
+	if (NV_ALIGN(nvp->nvp_name_sz) - nvp->nvp_name_sz >= 8)
+		size -= 8;
+
+	/*
+	 * Handle values.  Simple things set unpadded_size which is handled
+	 * at the end of the switch.  More complex things leave it set to
+	 * zero and update size as needed.
+	 */
+	unpadded_size = 0;
+	switch (nvp->nvp_type) {
+	case DATA_TYPE_BOOLEAN:
+		break;
+
+	case DATA_TYPE_BOOLEAN_VALUE:
+	case DATA_TYPE_BYTE:
+	case DATA_TYPE_INT8:
+	case DATA_TYPE_UINT8:
+	case DATA_TYPE_INT16:
+	case DATA_TYPE_UINT16:
+	case DATA_TYPE_INT32:
+	case DATA_TYPE_UINT32:
+	case DATA_TYPE_INT64:
+	case DATA_TYPE_UINT64:
+	case DATA_TYPE_HRTIME:
+#if !defined(_KERNEL)
+	case DATA_TYPE_DOUBLE:
+#endif
+		size -= 8;
+		break;
+
+	case DATA_TYPE_STRING:
+		unpadded_size = strlen(NVP_VALUE(nvp)) + 1;
+		break;
+
+	case DATA_TYPE_BOOLEAN_ARRAY:
+		unpadded_size = nvp->nvp_value_elem * sizeof (boolean_t);
+		break;
+	case DATA_TYPE_BYTE_ARRAY:
+		unpadded_size = nvp->nvp_value_elem * sizeof (char);
+		break;
+	case DATA_TYPE_INT8_ARRAY:
+	case DATA_TYPE_UINT8_ARRAY:
+		unpadded_size = nvp->nvp_value_elem * sizeof (int8_t);
+		break;
+	case DATA_TYPE_INT16_ARRAY:
+	case DATA_TYPE_UINT16_ARRAY:
+		unpadded_size = nvp->nvp_value_elem * sizeof (int16_t);
+		break;
+	case DATA_TYPE_INT32_ARRAY:
+	case DATA_TYPE_UINT32_ARRAY:
+		unpadded_size = nvp->nvp_value_elem * sizeof (int32_t);
+		break;
+	case DATA_TYPE_INT64_ARRAY:
+	case DATA_TYPE_UINT64_ARRAY:
+		unpadded_size = nvp->nvp_value_elem * sizeof (int64_t);
+		break;
+
+	case DATA_TYPE_NVLIST:
+		size -= sizeof (nvlist_t) - (4 + 4 + 8 + 4 + 4);
+		break;
+
+	case DATA_TYPE_STRING_ARRAY:
+		if (nvp->nvp_value_elem > 0) {
+			char **array, *last_nul;
+
+			array = (char **)NVP_VALUE(nvp);
+			last_nul = strchr(array[nvp->nvp_value_elem - 1], 0);
+
+			/* Shrink pointers */
+			size -= nvp->nvp_value_elem * (sizeof (uintptr_t) - 8);
+			/* Shrink string space */
+			if (nvp->nvp_size - (last_nul - (char *)nvp) >= 8)
+				size -= 8;
+		}
+		break;
+
+	case DATA_TYPE_NVLIST_ARRAY:
+		if (nvp->nvp_value_elem > 0) {
+			/* Shrink pointer */
+			size -= nvp->nvp_value_elem * (sizeof (uintptr_t) - 8);
+			/* Shrink nvlist_t */
+			size -= nvp->nvp_value_elem *
+			    (sizeof (nvlist_t) - (4 + 4 + 8 + 4 + 4));
+		}
+		break;
+	default:
+		return (-1);
+	}
+
+	if (NV_ALIGN(unpadded_size) - unpadded_size >= 8)
+		size -= 8;
+
+	return (size);
+#else /* !__CHERI_PURE_CAPABILITY__ */
+	return (nvp->nvp_size);
+#endif /* __CHERI_PURE_CAPABILITY__ */
+}
+
 static int
 nvs_xdr_nvpair(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 {
@@ -3616,7 +3741,7 @@ nvs_xdr_nvpair(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 		if (nvs_xdr_nvp_size(nvs, nvp, &nvsize) != 0)
 			return (EFAULT);
 
-		decode_len = nvp->nvp_size;
+		decode_len = nvpair_nominal_decode_size(nvp);
 		encode_len = nvsize;
 		if (!xdr_int(xdr, &encode_len) || !xdr_int(xdr, &decode_len))
 			return (EFAULT);
@@ -3641,6 +3766,15 @@ nvs_xdr_nvpair(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 
 		if (*size > NVS_XDR_MAX_LEN(bytesrec.xc_num_avail))
 			return (EFAULT);
+#ifdef NVPAIR_OVER_ALLOCATE_DECODE
+		/*
+		 * Waste space to make sure we have enough room to
+		 * decode the nvlist.  We need to account for string
+		 * alignment and the increaed size of a number of
+		 * messages, but just doubling will do that for now...
+		 */
+		*size *= 2;
+#endif
 		break;
 	}
 

--- a/sys/contrib/openzfs/module/os/freebsd/spl/acl_common.c
+++ b/sys/contrib/openzfs/module/os/freebsd/spl/acl_common.c
@@ -1654,13 +1654,13 @@ acl_trivial_create(mode_t mode, boolean_t isdir, ace_t **acl, int *count)
  */
 int
 ace_trivial_common(void *acep, int aclcnt,
-    uint64_t (*walk)(void *, uint64_t, int aclcnt,
+    uintptr_t (*walk)(void *, uintptr_t, int aclcnt,
     uint16_t *, uint16_t *, uint32_t *))
 {
 	uint16_t flags;
 	uint32_t mask;
 	uint16_t type;
-	uint64_t cookie = 0;
+	uintptr_t cookie = 0;
 
 	while ((cookie = walk(acep, cookie, aclcnt, &flags, &type, &mask))) {
 		switch (flags & ACE_TYPE_FLAGS) {

--- a/sys/contrib/openzfs/module/os/freebsd/spl/spl_misc.c
+++ b/sys/contrib/openzfs/module/os/freebsd/spl/spl_misc.c
@@ -71,27 +71,27 @@ kmem_strdup(const char *s)
 }
 
 int
-ddi_copyin(const void *from, void *to, size_t len, int flags)
+ddi_copyin(const void * __capability from, void *to, size_t len, int flags)
 {
 	/* Fake ioctl() issued by kernel, 'from' is a kernel address */
 	if (flags & FKIOCTL) {
-		memcpy(to, from, len);
+		memcpy(to, (__cheri_fromcap const void *)from, len);
 		return (0);
 	}
 
-	return (copyin(from, to, len));
+	return (copyincap(from, to, len));
 }
 
 int
-ddi_copyout(const void *from, void *to, size_t len, int flags)
+ddi_copyout(const void *from, void * __capability to, size_t len, int flags)
 {
 	/* Fake ioctl() issued by kernel, 'from' is a kernel address */
 	if (flags & FKIOCTL) {
-		memcpy(to, from, len);
+		memcpy((__cheri_fromcap void *)to, from, len);
 		return (0);
 	}
 
-	return (copyout(from, to, len));
+	return (copyoutcap(from, to, len));
 }
 
 int

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_acl.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_acl.c
@@ -631,8 +631,8 @@ zfs_acl_next_ace(zfs_acl_t *aclp, void *start, uint64_t *who,
 	return (NULL);
 }
 
-static uint64_t
-zfs_ace_walk(void *datap, uint64_t cookie, int aclcnt,
+static uintptr_t
+zfs_ace_walk(void *datap, uintptr_t cookie, int aclcnt,
     uint16_t *flags, uint16_t *type, uint32_t *mask)
 {
 	(void) aclcnt;
@@ -642,7 +642,7 @@ zfs_ace_walk(void *datap, uint64_t cookie, int aclcnt,
 
 	acep = zfs_acl_next_ace(aclp, acep, &who, mask,
 	    flags, type);
-	return ((uint64_t)(uintptr_t)acep);
+	return ((uintptr_t)acep);
 }
 
 /*

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_file_os.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_file_os.c
@@ -58,7 +58,7 @@ zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 	td = curthread;
 	pwd_ensure_dirs();
 	/* 12.x doesn't take a const char * */
-	rc = kern_openat(td, AT_FDCWD, __DECONST(char *, path),
+	rc = kern_openat(td, AT_FDCWD, PTR2CAP(path),
 	    UIO_SYSSPACE, flags, mode);
 	if (rc)
 		return (SET_ERROR(rc));
@@ -289,7 +289,8 @@ zfs_file_unlink(const char *fnamep)
 	int rc;
 
 #if __FreeBSD_version >= 1300018
-	rc = kern_funlinkat(curthread, AT_FDCWD, fnamep, FD_NONE, seg, 0, 0);
+	rc = kern_funlinkat(curthread, AT_FDCWD, PTR2CAP(fnamep), FD_NONE,
+	    seg, 0, 0);
 #elif __FreeBSD_version >= 1202504 || defined(AT_BENEATH)
 	rc = kern_unlinkat(curthread, AT_FDCWD, __DECONST(char *, fnamep),
 	    seg, 0, 0);

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_file_os.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_file_os.c
@@ -85,8 +85,7 @@ zfs_file_write_impl(zfs_file_t *fp, const void *buf, size_t count, loff_t *offp,
 	struct iovec aiov;
 
 	td = curthread;
-	aiov.iov_base = (void *)(uintptr_t)buf;
-	aiov.iov_len = count;
+	IOVEC_INIT(&aiov, __DECONST(void *, buf), count);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_segflg = UIO_SYSSPACE;
@@ -142,8 +141,7 @@ zfs_file_read_impl(zfs_file_t *fp, void *buf, size_t count, loff_t *offp,
 	struct iovec aiov;
 
 	td = curthread;
-	aiov.iov_base = (void *)(uintptr_t)buf;
-	aiov.iov_len = count;
+	IOVEC_INIT(&aiov, buf, count);
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
 	auio.uio_segflg = UIO_SYSSPACE;

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_ioctl_compat.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_ioctl_compat.c
@@ -39,6 +39,8 @@ __FBSDID("$FreeBSD$");
 #include <sys/cmn_err.h>
 #include <sys/zfs_ioctl_compat.h>
 
+#ifdef ZFS_LEGACY_SUPPORT
+
 enum zfs_ioc_legacy {
 	ZFS_IOC_LEGACY_NONE =	-1,
 	ZFS_IOC_LEGACY_FIRST =	0,
@@ -361,3 +363,4 @@ zfs_cmd_ozfs_to_legacy(zfs_cmd_t *src, zfs_cmd_legacy_t *dst)
 	    sizeof (zfs_cmd_t) - 8 - offsetof(zfs_cmd_t, zc_sendobj));
 	dst->zc_jailid = src->zc_zoneid;
 }
+#endif /* ZFS_LEGACY_SUPPORT */

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vfsops.c
@@ -101,10 +101,10 @@ SYSCTL_INT(_vfs_zfs_version, OID_AUTO, zpl, CTLFLAG_RD, &zfs_version_zpl, 0,
 	"ZPL_VERSION");
 
 #if __FreeBSD_version >= 1400018
-static int zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void *arg,
+static int zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void * __capability arg,
     bool *mp_busy);
 #else
-static int zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void *arg);
+static int zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void * __capability arg);
 #endif
 static int zfs_mount(vfs_t *vfsp);
 static int zfs_umount(vfs_t *vfsp, int fflag);
@@ -271,9 +271,9 @@ done:
 
 static int
 #if __FreeBSD_version >= 1400018
-zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void *arg, bool *mp_busy)
+zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void * __capability arg, bool *mp_busy)
 #else
-zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void *arg)
+zfs_quotactl(vfs_t *vfsp, int cmds, uid_t id, void * __capability arg)
 #endif
 {
 	zfsvfs_t *zfsvfs = vfsp->vfs_data;

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -1742,7 +1742,7 @@ zfs_readdir(vnode_t *vp, zfs_uio_t *uio, cred_t *cr, int *eofp,
 	} else {
 		bufsize = bytes_wanted;
 		outbuf = NULL;
-		odp = (struct dirent64 *)iovp->iov_base;
+		odp = (__cheri_fromcap struct dirent64 *)iovp->iov_base;
 	}
 	eodp = (struct edirent *)odp;
 
@@ -5847,8 +5847,7 @@ zfs_listextattr_dir(struct vop_listextattr_args *ap, const char *attrprefix)
 	size_t plen = strlen(attrprefix);
 
 	do {
-		aiov.iov_base = (void *)dirbuf;
-		aiov.iov_len = sizeof (dirbuf);
+		IOVEC_INIT(&aiov, dirbuf, sizeof (dirbuf));
 		auio.uio_resid = sizeof (dirbuf);
 		error = VOP_READDIR(vp, &auio, ap->a_cred, &eof, NULL, NULL);
 		if (error != 0)

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -5352,7 +5352,8 @@ zfs_getextattr_dir(struct vop_getextattr_args *ap, const char *attrname)
 	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, attrname,
 	    xvp, td);
 #else
-	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, attrname, xvp);
+	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(attrname),
+	    xvp);
 #endif
 	error = vn_open_cred(&nd, &flags, 0, VN_OPEN_INVFS, ap->a_cred, NULL);
 	vp = nd.ni_vp;
@@ -5497,7 +5498,7 @@ zfs_deleteextattr_dir(struct vop_deleteextattr_args *ap, const char *attrname)
 	    UIO_SYSSPACE, attrname, xvp, ap->a_td);
 #else
 	NDINIT_ATVP(&nd, DELETE, NOFOLLOW | LOCKPARENT | LOCKLEAF,
-	    UIO_SYSSPACE, attrname, xvp);
+	    UIO_SYSSPACE, PTR2CAP(attrname), xvp);
 #endif
 	error = namei(&nd);
 	vp = nd.ni_vp;
@@ -5641,7 +5642,7 @@ zfs_setextattr_dir(struct vop_setextattr_args *ap, const char *attrname)
 #if __FreeBSD_version < 1400043
 	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, attrname, xvp, td);
 #else
-	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, attrname, xvp);
+	NDINIT_ATVP(&nd, LOOKUP, NOFOLLOW, UIO_SYSSPACE, PTR2CAP(attrname), xvp);
 #endif
 	error = vn_open_cred(&nd, &flags, 0600, VN_OPEN_INVFS, ap->a_cred,
 	    NULL);

--- a/sys/contrib/openzfs/module/zfs/fm.c
+++ b/sys/contrib/openzfs/module/zfs/fm.c
@@ -226,7 +226,7 @@ zfs_zevent_post(nvlist_t *nvl, nvlist_t *detector, zevent_cb_t *cb)
 		goto out;
 	}
 
-	error = nvlist_size(nvl, &nvl_size, NV_ENCODE_NATIVE);
+	error = nvlist_size(nvl, &nvl_size, NV_ENCODE_XDR);
 	if (error) {
 		atomic_inc_64(&erpt_kstat_data.erpt_dropped.value.ui64);
 		goto out;
@@ -337,7 +337,7 @@ zfs_zevent_next(zfs_zevent_t *ze, nvlist_t **event, uint64_t *event_size,
 		}
 	}
 
-	VERIFY(nvlist_size(ev->ev_nvl, &size, NV_ENCODE_NATIVE) == 0);
+	VERIFY(nvlist_size(ev->ev_nvl, &size, NV_ENCODE_XDR) == 0);
 	if (size > *event_size) {
 		*event_size = size;
 		error = ENOMEM;

--- a/sys/contrib/openzfs/module/zfs/spa_errlog.c
+++ b/sys/contrib/openzfs/module/zfs/spa_errlog.c
@@ -282,7 +282,7 @@ find_birth_txg(dsl_dataset_t *ds, zbookmark_err_phys_t *zep,
  */
 static int
 check_filesystem(spa_t *spa, uint64_t head_ds, zbookmark_err_phys_t *zep,
-    uint64_t *count, void *uaddr, boolean_t only_count)
+    uint64_t *count, void * __capability uaddr, boolean_t only_count)
 {
 	dsl_dataset_t *ds;
 	dsl_pool_t *dp = spa->spa_dsl_pool;
@@ -301,7 +301,7 @@ check_filesystem(spa_t *spa, uint64_t head_ds, zbookmark_err_phys_t *zep,
 			if (!only_count) {
 				zbookmark_phys_t zb;
 				zep_to_zb(head_ds, zep, &zb);
-				if (copyout(&zb, (char *)uaddr + (*count - 1)
+				if (copyout(&zb, (char * __capability)uaddr + (*count - 1)
 				    * sizeof (zbookmark_phys_t),
 				    sizeof (zbookmark_phys_t)) != 0) {
 					dsl_dataset_rele(ds, FTAG);
@@ -366,7 +366,7 @@ check_filesystem(spa_t *spa, uint64_t head_ds, zbookmark_err_phys_t *zep,
 			if (!only_count) {
 				zbookmark_phys_t zb;
 				zep_to_zb(snap_obj, zep, &zb);
-				if (copyout(&zb, (char *)uaddr + (*count - 1) *
+				if (copyout(&zb, (char * __capability)uaddr + (*count - 1) *
 				    sizeof (zbookmark_phys_t),
 				    sizeof (zbookmark_phys_t)) != 0) {
 					dsl_dataset_rele(ds, FTAG);
@@ -433,7 +433,7 @@ find_top_affected_fs(spa_t *spa, uint64_t head_ds, zbookmark_err_phys_t *zep,
 
 static int
 process_error_block(spa_t *spa, uint64_t head_ds, zbookmark_err_phys_t *zep,
-    uint64_t *count, void *uaddr, boolean_t only_count)
+    uint64_t *count, void * __capability uaddr, boolean_t only_count)
 {
 	dsl_pool_t *dp = spa->spa_dsl_pool;
 	dsl_pool_config_enter(dp, FTAG);
@@ -694,7 +694,7 @@ spa_upgrade_errlog(spa_t *spa, dmu_tx_t *tx)
  * detailed message see spa_get_errlog_size() above.
  */
 static int
-process_error_log(spa_t *spa, uint64_t obj, void *uaddr, uint64_t *count)
+process_error_log(spa_t *spa, uint64_t obj, void * __capability uaddr, uint64_t *count)
 {
 	zap_cursor_t zc;
 	zap_attribute_t za;
@@ -714,7 +714,7 @@ process_error_log(spa_t *spa, uint64_t obj, void *uaddr, uint64_t *count)
 			zbookmark_phys_t zb;
 			name_to_bookmark(za.za_name, &zb);
 
-			if (copyout(&zb, (char *)uaddr +
+			if (copyout(&zb, (char * __capability)uaddr +
 			    (*count - 1) * sizeof (zbookmark_phys_t),
 			    sizeof (zbookmark_phys_t)) != 0) {
 				zap_cursor_fini(&zc);
@@ -759,7 +759,7 @@ process_error_log(spa_t *spa, uint64_t obj, void *uaddr, uint64_t *count)
 }
 
 static int
-process_error_list(spa_t *spa, avl_tree_t *list, void *uaddr, uint64_t *count)
+process_error_list(spa_t *spa, avl_tree_t *list, void * __capability uaddr, uint64_t *count)
 {
 	spa_error_entry_t *se;
 
@@ -770,7 +770,7 @@ process_error_list(spa_t *spa, avl_tree_t *list, void *uaddr, uint64_t *count)
 			if (*count == 0)
 				return (SET_ERROR(ENOMEM));
 
-			if (copyout(&se->se_bookmark, (char *)uaddr +
+			if (copyout(&se->se_bookmark, (char * __capability)uaddr +
 			    (*count - 1) * sizeof (zbookmark_phys_t),
 			    sizeof (zbookmark_phys_t)) != 0)
 				return (SET_ERROR(EFAULT));
@@ -813,7 +813,7 @@ process_error_list(spa_t *spa, avl_tree_t *list, void *uaddr, uint64_t *count)
  * the error list lock when we are finished.
  */
 int
-spa_get_errlog(spa_t *spa, void *uaddr, uint64_t *count)
+spa_get_errlog(spa_t *spa, void * __capability uaddr, uint64_t *count)
 {
 	int ret = 0;
 

--- a/sys/contrib/openzfs/module/zfs/spa_history.c
+++ b/sys/contrib/openzfs/module/zfs/spa_history.c
@@ -330,7 +330,7 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 		    fnvlist_lookup_string(nvl, ZPOOL_HIST_IOCTL));
 	}
 
-	VERIFY3U(nvlist_pack(nvl, &record_packed, &reclen, NV_ENCODE_NATIVE,
+	VERIFY3U(nvlist_pack(nvl, &record_packed, &reclen, NV_ENCODE_XDR,
 	    KM_SLEEP), ==, 0);
 
 	mutex_enter(&spa->spa_history_lock);

--- a/sys/contrib/openzfs/module/zfs/zap_micro.c
+++ b/sys/contrib/openzfs/module/zfs/zap_micro.c
@@ -708,7 +708,7 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	mzap_phys_t *zp = db->db_data;
 	zp->mz_block_type = ZBT_MICRO;
 	zp->mz_salt =
-	    ((uintptr_t)db ^ (uintptr_t)tx ^ (dn->dn_object << 1)) | 1ULL;
+	    ((ptraddr_t)db ^ (ptraddr_t)tx ^ (dn->dn_object << 1)) | 1ULL;
 	zp->mz_normflags = normflags;
 
 	if (flags != 0) {

--- a/sys/contrib/openzfs/module/zfs/zfs_chksum.c
+++ b/sys/contrib/openzfs/module/zfs/zfs_chksum.c
@@ -212,8 +212,11 @@ chksum_benchmark(void)
 #endif
 
 	chksum_stat_t *cs;
-	int cbid = 0, id;
+	int cbid = 0;
+#ifndef __CHERI_PURE_CAPABILITY__
+	int id;
 	uint64_t max = 0;
+#endif
 
 	/* space for the benchmark times */
 	chksum_stat_cnt = 4;
@@ -257,6 +260,7 @@ chksum_benchmark(void)
 	cs->impl = "generic";
 	chksum_benchit(cs);
 
+#ifndef __CHERI_PURE_CAPABILITY__
 	/* blake3 */
 	for (id = 0; id < blake3_get_impl_count(); id++) {
 		blake3_set_impl_id(id);
@@ -272,6 +276,7 @@ chksum_benchmark(void)
 			blake3_set_impl_fastest(id);
 		}
 	}
+#endif
 }
 
 void

--- a/sys/contrib/openzfs/module/zfs/zfs_ioctl.c
+++ b/sys/contrib/openzfs/module/zfs/zfs_ioctl.c
@@ -282,7 +282,7 @@ static int zfs_check_clearable(const char *dataset, nvlist_t *props,
 static int zfs_fill_zplprops_root(uint64_t, nvlist_t *, nvlist_t *,
     boolean_t *);
 int zfs_set_prop_nvlist(const char *, zprop_source_t, nvlist_t *, nvlist_t *);
-static int get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp);
+static int get_nvlist(uintcap_t nvl, uint64_t size, int iflag, nvlist_t **nvp);
 
 static void
 history_str_free(char *buf)
@@ -299,7 +299,7 @@ history_str_get(zfs_cmd_t *zc)
 		return (NULL);
 
 	buf = kmem_alloc(HIS_MAX_RECORD_LEN, KM_SLEEP);
-	if (copyinstr((void *)(uintptr_t)zc->zc_history,
+	if (copyinstr((const void * __capability)(uintcap_t)zc->zc_history,
 	    buf, HIS_MAX_RECORD_LEN, NULL) != 0) {
 		history_str_free(buf);
 		return (NULL);
@@ -1265,7 +1265,7 @@ zfs_secpolicy_change_key(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  * Returns the nvlist as specified by the user in the zfs_cmd_t.
  */
 static int
-get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
+get_nvlist(uintcap_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
 {
 	char *packed;
 	int error;
@@ -1279,7 +1279,7 @@ get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
 
 	packed = vmem_alloc(size, KM_SLEEP);
 
-	if ((error = ddi_copyin((void *)(uintptr_t)nvl, packed, size,
+	if ((error = ddi_copyin((void * __capability)(uintcap_t)nvl, packed, size,
 	    iflag)) != 0) {
 		vmem_free(packed, size);
 		return (SET_ERROR(EFAULT));
@@ -1348,7 +1348,7 @@ put_nvlist(zfs_cmd_t *zc, nvlist_t *nvl)
 		error = SET_ERROR(ENOMEM);
 	} else {
 		packed = fnvlist_pack(nvl, &size);
-		if (ddi_copyout(packed, (void *)(uintptr_t)zc->zc_nvlist_dst,
+		if (ddi_copyout(packed, (void * __capability)(uintcap_t)zc->zc_nvlist_dst,
 		    size, zc->zc_iflags) != 0)
 			error = SET_ERROR(EFAULT);
 		fnvlist_pack_free(packed, size);
@@ -1744,7 +1744,7 @@ zfs_ioc_pool_get_history(zfs_cmd_t *zc)
 	if ((error = spa_history_get(spa, &zc->zc_history_offset,
 	    &zc->zc_history_len, hist_buf)) == 0) {
 		error = ddi_copyout(hist_buf,
-		    (void *)(uintptr_t)zc->zc_history,
+		    (void * __capability)(uintcap_t)zc->zc_history,
 		    zc->zc_history_len, zc->zc_iflags);
 	}
 
@@ -5676,7 +5676,7 @@ zfs_ioc_error_log(zfs_cmd_t *zc)
 	if ((error = spa_open(zc->zc_name, &spa, FTAG)) != 0)
 		return (error);
 
-	error = spa_get_errlog(spa, (void *)(uintptr_t)zc->zc_nvlist_dst,
+	error = spa_get_errlog(spa, (void * __capability)(uintcap_t)zc->zc_nvlist_dst,
 	    &count);
 	if (error == 0)
 		zc->zc_nvlist_dst_size = count;
@@ -5952,7 +5952,7 @@ zfs_ioc_userspace_many(zfs_cmd_t *zc)
 
 	if (error == 0) {
 		error = xcopyout(buf,
-		    (void *)(uintptr_t)zc->zc_nvlist_dst,
+		    (void * __capability)(uintcap_t)zc->zc_nvlist_dst,
 		    zc->zc_nvlist_dst_size);
 	}
 	vmem_free(buf, bufsize);

--- a/sys/contrib/openzfs/module/zfs/zfs_onexit.c
+++ b/sys/contrib/openzfs/module/zfs/zfs_onexit.c
@@ -151,7 +151,7 @@ zfs_onexit_minor_to_state(minor_t minor, zfs_onexit_t **zo)
  */
 int
 zfs_onexit_add_cb(minor_t minor, void (*func)(void *), void *data,
-    uint64_t *action_handle)
+    uintptr_t *action_handle)
 {
 	zfs_onexit_t *zo;
 	zfs_onexit_action_node_t *ap;
@@ -170,7 +170,7 @@ zfs_onexit_add_cb(minor_t minor, void (*func)(void *), void *data,
 	list_insert_tail(&zo->zo_actions, ap);
 	mutex_exit(&zo->zo_lock);
 	if (action_handle)
-		*action_handle = (uint64_t)(uintptr_t)ap;
+		*action_handle = (uintptr_t)ap;
 
 	return (0);
 }

--- a/sys/contrib/openzfs/module/zfs/zfs_vnops.c
+++ b/sys/contrib/openzfs/module/zfs/zfs_vnops.c
@@ -63,7 +63,7 @@ zfs_fsync(znode_t *zp, int syncflag, cred_t *cr)
 {
 	zfsvfs_t *zfsvfs = ZTOZSB(zp);
 
-	(void) tsd_set(zfs_fsyncer_key, (void *)zfs_fsync_sync_cnt);
+	(void) tsd_set(zfs_fsyncer_key, (void *)(uintptr_t)zfs_fsync_sync_cnt);
 
 	if (zfsvfs->z_os->os_sync != ZFS_SYNC_DISABLED) {
 		ZFS_ENTER(zfsvfs);

--- a/sys/contrib/openzfs/tests/zfs-tests/cmd/libzfs_input_check.c
+++ b/sys/contrib/openzfs/tests/zfs-tests/cmd/libzfs_input_check.c
@@ -153,10 +153,10 @@ lzc_ioctl_run(zfs_ioc_t ioc, const char *name, nvlist_t *innvl, int expected)
 	packed = fnvlist_pack(innvl, &size);
 	(void) strlcpy(zc.zc_name, name, sizeof (zc.zc_name));
 	zc.zc_name[sizeof (zc.zc_name) - 1] = '\0';
-	zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
+	zc.zc_nvlist_src = (uintptr_t)packed;
 	zc.zc_nvlist_src_size = size;
 	zc.zc_nvlist_dst_size = MAX(size * 2, 128 * 1024);
-	zc.zc_nvlist_dst = (uint64_t)(uintptr_t)malloc(zc.zc_nvlist_dst_size);
+	zc.zc_nvlist_dst = (uintptr_t)malloc(zc.zc_nvlist_dst_size);
 
 	if (lzc_ioctl_fd(zfs_fd, ioc, &zc) != 0)
 		error = errno;

--- a/sys/modules/zfs/Makefile
+++ b/sys/modules/zfs/Makefile
@@ -482,3 +482,7 @@ CFLAGS.zstd_fast.c+= ${NO_WBITWISE_INSTEAD_OF_LOGICAL}
 CFLAGS.zstd_lazy.c+= ${NO_WBITWISE_INSTEAD_OF_LOGICAL}
 CFLAGS.zstd_ldm.c+= ${NO_WBITWISE_INSTEAD_OF_LOGICAL}
 CFLAGS.zstd_opt.c+= ${NO_WBITWISE_INSTEAD_OF_LOGICAL}
+
+.if ${MACHINE_ARCH} == "aarch64c" || ${MACHINE_ARCH} == "riscv64c"
+CFLAGS+=-Xclang -cheri-bounds=conservative
+.endif

--- a/sys/rpc/xdr.h
+++ b/sys/rpc/xdr.h
@@ -136,10 +136,7 @@ typedef struct XDR {
 #ifdef _KERNEL
 typedef	bool_t (*xdrproc_t)(XDR *, void *, ...);
 #else
-/*
- * XXX can't actually prototype it, because some take three args!!!
- */
-typedef	bool_t (*xdrproc_t)(XDR *, ...);
+typedef	bool_t (*xdrproc_t)(XDR *, void *, u_int);
 #endif
 
 /*

--- a/usr.sbin/bsdinstall/scripts/auto
+++ b/usr.sbin/bsdinstall/scripts/auto
@@ -46,8 +46,16 @@ msg_auto_ufs="Auto (UFS)"
 msg_auto_ufs_desc="Guided UFS Disk Setup"
 msg_auto_ufs_help="Menu options help choose which disk to setup using UFS and standard partitions"
 msg_auto_zfs="Auto (ZFS)"
-msg_auto_zfs_desc="Guided Root-on-ZFS"
-msg_auto_zfs_help="To use ZFS with less than 8GB RAM, see https://wiki.freebsd.org/ZFSTuningGuide"
+case `uname -p` in
+aarch64*c*|riscv*c*)
+	msg_auto_zfs_desc="EXPERIMENTAL Guided Root-on-ZFS"
+	msg_auto_zfs_help="ZFS is pre-Alpha quality. See the Getting Started with CheriBSD guide for caveats."
+	;;
+*)
+	msg_auto_zfs_desc="Guided Root-on-ZFS"
+	msg_auto_zfs_help="To use ZFS with less than 8GB RAM, see https://wiki.freebsd.org/ZFSTuningGuide"
+	;;
+esac
 msg_exit="Exit"
 msg_freebsd_installer="$OSNAME Installer"
 msg_gpt_active_fix="Your hardware is known to have issues booting in CSM/Legacy/BIOS mode from GPT partitions that are not set active. Would you like the installer to apply this workaround for you?"
@@ -275,14 +283,25 @@ if f_interactive; then
 	esac
 fi
 
-PMODES="
-	'$msg_auto_ufs' '$msg_auto_ufs_desc' '$msg_auto_ufs_help'
-	'$msg_manual' '$msg_manual_desc' '$msg_manual_help'
-	'$msg_shell' '$msg_shell_desc' '$msg_shell_help'
-" # END-QUOTE
+case `uname -p` in
+aarch64*c*|riscv*c*)
+	# Allow ZFS on CHERI, but make UFS first
+	PMODES="
+		'$msg_auto_ufs' '$msg_auto_ufs_desc' '$msg_auto_ufs_help'
+		'$msg_auto_zfs' '$msg_auto_zfs_desc' '$msg_auto_zfs_help'
+		'$msg_manual' '$msg_manual_desc' '$msg_manual_help'
+		'$msg_shell' '$msg_shell_desc' '$msg_shell_help'
+	" # END-QUOTE
+	;;
+*)
+	PMODES="
+		'$msg_auto_ufs' '$msg_auto_ufs_desc' '$msg_auto_ufs_help'
+		'$msg_manual' '$msg_manual_desc' '$msg_manual_help'
+		'$msg_shell' '$msg_shell_desc' '$msg_shell_help'
+	" # END-QUOTE
 
-CURARCH=$( uname -m )
-case $CURARCH in
+	CURARCH=$( uname -m )
+	case $CURARCH in
 	amd64|arm64|i386|riscv)	# Booting ZFS Supported
 		PMODES="
 			'$msg_auto_zfs' '$msg_auto_zfs_desc' '$msg_auto_zfs_help'
@@ -291,6 +310,8 @@ case $CURARCH in
 		;;
 	*)			# Booting ZFS Unsupported
 		;;
+	esac
+	;;
 esac
 
 exec 3>&1

--- a/usr.sbin/bsdinstall/scripts/auto
+++ b/usr.sbin/bsdinstall/scripts/auto
@@ -283,17 +283,11 @@ PMODES="
 
 CURARCH=$( uname -m )
 case $CURARCH in
-	amd64|arm64|i386|riscv)	# Booting ZFS Supported if not CHERI
-		case `uname -p` in
-			aarch64*c*|riscv*c*)
-				;;
-			*)
-				PMODES="
-					'$msg_auto_zfs' '$msg_auto_zfs_desc' '$msg_auto_zfs_help'
-					$PMODES
-				" # END-QUOTE
-				;;
-		esac
+	amd64|arm64|i386|riscv)	# Booting ZFS Supported
+		PMODES="
+			'$msg_auto_zfs' '$msg_auto_zfs_desc' '$msg_auto_zfs_help'
+			$PMODES
+		" # END-QUOTE
 		;;
 	*)			# Booting ZFS Unsupported
 		;;


### PR DESCRIPTION
This is a work in progress ZFS patch that is (somewhat) useable on hybrid kernels. The actual FS functionality is expected to be reliable on such kernels as it will be unchanged. The focus of porting has been on on the management side of things. There, I've plumbed capabilities into (most of?) the right places and altered nvlists to be serialized in a capability-aligned manner. The resulting change are enough to create and do at list minimal management of single-disk pools. I'm posting a PR to make it easier for people to take a look at it.

Known broken things:
 - [x] Creating pools with multiple disks. Both `zpool create foo disk1 disk2` and `zpool create foo mirror disk1 disk2` fail.~
 - [x] You can add a second disk to an existing pool, but then `zpool status` fails. Such pools do seem to work.
 - [ ] freebsd64 compat isn't implemented ~and is going to be complicated. I believe it will require threading a set of ifdefs through the whole management code including building the nvpair code twice with namespace ifdefs.~

Unknown things:
- [ ] purecap kernel compiles, but is untested.
- [x] does property management work?
- [x] Is the on purecap kernel on-disk format unchanged?