### PR TITLE
Mini malloc cleanups

### DIFF
--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -82,7 +82,6 @@
 static spinlock_t tls_malloc_lock = _SPINLOCK_INITIALIZER;
 #define	TLS_MALLOC_LOCK		if (__isthreaded) _SPINLOCK(&tls_malloc_lock)
 #define	TLS_MALLOC_UNLOCK	if (__isthreaded) _SPINUNLOCK(&tls_malloc_lock)
-union overhead;
 static void morecore(int);
 static void *__tls_malloc_aligned(size_t size, size_t align);
 
@@ -91,17 +90,19 @@ static void *__tls_malloc_aligned(size_t size, size_t align);
  * contains a pointer to the next free block. When in use, the first
  * byte is set to MAGIC, and the second byte is the size index.
  */
-union	overhead {
-	union	overhead *ov_next;	/* when free */
-	struct {
-		u_char	ovu_magic;	/* magic number */
-		u_char	ovu_index;	/* bucket # */
-	} ovu;
+struct overhead {
+	union {
+		struct overhead	*ov_next;	/* when free */
+		struct {
+			u_char	ovu_magic;	/* magic number */
+			u_char	ovu_index;	/* bucket # */
+		} ovu;
+	};
 #define	ov_magic	ovu.ovu_magic
 #define	ov_index	ovu.ovu_index
 };
 
-#define	MALLOC_ALIGNMENT	sizeof(union overhead)
+#define	MALLOC_ALIGNMENT	sizeof(struct overhead)
 
 #define	MAGIC		0xef		/* magic # on accounting info */
 
@@ -112,7 +113,7 @@ union	overhead {
  */
 #define	FIRST_BUCKET_SIZE	32
 #define	NBUCKETS 30
-static	union overhead *nextf[NBUCKETS];
+static struct overhead *nextf[NBUCKETS];
 
 static const size_t pagesz = PAGE_SIZE;			/* page size */
 
@@ -229,7 +230,7 @@ bound_ptr(void *mem, size_t nbytes)
 static void *
 __tls_malloc(size_t nbytes)
 {
-	union overhead *op;
+	struct overhead *op;
 	int bucket;
 	size_t amt;
 
@@ -325,7 +326,7 @@ static void
 morecore(int bucket)
 {
 	char *buf;
-	union overhead *op;
+	struct overhead *op;
 	size_t sz;			/* size of desired block */
 	int amt;			/* amount to allocate */
 	int nblks;			/* how many blocks we get */
@@ -350,18 +351,18 @@ morecore(int bucket)
 	 * Add new memory allocated to that on
 	 * free list for this hash bucket.
 	 */
-	nextf[bucket] = op = (union overhead *)(void *)cheri_setbounds(buf, sz);
+	nextf[bucket] = op = (struct overhead *)(void *)cheri_setbounds(buf, sz);
 	while (--nblks > 0) {
-		op->ov_next = (union overhead *)(void *)cheri_setbounds(buf + sz, sz);
+		op->ov_next = (struct overhead *)(void *)cheri_setbounds(buf + sz, sz);
 		buf += sz;
 		op = op->ov_next;
 	}
 }
 
-static union overhead *
+static struct overhead *
 find_overhead(void * cp)
 {
-	union overhead *op;
+	struct overhead *op;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (!cheri_gettag(cp))
@@ -407,7 +408,7 @@ find_overhead(void * cp)
 static void
 nextf_insert(void *mem, size_t size, int xbucket)
 {
-	union overhead *op;
+	struct overhead *op;
 	int bucket;
 
 	bucket = __builtin_ctzl(size) - __builtin_ctzl(FIRST_BUCKET_SIZE);
@@ -421,7 +422,7 @@ void
 tls_free(void *cp)
 {
 	int bucket;
-	union overhead *op;
+	struct overhead *op;
 
 	if (cp == NULL)
 		return;

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -408,19 +408,6 @@ find_overhead(void * cp)
 	return (NULL);
 }
 
-static void
-nextf_insert(void *mem, size_t size, int xbucket)
-{
-	struct overhead *op;
-	int bucket;
-
-	bucket = __builtin_ctzl(size) - __builtin_ctzl(FIRST_BUCKET_SIZE);
-	if (bucket != xbucket) abort();
-	op = mem;
-	op->ov_next = nextf[bucket];
-	nextf[bucket] = op;
-}
-
 void
 tls_free(void *cp)
 {
@@ -434,9 +421,9 @@ tls_free(void *cp)
 		return;
 	TLS_MALLOC_LOCK;
 	bucket = op->ov_index;
-	if (bucket < NBUCKETS)
-		abort();
-	nextf_insert(op, FIRST_BUCKET_SIZE << bucket, bucket);
+	assert(bucket < NBUCKETS);
+	op->ov_next = nextf[bucket];	/* also clobbers ov_magic */
+	nextf[bucket] = op;
 	TLS_MALLOC_UNLOCK;
 }
 

--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -202,15 +202,13 @@ __rederive_pointer(void *ptr)
 	return (ptr);
 #else
 	size_t i;
-	vm_offset_t addr;
 
-	addr = cheri_getaddress(ptr);
 	TLS_MALLOC_LOCK;
 	for (i = 0; i < n_pagepools; i++) {
 		char *pool = pagepool_list[i];
-		if (cheri_is_address_inbounds(pool, addr)) {
+		if (cheri_is_address_inbounds(pool, cheri_getbase(ptr))) {
 			TLS_MALLOC_UNLOCK;
-			return (cheri_setaddress(pool, addr));
+			return (cheri_setaddress(pool, cheri_getaddress(ptr)));
 		}
 	}
 	TLS_MALLOC_UNLOCK;

--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -160,14 +160,12 @@ void *
 __rederive_pointer(void *ptr)
 {
 	size_t i;
-	vm_offset_t addr;
 
-	addr = cheri_getaddress(ptr);
 	for (i = 0; i < n_pagepools; i++) {
 		char *pool = pagepool_list[i];
 
-		if (cheri_is_address_inbounds(pool, addr))
-			return (cheri_setaddress(pool, addr));
+		if (cheri_is_address_inbounds(pool, cheri_getbase(ptr)))
+			return (cheri_setaddress(pool, cheri_getaddress(ptr)));
 	}
 
 	return (NULL);

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -81,6 +81,7 @@ static void morecore(int);
 struct overhead {
 	union {
 		struct overhead	*ov_next;	/* when free */
+		void	*ov_real_allocation;	/* when realigned */
 		struct {
 			u_char	ovu_magic;	/* magic number */
 			u_char	ovu_index;	/* bucket # */
@@ -175,20 +176,20 @@ __simple_malloc_unaligned(size_t nbytes)
 	/* remove from linked list */
 	nextf[bucket] = op->ov_next;
 	/*
-	 * XXXQEMU: Set an ov_next capability to a NULL capability, clearing any
-	 * permissions.
+	 * XXXQEMU: Clear the overhead struct to remove any capability
+	 * permissions in ov_real_allocation.
 	 *
-	 * Based on a tag and permissions of ov_next, find_overhead() determines
-	 * if an allocation is aligned. The QEMU user mode for CheriABI doesn't
-	 * implement tagged memory and find_overhead() might incorrectly assume
-	 * the allocation is aligned because of a non-cleared tag. Having the
-	 * permissions cleared, find_overhead() behaves as expected under the
-	 * user mode.
+	 * Based on a tag and permissions of ov_real_allocation, find_overhead()
+	 * determines if an allocation is aligned. The QEMU user mode for
+	 * CheriABI doesn't implement tagged memory and find_overhead() might
+	 * incorrectly assume the allocation is aligned because of a
+	 * non-cleared tag. Having the permissions cleared, find_overhead()
+	 * behaves as expected under the user mode.
 	 *
 	 * This is a workaround and should be reverted once the user mode
 	 * implements tagged memory.
 	 */
-	op->ov_next = NULL;
+	memset(op, 0, sizeof(*op));
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
 	return (op + 1);
@@ -198,17 +199,19 @@ static void *
 __simple_malloc_aligned(size_t nbytes, size_t align)
 {
 	ptraddr_t memshift;
-	void *mem, *res;
+	void *mem;
+	struct overhead *op;
+
 	if (align < sizeof(void *))
 		align = sizeof(void *);
 
-	mem = __simple_malloc_unaligned(nbytes + sizeof(void *) + align - 1);
-	memshift = roundup2((ptraddr_t)mem + sizeof(void *), align) -
+	mem = __simple_malloc_unaligned(nbytes + sizeof(*op) + align - 1);
+	memshift = roundup2((ptraddr_t)mem + sizeof(*op), align) -
 	    (ptraddr_t)mem;
 
-	res = (void *)((uintptr_t)mem + memshift);
-	*(void **)((uintptr_t)res - sizeof(void *)) = mem;
-	return (res);
+	op = (struct overhead *)((uintptr_t)mem + memshift);
+	(op - 1)->ov_real_allocation = mem;
+	return ((void *)op);
 }
 
 static void *
@@ -316,14 +319,14 @@ find_overhead(void * cp)
 	 *  - Be an internal allocator pointer (have the VMMAP permision).
 	 *  - Point somewhere before us and within the current pagepool.
 	 */
-	if (cheri_gettag(op->ov_next) &&
-	    (cheri_getperm(op->ov_next) & CHERI_PERM_SW_VMEM) != 0) {
+	if (cheri_gettag(op->ov_real_allocation) &&
+	    (cheri_getperm(op->ov_real_allocation) & CHERI_PERM_SW_VMEM) != 0) {
 		ptraddr_t base, pp_base;
 
 		pp_base = cheri_getbase(op);
-		base = cheri_getbase(op->ov_next);
+		base = cheri_getbase(op->ov_real_allocation);
 		if (base >= pp_base && base < cheri_getaddress(op)) {
-			op = op->ov_next;
+			op = op->ov_real_allocation;
 			op--;
 		}
 	}


### PR DESCRIPTION
Assorted improvements to the light weight malloc implementations used in libc (for TLS) and rtld on CheriABI. Most of these were inspired by feedback to #1497.