### PR TITLE
cheribsdtest: avoid redundant names

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -228,6 +228,8 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 	const char *skip_reason, *xfail_reason, *flaky_reason;
 	char* failure_message;
 	ssize_t len;
+	const char *disallowed_prefixes[] = { "cheribsdtest_", "test_" };
+
 	xo_attr("classname", "%s.%s", PROG, ctp->ct_name);
 	xo_attr("name", "%s", ctp->ct_desc);
 	xo_open_instance("testcase");
@@ -236,6 +238,18 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 		    ctp->ct_desc);
 	reason[0] = '\0';
 	visreason[0] = '\0';
+	xfail_reason = NULL;
+
+	for (size_t i = 0; i < nitems(disallowed_prefixes); i++) {
+		if (strncmp(ctp->ct_name, disallowed_prefixes[i],
+		    strlen(disallowed_prefixes[i])) == 0) {
+
+			snprintf(reason, sizeof(reason),
+			    "test name begins with disallowed prefix '%s'",
+			    disallowed_prefixes[i]);
+			goto fail;
+		}
+	}
 
 	if (fast_tests_only && (ctp->ct_flags & CT_FLAG_SLOW))
 		return;

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -78,7 +78,7 @@
  * offsets and sizes as desired.
  */
 #define TEST_BOUNDS(test, desc, ...)						\
