### PR TITLE
__USER_CAP fixes

### DIFF
--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -45,6 +45,12 @@
     (void * __capability)curthread->td_pcb->pcb_rddc_el0)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
+/* Does the current thread add the base in CToPtr */
+#define __USER_DDC_OFFSET_ENABLED	\
+    (READ_SPECIALREG(cctlr_el0) & CCTLR_DDCBO_MASK)
+#define __USER_PCC_OFFSET_ENABLED	\
+    (READ_SPECIALREG(cctlr_el0) & CCTLR_PCCBO_MASK)
+
 /*
  * Special marker NOPs for the Morello FVP to start / stop region of interest
  * in trace.

--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -40,7 +40,9 @@
 #endif
 
 #ifdef _KERNEL
-#define	__USER_DDC	((void * __capability)curthread->td_frame->tf_ddc)
+#define	__USER_DDC ((cheri_getperm(__USER_PCC) & CHERI_PERM_EXECUTIVE) ? \
+    (void * __capability)curthread->td_frame->tf_ddc :			\
+    (void * __capability)curthread->td_pcb->pcb_rddc_el0)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
 /*

--- a/sys/riscv/include/cheri.h
+++ b/sys/riscv/include/cheri.h
@@ -38,6 +38,10 @@
 #define	__USER_DDC	((void * __capability)curthread->td_frame->tf_ddc)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_sepc)
 
+/* RISC-V always adds the base in CToPtr */
+#define	__USER_DDC_OFFSET_ENABLED	1
+#define	__USER_PCC_OFFSET_ENABLED	1
+
 /*
  * CHERI-RISC-V-specific kernel utility functions.
  */

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -122,18 +122,20 @@ struct ucred;
  * Derive out-of-bounds and small values from NULL.  This allows common
  * sentinel values to work.
  */
-#define ___USER_CFROMPTR(ptr, cap)					\
+#define ___USER_CFROMPTR(ptr, cap, is_offset)				\
     ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
-	__builtin_cheri_offset_set(NULL, (ptraddr_t)(ptr)) :		\
-	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)))
+	__builtin_cheri_address_set(NULL, (ptraddr_t)(ptr)) :		\
+	(is_offset) ?							\
+	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)) :		\
+	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))
 
 #define	__USER_CAP_UNBOUND(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_DDC)
+	___USER_CFROMPTR((ptr), __USER_DDC, __USER_DDC_OFFSET_ENABLED)
 
 #define	__USER_CODE_CAP(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_PCC)
+	___USER_CFROMPTR((ptr), __USER_PCC, __USER_PCC_OFFSET_ENABLED)
 
 #define	__USER_CAP(ptr, len)						\
 ({									\


### PR DESCRIPTION
Use the right DDC in restricted mode when creating userspace caps for hybrid processes.

Match base offsetting mode of userspace thread when creating userspace caps.