### PR TITLE
Do not start user-mode tracing in qtrace when using per-thread tracing.

### DIFF
--- a/usr.bin/qtrace/qtrace.c
+++ b/usr.bin/qtrace/qtrace.c
@@ -87,7 +87,6 @@ set_thread_tracing(void)
 		error = sysarch(QEMU_SET_QTRACE_USER, &intval);
 		if (error)
 			err(EX_OSERR, "QEMU_SET_QTRACE_USER");
-		CHERI_START_USER_TRACE;
 	}
 }
 


### PR DESCRIPTION
The per-thread tracing flag will cause the kernel to enable tracing in the user process after execvp(). Enabling the tracing mode within qtrace is wrong and will produce a polluted trace with a portion of instructions from qtrace.