### PR TITLE
bmake: avoid deprecated egrep on Linux

### DIFF
--- a/contrib/bmake/unit-tests/Makefile
+++ b/contrib/bmake/unit-tests/Makefile
@@ -726,7 +726,15 @@ TMPDIR:=	/tmp/uid${.MAKE.UID}
 _!= mkdir -p ${TMPDIR}
 .endif
 
-MAKE_TEST_ENV=	MALLOC_OPTIONS="JA"	# for jemalloc 100
+# Some systems have deprecated egrep for grep -E
+# but not everyone supports that
+.if ${.MAKE.OS:NLinux} == ""
+EGREP= grep -E
+.endif
+EGREP?= egrep
+
+MAKE_TEST_ENV=  EGREP="${EGREP}"
+MAKE_TEST_ENV+=	MALLOC_OPTIONS="JA"	# for jemalloc 100
 MAKE_TEST_ENV+=	MALLOC_CONF="junk:true"	# for jemalloc 510
 MAKE_TEST_ENV+= TMPDIR=${TMPDIR}
 
@@ -781,6 +789,7 @@ _SED_CMDS+=	-e 's,\(Error code\) 255,\1 1,'
 .if ${.SHELL:T} == "ksh"
 _SED_CMDS+=	-e '/^set [+-]v/d'
 .endif
+_SED_CMDS+=	-e '/EGREP=/d'
 
 .rawout.out:
 	@${TOOL_SED} ${_SED_CMDS} ${SED_CMDS.${.PREFIX:T}} \

--- a/contrib/bmake/unit-tests/export.mk
+++ b/contrib/bmake/unit-tests/export.mk
@@ -40,7 +40,7 @@ BAR=	bar is ${UT_FU}
 
 .MAKE.EXPORTED+=	UT_ZOO UT_TEST
 
-FILTER_CMD?=	egrep -v '^(MAKEFLAGS|MALLOC_.*|PATH|PWD|SHLVL|_|&)='
+FILTER_CMD?=	${EGREP} -v '^(MAKEFLAGS|MALLOC_.*|PATH|PWD|SHLVL|_|&)='
 
 all:
 	@env | ${FILTER_CMD} | sort

--- a/contrib/bmake/unit-tests/make-exported.mk
+++ b/contrib/bmake/unit-tests/make-exported.mk
@@ -22,4 +22,4 @@ UT_VAR=		${UNEXPANDED}
 .MAKE.EXPORTED=		-literal UT_VAR
 
 all:
-	@env | sort | egrep '^UT_|make-exported-value' || true
+	@env | sort | ${EGREP} '^UT_|make-exported-value' || true


### PR DESCRIPTION
Some Linux variants have deprecated egrep breaking the bmake tests that rely on it.  Manually apply the change from NetBSD as FreeBSD doesn't yet have a bmake import the contains the fix:
https://github.com/NetBSD/src/commit/bc7acecb42334194bab81ed2c204681ee53845ea

Fixes: #1562