### PR TITLE
freebsd*: Make sendmsg match native ABI for unpadded final control message

### DIFF
--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -1479,15 +1479,19 @@ freebsd32_copyin_control(struct mbuf **mp, caddr_t buf, u_int buflen)
 			break;
 		}
 		cm = (struct cmsghdr *)in1;
-		if (cm->cmsg_len < FREEBSD32_ALIGN(sizeof(*cm))) {
+		if (cm->cmsg_len < FREEBSD32_ALIGN(sizeof(*cm)) ||
+		    cm->cmsg_len > buflen) {
 			error = EINVAL;
 			break;
 		}
 		msglen = FREEBSD32_ALIGN(cm->cmsg_len);
-		if (msglen > buflen || msglen < cm->cmsg_len) {
+		if (msglen < cm->cmsg_len) {
 			error = EINVAL;
 			break;
 		}
+		/* The native ABI permits the final padding to be omitted. */
+		if (msglen > buflen)
+			msglen = buflen;
 		buflen -= msglen;
 
 		in1 = (char *)in1 + msglen;

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -286,15 +286,19 @@ freebsd64_copyin_control(struct mbuf **mp, char * __capability buf,
 			break;
 		}
 		cm = (struct cmsghdr *)in1;
-		if (cm->cmsg_len < FREEBSD64_ALIGN(sizeof(*cm))) {
+		if (cm->cmsg_len < FREEBSD64_ALIGN(sizeof(*cm)) ||
+		    cm->cmsg_len > buflen) {
 			error = EINVAL;
 			break;
 		}
 		msglen = FREEBSD64_ALIGN(cm->cmsg_len);
-		if (msglen > buflen || msglen < cm->cmsg_len) {
+		if (msglen < cm->cmsg_len) {
 			error = EINVAL;
 			break;
 		}
+		/* The native ABI permits the final padding to be omitted. */
+		if (msglen > buflen)
+			msglen = buflen;
 		buflen -= msglen;
 
 		in1 = (char *)in1 + msglen;


### PR DESCRIPTION
The API says that CMSG_SPACE should be used for msg_controllen, but in practice the native ABI allows you to only use CMSG_LEN for the final (typically only) control message, and real-world software does this, including Wayland. For freebsd32, this is in practice mostly harmless, since control messages are generally used to carry file descriptors, which are already 4 bytes in size and thus no padding is needed, but they can carry other quantities that may not result in an aligned length. However, freebsd64 uses 8 byte alignment which does break the file descriptor use case, and thus Wayland.
