### PR TITLE
Support event aliases in pmcstat

### DIFF
--- a/lib/libpmc/libpmc.c
+++ b/lib/libpmc/libpmc.c
@@ -1114,6 +1114,12 @@ pmc_allocate(const char *ctrspec, enum pmc_mode mode,
 				break;
 			}
 
+	/* Try pmu_alias_get as another generic fallback/ */
+	if (spec_copy == NULL) {
+		const char* alias_name = _pmu_alias_get(ctrspec);
+		if (alias_name)
+			spec_copy = strdup(alias_name);
+	}
 	if (spec_copy == NULL)
 		spec_copy = strdup(ctrspec);
 

--- a/lib/libpmc/libpmc.c
+++ b/lib/libpmc/libpmc.c
@@ -1103,28 +1103,29 @@ pmc_allocate(const char *ctrspec, enum pmc_mode mode,
 		pmc_config.pm_caps = 0;
 		pmc_config.pm_class = 0;
 	}
-	free(spec_copy);
-	spec_copy = NULL;
 
 	/* replace an event alias with the canonical event specifier */
 	if (pmc_mdep_event_aliases)
 		for (alias = pmc_mdep_event_aliases; alias->pm_alias; alias++)
-			if (!strcasecmp(ctrspec, alias->pm_alias)) {
-				spec_copy = strdup(alias->pm_spec);
+			if (!strcasecmp(ctrname, alias->pm_alias)) {
+				/* Aliases must not contain a comma. */
+				if (strchr(alias->pm_alias, ',')) {
+					errno = EDOOFUS;
+					goto out;
+				}
+				ctrname = alias->pm_spec;
 				break;
 			}
-
-	/* Try pmu_alias_get as another generic fallback/ */
-	if (spec_copy == NULL) {
-		const char* alias_name = _pmu_alias_get(ctrspec);
-		if (alias_name)
-			spec_copy = strdup(alias_name);
+	/* Try pmu_alias_get as another generic fallback. */
+	const char* alias_name = _pmu_alias_get(ctrname);
+	if (alias_name != ctrname) {
+		/* Aliases must not contain a comma. */
+		if (strchr(alias_name, ',')) {
+			errno = EDOOFUS;
+			goto out;
+		}
+		ctrname = alias_name;
 	}
-	if (spec_copy == NULL)
-		spec_copy = strdup(ctrspec);
-
-	r = spec_copy;
-	ctrname = strsep(&r, ",");
 
 	/*
 	 * If a explicit class prefix was given by the user, restrict the
@@ -1173,8 +1174,7 @@ found:
 		retval = 0;
 	}
 out:
-	if (spec_copy)
-		free(spec_copy);
+	free(spec_copy);
 
 	return (retval);
 }

--- a/lib/libpmc/libpmc_pmu_util.c
+++ b/lib/libpmc/libpmc_pmu_util.c
@@ -176,6 +176,7 @@ static struct pmu_alias pmu_armv8_alias_table[] = {
 	{"BRANCH-INSTRUCTION-RETIRED", "BR_RETIRED"},
 	{"BRANCH_MISSES_RETIRED", "BR_MIS_PRED_RETIRED"},
 	{"BRANCH-MISSES-RETIRED", "BR_MIS_PRED_RETIRED"},
+	{"cycles", "CPU_CYCLES"},
 	{"unhalted-cycles", "CPU_CYCLES"},
 	{"instructions", "INST_RETIRED",},
 	{"branch-mispredicts", "BR_MIS_PRED_RETIRED"},

--- a/lib/libpmc/libpmc_pmu_util.c
+++ b/lib/libpmc/libpmc_pmu_util.c
@@ -45,6 +45,7 @@
 #include <pmclog.h>
 #include <assert.h>
 #include <libpmcstat.h>
+#include "libpmcinternal.h"
 #include "pmu-events/pmu-events.h"
 
 struct pmu_alias {
@@ -132,8 +133,8 @@ pmu_events_mfr(void)
  *
  */
 
-static const char *
-pmu_alias_get(const char *name)
+const char *
+_pmu_alias_get(const char *name)
 {
 	pmu_mfr_t mfr;
 	struct pmu_alias *pa;
@@ -156,8 +157,8 @@ pmu_alias_get(const char *name)
 }
 #elif defined(__powerpc64__)
 
-static const char *
-pmu_alias_get(const char *name)
+const char *
+_pmu_alias_get(const char *name)
 {
 	return (name);
 }
@@ -183,8 +184,8 @@ static struct pmu_alias pmu_armv8_alias_table[] = {
 	{NULL, NULL},
 };
 
-static const char *
-pmu_alias_get(const char *name)
+const char *
+_pmu_alias_get(const char *name)
 {
 	struct pmu_alias *pa;
 
@@ -197,8 +198,8 @@ pmu_alias_get(const char *name)
 
 #else
 
-static const char *
-pmu_alias_get(const char *name)
+const char *
+_pmu_alias_get(const char *name)
 {
 
 	return (name);
@@ -284,7 +285,7 @@ pmc_pmu_idx_get_by_event(const char *cpuid, const char *event)
 	int idx;
 	const char *realname;
 
-	realname = pmu_alias_get(event);
+	realname = _pmu_alias_get(event);
 	if (pmu_event_get(cpuid, realname, &idx) == NULL)
 		return (-1);
 	return (idx);
@@ -365,7 +366,7 @@ pmc_pmu_sample_rate_get(const char *event_name)
 	const struct pmu_event *pe;
 	struct pmu_event_desc ped;
 
-	event_name = pmu_alias_get(event_name);
+	event_name = _pmu_alias_get(event_name);
 	if ((pe = pmu_event_get(NULL, event_name, NULL)) == NULL)
 		return (DEFAULT_SAMPLE_COUNT);
 	if (pe->event == NULL)
@@ -587,7 +588,7 @@ pmc_pmu_pmcallocate(const char *event_name, struct pmc_op_pmcallocate *pm)
 
 	bzero(&pm->pm_md, sizeof(pm->pm_md));
 	pm->pm_caps |= (PMC_CAP_READ | PMC_CAP_WRITE);
-	event_name = pmu_alias_get(event_name);
+	event_name = _pmu_alias_get(event_name);
 	if ((pe = pmu_event_get(NULL, event_name, &idx)) == NULL)
 		return (ENOENT);
 	assert(idx >= 0);
@@ -615,7 +616,7 @@ pmc_pmu_pmcallocate(const char *event_name, struct pmc_op_pmcallocate *pm)
 
 	bzero(&pm->pm_md, sizeof(pm->pm_md));
 	pm->pm_caps |= (PMC_CAP_READ | PMC_CAP_WRITE);
-	event_name = pmu_alias_get(event_name);
+	event_name = _pmu_alias_get(event_name);
 
 	if ((pe = pmu_event_get(NULL, event_name, &idx)) == NULL)
 		return (ENOENT);
@@ -640,7 +641,7 @@ pmc_pmu_pmcallocate(const char *event_name, struct pmc_op_pmcallocate *pm)
 	struct pmu_event_desc ped;
 	int idx = -1;
 
-	event_name = pmu_alias_get(event_name);
+	event_name = _pmu_alias_get(event_name);
 	if ((pe = pmu_event_get(NULL, event_name, &idx)) == NULL)
 		return (ENOENT);
 	if (pe->event == NULL)

--- a/lib/libpmc/libpmcinternal.h
+++ b/lib/libpmc/libpmcinternal.h
@@ -35,5 +35,6 @@
  * Prototypes.
  */
 const char *_pmc_name_of_event(enum pmc_event _ev, enum pmc_cputype _cpu);
+const char *_pmu_alias_get(const char *name);
 
 #endif	/* LIBPMC_INTERNAL_H */


### PR DESCRIPTION
Since we don't have a .json pmu event description file for Morello, the
pmc_pmu_enabled() check always fails and we don't use pmc_pmu_pmcallocate()
which would check for aliases.

If this looks reasonable, I'll send the changes upstream as well - just wanted something that unbreaks `pmc stat` and `pmcstat -p cycles` on my morello board.