### PR TITLE
Drop an old local diff and update testsuite Jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -281,7 +281,7 @@ selectedArchitectures.each { suffix ->
         def extraBuildOptions = '-s'
         if (GlobalVars.isTestSuiteJob) {
             // Enable additional debug checks when running the testsuite
-            extraBuildOptions += ' -DMALLOC_DEBUG'
+            extraBuildOptions += ' -DWITHOUT_MALLOC_PRODUCTION'
         }
         def cheribuildArgs = [
                 "'--cheribsd/build-options=${extraBuildOptions}'",

--- a/lib/libc/stdlib/jemalloc/Makefile.inc
+++ b/lib/libc/stdlib/jemalloc/Makefile.inc
@@ -49,8 +49,6 @@ MLINKS+= \
 	jemalloc.3 nallocx.3 \
 	jemalloc.3 malloc.conf.5
 
-.if defined(MALLOC_DEBUG)
-CFLAGS+=	-DJEMALLOC_DEBUG
-.elif ${MK_MALLOC_PRODUCTION} != "no" || defined(MALLOC_PRODUCTION)
+.if ${MK_MALLOC_PRODUCTION} != "no" || defined(MALLOC_PRODUCTION)
 CFLAGS+=	-DMALLOC_PRODUCTION
 .endif


### PR DESCRIPTION
Instead of setting MALLOC_DEBUG (which will result in a -Werror compile failure), override cheribuild's default of -DWITH_MALLOC_PRODUCTION by passing -DWITHOUT_MALLOC_PRODUCTION. We could also set the build type to Debug, but for the sake of vaguely reasonable testsuite run times on QEMU, we should keep it as release+debug info+malloc assertions.