### PR TITLE
cheribsdtest find_address_space_gap bug

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_util_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_util_vm.c
@@ -82,6 +82,8 @@ find_address_space_gap(size_t len, size_t align)
 	for (u_int i = 1; i < vmcnt; i++) {
 		ptraddr_t aligned_start = __align_up(kivp[i-1].kve_end, align);
 		ptraddr_t end = kivp[i].kve_start;
+		if (aligned_start > end)
+			continue;
 		if (end - aligned_start >= len) {
 			addr = aligned_start;
 			break;


### PR DESCRIPTION
For large enough gaps (and thus alignements) it was possible to align the start address above the end address.  Due to ptraddr_t being signed, this could result in returning an address that was not a gap in the address spacep map.

Somewhat oddly this turned up in cheribsdtest-c18n-mt on the caprevoke branch and not somewhere earlier.