### PR TITLE
CHERI-RISC-V pmap fixes for cap handling

### DIFF
--- a/sys/riscv/include/pte.h
+++ b/sys/riscv/include/pte.h
@@ -74,7 +74,7 @@ typedef	uint64_t	pn_t;			/* page number */
 #define	PTE_CR		(1UL << 62) /* Capability Read */
 #define	PTE_CD		(1UL << 61) /* Capability Dirty */
 #define	PTE_KERN_CHERI	(PTE_CR | PTE_CW | PTE_CD)
-#define	PTE_PROMOTE_CHERI (PTE_CR | PTE_CW | PTE_CD)
+#define	PTE_PROMOTE_CHERI (PTE_CR | PTE_CW | PTE_CD | PTE_CRM | PTE_CRG)
 #else
 #define	PTE_KERN_CHERI	0
 #define	PTE_PROMOTE_CHERI 0

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -2859,6 +2859,27 @@ pmap_promote_l2(pmap_t pmap, pd_entry_t *l2, vm_offset_t va,
 		return;
 	}
 
+	if ((firstl3e & (PTE_CW | PTE_CD)) == PTE_CW) {
+		/*
+		 * Prohibit superpages involving CW-set CD-clear PTEs.  We
+		 * could, as with D and W below, downgrade this to CW-clear,
+		 * except that our experimental capability revoker occasionally
+		 * creates these from CD-set PTEs without invalidating TLBs, and
+		 * so it's possible that there are CD-set TLB entries lurking in
+		 * the system (until all TLBs having seen this pmap are
+		 * invalidated, which happens at least once per revocation
+		 * epoch).
+		 *
+		 * We need only explicitly exclude this on firstl3e, as CW and
+		 * CD are both in the PTE_PROMOTE mask used to test equivalence
+		 * below.
+		 */
+		CTR2(KTR_PMAP, "pmap_promote_l2: fail CW for va %#lx pmap %p",
+		    va, pmap);
+		atomic_add_long(&pmap_l2_p_failures, 1);
+		return;
+	}
+
 	/*
 	 * Downgrade a clean, writable mapping to read-only to ensure that the
 	 * hardware does not set PTE_D while we are comparing PTEs.

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -2702,13 +2702,13 @@ pmap_fault(pmap_t pmap, vm_offset_t va, vm_prot_t ftype)
 	}
 
 	if ((pmap != kernel_pmap && (oldpte & PTE_U) == 0) ||
-	    (ftype == VM_PROT_WRITE && (oldpte & PTE_W) == 0) ||
+	    (((ftype & VM_PROT_WRITE) != 0) && (oldpte & PTE_W) == 0) ||
 	    (ftype == VM_PROT_EXECUTE && (oldpte & PTE_X) == 0) ||
 	    (ftype == VM_PROT_READ && (oldpte & PTE_R) == 0))
 		goto done;
 
 	bits = PTE_A;
-	if (ftype == VM_PROT_WRITE)
+	if ((ftype & VM_PROT_WRITE) != 0)
 		bits |= PTE_D;
 
 	/*


### PR DESCRIPTION
Pulling things that should go upstream from from the `caprevoke` branch.