### PR TITLE
Add find_address_space_gap() to cheribsdtest

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -25,6 +25,7 @@ SRCS+=	cheribsdtest_bounds_globals.c					\
 	cheribsdtest_syscall.c						\
 	cheribsdtest_tls.c						\
 	cheribsdtest_util.c						\
+	cheribsdtest_util_vm.c						\
 	cheribsdtest_vm.c						\
 	cheribsdtest_zlib.c
 .if ${MACHINE_ABI:Mpurecap}
@@ -60,8 +61,7 @@ CFLAGS+=	-DCHERIBSD_THREAD_TESTS
 
 MAN=
 
-LIBADD= 	z
-LIBADD+=	xo util
+LIBADD+=	procstat util xo z
 
 .ifdef CHERIBSD_DYNAMIC_TESTS
 CFLAGS+=	-DCHERIBSD_DYNAMIC_TESTS

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -330,4 +330,6 @@ _cheribsdtest_check_errno(const char *context, int actual, int expected)
 extern void *cheribsdtest_memcpy(void *dst, const void *src, size_t n);
 extern void *cheribsdtest_memmove(void *dst, const void *src, size_t n);
 
+extern ptraddr_t find_address_space_gap(size_t len, size_t align);
+
 #endif /* !_CHERIBSDTEST_H_ */

