### PR TITLE
CheriABI: libnv fd_send/fd_recv limit fix

### DIFF
--- a/lib/libnv/msgio.c
+++ b/lib/libnv/msgio.c
@@ -68,8 +68,15 @@ __FBSDID("$FreeBSD$");
  * machine-independent limit on the number of FDs per message.  Each control
  * message contains 1 FD and requires 12 bytes for the header, 4 pad bytes,
  * 4 bytes for the descriptor, and another 4 pad bytes.
+ *
+ * For CheriABI, we have 12 bytes of pad for capability alignment after
+ * the descriptor.
  */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	PKG_MAX_SIZE	(MCLBYTES / 32)
+#else
 #define	PKG_MAX_SIZE	(MCLBYTES / 24)
+#endif
 #endif
 
 static int


### PR DESCRIPTION
This change allows a CheriABI nm to work with long argument lists, but it's a workaround since hybrid or native binaries are also broken and we can't change their control message size limits retroactively.