### PR TITLE
panfrost: Fix ioctl return values to use Linux convention

### DIFF
--- a/sys/dev/drm/panfrost/panfrost_drv.c
+++ b/sys/dev/drm/panfrost/panfrost_drv.c
@@ -329,10 +329,10 @@ panfrost_ioctl_submit(struct drm_device *dev, void *data,
 	dprintf("%s: jc %x\n", __func__, args->jc);
 
 	if (args->jc == 0)
-		return (EINVAL);
+		return (-EINVAL);
 
 	if (args->requirements && args->requirements != PANFROST_JD_REQ_FS)
-		return (EINVAL);
+		return (-EINVAL);
 
 	if (args->out_sync > 0) {
 		sync_out = drm_syncobj_find(file, args->out_sync);
@@ -353,15 +353,15 @@ panfrost_ioctl_submit(struct drm_device *dev, void *data,
 
 	error = panfrost_copy_in_fences(dev, file, args, job);
 	if (error)
-		return (EINVAL);
+		return (-EINVAL);
 
 	error = panfrost_lookup_bos(dev, file, args, job);
 	if (error)
-		return (EINVAL);
+		return (-EINVAL);
 
 	error = panfrost_job_push(job);
 	if (error)
-		return (EINVAL);
+		return (-EINVAL);
 
 	if (sync_out)
 		drm_syncobj_replace_fence(sync_out, job->render_done_fence);
@@ -385,13 +385,13 @@ panfrost_ioctl_wait_bo(struct drm_device *dev, void *data,
 
 	args = data;
 	if (args->pad)
-		return (EINVAL);
+		return (-EINVAL);
 
 	timeout = drm_timeout_abs_to_jiffies(args->timeout_ns);
 
 	gem_obj = drm_gem_object_lookup(file_priv, args->handle);
 	if (!gem_obj)
-		return (ENOENT);
+		return (-ENOENT);
 
 	error = reservation_object_wait_timeout_rcu(gem_obj->resv, true,
 	    true, timeout);
@@ -402,7 +402,7 @@ panfrost_ioctl_wait_bo(struct drm_device *dev, void *data,
 	 */
 
 	if (error == 0)
-		error = timeout ? ETIMEDOUT : EBUSY;
+		error = timeout ? -ETIMEDOUT : -EBUSY;
 	else if (error > 0)
 		error = 0;
 
@@ -435,7 +435,7 @@ panfrost_ioctl_create_bo(struct drm_device *dev, void *data,
 	if (bo == NULL) {
 		device_printf(sc->dev, "%s: Failed to create object\n",
 		    __func__);
-		return (EINVAL);
+		return (-EINVAL);
 	}
 
 	mapping = panfrost_gem_mapping_get(bo, file->driver_priv);
@@ -443,7 +443,7 @@ panfrost_ioctl_create_bo(struct drm_device *dev, void *data,
 		mutex_lock(&dev->struct_mutex);
 		drm_gem_object_put(&bo->base);
 		mutex_unlock(&dev->struct_mutex);
-		return (EINVAL);
+		return (-EINVAL);
 	}
 
 	args->offset = mapping->mmnode.start << PAGE_SHIFT;
@@ -463,11 +463,11 @@ panfrost_ioctl_mmap_bo(struct drm_device *dev, void *data,
 	args = data;
 
 	if (args->flags != 0)
-		return (EINVAL);
+		return (-EINVAL);
 
 	obj = drm_gem_object_lookup(file, args->handle);
 	if (obj == NULL)
-		return (EINVAL);
+		return (-EINVAL);
 
 	error = drm_gem_create_mmap_offset(obj);
 	if (error == 0)
@@ -494,7 +494,7 @@ panfrost_ioctl_get_param(struct drm_device *ddev, void *data,
 	param = data;
 
 	if (param->pad != 0)
-		return (EINVAL);
+		return (-EINVAL);
 
 	dprintf("%s: param %d\n", __func__, param->param);
 
@@ -573,7 +573,7 @@ panfrost_ioctl_get_param(struct drm_device *ddev, void *data,
 		param->value = sc->features.afbc_features;
 		break;
 	default:
-		return (EINVAL);
+		return (-EINVAL);
 	}
 
 	return (0);
@@ -594,7 +594,7 @@ panfrost_ioctl_get_bo_offset(struct drm_device *dev, void *data,
 
 	obj = drm_gem_object_lookup(file_priv, args->handle);
 	if (obj == NULL)
-		return (EINVAL);
+		return (-EINVAL);
 
 	bo = (struct panfrost_gem_object *)obj;
 
@@ -605,7 +605,7 @@ panfrost_ioctl_get_bo_offset(struct drm_device *dev, void *data,
 	mutex_unlock(&dev->struct_mutex);
 
 	if (mapping == NULL)
-		return (EINVAL);
+		return (-EINVAL);
 
 	args->offset = mapping->mmnode.start << PAGE_SHIFT;
 	panfrost_gem_mapping_put(mapping);
@@ -630,7 +630,7 @@ panfrost_ioctl_madvise(struct drm_device *dev, void *data,
 
 	obj = drm_gem_object_lookup(file_priv, args->handle);
 	if (obj == NULL)
-		return (EINVAL);
+		return (-EINVAL);
 
 	bo = (struct panfrost_gem_object *)obj;
 


### PR DESCRIPTION
Now that drm_ioctl correctly converts from the negative Linux convention to the positive FreeBSD convention, return values from panfrost's own ioctls also get negated by drm_ioctl and thus need to be negative in the first place. However, most of them were not, and so userspace sees errno as a negative value. In particular, panfrost_bo_wait in Mesa asserts that errno is either ETIMEDOUT or EBUSY, but was seeing -EBUSY and thus aborting.