### PR TITLE
MACHINE_ABI: add long and time, fix ptr

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -72,7 +72,12 @@ LIB32WMAKEFLAGS+= OBJCOPY="${XOBJCOPY}"
 LIB32CFLAGS=	-DCOMPAT_32BIT
 LIB32DTRACE=	${DTRACE} -32
 LIB32WMAKEFLAGS+=	-DCOMPAT_32BIT
-LIB32_MACHINE_ABI=	${MACHINE_ABI}
+LIB32_MACHINE_ABI=	${MACHINE_ABI:N*64:Nptr*:Npurecap} long32 ptr32
+.if ${COMPAT_ARCH} == "amd64"
+LIB32_MACHINE_ABI+=	time32
+.else
+LIB32_MACHINE_ABI+=	time64
+.endif
 .endif # ${MK_LIB32} != "no"
 
 # -------------------------------------------------------------------
@@ -109,7 +114,7 @@ LIB64WMAKEFLAGS+= NM="${XNM}" OBJCOPY="${XOBJCOPY}"
 LIB64CFLAGS=	-DCOMPAT_64BIT
 LIB64DTRACE=	${DTRACE} -64
 LIB64WMAKEFLAGS+=	-DCOMPAT_64BIT
-LIB64_MACHINE_ABI=	${MACHINE_ABI:Npurecap}
+LIB64_MACHINE_ABI=	${MACHINE_ABI:Npurecap:Nptr*} ptr64
 .endif # ${MK_LIB64} != "no"
 
 # -------------------------------------------------------------------
@@ -151,7 +156,7 @@ COMPAT_RISCV_MARCH:=	${COMPAT_RISCV_MARCH}xcheri
 .if defined(HAS_COMPAT) && ${HAS_COMPAT:M64C}
 LIB64CCFLAGS+=	-DCOMPAT_CHERI
 LIB64CWMAKEFLAGS+=	COMPAT_CHERI=yes
-LIB64C_MACHINE_ABI=	${MACHINE_ABI} purecap
+LIB64C_MACHINE_ABI=	${MACHINE_ABI:Nptr*} purecap ptr128c
 
 # This duplicates some logic in bsd.cpu.mk that is needed for the
 # WANT_COMPAT/NEED_COMPAT case.

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -410,20 +410,38 @@ CXXFLAGS += ${CXXFLAGS.${MACHINE_ARCH}}
 
 #
 # MACHINE_ABI is a list of properties about the ABI used for MACHINE_ARCH.
+# The following properties are indicated with one of the follow values:
+#
+# Floating point ABI:		soft-float, hard-float
+# Size of long (size_t, etc):	long32, long64
+# Pointer type:			ptr32, ptr64, ptr128c
+# Size of time_t:		time32, time64
+# Capability ABI:		purecap
 #
 .if ${MACHINE_ARCH:Mriscv*sf*}
 MACHINE_ABI+=	soft-float
 .else
 MACHINE_ABI+=	hard-float
 .endif
-.if (${MACHINE_ARCH:Maarch64*c*} || ${MACHINE_ARCH:Mriscv*c*})
-MACHINE_ABI+=	purecap
-.endif
 # Currently all 64-bit architectures include 64 in their name (see arch(7)).
 .if ${MACHINE_ARCH:M*64*}
+MACHINE_ABI+=	long64
+.else
+MACHINE_ABI+=	long32
+.endif
+.if (${MACHINE_ARCH:Maarch64*c*} || ${MACHINE_ARCH:Mriscv*c*})
+MACHINE_ABI+=	purecap ptr128c
+.else
+.if ${MACHINE_ABI:Mlong64}
 MACHINE_ABI+=	ptr64
 .else
 MACHINE_ABI+=	ptr32
+.endif
+.endif
+.if ${MACHINE_ARCH} == "i386"
+MACHINE_ABI+=	time32
+.else
+MACHINE_ABI+=	time64
 .endif
 
 .if ${MACHINE_ABI:Mpurecap}


### PR DESCRIPTION
Don't declare a ptr## entry if we're in purecap.  It might be we want a
ptr128c instead of purecap, but leave it alone for now.

Add long## and time## for the other common ABI aspects.

Fixes #639