### PR TITLE
panfrost: Fix MMU/fd race

### DIFF
--- a/sys/dev/drm/panfrost/panfrost_device.h
+++ b/sys/dev/drm/panfrost/panfrost_device.h
@@ -36,18 +36,20 @@
 #define	NUM_JOB_SLOTS	3
 
 struct panfrost_mmu {
+	struct panfrost_softc	*sc;
+	u_int			refcount;
 	struct pmap p;
 	int as;		/* asid set */
 	int as_count;	/* usage count */
 	TAILQ_ENTRY(panfrost_mmu)	next;	/* entry in mmu_in_use list */
+	struct		drm_mm mm;
+	struct mtx	mm_lock;
 };
 
 struct panfrost_file {
 	struct		panfrost_softc *sc;
-	struct		panfrost_mmu mmu __subobject_use_container_bounds;
+	struct		panfrost_mmu *mmu;
 	struct		drm_sched_entity sched_entity[NUM_JOB_SLOTS];
-	struct		drm_mm mm;
-	struct mtx	mm_lock;
 };
 
 int panfrost_device_init(struct panfrost_softc *);

--- a/sys/dev/drm/panfrost/panfrost_drv.c
+++ b/sys/dev/drm/panfrost/panfrost_drv.c
@@ -79,13 +79,6 @@ __FBSDID("$FreeBSD$");
 #include "panfrost_mmu.h"
 #include "panfrost_job.h"
 
-#define	PN_16M		0x1000
-#define	PN_4GB		0x100000
-#define	PN_4GB_MASK	(PN_4GB - 1)
-
-#define	SZ_32MB		(32 * 1024 * 1024)
-#define	SZ_4GB		(4 * 1024 * 1024 * 1024ULL)
-
 MALLOC_DEFINE(M_PANFROST, "panfrost", "Panfrost driver");
 MALLOC_DEFINE(M_PANFROST1, "panfrost1", "Panfrost 1 driver");
 MALLOC_DEFINE(M_PANFROST2, "panfrost2", "Panfrost 2 driver");
@@ -127,24 +120,6 @@ static const struct file_operations panfrost_drm_driver_fops = {
 	.mmap		= drm_gem_mmap,
 };
 
