### PR TITLE
Don't use subobject bounds for vop_F_args.a_gen

### DIFF
--- a/sys/fs/nullfs/null_vnops.c
+++ b/sys/fs/nullfs/null_vnops.c
@@ -484,7 +484,7 @@ null_open(struct vop_open_args *ap)
 
 	vp = ap->a_vp;
 	ldvp = NULLVPTOLOWERVP(vp);
-	retval = null_bypass(&ap->a_gen);
+	retval = null_bypass((struct vop_generic_args *)ap);
 	if (retval == 0) {
 		vp->v_object = ldvp->v_object;
 		if ((vn_irflag_read(ldvp) & VIRF_PGREAD) != 0) {
@@ -641,7 +641,7 @@ null_remove(struct vop_remove_args *ap)
 	} else
 		vreleit = 0;
 	VTONULL(vp)->null_flags |= NULLV_DROP;
-	retval = null_bypass(&ap->a_gen);
+	retval = null_bypass((struct vop_generic_args *)ap);
 	if (vreleit != 0)
 		vrele(lvp);
 	return (retval);
@@ -735,7 +735,7 @@ null_rmdir(struct vop_rmdir_args *ap)
 {
 
 	VTONULL(ap->a_vp)->null_flags |= NULLV_DROP;
-	return (null_bypass(&ap->a_gen));
+	return (null_bypass((struct vop_generic_args *)ap));
 }
 
 /*

--- a/sys/tools/vnode_if.awk
+++ b/sys/tools/vnode_if.awk
@@ -319,7 +319,7 @@ while ((getline < srcfile) > 0) {
 
 	if (hfile) {
 		# Print out the vop_F_args structure.
-		printh("struct "name"_args {\n\tstruct vop_generic_args a_gen;");
+		printh("struct "name"_args {\n\tstruct vop_generic_args a_gen __subobject_member_used_for_c_inheritance;");
 		for (i = 0; i < numargs; ++i)
 			printh("\t" t_spc(types[i]) "a_" args[i] ";");
 		printh("};");


### PR DESCRIPTION
Issue: https://github.com/CTSRD-CHERI/cheribsd/issues/1539