### PR TITLE
c18n: Additional changes and fixes

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -481,6 +481,8 @@ END(_rtld_tlsdesc_dynamic)
 ENTRY(_rtld_setjmp)
 	/*
 	 * Before setjmp is called, the top of the Executive stack contains:
+	 * 	-2.	Caller's stack
+	 * 	-1.	Return address
 	 * 	0.	Link to previous frame
 	 * When setjmp is called, the following is pushed to the Executive stack:
 	 * 	1.	Caller's stack
@@ -491,9 +493,11 @@ ENTRY(_rtld_setjmp)
 	 * 	5.	Return address
 	 * 	6.	Link to 3
 	 * In _rtld_setjmp, we manipulate the stack content to the following:
+	 * 	-5.	Copy of 1
+	 * 	-4.	Copy of 2
 	 * 	-3.	Link to 0
-	 * 	-2.	Copy of 1
-	 * 	-1.	Copy of 2
+	 * 	-2.	Caller's stack
+	 * 	-1.	Return address
 	 * 	0.	Link to previous frame
 	 * 	------------------------------
 	 * 	1.	Caller's stack
@@ -517,7 +521,7 @@ ENTRY(_rtld_setjmp)
 
 	add	c0, csp, #(CAP_WIDTH)
 
-	/* Shift 4-5 */
+	/* Shift 4 and 5 */
 	ldp	c1, c2, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
 	stp	c1, c2, [c0], #(2 * CAP_WIDTH)
 
@@ -526,18 +530,25 @@ ENTRY(_rtld_setjmp)
 	sub	c1, c1, #(SETJMP_SHIFT * CAP_WIDTH)
 	str	c1, [c0], #(CAP_WIDTH)
 
-	/* Shift 1-2 */
+	/* Shift 1 and 2 */
 	ldp	c1, c2, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
 	stp	c1, c2, [c0], #(2 * CAP_WIDTH)
 
-	/* Shift 0 and store -3 */
+	/* Shift 0 */
 	ldr	c1, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
-	str	c0, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
 	str	c1, [c0], #(CAP_WIDTH)
 
-	/* Store -1, -2 */
-	ldp	c1, c2, [c0, #-(SETJMP_SHIFT * CAP_WIDTH)]
-	stp	c1, c2, [c0]
+	/* Shift -1 and -2 */
+	ldp	c1, c2, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
+	stp	c1, c2, [c0], #(2 * CAP_WIDTH)
+
+	/* Store -3 */
+	ldr	c1, [c0, #-(2 * SETJMP_SHIFT * CAP_WIDTH)]
+	str	c1, [c0]
+
+	/* Store -4 and -5 */
+	ldp	c1, c2, [c0, #-(2 * SETJMP_SHIFT * CAP_WIDTH - CAP_WIDTH)]
+	stp	c1, c2, [c0, #(CAP_WIDTH)]
 
 	scbnds	c0, c0, #(SETJMP_SHIFT * CAP_WIDTH)
 	/* TODO: seal	c0, c0 */
@@ -558,16 +569,14 @@ ENTRY(_rtld_longjmp)
 	 * 	5.	Return address
 	 * 	6.	Link to 2
 	 * In _rtld_longjmp, we manipulate the stack content to the following:
-	 * 	-n-2.	Link to previous frame
+	 * 	-n.	Link to previous frame
 	 * 	------------------------------
-	 * 	-n-1.	Supplied caller's stack
-	 * 	-n.	Supplied return address
 	 * 	...
 	 * 	0.	Link to previous frame
 	 * 	------------------------------
-	 * 	1.	Caller's stack
-	 * 	2.	Return address
-	 * 	3.	Link to supplied Executive stack pointer (-n-2)
+	 * 	1.	Supplied caller's stack
+	 * 	2.	Supplied return address
+	 * 	3.	Link to supplied Executive stack pointer (-n)
 	 * 	------------------------------
 	 * 	4.	Caller's stack
 	 * 	5.	Return address
@@ -588,7 +597,7 @@ ENTRY(_rtld_longjmp)
 	b.hs	1f
 
 	/* Load the link from the supplied buffer */
-	ldr	c2, [c0, #(2 * CAP_WIDTH)]
+	ldr	c2, [c0]
 
 	/*
 	 * Compare its generation counter with that of the capability to the
@@ -617,18 +626,18 @@ ENTRY(_rtld_longjmp)
 
 	/* Unwind the frames */
 	mov	c3, c2
-4:	cmp	c3, c1
+4:	ldr	c3, [c3]
+	cmp	c3, c1
 	b.eq	3f
 
-	/* Enforce security policy here for each frame being unwinded */
+	/* Enforce security policy here for each frame being unwound */
 
-	ldr	c3, [c3]
 	b	4b
 
-3:	ldp	c3, c4, [c0]
+3:	ldp	c3, c4, [c0, #(CAP_WIDTH)]
 
 	str	c1, [c2]
-	stp	c3, c4, [c1, #-(2 * CAP_WIDTH)]
+	stp	c3, c4, [c2, #(CAP_WIDTH)]
 
 	ret
 
@@ -668,15 +677,15 @@ target_cap_exe:
 	 * If caller is Restricted, restore to its saved rcsp
 	 * at the top of the Executive stack
 	 */
-	ldr	c10, [csp]
-	mov	csp, c10
-	ldp	c30, c10, [csp, #-(CAP_WIDTH * 2)]
+	ldp	c10, c30, [csp]
 	gcperm	x11, c30
 	tbnz	x11, #1, 1f
 
-	msr	rcsp_el0, c10
+	ldr	c11, [csp, #(CAP_WIDTH * 2)]
+	msr	rcsp_el0, c11
 
-1:	retr	c30
+1:	mov	csp, c10
+	retr	c30
 EEND(tramp_template_exe)
 etramp_template_exe:
 
@@ -735,15 +744,15 @@ dst_obj:
 	 * If caller is Restricted, restore to its saved rcsp
 	 * at the top of the Executive stack
 	 */
-	ldr	c10, [csp]
-	mov	csp, c10
-	ldp	c30, c10, [csp, #-(CAP_WIDTH * 2)]
+	ldp	c10, c30, [csp]
 	gcperm	x11, c30
 	tbnz	x11, #1, 3f
 
-	msr	rcsp_el0, c10
+	ldr	c11, [csp, #(CAP_WIDTH * 2)]
+	msr	rcsp_el0, c11
 
-3:	retr	c30
+3:	mov	csp, c10
+	retr	c30
 
 2:	stp	c8, c9, [csp, #-(1 * CAP_WIDTH * 2)]
 	stp	c6, c7, [csp, #-(2 * CAP_WIDTH * 2)]

--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -84,7 +84,7 @@ No
 .Em policy
 has been enforced yet.
 .Pp
-Below is an incomplete list of known limitations and known problems.
+Below is a list of known limitations and problems.
 For more up-to-date information, visit
 .Lk https://github.com/CTSRD-CHERI/cheripedia/wiki/Library-based-Compartmentalisation .
 .Bl -bullet
@@ -93,6 +93,8 @@ Functions that take more than 8 arguments (not counting variadic arguments) are
 not expected to work correctly
 .Em when they are called from another library .
 Calling such functions from within the same library is not impacted.
+.It
+Compatibility with C++ software is not expected.
 .It
 Stack unwinding is not expected to work.
 This includes C++ exceptions and stack tracing in debuggers.


### PR DESCRIPTION
* The layout of trusted stack frames is changed to make it easier for setjmp/longjmp to unwind the stack.
* Adds a comment to the man page about C++ compatibility.

Closes #1556.