### PR TITLE
Improve cheri_capability_build_user_* use and implementation

### DIFF
--- a/sys/arm64/include/cherireg.h
+++ b/sys/arm64/include/cherireg.h
@@ -117,6 +117,9 @@
 	CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP |		\
 	CHERI_PERM_MUTABLE_LOAD)
 
+#define	CHERI_PERMS_USERSPACE_RODATA					\
+	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD)
+
 /*
  * Corresponding permission masks for kernel code and data; these are
  * currently a bit broad, and should be narrowed over time as the kernel

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -67,6 +67,9 @@ void * __capability	_cheri_capability_build_user_data(uint32_t perms,
 void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 			    ptraddr_t basep, size_t length, off_t off,
 			    const char* func, int line, bool exact);
+void * __capability	_cheri_capability_build_user_rwx_unchecked(
+			    uint32_t perms, ptraddr_t basep, size_t length,
+			    off_t off, const char* func, int line, bool exact);
 #define cheri_capability_build_user_code(td, perms, basep, length, off)	\
 	_cheri_capability_build_user_code(td, perms, basep, length, off,\
 	    __func__, __LINE__)
@@ -78,6 +81,9 @@ void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
 	    __func__, __LINE__, false)
 #define cheri_capability_build_user_rwx(perms, basep, length, off)	\
 	_cheri_capability_build_user_rwx(perms, basep, length, off,	\
+	    __func__, __LINE__, true)
+#define cheri_capability_build_user_rwx_unchecked(perms, basep, length, off) \
+	_cheri_capability_build_user_rwx_unchecked(perms, basep, length, off, \
 	    __func__, __LINE__, true)
 
 /*

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -33,6 +33,12 @@
 #include <sys/sysent.h>
 #include <sys/systm.h>
 
+#ifdef INVARIANTS
+#include <vm/vm.h>
+#include <vm/pmap.h>
+#include <vm/vm_map.h>
+#endif
+
 #include <cheri/cheric.h>
 
 /* Set to -1 to prevent it from being zeroed with the rest of BSS */
@@ -96,13 +102,57 @@ _cheri_capability_build_user_rwx(uint32_t perms, ptraddr_t basep, size_t length,
     off_t off, const char* func __unused, int line __unused, bool exact)
 {
 	void * __capability tmpcap;
+#ifdef INVARIANTS
+	vm_map_entry_t entry;
+	vm_map_t map;
+	vm_offset_t reservation;
 
-	tmpcap = cheri_setoffset(cheri_andperm(cheri_setbounds(
-	    cheri_setoffset(userspace_root_cap, basep), length), perms), off);
+	if (SV_CURPROC_FLAG(SV_CHERI)) {
+		map = &curproc->p_vmspace->vm_map;
+		vm_map_lock_read(map);
+		KASSERT(vm_map_lookup_entry(map, basep, &entry),
+		    ("%s:%d: vm_map does not contain basep 0x%zx "
+		    "(length 0x%zu, offset 0x%ju)", func, line,
+		    (size_t)basep, length, (uintmax_t)off));
+		reservation = entry->reservation;
+		for( ; basep + length > entry->end;
+		    entry = vm_map_entry_succ(entry)) {
+			/*
+			 * Check that the created capability is within a
+			 * single reservation.  This ensures we don't
+			 * make capabilities that might alias with a
+			 * later mapping.
+			 */
+			KASSERT((map->flags & MAP_RESERVATIONS) == 0 ||
+			    entry->reservation == reservation,
+			    ("Can't create a capability that spans reservations"));
+
+			/*
+			 * XXX: Disallow quarantined or abandoned pages?
+			 *
+			 * XXX: Require page maxprot to be a superset of
+			 * perms?
+			 */
+		}
+		vm_map_unlock_read(map);
+	}
+#endif
+
+	tmpcap = _cheri_capability_build_user_rwx_unchecked(perms, basep,
+	    length, off, func, line, exact);
 
 	KASSERT(!exact || cheri_getlen(tmpcap) == length,
 	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx: "
 	     "%#lp", func, line, cheri_getlen(tmpcap), length, tmpcap));
 
 	return (tmpcap);
+}
+
+void * __capability
+_cheri_capability_build_user_rwx_unchecked(uint32_t perms, ptraddr_t basep,
+    size_t length, off_t off, const char* func __unused, int line __unused,
+    bool exact)
+{
+	return (cheri_setoffset(cheri_andperm(cheri_setbounds(
+	    cheri_setoffset(userspace_root_cap, basep), length), perms), off));
 }

--- a/sys/cheri/cherireg.h
+++ b/sys/cheri/cherireg.h
@@ -93,6 +93,8 @@
 #define	CHERI_CAP_USER_DATA_LENGTH	(VM_MAXUSER_ADDRESS - VM_MINUSER_ADDRESS)
 #define	CHERI_CAP_USER_DATA_OFFSET	0x0
 
+#define	CHERI_CAP_USER_RODATA_PERMS	CHERI_PERMS_USERSPACE_RODATA
+
 /*
  * Root sealing capability for all userspace object capabilities.
  */

