### PR TITLE
Colocation tests

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -29,6 +29,8 @@ SRCS+=	cheribsdtest_bounds_globals.c					\
 SRCS+=	cheribsdtest_bounds_subobject.c					\
 	cheribsdtest_bounds_varargs.c					\
 	cheribsdtest_sentries.c
+
+SRCS+=		cheribsdtest_colocation.c
 .endif
 
 CHERIBSDTEST_DIR:=	${.PARSEDIR}
@@ -60,6 +62,9 @@ MAN=
 
 LIBADD= 	z
 LIBADD+=	xo util
+.if ${MACHINE_ABI:Mpurecap}
+LIBADD+=	procstat
+.endif
 
 .ifdef CHERIBSD_DYNAMIC_TESTS
 CFLAGS+=	-DCHERIBSD_DYNAMIC_TESTS

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -158,11 +158,8 @@ list_tests(void)
 }
 
 static void
-signal_handler(int signum, siginfo_t *info, void *vuap)
+signal_handler(int signum, siginfo_t *info, void *vuap __unused)
 {
-	ucontext_t *uap;
-
-	uap = (ucontext_t *)vuap;
 	ccsp->ccs_signum = signum;
 	ccsp->ccs_si_code = info->si_code;
 	ccsp->ccs_si_trapno = info->si_trapno;

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -37,6 +37,7 @@
 #endif
 
 #include <sys/param.h>
+#include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/sysctl.h>
@@ -81,8 +82,11 @@ static StringList* cheri_xpassed_tests;
 /* Shared memory page with child process. */
 struct cheribsdtest_child_state *ccsp;
 
+static char *argv0;
+
 static int tests_run;
 static int tests_failed, tests_passed, tests_xfailed, tests_xpassed;
+static int execed;
 static int expected_failures;
 static int list;
 static int run_all;
@@ -578,6 +582,80 @@ cheribsdtest_run_test_name(const char *name)
 	errx(EX_USAGE, "unknown test: %s", name);
 }
 
