### PR TITLE
find: fix -exec on CheriABI

### DIFF
--- a/usr.bin/find/function.c
+++ b/usr.bin/find/function.c
@@ -747,7 +747,8 @@ c_exec(OPTION *option, char ***argvp)
 		 * Files from the same directory should be handled
 		 * in one invocation but there is no code for it.
 		 */
-		new->e_pnummax = new->flags & F_EXECDIR ? 1 : argmax / 16;
+		new->e_pnummax = new->flags & F_EXECDIR ? 1 :
+		    argmax / MAX(8 + sizeof(char *), 16);
 		argmax -= sizeof(char *) * new->e_pnummax;
 		if (argmax <= 0)
 			errx(1, "no space for arguments");


### PR DESCRIPTION
The find command would fail with "no space for arguments" when the
size of the environment conspired to leave a multiple of 16 bytes for
strings. A magic 16 was used to represent some sort of average minimum
size of an argument plus pointer pair, but since our pointers are
16-bytes the next line that removed space for the pointers could result
in no space being available.  Change the code to use 8 + sizeof(char *)
with a minimum value of 16 to avoid perturbing 32-bit systems.

Diagnosed by:	@jrtc27