### PR TITLE
test_ptrace_readtags: stack alloc & align probe region

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_ptrace.c
+++ b/bin/cheribsdtest/cheribsdtest_ptrace.c
@@ -133,10 +133,13 @@ CHERIBSDTEST(test_ptrace_readtags, "Basic test of PIOD_READ_CHERI_TAGS")
 {
 	struct ptrace_io_desc piod;
 	pid_t pid;
+	size_t ppsz = 8 * sizeof(uintcap_t);
 	uintcap_t *pp;
 	char tagbuf[1];
 
-	pp = calloc(8, sizeof(*pp));
+	pp = aligned_alloc(ppsz, ppsz);
+	memset(pp, 0, ppsz);
+
 	pp[0] = (uintcap_t)(__cheri_tocap void * __capability)&piod;
 	pp[2] = (uintcap_t)(__cheri_tocap void * __capability)tagbuf;
 


### PR DESCRIPTION
ptrace()'s PIOD_READ_CHERI_TAGS requires that we operate on granules that are not merely eight capabilities wide but aligned to eight capabilities as well. calloc() does not, in general, impose sufficient alignment on its results, though SLAB-esque allocators like jemalloc and snmalloc probably will happen to do so.  Instead, switch to allocating the probe region on the stack and using an attribute to align it sufficiently.

Testing locally suggests this solves the problem, but I've also pushed this delta to `caprevoke` to get CI's opinion.  See https://ctsrd-build.cl.cam.ac.uk/job/CheriBSD-pipeline/job/caprevoke/21/ .