+static void
+cheribsdtest_run_child(struct cheri_test *ctp)
+{
+	if (ctp->ct_child_func == NULL)
+		errx(EX_SOFTWARE, "%s has no child function", ctp->ct_name);
+	ctp->ct_child_func(ctp);
+	errx(EX_SOFTWARE, "%s child function returned", ctp->ct_name);
+}
+
+static void
+cheribsdtest_run_child_name(const char *name)
+{
+	struct cheri_test **ctpp, *ctp;
+
+	SET_FOREACH(ctpp, cheri_tests_set) {
+		ctp = *ctpp;
+		if (strcmp(name, ctp->ct_name) == 0) {
+			cheribsdtest_run_child(ctp);
+		}
+	}
+	errx(EX_USAGE, "unknown test: %s", name);
+}
+
+static char **
+mk_exec_args(const struct cheri_test *ctp)
+{
+	char *execpath;
+	char const **exec_args;
+	int argc = 0, error;
+
+	execpath = malloc(MAXPATHLEN);
+	if (execpath == NULL)
+		err(EX_OSERR, "malloc");
+	exec_args = calloc(5, sizeof(*exec_args));
+	if (exec_args == NULL)
+		err(EX_OSERR, "calloc");
+
+	/*
+	 * XXXBD: it would be nice if there was a way to say "coexecve
+	 * myself".
+	 */
+	error = elf_aux_info(AT_EXECPATH, execpath, MAXPATHLEN);
+	if (error != 0)
+		errx(EX_OSERR, "elf_aux_info: %s", strerror(error));
+	exec_args[argc++] = execpath;
+	exec_args[argc++] = "-E";
+	if (coredump_enabled)
+		exec_args[argc++] = "-c";
+	exec_args[argc++] = ctp->ct_name;
+	exec_args[argc++] = NULL;
+
+	return (__DECONST(char **, exec_args));
+}
+
+void
+cheribsdtest_coexec_child(const struct cheri_test *ctp)
+{
+	char **exec_args;
+
+	exec_args = mk_exec_args(ctp);
+	coexecve(getppid(), exec_args[0], exec_args, NULL);
+	err(EX_OSERR, "%s: coexecve", __func__);
+}
+
+void
+cheribsdtest_exec_child(const struct cheri_test *ctp)
+{
+	char **exec_args;
+
+	exec_args = mk_exec_args(ctp);
+	execve(exec_args[0], exec_args, NULL);
+	err(EX_OSERR, "%s: execve", __func__);
+}
+
 __noinline void *
 cheribsdtest_memcpy(void *dst, const void *src, size_t n)
 {
@@ -603,10 +681,11 @@ main(int argc, char *argv[])
 	const char *sep;
 	struct cheri_test **ctp, *ct;
 
+	argv0 = argv[0];
 	argc = xo_parse_args(argc, argv);
 	if (argc < 0)
 		errx(1, "xo_parse_args failed\n");
-	while ((opt = getopt(argc, argv, "acdfglQqsuvx")) != -1) {
+	while ((opt = getopt(argc, argv, "acdEfglQqsuvx")) != -1) {
 		switch (opt) {
 		case 'a':
 			run_all = 1;
@@ -616,6 +695,9 @@ main(int argc, char *argv[])
 			break;
 		case 'd':
 			debugger_enabled = 1;
+			break;
+		case 'E':
+			execed = 1;
 			break;
 		case 'f':
 			fast_tests_only = 1;
@@ -659,6 +741,16 @@ main(int argc, char *argv[])
 	}
 	argc -= optind;
 	argv += optind;
+	if (execed) {
+		if (run_all || glob || list) {
+			warnx("-E is incompatbile with -a, -g, and -l");
+			usage();
+		}
+		if (argc != 1) {
+			warnx("-E requires exactly one test argument");
+			usage();
+		}
+	}
 	if (run_all && list) {
 		warnx("-a and -l are incompatible");
 		usage();
@@ -699,6 +791,12 @@ main(int argc, char *argv[])
 	stack.ss_flags = 0;
 	if (sigaltstack(&stack, NULL) < 0)
 		err(EX_OSERR, "sigaltstack");
+
+	/*
+	 * We've been (co)execed so look up our child function and run it.
+	 */
+	if (execed)
+		cheribsdtest_run_child_name(argv[0]);
 
 	/*
 	 * Allocate a page shared with children processes to return success/

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -163,6 +163,7 @@ struct cheri_test {
 	const char	*ct_name;
 	const char	*ct_desc;
 	void		(*ct_func)(const struct cheri_test *);
+	void		(*ct_child_func)(const struct cheri_test *);
 	const char *	(*ct_check_xfail)(const char *);
 	u_int		 ct_flags;
 	int		 ct_signum;
@@ -319,5 +320,12 @@ _cheribsdtest_check_errno(const char *context, int actual, int expected)
 /* For libc_memcpy and libc_memset tests and the unaligned copy tests: */
 extern void *cheribsdtest_memcpy(void *dst, const void *src, size_t n);
 extern void *cheribsdtest_memmove(void *dst, const void *src, size_t n);
+
+/*
+ * (co)exec a new copy of cheribsdtest and run the test's associated child
+ * function.
+ */
+extern void cheribsdtest_coexec_child(const struct cheri_test *ctp);
+extern void cheribsdtest_exec_child(const struct cheri_test *ctp);
 
 #endif /* !_CHERIBSDTEST_H_ */

--- a/bin/cheribsdtest/cheribsdtest_colocation.c
+++ b/bin/cheribsdtest/cheribsdtest_colocation.c
@@ -1,0 +1,178 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2022 SRI International
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under Defense Advanced Research Projects Agency (DARPA)
+ * Contract No. HR001122C0110 ("ETC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/procdesc.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+
+#include <err.h>
+#include <errno.h>
+#include <kvm.h>
+#include <libprocstat.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sysexits.h>
+#include <unistd.h>
+
+#include "cheribsdtest.h"
+
+static bool
+is_colocated_with_parent(void)
+{
+	struct procstat *psp;
+	struct kinfo_proc *kipp;
+	struct kinfo_vmentry *kivp;
+	pid_t pid, ppid;
+	uint pcnt, vmcnt;
+	bool found_self, found_parent;
+
+	pid = getpid();
+	ppid = getppid();
+
+	psp = procstat_open_sysctl();
+	if (psp == NULL)
+		err(EX_OSERR, "procstat_open_sysctl");
+
+	kipp = procstat_getprocs(psp, KERN_PROC_PID, getpid(), &pcnt);
+	if (kipp == NULL)
+		err(EX_OSERR, "procstat_getprocs");
+	if (pcnt != 1)
+		warnx("got %d processes", pcnt);
+
+	kivp = procstat_getvmmap(psp, kipp, &vmcnt);
+	if (kivp == NULL)
+		err(EX_OSERR, "procstat_getvmmap");
+
+	found_self = found_parent = false;
+	for (u_int i = 0; i < vmcnt; i++) {
+		if (kivp[i].kve_pid == pid)
+			found_self = true;
+		if (kivp[i].kve_pid == ppid)
+			found_parent = true;
+	}
+	if (!found_self)
+		errx(EX_SOFTWARE, "Didn't find self in vmstate");
+
+	procstat_freevmmap(psp, kivp);
+	procstat_freeprocs(psp, kipp);
+	procstat_close(psp);
+	return (found_parent);
+}
+
+#ifdef CHERIBSD_DYNAMIC_TESTS
+static void
+coexec_child_cf(const struct cheri_test * __unused ctp)
+{
+	if (is_colocated_with_parent())
+		exit (0);
+	errx(EX_OSERR, "Not colocated with parent");
+}
+
+CHERIBSDTEST(colocation_coexec_child,
+    "Check that we can coexecve a child and we share a vmspace",
+    .ct_child_func = coexec_child_cf)
+{
+	int pfd, pid;
+
+	pid = pdfork(&pfd, 0);
+	if (pid == -1)
+		cheribsdtest_failure_err("Fork failed");
+
+	if (pid == 0) {
+		cheribsdtest_coexec_child(ctp);
+	} else {
+		int res;
+
+		waitpid(pid, &res, 0);
+		if (res == 0) {
+			cheribsdtest_success();
+		} else if (WIFEXITED(res)) {
+			cheribsdtest_failure_errx(
+			    "coexecved process exited with %d",
+			    WEXITSTATUS(res));
+		} else {
+			cheribsdtest_failure_errx(
+			    "coexecved process failed with status 0x%x", res);
+		}
+	}
+}
+#endif
+
+static void
+exec_child_cf(const struct cheri_test * __unused ctp)
+{
+	if (!is_colocated_with_parent())
+		exit (0);
+	/*
+	 * No output because we might be coexeced if opportunistic
+	 * coexecve is enabled.
+	 */
+	exit(1);
+}
+
+CHERIBSDTEST(colocation_exec_child,
+    "Check that we do not share a namespace with execve'd child",
+    .ct_child_func = exec_child_cf)
+{
+	int pfd, pid;
+
+	pid = pdfork(&pfd, 0);
+	if (pid == -1)
+		cheribsdtest_failure_err("Fork failed");
+
+	if (pid == 0) {
+		cheribsdtest_exec_child(ctp);
+	} else {
+		int res;
+
+		waitpid(pid, &res, 0);
+		if (res == 0) {
+			cheribsdtest_success();
+		} else if (WIFEXITED(res) && WEXITSTATUS(res) == 1) {
+			/*
+			 * XXX: this might happen if sysctl
+			 * kern.opportunistic_coexecve=1, but that isn't
+			 * the default and this doesn't currently happen
+			 * if it is enabled.
+			 */
+			cheribsdtest_failure_errx(
+			    "execved process is co-located with parent");
+		} else {
+			cheribsdtest_failure_errx(
+			    "execved process failed with status 0x%x", res);
+		}
+	}
+}

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -167,7 +167,7 @@ SYSCTL_INT(_kern, OID_AUTO, core_dump_can_intr, CTLFLAG_RWTUN,
     &core_dump_can_intr, 0,
     "Core dumping interruptible with SIGKILL");
 
-static int opportunistic_coexecve = 0;
+int opportunistic_coexecve = 0;
 SYSCTL_INT(_kern, OID_AUTO, opportunistic_coexecve, CTLFLAG_RW,
     &opportunistic_coexecve, 0,
     "Try to colocate binaries on execve(2)");


### PR DESCRIPTION
Add infrastructure to (co)exec cheribsdtest and call a test-specific function in the child. Use this to add a couple tests to verify that colocation happens as expected.