--- a/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -650,7 +650,7 @@ zfs_write_simple(znode_t *zp, const void *data, size_t len,
 	int error = 0;
 	ssize_t resid;
 
-	error = vn_rdwr(UIO_WRITE, ZTOV(zp), __DECONST(void *, data), len, pos,
+	error = vn_rdwr(UIO_WRITE, ZTOV(zp), PTR2CAP(__DECONST(void *, data)), len, pos,
 	    UIO_SYSSPACE, IO_SYNC, kcred, NOCRED, &resid, curthread);
 
 	if (error) {

--- a/sys/fs/ext2fs/ext2_lookup.c
+++ b/sys/fs/ext2fs/ext2_lookup.c
@@ -1174,7 +1174,7 @@ ext2_dirempty(struct inode *ip, ino_t parentino, struct ucred *cred)
 #define	MINDIRSIZ (sizeof(struct dirtemplate) / 2)
 
 	for (off = 0; off < ip->i_size; off += le16toh(dp->e2d_reclen)) {
-		error = vn_rdwr(UIO_READ, ITOV(ip), (caddr_t)dp, MINDIRSIZ,
+		error = vn_rdwr(UIO_READ, ITOV(ip), PTR2CAP(dp), MINDIRSIZ,
 		    off, UIO_SYSSPACE, IO_NODELOCKED | IO_NOMACCHECK, cred,
 		    NOCRED, &count, (struct thread *)0);
 		/*
@@ -1236,7 +1236,7 @@ ext2_checkpath(struct inode *source, struct inode *target, struct ucred *cred)
 			error = ENOTDIR;
 			break;
 		}
-		error = vn_rdwr(UIO_READ, vp, (caddr_t)&dirbuf,
+		error = vn_rdwr(UIO_READ, vp, PTR2CAP(&dirbuf),
 		    sizeof(struct dirtemplate), (off_t)0, UIO_SYSSPACE,
 		    IO_NODELOCKED | IO_NOMACCHECK, cred, NOCRED, NULL,
 		    NULL);

--- a/sys/fs/ext2fs/ext2_vnops.c
+++ b/sys/fs/ext2fs/ext2_vnops.c
@@ -1087,7 +1087,7 @@ abortit:
 			ext2_dec_nlink(dp);
 			dp->i_flag |= IN_CHANGE;
 			dirbuf = malloc(dp->i_e2fs->e2fs_bsize, M_TEMP, M_WAITOK | M_ZERO);
-			error = vn_rdwr(UIO_READ, fvp, (caddr_t)dirbuf,
+			error = vn_rdwr(UIO_READ, fvp, PTR2CAP(dirbuf),
 			    ip->i_e2fs->e2fs_bsize, (off_t)0,
 			    UIO_SYSSPACE, IO_NODELOCKED | IO_NOMACCHECK,
 			    tcnp->cn_cred, NOCRED, NULL, NULL);
@@ -1110,7 +1110,7 @@ abortit:
 					ext2_dx_csum_set(ip,
 					    (struct ext2fs_direct_2 *)dirbuf);
 					(void)vn_rdwr(UIO_WRITE, fvp,
-					    (caddr_t)dirbuf,
+					    PTR2CAP(dirbuf),
 					    ip->i_e2fs->e2fs_bsize,
 					    (off_t)0, UIO_SYSSPACE,
 					    IO_NODELOCKED | IO_SYNC |
@@ -1404,7 +1404,7 @@ ext2_mkdir(struct vop_mkdir_args *ap)
 	}
 	memcpy(buf, &dirtemplate, sizeof(dirtemplate));
 	ext2_dirent_csum_set(ip, (struct ext2fs_direct_2 *)buf);
-	error = vn_rdwr(UIO_WRITE, tvp, (caddr_t)buf,
+	error = vn_rdwr(UIO_WRITE, tvp, PTR2CAP(buf),
 	    DIRBLKSIZ, (off_t)0, UIO_SYSSPACE,
 	    IO_NODELOCKED | IO_SYNC | IO_NOMACCHECK, cnp->cn_cred, NOCRED,
 	    NULL, NULL);
@@ -1537,7 +1537,7 @@ ext2_symlink(struct vop_symlink_args *ap)
 		ip->i_size = len;
 		ip->i_flag |= IN_CHANGE | IN_UPDATE;
 	} else
-		error = vn_rdwr(UIO_WRITE, vp, __DECONST(void *, ap->a_target),
+		error = vn_rdwr(UIO_WRITE, vp, PTR2CAP(__DECONST(void *, ap->a_target)),
 		    len, (off_t)0, UIO_SYSSPACE, IO_NODELOCKED | IO_NOMACCHECK,
 		    ap->a_cnp->cn_cred, NOCRED, NULL, NULL);
 	if (error)

--- a/sys/fs/nfsserver/nfs_nfsdstate.c
+++ b/sys/fs/nfsserver/nfs_nfsdstate.c
@@ -4893,7 +4893,7 @@ nfsrv_setupstable(NFSPROC_T *p)
 	if (sf->nsf_fp == NULL)
 		return;
 	error = NFSD_RDWR(UIO_READ, NFSFPVNODE(sf->nsf_fp),
-	    (caddr_t)&sf->nsf_rec, sizeof (struct nfsf_rec), off, UIO_SYSSPACE,
+	    PTR2CAP(&sf->nsf_rec), sizeof (struct nfsf_rec), off, UIO_SYSSPACE,
 	    0, NFSFPCRED(sf->nsf_fp), &aresid, p);
 	if (error || aresid || sf->nsf_numboots == 0 ||
 		sf->nsf_numboots > NFSNSF_MAXNUMBOOTS)
@@ -4906,7 +4906,7 @@ nfsrv_setupstable(NFSPROC_T *p)
 		sizeof (time_t), M_TEMP, M_WAITOK);
 	off = sizeof (struct nfsf_rec);
 	error = NFSD_RDWR(UIO_READ, NFSFPVNODE(sf->nsf_fp),
-	    (caddr_t)sf->nsf_bootvals, sf->nsf_numboots * sizeof (time_t), off,
+	    PTR2CAP(sf->nsf_bootvals), sf->nsf_numboots * sizeof (time_t), off,
 	    UIO_SYSSPACE, 0, NFSFPCRED(sf->nsf_fp), &aresid, p);
 	if (error || aresid) {
 		free(sf->nsf_bootvals, M_TEMP);
@@ -4943,7 +4943,7 @@ nfsrv_setupstable(NFSPROC_T *p)
 		NFSV4_OPAQUELIMIT - 1, M_TEMP, M_WAITOK);
 	do {
 	    error = NFSD_RDWR(UIO_READ, NFSFPVNODE(sf->nsf_fp),
-	        (caddr_t)tsp, sizeof (struct nfst_rec) + NFSV4_OPAQUELIMIT - 1,
+	        PTR2CAP(tsp), sizeof (struct nfst_rec) + NFSV4_OPAQUELIMIT - 1,
 	        off, UIO_SYSSPACE, 0, NFSFPCRED(sf->nsf_fp), &aresid, p);
 	    len = (sizeof (struct nfst_rec) + NFSV4_OPAQUELIMIT - 1) - aresid;
 	    if (error || (len > 0 && (len < sizeof (struct nfst_rec) ||
@@ -5049,11 +5049,11 @@ nfsrv_updatestable(NFSPROC_T *p)
 	vn_finished_write(mp);
 	if (!error)
 	    error = NFSD_RDWR(UIO_WRITE, vp,
-		(caddr_t)&sf->nsf_rec, sizeof (struct nfsf_rec), (off_t)0,
+		PTR2CAP(&sf->nsf_rec), sizeof (struct nfsf_rec), (off_t)0,
 		UIO_SYSSPACE, IO_SYNC, NFSFPCRED(sf->nsf_fp), NULL, p);
 	if (!error)
 	    error = NFSD_RDWR(UIO_WRITE, vp,
-		(caddr_t)sf->nsf_bootvals,
+		PTR2CAP(sf->nsf_bootvals),
 		sf->nsf_numboots * sizeof (time_t),
 		(off_t)(sizeof (struct nfsf_rec)),
 		UIO_SYSSPACE, IO_SYNC, NFSFPCRED(sf->nsf_fp), NULL, p);
@@ -5100,7 +5100,7 @@ nfsrv_writestable(u_char *client, int len, int flag, NFSPROC_T *p)
 	NFSBCOPY(client, sp->client, len);
 	sp->flag = flag;
 	error = NFSD_RDWR(UIO_WRITE, NFSFPVNODE(sf->nsf_fp),
-	    (caddr_t)sp, sizeof (struct nfst_rec) + len - 1, (off_t)0,
+	    PTR2CAP(sp), sizeof (struct nfst_rec) + len - 1, (off_t)0,
 	    UIO_SYSSPACE, (IO_SYNC | IO_APPEND), NFSFPCRED(sf->nsf_fp), NULL, p);
 	free(sp, M_TEMP);
 	if (error) {
@@ -8465,7 +8465,7 @@ tryagain2:
 		ret = VOP_GETATTR(fvp, &va, cred);
 		aresid = 0;
 		while (ret == 0 && aresid == 0) {
-			ret = vn_rdwr(UIO_READ, fvp, dat, PNFSDS_COPYSIZ,
+			ret = vn_rdwr(UIO_READ, fvp, PTR2CAP(dat), PNFSDS_COPYSIZ,
 			    rdpos, UIO_SYSSPACE, IO_NODELOCKED, cred, NULL,
 			    &aresid, p);
 			xfer = PNFSDS_COPYSIZ - aresid;
@@ -8478,7 +8478,7 @@ tryagain2:
 				if (xfer < PNFSDS_COPYSIZ || rdpos ==
 				    va.va_size || NFSBCMP(dat,
 				    nfsrv_zeropnfsdat, PNFSDS_COPYSIZ) != 0)
-					ret = vn_rdwr(UIO_WRITE, tvp, dat, xfer,
+					ret = vn_rdwr(UIO_WRITE, tvp, PTR2CAP(dat), xfer,
 					    wrpos, UIO_SYSSPACE, IO_NODELOCKED,
 					    cred, NULL, NULL, p);
 				if (ret == 0)

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1727,8 +1727,7 @@ timekeep_cap(struct image_params *imgp)
 	KASSERT(timekeep_len == CHERI_REPRESENTABLE_LENGTH(timekeep_len),
 	    ("timekeep_len needs rounding"));
 
-	/* XXX: Read-only? */
-	return (cheri_capability_build_user_rwx(CHERI_CAP_USER_DATA_PERMS,
+	return (cheri_capability_build_user_data(CHERI_PERMS_USERSPACE_RODATA,
 	    timekeep_base, timekeep_len, 0));
 }
 #endif

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1212,7 +1212,7 @@ __elfN(get_interp)(struct image_params *imgp, const Elf_Phdr *phdr,
 			vn_lock(imgp->vp, LK_SHARED | LK_RETRY);
 		}
 
-		error = vn_rdwr(UIO_READ, imgp->vp, interp,
+		error = vn_rdwr(UIO_READ, imgp->vp, PTR2CAP(interp),
 		    interp_name_len, phdr->p_offset,
 		    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred,
 		    NOCRED, NULL, td);
@@ -1947,7 +1947,7 @@ static int
 core_compressed_write(void *base, size_t len, off_t offset, void *arg)
 {
 
-	return (core_write((struct coredump_params *)arg, base, len, offset,
+	return (core_write((struct coredump_params *)arg, PTR2CAP(base), len, offset,
 	    UIO_SYSSPACE, NULL));
 }
 
@@ -3215,7 +3215,7 @@ __elfN(parse_notes)(const struct image_params *imgp,
 			buf = malloc(pnote->p_filesz, M_TEMP, M_WAITOK);
 			vn_lock(imgp->vp, LK_SHARED | LK_RETRY);
 		}
-		error = vn_rdwr(UIO_READ, imgp->vp, buf, pnote->p_filesz,
+		error = vn_rdwr(UIO_READ, imgp->vp, PTR2CAP(buf), pnote->p_filesz,
 		    pnote->p_offset, UIO_SYSSPACE, IO_NODELOCKED,
 		    curthread->td_ucred, NOCRED, NULL, curthread);
 		if (error != 0) {

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1713,8 +1713,9 @@ interp_cap(struct image_params *imgp, Elf_Auxargs *args, uint64_t perms)
 static void * __capability
 timekeep_cap(struct image_params *imgp)
 {
+	void * __capability tmpcap;
 	struct vmspace *vmspace = imgp->proc->p_vmspace;
-	ptraddr_t timekeep_base;
+	uintcap_t timekeep_base;
 	size_t timekeep_len;
 
 	timekeep_base = vmspace->vm_shp_base + imgp->sysent->sv_timekeep_offset;
@@ -1727,8 +1728,11 @@ timekeep_cap(struct image_params *imgp)
 	KASSERT(timekeep_len == CHERI_REPRESENTABLE_LENGTH(timekeep_len),
 	    ("timekeep_len needs rounding"));
 
-	return (cheri_capability_build_user_data(CHERI_PERMS_USERSPACE_RODATA,
-	    timekeep_base, timekeep_len, 0));
+	tmpcap = (void * __capability)cheri_setboundsexact(
+	    cheri_andperm(timekeep_base, CHERI_PERMS_USERSPACE_RODATA),
+	    timekeep_len);
+
+	return (tmpcap);
 }
 #endif
 

--- a/sys/kern/kern_acct.c
+++ b/sys/kern/kern_acct.c
@@ -435,7 +435,7 @@ acct_process(struct thread *td)
 	/*
 	 * Write the accounting information to the file.
 	 */
-	ret = vn_rdwr(UIO_WRITE, acct_vp, (caddr_t)&acct, sizeof (acct),
+	ret = vn_rdwr(UIO_WRITE, acct_vp, PTR2CAP(&acct), sizeof (acct),
 	    (off_t)0, UIO_SYSSPACE, IO_APPEND|IO_UNIT, acct_cred, NOCRED,
 	    NULL, td);
 	sx_sunlock(&acct_sx);

--- a/sys/kern/kern_ctf.c
+++ b/sys/kern/kern_ctf.c
@@ -106,7 +106,7 @@ link_elf_ctf_get(linker_file_t lf, linker_ctf_t *lc)
 	hdr = malloc(sizeof(*hdr), M_LINKER, M_WAITOK);
 
 	/* Read the ELF header. */
-	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, hdr, sizeof(*hdr),
+	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(hdr), sizeof(*hdr),
 	    0, UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED, NULL,
 	    td)) != 0)
 		goto out;
@@ -128,7 +128,7 @@ link_elf_ctf_get(linker_file_t lf, linker_ctf_t *lc)
 	shdr = malloc(nbytes, M_LINKER, M_WAITOK);
 
 	/* Read all the section headers */
-	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, (caddr_t)shdr, nbytes,
+	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(shdr), nbytes,
 	    hdr->e_shoff, UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    NULL, td)) != 0)
 		goto out;
@@ -150,7 +150,7 @@ link_elf_ctf_get(linker_file_t lf, linker_ctf_t *lc)
 	shstrtab = malloc(shdr[hdr->e_shstrndx].sh_size, M_LINKER, M_WAITOK);
 
 	/* Read the section header strings. */
-	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, shstrtab,
+	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(shstrtab),
 	    shdr[hdr->e_shstrndx].sh_size, shdr[hdr->e_shstrndx].sh_offset,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED, NULL, td)) != 0)
 		goto out;
@@ -169,7 +169,7 @@ link_elf_ctf_get(linker_file_t lf, linker_ctf_t *lc)
 	}
 
 	/* Read the CTF header. */
-	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, &cth, sizeof(cth),
+	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(&cth), sizeof(cth),
 	    shdr[i].sh_offset, UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred,
 	    NOCRED, NULL, td)) != 0)
 		goto out;
