### PR TITLE
Check alignment of fp in unwind_frame

### DIFF
--- a/sys/arm64/arm64/unwind.c
+++ b/sys/arm64/arm64/unwind.c
@@ -41,7 +41,8 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 	fp = frame->fp;
 
-	if (!kstack_contains(td, fp, sizeof(uintptr_t) * 2))
+	if (!__is_aligned(fp, sizeof(fp)) ||
+	    !kstack_contains(td, fp, sizeof(fp) * 2))
 		return (false);
 
 #ifdef __CHERI_PURE_CAPABILITY__

--- a/sys/riscv/riscv/unwind.c
+++ b/sys/riscv/riscv/unwind.c
@@ -47,7 +47,8 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 	fp = frame->fp;
 
-	if (!kstack_contains(td, fp - sizeof(fp) * 2, sizeof(fp) * 2))
+	if (!__is_aligned(fp, sizeof(fp)) ||
+	    !kstack_contains(td, fp - sizeof(fp) * 2, sizeof(fp) * 2))
 		return (false);
 
 #ifdef __CHERI_PURE_CAPABILITY__


### PR DESCRIPTION
Without this I can't boot a purecap kernel to the login prompt in qemu.