### PR TITLE
___USER_CFROMPTR: simplify NULL-derived cap creation

### DIFF
--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -42,7 +42,7 @@
 #ifdef _KERNEL
 #define	__USER_DDC ((cheri_getperm(__USER_PCC) & CHERI_PERM_EXECUTIVE) ? \
     (void * __capability)curthread->td_frame->tf_ddc :			\
-    (void * __capability)curthread->td_pcb->pcb_rddc_el0)
+    (void * __capability)READ_SPECIALREG_CAP(rddc_el0))
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
 /* Does the current thread add the base in CToPtr */

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -126,7 +126,7 @@ struct ucred;
     ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
-	__builtin_cheri_address_set(NULL, (ptraddr_t)(ptr)) :		\
+	(void * __capability)(uintcap_t)(ptraddr_t)(ptr) :		\
 	(is_offset) ?							\
 	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)) :		\
 	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))


### PR DESCRIPTION
Use a set of casts to create NULL-derived capabilities rather than a builtin since it doesn't matter if offset or address mode is used (the compiler might well add the value to the zero capability register).

Co-authored-by:	Jessica Clarke <jrtc27@jrtc27.com>