### PR TITLE
freebsd64_sendmsg: allow more control messages

### DIFF
--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -287,10 +287,10 @@ freebsd64_copyin_control(struct mbuf **mp, char * __capability buf,
 		newlen += CMSG_SPACE(datalen);
 	}
 
-	if (newlen > MCLBYTES)
+	m = m_get2(newlen, M_WAITOK, MT_CONTROL, 0);
+	if (m == NULL)
 		return (EINVAL);
 
-	m = m_get2(newlen, M_WAITOK, MT_CONTROL, 0);
 	m->m_len = newlen;
 
 	/* Copyin and realign the control data. */


### PR DESCRIPTION
When a freebsd64 caller uses all or most allowed space for control
messages (MCLBYTES) then the message may no longer fit when the messages
are padded for capability alignment. Historically (with freebsd32) we've
just shrugged and said there is no ABI guarantee. Unfortunatly, libnv
breaks this assumption so capsicumized programs link nm fail on CHERI
systems.

Fix this by using external storage in mbufs if the expansion requires
it.