### PR TITLE
ktrace: Convert ktr_tid to a long in the new header structure.

### DIFF
--- a/sys/sys/ktrace.h
+++ b/sys/sys/ktrace.h
@@ -68,7 +68,7 @@ struct ktr_header {
 	pid_t	ktr_pid;		/* process id */
 	char	ktr_comm[MAXCOMLEN + 1];/* command name */
 	struct	timespec ktr_time;	/* timestamp */
-	intptr_t	ktr_tid;	/* thread id */
+	long	ktr_tid;		/* thread id */
 	int	ktr_cpu;		/* cpu id */
 };
 


### PR DESCRIPTION
This applies cfa4ccfbd169 to the new version of the header structure
added in 640b6110a7e8.