### PR TITLE
Misc DRM fixes

### DIFF
--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -267,7 +267,7 @@ drm_fstub_ioctl(struct file *file, u_long cmd, void *data, struct ucred *cred,
 		goto out_release;
 	}
 
-	rv = fops->unlocked_ioctl(file, cmd, (uintcap_t)PTR2CAP(data));
+	rv = -fops->unlocked_ioctl(file, cmd, (uintcap_t)PTR2CAP(data));
 
 	dev_relthread(cdev, ref);
 	return (rv);

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -76,7 +76,7 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 			    (void *)(__cheri_addr uintptr_t)src));
 
 			/* Copy capabilities. */
-			while (len > sizeof(uintcap_t)) {
+			while (len >= sizeof(uintcap_t)) {
 				*(uintcap_t * __capability)dst =
 				    *(const uintcap_t * __capability)src;
 				dst += sizeof(uintcap_t);
@@ -118,7 +118,7 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 			    ("src %p not aligned", (void *)(__cheri_addr uintptr_t)src));
 
 			/* Copy capabilities. */
-			while (len > sizeof(uintcap_t)) {
+			while (len >= sizeof(uintcap_t)) {
 				dst -= sizeof(uintcap_t);
 				src -= sizeof(uintcap_t);
 				*(uintcap_t * __capability)dst =


### PR DESCRIPTION
The first commit fixes KWin's ability to start Xwayland (though required X processes started by startplasma-wayland still crash and block plasma actually starting; one looks to be an unaligned allocation, and the other has the hallmarks of an adjust-pointers-by-realloc-diff bug, crashing on strlen of a capability to a string that points to valid data but has a cleared tag and is way out of bounds).

The second commit is why hybrid kernels are more broken than purecap kernels when it comes to DRM ioctls.