--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -143,24 +143,6 @@ struct adjacent_mappings {
 };
 
 /*
- * "Reserve" a chunk of address space by mapping pages, unmapping them,
- * and returning the base address.  This is necessary because small
- * mappings (e.g. 2 pages) might land between other mappings and thus
- * the next N pages might not be free.
- */
-static ptraddr_t
-reserve_address_space(size_t len)
-{
-	void *addr;
-
-	addr = CHERIBSDTEST_CHECK_SYSCALL(
-	    mmap(0, len, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
-	CHERIBSDTEST_CHECK_SYSCALL(munmap(addr, len));
-	/* XXX: With temporal safety we will need to force revocation here. */
-	return ((ptraddr_t)addr);
-}
-
-/*
  * Create three adjacent memory mappings that be used to check that the memory
  * mapping system calls reject out-of-bounds capabilities that have the address
  * of a valid mapping.
@@ -173,7 +155,7 @@ create_adjacent_mappings(struct adjacent_mappings *mappings)
 
 	len = getpagesize() * 2;
 	memset(mappings, 0, sizeof(*mappings));
-	requested_addr = (void *)(uintcap_t)reserve_address_space(len * 3);
+	requested_addr = (void *)(uintcap_t)find_address_space_gap(len * 3, 0);
 	mappings->first = CHERIBSDTEST_CHECK_SYSCALL(mmap(requested_addr, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0));
 	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->first));
@@ -326,7 +308,7 @@ create_adjacent_mappings_shm(struct adjacent_mappings *mappings)
 	len = getpagesize() * 2;
 	memset(mappings, 0, sizeof(*mappings));
 	shmid = CHERIBSDTEST_CHECK_SYSCALL(shmget(IPC_PRIVATE, len, 0600));
-	requested_addr = (void *)(uintcap_t)reserve_address_space(len * 3);
+	requested_addr = (void *)(uintcap_t)find_address_space_gap(len * 3, 0);
 	mappings->first = CHERIBSDTEST_CHECK_SYSCALL(shmat(shmid,
 	    requested_addr, 0));
 	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->first));

--- a/bin/cheribsdtest/cheribsdtest_util_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_util_vm.c
@@ -1,0 +1,99 @@
+/*-
+ * Copyright (c) 2021, 2022 SRI International
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory under DARPA/AFRL contract (FA8750-10-C-0237)
+ * ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+
+#include <cheri/cheric.h>
+
+#include <libprocstat.h>
+#include <unistd.h>
+
+#include "cheribsdtest.h"
+
+/*
+ * Find a region of address space unoccupied by any memory mappings.
+ *
+ * Caveats:
+ * - This is not concurency safe and the found region could be disrupted
+ *   by any non-MAP_FIXED mmap() call.  This includes anything that
+ *   allocates heap memory.
+ * - The region between PAGE_SIZE and the first mapping is not currently
+ *   searched.
+ * - The top of the address space will be searched due to the shared
+ *   page at the topmost address.
+ * - If an alignment of 0 is pased, the address of a region representable as a
+ *   capability will be returned.  It a non-zero alignment is passed it
+ *   will be honored even if that results in an address that is
+ *   under-aligned relative to a representable capability.
+ */
+ptraddr_t
+find_address_space_gap(size_t len, size_t align)
+{
+	struct procstat *psp;
+	struct kinfo_proc *kipp;
+	struct kinfo_vmentry *kivp;
+	uint pcnt, vmcnt;
+	ptraddr_t addr = 0;
+
+	psp = procstat_open_sysctl();
+	CHERIBSDTEST_VERIFY(psp != NULL);
+	kipp = procstat_getprocs(psp, KERN_PROC_PID, getpid(), &pcnt);
+	CHERIBSDTEST_VERIFY(kipp != NULL);
+	CHERIBSDTEST_VERIFY(pcnt == 1);
+	kivp = procstat_getvmmap(psp, kipp, &vmcnt);
+	CHERIBSDTEST_VERIFY(kivp != NULL);
+
+	if (align == 0) {
+		len = CHERI_REPRESENTABLE_LENGTH(len);
+		align = CHERI_REPRESENTABLE_ALIGNMENT(len) + 1;
+	}
+
+	for (u_int i = 1; i < vmcnt; i++) {
+		ptraddr_t aligned_start = __align_up(kivp[i-1].kve_end, align);
+		ptraddr_t end = kivp[i].kve_start;
+		if (end - aligned_start >= len) {
+			addr = aligned_start;
+			break;
+		}
+	}
+	if (addr == 0) {
+		cheribsdtest_failure_errx("no free region of length %#jx\n",
+		    len);
+	}
+
+	procstat_freevmmap(psp, kivp);
+	procstat_freeprocs(psp, kipp);
+	procstat_close(psp);
+	return (addr);
+}

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -971,9 +971,10 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_invalid_cap,
 CHERIBSDTEST(cheribsdtest_vm_reservation_mmap,
     "check mmap with NULL-derived hint address")
 {
-	uintptr_t hint = 0x560000000;
+	uintptr_t hint;
 	void *map;
 
+	hint = find_address_space_gap(PAGE_SIZE, 0);
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap((void *)hint, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
 	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
@@ -991,16 +992,18 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap,
 CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_fixed_unreserved,
     "check mmap MAP_FIXED with NULL-derived hint address")
 {
-	uintptr_t hint = 0x560000000;
+	uintptr_t hint;
 	void *map;
 
-	map = CHERIBSDTEST_CHECK_SYSCALL(mmap((void *)hint, PAGE_SIZE,
-	    PROT_MAX(PROT_READ | PROT_WRITE), MAP_ANON | MAP_FIXED, -1, 0));
+	hint = find_address_space_gap(PAGE_SIZE * 2, 0);
+	map = CHERIBSDTEST_CHECK_SYSCALL(mmap((void *)(hint + PAGE_SIZE),
+	    PAGE_SIZE, PROT_MAX(PROT_READ | PROT_WRITE), MAP_ANON | MAP_FIXED,
+	    -1, 0));
 	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
 	    "mmap fixed with NULL-derived hint failed to return "
 	    "valid capability");
 
-	map = mmap((void *)(hint - PAGE_SIZE), 2 * PAGE_SIZE,
+	map = mmap((void *)hint, 2 * PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0);
 	CHERIBSDTEST_VERIFY2(map == MAP_FAILED,
 	    "mmap fixed with NULL-derived hint does not imply MAP_EXCL");

--- a/tools/build/Makefile
+++ b/tools/build/Makefile
@@ -157,17 +157,17 @@ INCS+=	${SRCTOP}/include/nlist.h
 SYSINCS+=	${SRCTOP}/sys/sys/imgact_aout.h
 SYSINCS+=	${SRCTOP}/sys/sys/nlist_aout.h
 
+# macOS's bitstring lacks FreeBSD-specific additions used by makefs's ZFS code
+# and Linux doesn't have it at all.  Older FreeBSD versions lack recent
+# additions.
+INCS+=	${SRCTOP}/include/bitstring.h
+SYSINCS+=	${SRCTOP}/sys/sys/bitstring.h
 
 .if ${.MAKE.OS} != "FreeBSD"
 .PATH: ${.CURDIR}/cross-build
 
 # Needed by our sys/types.h wrapper
 SYSINCS+=	${SRCTOP}/sys/sys/bitcount.h
-
-# macOS's bitstring lacks FreeBSD-specific additions used by makefs's ZFS code
-# and Linux doesn't have it at all.
-INCS+=	${SRCTOP}/include/bitstring.h
-SYSINCS+=	${SRCTOP}/sys/sys/bitstring.h
 
 # dbopen() behaves differently on Linux and FreeBSD so we ensure that we
 # bootstrap the FreeBSD db code. The cross-build headers #define dbopen() to


### PR DESCRIPTION
Add an use a new function to cheribsdtest to find empty sections of address space and use it remove some magic numbers.

Also included: a bootstrapping fix for makefs on older FreeBSD systems.