### PR TITLE
Fix vm_object leak in the implementation of munmap

### DIFF
--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -4433,6 +4433,9 @@ vm_map_delete(vm_map_t map, vm_offset_t start, vm_offset_t end,
 			if ((entry->eflags & MAP_ENTRY_UNMAPPED) == 0) {
 				vm_map_entry_clean(map, entry);
 				/* XXX-AM: How do we reset maxprot? */
+				if ((entry->eflags & MAP_ENTRY_IS_SUB_MAP) == 0)
+					vm_object_deallocate(
+					    entry->object.vm_object);
 				vm_map_reservation_init_entry(entry);
 			}
 			vm_map_try_merge_entries(map, prev_entry, entry);


### PR DESCRIPTION
I noticed this bug because its knock-on effects cause significant performance issues with some graphics applications. In more detail, some GEM buffers of the panfrost GPU driver and their page frames are not freed even if the client process exits because the associated vm_objects are not freed.

This bug can also cause issues with non-graphics applications. Here is a small demo program that mmaps and munmaps one million pages: https://github.com/CTSRD-CHERI/pffm2/blob/cheribsd/misc/unmap_bug_investigation/torture_test.c
After each execution ~4GB of main memory remain used up without this fix, even after the process exits. With vmstat -z one can see how the "used" objects count of the VM OBJECT zone increases with each execution.
The demo application also runs ~1.11x slower without this fix. Maybe because the UMA zone for vm_objects has to allocate new slabs more frequently.

This bug is only triggered if the user space application uses purecap ABI. I've not seen performance degradation with hybrid ABI graphics applications. Maybe this bug can also interfere with performance comparisons between hybrid and purecap ABI that don't use graphics applications, because the bug is in non-graphics specific code of the VM subsystem.

Best regards,
Paul