### PR TITLE
bsdinstall: Add off-by-default debugger_on_panic option to services menu

### DIFF
--- a/usr.sbin/bsdinstall/scripts/services
+++ b/usr.sbin/bsdinstall/scripts/services
@@ -32,8 +32,8 @@ BSDCFG_SHARE="/usr/share/bsdconfig"
 : ${BSDDIALOG_OK=0}
 
 if [ -f $BSDINSTALL_TMPETC/rc.conf.services ]; then
-	eval $( sed -e s/YES/on/i -e s/NO/off/i \
-		$BSDINSTALL_TMPETC/rc.conf.services )
+	eval "$( sed -E -e 's/\<(YES|AUTO)\>/on/i' -e 's/\<NO\>/off/i' \
+		$BSDINSTALL_TMPETC/rc.conf.services )"
 else
 	# Default service states. Everything is off if not enabled.
 	sshd_enable="on"

--- a/usr.sbin/bsdinstall/scripts/services
+++ b/usr.sbin/bsdinstall/scripts/services
@@ -39,7 +39,14 @@ else
 	sshd_enable="on"
 fi
 
+if [ -f $BSDINSTALL_TMPBOOT/loader.conf.services ]; then
+	eval "$( sed -E -e 's/\<1\>/on/' -e 's/\<0\>/off/' \
+		-e 's/[[:alnum:].]*\.//' \
+		$BSDINSTALL_TMPBOOT/loader.conf.services )"
+fi
+
 echo -n > $BSDINSTALL_TMPETC/rc.conf.services
+echo -n > $BSDINSTALL_TMPBOOT/loader.conf.services
 
 exec 3>&1
 DAEMONS=$( bsddialog --backtitle "$OSNAME Installer" \
@@ -56,6 +63,7 @@ DAEMONS=$( bsddialog --backtitle "$OSNAME Installer" \
 	powerd	"Adjust CPU frequency dynamically if supported" \
 		${powerd_enable:-off} \
 	dumpdev "Enable kernel crash dumps to /var/crash" ${dumpdev:-on} \
+	debugger_on_panic "Run debugger on kernel panic" ${debugger_on_panic:-off} \
 2>&1 1>&3 )
 retval=$?
 exec 3>&-
@@ -66,8 +74,10 @@ fi
 
 havedump=
 havemouse=
+have_debugger_on_panic=
 for daemon in $DAEMONS; do
 	[ "$daemon" = "dumpdev" ] && havedump=1 continue
+	[ "$daemon" = "debugger_on_panic" ] && have_debugger_on_panic=1 continue
 	[ "$daemon" = "moused" ] && havemouse=1
 	if [ "$daemon" = "ntpd_sync_on_start" ]; then
 		rcvar=${daemon}
@@ -87,4 +97,10 @@ if [ "$havedump" ]; then
 	echo dumpdev=\"AUTO\" >> $BSDINSTALL_TMPETC/rc.conf.services
 else
 	echo dumpdev=\"NO\" >> $BSDINSTALL_TMPETC/rc.conf.services
+fi
+
+if [ "$have_debugger_on_panic" ]; then
+	echo debug.debugger_on_panic=1 >> $BSDINSTALL_TMPBOOT/loader.conf.services
+else
+	echo debug.debugger_on_panic=0 >> $BSDINSTALL_TMPBOOT/loader.conf.services
 fi

--- a/usr.sbin/bsdinstall/scripts/services
+++ b/usr.sbin/bsdinstall/scripts/services
@@ -46,7 +46,8 @@ DAEMONS=$( bsddialog --backtitle "$OSNAME Installer" \
     --title "System Configuration" --no-cancel --separate-output \
     --checklist "Choose the services you would like to be started at boot:" \
     0 0 0 \
-	local_unbound "Local caching validating resolver" ${local_unbound:-off} \
+	local_unbound "Local caching validating resolver" \
+		${local_unbound_enable:-off} \
 	sshd	"Secure shell daemon" ${sshd_enable:-off} \
 	moused	"PS/2 mouse pointer on console" ${moused_enable:-off} \
 	ntpd	"Synchronize system and network time" ${ntpd_enable:-off} \

--- a/usr.sbin/bsdinstall/scripts/services
+++ b/usr.sbin/bsdinstall/scripts/services
@@ -68,7 +68,12 @@ havemouse=
 for daemon in $DAEMONS; do
 	[ "$daemon" = "dumpdev" ] && havedump=1 continue
 	[ "$daemon" = "moused" ] && havemouse=1
-	echo ${daemon}_enable=\"YES\" >> $BSDINSTALL_TMPETC/rc.conf.services
+	if [ "$daemon" = "ntpd_sync_on_start" ]; then
+		rcvar=${daemon}
+	else
+		rcvar=${daemon}_enable
+	fi
+	echo ${rcvar}=\"YES\" >> $BSDINSTALL_TMPETC/rc.conf.services
 done
 
 if [ ! "$havemouse" ]; then


### PR DESCRIPTION
This isn't quite a service but given dumpdev is here this seems like a
sensible place to put the option.
    
Fixes https://github.com/CTSRD-CHERI/cheribsd/issues/1565

Also includes a bunch of fixes I just committed upstream to this file.