### PR TITLE
Fix kernel coverage support.

### DIFF
--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -181,7 +181,7 @@ reloc_instr_imm(Elf32_Addr *where, Elf_Addr val, u_int msb, u_int lsb)
 }
 
 #if __has_feature(capabilities)
-static uintcap_t
+static uintcap_t __nosanitizecoverage
 build_cap_from_fragment(Elf_Addr *fragment, Elf_Addr relocbase,
     Elf_Addr offset, void * __capability data_cap,
     const void * __capability code_cap)
@@ -438,7 +438,7 @@ elf_cpu_parse_dynamic(caddr_t loadbase __unused, Elf_Dyn *dynamic __unused)
 /*
  * Handle boot-time kernel relocations, this is called by locore.
  */
-void
+void __nosanitizecoverage
 elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 {
 	const Elf_Rela *rela = NULL, *rela_end;

--- a/sys/arm64/cheri/cheri_machdep.c
+++ b/sys/arm64/cheri/cheri_machdep.c
@@ -48,7 +48,7 @@ void * __capability smccc_ddc_el0;
 void *kernel_root_cap = (void *)(intcap_t)-1;
 #endif
 
-void
+void __nosanitizecoverage
 cheri_init_capabilities(void * __capability kroot)
 {
 	void * __capability ctemp;

--- a/sys/arm64/conf/GENERIC-MORELLO-PURECAP-SYZKALLER
+++ b/sys/arm64/conf/GENERIC-MORELLO-PURECAP-SYZKALLER
@@ -1,0 +1,11 @@
+#
+# Pure capability ABI kernel for syzkaller fuzzing
+#
+# $FreeBSD$
+
+include "GENERIC-MORELLO-PURECAP"
+
+ident		GENERIC-MORELLO-PURECAP-SYZKALLER
+
+options 	COVERAGE
+options 	KCOV

--- a/sys/arm64/conf/GENERIC-MORELLO-PURECAP-SYZKALLER-NODEBUG
+++ b/sys/arm64/conf/GENERIC-MORELLO-PURECAP-SYZKALLER-NODEBUG
@@ -1,0 +1,13 @@
+#
+# Pure capability ABI kernel for syzkaller fuzzing without debug options
+#
+# $FreeBSD$
+
+include "GENERIC-MORELLO-PURECAP-SYZKALLER"
+include "../../conf/std.nodebug"
+
+ident		GENERIC-MORELLO-PURECAP-SYZKALLER-NODEBUG
+
+# Re-enable options after being disabled in std.nodebug
+options 	COVERAGE
+options 	KCOV

--- a/sys/kern/kern_kcov.c
+++ b/sys/kern/kern_kcov.c
@@ -128,7 +128,7 @@ typedef enum {
 struct kcov_info {
 	struct thread	*thread;	/* (l) */
 	vm_object_t	bufobj;		/* (o) */
-	vm_offset_t	kvaddr;		/* (o) */
+	vm_pointer_t	kvaddr;		/* (o) */
 	size_t		entries;	/* (o) */
 	size_t		bufsize;	/* (o) */
 	kcov_state_t	state;		/* (s) */

--- a/sys/kern/subr_devmap.c
+++ b/sys/kern/subr_devmap.c
@@ -383,7 +383,7 @@ pmap_unmapdev(vm_pointer_t va, vm_size_t size)
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
-void
+void __nosanitizecoverage
 devmap_init_capability(void * __capability cap)
 {
 	devmap_capability = cap;

--- a/sys/sys/cdefs.h
+++ b/sys/sys/cdefs.h
@@ -1058,9 +1058,11 @@
 #define __nosanitizeaddress	__attribute__((no_sanitize("address")))
 #define __nosanitizememory	__attribute__((no_sanitize("memory")))
 #endif
+#define __nosanitizecoverage	__attribute__((no_sanitize("coverage")))
 #define __nosanitizethread	__attribute__((no_sanitize("thread")))
 #else
 #define __nosanitizeaddress
+#define __nosanitizecoverage
 #define __nosanitizememory
 #define __nosanitizethread
 #endif


### PR DESCRIPTION
The KCOV option is broken. This was likely due to a lost changeset for kern_kcov from the MIPS purecap kernel.