### PR TITLE
cheribsdtest: remove 'all' as a synonym for -a

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -683,10 +683,6 @@ main(int argc, char *argv[])
 		warnx("-a and a list of test are incompatible");
 		usage();
 	}
-	if (argc == 1 && strcmp(argv[0], "all") == 0) {
-		warnx("'all' as a synonym for -a is deprecated");
-		run_all = 1;
-	}
 
 	/*
 	 * Allocate an alternative stack, required to safely process signals in


### PR DESCRIPTION
The use of 'all' was depreceted almost 8 years ago in a1d9b6c0a01d9.