### PR TITLE
Remove workarounds for older versions of Morello LLVM.

### DIFF
--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -228,11 +228,6 @@ CWARNFLAGS+=	-Wno-error=pass-failed
 CXXWARNFLAGS+=	-Wno-error=non-c-typedef-for-linkage
 .endif
 
-.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
-# Work around c++/v1/__bit_reference warning until we update subrepocheri-libc++
-CXXWARNFLAGS+=  -Wno-error=deprecated-copy
-.endif
-
 # How to handle FreeBSD custom printf format specifiers.
 .if ${COMPILER_TYPE} == "clang"
 FORMAT_EXTENSIONS=	-D__printf__=__freebsd_kprintf__

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -221,13 +221,6 @@ CWARNFLAGS+=	-Wno-system-headers
 CWARNFLAGS+=	-Wno-error=pass-failed
 .endif
 
-.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 110000
-# This warning is no longer emitted by CHERI LLVM, but it does trigger with
-# the current Morello LLVM version.
-# TODO: remove this warning flag when the morello compiler has been updated.
-CXXWARNFLAGS+=	-Wno-error=non-c-typedef-for-linkage
-.endif
-
 # How to handle FreeBSD custom printf format specifiers.
 .if ${COMPILER_TYPE} == "clang"
 FORMAT_EXTENSIONS=	-D__printf__=__freebsd_kprintf__

--- a/sys/conf/Makefile.arm64
+++ b/sys/conf/Makefile.arm64
@@ -32,14 +32,7 @@ CFLAGS += -DLINUX_DTS_VERSION=\"${LINUX_DTS_VERSION}\"
 
 PERTHREAD_SSP_ENABLED!=	grep PERTHREAD_SSP opt_global.h || true ; echo
 .if !empty(PERTHREAD_SSP_ENABLED)
-# CHERI/Morello LLVM versions that include the April 2021 upstream merge but
-# not the September one identify as 13.0.0 but do not include per-thread SSP
-# support. Detect these until we can stop supporting them.
 . if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000
-_mstack_protector_guard_sysreg_broken!=	{CC:N${CCACHE_BIN}} ${CFLAGS} -fsyntax-only -xc /dev/null -mstack-protector-guard=sysreg 2>/dev/null && echo "no" || echo "yes"
-. endif
-. if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 130000 && \
-	${_mstack_protector_guard_sysreg_broken} != "yes"
 ARM64_SSP_CFLAGS = -mstack-protector-guard=sysreg
 ARM64_SSP_CFLAGS += -mstack-protector-guard-reg=sp_el0
 ARM64_SSP_CFLAGS += -mstack-protector-guard-offset=0


### PR DESCRIPTION
…round.

Just assume it isn't broken for versions != 13 rather than doing the
runtime check.