### PR TITLE
makefs ZFS improvements

### DIFF
--- a/usr.sbin/makefs/zfs/fs.c
+++ b/usr.sbin/makefs/zfs/fs.c
@@ -297,15 +297,23 @@ fs_readlink(const fsnode *cur, struct fs_populate_arg *arg,
     char *buf, size_t bufsz)
 {
 	char path[PATH_MAX];
-	ssize_t n;
 	int fd;
 
-	fs_populate_path(cur, arg, path, sizeof(path), &fd);
+	if (cur->symlink != NULL) {
+		size_t n;
 
-	n = readlinkat(fd, path, buf, bufsz - 1);
-	if (n == -1)
-		err(1, "readlinkat(%s)", cur->name);
-	buf[n] = '\0';
+		n = strlcpy(buf, cur->symlink, bufsz);
+		assert(n < bufsz);
+	} else {
+		ssize_t n;
+
+		fs_populate_path(cur, arg, path, sizeof(path), &fd);
+
+		n = readlinkat(fd, path, buf, bufsz - 1);
+		if (n == -1)
+			err(1, "readlinkat(%s)", cur->name);
+		buf[n] = '\0';
+	}
 }
 
 static void

--- a/usr.sbin/makefs/zfs/fs.c
+++ b/usr.sbin/makefs/zfs/fs.c
@@ -255,7 +255,13 @@ static void
 fs_populate_path(const fsnode *cur, struct fs_populate_arg *arg,
     char *path, size_t sz, int *dirfdp)
 {
-	if (cur->root == NULL) {
+	if (cur->contents != NULL) {
+		size_t n;
+
+		*dirfdp = AT_FDCWD;
+		n = strlcpy(path, cur->contents, sz);
+		assert(n < sz);
+	} else if (cur->root == NULL) {
 		size_t n;
 
 		*dirfdp = SLIST_FIRST(&arg->dirs)->dirfd;


### PR DESCRIPTION
Cherry-picks of changes sufficient to use `makefs -t zfs` with the METALOG files generated by cheribuild.