### PR TITLE
Add (u)int64ptr_t types

### DIFF
--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -88,6 +88,14 @@ typedef	__intptr_t		intptr_t;
 typedef	__uintptr_t		uintptr_t;
 #define	_UINTPTR_T_DECLARED
 #endif
+#ifndef	_INT64PTR_T_DECLARED
+typedef	__int64ptr_t            int64ptr_t;
+#define	_INT64PTR_T_DECLARED
+#endif
+#ifndef _UINT64PTR_T_DECLARED
+typedef	__uint64ptr_t           uint64ptr_t;
+#define	_UINT64PTR_T_DECLARED
+#endif
 #ifndef _INTMAX_T_DECLARED
 typedef	__intmax_t		intmax_t;
 #define	_INTMAX_T_DECLARED

--- a/sys/sys/_types.h
+++ b/sys/sys/_types.h
@@ -74,18 +74,24 @@ typedef	__uint64_t	__uintmax_t;
 #ifdef __CHERI_PURE_CAPABILITY__
 typedef	__intcap_t	__intptr_t;
 typedef	__intcap_t	__intfptr_t;
+typedef	__intptr_t	__int64ptr_t;
 typedef	__uintcap_t	__uintptr_t;
 typedef	__uintcap_t	__uintfptr_t;
+typedef	__uintptr_t	__uint64ptr_t;
 #elif __SIZEOF_POINTER__ == 8
 typedef	__int64_t	__intptr_t;
 typedef	__int64_t	__intfptr_t;
+typedef	__intptr_t	__int64ptr_t;
 typedef	__uint64_t	__uintptr_t;
 typedef	__uint64_t	__uintfptr_t;
+typedef	__uintptr_t	__uint64ptr_t;
 #elif __SIZEOF_POINTER__ == 4
 typedef	__int32_t	__intptr_t;
 typedef	__int32_t	__intfptr_t;
+typedef	__int64_t	__int64ptr_t;
 typedef	__uint32_t	__uintptr_t;
 typedef	__uint32_t	__uintfptr_t;
+typedef	__uint64_t	__uint64ptr_t;
 #else
 #error unsupported pointer size
 #endif


### PR DESCRIPTION
These are integer(ish) types capable of storing a pointer and at least 64-bits in size.  They are suitable for use in objects that previously used uint64_t to store 32/64-bit agnostic pointers in a fixed size where the object is not used as a kernel interface.  (If the object is used as a kernel interface then kuint64cap_t should be used.)

These are useful for ZFS where some types have uint64_t members that hold pointers and are not used as part of the userspace/kernel interface.