@@ -225,7 +225,8 @@ link_elf_ctf_get(linker_file_t lf, linker_ctf_t *lc)
 	 * Read the CTF data into the raw buffer if compressed, or
 	 * directly into the CTF buffer otherwise.
 	 */
-	if ((error = vn_rdwr(UIO_READ, nd.ni_vp, raw == NULL ? ctftab : raw,
+	if ((error = vn_rdwr(UIO_READ, nd.ni_vp,
+	    PTR2CAP(raw == NULL ? ctftab : raw),
 	    shdr[i].sh_size, shdr[i].sh_offset, UIO_SYSSPACE, IO_NODELOCKED,
 	    td->td_ucred, NOCRED, NULL, td)) != 0)
 		goto out;

--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -1982,7 +1982,7 @@ linker_hints_lookup(const char *path, int pathlen, const char *modname,
 		goto bad;
 	}
 	hints = malloc(vattr.va_size, M_TEMP, M_WAITOK);
-	error = vn_rdwr(UIO_READ, nd.ni_vp, (caddr_t)hints, vattr.va_size, 0,
+	error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(hints), vattr.va_size, 0,
 	    UIO_SYSSPACE, IO_NODELOCKED, cred, NOCRED, &reclen, td);
 	if (error)
 		goto bad;

--- a/sys/kern/kern_vnodedumper.c
+++ b/sys/kern/kern_vnodedumper.c
@@ -175,7 +175,7 @@ vnode_dump(void *arg, void *virtual, off_t offset, size_t length)
 	if (virtual == NULL)
 		return (0);
 
-	error = vn_rdwr(UIO_WRITE, vp, virtual, length, offset, UIO_SYSSPACE,
+	error = vn_rdwr(UIO_WRITE, vp, PTR2CAP(virtual), length, offset, UIO_SYSSPACE,
 	    IO_NODELOCKED, curthread->td_ucred, NOCRED, NULL, curthread);
 	if (error != 0)
 		uprintf("%s: error writing livedump block at offset %jx: %d\n",
@@ -201,7 +201,7 @@ vnode_write_headers(struct dumperinfo *di, struct kerneldumpheader *kdh)
 	offset = roundup2(di->dumpoff, di->blocksize);
 
 	/* Write the kernel dump header to the end of the file. */
-	error = vn_rdwr(UIO_WRITE, vp, kdh, sizeof(*kdh), offset,
+	error = vn_rdwr(UIO_WRITE, vp, PTR2CAP(kdh), sizeof(*kdh), offset,
 	    UIO_SYSSPACE, IO_NODELOCKED, curthread->td_ucred, NOCRED, NULL,
 	    curthread);
 	if (error != 0)

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -1105,7 +1105,7 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 	 */
 	firstpage = malloc(PAGE_SIZE, M_LINKER, M_WAITOK);
 	hdr = (Elf_Ehdr *)firstpage;
-	error = vn_rdwr(UIO_READ, nd.ni_vp, firstpage, PAGE_SIZE, 0,
+	error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(firstpage), PAGE_SIZE, 0,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
 	nbytes = PAGE_SIZE - resid;
@@ -1285,7 +1285,7 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 #endif
 
 		error = vn_rdwr(UIO_READ, nd.ni_vp,
-		    segbase, segs[i]->p_filesz, segs[i]->p_offset,
+		    PTR2CAP(segbase), segs[i]->p_filesz, segs[i]->p_offset,
 		    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 		    &resid, td);
 		if (error != 0)
@@ -1367,7 +1367,7 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 		goto nosyms;
 	shdr = malloc(nbytes, M_LINKER, M_WAITOK | M_ZERO);
 	error = vn_rdwr(UIO_READ, nd.ni_vp,
-	    (caddr_t)shdr, nbytes, hdr->e_shoff,
+	    PTR2CAP(shdr), nbytes, hdr->e_shoff,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
 	if (error != 0)
@@ -1379,7 +1379,7 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 	    shdr[shstrindex].sh_size != 0) {
 		nbytes = shdr[shstrindex].sh_size;
 		shstrs = malloc(nbytes, M_LINKER, M_WAITOK | M_ZERO);
-		error = vn_rdwr(UIO_READ, nd.ni_vp, (caddr_t)shstrs, nbytes,
+		error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(shstrs), nbytes,
 		    shdr[shstrindex].sh_offset, UIO_SYSSPACE, IO_NODELOCKED,
 		    td->td_ucred, NOCRED, &resid, td);
 		if (error)
@@ -1408,13 +1408,13 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 	ef->strbase = malloc(strcnt, M_LINKER, M_WAITOK);
 
 	error = vn_rdwr(UIO_READ, nd.ni_vp,
-	    ef->symbase, symcnt, shdr[symtabindex].sh_offset,
+	    PTR2CAP(ef->symbase), symcnt, shdr[symtabindex].sh_offset,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
 	if (error != 0)
 		goto out;
 	error = vn_rdwr(UIO_READ, nd.ni_vp,
-	    ef->strbase, strcnt, shdr[symstrindex].sh_offset,
+	    PTR2CAP(ef->strbase), strcnt, shdr[symstrindex].sh_offset,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
 	if (error != 0)

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -758,7 +758,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 
 	/* Read the elf header from the file. */
 	hdr = malloc(sizeof(*hdr), M_LINKER, M_WAITOK);
-	error = vn_rdwr(UIO_READ, nd->ni_vp, (void *)hdr, sizeof(*hdr), 0,
+	error = vn_rdwr(UIO_READ, nd->ni_vp, PTR2CAP(hdr), sizeof(*hdr), 0,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
 	if (error)
@@ -830,7 +830,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 	}
 	shdr = malloc(nbytes, M_LINKER, M_WAITOK);
 	ef->e_shdr = shdr;
-	error = vn_rdwr(UIO_READ, nd->ni_vp, (caddr_t)shdr, nbytes,
+	error = vn_rdwr(UIO_READ, nd->ni_vp, PTR2CAP(shdr), nbytes,
 	    hdr->e_shoff, UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred,
 	    NOCRED, &resid, td);
 	if (error)
@@ -920,7 +920,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 	/* Allocate space for and load the symbol table */
 	ef->ddbsymcnt = shdr[symtabindex].sh_size / sizeof(Elf_Sym);
 	ef->ddbsymtab = malloc(shdr[symtabindex].sh_size, M_LINKER, M_WAITOK);
-	error = vn_rdwr(UIO_READ, nd->ni_vp, (void *)ef->ddbsymtab,
+	error = vn_rdwr(UIO_READ, nd->ni_vp, PTR2CAP(ef->ddbsymtab),
 	    shdr[symtabindex].sh_size, shdr[symtabindex].sh_offset,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
@@ -934,7 +934,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 	/* Allocate space for and load the symbol strings */
 	ef->ddbstrcnt = shdr[symstrindex].sh_size;
 	ef->ddbstrtab = malloc(shdr[symstrindex].sh_size, M_LINKER, M_WAITOK);
-	error = vn_rdwr(UIO_READ, nd->ni_vp, ef->ddbstrtab,
+	error = vn_rdwr(UIO_READ, nd->ni_vp, PTR2CAP(ef->ddbstrtab),
 	    shdr[symstrindex].sh_size, shdr[symstrindex].sh_offset,
 	    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 	    &resid, td);
@@ -953,7 +953,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 		ef->shstrcnt = shdr[shstrindex].sh_size;
 		ef->shstrtab = malloc(shdr[shstrindex].sh_size, M_LINKER,
 		    M_WAITOK);
-		error = vn_rdwr(UIO_READ, nd->ni_vp, ef->shstrtab,
+		error = vn_rdwr(UIO_READ, nd->ni_vp, PTR2CAP(ef->shstrtab),
 		    shdr[shstrindex].sh_size, shdr[shstrindex].sh_offset,
 		    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 		    &resid, td);
@@ -1142,7 +1142,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 #endif
 			    ) {
 				error = vn_rdwr(UIO_READ, nd->ni_vp,
-				    ef->progtab[pb].addr,
+				    PTR2CAP(ef->progtab[pb].addr),
 				    shdr[i].sh_size, shdr[i].sh_offset,
 				    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred,
 				    NOCRED, &resid, td);
@@ -1185,7 +1185,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 			ef->reltab[rl].nrel = shdr[i].sh_size / sizeof(Elf_Rel);
 			ef->reltab[rl].sec = shdr[i].sh_info;
 			error = vn_rdwr(UIO_READ, nd->ni_vp,
-			    (void *)ef->reltab[rl].rel,
+			    PTR2CAP((void *)ef->reltab[rl].rel),
 			    shdr[i].sh_size, shdr[i].sh_offset,
 			    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 			    &resid, td);
@@ -1206,7 +1206,7 @@ link_elf_load_file(linker_class_t cls, const char *filename,
 			    shdr[i].sh_size / sizeof(Elf_Rela);
 			ef->relatab[ra].sec = shdr[i].sh_info;
 			error = vn_rdwr(UIO_READ, nd->ni_vp,
-			    (void *)ef->relatab[ra].rela,
+			    PTR2CAP((void *)ef->relatab[ra].rela),
 			    shdr[i].sh_size, shdr[i].sh_offset,
 			    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED,
 			    &resid, td);

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -515,39 +515,6 @@ copyout_unmap(struct thread *td, vm_pointer_t addr, size_t sz)
 	return (0);
 }
 
-#if __has_feature(capabilities)
-int
-copyin_implicit_cap(const void *uaddr, void *kaddr, size_t len)
-{
-
-	return (copyin(cheri_capability_build_user_data(
-	    CHERI_CAP_USER_DATA_PERMS, (ptraddr_t)uaddr, len, 0), kaddr, len));
-}
-
-int
-copyout_implicit_cap(const void *kaddr, void *uaddr, size_t len)
-{
-
-	return (copyout(kaddr,
-	    cheri_capability_build_user_data(CHERI_CAP_USER_DATA_PERMS,
-	    (ptraddr_t)uaddr, len, 0), len));
-}
-#else
-int
-copyin_implicit_cap(const void *uaddr, void *kaddr, size_t len)
-{
-
-	return (copyin(uaddr, kaddr, len));
-}
-
-int
-copyout_implicit_cap(const void *kaddr, void *uaddr, size_t len)
-{
-
-	return (copyout(kaddr, uaddr, len));
-}
-#endif
-
 int32_t
 fuword32(volatile const void * __capability addr)
 {

--- a/sys/kern/vfs_mountroot.c
+++ b/sys/kern/vfs_mountroot.c
@@ -956,7 +956,7 @@ vfs_mountroot_readconf(struct thread *td, struct sbuf *sb)
 	ofs = 0;
 	len = sizeof(buf) - 1;
 	while (1) {
-		error = vn_rdwr(UIO_READ, nd.ni_vp, buf, len, ofs,
+		error = vn_rdwr(UIO_READ, nd.ni_vp, PTR2CAP(buf), len, ofs,
 		    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred,
 		    NOCRED, &resid, td);
 		if (error)

--- a/sys/riscv/include/cherireg.h
+++ b/sys/riscv/include/cherireg.h
@@ -118,6 +118,9 @@
 	(CHERI_PERMS_USERSPACE | CHERI_PERM_STORE |			\
 	CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP)
 
+#define	CHERI_PERMS_USERSPACE_RODATA					\
+	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD)
+
 /*
  * Corresponding permission masks for kernel code and data; these are
  * currently a bit broad, and should be narrowed over time as the kernel

--- a/sys/security/audit/audit_worker.c
+++ b/sys/security/audit/audit_worker.c
@@ -266,7 +266,7 @@ audit_record_write(struct vnode *vp, struct ucred *cred, void *data,
 		}
 	}
 
-	error = vn_rdwr(UIO_WRITE, vp, data, len, (off_t)0, UIO_SYSSPACE,
+	error = vn_rdwr(UIO_WRITE, vp, PTR2CAP(data), len, (off_t)0, UIO_SYSSPACE,
 	    IO_APPEND|IO_UNIT, cred, NULL, NULL, curthread);
 	if (error == ENOSPC)
 		goto fail_enospc;

--- a/sys/security/mac_veriexec/veriexec_fingerprint.c
+++ b/sys/security/mac_veriexec/veriexec_fingerprint.c
@@ -153,7 +153,7 @@ evaluate_fingerprint(struct vnode *vp, struct mac_veriexec_file_info *ip,
 		else
 			count = PAGE_SIZE;
 
-		error = vn_rdwr_inchunks(UIO_READ, vp, filebuf, count, offset,
+		error = vn_rdwr_inchunks(UIO_READ, vp, PTR2CAP(filebuf), count, offset,
 		    UIO_SYSSPACE, IO_NODELOCKED, td->td_ucred, NOCRED, &resid,
 		    td);
 		if (error)

--- a/sys/security/mac_veriexec_parser/mac_veriexec_parser.c
+++ b/sys/security/mac_veriexec_parser/mac_veriexec_parser.c
@@ -278,7 +278,7 @@ read_manifest(char *path, unsigned char *digest)
 
 	while (bytes_read < va.va_size) {
 		rc = vn_rdwr(
-		    UIO_READ, nid.ni_vp, data,
+		    UIO_READ, nid.ni_vp, PTR2CAP(data),
 		    va.va_size - bytes_read, bytes_read,
 		    UIO_SYSSPACE, IO_NODELOCKED,
 		    curthread->td_ucred, NOCRED, &resid, curthread);

--- a/sys/sys/exec.h
+++ b/sys/sys/exec.h
@@ -109,7 +109,7 @@ enum uio_seg;
 
 #define   CORE_BUF_SIZE   (16 * 1024)
 
-int core_write(struct coredump_params *, const void *, size_t, off_t,
+int core_write(struct coredump_params *, const void * __capability, size_t, off_t,
     enum uio_seg, size_t *);
 int core_output(char * __capability, size_t, off_t, struct coredump_params *,
     void *);

--- a/sys/sys/malloc.h
+++ b/sys/sys/malloc.h
@@ -232,7 +232,8 @@ void	*malloc(size_t size, struct malloc_type *type, int flags) __malloc_like
  */
 #define	malloc(size, type, flags) ({					\
 	void *_malloc_item;						\
-	size_t _size = (size);						\
+	/* XXX-CHERI: work around CTSRD-CHERI/llvm-project#647 */	\
+	size_t _size = CHERI_REPRESENTABLE_LENGTH(size);		\
 	if (__builtin_constant_p(size) && __builtin_constant_p(flags) &&\
 	    ((flags) & M_ZERO) != 0) {					\
 		_malloc_item = malloc(_size, type, (flags) &~ M_ZERO);	\

--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -430,7 +430,7 @@ __END_DECLS
 	KASSERT((ptraddr_t)((p)) == 0 ||			\
 	    (ptraddr_t)((p)) >= VM_MAXUSER_ADDRESS,		\
 	    ("PTR2CAP on user address: %p", (p)));		\
-	(__cheri_tocap __typeof__((*p)) * __capability)(p);	\
+	(__cheri_tocap __typeof__((*(p))) * __capability)(p);	\
 	})
 #else
 #define	PTR2CAP(p)	(p)

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -377,8 +377,6 @@ int	copyinstr(const void * __restrict __capability udaddr,
 	    size_t * __restrict lencopied);
 int	copyin(const void * __restrict __capability udaddr,
 	    void * _Nonnull __restrict kaddr, size_t len);
-int	copyin_implicit_cap(const void * __restrict udaddr,
-	    void * _Nonnull __restrict kaddr, size_t len);
 #if __has_feature(capabilities)
 int	copyincap(const void * __restrict __capability udaddr,
 	    void * _Nonnull __restrict kaddr, size_t len);
@@ -389,8 +387,6 @@ int	copyin_nofault(const void * __capability __restrict udaddr,
 	    void * _Nonnull __restrict kaddr, size_t len);
 int	copyout(const void * _Nonnull __restrict kaddr,
 	    void * __restrict __capability udaddr, size_t len);
-int	copyout_implicit_cap(const void * _Nonnull __restrict kaddr,
-	    void * __restrict udaddr, size_t len);
 #if __has_feature(capabilities)
 int	copyoutcap(const void * _Nonnull __restrict kaddr,
 	    void * __capability __restrict udaddr, size_t len);

--- a/sys/sys/vnode.h
+++ b/sys/sys/vnode.h
@@ -777,11 +777,11 @@ void	vn_pages_remove(struct vnode *vp, vm_pindex_t start, vm_pindex_t end);
 void	vn_pages_remove_valid(struct vnode *vp, vm_pindex_t start,
 	    vm_pindex_t end);
 int	vn_pollrecord(struct vnode *vp, struct thread *p, int events);
-int	vn_rdwr(enum uio_rw rw, struct vnode *vp, void *base,
+int	vn_rdwr(enum uio_rw rw, struct vnode *vp, void * __capability base,
 	    int len, off_t offset, enum uio_seg segflg, int ioflg,
 	    struct ucred *active_cred, struct ucred *file_cred, ssize_t *aresid,
 	    struct thread *td);
-int	vn_rdwr_inchunks(enum uio_rw rw, struct vnode *vp, void *base,
+int	vn_rdwr_inchunks(enum uio_rw rw, struct vnode *vp, void * __capability base,
 	    size_t len, off_t offset, enum uio_seg segflg, int ioflg,
 	    struct ucred *active_cred, struct ucred *file_cred, size_t *aresid,
 	    struct thread *td);

--- a/sys/ufs/ufs/ufs_lookup.c
+++ b/sys/ufs/ufs/ufs_lookup.c
@@ -1326,7 +1326,7 @@ ufs_dirempty(struct inode *ip, ino_t parentino, struct ucred *cred)
 #define	MINDIRSIZ (sizeof (struct dirtemplate) / 2)
 
 	for (off = 0; off < ip->i_size; off += dp->d_reclen) {
-		error = vn_rdwr(UIO_READ, ITOV(ip), (caddr_t)dp, MINDIRSIZ,
+		error = vn_rdwr(UIO_READ, ITOV(ip), PTR2CAP(dp), MINDIRSIZ,
 		    off, UIO_SYSSPACE, IO_NODELOCKED | IO_NOMACCHECK, cred,
 		    NOCRED, &count, (struct thread *)0);
 		/*
@@ -1394,7 +1394,7 @@ ufs_dir_dd_ino(struct vnode *vp, struct ucred *cred, ino_t *dd_ino,
 	/*
 	 * Have to read the directory.
 	 */
-	error = vn_rdwr(UIO_READ, vp, (caddr_t)&dirbuf,
+	error = vn_rdwr(UIO_READ, vp, PTR2CAP(&dirbuf),
 	    sizeof (struct dirtemplate), (off_t)0, UIO_SYSSPACE,
 	    IO_NODELOCKED | IO_NOMACCHECK, cred, NOCRED, NULL, NULL);
 	if (error != 0)

--- a/sys/ufs/ufs/ufs_vnops.c
+++ b/sys/ufs/ufs/ufs_vnops.c
@@ -2391,7 +2391,7 @@ ufs_symlink(
 		UFS_INODE_SET_FLAG(ip, IN_SIZEMOD | IN_CHANGE | IN_UPDATE);
 		error = UFS_UPDATE(vp, 0);
 	} else
-		error = vn_rdwr(UIO_WRITE, vp, __DECONST(void *, ap->a_target),
+		error = vn_rdwr(UIO_WRITE, vp, PTR2CAP(__DECONST(void *, ap->a_target)),
 		    len, (off_t)0, UIO_SYSSPACE, IO_NODELOCKED | IO_NOMACCHECK,
 		    ap->a_cnp->cn_cred, NOCRED, NULL, NULL);
 	if (error)

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5427,7 +5427,13 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	    ("Unrepresentable length for new vmspace"));
 
 	user_length = CHERI_REPRESENTABLE_LENGTH(user_length);
-	minuser_cap = (vm_pointer_t)cheri_capability_build_user_rwx(
+	/*
+	 * XXX: Use the unchecked version here because the map is empty
+	 * at this point.
+	 *
+	 * XXX: It seems like this should be an sv_* member.
+	 */
+	minuser_cap = (vm_pointer_t)cheri_capability_build_user_rwx_unchecked(
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_PERMS_SWALL, padded_minuser, user_length, minuser);
 	maxuser_cap = cheri_setaddress(minuser_cap, maxuser);

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -309,7 +309,7 @@ struct vmspace {
 	caddr_t vm_daddr;	/* (c) user virtual address of data */
 	vm_offset_t vm_maxsaddr;	/* user VA at max stack growth */
 	vm_offset_t vm_stacktop; /* top of the stack, may not be page-aligned */
-	vm_offset_t vm_shp_base; /* shared page address */
+	uintcap_t vm_shp_base;	/* shared page pointer */
 	u_int vm_refcnt;	/* number of references */
 	/*
 	 * Keep the PMAP last, so that CPU-specific variations of that


### PR DESCRIPTION
The final commit of this series contains a check that cheri_capability_build_user_* creates that fall within a single reservation so their properties don't differ from those created by mmap. Validating this change spurred me to look at other cheri_capability_build_user_* users and I was able to eliminate some and consolidate others. Now most of them are appropriately concentrated in the exec/imgact path.