### PR TITLE
Revert "Allow building with CHERI-LLVM prior to the Sep 2021 merge"

### DIFF
--- a/lib/libefivar/Makefile
+++ b/lib/libefivar/Makefile
@@ -67,6 +67,6 @@ WARNS?=		9
 CWARNFLAGS+=	-Wno-cast-align
 CWARNFLAGS+=	-Wno-unused-parameter
 
-.if ${COMPILER_TYPE} == "clang" && ${COMPILER_FEATURES:MWunused-but-set-variable}
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
 CWARNFLAGS+=	-Wno-unused-but-set-variable
 .endif

--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -270,19 +270,6 @@ ${X_}COMPILER_FEATURES+=	retpoline init-all
     ${TARGET_ENDIANNESS} == "1234"
 ${X_}COMPILER_FEATURES+=	compressed-debug
 .endif
-# Detect certain supported warning flags to allow building with clang versions
-# built from git between releases. For example this affects all CHERI LLVM
-# versions that include the April 2021 upstream merge but not the September one.
-# Without this check we get the following build failure:
-# error: unknown warning option '-Werror=unused-but-set-variable'
-_check_flag=${${cc}:N${CCACHE_BIN}} -Werror=unknown-warning-option -fsyntax-only -xc /dev/null
-_warning_flags_to_check=unused-but-set-variable
-.for _flag in ${_warning_flags_to_check}
-_flag_supported!=	${_check_flag} -Werror=${_flag} 2>/dev/null && echo "yes" || echo "no"
-.if ${_flag_supported} == "yes"
-${X_}COMPILER_FEATURES+= W${_flag}
-.endif
-.endfor
 .endif
 
 .if ${${cc}:N${CCACHE_BIN}:[1]:M/*} && exists(${${cc}:N${CCACHE_BIN}:[1]})

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -80,7 +80,7 @@ CWARNFLAGS+=	-Wno-pointer-sign
 .if ${WARNS} <= 6
 CWARNFLAGS.clang+=	-Wno-empty-body -Wno-string-plus-int
 CWARNFLAGS.clang+=	-Wno-unused-const-variable
-.if ${COMPILER_TYPE} == "clang" && ${COMPILER_FEATURES:MWunused-but-set-variable}
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
 CWARNFLAGS.clang+=	-Wno-error=unused-but-set-variable
 .endif
 .endif # WARNS <= 6

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -28,7 +28,7 @@ NO_WTAUTOLOGICAL_POINTER_COMPARE= -Wno-tautological-pointer-compare
 .if ${COMPILER_VERSION} >= 100000
 NO_WMISLEADING_INDENTATION=	-Wno-misleading-indentation
 .endif
-.if ${COMPILER_FEATURES:MWunused-but-set-variable}
+.if ${COMPILER_VERSION} >= 130000
 NO_WUNUSED_BUT_SET_VARIABLE=	-Wno-unused-but-set-variable
 .endif
 .if ${COMPILER_VERSION} >= 140000


### PR DESCRIPTION
Both CHERI LLVM and Morello LLVM are upgraded to LLVM 13 and no longer
need this workaround.

This reverts commit 651987560ba1c2df5aae91a19fb6287c3cb95b6b.