### PR TITLE
ZFS purecap fixes

### DIFF
--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -371,7 +371,7 @@ init_proc0(vm_pointer_t kstack)
 	/* XXX-AM: We need to set bounds on pcb and kstack here as in MIPS */
 	proc_linkup0(&proc0, &thread0);
 	thread0.td_kstack = kstack;
-	thread0.td_kstack_pages = KSTACK_PAGES;
+	thread0.td_kstack_pages = kstack_pages;
 #if defined(PERTHREAD_SSP)
 	thread0.td_md.md_canary = boot_canary;
 #endif

--- a/sys/arm64/include/param.h
+++ b/sys/arm64/include/param.h
@@ -109,7 +109,11 @@
 #define	MAXPAGESIZES	3		/* maximum number of supported page sizes */
 
 #ifndef KSTACK_PAGES
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	KSTACK_PAGES	5	/* pages of kernel stack (with pcb) */
+#else
 #define	KSTACK_PAGES	4	/* pages of kernel stack (with pcb) */
+#endif
 #endif
 
 #define	KSTACK_GUARD_PAGES	1	/* pages of kstack guard; 0 disables */

--- a/sys/contrib/subrepo-openzfs/.gitrepo
+++ b/sys/contrib/subrepo-openzfs/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/CTSRD-CHERI/zfs.git
 	branch = cheri-hybrid
-	commit = b7525de761c1e1fb95a9f9213579d62a657be002
-	parent = d85b978551f3fc97a41756044080f1e8d919c676
+	commit = e4b13903a284500e039166ef3d820902bdd5a713
+	parent = a972a28dec03fc96111471507943d5b2a29ae4d6
 	method = merge
 	cmdver = 0.4.3

--- a/sys/contrib/subrepo-openzfs/module/zfs/zfs_chksum.c
+++ b/sys/contrib/subrepo-openzfs/module/zfs/zfs_chksum.c
@@ -245,10 +245,8 @@ chksum_benchmark(void)
 
 	chksum_stat_t *cs;
 	int cbid = 0;
-#ifndef __CHERI_PURE_CAPABILITY__
 	uint64_t max = 0;
 	uint32_t id, id_save;
-#endif
 
 	/* space for the benchmark times */
 	chksum_stat_cnt = 4;
@@ -292,8 +290,6 @@ chksum_benchmark(void)
 	cs->impl = "generic";
 	chksum_benchit(cs);
 
-#ifndef __CHERI_PURE_CAPABILITY__
-	/* XXX: hangs during module load on a purecap kernel */
 	/* blake3 */
 	id_save = blake3_impl_getid();
 	for (id = 0; id < blake3_impl_getcnt(); id++) {
@@ -313,7 +309,6 @@ chksum_benchmark(void)
 
 	/* restore initial value */
 	blake3_impl_setid(id_save);
-#endif
 }
 
 void

--- a/sys/riscv/include/param.h
+++ b/sys/riscv/include/param.h
@@ -118,7 +118,11 @@
 #define	MAXPAGESIZES	3	/* maximum number of supported page sizes */
 
 #ifndef KSTACK_PAGES
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	KSTACK_PAGES	5	/* pages of kernel stack (with pcb) */
+#else
 #define	KSTACK_PAGES	4	/* pages of kernel stack (with pcb) */
+#endif
 #endif
 
 #define	KSTACK_GUARD_PAGES	1	/* pages of kstack guard; 0 disables */

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -345,7 +345,7 @@ init_proc0(vm_pointer_t kstack)
 
 	proc_linkup0(&proc0, &thread0);
 	thread0.td_kstack = kstack;
-	thread0.td_kstack_pages = KSTACK_PAGES;
+	thread0.td_kstack_pages = kstack_pages;
 	thread0.td_pcb = (struct pcb *)(thread0.td_kstack +
 	    thread0.td_kstack_pages * PAGE_SIZE) - 1;
 	thread0.td_pcb->pcb_fpflags = 0;


### PR DESCRIPTION
Pull in fixes for bugs preventing KSTACK_PAGES from being increased via the kernel config, increase the default for pure capability kernels, and remove a no-longer needed workaround in ZFS for allow the module to load.  This is now sufficient to allow a pure capability kernel to boot on a ZFS root file system.