### PR TITLE
usr.sbin/pmcstat: return non-zero if the launched command fails

### DIFF
--- a/usr.sbin/pmcstat/pmcstat.c
+++ b/usr.sbin/pmcstat/pmcstat.c
@@ -452,6 +452,7 @@ main(int argc, char **argv)
 	int do_callchain, do_descendants, do_logproccsw, do_logprocexit;
 	int do_print, do_read, do_listcounters, do_descr, domains;
 	int do_userspace, i;
+	int exitcode;
 	size_t len;
 	int graphdepth;
 	int pipefd[2], rfd;
@@ -480,6 +481,7 @@ main(int argc, char **argv)
 	do_logprocexit          = 0;
 	do_listcounters         = 0;
 	domains			= 0;
+	exitcode		= EXIT_SUCCESS;
 	use_cumulative_counts   = 0;
 	graphfilename		= "-";
 	args.pa_required	= 0;
@@ -1420,6 +1422,8 @@ main(int argc, char **argv)
 				 * ourselves.
 				 */
 				(void) wait(&c);
+				if (!WIFEXITED(c) || WEXITSTATUS(c) != 0)
+					exitcode = EXIT_FAILURE;
 				runstate = PMCSTAT_FINISHED;
 			} else if (kev.ident == SIGIO) {
 				/*
@@ -1516,5 +1520,5 @@ main(int argc, char **argv)
 			    );
 	}
 
-	exit(EX_OK);
+	exit(exitcode);
 }


### PR DESCRIPTION
Previously pmcstat would return a success return code even if the process that it launched crashed or returned a failure code. Returning a non-zero exit code means that we can more easily detect if a benchmark did not run as expected even when running it under pmcstat.

While it might make sense to propagate the exit code/signal via pmcstat, simply returning 1 if the child process fails should be sufficient.