### PR TITLE
Accumulate tags correctly.

### DIFF
--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -519,7 +519,7 @@ proc_read_cheri_tags_page(vm_map_t map, vm_offset_t va, void *tagbuf,
 	tagbits = 0;
 	hastags = false;
 	while (len > 0) {
-		tags = (tags << cheri_cloadtags_stride) | cheri_loadtags(src);
+		tags |= cheri_loadtags(src) << tagbits;
 		tagbits += cheri_cloadtags_stride;
 		if (tags != 0)
 			hastags = true;


### PR DESCRIPTION
The first sub-byte mask of tags fetched should stay at LSB and subsequent masks appended at higher bits rather than the other way around.

I had fixed this before, but merged a stale version of the memory tags in coredumps PR that didn't yet have this fix.