### PR TITLE
Revert "Disable PAM, it doesn't work with static sshd."

### DIFF
--- a/crypto/openssh/sshd_config
+++ b/crypto/openssh/sshd_config
@@ -62,7 +62,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #PermitEmptyPasswords no
 
 # Change to no to disable PAM authentication
-KbdInteractiveAuthentication no
+#KbdInteractiveAuthentication yes
 
 # Kerberos options
 #KerberosAuthentication no
@@ -83,7 +83,7 @@ KbdInteractiveAuthentication no
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and KbdInteractiveAuthentication to 'no'.
-UsePAM no
+#UsePAM yes
 
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes


### PR DESCRIPTION
CheriABI now supports dynamic binaries and having PAM authentication
working out of the box is friendlier to new installs on Morello
systems.

This reverts commit 98c1f564e3f06c66d264bcaa4808557278bc09f0.