### PR TITLE
drm_os_freebsd: Map Linux ERESTARTSYS to FreeBSD ERESTART for ioctls

### DIFF
--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -268,6 +268,8 @@ drm_fstub_ioctl(struct file *file, u_long cmd, void *data, struct ucred *cred,
 	}
 
 	rv = -fops->unlocked_ioctl(file, cmd, (uintcap_t)PTR2CAP(data));
+	if (rv == ERESTARTSYS)
+		rv = ERESTART;
 
 	dev_relthread(cdev, ref);
 	return (rv);


### PR DESCRIPTION
This fixes an assertion failure in Mesa's panfrost_bo_wait in Xwayland when running Firefox, as the ERESTARTSYS was leaking up into errno and not being one of the two expected values.