### PR TITLE
libkern: provide memset_c in hybrid kernels

### DIFF
--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -15,6 +15,8 @@ libkern/memcmp.c				standard	\
 	compile-with "${NORMAL_C:N-fsanitize*}"
 libkern/memset.c				standard	\
 	compile-with "${NORMAL_C:N-fsanitize*}"
+libkern/memset_c.c				optional cpu_cheri !cheri_purecap_kernel \
+	compile-with "${NORMAL_C:N-fsanitize*}"
 libkern/strlen.c		standard
 libkern/arm64/crc32c_armv8.S			standard
 

--- a/sys/conf/files.riscv
+++ b/sys/conf/files.riscv
@@ -33,6 +33,7 @@ libkern/flsl.c			standard
 libkern/flsll.c			standard
 libkern/memcmp.c		standard
 libkern/memset.c		standard
+libkern/memset_c.c		optional	cpu_cheri !cheri_purecap_kernel
 libkern/strlen.c		standard
 riscv/cheri/cheri_debug.c	optional	cpu_cheri ddb
 riscv/cheri/cheri_exception.c	optional	cpu_cheri

--- a/sys/libkern/memset_c.c
+++ b/sys/libkern/memset_c.c
@@ -1,7 +1,10 @@
 /*-
- * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2014 SRI International
+ * All rights reserved.
  *
- * Copyright (C) 1992-2007 The FreeBSD Project. All rights reserved.
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -12,10 +15,10 @@
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
@@ -24,28 +27,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
-#define	LIBKERN_INLINE
-
-#include <sys/types.h>
-#include <sys/libkern.h>
-
-#ifdef CAPABILITY_VERSION
-#define	__CAPSUFFIX(func)	(func ## _c)
-#define	__CAP		__capability
-#else
-#define	__CAPSUFFIX(func)	(func)
-#define	__CAP
-#endif
-
-void * __CAP
-__CAPSUFFIX(memset)(void * __CAP b, int c, size_t len)
-{
-	char * __CAP bb;
-
-	for (bb = (char * __CAP)b; len--; )
-		*bb++ = c;
-	return (b);
-}
+#define CAPABILITY_VERSION
+#include "memset.c"

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -310,6 +310,8 @@ void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
 #define	memmovenocap	memmove
 #endif
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
+void	* __capability memset_c(void * _Nonnull __capability buf, int c,
+	    size_t len);
 void	* __capability memcpy_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
 void	* __capability memcpynocap_c(void * _Nonnull __capability to,
@@ -319,6 +321,7 @@ void	* __capability memmove_c(void * _Nonnull __capability dest,
 void	* __capability memmovenocap_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
 #else
+#define	memset_c	memset
 #define	memcpy_c	memcpy
 #define	memcpynocap_c	memcpynocap
 #define	memmove_c	memmove


### PR DESCRIPTION
LLVM 14's MemcpyOpt pass now optimizes the following code to call memset_c:
```
dp = (__cheri_fromcap struct dirent *)uiop->uio_iov->iov_base;
NFSBZERO(dp, DIRBLKSIZ);
dp->d_type = DT_UNKNOWN;
```