### PR TITLE
usb_generic: Copy in endpoints with copyincap

### DIFF
--- a/sys/dev/usb/usb_generic.c
+++ b/sys/dev/usb/usb_generic.c
@@ -1285,7 +1285,7 @@ ugen_fs_copyin(struct usb_fifo *f, uint8_t ep_index,
 
 	switch (f->fs_ep_sz) {
 	case sizeof(struct usb_fs_endpoint):
-		error = copyin(ugen_fs_ep_uptr(f, ep_index), fs_ep,
+		error = copyincap(ugen_fs_ep_uptr(f, ep_index), fs_ep,
 		    f->fs_ep_sz);
 		if (error != 0)
 			return (error);


### PR DESCRIPTION
Without this it'll lose the tags on ppBuffer and pLength, which has been
seen to make libusb hang. It's unclear why it hangs rather than giving
an error (likely missing error handling) but that's probably an upstream
issue that could be hit by using junk pointer values whereas this is a
CHERI-specific bug.

Fixes https://github.com/CTSRD-CHERI/cheribsd/issues/1616
