### PR TITLE
readelf: Dump NT_CHERIBSD_ABI_TAG

### DIFF
--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -373,6 +373,7 @@ static const char *note_type(const char *note_name, unsigned int et,
     unsigned int nt);
 static const char *note_type_freebsd(unsigned int nt);
 static const char *note_type_freebsd_core(unsigned int nt);
+static const char *note_type_cheribsd(unsigned int nt);
 static const char *note_type_go(unsigned int nt);
 static const char *note_type_gnu(unsigned int nt);
 static const char *note_type_linux_core(unsigned int nt);
@@ -1152,6 +1153,8 @@ note_type(const char *name, unsigned int et, unsigned int nt)
 			return note_type_freebsd_core(nt);
 		else
 			return note_type_freebsd(nt);
+	else if (strcmp(name, "CheriBSD") == 0 && et != ET_CORE)
+		return note_type_cheribsd(nt);
 	else if (strcmp(name, "GNU") == 0 && et != ET_CORE)
 		return note_type_gnu(nt);
 	else if (strcmp(name, "Go") == 0 && et != ET_CORE)
@@ -1163,6 +1166,15 @@ note_type(const char *name, unsigned int et, unsigned int nt)
 	else if (strcmp(name, "Xen") == 0 && et != ET_CORE)
 		return note_type_xen(nt);
 	return note_type_unknown(nt);
+}
+
+static const char *
+note_type_cheribsd(unsigned int nt)
+{
+	switch (nt) {
+	case NT_CHERIBSD_ABI_TAG: return "NT_CHERIBSD_ABI_TAG";
+	default: return (note_type_unknown(nt));
+	}
 }
 
 static const char *
@@ -3841,6 +3853,13 @@ dump_notes_data(struct readelf *re, const char *name, uint32_t type,
 				goto unknown;
 			printf("   Features:");
 			dump_flags(note_feature_ctl_flags, ubuf[0]);
+			return;
+		}
+	} else if (strcmp(name, "CheriBSD") == 0) {
+		if (type == NT_CHERIBSD_ABI_TAG) {
+			if (sz != 4)
+				goto unknown;
+			printf("   ABI tag: %u\n", ubuf[0]);
 			return;
 		}
 	} else if (strcmp(name, "Go") == 0) {


### PR DESCRIPTION
I was trying to figure out why pkg was not happy after rebuilding from dev and noticed that NT_CHERIBSD_ABI_TAG was not being pretty-printed:
```
Notes at offset 0x000002d8 with length 0x00000064:
  Owner         Data size       Description
  FreeBSD       0x00000004      NT_FREEBSD_ABI_TAG
   ABI tag: 1400064
  CheriBSD      0x00000004      <unknown: 1>
   description data: 9c 8b 34 01
  FreeBSD       0x00000004      NT_FREEBSD_FEATURE_CTL
   Features:
  FreeBSD       0x00000004      NT_FREEBSD_NOINIT_TAG
   description data: 00 00 00 00
```

After:
```
Notes at offset 0x000002d8 with length 0x00000064:
  Owner         Data size       Description
  FreeBSD       0x00000004      NT_FREEBSD_ABI_TAG
   ABI tag: 1400064
  CheriBSD      0x00000004      NT_CHERIBSD_ABI_TAG
   ABI tag: 20220828
  FreeBSD       0x00000004      NT_FREEBSD_FEATURE_CTL
   Features:
  FreeBSD       0x00000004      NT_FREEBSD_NOINIT_TAG
   description data: 00 00 00 00
```