### PR TITLE
Malloc overalignment

### DIFF
--- a/contrib/jemalloc/src/pages.c
+++ b/contrib/jemalloc/src/pages.c
@@ -652,9 +652,6 @@ pages_boot(void) {
 #ifndef _WIN32
 	mmap_flags = MAP_PRIVATE | MAP_ANON;
 #endif
-#ifdef __CHERI_PURE_CAPABILITY__
-	mmap_flags |= MAP_ALIGNED(LG_PAGE);
-#endif
 
 #ifdef JEMALLOC_SYSCTL_VM_OVERCOMMIT
 	os_overcommits = os_overcommits_sysctl();

--- a/sys/contrib/subrepo-openzfs/.gitrepo
+++ b/sys/contrib/subrepo-openzfs/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/CTSRD-CHERI/zfs.git
 	branch = cheri-hybrid
 	commit = e4b13903a284500e039166ef3d820902bdd5a713
-	parent = a972a28dec03fc96111471507943d5b2a29ae4d6
+	parent = 4d0ede3132ec304e78632272405f6b9552d4f49d
 	method = merge
 	cmdver = 0.4.3


### PR DESCRIPTION
Revert a very obsolete malloc change causing excessive alignment (and thus fragmentation) of mmap's regions.

Also include a fixup for the zfs subrepo.