### PR TITLE
Add quarantine and revocation of unmapped reservations

### DIFF
--- a/bin/cheribsdtest/Makefile.purecap
+++ b/bin/cheribsdtest/Makefile.purecap
@@ -12,6 +12,7 @@ CHERI_C_TESTS=	yes
 .if ${MK_CHERI_CAPREVOKE} == "yes"
 LIBADD+=cheri_caprevoke
 CFLAGS+=-DCHERI_REVOKE
+LIBADD+=procstat
 .endif
 
 .include "${.PARSEDIR}/Makefile.cheribsdtest"

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -1250,9 +1250,7 @@ CHERIBSDTEST(vm_capdirty, "verify capdirty marking and mincore")
 static inline uint64_t
 get_cyclecount()
 {
-#if defined(__mips__)
-	return cheri_get_cyclecount();
-#elif defined(__riscv)
+#if defined(__riscv)
 	return __builtin_readcyclecounter();
 #elif defined(__aarch64__)
 	uint64_t count;

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -2020,5 +2020,6 @@ CHERIBSDTEST(cheri_revoke_lib_fork,
 
 	cheribsdtest_success();
 }
-#endif
+#endif /* CHERI_REVOKE */
+
 #endif /* __CHERI_PURE_CAPABILITY__ */

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -2116,6 +2116,98 @@ CHERIBSDTEST(revoke_largest_quarantined_reservation,
 	procstat_close(psp);
 	cheribsdtest_success();
 }
+
+#define	NRES	3
+CHERIBSDTEST(revoke_merge_quarantined,
+    "Verify that adjacent non-neighbor reservations are revoked")
+{
+	const size_t big_res_size = 0x100000000;
+	const size_t res_sizes[NRES] =
+	    { PAGE_SIZE, big_res_size, PAGE_SIZE };
+	const size_t res_offsets[NRES] =
+	    { PAGE_SIZE, big_res_size, 3 * big_res_size };
+	void * __capability res;
+	ptraddr_t res_addrs[NRES], working_space;
+	struct procstat *psp;
+	struct kinfo_proc *kipp;
+	struct kinfo_vmentry *kivp;
+	uint pcnt, vmcnt;
+	bool found_res[NRES] = {};
+
+	/*
+	 * Create a single large quarantined reservation with three
+	 * non-adjacent, quarantined neighbors inside it (the edges are
+	 * padded to prevent merging with neighbors are creation time).
+	 *
+	 * The three quarantined regions are:
+	 *  - A PAGE_SIZE entry at offset PAGE_SIZE.
+	 *  - A large (big_res_size) allocation at offset big_res_size.
+	 *  - A PAGE_SIZE reservation at offset 3*big_res_size.
+	 */
+	working_space = find_address_space_gap(big_res_size * 4, 0);
+	for (int r = 0; r < NRES; r++) {
+		res = CHERIBSDTEST_CHECK_SYSCALL(mmap(
+		    (void *)(uintptr_t)(working_space + res_offsets[r]),
+		    res_sizes[r], PROT_READ, MAP_ANON, -1, 0));
+		res_addrs[r] = (ptraddr_t)res;
+		CHERIBSDTEST_CHECK_SYSCALL(munmap(res, res_sizes[r]));
+	}
+
+	psp = procstat_open_sysctl();
+	CHERIBSDTEST_VERIFY(psp != NULL);
+	kipp = procstat_getprocs(psp, KERN_PROC_PID, getpid(), &pcnt);
+	CHERIBSDTEST_VERIFY(kipp != NULL);
+	CHERIBSDTEST_VERIFY(pcnt == 1);
+	kivp = procstat_getvmmap(psp, kipp, &vmcnt);
+	CHERIBSDTEST_VERIFY(kivp != NULL);
+
+	/*
+	 * Check that there are quarantines resevations at each expected
+	 * location.
+	 */
+	for (u_int i = 0; i < vmcnt; i++) {
+		for (int r = 0; r < NRES; r++) {
+			if (kivp[i].kve_start == res_addrs[r]) {
+				found_res[r] = true;
+				CHERIBSDTEST_VERIFY(kivp[i].kve_type ==
+				    KVME_TYPE_QUARANTINED);
+			}
+		}
+	}
+	for (int r = 0; r < NRES; r++)
+		CHERIBSDTEST_VERIFY2(found_res[r],
+		    "reservation not found in vmmap");
+
+	procstat_freevmmap(psp, kivp);
+
+	/*
+	 * XXX: Assume that the revoker will revoke the largest
+	 * quarantined reservation and merge it with it's neighbors.
+	 */
+	malloc_revoke();
+
+	kivp = procstat_getvmmap(psp, kipp, &vmcnt);
+	CHERIBSDTEST_VERIFY(kivp != NULL);
+
+	for (u_int i = 0; i < vmcnt; i++) {
+		/*
+		 * Check that no entries overlap our working space.
+		 */
+		if ((kivp[i].kve_start >= working_space &&
+		    kivp[i].kve_start < working_space + (4 * big_res_size)) ||
+		    (kivp[i].kve_end - 1 >= working_space &&
+		    kivp[i].kve_end - 1 < working_space + (4 * big_res_size))) {
+			cheribsdtest_failure_errx(
+			    "reservation(s) still in memory map");
+		}
+	}
+
+	procstat_freevmmap(psp, kivp);
+	procstat_freeprocs(psp, kipp);
+	procstat_close(psp);
+	cheribsdtest_success();
+}
+#undef NRES
 #endif /* CHERI_REVOKE */
 
 #endif /* __CHERI_PURE_CAPABILITY__ */

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -40,12 +40,15 @@
 #endif
 
 #include <sys/types.h>
+#include <sys/param.h>
 #include <sys/mman.h>
 #include <sys/mount.h>
+#include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/ucontext.h>
+#include <sys/user.h>
 #include <sys/wait.h>
 
 #include <cheri/revoke.h>
@@ -63,11 +66,14 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sysexits.h>
 #include <unistd.h>
+
+#include <libprocstat.h>
 
 #include "cheribsdtest.h"
 
@@ -2032,6 +2038,82 @@ CHERIBSDTEST(cheri_revoke_lib_fork,
 
 	munmap(bigblock, bigblock_caps * sizeof(void * __capability));
 
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(revoke_largest_quarantined_reservation,
+    "Verify that the largest quarantined reservation is revoked")
+{
+	const size_t res_size = 0x100000000;
+	void * __capability res;
+	ptraddr_t res_addr;
+	struct procstat *psp;
+	struct kinfo_proc *kipp;
+	struct kinfo_vmentry *kivp;
+	uint pcnt, vmcnt;
+	bool found_res;
+
+	res = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, res_size, PROT_READ,
+	    MAP_ANON, -1, 0));
+	res_addr = (ptraddr_t)res;
+	CHERIBSDTEST_CHECK_SYSCALL(munmap(res, res_size));
+
+	psp = procstat_open_sysctl();
+	CHERIBSDTEST_VERIFY(psp != NULL);
+	kipp = procstat_getprocs(psp, KERN_PROC_PID, getpid(), &pcnt);
+	CHERIBSDTEST_VERIFY(kipp != NULL);
+	CHERIBSDTEST_VERIFY(pcnt == 1);
+	kivp = procstat_getvmmap(psp, kipp, &vmcnt);
+	CHERIBSDTEST_VERIFY(kivp != NULL);
+
+	found_res = false;
+	for (u_int i = 0; i < vmcnt; i++) {
+		/*
+		 * Look for an entry containing our reservation.  It
+		 * may have been merged with a previously quarantined
+		 * region so don't expect an exact match.
+		 */
+		if (kivp[i].kve_start <= res_addr &&
+		    kivp[i].kve_end >= res_addr + res_size) {
+			found_res = true;
+			CHERIBSDTEST_VERIFY(kivp[i].kve_type ==
+			    KVME_TYPE_QUARANTINED);
+		}
+	}
+	CHERIBSDTEST_VERIFY2(found_res, "reservation not found in vmmap");
+
+	procstat_freevmmap(psp, kivp);
+
+	/*
+	 * XXX: Assume that the revoker will revoke the largest
+	 * quarantined reservation.
+	 */
+	malloc_revoke();
+
+	kivp = procstat_getvmmap(psp, kipp, &vmcnt);
+	CHERIBSDTEST_VERIFY(kivp != NULL);
+
+	for (u_int i = 0; i < vmcnt; i++) {
+		/*
+		 * Look for an entry containing our reservation.  We
+		 * assuming res_size is large enough that it's the
+		 * reservation we revoke, we shouldn't find it.
+		 *
+		 * XXX: It's possible procstat_getvmmap() could trigger
+		 * reuse of this space, but probably not since we'll
+		 * have just flushed malloc()'s quarantine list so
+		 * there should be plenty of objects on the free list(s).
+		 */
+		if (kivp[i].kve_start <= res_addr &&
+		    kivp[i].kve_end >= res_addr + res_size) {
+			cheribsdtest_failure_errx(
+			    "reservation still in memory map");
+		}
+	}
+
+	procstat_freevmmap(psp, kivp);
+	procstat_freeprocs(psp, kipp);
+	procstat_close(psp);
 	cheribsdtest_success();
 }
 #endif /* CHERI_REVOKE */

