### PR TITLE
panfrost_gem: Fix panics on page allocation failure

### DIFF
--- a/sys/dev/drm/panfrost/panfrost_gem.c
+++ b/sys/dev/drm/panfrost/panfrost_gem.c
@@ -183,7 +183,6 @@ panfrost_gem_open(struct drm_gem_object *obj, struct drm_file *file_priv)
 
 error:
 	panfrost_gem_mapping_put(mapping);
-	drm_gem_object_put(obj);
 	return (error);
 }
 

--- a/sys/dev/drm/panfrost/panfrost_gem.c
+++ b/sys/dev/drm/panfrost/panfrost_gem.c
@@ -96,6 +96,9 @@ panfrost_gem_free_object(struct drm_gem_object *obj)
 	if (bo->pages) {
 		for (i = 0; i < bo->npages; i++) {
 			m = bo->pages[i];
+			if (m == NULL)
+				continue;
+
 			vm_page_lock(m);
 			m->flags &= ~PG_FICTITIOUS;
 			m->oflags |= VPO_UNMANAGED;


### PR DESCRIPTION
If allocating pages fails, we will have a pages array but entries will be NULL, resulting in a NULL dereference. Ignore such entries just like other partial states.

The panfrost_gem_mapping_put call already does a put on the object (our get at the start of the function was in order to give the mapping a reference) so we shouldn't do a second one manually, as that will result in a use-after-free in panfrost_gem_create_object_with_handle when it does the final panfrost_gem_object_put intending to take the refcount to 0, since drm_gem_handle_create_tail's balanced put will already have done that and freed the object.