### PR TITLE
rtwn: Add subobject bounds annotations for softc subclasses.

### DIFF
--- a/sys/dev/rtwn/pci/rtwn_pci_var.h
+++ b/sys/dev/rtwn/pci/rtwn_pci_var.h
@@ -102,7 +102,7 @@ enum {
 	 RTWN_PCI_INTR_RX_DESC_UNAVAIL | RTWN_PCI_INTR_RX_DONE)
 
 struct rtwn_pci_softc {
-	struct rtwn_softc	pc_sc;		/* must be the first */
+	struct rtwn_softc	pc_sc __subobject_member_used_for_c_inheritance;		/* must be the first */
 
 	struct resource		*irq;
 	struct resource		*mem;

--- a/sys/dev/rtwn/usb/rtwn_usb_var.h
+++ b/sys/dev/rtwn/usb/rtwn_usb_var.h
@@ -57,7 +57,7 @@ enum {
 #define RTWN_EP_QUEUES		RTWN_BULK_RX
 
 struct rtwn_usb_softc {
-	struct rtwn_softc	uc_sc;		/* must be the first */
+	struct rtwn_softc	uc_sc __subobject_member_used_for_c_inheritance;		/* must be the first */
 	struct usb_device	*uc_udev;
 	struct usb_xfer		*uc_xfer[RTWN_N_TRANSFER];
 


### PR DESCRIPTION
The bus-specific drivers extend the common struct rtwn_softc with bus-specific fields and expect to cast a pointer to the base class back to the sub class.

Fixes #1636