### PR TITLE
Morello pmap bootstrap dmap with ATTR_SC

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -981,7 +981,7 @@ pmap_bootstrap_dmap_l2_block(struct dmap_bootstrap_state *state, int i)
 		MPASS(state->l2[l2_slot] == 0);
 		pmap_store(&state->l2[l2_slot], state->pa | ATTR_DEFAULT |
 #if __has_feature(capabilities)
-		    ATTR_CAP_RW |
+		    ATTR_CAP_RW | ATTR_SC |
 #endif
 		    ATTR_S1_XN | ATTR_S1_IDX(VM_MEMATTR_WRITE_BACK) |
 		    L2_BLOCK);
@@ -1019,7 +1019,7 @@ pmap_bootstrap_dmap_l3_page(struct dmap_bootstrap_state *state, int i)
 		MPASS(state->l3[l3_slot] == 0);
 		pmap_store(&state->l3[l3_slot], state->pa | ATTR_DEFAULT |
 #if __has_feature(capabilities)
-		    ATTR_CAP_RW |
+		    ATTR_CAP_RW | ATTR_SC |
 #endif
 		    ATTR_S1_XN | ATTR_S1_IDX(VM_MEMATTR_WRITE_BACK) |
 		    L3_PAGE);
@@ -1068,7 +1068,7 @@ pmap_bootstrap_dmap(vm_pointer_t kern_l1, vm_paddr_t min_pa,
 			pmap_store(&state.l1[pmap_l1_index(state.va)],
 			    state.pa | ATTR_DEFAULT | ATTR_S1_XN |
 #if __has_feature(capabilities)
-			    ATTR_CAP_RW |
+			    ATTR_CAP_RW | ATTR_SC |
 #endif
 			    ATTR_S1_IDX(VM_MEMATTR_WRITE_BACK) |
 			    L1_BLOCK);
@@ -1853,7 +1853,7 @@ pmap_qenter(vm_offset_t sva, vm_page_t *ma, int count)
 		m = ma[i];
 		pa = VM_PAGE_TO_PHYS(m) | ATTR_DEFAULT |
 #if __has_feature(capabilities)
-		    ATTR_CAP_RW |
+		    ATTR_CAP_RW | ATTR_SC |
 #endif
 		    ATTR_S1_AP(ATTR_S1_AP_RW) | ATTR_S1_XN |
 		    ATTR_S1_IDX(m->md.pv_memattr) | L3_PAGE;


### PR DESCRIPTION
We aren't tracking capdirty on bootstrap dmap mappings, and while Morello itself
has no trouble performing the PTW AMO to transmute a PTE with CDBM to include
SC, the QEMU TLB is not (at present) so capable.

Without this change, making QEMU raise data aborts on missing SC (that is,
causing it to ignore CDBM rather than take CDBM to mean the same thing as SC)
causes the kernel to enter a trap loop as it takes a data abort, attempts to
spill capabilities onto its stack, and, so, triggers another data abort.
Eventually, this tends to overflow the stack and trigger a kernel panic, but
said panic will not reflect the actual cause of the error.

Merge before landing https://github.com/CTSRD-CHERI/qemu/pull/200 