### PR TITLE
Explicitly use -mabi=aapcs for hybrid and vanilla AArch64 code

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -125,7 +125,7 @@ HAS_COMPAT+=64C
 LIB64C_MACHINE=	arm64
 LIB64C_MACHINE_ARCH=	aarch64c
 LIB64CCPUFLAGS=	-target aarch64-unknown-freebsd13.0
-LIB64CCPUFLAGS+=	-march=morello+c64 -mabi=purecap
+LIB64CCPUFLAGS+=	-march=morello -mabi=purecap
 .elif ${COMPAT_ARCH:Mriscv64*} && !${COMPAT_ARCH:Mriscv64*c*}
 HAS_COMPAT+=64C
 LIB64C_MACHINE=	riscv

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -140,8 +140,9 @@ _CPUCFLAGS = -mcpu=${CPUTYPE}
 # Use -march when the CPU type is an architecture value, e.g. armv8.1-a
 _CPUCFLAGS = -march=${CPUTYPE}
 .  elif ${CPUTYPE} == "morello"
-# Don't use -march; we will add -march=morello or -march=morello+c64 later but
-# adding -march=morello here would override that as _CPUCFLAGS is added late.
+# Don't use -march; we will add -march=morello later so it's not necessary, and
+# it's not sufficient to use _CPUCFLAGS either as NO_CPU_CFLAGS should not
+# suppress enabling Morello support.
 # It is also not a valid value for -mcpu.
 .  else
 # Otherwise assume we have a CPU type
@@ -303,14 +304,18 @@ MACHINE_CPU += riscv
 .endif
 
 .if ${MACHINE_CPUARCH} == "aarch64"
+. if ${MACHINE_CPU:Mcheri}
+CFLAGS+=	-march=morello
+CFLAGS+=	-Xclang -morello-vararg=new
+LDFLAGS+=	-march=morello
+. endif
+
 . if ${MACHINE_ARCH:Maarch64*c*}
-CFLAGS+=	-march=morello+c64 -mabi=purecap
-CFLAGS+=	-Xclang -morello-vararg=new
-LDFLAGS+=	-march=morello+c64 -mabi=purecap
-. elif defined(CPUTYPE) && ${CPUTYPE} == "morello"
-CFLAGS+=	-march=morello -mabi=aapcs
-CFLAGS+=	-Xclang -morello-vararg=new
-LDFLAGS+=	-march=morello -mabi=aapcs
+CFLAGS+=	-mabi=purecap
+LDFLAGS+=	-mabi=purecap
+. else
+CFLAGS+=	-mabi=aapcs
+LDFLAGS+=	-mabi=aapcs
 . endif
 .endif
 

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -135,13 +135,14 @@ CFLAGS += -ffixed-x18
 INLINE_LIMIT?=	8000
 
 .if ${MACHINE_CPU:Mcheri}
-AARCH64_MARCH=	morello
-.if ${MACHINE_ARCH:Maarch*c*}
-CFLAGS+=	-march=morello+c64 -mabi=purecap
-.else
 CFLAGS+=	-march=morello
-.endif
 CFLAGS+=	-Xclang -morello-vararg=new
+.endif
+
+.if ${MACHINE_ARCH:Maarch*c*}
+CFLAGS+=	-mabi=purecap
+.else
+CFLAGS+=	-mabi=aapcs
 .endif
 .endif
 


### PR DESCRIPTION
This ensures we don't accidentally get purecap when using a toolchain
that defaults to it (which currently happens for hybrid kernels when
using llvm-base's cc). As part of this, to simplify the various
conditions, we drop support for toolchains that require the use of +c64,
since the patch to infer the encoding mode from the ABI was merged 8
days after the merge of CHERI LLVM 13, our current baseline.
