### PR TITLE
kuint64cap t

### DIFF
--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -112,6 +112,14 @@ typedef __uintptr_t	kuintcap_t;
 #endif
 #define	_KUINTCAP_T_DECLARED
 #endif
+#ifndef _KUINT64CAP_T_DECLARED
+#ifdef __ILP32__
+typedef	uint64_t	kuint64cap_t;
+#else
+typedef	kuintcap_t	kuint64cap_t;
+#endif
+#define	_KUINT64CAP_T_DECLARED
+#endif
 
 #ifndef _PTRADDR_T_DECLARED
 typedef	__ptraddr_t	ptraddr_t;


### PR DESCRIPTION
kuint64cap_t is an integer type that can hold a pointer.  On CHERI
systems it's an __uintcap_t in the kernel and an uintptr_t elsewere.
On 32-bit systems it's a uint64_t so 32- and 64-bit systems have
data structures the same size (module i386's weak aligment
requirements).