--- a/sys/arm64/arm64/cheri_revoke_machdep.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep.c
@@ -94,7 +94,9 @@ vm_do_cheri_revoke(int *res,
 		const uint8_t * __capability crshadow,
 		vm_cheri_revoke_test_fn ctp,
 		uintcap_t * __capability cutp,
-		uintcap_t cut)
+		uintcap_t cut,
+		vm_offset_t start,
+		vm_offset_t end)
 {
 	int perms = cheri_getperm(cut);
 	CHERI_REVOKE_STATS_FOR(crst, crc);
@@ -110,7 +112,7 @@ vm_do_cheri_revoke(int *res,
 		 */
 
 		CHERI_REVOKE_STATS_BUMP(crst, caps_found_revoked);
-	} else if (cheri_gettag(cut) && ctp(crshadow, cut, perms)) {
+	} else if (cheri_gettag(cut) && ctp(crshadow, cut, perms, start, end)) {
 		void * __capability cscratch;
 		int stxr_status;
 
@@ -222,11 +224,20 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 				 const uint8_t * __capability,
 				 vm_cheri_revoke_test_fn,
 				 uintcap_t * __capability,
-				 uintcap_t),
+				 uintcap_t,
+				 vm_offset_t,
+				 vm_offset_t),
 		       uintcap_t * __capability mvu,
 		       vm_offset_t mve)
 {
 	int res = 0;
+	vm_offset_t start, end;
+
+	if (crc->map->rev_entry != NULL) {
+		start = crc->map->rev_entry->start;
+		end = crc->map->rev_entry->end;
+	} else
+		start = end = 0;
 
 	/* Load once up front, which is almost as good as const */
 	vm_cheri_revoke_test_fn ctp = crc->map->vm_cheri_revoke_test;
@@ -240,7 +251,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 	for (; cheri_getaddress(mvu) < mve; mvu++) {
 		uintcap_t cut = *mvu;
 		if (cheri_gettag(cut)) {
-			if (cb(&res, crc, crshadow, ctp, mvu, cut))
+			if (cb(&res, crc, crshadow, ctp, mvu, cut, start, end))
 				goto out;
 		}
 	}
@@ -258,13 +269,21 @@ vm_cheri_revoke_test(const struct vm_cheri_revoke_cookie *crc, uintcap_t cut)
 {
 	if (cheri_gettag(cut)) {
 		int res;
+		vm_offset_t start, end;
+
+		if (crc->map->rev_entry != NULL) {
+			start = crc->map->rev_entry->start;
+			end = crc->map->rev_entry->end;
+		} else
+			start = end = 0;
+
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
 		curthread->td_pcb->pcb_onfault =
 		    (vm_offset_t)vm_cheri_revoke_tlb_fault;
 		enable_user_memory_access();
 #endif
 		res = crc->map->vm_cheri_revoke_test(crc->crshadow, cut,
-		    cheri_getperm(cut));
+		    cheri_getperm(cut), start, end);
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
 		disable_user_memory_access();
 		curthread->td_pcb->pcb_onfault = 0;
@@ -330,7 +349,9 @@ vm_cheri_revoke_page_ro_adapt(int *res,
 		           const uint8_t * __capability crshadow,
 			   vm_cheri_revoke_test_fn ctp,
 			   uintcap_t * __capability cutp,
-			   uintcap_t cut)
+			   uintcap_t cut,
+			   vm_offset_t start,
+			   vm_offset_t end)
 {
 	(void)cutp;
 
@@ -346,7 +367,7 @@ vm_cheri_revoke_page_ro_adapt(int *res,
 
 	*res |= VM_CHERI_REVOKE_PAGE_HASCAPS;
 
-	if (ctp(crshadow, cut, cheri_getperm(cut))) {
+	if (ctp(crshadow, cut, cheri_getperm(cut), start, end)) {
 		*res |= VM_CHERI_REVOKE_PAGE_DIRTY;
 
 		/* One dirty answer is as good as any other; stop eary */

--- a/sys/arm64/arm64/cheri_revoke_machdep_tests.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep_tests.c
@@ -122,12 +122,21 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 	return bmbits & (1 << ((va / VM_CHERI_REVOKE_GSZ_MEM_NOMAP) % 8));
 }
 
+static inline unsigned
+vm_cheri_revoke_test_range(vm_offset_t start, vm_offset_t end, uintcap_t cut)
+{
+	ptraddr_t va = cheri_getbase(cut);
+
+	return (va >= start && va < end);
+}
+
 // TODO: if ((perms & CHERI_PERMS_HWALL_OTYPE) != 0)
 // TODO: if ((perms & CHERI_PERMS_HWALL_CID) != 0)
 
 static unsigned long
 vm_cheri_revoke_test_just_mem(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms)
+		      uintcap_t cut, unsigned long perms,
+		      vm_offset_t start, vm_offset_t end)
 {
 	if ((perms & (CHERI_PERMS_HWALL_MEMORY
 		     | CHERI_PERM_SW_VMEM)) != 0) {
@@ -143,7 +152,8 @@ vm_cheri_revoke_test_just_mem(const uint8_t * __capability crshadow,
 
 static unsigned long
 vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms)
+		      uintcap_t cut, unsigned long perms,
+		      vm_offset_t start, vm_offset_t end)
 {
 	/*
 	 * Most capabilities are memory capabilities, most are unrevoked,
@@ -162,6 +172,26 @@ vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
 	return 0;
 }
 
+static unsigned long
+vm_cheri_revoke_test_mem_fine_range(const uint8_t * __capability crshadow,
+		      uintcap_t cut, unsigned long perms,
+		      vm_offset_t start, vm_offset_t end)
+{
+	/*
+	 * Only check the capability if it has some memory permissions.
+	 */
+	if ((perms & CHERI_PERMS_HWALL_MEMORY) != 0) {
+		if (vm_cheri_revoke_test_range(start, end, cut))
+			return (1);
+
+		if ((perms & CHERI_PERM_SW_VMEM) == 0) {
+			return vm_cheri_revoke_test_mem_nomap(crshadow, cut);
+		}
+	}
+
+	return (0);
+}
+
 /*
  *
  */
@@ -173,11 +203,20 @@ vm_cheri_revoke_set_test(vm_map_t map, int flags)
 		| VM_CHERI_REVOKE_CF_NO_OTYPES
 		| VM_CHERI_REVOKE_CF_NO_CIDS :
 
+		map->vm_cheri_revoke_test = vm_cheri_revoke_test_mem_fine_range;
+		break;
+
+	case VM_CHERI_REVOKE_CF_NO_COARSE_MEM
+		| VM_CHERI_REVOKE_CF_NO_OTYPES
+		| VM_CHERI_REVOKE_CF_NO_CIDS
+		| VM_CHERI_REVOKE_CF_NO_REV_ENTRY :
+
 		map->vm_cheri_revoke_test = vm_cheri_revoke_test_just_mem_fine;
 		break;
 
 	case VM_CHERI_REVOKE_CF_NO_OTYPES
-		| VM_CHERI_REVOKE_CF_NO_CIDS :
+		| VM_CHERI_REVOKE_CF_NO_CIDS
+		| VM_CHERI_REVOKE_CF_NO_REV_ENTRY :
 
 		map->vm_cheri_revoke_test = vm_cheri_revoke_test_just_mem;
 		break;

--- a/sys/riscv/riscv/cheri_revoke_machdep_tests.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep_tests.c
@@ -122,12 +122,21 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 	return bmbits & (1 << ((va / VM_CHERI_REVOKE_GSZ_MEM_NOMAP) % 8));
 }
 
+static inline unsigned
+vm_cheri_revoke_test_range(vm_offset_t start, vm_offset_t end, uintcap_t cut)
+{
+	ptraddr_t va = cheri_getbase(cut);
+
+	return (va >= start && va < end);
+}
+
 // TODO: if ((perms & CHERI_PERMS_HWALL_OTYPE) != 0)
 // TODO: if ((perms & CHERI_PERMS_HWALL_CID) != 0)
 
 static unsigned long
 vm_cheri_revoke_test_just_mem(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms)
+		      uintcap_t cut, unsigned long perms,
+		      vm_offset_t start, vm_offset_t end)
 {
 	if ((perms & (CHERI_PERMS_HWALL_MEMORY
 		     | CHERI_PERM_SW_VMEM)) != 0) {
@@ -143,7 +152,8 @@ vm_cheri_revoke_test_just_mem(const uint8_t * __capability crshadow,
 
 static unsigned long
 vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms)
+		      uintcap_t cut, unsigned long perms,
+		      vm_offset_t start, vm_offset_t end)
 {
 	/*
 	 * Most capabilities are memory capabilities, most are unrevoked,
@@ -162,6 +172,26 @@ vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
 	return 0;
 }
 
+static unsigned long
+vm_cheri_revoke_test_mem_fine_range(const uint8_t * __capability crshadow,
+		      uintcap_t cut, unsigned long perms,
+		      vm_offset_t start, vm_offset_t end)
+{
+	/*
+	 * Only check the capability if it has some memory permissions.
+	 */
+	if ((perms & CHERI_PERMS_HWALL_MEMORY) != 0) {
+		if (vm_cheri_revoke_test_range(start, end, cut))
+			return (1);
+
+		if ((perms & CHERI_PERM_SW_VMEM) == 0) {
+			return vm_cheri_revoke_test_mem_nomap(crshadow, cut);
+		}
+	}
+
+	return (0);
+}
+
 /*
  *
  */
@@ -173,11 +203,20 @@ vm_cheri_revoke_set_test(vm_map_t map, int flags)
 		| VM_CHERI_REVOKE_CF_NO_OTYPES
 		| VM_CHERI_REVOKE_CF_NO_CIDS :
 
+		map->vm_cheri_revoke_test = vm_cheri_revoke_test_mem_fine_range;
+		break;
+
+	case VM_CHERI_REVOKE_CF_NO_COARSE_MEM
+		| VM_CHERI_REVOKE_CF_NO_OTYPES
+		| VM_CHERI_REVOKE_CF_NO_CIDS
+		| VM_CHERI_REVOKE_CF_NO_REV_ENTRY :
+
 		map->vm_cheri_revoke_test = vm_cheri_revoke_test_just_mem_fine;
 		break;
 
 	case VM_CHERI_REVOKE_CF_NO_OTYPES
-		| VM_CHERI_REVOKE_CF_NO_CIDS :
+		| VM_CHERI_REVOKE_CF_NO_CIDS
+		| VM_CHERI_REVOKE_CF_NO_REV_ENTRY :
 
 		map->vm_cheri_revoke_test = vm_cheri_revoke_test_just_mem;
 		break;

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -496,6 +496,7 @@ struct kinfo_lockf {
 #define	KVME_TYPE_SG		7
 #define	KVME_TYPE_MGTDEVICE	8
 #define	KVME_TYPE_GUARD		9
+#define	KVME_TYPE_QUARANTINED	10
 #define	KVME_TYPE_UNKNOWN	255
 
 #define	KVME_PROT_READ		0x00000001

--- a/sys/vm/vm.h
+++ b/sys/vm/vm.h
@@ -71,6 +71,7 @@ typedef char vm_inherit_t;	/* inheritance codes */
 #define	VM_INHERIT_COPY		((vm_inherit_t) 1)
 #define	VM_INHERIT_NONE		((vm_inherit_t) 2)
 #define	VM_INHERIT_ZERO		((vm_inherit_t) 3)
+#define	VM_INHERIT_QUARANTINE	((vm_inherit_t) 4)
 #define	VM_INHERIT_DEFAULT	VM_INHERIT_COPY
 
 typedef u_char vm_prot_t;	/* protection codes */

--- a/sys/vm/vm_cheri_revoke.h
+++ b/sys/vm/vm_cheri_revoke.h
@@ -132,12 +132,15 @@ void vm_cheri_revoke_publish_epochs(
 int vm_cheri_revoke_test(const struct vm_cheri_revoke_cookie *, uintcap_t);
 
 enum {
-	/* If no coarse bits set, VMMAP-bearing caps are imune */
+	/* If no coarse bits set */
 	VM_CHERI_REVOKE_CF_NO_COARSE_MEM = 0x01,
 
 	/* If no otype bits set, Permit_Seal and _Unseal are imune */
 	VM_CHERI_REVOKE_CF_NO_OTYPES = 0x02,
 	VM_CHERI_REVOKE_CF_NO_CIDS = 0x04,
+
+	/* If no rev_entry selected in the vm_map */
+	VM_CHERI_REVOKE_CF_NO_REV_ENTRY = 0x08,
 };
 void vm_cheri_revoke_set_test(struct vm_map *map, int flags);
 

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -999,6 +999,7 @@ _vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
 
 #ifdef CHERI_CAPREVOKE
 	map->vm_cheri_revoke_st = CHERI_REVOKE_ST_NONE; /* and epoch 0 */
+	LIST_INIT(&map->quarantine);
 #endif
 }
 
@@ -1576,11 +1577,77 @@ vm_map_entry_unlink(vm_map_t map, vm_map_entry_t entry,
 	if (root != NULL)
 		root->max_free = vm_size_max(max_free_left, max_free_right);
 	map->root = root;
+#ifdef CHERI_CAPREVOKE
+	KASSERT(entry != map->rev_entry, ("Can't remove map->rev_entry"));
+	if (entry->inheritance == VM_INHERIT_QUARANTINE) {
+		LIST_REMOVE(entry, quarantine);
+	}
+#endif
 	VM_MAP_ASSERT_CONSISTENT(map);
 	map->nentries--;
 	CTR3(KTR_VM, "vm_map_entry_unlink: map %p, nentries %d, entry %p", map,
 	    map->nentries, entry);
 }
+
+#ifdef CHERI_CAPREVOKE
+static void
+vm_map_entry_quarantine(vm_map_t map, vm_map_entry_t entry)
+{
+	KASSERT((entry->eflags & MAP_ENTRY_UNMAPPED) != 0,
+	    ("Can only quarantine unmappled pages %x\n", entry->eflags));
+	CTR3(KTR_VM,
+	    __func__ ": map %p, nentries %d, entry %p", map, map->nentries,
+	    entry);
+	VM_MAP_ASSERT_LOCKED(map);
+	/*
+	 * XXX: We should try to merge with immediate neighbors (but not
+	 * with map->rev_entry).
+	 */
+	entry->inheritance = VM_INHERIT_QUARANTINE;
+	LIST_INSERT_HEAD(&map->quarantine, entry, quarantine);
+	/* XXX stats */
+}
+
+bool
+vm_map_entry_start_revocation(vm_map_t map, vm_map_entry_t *entry)
+{
+
+	KASSERT(map->rev_entry == NULL,
+	   ("an entry %p is already being revoked", map->rev_entry));
+	VM_MAP_ASSERT_LOCKED(map);
+	if (LIST_EMPTY(&map->quarantine))
+		return (FALSE);
+	/*
+	 * Just pop the most recent entry off the list to do something.
+	 *
+	 * We'll eventually want this to find the "most impactful" entry
+	 * to free and expand the selection to include non-adjacent
+	 * neighbors in order to return at much VA to use as possible in
+	 * a given round of revocation.
+	 */
+	map->rev_entry = LIST_FIRST(&map->quarantine);
+	if (entry != NULL)
+		*entry = map->rev_entry;
+	/* XXX stats */
+	return (TRUE);
+}
+
+void
+vm_map_entry_end_revocation(vm_map_t map)
+{
+	vm_map_entry_t rev_entry;
+
+	if (map->rev_entry == NULL)
+		return;	/* we weren't revoking a map entry this round */
+
+	vm_map_lock(map);
+	rev_entry = map->rev_entry;
+	map->rev_entry = NULL;
+	vm_map_entry_unlink(map, rev_entry, UNLINK_MERGE_NONE);
+	/* XXX stats */
+	vm_map_unlock(map);
+}
+#endif
 
 /*
  *	vm_map_entry_resize:
@@ -1769,6 +1836,7 @@ vm_map_insert(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
 		    new_entry->reservation != reservation)
 			return (KERN_PROTECTION_FAILURE);
 		if ((new_entry->eflags & MAP_ENTRY_UNMAPPED) == 0 ||
+		    new_entry->inheritance == VM_INHERIT_QUARANTINE ||
 		    new_entry->end < end)
 			return (KERN_NO_SPACE);
 		/* XXX-AM: TODO Check maxprot consistency with the reserved entry */
@@ -3498,6 +3566,7 @@ vm_map_inherit(vm_map_t map, vm_offset_t start, vm_offset_t end,
 	case VM_INHERIT_COPY:
 	case VM_INHERIT_SHARE:
 	case VM_INHERIT_ZERO:
+	/* Don't allow VM_INHERIT_QUARANTINE */
 		break;
 	default:
 		return (KERN_INVALID_ARGUMENT);
@@ -3514,6 +3583,15 @@ vm_map_inherit(vm_map_t map, vm_offset_t start, vm_offset_t end,
 		if (rv != KERN_SUCCESS)
 			goto unlock;
 	}
+#ifdef CHERI_CAPREVOKE
+	for (entry = start_entry; entry->start < end;
+	    prev_entry = entry, entry = vm_map_entry_succ(entry)) {
+		if (entry->inheritance == VM_INHERIT_QUARANTINE) {
+			rv = KERN_PROTECTION_FAILURE;
+			goto unlock;
+		}
+	}
+#endif
 	if (new_inheritance == VM_INHERIT_COPY) {
 		for (entry = start_entry; entry->start < end;
 		    prev_entry = entry, entry = vm_map_entry_succ(entry)) {
@@ -4544,8 +4622,23 @@ vm_map_remove_locked(vm_map_t map, vm_offset_t start, vm_offset_t end)
 	}
 
 	result = vm_map_delete(map, start, end, true);
-	if (vm_map_reservation_is_unmapped(map, reservation))
-		vm_map_reservation_delete_locked(map, reservation);
+	if (vm_map_reservation_is_unmapped(map, reservation)) {
+#ifdef CHERI_CAPREVOKE
+		if (start < VM_MAXUSER_ADDRESS) {
+			/*
+			 * If we're here, [start, end) was the last mapped
+			 * range in reservation and it has transitioned to
+			 * fully unmapped with a new entry.  Look up the
+			 * entry and quarantine it.
+			 */
+			vm_map_lookup_entry(map, start, &entry);
+			KASSERT(entry->start <= start && entry->end >= end,
+			    ("entry doesn't cover removed range"));
+			vm_map_entry_quarantine(map, entry);
+		} else
+#endif
+			vm_map_reservation_delete_locked(map, reservation);
+	}
 
 	return (result);
 }
@@ -4893,7 +4986,7 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 		inh = old_entry->inheritance;
 		if ((old_entry->eflags &
 		    (MAP_ENTRY_GUARD | MAP_ENTRY_UNMAPPED)) != 0 &&
-		    inh != VM_INHERIT_NONE)
+		    inh != VM_INHERIT_NONE && inh != VM_INHERIT_QUARANTINE)
 			inh = VM_INHERIT_COPY;
 
 		switch (inh) {
@@ -5045,6 +5138,24 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 			*fork_charge += (new_entry->end - new_entry->start);
 
 			break;
+
+#ifdef CHERI_CAPREVOKE
+		case VM_INHERIT_QUARANTINE:
+			new_entry = vm_map_entry_create(new_map);
+			memset(new_entry, 0, sizeof(*new_entry));
+			new_entry->start = old_entry->start;
+			new_entry->end = old_entry->end;
+			new_entry->reservation = old_entry->reservation;
+			new_entry->eflags = MAP_ENTRY_UNMAPPED;
+			new_entry->inheritance = VM_INHERIT_QUARANTINE;
+			new_entry->cred = NULL;
+
+			vm_map_entry_link(new_map, new_entry);
+			vm_map_entry_quarantine(new_map, new_entry);
+			vmspace_map_entry_forked(vm1, vm2, new_entry);
+
+			break;
+#endif
 		}
 	}
 	/*

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -74,6 +74,8 @@
 #include <sys/condvar.h>
 
 #ifdef CHERI_CAPREVOKE
+#include <sys/tree.h>
+
 #include <cheri/revoke.h>
 #include <cheri/revoke_kern.h>
 #endif
@@ -108,7 +110,7 @@ struct vm_map_entry {
 	struct vm_map_entry *left;	/* left child or previous entry */
 	struct vm_map_entry *right;	/* right child or next entry */
 #ifdef CHERI_CAPREVOKE
-	LIST_ENTRY(vm_map_entry) quarantine; /* quarantined entries */
+	RB_ENTRY(vm_map_entry) quarantine; /* quarantined entries */
 #endif
 	vm_offset_t start;		/* start address */
 	vm_offset_t end;		/* end address */
@@ -244,12 +246,10 @@ struct vm_map {
 	 */
 	vm_cheri_revoke_test_fn vm_cheri_revoke_test;
 	/*
-	 * List containing map entries awaiting revocation.
-	 *
-	 * XXX: should this be some other structure?  Maybe a tree
-	 * ordered by size?
+	 * Tree of map entries awaiting revocation, ordered by size and
+	 * virtual address.
 	 */
-	LIST_HEAD(vm_map_quarantine, vm_map_entry) quarantine;
+	RB_HEAD(vm_map_quarantine, vm_map_entry) quarantine;
 	struct vm_map_entry *rev_entry;	/* entry being revoked */
 #ifdef CHERI_CAPREVOKE_STATS
 	/*

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -699,6 +699,8 @@ device with managed pages
 .Pq GEM/TTM
 .It ph
 physical
+.It qu
+quarantined (pseudo-type)
 .It sg
 scatter/gather
 .It sw

--- a/usr.bin/procstat/procstat_vm.c
+++ b/usr.bin/procstat/procstat_vm.c
@@ -197,6 +197,10 @@ procstat_vm(struct procstat *procstat, struct kinfo_proc *kipp)
 			str = "gd";
 			lstr = "guard";
 			break;
+		case KVME_TYPE_QUARANTINED:
+			str = "qu";
+			lstr = "quarantined";
+			break;
 		case KVME_TYPE_UNKNOWN:
 		default:
 			str = "??";


### PR DESCRIPTION
This PR adds quarantine and revocation of unmapped reservations. It can revoke a single range of address space per pass which currently means a single reservation. Posting now for discussion. Further work will add tests, ~add~ enhance merging of entries to improve the impact of a given revocation pass, and consider better options for selecting which entry to revoke.
