### PR TITLE
etc/defaults/rc.conf: add pkg64 service support

### DIFF
--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -61,7 +61,7 @@ varmfs_flags="-S"	# Extra mount options for the mfs /var
 mfs_type="auto"		# "md", "tmpfs", "auto" to prefer tmpfs with md as fallback
 populate_var="AUTO"	# Set to YES to always (re)populate /var, NO to never
 cleanvar_enable="YES" 	# Clean the /var directory
-local_startup="${_localbase}/etc/rc.d" # startup script dirs.
+local_startup="${_localbase}/etc/rc.d /usr/local64/etc/rc.d" # startup script dirs.
 script_name_sep=" "	# Change if your startup scripts' names contain spaces
 rc_conf_files="/etc/rc.conf /etc/rc.conf.local"
 


### PR DESCRIPTION
Services installed via `pkg64` (stable hybrid ABI packages) are installed into `/usr/local64/etc/rc.d`.
By including it in the `local_startup` list, services in this folder will be automatically detected by FreeBSD's `init` system.

This shouldn't cause issues if we're not running purecap and the `/usr/local64/etc/rc.d` folder doesn't exist. [^1]

Example: After running `pkg64 install mDNSResponder` and adding `/usr/local64/etc/rc.d` to `local_startup`, services appear when running `service -l`, and can be startup/enabled using `service mdnsresponderposix start`.

[^1]: I've tested this by adding a `/this/folder/does/not/exist` to the var; everything still seems to work, and there doesn't seem to be any warnings/errors anywhere