-static void
-panfrost_drm_mm_color_adjust(const struct drm_mm_node *node,
-    unsigned long color, uint64_t *start, uint64_t *end)
-{
-	uint64_t next_seg;
-
-	if ((color & PANFROST_BO_NOEXEC) == 0) {
-		if ((*start & PN_4GB_MASK) == 0)
-			(*start)++;
-		if ((*end & PN_4GB_MASK) == 0)
-			(*end)--;
-		next_seg = ALIGN(*start, PN_4GB);
-		if (next_seg - *start <= PN_16M)
-			*start = next_seg + 1;
-		*end = min(*end, ALIGN(*start, PN_4GB) - 1);
-	}
-}
-
 static int
 panfrost_open(struct drm_device *dev, struct drm_file *file)
 {
@@ -160,19 +135,12 @@ panfrost_open(struct drm_device *dev, struct drm_file *file)
 	pfile->sc = sc;
 	file->driver_priv = pfile;
 
-	mtx_init(&pfile->mm_lock, "mm", NULL, MTX_SPIN);
-
-	drm_mm_init(&pfile->mm, SZ_32MB >> PAGE_SHIFT,
-	    (SZ_4GB - SZ_32MB) >> PAGE_SHIFT);
-	pfile->mm.color_adjust = panfrost_drm_mm_color_adjust;
-
-	error = panfrost_mmu_pgtable_alloc(pfile);
-	if (error != 0) {
-		device_printf(sc->dev, "%s: could not allocate pgtable\n",
+	pfile->mmu = panfrost_mmu_ctx_create(sc);
+	if (pfile->mmu == NULL) {
+		device_printf(sc->dev, "%s: can't create mmu context\n",
 		    __func__);
-		drm_mm_takedown(&pfile->mm);
 		free(pfile, M_PANFROST);
-		return (error);
+		return (-ENXIO);
 	}
 
 	error = panfrost_job_open(pfile);
@@ -193,10 +161,8 @@ panfrost_postclose(struct drm_device *dev, struct drm_file *file)
 
 	pfile = file->driver_priv;
 
-	panfrost_mmu_pgtable_free(pfile);
 	panfrost_job_close(pfile);
-
-	drm_mm_takedown(&pfile->mm);
+	panfrost_mmu_ctx_put(pfile->mmu);
 
 	free(pfile, M_PANFROST);
 }
@@ -291,6 +257,7 @@ static int
 panfrost_ioctl_submit(struct drm_device *dev, void *data,
     struct drm_file *file)
 {
+	struct panfrost_file *pfile;
 	struct panfrost_softc *sc;
 #ifdef COMPAT_FREEBSD64
 	struct drm_panfrost_submit64 *args64;
@@ -300,7 +267,9 @@ panfrost_ioctl_submit(struct drm_device *dev, void *data,
 	struct drm_panfrost_submit *args;
 	struct panfrost_job *job;
 	struct drm_syncobj *sync_out;
+	struct drm_sched_entity *entity;
 	int error;
+	int slot;
 
 	sc = dev->dev_private;
 
@@ -342,14 +311,26 @@ panfrost_ioctl_submit(struct drm_device *dev, void *data,
 		}
 	}
 
+	pfile = file->driver_priv;
+
 	job = malloc(sizeof(*job), M_PANFROST1, M_WAITOK | M_ZERO);
 	job->sc = sc;
 	job->jc = args->jc;
 	job->requirements = args->requirements;
 	job->flush_id = panfrost_device_get_latest_flush_id(sc);
-	job->pfile = file->driver_priv;
+	job->mmu = pfile->mmu;
 
 	refcount_init(&job->refcount, 1);
+
+	slot = panfrost_job_get_slot(job);
+
+	job->slot = slot;
+
+	entity = &pfile->sched_entity[slot];
+
+	error = drm_sched_job_init(&job->base, entity, NULL);
+	if (error)
+		return (-EINVAL);
 
 	error = panfrost_copy_in_fences(dev, file, args, job);
 	if (error)

--- a/sys/dev/drm/panfrost/panfrost_gem.c
+++ b/sys/dev/drm/panfrost/panfrost_gem.c
@@ -66,9 +66,9 @@ __FBSDID("$FreeBSD$");
 #include <linux/dma-buf.h>
 
 #include "panfrost_drv.h"
-#include "panfrost_job.h"
 #include "panfrost_drm.h"
 #include "panfrost_device.h"
+#include "panfrost_job.h"
 #include "panfrost_gem.h"
 #include "panfrost_regs.h"
 #include "panfrost_features.h"
@@ -132,7 +132,7 @@ panfrost_gem_open(struct drm_gem_object *obj, struct drm_file *file_priv)
 
 	mapping = malloc(sizeof(*mapping), M_PANFROST1, M_ZERO | M_WAITOK);
 	mapping->obj = bo;
-	mapping->mmu = &pfile->mmu;
+	mapping->mmu = panfrost_mmu_ctx_get(pfile->mmu);
 	refcount_init(&mapping->refcount, 1);
 	drm_gem_object_get(obj);
 
@@ -144,10 +144,10 @@ panfrost_gem_open(struct drm_gem_object *obj, struct drm_file *file_priv)
 		color = PANFROST_BO_NOEXEC;
 	}
 
-	mtx_lock_spin(&pfile->mm_lock);
-	error = drm_mm_insert_node_generic(&pfile->mm, &mapping->mmnode,
+	mtx_lock_spin(&mapping->mmu->mm_lock);
+	error = drm_mm_insert_node_generic(&mapping->mmu->mm, &mapping->mmnode,
 	    obj->size >> PAGE_SHIFT, align, color, 0 /* mode */);
-	mtx_unlock_spin(&pfile->mm_lock);
+	mtx_unlock_spin(&mapping->mmu->mm_lock);
 	if (error) {
 		device_printf(sc->dev,
 		    "%s: Failed to insert: sz %d, align %d, color %d, err %d\n",
@@ -202,7 +202,7 @@ panfrost_gem_close(struct drm_gem_object *obj, struct drm_file *file_priv)
 
 	mtx_lock(&bo->mappings_lock);
 	TAILQ_FOREACH_SAFE(mapping, &bo->mappings, next, tmp) {
-		if (mapping->mmu == &pfile->mmu) {
+		if (mapping->mmu == pfile->mmu) {
 			result = mapping;
 			TAILQ_REMOVE(&bo->mappings, mapping, next);
 			break;
@@ -493,19 +493,17 @@ panfrost_gem_create_object_with_handle(struct drm_file *file,
 static void
 panfrost_gem_teardown_mapping(struct panfrost_gem_mapping *mapping)
 {
-	struct panfrost_file *pfile;
-	struct panfrost_softc *sc;
+	struct panfrost_mmu *mmu;
 
-	pfile = container_of(mapping->mmu, struct panfrost_file, mmu);
-	sc = pfile->sc;
+	mmu = mapping->mmu;
 
 	if (mapping->active)
-		panfrost_mmu_unmap(sc, mapping);
+		panfrost_mmu_unmap(mmu->sc, mapping);
 
-	mtx_lock_spin(&pfile->mm_lock);
+	mtx_lock_spin(&mmu->mm_lock);
 	if (drm_mm_node_allocated(&mapping->mmnode))
 		drm_mm_remove_node(&mapping->mmnode);
-	mtx_unlock_spin(&pfile->mm_lock);
+	mtx_unlock_spin(&mmu->mm_lock);
 }
 
 void
@@ -539,6 +537,7 @@ panfrost_gem_mapping_release(struct panfrost_gem_mapping *mapping)
 
 	panfrost_gem_teardown_mapping(mapping);
 	panfrost_gem_object_put(mapping->obj);
+	panfrost_mmu_ctx_put(mapping->mmu);
 	free(mapping, M_PANFROST1);
 }
 
@@ -560,7 +559,7 @@ panfrost_gem_mapping_get(struct panfrost_gem_object *bo,
 
 	mtx_lock(&bo->mappings_lock);
 	TAILQ_FOREACH(mapping, &bo->mappings, next) {
-		if (mapping->mmu == &file->mmu) {
+		if (mapping->mmu == file->mmu) {
 			result = mapping;
 			refcount_acquire(&mapping->refcount);
 			break;

--- a/sys/dev/drm/panfrost/panfrost_job.h
+++ b/sys/dev/drm/panfrost/panfrost_job.h
@@ -36,7 +36,7 @@
 struct panfrost_job {
 	struct drm_sched_job base __subobject_use_container_bounds; /* must go first */
 	struct panfrost_softc *sc;
-	struct panfrost_file *pfile;
+	struct panfrost_mmu *mmu;
 	uint64_t jc;
 	uint32_t requirements;
 	uint32_t flush_id;
@@ -66,5 +66,6 @@ void panfrost_job_intr(void *arg);
 void panfrost_job_put(struct panfrost_job *job);
 void panfrost_job_close(struct panfrost_file *pfile);
 void panfrost_job_enable_interrupts(struct panfrost_softc *sc);
+int panfrost_job_get_slot(struct panfrost_job *job);
 
 #endif /* !_DEV_DRM_PANFROST_PANFROST_JOB_H_ */

--- a/sys/dev/drm/panfrost/panfrost_mmu.h
+++ b/sys/dev/drm/panfrost/panfrost_mmu.h
@@ -33,7 +33,6 @@
 #ifndef	_DEV_DRM_PANFROST_PANFROST_MMU_H_
 #define	_DEV_DRM_PANFROST_PANFROST_MMU_H_
 
-int panfrost_mmu_pgtable_alloc(struct panfrost_file *pfile);
 int panfrost_mmu_map(struct panfrost_softc *sc,
     struct panfrost_gem_mapping *mapping);
 int panfrost_mmu_enable(struct panfrost_softc *sc, struct panfrost_mmu *mmu);
@@ -42,9 +41,11 @@ uint32_t panfrost_mmu_as_get(struct panfrost_softc *sc,
     struct panfrost_mmu *mmu);
 void panfrost_mmu_intr(void *arg);
 int panfrost_mmu_init(struct panfrost_softc *sc);
-void panfrost_mmu_pgtable_free(struct panfrost_file *pfile);
 void panfrost_mmu_unmap(struct panfrost_softc *sc,
     struct panfrost_gem_mapping *mapping);
 void panfrost_mmu_reset(struct panfrost_softc *sc);
+struct panfrost_mmu *panfrost_mmu_ctx_create(struct panfrost_softc *sc);
+void panfrost_mmu_ctx_put(struct panfrost_mmu *mmu);
+struct panfrost_mmu * panfrost_mmu_ctx_get(struct panfrost_mmu *mmu);
 
 #endif /* !_DEV_DRM_PANFROST_PANFROST_MMU_H_ */


### PR DESCRIPTION
This fixes the race when file descriptor is closed abruptly, but jobs are still running.