### PR TITLE
usb: Annotate struct usb_proc_msg inheritance for purecap kernel

### DIFF
--- a/sys/dev/sound/usb/uaudio.c
+++ b/sys/dev/sound/usb/uaudio.c
@@ -209,7 +209,7 @@ struct uaudio_mixer_node {
 };
 
 struct uaudio_configure_msg {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct uaudio_softc *sc;
 };
 

--- a/sys/dev/usb/misc/ugold.c
+++ b/sys/dev/usb/misc/ugold.c
@@ -92,7 +92,7 @@ static uint8_t cmd_type[8] = {0x01, 0x86, 0xff, 0x01, 0x00, 0x00, 0x00, 0x00};
 
 struct ugold_softc;
 struct ugold_readout_msg {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct ugold_softc *sc;
 };
 

--- a/sys/dev/usb/serial/usb_serial.h
+++ b/sys/dev/usb/serial/usb_serial.h
@@ -119,12 +119,12 @@ struct ucom_callback {
 #define	ULSR_RCV_MASK	0x1f		/* Mask for incoming data or error */
 
 struct ucom_cfg_task {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct ucom_softc *sc;
 };
 
 struct ucom_param_task {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct ucom_softc *sc;
 	struct termios termios_copy;
 };

--- a/sys/dev/usb/usb_bus.h
+++ b/sys/dev/usb/usb_bus.h
@@ -37,7 +37,7 @@ struct usb_fs_privdata;
  */
 
 struct usb_bus_msg {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct usb_bus *bus;
 };
 

--- a/sys/dev/usb/usb_device.h
+++ b/sys/dev/usb/usb_device.h
@@ -56,7 +56,7 @@ struct usb_symlink;		/* UGEN */
 #define	USB_UNCFG_FLAG_FREE_EP0	0x02		/* endpoint zero is freed */
 
 struct usb_udev_msg {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct usb_device *udev;
 };
 

--- a/sys/dev/usb/usb_transfer.h
+++ b/sys/dev/usb/usb_transfer.h
@@ -45,7 +45,7 @@
  * the "done_p" USB process.
  */
 struct usb_done_msg {
-	struct usb_proc_msg hdr;
+	struct usb_proc_msg hdr __subobject_member_used_for_c_inheritance;
 	struct usb_xfer_root *xroot;
 };
 


### PR DESCRIPTION
This fixes a nested panic seen when testing GUI support, likely
dependent on having USB HID devices connected, as usbd_clear_stall_proc
was hitting a bounds fault.