-	CHERIBSDTEST(test_bounds_##test,				\
+	CHERIBSDTEST(bounds_##test,				\
 	"Check bounds on " desc,					\
 	.ct_xfail_reason = XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC,		\
 	__VA_ARGS__)							\
@@ -483,7 +483,7 @@ TEST_BOUNDS(extern_global_array65536, "extern global uint8_t[16] (C size)");
  * variable is a correct source of size information.
  */
 #define	TEST_DYNAMIC_BOUNDS(test, type, ...)				\
-	CHERIBSDTEST(test_bounds_##test,				\
+	CHERIBSDTEST(bounds_##test,				\
 	"Check bounds on extern global " #type " (dynamic size)",	\
 	.ct_xfail_reason = XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN,		\
 	__VA_ARGS__)							\

--- a/bin/cheribsdtest/cheribsdtest_bounds_heap.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_heap.c
@@ -54,7 +54,7 @@
 #include "cheribsdtest.h"
 
 #ifdef __CHERI_PURE_CAPABILITY__
-CHERIBSDTEST(test_bounds_calloc,
+CHERIBSDTEST(bounds_calloc,
     "Check bounds on variously sized heap allocations")
 {
 	size_t i;

--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -107,7 +107,7 @@ test_bounds_stack_vla(size_t len)
 	test_bounds_precise(c, len);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_uint8,
+CHERIBSDTEST(bounds_stack_static_uint8,
     "Check bounds on 8-bit static stack allocation")
 {
 	uint8_t u8;
@@ -116,19 +116,19 @@ CHERIBSDTEST(test_bounds_stack_static_uint8,
 	test_bounds_precise(u8p, sizeof(*u8p));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_uint8,
+CHERIBSDTEST(bounds_stack_alloca_uint8,
     "Check bounds on 8-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint8_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_uint8,
+CHERIBSDTEST(bounds_stack_vla_uint8,
     "Check bounds on 8-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint8_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_static_uint16,
+CHERIBSDTEST(bounds_stack_static_uint16,
     "Check bounds on 16-bit static stack allocation")
 {
 	uint16_t u16;
@@ -137,19 +137,19 @@ CHERIBSDTEST(test_bounds_stack_static_uint16,
 	test_bounds_precise(u16p, sizeof(*u16p));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_uint16,
+CHERIBSDTEST(bounds_stack_alloca_uint16,
     "Check bounds on 16-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint16_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_uint16,
+CHERIBSDTEST(bounds_stack_vla_uint16,
     "Check bounds on 16-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint16_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_static_uint32,
+CHERIBSDTEST(bounds_stack_static_uint32,
     "Check bounds 32-bit static stack allocation")
 {
 	uint32_t u32;
@@ -158,19 +158,19 @@ CHERIBSDTEST(test_bounds_stack_static_uint32,
 	test_bounds_precise(u32p, sizeof(*u32p));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_uint32,
+CHERIBSDTEST(bounds_stack_alloca_uint32,
     "Check bounds 32-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint32_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_uint32,
+CHERIBSDTEST(bounds_stack_vla_uint32,
     "Check bounds 32-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint32_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_static_uint64,
+CHERIBSDTEST(bounds_stack_static_uint64,
     "Check bounds on 64-bit static stack allocation")
 {
 	uint64_t u64;
@@ -179,19 +179,19 @@ CHERIBSDTEST(test_bounds_stack_static_uint64,
 	test_bounds_precise(u64p, sizeof(*u64p));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_uint64,
+CHERIBSDTEST(bounds_stack_alloca_uint64,
     "Check bounds on 64-bit alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(uint64_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_uint64,
+CHERIBSDTEST(bounds_stack_vla_uint64,
     "Check bounds on 64-bit VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(uint64_t));
 }
 
-CHERIBSDTEST(test_bounds_stack_static_cap,
+CHERIBSDTEST(bounds_stack_static_cap,
     "Check bounds on a capability static stack allocation")
 {
 	void * __capability c;
@@ -201,19 +201,19 @@ CHERIBSDTEST(test_bounds_stack_static_cap,
 	test_bounds_precise(cp, sizeof(*cp));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_cap,
+CHERIBSDTEST(bounds_stack_alloca_cap,
     "Check bounds on a capability alloca stack allocation")
 {
 	test_bounds_stack_alloca(sizeof(void * __capability));
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_cap,
+CHERIBSDTEST(bounds_stack_vla_cap,
     "Check bounds on a capability VLA stack allocation")
 {
 	test_bounds_stack_vla(sizeof(void * __capability));
 }
 
-CHERIBSDTEST(test_bounds_stack_static_16,
+CHERIBSDTEST(bounds_stack_static_16,
     "Check bounds on a 16-byte static stack allocation")
 {
 	uint8_t array[16];
@@ -222,19 +222,19 @@ CHERIBSDTEST(test_bounds_stack_static_16,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_16,
+CHERIBSDTEST(bounds_stack_alloca_16,
     "Check bounds on a 16-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(16);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_16,
+CHERIBSDTEST(bounds_stack_vla_16,
     "Check bounds on a 16-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(16);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_32,
+CHERIBSDTEST(bounds_stack_static_32,
     "Check bounds on a 32-byte static stack allocation")
 {
 	uint8_t array[32];
@@ -243,19 +243,19 @@ CHERIBSDTEST(test_bounds_stack_static_32,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_32,
+CHERIBSDTEST(bounds_stack_alloca_32,
     "Check bounds on a 32-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(32);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_32,
+CHERIBSDTEST(bounds_stack_vla_32,
     "Check bounds on a 32-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(32);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_64,
+CHERIBSDTEST(bounds_stack_static_64,
     "Check bounds on a 64-byte static stack allocation")
 {
 	uint8_t array[64];
@@ -264,19 +264,19 @@ CHERIBSDTEST(test_bounds_stack_static_64,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_64,
+CHERIBSDTEST(bounds_stack_alloca_64,
     "Check bounds on a 64-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(64);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_64,
+CHERIBSDTEST(bounds_stack_vla_64,
     "Check bounds on a 64-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(64);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_128,
+CHERIBSDTEST(bounds_stack_static_128,
     "Check bounds on a 128-byte static stack allocation")
 {
 	uint8_t array[128];
@@ -285,19 +285,19 @@ CHERIBSDTEST(test_bounds_stack_static_128,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_128,
+CHERIBSDTEST(bounds_stack_alloca_128,
     "Check bounds on a 128-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(128);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_128,
+CHERIBSDTEST(bounds_stack_vla_128,
     "Check bounds on a 128-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(128);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_256,
+CHERIBSDTEST(bounds_stack_static_256,
     "Check bounds on a 256-byte static stack allocation")
 {
 	uint8_t array[256];
@@ -306,19 +306,19 @@ CHERIBSDTEST(test_bounds_stack_static_256,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_256,
+CHERIBSDTEST(bounds_stack_alloca_256,
     "Check bounds on a 256-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(256);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_256,
+CHERIBSDTEST(bounds_stack_vla_256,
     "Check bounds on a 256-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(256);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_512,
+CHERIBSDTEST(bounds_stack_static_512,
     "Check bounds on a 512-byte static stack allocation")
 {
 	uint8_t array[512];
@@ -327,19 +327,19 @@ CHERIBSDTEST(test_bounds_stack_static_512,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_512,
+CHERIBSDTEST(bounds_stack_alloca_512,
     "Check bounds on a 512-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(512);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_512,
+CHERIBSDTEST(bounds_stack_vla_512,
     "Check bounds on a 512-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(512);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_1024,
+CHERIBSDTEST(bounds_stack_static_1024,
     "Check bounds on a 1,024-byte static stack allocation")
 {
 	uint8_t array[1024];
@@ -348,19 +348,19 @@ CHERIBSDTEST(test_bounds_stack_static_1024,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_1024,
+CHERIBSDTEST(bounds_stack_alloca_1024,
     "Check bounds on a 1,024-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(1024);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_1024,
+CHERIBSDTEST(bounds_stack_vla_1024,
     "Check bounds on a 1,024-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(1024);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_2048,
+CHERIBSDTEST(bounds_stack_static_2048,
     "Check bounds on a 2,048-byte static stack allocation")
 {
 	uint8_t array[2048];
@@ -369,19 +369,19 @@ CHERIBSDTEST(test_bounds_stack_static_2048,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_2048,
+CHERIBSDTEST(bounds_stack_alloca_2048,
     "Check bounds on a 2,048-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(2048);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_2048,
+CHERIBSDTEST(bounds_stack_vla_2048,
     "Check bounds on a 2,048-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(2048);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_4096,
+CHERIBSDTEST(bounds_stack_static_4096,
     "Check bounds on a 4,096-byte static stack allocation")
 {
 	uint8_t array[4096];
@@ -390,19 +390,19 @@ CHERIBSDTEST(test_bounds_stack_static_4096,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_4096,
+CHERIBSDTEST(bounds_stack_alloca_4096,
     "Check bounds on a 4,096-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(4096);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_4096,
+CHERIBSDTEST(bounds_stack_vla_4096,
     "Check bounds on a 4,096-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(4096);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_8192,
+CHERIBSDTEST(bounds_stack_static_8192,
     "Check bounds on a 8,192-byte static stack allocation")
 {
 	uint8_t array[8192];
@@ -411,19 +411,19 @@ CHERIBSDTEST(test_bounds_stack_static_8192,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_8192,
+CHERIBSDTEST(bounds_stack_alloca_8192,
     "Check bounds on a 8,192-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(8192);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_8192,
+CHERIBSDTEST(bounds_stack_vla_8192,
     "Check bounds on a 8,192-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(8192);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_16384,
+CHERIBSDTEST(bounds_stack_static_16384,
     "Check bounds on a 16,384-byte static stack allocation")
 {
 	uint8_t array[16384];
@@ -432,19 +432,19 @@ CHERIBSDTEST(test_bounds_stack_static_16384,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_16384,
+CHERIBSDTEST(bounds_stack_alloca_16384,
     "Check bounds on a 16,384-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(16384);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_16384,
+CHERIBSDTEST(bounds_stack_vla_16384,
     "Check bounds on a 16,384-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(16384);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_32768,
+CHERIBSDTEST(bounds_stack_static_32768,
     "Check bounds on a 32,768-byte static stack allocation")
 {
 	uint8_t array[32768];
@@ -453,19 +453,19 @@ CHERIBSDTEST(test_bounds_stack_static_32768,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_32768,
+CHERIBSDTEST(bounds_stack_alloca_32768,
     "Check bounds on a 32,768-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(32768);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_32768,
+CHERIBSDTEST(bounds_stack_vla_32768,
     "Check bounds on a 32,768-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(32768);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_65536,
+CHERIBSDTEST(bounds_stack_static_65536,
     "Check bounds on a 65,536-byte static stack allocation")
 {
 	uint8_t array[65536];
@@ -474,19 +474,19 @@ CHERIBSDTEST(test_bounds_stack_static_65536,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_65536,
+CHERIBSDTEST(bounds_stack_alloca_65536,
     "Check bounds on a 65,536-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(65536);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_65536,
+CHERIBSDTEST(bounds_stack_vla_65536,
     "Check bounds on a 65,536-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(65536);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_131072,
+CHERIBSDTEST(bounds_stack_static_131072,
     "Check bounds on a 131,072-byte static stack allocation")
 {
 	uint8_t array[131072];
@@ -495,19 +495,19 @@ CHERIBSDTEST(test_bounds_stack_static_131072,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_131072,
+CHERIBSDTEST(bounds_stack_alloca_131072,
     "Check bounds on a 131,072-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(131072);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_131072,
+CHERIBSDTEST(bounds_stack_vla_131072,
     "Check bounds on a 131,072-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(131072);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_262144,
+CHERIBSDTEST(bounds_stack_static_262144,
     "Check bounds on a 262,144-byte static stack allocation")
 {
 	uint8_t array[262144];
@@ -516,19 +516,19 @@ CHERIBSDTEST(test_bounds_stack_static_262144,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_262144,
+CHERIBSDTEST(bounds_stack_alloca_262144,
     "Check bounds on a 262,144-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(262144);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_262144,
+CHERIBSDTEST(bounds_stack_vla_262144,
     "Check bounds on a 262,144-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(262144);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_524288,
+CHERIBSDTEST(bounds_stack_static_524288,
     "Check bounds on a 524,288-byte static stack allocation")
 {
 	uint8_t array[524288];
@@ -537,19 +537,19 @@ CHERIBSDTEST(test_bounds_stack_static_524288,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_524288,
+CHERIBSDTEST(bounds_stack_alloca_524288,
     "Check bounds on a 524,288-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(524288);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_524288,
+CHERIBSDTEST(bounds_stack_vla_524288,
     "Check bounds on a 524,288-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(524288);
 }
 
-CHERIBSDTEST(test_bounds_stack_static_1048576,
+CHERIBSDTEST(bounds_stack_static_1048576,
     "Check bounds on a 1,048,576-byte static stack allocation")
 {
 	uint8_t array[1048576];
@@ -558,13 +558,13 @@ CHERIBSDTEST(test_bounds_stack_static_1048576,
 	test_bounds_precise(arrayp, sizeof(array));
 }
 
-CHERIBSDTEST(test_bounds_stack_alloca_1048576,
+CHERIBSDTEST(bounds_stack_alloca_1048576,
     "Check bounds on a 1,048,576-byte alloca stack allocation")
 {
 	test_bounds_stack_alloca(1048576);
 }
 
-CHERIBSDTEST(test_bounds_stack_vla_1048576,
+CHERIBSDTEST(bounds_stack_vla_1048576,
     "Check bounds on a 1,048,576-byte VLA stack allocation")
 {
 	test_bounds_stack_vla(1048576);

--- a/bin/cheribsdtest/cheribsdtest_bounds_subobject.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_subobject.c
@@ -79,7 +79,7 @@ struct struct_char {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_char,
+CHERIBSDTEST(bounds_subobject_struct_char,
     "Check subobject bounds on a 1-character field in a structure")
 {
 	struct struct_char sc;
@@ -96,7 +96,7 @@ struct struct_int {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_int,
+CHERIBSDTEST(bounds_subobject_struct_int,
     "Check subobject bounds on an integer field in a structure")
 {
 	struct struct_int si;
@@ -113,7 +113,7 @@ struct struct_chararray1 {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_chararray1,
+CHERIBSDTEST(bounds_subobject_struct_chararray1,
     "Check subobject bounds on a char array of size 1 within a struct")
 {
 	struct struct_chararray1 sc1;
@@ -130,7 +130,7 @@ struct struct_chararray2 {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_chararray2,
+CHERIBSDTEST(bounds_subobject_struct_chararray2,
     "Check subobject bounds on a char array of size 2 within a struct")
 {
 	struct struct_chararray2 sc2;
@@ -147,7 +147,7 @@ struct struct_chararray128 {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_chararray128,
+CHERIBSDTEST(bounds_subobject_struct_chararray128,
     "Check subobject bounds on a char array of size 128 within a struct")
 {
 	struct struct_chararray128 sc128;
@@ -164,7 +164,7 @@ struct struct_chararray129 {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_chararray129,
+CHERIBSDTEST(bounds_subobject_struct_chararray129,
     "Check subobject bounds on a char array of size 129 within a struct")
 {
 	struct struct_chararray129 sc129;
@@ -181,7 +181,7 @@ struct struct_chararray2048 {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_chararray2048,
+CHERIBSDTEST(bounds_subobject_struct_chararray2048,
     "Check subobject bounds on a char array of size 2048 within a struct")
 {
 	struct struct_chararray2048 sc2048;
@@ -205,7 +205,7 @@ CHERIBSDTEST(test_bounds_subobject_struct_chararray2048,
 extern volatile struct struct_chararray2048 sc2048_sideeffect;
 volatile struct struct_chararray2048 sc2048_sideeffect;
 
-CHERIBSDTEST(test_bounds_subjobject_struct_chararray2048_inbounds,
+CHERIBSDTEST(bounds_subjobject_struct_chararray2048_inbounds,
     "Check in-bounds store in subjobject character array of size 2048")
 {
 
@@ -220,7 +220,7 @@ CHERIBSDTEST(test_bounds_subjobject_struct_chararray2048_inbounds,
 extern volatile char * __capability subobject_ptr_outofbounds;
 volatile char * __capability subobject_ptr_outofbounds;
 
-CHERIBSDTEST(test_bounds_subobject_struct_chararray2048_overflow,
+CHERIBSDTEST(bounds_subobject_struct_chararray2048_overflow,
     "Check that an overflow of a 2048-byte subobject array faults",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
@@ -244,7 +244,7 @@ struct struct_trailing_chararray1 {
 	char chararray1[1];
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_trailing_chararray1,
+CHERIBSDTEST(bounds_subobject_struct_trailing_chararray1,
     "Check subobject bounds on a trailing non-exempt 1-byte character array")
 {
 	struct struct_trailing_chararray1 stc1;
@@ -265,7 +265,7 @@ union union_two_chararrays {
 	char chararray32[32];
 };
 
-CHERIBSDTEST(test_bounds_subobject_union_two_chararrays,
+CHERIBSDTEST(bounds_subobject_union_two_chararrays,
     "Check that unions do enforce subobject bounds on individual structures")
 {
 	union union_two_chararrays twoarrays;
@@ -287,7 +287,7 @@ struct struct_trailing_chararray_fla {
 };
 #define	FLA_LENGTH	16
 
-CHERIBSDTEST(test_bounds_subobject_struct_trailing_chararray_fla,
+CHERIBSDTEST(bounds_subobject_struct_trailing_chararray_fla,
     "Check subobject bounds on a flexible array member")
 {
 	struct struct_trailing_chararray_fla *stcf = alloca(FLA_LENGTH);
@@ -308,7 +308,7 @@ struct struct_trailing_chararray_zla {
 };
 #define	ZLA_LENGTH	16
 
-CHERIBSDTEST(test_bounds_subobject_struct_trailing_chararray_zla,
+CHERIBSDTEST(bounds_subobject_struct_trailing_chararray_zla,
     "Check subobject bounds on a zero length array")
 {
 	struct struct_trailing_chararray_zla *stca = alloca(ZLA_LENGTH);
@@ -329,7 +329,7 @@ struct struct_exempt_char {
 	char overflow;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_exempt_char,
+CHERIBSDTEST(bounds_subobject_struct_exempt_char,
     "Check that a char within a struct can be exempted from subobject bounds")
 {
 	struct struct_exempt_char sec;
@@ -360,7 +360,7 @@ struct struct_remaininglength_chararray16 {
 };
 #define	RLA_LENGTH	64
 
-CHERIBSDTEST(test_bounds_subobject_chararray_remaininglength,
+CHERIBSDTEST(bounds_subobject_chararray_remaininglength,
     "Check the remaining length struct annotation")
 {
 	struct struct_trailing_chararray_fla *stcf = alloca(RLA_LENGTH);
@@ -386,7 +386,7 @@ struct struct_remaininglength_size_chararray {
 	    ((cheri_subobject_bounds_use_remaining_size(RLAS_STATIC_BOUND)));
 };
 
-CHERIBSDTEST(test_bounds_subobject_chararray_remaininglength_size,
+CHERIBSDTEST(bounds_subobject_chararray_remaininglength_size,
     "Check the remaining length structure annotation with a fixed size")
 {
 	struct struct_remaininglength_size_chararray *srsc =
@@ -414,7 +414,7 @@ struct struct_queue_slist_entry {
 	int i;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_exempt_queue_slist,
+CHERIBSDTEST(bounds_subobject_struct_exempt_queue_slist,
     "Check queue(3) SLIST macros subobject bounds exemptions")
 {
 	SLIST_HEAD(, struct_queue_slist_entry) slist;
@@ -439,7 +439,7 @@ struct struct_queue_stailq_entry {
 	int i;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_exempt_queue_stailq,
+CHERIBSDTEST(bounds_subobject_struct_exempt_queue_stailq,
     "Check queue(3) STAILQ macros subobject bounds exemptions")
 {
 	STAILQ_HEAD(, struct_queue_stailq_entry) stailq;
@@ -464,7 +464,7 @@ struct struct_queue_list_entry {
 	int i;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_exempt_queue_list,
+CHERIBSDTEST(bounds_subobject_struct_exempt_queue_list,
     "Check queue(3) LIST macros subobject bounds exemptions")
 {
 	LIST_HEAD(, struct_queue_list_entry) list;
@@ -489,7 +489,7 @@ struct struct_queue_tailq_entry {
 	int i;
 };
 
-CHERIBSDTEST(test_bounds_subobject_struct_exempt_queue_tailq,
+CHERIBSDTEST(bounds_subobject_struct_exempt_queue_tailq,
     "Check queue(3) TAILQ macros subobject bounds exemptions")
 {
 	TAILQ_HEAD(, struct_queue_tailq_entry) tailq;

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -75,7 +75,7 @@ varargs_test_onearg(const char *fmt, ...)
 	cheribsdtest_failure_errx("va_arg() overran bounds without fault");
 }
 
-CHERIBSDTEST(test_bounds_varargs_vaarg_overflow,
+CHERIBSDTEST(bounds_varargs_vaarg_overflow,
     "check that va_arg() triggers a fault on overrun",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
@@ -98,7 +98,7 @@ CHERIBSDTEST(test_bounds_varargs_vaarg_overflow,
  * zero-length pointer would also be fine -- if one arises in one of our ABIs,
  * the acceptable conditions may need to be updated.
  */
-CHERIBSDTEST(test_bounds_varargs_empty_pointer_null,
+CHERIBSDTEST(bounds_varargs_empty_pointer_null,
     "check that empty varargs gives a tag violation on load",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
@@ -119,7 +119,7 @@ CHERIBSDTEST(test_bounds_varargs_empty_pointer_null,
  * Check that if we overflow the varargs array with a load, we get a bounds
  * violation.
  */
-CHERIBSDTEST(test_bounds_varargs_printf_load,
+CHERIBSDTEST(bounds_varargs_printf_load,
     "check that load via printf varargs overflow faults",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
@@ -141,7 +141,7 @@ CHERIBSDTEST(test_bounds_varargs_printf_load,
  * store via (%n), we get a bounds violation -- rather than, say, a tag
  * violation as a result of dereferencing that pointer.
  */
-CHERIBSDTEST(test_bounds_varargs_printf_store,
+CHERIBSDTEST(bounds_varargs_printf_store,
     "check that store via printf varargs overflow faults",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,

--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -60,7 +60,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(test_cheriabi_mmap_unrepresentable,
+CHERIBSDTEST(cheriabi_mmap_unrepresentable,
     "Test CheriABI mmap() with unrepresentable lengths")
 {
 	int shift = 0;
@@ -93,7 +93,7 @@ CHERIBSDTEST(test_cheriabi_mmap_unrepresentable,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_mmap_fixed,
+CHERIBSDTEST(cheriabi_mmap_fixed,
     "Verify that we can MAP_FIXED over multiple vm map entries")
 {
 	void *p1, *p2;
@@ -123,7 +123,7 @@ CHERIBSDTEST(test_cheriabi_mmap_fixed,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_malloc_zero_size,
+CHERIBSDTEST(cheriabi_malloc_zero_size,
     "Check that zero-sized mallocs are properly bounded")
 {
 	void *cap;
@@ -187,7 +187,7 @@ free_adjacent_mappings(struct adjacent_mappings *mappings)
 	CHERIBSDTEST_CHECK_SYSCALL(munmap(mappings->last, mappings->maplen));
 }
 
-CHERIBSDTEST(test_cheriabi_munmap_invalid_ptr,
+CHERIBSDTEST(cheriabi_munmap_invalid_ptr,
     "Check that munmap() rejects invalid pointer arguments")
 {
 	struct adjacent_mappings mappings;
@@ -220,7 +220,7 @@ CHERIBSDTEST(test_cheriabi_munmap_invalid_ptr,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_mprotect_invalid_ptr,
+CHERIBSDTEST(cheriabi_mprotect_invalid_ptr,
     "Check that mprotect() rejects invalid pointer arguments")
 {
 	struct adjacent_mappings mappings;
@@ -259,7 +259,7 @@ CHERIBSDTEST(test_cheriabi_mprotect_invalid_ptr,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_minherit_invalid_ptr,
+CHERIBSDTEST(cheriabi_minherit_invalid_ptr,
     "Check that minherit() rejects invalid pointer arguments")
 {
 	struct adjacent_mappings mappings;
@@ -340,7 +340,7 @@ free_adjacent_mappings_shm(struct adjacent_mappings *mappings)
 	CHERIBSDTEST_CHECK_SYSCALL(shmdt(mappings->last));
 }
 
-CHERIBSDTEST(test_cheriabi_shmdt_invalid_ptr,
+CHERIBSDTEST(cheriabi_shmdt_invalid_ptr,
     "Check that shmdt() rejects invalid pointer arguments")
 {
 	struct adjacent_mappings mappings;

--- a/bin/cheribsdtest/cheribsdtest_cheriabi_libc.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_libc.c
@@ -41,7 +41,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(test_cheriabi_libc_memchr,
+CHERIBSDTEST(cheriabi_libc_memchr,
     "Check that memchr() works as required")
 {
 	_Alignas(16) char string[] = "0123456789abcde";
@@ -68,7 +68,7 @@ CHERIBSDTEST(test_cheriabi_libc_memchr,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_libc_strchr,
+CHERIBSDTEST(cheriabi_libc_strchr,
     "Check that strchr() works as required")
 {
 	_Alignas(16) char string[] = "0123456789abcdefghij";
@@ -91,7 +91,7 @@ CHERIBSDTEST(test_cheriabi_libc_strchr,
 }
 
 
-CHERIBSDTEST(test_cheriabi_libc_strchrnul,
+CHERIBSDTEST(cheriabi_libc_strchrnul,
     "Check that strchrnul() works as required")
 {
 	_Alignas(16) char string[] = "0123456789abcdefghij";

--- a/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
@@ -53,7 +53,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(test_cheriabi_open_ordinary, "Smoke test for open(2)")
+CHERIBSDTEST(cheriabi_open_ordinary, "Smoke test for open(2)")
 {
 	char path[] = "/dev/null";
 	int error, fd;
@@ -69,7 +69,7 @@ CHERIBSDTEST(test_cheriabi_open_ordinary, "Smoke test for open(2)")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_offset, "Path with non-zero offset")
+CHERIBSDTEST(cheriabi_open_offset, "Path with non-zero offset")
 {
 	char pathbuf[] = "xxxx/dev/null";;
 	char *path;
@@ -89,7 +89,7 @@ CHERIBSDTEST(test_cheriabi_open_offset, "Path with non-zero offset")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_shortened,
+CHERIBSDTEST(cheriabi_open_shortened,
     "Path shorter than its capability bounds")
 {
 	char path[] = "/dev/null/xxxx";
@@ -108,7 +108,7 @@ CHERIBSDTEST(test_cheriabi_open_shortened,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_bad_addr, "Path with nonsensical address")
+CHERIBSDTEST(cheriabi_open_bad_addr, "Path with nonsensical address")
 {
 	char *path;
 	int fd;
@@ -125,7 +125,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_addr, "Path with nonsensical address")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_bad_addr_2,
+CHERIBSDTEST(cheriabi_open_bad_addr_2,
     "Path with nonsensical address in kernel range")
 {
 	char *path;
@@ -143,7 +143,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_addr_2,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_bad_len,
+CHERIBSDTEST(cheriabi_open_bad_len,
     "Path too long for the capaility bounds")
 {
 	char pathbuf[] = "/dev/null";
@@ -162,7 +162,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_len,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_bad_len_2, "Path with offset past its bounds")
+CHERIBSDTEST(cheriabi_open_bad_len_2, "Path with offset past its bounds")
 {
 	char pathbuf[] = "xxxx/dev/null";;
 	char *path;
@@ -181,7 +181,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_len_2, "Path with offset past its bounds")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_bad_tag, "Path with tag bit missing")
+CHERIBSDTEST(cheriabi_open_bad_tag, "Path with tag bit missing")
 {
 	char pathbuf[] = "/dev/null";
 	char *path;
@@ -199,7 +199,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_tag, "Path with tag bit missing")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_bad_perm,
+CHERIBSDTEST(cheriabi_open_bad_perm,
     "Path with CHERI_PERM_LOAD permission missing")
 {
 	char pathbuf[] = "/dev/null";
@@ -218,7 +218,7 @@ CHERIBSDTEST(test_cheriabi_open_bad_perm,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_cheriabi_open_sealed, "Sealed path")
+CHERIBSDTEST(cheriabi_open_sealed, "Sealed path")
 {
 	char *path, *sealed_path;
 	void *sealer;

--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -75,7 +75,7 @@
 static char array[ARRAY_LEN];
 static char sink;
 
-CHERIBSDTEST(test_fault_bounds, "Exercise capability bounds check failure",
+CHERIBSDTEST(fault_bounds, "Exercise capability bounds check failure",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
     .ct_si_code = PROT_CHERI_BOUNDS,
@@ -91,7 +91,7 @@ CHERIBSDTEST(test_fault_bounds, "Exercise capability bounds check failure",
 	cheribsdtest_failure_errx("out of bounds access did not fault");
 }
 
-CHERIBSDTEST(test_fault_perm_load,
+CHERIBSDTEST(fault_perm_load,
     "Exercise capability load permission failure",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
@@ -105,7 +105,7 @@ CHERIBSDTEST(test_fault_perm_load,
 	cheribsdtest_failure_errx("access without required permissions did not fault");
 }
 
-CHERIBSDTEST(test_nofault_perm_load,
+CHERIBSDTEST(nofault_perm_load,
     "Exercise capability load permission success")
 {
 	char * __capability arrayp = cheri_ptrperm(array, sizeof(array),
@@ -115,7 +115,7 @@ CHERIBSDTEST(test_nofault_perm_load,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_illegal_perm_seal,
+CHERIBSDTEST(illegal_perm_seal,
     "Exercise capability seal permission failure",
     CT_SEAL_VIOLATION_EXCEPTION)
 {
@@ -139,7 +139,7 @@ CHERIBSDTEST(test_illegal_perm_seal,
 	    "%#lp with bad sealcap %#lp", sealed, sealcap);
 }
 
-CHERIBSDTEST(test_fault_perm_store,
+CHERIBSDTEST(fault_perm_store,
     "Exercise capability store permission failure",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
@@ -151,7 +151,7 @@ CHERIBSDTEST(test_fault_perm_store,
 	arrayp[0] = sink;
 }
 
-CHERIBSDTEST(test_nofault_perm_store,
+CHERIBSDTEST(nofault_perm_store,
     "Exercise capability store permission success")
 {
 	char * __capability arrayp = cheri_ptrperm(array, sizeof(array),
@@ -161,7 +161,7 @@ CHERIBSDTEST(test_nofault_perm_store,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_illegal_perm_unseal,
+CHERIBSDTEST(illegal_perm_unseal,
     "Exercise capability unseal permission failure",
     CT_SEAL_VIOLATION_EXCEPTION)
 {
@@ -189,7 +189,7 @@ CHERIBSDTEST(test_illegal_perm_unseal,
 	    "%#lp with bad unsealcap %#lp", unsealed, sealcap);
 }
 
-CHERIBSDTEST(test_fault_tag, "Store via untagged capability",
+CHERIBSDTEST(fault_tag, "Store via untagged capability",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,
     .ct_si_code = PROT_CHERI_TAG,
@@ -202,7 +202,7 @@ CHERIBSDTEST(test_fault_tag, "Store via untagged capability",
 	*chp = '\0';
 }
 
-CHERIBSDTEST(test_nofault_cfromptr, "Exercise CFromPtr success")
+CHERIBSDTEST(nofault_cfromptr, "Exercise CFromPtr success")
 {
 	char buf[256];
 	void * __capability cb; /* derived from here */

--- a/bin/cheribsdtest/cheribsdtest_flag_captured.c
+++ b/bin/cheribsdtest/cheribsdtest_flag_captured.c
@@ -92,25 +92,25 @@ call_flag_captured(const char *message, uint32_t key)
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_flag_captured, "Call flag_captured(2) with a message")
+CHERIBSDTEST(flag_captured_message, "Call flag_captured(2) with a message")
 {
 	call_flag_captured(__func__, CORRECT_KEY);
 }
 
-CHERIBSDTEST(test_flag_captured_incorrect_key,
+CHERIBSDTEST(flag_captured_incorrect_key,
     "Call flag_captured(2) with an incorrect key")
 {
 	call_flag_captured(__func__, INCORRECT_KEY);
 }
 
-CHERIBSDTEST(test_flag_captured_null,
+CHERIBSDTEST(flag_captured_null,
     "Call flag_captured(2) without a message")
 {
 	call_flag_captured(NULL, CORRECT_KEY);
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
-CHERIBSDTEST(test_flag_captured_empty,
+CHERIBSDTEST(flag_captured_empty,
     "Call flag_captured(2) with a zero-length capability")
 {
 	char buf[] = "";

--- a/bin/cheribsdtest/cheribsdtest_fs.c
+++ b/bin/cheribsdtest/cheribsdtest_fs.c
@@ -68,7 +68,7 @@ create_tempfile(void)
 	return (fd);
 }
 
-CHERIBSDTEST(cheribsdtest_tmpfs_rw_nocaps,
+CHERIBSDTEST(tmpfs_rw_nocaps,
     "check that read(2) and write(2) of tmpfs files do not return tags",
     .ct_check_skip = skip_non_tmpfs_tmp)
 {

--- a/bin/cheribsdtest/cheribsdtest_ifunc.c
+++ b/bin/cheribsdtest/cheribsdtest_ifunc.c
@@ -40,7 +40,7 @@ DEFINE_UIFUNC(static, int, simple_ifunc, (void))
 	return (simple_ifunc_impl);
 }
 
-CHERIBSDTEST(test_call_ifunc, "Check that IFUNCs can be called")
+CHERIBSDTEST(call_ifunc, "Check that IFUNCs can be called")
 {
 	int ret;
 

--- a/bin/cheribsdtest/cheribsdtest_ipc.c
+++ b/bin/cheribsdtest/cheribsdtest_ipc.c
@@ -70,7 +70,7 @@
 
 #define	BUFFER_SIZE	8192
 
-CHERIBSDTEST(test_ipc_pipe_sleep_signal,
+CHERIBSDTEST(ipc_pipe_sleep_signal,
     "check that direct write pipe IPC of a capability can be interrupted",
     .ct_flags = CT_FLAG_SIGNAL,
     .ct_signum = SIGALRM)
@@ -89,7 +89,7 @@ CHERIBSDTEST(test_ipc_pipe_sleep_signal,
 	cheribsdtest_failure_errx("write didn't block");
 }
 
-CHERIBSDTEST(test_ipc_pipe_nocaps,
+CHERIBSDTEST(ipc_pipe_nocaps,
     "check that read/write of a pipe(2) strips tags")
 {
 	void * __capability *buffer;

--- a/bin/cheribsdtest/cheribsdtest_kbounce.c
+++ b/bin/cheribsdtest/cheribsdtest_kbounce.c
@@ -87,7 +87,7 @@ checkbuf(const char *buf, size_t offset, size_t len, const char *where)
 	}
 }
 
-CHERIBSDTEST(test_kbounce, "Exercise copyin/out via kbounce(2) syscall")
+CHERIBSDTEST(sys_kbounce, "Exercise copyin/out via kbounce(2) syscall")
 {
 	char *buf, *dst, *src;
 

--- a/bin/cheribsdtest/cheribsdtest_lazy_bind.c
+++ b/bin/cheribsdtest/cheribsdtest_lazy_bind.c
@@ -34,7 +34,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(test_lazy_bind_args,
+CHERIBSDTEST(lazy_bind_args,
     "Check that lazy binding preserves capability argument metadata")
 {
 	void * __capability cap, * __capability cap2;

--- a/bin/cheribsdtest/cheribsdtest_local_global.c
+++ b/bin/cheribsdtest/cheribsdtest_local_global.c
@@ -50,7 +50,7 @@
 
 #define	STR_VAL	"123"
 
-CHERIBSDTEST(test_store_local_allowed,
+CHERIBSDTEST(store_local_allowed,
     "Checks local capabilities can be stored via default capabilities")
 {
 	char str[] = STR_VAL;
@@ -74,7 +74,7 @@ CHERIBSDTEST(test_store_local_allowed,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_store_local_disallowed,
+CHERIBSDTEST(store_local_disallowed,
     "Checks local capabilities can not be stored via non-store-local capabilities",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
     .ct_signum = SIGPROT,

--- a/bin/cheribsdtest/cheribsdtest_longjmp.c
+++ b/bin/cheribsdtest/cheribsdtest_longjmp.c
@@ -44,7 +44,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(cheribsdtest_setjmp, "Exercise setjmp without longjmp")
+CHERIBSDTEST(libc_setjmp, "Exercise setjmp without longjmp")
 {
 	jmp_buf jumpbuf;
 	int ret;
@@ -55,7 +55,7 @@ CHERIBSDTEST(cheribsdtest_setjmp, "Exercise setjmp without longjmp")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_setjmp_longjmp, "Exercise setjmp with longjmp")
+CHERIBSDTEST(libc_setjmp_longjmp, "Exercise setjmp with longjmp")
 {
 	jmp_buf jumpbuf;
 	int ret;

--- a/bin/cheribsdtest/cheribsdtest_printf.c
+++ b/bin/cheribsdtest/cheribsdtest_printf.c
@@ -154,7 +154,7 @@ test_printf_cap_one(void * __capability p, int expected_tokens,
 	}
 }
 
-CHERIBSDTEST(test_printf_cap, "Various checks of %#p")
+CHERIBSDTEST(printf_cap, "Various checks of %#p")
 {
 	char data[64];
 	void * __capability scalar = (void * __capability)(uintcap_t)4;

--- a/bin/cheribsdtest/cheribsdtest_ptrace.c
+++ b/bin/cheribsdtest/cheribsdtest_ptrace.c
@@ -90,7 +90,7 @@ finish_child(pid_t pid)
 	CHERIBSDTEST_VERIFY(WIFEXITED(status));
 }
 
-CHERIBSDTEST(test_ptrace_readcap, "Basic tests of PIOD_READ_CHERI_CAP")
+CHERIBSDTEST(ptrace_readcap, "Basic tests of PIOD_READ_CHERI_CAP")
 {
 	struct ptrace_io_desc piod;
 	pid_t pid;
@@ -129,7 +129,7 @@ CHERIBSDTEST(test_ptrace_readcap, "Basic tests of PIOD_READ_CHERI_CAP")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_ptrace_readtags, "Basic test of PIOD_READ_CHERI_TAGS")
+CHERIBSDTEST(ptrace_readtags, "Basic test of PIOD_READ_CHERI_TAGS")
 {
 	struct ptrace_io_desc piod;
 	pid_t pid;
@@ -168,7 +168,7 @@ CHERIBSDTEST(test_ptrace_readtags, "Basic test of PIOD_READ_CHERI_TAGS")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_ptrace_readcap_pageend,
+CHERIBSDTEST(ptrace_readcap_pageend,
     "Use PIOD_READ_CHERI_CAP to fetch capability at the end of a page")
 {
 	struct ptrace_io_desc piod;

--- a/bin/cheribsdtest/cheribsdtest_registers.c
+++ b/bin/cheribsdtest/cheribsdtest_registers.c
@@ -279,7 +279,7 @@ check_initreg_data_full_addrspace(void * __capability c)
 }
 #endif
 
-CHERIBSDTEST(test_initregs_default, "Test initial value of default capability")
+CHERIBSDTEST(initregs_default, "Test initial value of default capability")
 {
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -313,7 +313,7 @@ CHERIBSDTEST(test_initregs_default, "Test initial value of default capability")
 
 #define	CHERI_STACK_USE_MAX	(256 * 1024)
 
-CHERIBSDTEST(test_initregs_stack_user_perms,
+CHERIBSDTEST(initregs_stack_user_perms,
     "Test user permissions of stack capability")
 {
 	register_t v;
@@ -327,7 +327,7 @@ CHERIBSDTEST(test_initregs_stack_user_perms,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_initregs_stack,
+CHERIBSDTEST(initregs_stack,
     "Test initial value of stack capability")
 {
 	void * __capability c = cheri_getstack();
@@ -413,7 +413,7 @@ CHERIBSDTEST(test_initregs_stack,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_initregs_returncap, "Test value of return capability")
+CHERIBSDTEST(initregs_returncap, "Test value of return capability")
 {
 	void *c;
 	uintmax_t v;
@@ -444,7 +444,7 @@ CHERIBSDTEST(test_initregs_returncap, "Test value of return capability")
 }
 #endif
 
-CHERIBSDTEST(test_initregs_pcc,
+CHERIBSDTEST(initregs_pcc,
     "Test initial value of program-counter capability")
 {
 	void * __capability c;
@@ -457,7 +457,7 @@ CHERIBSDTEST(test_initregs_pcc,
 
 #ifdef __aarch64__
 #ifndef CHERIBSD_C18N_TESTS
-CHERIBSDTEST(test_initregs_restricted_default,
+CHERIBSDTEST(initregs_restricted_default,
     "Test initial value of restricted default capability")
 {
 	void * __capability c;
@@ -469,7 +469,7 @@ CHERIBSDTEST(test_initregs_restricted_default,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_initregs_restricted_stack,
+CHERIBSDTEST(initregs_restricted_stack,
     "Test initial value of restricted stack capability")
 {
 	void * __capability c;
@@ -481,7 +481,7 @@ CHERIBSDTEST(test_initregs_restricted_stack,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_initregs_restricted_thread,
+CHERIBSDTEST(initregs_restricted_thread,
     "Test initial value of restricted thread capability")
 {
 	void * __capability c;

--- a/bin/cheribsdtest/cheribsdtest_sealcap.c
+++ b/bin/cheribsdtest/cheribsdtest_sealcap.c
@@ -45,7 +45,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(test_sealcap_sysctl, "Retrieve sealcap using sysctl(3)")
+CHERIBSDTEST(sealcap_sysctl, "Retrieve sealcap using sysctl(3)")
 {
 	void * __capability sealcap;
 	size_t sealcap_size;
@@ -149,7 +149,7 @@ CHERIBSDTEST(test_sealcap_sysctl, "Retrieve sealcap using sysctl(3)")
 
 static uint8_t sealdata[4096] __attribute__ ((aligned(4096)));
 
-CHERIBSDTEST(test_sealcap_seal, "Use sealcap to seal a capability")
+CHERIBSDTEST(sealcap_seal, "Use sealcap to seal a capability")
 {
 	void * __capability sealdatap;
 	void * __capability sealcap;
@@ -208,7 +208,7 @@ CHERIBSDTEST(test_sealcap_seal, "Use sealcap to seal a capability")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_sealcap_seal_unseal,
+CHERIBSDTEST(sealcap_seal_unseal,
     "Use sealcap to seal and unseal a capability")
 {
 	void * __capability sealdatap;

--- a/bin/cheribsdtest/cheribsdtest_sentries.c
+++ b/bin/cheribsdtest/cheribsdtest_sentries.c
@@ -72,7 +72,7 @@ check_fptr(uintptr_t fptr)
 }
 
 #ifdef CHERIBSD_DYNAMIC_TESTS
-CHERIBSDTEST(test_sentry_dlsym,
+CHERIBSDTEST(sentry_dlsym,
     "Check that a function pointer obtaine dfrom via dlsym is a sentry")
 {
 	unsigned int (*fptr)(unsigned int seconds);
@@ -93,7 +93,7 @@ CHERIBSDTEST(test_sentry_dlsym,
 }
 #endif
 
-CHERIBSDTEST(test_sentry_libc,
+CHERIBSDTEST(sentry_libc,
     "Check that a function pointer from libc is a sentry")
 {
 	unsigned int (*fptr)(unsigned int seconds) = sleep;
@@ -101,7 +101,7 @@ CHERIBSDTEST(test_sentry_libc,
 	check_fptr((uintptr_t)fptr);
 }
 
-CHERIBSDTEST(test_sentry_static,
+CHERIBSDTEST(sentry_static,
     "Check that a statically initialized function pointer is a sentry")
 {
 

--- a/bin/cheribsdtest/cheribsdtest_signal.c
+++ b/bin/cheribsdtest/cheribsdtest_signal.c
@@ -54,7 +54,7 @@ handler_func(int signum)
 	handler_signum = signum;
 }
 
-CHERIBSDTEST(test_signal_handler_usr1,
+CHERIBSDTEST(signal_handler_usr1,
     "Install a signal handler (sa_handler) for SIGUSR1 and check it works")
 {
 	struct sigaction sa;
@@ -88,7 +88,7 @@ sigaction_func(int signum, siginfo_t *siginfo, void *context __unused)
 	sigaction_info_si_code = siginfo->si_code;
 }
 
-CHERIBSDTEST(test_signal_sigaction_usr1,
+CHERIBSDTEST(signal_sigaction_usr1,
     "Install a signal handler (sa_sigaction) for SIGUSR1 and check it works")
 {
 	struct sigaction sa;
@@ -127,7 +127,7 @@ sigaltstack_func(int signum __unused)
 	sigaltstack_local_addr = (__cheri_addr size_t)&x;
 }
 
-CHERIBSDTEST(test_signal_sigaltstack,
+CHERIBSDTEST(signal_sigaltstack,
     "Check signal handlers use the alternate stack when enabled",
     .ct_xfail_reason = XFAIL_C18N_SIGALTSTACK)
 {
@@ -180,7 +180,7 @@ sigaltstack_disable_func(int signum __unused)
 	sigaltstack_disable_local_addr = (__cheri_addr size_t)&x;
 }
 
-CHERIBSDTEST(test_signal_sigaltstack_disable,
+CHERIBSDTEST(signal_sigaltstack_disable,
     "Check signal handlers don't use a given alternate stack when re-disabled")
 {
 	stack_t sigstk;
@@ -235,7 +235,7 @@ returncap_func(int signum __unused)
 	handler_returncap = __builtin_return_address(0);
 }
 
-CHERIBSDTEST(test_signal_returncap,
+CHERIBSDTEST(signal_returncap,
     "Test value of signal handler return capability")
 {
 	struct sigaction sa;

--- a/bin/cheribsdtest/cheribsdtest_strfcap.c
+++ b/bin/cheribsdtest/cheribsdtest_strfcap.c
@@ -254,7 +254,7 @@ test_strfcap_number_one_cap(uintcap_t cap, const char *cap_desc)
 
 }
 
-CHERIBSDTEST(test_strfcap_numbers, "Checks of formats of a single number")
+CHERIBSDTEST(strfcap_numbers, "Checks of formats of a single number")
 {
 	char foo[4];
 	char * __capability foop = foo;
@@ -275,7 +275,7 @@ CHERIBSDTEST(test_strfcap_numbers, "Checks of formats of a single number")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_strfcap_T, "Check of tag in format")
+CHERIBSDTEST(strfcap_T, "Check of tag in format")
 {
 	char str_t[128], str_u[128];
 	char * __capability cap = (__cheri_tocap char * __capability)str_t;
@@ -295,7 +295,7 @@ CHERIBSDTEST(test_strfcap_T, "Check of tag in format")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_strfcap_textual, "Checks of %? and %%")
+CHERIBSDTEST(strfcap_textual, "Checks of %? and %%")
 {
 	char str[128];
 	char * __capability cap = str;
@@ -327,7 +327,7 @@ CHERIBSDTEST(test_strfcap_textual, "Checks of %? and %%")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_strfcap_C, "Various checks of %C (%A and %P indirectly)")
+CHERIBSDTEST(strfcap_C, "Various checks of %C (%A and %P indirectly)")
 {
 	char data[64];
 	uintcap_t scalar = (uintcap_t)4;

--- a/bin/cheribsdtest/cheribsdtest_string.c
+++ b/bin/cheribsdtest/cheribsdtest_string.c
@@ -110,7 +110,7 @@ invalidate(struct Test *t1)
 		*x = 0xa5;
 }
 
-CHERIBSDTEST(test_string_memcpy_c, "Test explicit capability memcpy")
+CHERIBSDTEST(string_memcpy_c, "Test explicit capability memcpy")
 {
 	int i;
 	void * __capability cpy;
@@ -211,7 +211,7 @@ CHERIBSDTEST(test_string_memcpy_c, "Test explicit capability memcpy")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_string_memcpy, "Test implicit capability memcpy")
+CHERIBSDTEST(string_memcpy, "Test implicit capability memcpy")
 {
 	int i;
 	void *copy;
@@ -271,7 +271,7 @@ CHERIBSDTEST(test_string_memcpy, "Test implicit capability memcpy")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_string_memmove_c, "Test explicit capability memmove")
+CHERIBSDTEST(string_memmove_c, "Test explicit capability memmove")
 {
 	int i;
 	void * __capability cpy;
@@ -371,7 +371,7 @@ CHERIBSDTEST(test_string_memmove_c, "Test explicit capability memmove")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_string_memmove, "Test implicit capability memmove")
+CHERIBSDTEST(string_memmove, "Test implicit capability memmove")
 {
 	int i;
 	void *copy;
@@ -438,7 +438,7 @@ CHERIBSDTEST(test_string_memmove, "Test implicit capability memmove")
  * can't replace it with an inline loop. We could also use -fno-builtin but that
  * could interfere with the other tests.
  */
-CHERIBSDTEST(test_unaligned_capability_copy_memcpy,
+CHERIBSDTEST(unaligned_capability_copy_memcpy,
     "Check that a memcpy() of valid capabilities to an unaligned destination "
     "strips tags")
 {
@@ -472,7 +472,7 @@ CHERIBSDTEST(test_unaligned_capability_copy_memcpy,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_unaligned_capability_copy_memmove,
+CHERIBSDTEST(unaligned_capability_copy_memmove,
     "Check that a memmove() of valid capabilities to an unaligned destination "
     "strips tags")
 {
@@ -507,7 +507,7 @@ CHERIBSDTEST(test_unaligned_capability_copy_memmove,
 }
 
 #ifdef KERNEL_MEMCPY_TESTS
-CHERIBSDTEST(test_string_kern_memcpy_c,
+CHERIBSDTEST(string_kern_memcpy_c,
     "Test explicit capability memcpy (kernel version)")
 {
 	int i;
@@ -596,7 +596,7 @@ CHERIBSDTEST(test_string_kern_memcpy_c,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_string_kern_memmove_c,
+CHERIBSDTEST(string_kern_memmove_c,
     "Test explicit capability memmove (kernel version)")
 {
 	int i;

--- a/bin/cheribsdtest/cheribsdtest_syscall.c
+++ b/bin/cheribsdtest/cheribsdtest_syscall.c
@@ -62,7 +62,7 @@
 
 #include "cheribsdtest.h"
 
-CHERIBSDTEST(test_sig_dfl_neq_ign, "Test SIG_DFL != SIG_IGN")
+CHERIBSDTEST(sig_dfl_neq_ign, "Test SIG_DFL != SIG_IGN")
 {
 	void * __capability sic = (__cheri_tocap void * __capability)SIG_IGN;
 
@@ -92,7 +92,7 @@ test_sig_dfl_ign_handler(int x)
 	(void)x;
 }
 
-CHERIBSDTEST(test_sig_dfl_ign, "Test proper handling of SIG_DFL and SIG_IGN")
+CHERIBSDTEST(sig_dfl_ign, "Test proper handling of SIG_DFL and SIG_IGN")
 {
 	int cpid;
 	int res;
@@ -156,7 +156,7 @@ CHERIBSDTEST(test_sig_dfl_ign, "Test proper handling of SIG_DFL and SIG_IGN")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_ptrace_basic, "Test basic handling of ptrace functionality")
+CHERIBSDTEST(ptrace_basic, "Test basic handling of ptrace functionality")
 {
 	int cpid, res;
 
@@ -200,7 +200,7 @@ test_aio_sival_handler(int sig, siginfo_t *si, void *uc __unused)
 	test_aio_sival_info = *si;
 }
 
-CHERIBSDTEST(test_aio_sival, "Test pointer passing through AIO signals")
+CHERIBSDTEST(aio_sival, "Test pointer passing through AIO signals")
 {
 	char buf[128];
 	int pfd[2];

--- a/bin/cheribsdtest/cheribsdtest_tls.c
+++ b/bin/cheribsdtest/cheribsdtest_tls.c
@@ -62,7 +62,7 @@ static __thread void * __capability tls_cap1;
 
 static __thread char tls_array_4k[4096] __aligned(4096);
 
-CHERIBSDTEST(test_tls_align_ptr, "Test alignment of TLS pointers")
+CHERIBSDTEST(tls_align_ptr, "Test alignment of TLS pointers")
 {
 	int alignment, expected;
 
@@ -83,7 +83,7 @@ CHERIBSDTEST(test_tls_align_ptr, "Test alignment of TLS pointers")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_tls_align_cap, "Test alignment of TLS capabilities")
+CHERIBSDTEST(tls_align_cap, "Test alignment of TLS capabilities")
 {
 	int alignment, expected;
 
@@ -104,7 +104,7 @@ CHERIBSDTEST(test_tls_align_cap, "Test alignment of TLS capabilities")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_tls_align_4k, "Test alignment of TLS 4K array")
+CHERIBSDTEST(tls_align_4k, "Test alignment of TLS 4K array")
 {
 	int alignment, expected;
 

--- a/bin/cheribsdtest/cheribsdtest_tls_threads.c
+++ b/bin/cheribsdtest/cheribsdtest_tls_threads.c
@@ -110,7 +110,7 @@ test_tls_threads_get_vars(void *arg __unused)
 	return NULL;
 }
 
-CHERIBSDTEST(test_tls_threads, "Test TLS across threads")
+CHERIBSDTEST(tls_threads, "Test TLS across threads")
 {
 	pthread_t thread;
 	int error;

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -100,14 +100,14 @@ mmap_and_check_tag_stored(int fd, int protflags, int mapflags)
 		CHERIBSDTEST_CHECK_SYSCALL(close(fd));
 }
 
-CHERIBSDTEST(cheribsdtest_vm_tag_mmap_anon,
+CHERIBSDTEST(vm_tag_mmap_anon,
     "check tags are stored for MAP_ANON pages")
 {
 	mmap_and_check_tag_stored(-1, PROT_READ | PROT_WRITE, MAP_ANON);
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_shared,
+CHERIBSDTEST(vm_tag_shm_open_anon_shared,
     "check tags are stored for SHM_ANON MAP_SHARED pages")
 {
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
@@ -116,7 +116,7 @@ CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_shared,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_private,
+CHERIBSDTEST(vm_tag_shm_open_anon_private,
     "check tags are stored for SHM_ANON MAP_PRIVATE pages")
 {
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
@@ -128,7 +128,7 @@ CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_private,
 /*
  * Test aliasing of SHM_ANON objects
  */
-CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_shared2x,
+CHERIBSDTEST(vm_tag_shm_open_anon_shared2x,
     "test multiply-mapped SHM_ANON objects")
 {
 	void * __capability volatile * map2;
@@ -154,7 +154,7 @@ CHERIBSDTEST(cheribsdtest_vm_tag_shm_open_anon_shared2x,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_vm_shm_open_anon_unix_surprise,
+CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
     "test SHM_ANON vs SCM_RIGHTS",
     .ct_xfail_reason =
 	"Tags currently survive cross-AS aliasing of SHM_ANON objects")
@@ -269,7 +269,7 @@ CHERIBSDTEST(cheribsdtest_vm_shm_open_anon_unix_surprise,
 	}
 }
 
-CHERIBSDTEST(cheribsdtest_shm_open_read_nocaps,
+CHERIBSDTEST(shm_open_read_nocaps,
     "check that read(2) of a shm_open fd does not return tags")
 {
 	void * __capability *map;
@@ -299,7 +299,7 @@ CHERIBSDTEST(cheribsdtest_shm_open_read_nocaps,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_shm_open_write_nocaps,
+CHERIBSDTEST(shm_open_write_nocaps,
     "check that write(2) of a shm_open fd does not set tags")
 {
 	void * __capability *map;
@@ -336,7 +336,7 @@ CHERIBSDTEST(cheribsdtest_shm_open_write_nocaps,
  * them to flow between address spaces.  It is difficult to know what to do
  * about this case, but it seems important to acknowledge.
  */
-CHERIBSDTEST(cheribsdtest_vm_cap_share_fd_kqueue,
+CHERIBSDTEST(vm_cap_share_fd_kqueue,
     "Demonstrate capability passing via shared FD table",
     .ct_xfail_reason = "Tags currently survive cross-AS shared FD tables")
 {
@@ -396,7 +396,7 @@ extern int __sys_sigaction(int, const struct sigaction *, struct sigaction *);
  * We can rfork and share the sigaction table across parent and child, which
  * again allows for capability passing across address spaces.
  */
-CHERIBSDTEST(cheribsdtest_vm_cap_share_sigaction,
+CHERIBSDTEST(vm_cap_share_sigaction,
     "Demonstrate capability passing via shared sigaction table",
     .ct_xfail_reason = "Tags currently survive cross-AS shared sigaction table")
 {
@@ -458,7 +458,7 @@ CHERIBSDTEST(cheribsdtest_vm_cap_share_sigaction,
 
 #endif
 
-CHERIBSDTEST(cheribsdtest_vm_tag_dev_zero_shared,
+CHERIBSDTEST(vm_tag_dev_zero_shared,
     "check tags are stored for /dev/zero MAP_SHARED pages")
 {
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(open("/dev/zero", O_RDWR));
@@ -466,7 +466,7 @@ CHERIBSDTEST(cheribsdtest_vm_tag_dev_zero_shared,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_vm_tag_dev_zero_private,
+CHERIBSDTEST(vm_tag_dev_zero_private,
     "check tags are stored for /dev/zero MAP_PRIVATE pages")
 {
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(open("/dev/zero", O_RDWR));
@@ -489,7 +489,7 @@ create_tempfile()
  * This case should fault.
  * XXXRW: I wonder if we also need some sort of load-related test?
  */
-CHERIBSDTEST(cheribsdtest_vm_notag_tmpfile_shared,
+CHERIBSDTEST(vm_notag_tmpfile_shared,
     "check tags are not stored for tmpfile() MAP_SHARED pages",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO | CT_FLAG_SI_ADDR,
     .ct_signum = SIGSEGV,
@@ -510,7 +510,7 @@ CHERIBSDTEST(cheribsdtest_vm_notag_tmpfile_shared,
 	cheribsdtest_failure_errx("tagged store succeeded");
 }
 
-CHERIBSDTEST(cheribsdtest_vm_tag_tmpfile_private,
+CHERIBSDTEST(vm_tag_tmpfile_private,
     "check tags are stored for tmpfile() MAP_PRIVATE pages",
     .ct_check_skip = skip_need_writable_tmp)
 {
@@ -519,7 +519,7 @@ CHERIBSDTEST(cheribsdtest_vm_tag_tmpfile_private,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_vm_tag_tmpfile_private_prefault,
+CHERIBSDTEST(vm_tag_tmpfile_private_prefault,
     "check tags are stored for tmpfile() MAP_PRIVATE, MAP_PREFAULT_READ pages",
     .ct_check_skip = skip_need_writable_tmp)
 {
@@ -565,7 +565,7 @@ skip_need_writable_tmp(const char *name __unused)
  * copy-on-write, then read back the capability and confirm that it still has
  * a tag.  (cheribsdtest_vm_cow_write)
  */
-CHERIBSDTEST(cheribsdtest_vm_cow_read,
+CHERIBSDTEST(vm_cow_read,
     "read capabilities from a copy-on-write page")
 {
 	void * __capability volatile *cp_copy;
@@ -614,7 +614,7 @@ CHERIBSDTEST(cheribsdtest_vm_cow_read,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(cheribsdtest_vm_cow_write,
+CHERIBSDTEST(vm_cow_write,
     "read capabilities from a faulted copy-on-write page")
 {
 	void * __capability volatile *cp_copy;
@@ -704,7 +704,7 @@ get_unrepresentable_length()
 /*
  * Check that the padding of a reservation faults on access
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_access_fault,
+CHERIBSDTEST(vm_reservation_access_fault,
     "check that we fault when accessing padding of a reservation",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE,
     .ct_signum = SIGSEGV,
@@ -737,7 +737,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_access_fault,
  * Check that a reserved range can not be reused for another mapping,
  * until the whole mapping is freed.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_reuse,
+CHERIBSDTEST(vm_reservation_reuse,
     "check that we can not remap over a partially-unmapped reservation")
 {
 	void *map;
@@ -768,7 +768,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_reuse,
  * Check that alignment is promoted automatically to the first
  * representable boundary.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_align,
+CHERIBSDTEST(vm_reservation_align,
     "check that mmap correctly align mappings")
 {
 	void *map;
@@ -822,7 +822,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_align,
  * a proper temporal-safety implementation will lead to failures so
  * we catch these early.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_after_free_fixed,
+CHERIBSDTEST(vm_reservation_mmap_after_free_fixed,
     "check that an old capability can not be used to mmap with MAP_FIXED "
     "after the reservation has been deleted")
 {
@@ -848,7 +848,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_after_free_fixed,
  * a proper temporal-safety implementation will lead to failures so
  * we catch these early.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_after_free,
+CHERIBSDTEST(vm_reservation_mmap_after_free,
     "check that an old capability can not be used to mmap after the "
     "reservation has been deleted")
 {
@@ -869,7 +869,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_after_free,
 /*
  * Check that reservations are aligned and padded correctly for shared mappings.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_shared,
+CHERIBSDTEST(vm_reservation_mmap_shared,
     "check reservation alignment and bounds for shared mappings")
 {
 	void *map;
@@ -897,7 +897,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_shared,
  * Check that we require NULL-derived capabilities when mmap().
  * Test mmap() with an invalid capability and no backing reservation.
  */
-CHERIBSDTEST(cheribsdtest_vm_mmap_invalid_cap,
+CHERIBSDTEST(vm_mmap_invalid_cap,
     "check that mmap with invalid capability hint fails")
 {
 	void *invalid = cheri_cleartag(cheri_setaddress(
@@ -919,7 +919,7 @@ CHERIBSDTEST(cheribsdtest_vm_mmap_invalid_cap,
  * Check that we require NULL-derived capabilities when mmap().
  * Test mmap() MAP_FIXED with an invalid capability and no backing reservation.
  */
-CHERIBSDTEST(cheribsdtest_vm_mmap_invalid_cap_fixed,
+CHERIBSDTEST(vm_mmap_invalid_cap_fixed,
     "check that mmap MAP_FIXED with invalid capability hint fails")
 {
 	void *invalid = cheri_cleartag(cheri_setaddress(
@@ -942,7 +942,7 @@ CHERIBSDTEST(cheribsdtest_vm_mmap_invalid_cap_fixed,
  * Test mmap() MAP_FIXED with an invalid capability and existing
  * backing reservation.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_invalid_cap,
+CHERIBSDTEST(vm_reservation_mmap_invalid_cap,
     "check that mmap over existing reservation with invalid "
     "capability hint fails")
 {
@@ -968,7 +968,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_invalid_cap,
 /*
  * Check that mmap() with a null-derived hint address succeeds.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap,
+CHERIBSDTEST(vm_reservation_mmap,
     "check mmap with NULL-derived hint address")
 {
 	uintptr_t hint;
@@ -989,7 +989,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap,
  * Check that this fails if a mapping already exists at the target address
  * as MAP_FIXED implies MAP_EXCL in this case.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_fixed_unreserved,
+CHERIBSDTEST(vm_reservation_mmap_fixed_unreserved,
     "check mmap MAP_FIXED with NULL-derived hint address")
 {
 	uintptr_t hint;
@@ -1018,7 +1018,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_fixed_unreserved,
  * Check that mmap at fixed address with NULL-derived hint fails if
  * a reservation already exists at the target address.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_insert_null_derived,
+CHERIBSDTEST(vm_reservation_mmap_insert_null_derived,
     "check that mmap with NULL-derived hint address over existing "
     "reservation fails")
 {
@@ -1044,7 +1044,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_insert_null_derived,
  * Check that we can add a fixed mapping into an existing
  * reservation using a VM_MAP bearing capability.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_fixed_insert,
+CHERIBSDTEST(vm_reservation_mmap_fixed_insert,
     "check mmap MAP_FIXED into an existing reservation with a "
     "VM_MAP perm capability")
 {
@@ -1069,7 +1069,7 @@ CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_fixed_insert,
  * Check that attempting to add a fixed mapping into an existing
  * reservation using a capability without VM_MAP permission fails.
  */
-CHERIBSDTEST(cheribsdtest_vm_reservation_mmap_fixed_insert_noperm,
+CHERIBSDTEST(vm_reservation_mmap_fixed_insert_noperm,
     "check that mmap MAP_FIXED into an existing reservation "
     "with a capability missing VM_MAP permission fails")
 {
@@ -1111,7 +1111,7 @@ get_pagesizes(size_t ps[static MAXPAGESIZES])
 /*
  * Builds on FreeBSD testsuite posixshm_test:largepage_basic.
  */
-CHERIBSDTEST(cheribsdtest_vm_shm_largepage_basic,
+CHERIBSDTEST(vm_shm_largepage_basic,
     "Test basic largepage SHM mapping setup and teardown")
 {
 	void *addr;

--- a/bin/cheribsdtest/cheribsdtest_vm_swap.c
+++ b/bin/cheribsdtest/cheribsdtest_vm_swap.c
@@ -81,7 +81,7 @@ static void		 mix_patterns(void);
 static uint64_t		 quickhash(uint64_t v);
 static const char	*skip_swap_required(const char *name __unused)
 
-CHERIBSDTEST(cheribsdtest_vm_swap,
+CHERIBSDTEST(vm_swap,
     "check tags are swapped out by swap pager",
     .ct_check_skip = skip_swap_required})
 {

--- a/bin/cheribsdtest/cheribsdtest_zlib.c
+++ b/bin/cheribsdtest/cheribsdtest_zlib.c
@@ -98,7 +98,7 @@ check_uncompressed_data(const uint8_t *data, size_t datalen)
 	}
 }
 
-CHERIBSDTEST(test_deflate_zeroes, "Deflate a buffer of zeroes")
+CHERIBSDTEST(deflate_zeroes, "Deflate a buffer of zeroes")
 {
 	int ret;
 	size_t compsize;
@@ -132,7 +132,7 @@ CHERIBSDTEST(test_deflate_zeroes, "Deflate a buffer of zeroes")
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(test_inflate_zeroes, "Inflate a compressed buffer of zeroes")
+CHERIBSDTEST(inflate_zeroes, "Inflate a compressed buffer of zeroes")
 {
 	int ret;
 	uint8_t *outbuf;


### PR DESCRIPTION
By definition tests are in the namespace of tests.  We don't need to prefix them with "cheribsdtest_" or "test_" to disambiguate them from non-tests (which don't exist).  We've been extremely inconsistent about naming and it isn't useful.  Rename everything and add a guard to catch new additions while various feature branches are updates.