### PR TITLE
Work around nested panic in DRM

### DIFF
--- a/sys/dev/drm/core/drm_atomic_helper.c
+++ b/sys/dev/drm/core/drm_atomic_helper.c
@@ -1598,7 +1598,11 @@ void drm_atomic_helper_commit_tail_rpm(struct drm_atomic_state *old_state)
 
 	drm_atomic_helper_commit_hw_done(old_state);
 
-	drm_atomic_helper_wait_for_vblanks(dev, old_state);
+#ifdef __FreeBSD__
+	/* XXX: work around nested panic() */
+	if (!SKIP_SLEEP())
+		drm_atomic_helper_wait_for_vblanks(dev, old_state);
+#endif
 
 	drm_atomic_helper_cleanup_planes(dev, old_state);
 }

--- a/sys/dev/drm/core/drm_fb_helper.c
+++ b/sys/dev/drm/core/drm_fb_helper.c
@@ -510,7 +510,11 @@ out_state:
 
 	drm_atomic_state_put(state);
 out_ctx:
-	drm_modeset_drop_locks(&ctx);
+#ifdef __FreeBSD__
+	/* XXX: work around nested panic() */
+	if (!SKIP_SLEEP())
+		drm_modeset_drop_locks(&ctx);
+#endif
 	drm_modeset_acquire_fini(&ctx);
 
 	return ret;


### PR DESCRIPTION
When a kernel panic occurs while DRM graphics are enabled a second panic occurs before the message can be printed or a backtrace produced.  This prevents the users from seeing the panic message.

This change works around the panic in two parts:
 - dont wait for vblank during panic.
 - avoid call to drm_modeset_drop_locks as well due to unknown bug

This should really be done in a FreeBSD-specific layer.

Fixes #1564