### PR TITLE
c18n: Autumn 2023 release

### DIFF
--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -33,13 +33,10 @@
 
 ENTRY(_setjmp)
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	stp	REG(0), REGN(lr), [REGN(sp), #-(REG_WIDTH * 2)]!
-
 	/* Store Executive mode state */
+	str	REGN(lr), [REGN(sp), #-REG_WIDTH]!
 	bl	_rtld_setjmp
-	mov	c1, c0
-
-	ldp	REG(0), REGN(lr), [REGN(sp)], #(REG_WIDTH * 2)
+	ldr	REGN(lr), [REGN(sp)], #REG_WIDTH
 #endif
 
 	/* Store the magic value and stack pointer */
@@ -63,10 +60,6 @@ ENTRY(_setjmp)
 	stp	d14, d15, [REG(0)], #16
 #endif
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	str	c1, [REG(0)], #16
-#endif
-
 	/* Return value */
 	mov	x0, #0
 	RETURN
@@ -76,6 +69,11 @@ ENTRY(_setjmp)
 END(_setjmp)
 
 ENTRY(_longjmp)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	/* Restore Executive mode state */
+	bl	_rtld_longjmp
+#endif
+
 	/* Check the magic value */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
 	ldr	x9, .Lmagic
@@ -100,16 +98,6 @@ ENTRY(_longjmp)
 	ldp	d10, d11, [REG(0)], #16
 	ldp	d12, d13, [REG(0)], #16
 	ldp	d14, d15, [REG(0)], #16
-#endif
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	/* Restore Executive mode state */
-	stp	REG(1), REGN(lr), [REGN(sp), #-(REG_WIDTH * 2)]!
-
-	ldr	c0, [c0], #16
-	bl	_rtld_longjmp
-
-	ldp	REG(1), REGN(lr), [REGN(sp)], #(REG_WIDTH * 2)
 #endif
 
 	/* Load the return value */

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -53,14 +53,15 @@ ENTRY(setjmp)
 	mov	x0, #1				/* SIG_BLOCK */
 	bl	sigprocmask
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	/* Store Executive mode state */
-	bl	_rtld_setjmp
-	mov	c1, c0
-#endif
-
 	ldp	REG(0), REGN(lr), [REGN(sp)]
 	add	REGN(sp), REGN(sp), #(REG_WIDTH * 2)
+
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	/* Store Executive mode state */
+	str	REGN(lr), [REGN(sp), #-REG_WIDTH]!
+	bl	_rtld_setjmp
+	ldr	REGN(lr), [REGN(sp)], #REG_WIDTH
+#endif
 
 	/* Store the magic value and stack pointer */
 	ldr	x8, .Lmagic
@@ -80,11 +81,6 @@ ENTRY(setjmp)
 	stp	d10, d11, [REG(0)], #16
 	stp	d12, d13, [REG(0)], #16
 	stp	d14, d15, [REG(0)], #16
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	/* Store Executive mode state */
-	str	c1, [REG(0)], #16
-#endif
 
 	/* Return value */
 	mov	x0, #0
@@ -109,6 +105,11 @@ ENTRY(longjmp)
 	ldp	REG(0), REGN(lr), [REGN(sp)]
 	add	REGN(sp), REGN(sp), #(REG_WIDTH * 4)
 
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	/* Restore Executive mode state */
+	bl	_rtld_longjmp
+#endif
+
 	/* Check the magic value */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
 	ldr	x9, .Lmagic
@@ -132,16 +133,6 @@ ENTRY(longjmp)
 	ldp	d10, d11, [REG(0)], #16
 	ldp	d12, d13, [REG(0)], #16
 	ldp	d14, d15, [REG(0)], #16
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	/* Restore Executive mode state */
-	stp	REG(1), REGN(lr), [REGN(sp), #-(REG_WIDTH * 2)]!
-
-	ldr	c0, [c0], #16
-	bl	_rtld_longjmp
-
-	ldp	REG(1), REGN(lr), [REGN(sp)], #(REG_WIDTH * 2)
-#endif
 
 	/* Load the return value */
 	cmp	x1, #0

--- a/lib/libc/aarch64/sys/Makefile.inc
+++ b/lib/libc/aarch64/sys/Makefile.inc
@@ -11,3 +11,8 @@ MDASM=	cerror.S \
 # Don't generate default code for these syscalls:
 NOASM+=	sbrk.o \
 	vfork.o
+
+.ifdef RTLD_SANDBOX
+SRCS+=	thr_exit.c
+PSEUDO+=	_thr_exit.o
+.endif

--- a/lib/libc/aarch64/sys/thr_exit.c
+++ b/lib/libc/aarch64/sys/thr_exit.c
@@ -1,0 +1,39 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+void thr_exit(long *);
+
+void _rtld_thr_exit(long *);
+
+void
+thr_exit(long *state)
+{
+	_rtld_thr_exit(state);
+}

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -61,7 +61,7 @@ void _rtld_atfork_post(int *);
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 void _rtld_thread_start_init(void (*)(struct pthread *));
-void _rtld_sighandler_init(void *);
+void _rtld_sighandler_init(void (*)(int, siginfo_t *, void *));
 #endif
 
 /*
@@ -205,7 +205,7 @@ _rtld_thread_start_init(void (*p)(struct pthread *) __unused)
 
 #pragma weak _rtld_sighandler_init
 void
-_rtld_sighandler_init(void *p __unused)
+_rtld_sighandler_init(void (*p)(int, siginfo_t *, void *) __unused)
 {
 }
 #endif

--- a/lib/libsysdecode/utrace.c
+++ b/lib/libsysdecode/utrace.c
@@ -192,6 +192,16 @@ print_utrace_rtld(FILE *fp, void *p)
 	case UTRACE_RTLD_ERROR:
 		fprintf(fp, "RTLD: error: %s\n", ut->name);
 		break;
+	case UTRACE_COMPARTMENT_ENTER:
+		fprintf(fp,
+		    "RTLD: c18n: enter %s from %s at [%zu] %s (%p)",
+		    ut->callee, ut->caller, ut->mapsize, ut->symbol, ut->handle);
+		break;
+	case UTRACE_COMPARTMENT_LEAVE:
+		fprintf(fp,
+		    "RTLD: c18n: leave %s to %s at [%zu] %s",
+		    ut->callee, ut->caller, ut->mapsize, ut->symbol);
+		break;
 
 	default:
 		return (0);

--- a/lib/libthr/Makefile
+++ b/lib/libthr/Makefile
@@ -43,7 +43,8 @@ CFLAGS.thr_symbols.c+=	-Wno-missing-variable-declarations
 CFLAGS.thr_sig.c+=	-fno-sanitize=address
 .endif
 
-.if ${MACHINE_CPUARCH} == "arm"
+.if ${MACHINE_CPUARCH} == "arm" || defined(RTLD_SANDBOX)
+# XXX: RTLD_SANDBOX currently does not support stack unwinding.
 NO_THREAD_UNWIND_STACK= yes
 .endif
 

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -115,6 +115,10 @@ SRCS+=		cheri_reloc.c
 CFLAGS+=	-I${RTLD_ELF_DIR}/cheri
 .endif
 
+.ifdef RTLD_SANDBOX
+SRCS+=		rtld_c18n.c rtld_c18n_machdep.c rtld_c18n_asm.S
+.endif
+
 .if ${MACHINE_ABI:Mpurecap}
 .PATH: ${SRCTOP}/lib/libmalloc_simple
 SRCS+=		heap.c malloc.c

--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -1,8 +1,11 @@
 FBSDprivate_1.0 {
     _rtld_thread_start_init;
     _rtld_thread_start;
+    _rtld_thr_exit;
     _rtld_sighandler_init;
     _rtld_sighandler;
     _rtld_setjmp;
     _rtld_longjmp;
+    _rtld_safebox_code;
+    _rtld_sandbox_code;
 };

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -38,6 +38,9 @@
 
 #include "debug.h"
 #include "rtld.h"
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#include "rtld_c18n.h"
+#endif
 #include "rtld_printf.h"
 
 #if __has_feature(capabilities)
@@ -59,19 +62,13 @@ void *_rtld_tlsdesc_static(void *);
 void *_rtld_tlsdesc_undef(void *);
 void *_rtld_tlsdesc_dynamic(void *);
 
-void _exit(int);
-
 void
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-init_pltgot(Obj_Entry *obj, uintptr_t sealer_cap)
-#else
 init_pltgot(Obj_Entry *obj)
-#endif
 {
 
 	if (obj->pltgot != NULL) {
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-		obj->pltgot[1] = (uintptr_t) cheri_seal(obj, sealer_cap);
+		obj->pltgot[1] = (uintptr_t) cheri_seal(obj, sealer_pltgot);
 #else
 		obj->pltgot[1] = (uintptr_t) obj;
 #endif
@@ -175,257 +172,6 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 	}
 }
 #endif /* __CHERI_PURE_CAPABILITY__ */
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-
-void _rtld_thread_start(struct pthread *);
-void _rtld_sighandler(int, siginfo_t *, void *);
-
-struct tramp {
-	const void *target;
-	uint32_t compart_id;
-	char code[];
-};
-
-struct tramp_pg {
-	struct tramp *cursor;		/* Points to start of unused space */
-	SLIST_ENTRY(tramp_pg) entries;	/* Points to start of next page */
-	struct tramp trampolines[];	/* Points to start of trampolines */
-};
-
-SLIST_HEAD(tramp_pgs, tramp_pg);
-
-/* Default stack size in libthr */
-#define SANDBOX_STACK_DEFAULT	(sizeof(void *) / 4 * 1024 * 1024)
-#define DEFAULT_STACK_TABLE_SIZE 2
-
-typedef uintptr_t *tramp_stk_table_t;
-
-static void
-get_rstk(uint32_t index, tramp_stk_table_t table, const void *target)
-{
-	size_t len = cheri_getlen(table) / sizeof(*table);
-
-	if (index < len) {
-		size_t size;
-		void *stk;
-		struct {
-			uint8_t generation;
-			uintptr_t top;
-		} *metadata;
-		struct Struct_Stack_Entry *entry;
-		Obj_Entry *dst;
-
-		size = SANDBOX_STACK_DEFAULT;
-		stk = (char *)mmap(NULL,
-				   size,
-				   PROT_READ | PROT_WRITE,
-				   MAP_ANON | MAP_PRIVATE | MAP_STACK,
-				   -1, 0) + size;
-		if (stk == MAP_FAILED)
-			rtld_die();
-
-		stk = cheri_clearperm(stk, CHERI_PERM_EXECUTIVE | CHERI_PERM_SW_VMEM);
-		metadata = stk;
-		metadata[-1].generation = 0;
-		metadata[-1].top = (uintptr_t)&metadata[-1];
-
-		table[index] = (uintptr_t)stk;
-
-		entry = xmalloc(sizeof(*entry));
-		entry->stack = stk;
-
-		dst = obj_from_addr(target);
-		lockinfo.wlock_acquire(dst->stackslock);
-		SLIST_INSERT_HEAD(&dst->stacks, entry, link);
-		lockinfo.lock_release(dst->stackslock);
-
-	} else {
-		size_t new_len;
-		tramp_stk_table_t new_table;
-
-		new_len = len * 2;
-		new_table = xcalloc(new_len, sizeof(*new_table));
-		if (new_table == NULL)
-			rtld_die();
-
-		assert(cheri_getlen(new_table) / sizeof(*new_table) == new_len);
-
-		memcpy(new_table, table, len * sizeof(*table));
-
-		asm ("msr	ctpidr_el0, %0" :: "C" (new_table));
-		free(table);
-	}
-}
-
-static void (*thr_thread_start)(struct pthread *);
-
-void
-_rtld_thread_start(struct pthread *curthread)
-{
-	tramp_stk_table_t tls;
-	asm ("mrs	%0, ctpidr_el0" : "=C" (tls));
-	asm ("msr	rctpidr_el0, %0" :: "C" (tls));
-
-	tls = xcalloc(DEFAULT_STACK_TABLE_SIZE, sizeof(*tls));
-	tls[0] = (uintptr_t)get_rstk;
-	asm ("msr	ctpidr_el0, %0" :: "C" (tls));
-
-	thr_thread_start(curthread);
-}
-
-void
-_rtld_thread_start_init(void (*p)(struct pthread *))
-{
-	assert((cheri_getperm(p) & CHERI_PERM_EXECUTIVE) == 0);
-	assert(thr_thread_start == NULL);
-	thr_thread_start = tramp_pgs_append(p, obj_from_addr(p), NULL);
-}
-
-static void (*thr_sighandler)(int, siginfo_t *, void *);
-
-void
-_rtld_sighandler(int sig, siginfo_t *info, void *_ucp)
-{
-	uintptr_t csp, rcsp;
-	ucontext_t *ucp = _ucp;
-
-	csp = ucp->uc_mcontext.mc_capregs.cap_sp;
-	asm ("mrs	%0, rcsp_el0" : "=C" (rcsp));
-	ucp->uc_mcontext.mc_capregs.cap_sp = rcsp;
-
-	thr_sighandler(sig, info, ucp);
-
-	rcsp = ucp->uc_mcontext.mc_capregs.cap_sp;
-	asm ("msr	rcsp_el0, %0" :: "C" (rcsp));
-	ucp->uc_mcontext.mc_capregs.cap_sp = csp;
-}
-
-void
-_rtld_sighandler_init(void *p)
-{
-	assert((cheri_getperm(p) & CHERI_PERM_EXECUTIVE) == 0);
-	assert(thr_sighandler == NULL);
-	thr_sighandler = tramp_pgs_append(p, obj_from_addr(p), NULL);
-}
-
-static void *
-set_bounds_get_remainder(struct tramp **inout, size_t len)
-{
-	void *hi = *inout;
-	void *lo;
-	ptraddr_t top_lo, alignment;
-	size_t remaining;
-
-	*inout = lo = cheri_setbounds(hi, len);
-	top_lo = cheri_gettop(lo);
-	remaining = cheri_gettop(hi) - top_lo;
-	alignment = CHERI_REPRESENTABLE_ALIGNMENT(remaining);
-	return (cheri_setaddress(hi, roundup2(top_lo, alignment)));
-}
-
-static struct tramp_pg *
-tramp_pg_create(void)
-{
-	struct tramp_pg *p;
-	p = mmap(NULL,
-		getpagesize(),
-		PROT_READ | PROT_WRITE | PROT_EXEC,
-		MAP_ANON | MAP_PRIVATE,
-		-1, 0);
-	if (p == MAP_FAILED)
-		return (NULL);
-	p->cursor = p->trampolines;
-	return (p);
-}
-
-static int
-exclude_symbol_in_lib(const char *name, const char *sym, const Obj_Entry *obj, const Elf_Sym *def)
-{
-	Name_Entry *entry;
-
-	if (def == NULL ||
-	    strcmp(sym, strtab_value(obj, def->st_name)) != 0)
-		return (0);
-
-	STAILQ_FOREACH(entry, &obj->names, link) {
-		if (strcmp(name, entry->name) == 0)
-			return (1);
-	}
-	return (0);
-}
-
-void *
-tramp_pgs_append(void *target, const Obj_Entry *obj, const Elf_Sym *def)
-{
-	extern const struct tramp tramp_template_exe, tramp_template_res;
-	extern const size_t sztramp_template_exe, sztramp_template_res;
-
-	static struct tramp_pgs pgs = SLIST_HEAD_INITIALIZER(pgs);
-
-	const struct tramp *template;
-	size_t len;
-
-	RtldLockState lockstate;
-	struct tramp_pg *pg;
-	bool did_allocate = false;
-	struct tramp *t;
-
-	if (exclude_symbol_in_lib("libc.so.7", "rfork", obj, def) ||
-	    exclude_symbol_in_lib("libc.so.7", "vfork", obj, def)) {
-		return (target);
-	}
-
-	if (cheri_getperm(target) & CHERI_PERM_EXECUTIVE) {
-		template = &tramp_template_exe;
-		len = sztramp_template_exe;
-	} else {
-		template = &tramp_template_res;
-		len = sztramp_template_res;
-	}
-	assert(len == cheri_getlen(template));
-
-	wlock_acquire(rtld_tramp_lock, &lockstate);
-
-	pg = SLIST_FIRST(&pgs);
-	if (pg == NULL) {
-allocate_new_page:
-		if (did_allocate)
-			rtld_die();
-		pg = tramp_pg_create();
-		if (pg == NULL)
-			rtld_die();
-		SLIST_INSERT_HEAD(&pgs, pg, entries);
-		did_allocate = true;
-	}
-
-	t = roundup2(pg->cursor, _Alignof(typeof(*t)));
-	pg->cursor = set_bounds_get_remainder(&t, len);
-	if (!cheri_gettag(t))
-		goto allocate_new_page;
-
-	lock_release(rtld_tramp_lock, &lockstate);
-
-	memcpy(t, template, len);
-	/*
-	 * Ensure i- and d-cache coherency after writing executable code.
-	 * The __clear_cache procedure rounds the addresses to
-	 * cache-line-aligned addresses.
-	 * Derive the start/end addresses from pg so that they have sufficiently
-	 * large bounds to contain these rounded addresses.
-	 */
-	__clear_cache(cheri_copyaddress(pg, t->code),
-	    cheri_copyaddress(pg, (uintptr_t)t + len));
-
-	t->target = target;
-	if (obj != NULL)
-		t->compart_id = obj->compart_id;
-
-	t = cheri_clearperm(t, FUNC_PTR_REMOVE_PERMS);
-	return (cheri_sealentry(cheri_capmode(&t->code)));
-}
-
-#endif
 
 int
 do_copy_relocations(Obj_Entry *dstobj)
@@ -688,7 +434,13 @@ reloc_jmpslots(Obj_Entry *obj, int flags, RtldLockState *lockstate)
 			}
 			target = (uintptr_t)make_function_pointer(def, defobj);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-			target = (uintptr_t)tramp_pgs_append((void *)target, defobj, def);
+			target = (uintptr_t)tramp_intern(obj, &(struct tramp_data) {
+				.target = (void *)target,
+				.defobj = defobj,
+				.def = def,
+				.sig = tramp_fetch_sig(obj,
+				    ELF_R_SYM(rela->r_info))
+			});
 #endif
 			reloc_jmpslot(where, target, defobj, obj,
 			    (const Elf_Rel *)rela);
@@ -745,7 +497,12 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 #endif
 	lock_release(rtld_bind_lock, lockstate);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	ptr = (uintptr_t)tramp_pgs_append((void *)ptr, obj, NULL);
+	ptr = (uintptr_t)tramp_intern(NULL, &(struct tramp_data) {
+		.target = (void *)ptr,
+		.defobj = obj,
+		.sig = (struct func_sig) { .valid = true,
+		    .reg_args = 8, .mem_args = false, .ret_args = ONE }
+	});
 #endif
 	target = call_ifunc_resolver(ptr);
 	wlock_acquire(rtld_bind_lock, lockstate);
@@ -830,6 +587,15 @@ reloc_gnu_ifunc(Obj_Entry *obj, int flags,
 				continue;
 			lock_release(rtld_bind_lock, lockstate);
 			target = (uintptr_t)rtld_resolve_ifunc(defobj, def);
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+			target = (uintptr_t)tramp_intern(obj, &(struct tramp_data) {
+				.target = (void *)target,
+				.defobj = defobj,
+				.def = def,
+				.sig = tramp_fetch_sig(obj,
+				    ELF_R_TYPE(rela->r_info))
+			});
+#endif
 			wlock_acquire(rtld_bind_lock, lockstate);
 			reloc_jmpslot(where, target, defobj, obj,
 			    (const Elf_Rel *)rela);
@@ -1085,12 +851,6 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 void
 allocate_initial_tls(Obj_Entry *objs)
 {
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	tramp_stk_table_t tls = xcalloc(DEFAULT_STACK_TABLE_SIZE, sizeof(*tls));
-	tls[0] = (uintptr_t)get_rstk;
-	asm ("msr	ctpidr_el0, %0\n" :: "C" (tls));
-#endif
 
 	/*
 	* Fix the size of the static TLS block by using the maximum

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -1,0 +1,437 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021-2023 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <machine/asm.h>
+
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+ENTRY(_rtld_setjmp)
+	/*
+	 * This function MUST update c0 to point at the buffer that saves the
+	 * general purpose registers.
+	 */
+#define	TRUSTED_STACK	csp
+	mov	c2, TRUSTED_STACK
+	b	_rtld_setjmp_impl
+#undef	TRUSTED_STACK
+END(_rtld_setjmp)
+
+ENTRY(_rtld_longjmp)
+	/*
+	 * This function MUST preserve the value of x1 and update c0 to point at
+	 * the general purpose registers to be restored.
+	 */
+#define	TRUSTED_STACK	csp
+
+	mov	c2, TRUSTED_STACK
+
+	str	c30, [TRUSTED_STACK, #-CAP_WIDTH]!
+
+	bl	_rtld_longjmp_impl
+
+	ldr	c30, [TRUSTED_STACK], #CAP_WIDTH
+
+	ldr	x3, [TRUSTED_STACK]
+	scvalue	TRUSTED_STACK, TRUSTED_STACK, x3
+
+	RETURN
+#undef	TRUSTED_STACK
+END(_rtld_longjmp)
+
+ENTRY(_rtld_thread_start)
+	/*
+	 * Move the Executive mode thread pointer to Restricted mode.
+	 */
+	mrs	c10, ctpidr_el0
+	msr	rctpidr_el0, c10
+	b	_rtld_thread_start_impl
+END(_rtld_thread_start)
+
+ENTRY(_rtld_thr_exit)
+	b	_rtld_thr_exit_impl
+END(_rtld_thr_exit)
+
+ENTRY(_rtld_sighandler)
+	mov	c3, csp
+	b	_rtld_sighandler_impl
+END(_rtld_sighandler)
+
+ENTRY(_rtld_get_rstk)
+	/*
+	 * This function MUST preserve all caller-saved registers except:
+	 * - c11: Target restricted stack
+	 * - c18: Will be overwritten later in the trampoline
+	 */
+	stp	c18, c30, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c15, c16, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c13, c14, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c10, c12, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c8, c9, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c6, c7, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c4, c5, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c2, c3, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c0, c1, [csp, #-(CAP_WIDTH * 2)]!
+	stp	q6, q7, [csp, #-(16 * 2)]!
+	stp	q4, q5, [csp, #-(16 * 2)]!
+	stp	q2, q3, [csp, #-(16 * 2)]!
+	stp	q0, q1, [csp, #-(16 * 2)]!
+
+	mov	w0, w14					/* w0 = cid */
+	bl	get_rstk
+	mov	c11, c0
+
+	ldp	q6, q7, [csp, #(16 * 6)]
+	ldp	q4, q5, [csp, #(16 * 4)]
+	ldp	q2, q3, [csp, #(16 * 2)]
+	ldp	q0, q1, [csp], #(16 * 8)
+	ldp	c18, c30, [csp, #(CAP_WIDTH * 16)]
+	ldp	c15, c16, [csp, #(CAP_WIDTH * 14)]
+	ldp	c13, c14, [csp, #(CAP_WIDTH * 12)]
+	ldp	c10, c12, [csp, #(CAP_WIDTH * 10)]
+	ldp	c8, c9, [csp, #(CAP_WIDTH * 8)]
+	ldp	c6, c7, [csp, #(CAP_WIDTH * 6)]
+	ldp	c4, c5, [csp, #(CAP_WIDTH * 4)]
+	ldp	c2, c3, [csp, #(CAP_WIDTH * 2)]
+	ldp	c0, c1, [csp], #(CAP_WIDTH * 18)
+
+	RETURN
+END(_rtld_get_rstk)
+
+ENTRY(_rtld_tramp_hook)
+	/* Save floating point registers */
+	stp	q0, q1, [csp, #-(16 * 8)]!
+	stp	q2, q3, [csp, #(16 * 2)]
+	stp	q4, q5, [csp, #(16 * 4)]
+	stp	q6, q7, [csp, #(16 * 6)]
+
+	str	c30, [csp, #-CAP_WIDTH]!
+	bl	tramp_hook
+	ldr	c30, [csp], #CAP_WIDTH
+
+	/* Restore floating point registers */
+	ldp	q6, q7, [csp, #(16 * 6)]
+	ldp	q4, q5, [csp, #(16 * 4)]
+	ldp	q2, q3, [csp, #(16 * 2)]
+	ldp	q0, q1, [csp], #(16 * 8)
+
+	RETURN
+END(_rtld_tramp_hook)
+
+/*
+ * Trampoline templates are code but reside in rodata. Hence a new macro is
+ * defined to describe them.
+ */
+#define TRAMP(sym)							\
+	.section .rodata; .globl sym; .align 4; .type sym,#object; sym:
+
+#define TRAMPEND(sym)							\
+	end_##sym:							\
+	EEND(sym);							\
+	.section .rodata; .globl size_##sym; .align 3;			\
+	.type size_##sym,#object; .size size_##sym, 8; size_##sym:	\
+	.quad	end_##sym - sym
+
+#define	PATCH_POINT(tramp, name, label)					\
+	.section .rodata; .globl patch_##tramp##_##name; .align 3;	\
+	.type patch_##tramp##_##name,#object;				\
+	.size patch_##tramp##_##name, 4; patch_##tramp##_##name:	\
+	.word	label - end_##tramp
+
+TRAMP(tramp_header)
+tramp_header_target:
+	.chericap	0
+TRAMPEND(tramp_header)
+
+TRAMP(tramp_header_hook)
+tramp_header_hook_obj:
+	.chericap	0
+tramp_header_hook_def:
+	.chericap	0
+tramp_header_hook_function:
+	.chericap	0
+	/* Save argument registers */
+	stp	c0, c1, [csp, #-(CAP_WIDTH * 10)]!
+	stp	c2, c3, [csp, #(CAP_WIDTH * 2)]
+	stp	c4, c5, [csp, #(CAP_WIDTH * 4)]
+	stp	c6, c7, [csp, #(CAP_WIDTH * 6)]
+	stp	c8, c9, [csp, #(CAP_WIDTH * 8)]
+
+	ldr	c10, tramp_header_hook_function
+
+1:	mov	w0, #0		/* To be patched at runtime */
+2:	ldr	c1, #0		/* To be patched at runtime */
+	ldr	c2, tramp_header_hook_obj
+	ldr	c3, tramp_header_hook_def
+	mov	c4, c30
+	mrs	c5, rcsp_el0
+	blr	c10
+	mov	c30, c0
+
+	/* Restore argument registers */
+	ldp	c8, c9, [csp, #(CAP_WIDTH * 8)]
+	ldp	c6, c7, [csp, #(CAP_WIDTH * 6)]
+	ldp	c4, c5, [csp, #(CAP_WIDTH * 4)]
+	ldp	c2, c3, [csp, #(CAP_WIDTH * 2)]
+	ldp	c0, c1, [csp], #(CAP_WIDTH * 10)
+TRAMPEND(tramp_header_hook)
+
+PATCH_POINT(tramp_header_hook, event, 1b)
+PATCH_POINT(tramp_header_hook, target, 2b)
+
+TRAMP(tramp_save_caller)
+1:	ldr	c18, #0		/* To be patched at runtime */
+	mrs	c17, rcsp_el0
+	mov	x10, sp
+#define	TRUSTED_STACK	csp
+
+	/*
+	 * Maintain consistency of rcsp by saving it at the bottom of itself.
+	 * This step must be done before the table lookup so that
+	 * same-compartment switches get the correct stack.
+	 */
+	gclim	x11, c17
+	scvalue	c16, c17, x11
+	ldr	x13, [c16, #-CAP_WIDTH]
+	str	c17, [c16, #-CAP_WIDTH]
+
+	/* Push frame */
+	stp	x10, x13, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
+	str	c16, [TRUSTED_STACK, #(CAP_WIDTH * 1)]
+	stp	c30, c19, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
+	stp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
+	stp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 6)]
+	stp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 8)]
+	stp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 10)]
+	stp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
+#undef	TRUSTED_STACK
+TRAMPEND(tramp_save_caller)
+
+PATCH_POINT(tramp_save_caller, target, 1b)
+
+TRAMP(tramp_switch_stack)
+	mrs	c30, ctpidr_el0		/* c30 = table */
+1:	movz	w14, #0		/* w14 = cid, to be patched at runtime */
+	gclen	x15, c30	/* x15 = len(table) */
+
+	/*
+	 * Callee is Restricted, so switch to its saved rcsp at the bottom of
+	 * itself.
+	 *
+	 * Use subs instead of cmp to clear a register tag.
+	 */
+	subs	x16, x15, x14, lsl #4		/* if (len(table) <= cid) */
+	b.ls	2f				/* goto 2f */
+	ldr	c11, [c30, w14, uxtw #4]	/* c11 = table[cid] */
+	cbnz	x11, 3f
+
+	/*
+	 * Call get_rstk(), which may invoke Restricted code (e.g. locking
+	 * procedures in libthr), causing another trampoline to run. The
+	 * implications of re-entrancy must be carefully addressed.
+	 */
+2:
+	blr	[c30, #0]			/* get_rstk() */
+3:	ldr	c11, [c11, #-CAP_WIDTH]
+
+	/* Move the c9 buffer to the target stack */
+	cbz	x9, 6f
+	gclen	x16, c9
+	add	c17, c9, x16
+	lsr	x16, x16, #4
+	tst	x17, #0xf
+	b.eq	5f
+
+	orr	x30, x17, #0xfffffffffffffff0
+	add	c11, c11, x30
+7:	ldrb	w30, [c17, #-1]!
+	strb	w30, [c11, #-1]!
+	tst	x17, #0xf
+	b.ne	7b
+
+4:	cbz	x16, 6f
+5:	ldr	c30, [c17, #-CAP_WIDTH]!
+	str	c30, [c11, #-CAP_WIDTH]!
+	sub	x16, x16, #1
+	b	4b
+6:
+TRAMPEND(tramp_switch_stack)
+
+PATCH_POINT(tramp_switch_stack, cid, 1b)
+
+TRAMP(tramp_pre_invoke)
+#define	TRUSTED_STACK	csp
+	/*
+	 * Save the number of unused return value registers in the flags of csp.
+	 */
+1:	movz	x17, #0		/* To be patched at runtime */
+	scflgs	TRUSTED_STACK, TRUSTED_STACK, x17
+#undef	TRUSTED_STACK
+TRAMPEND(tramp_pre_invoke)
+
+PATCH_POINT(tramp_pre_invoke, ret_args, 1b)
+
+TRAMP(tramp_invoke_exe)
+	blr	c18
+TRAMPEND(tramp_invoke_exe)
+
+TRAMP(tramp_clear_mem_args)
+	mov	x9, xzr
+TRAMPEND(tramp_clear_mem_args)
+
+TRAMP(tramp_clear_ret_args_indirect)
+	mov	x8, xzr
+TRAMPEND(tramp_clear_ret_args_indirect)
+
+TRAMP(tramp_clear_ret_args)
+	mov	x7, xzr
+	mov	x6, xzr
+	mov	x5, xzr
+	mov	x4, xzr
+	mov	x3, xzr
+	mov	x2, xzr
+	mov	x1, xzr
+	mov	x0, xzr
+TRAMPEND(tramp_clear_ret_args)
+
+TRAMP(tramp_invoke_res)
+	/* Clear callee-saved registers */
+	mov	x29, xzr
+	mov	x28, xzr
+	mov	x27, xzr
+	mov	x26, xzr
+	mov	x25, xzr
+	mov	x24, xzr
+	mov	x23, xzr
+	mov	x22, xzr
+	mov	x21, xzr
+	mov	x20, xzr
+	mov	x19, xzr
+
+	/*
+	 * Clear temporary registers, except
+	 * - c10: Link to previous frame (scalar)
+	 * - c11: Callee's stack
+	 * - c12: Tag of csp (scalar)
+	 * - c13: Old top of caller's stack (scalar)
+	 * - c14: Callee's compartment ID (scalar)
+	 * - c15: Length of stack table (scalar)
+	 * - c16: Comparison result (scalar)
+	 * - c17: Flags of csp (scalar)
+	 * - c18: Callee's code
+	 */
+
+	msr	rcsp_el0, c11
+	blrr	c18
+TRAMPEND(tramp_invoke_res)
+
+TRAMP(tramp_return_hook)
+	/* Save return value registers */
+	stp	c0, c1, [csp, #-(CAP_WIDTH * 2)]!
+
+1:	ldr	c10, #0			/* To be patched at runtime */
+
+2:	mov	w0, #0			/* To be patched at runtime */
+	mov	x1, xzr
+3:	ldr	c2, #0			/* To be patched at runtime */
+4:	ldr	c3, #0			/* To be patched at runtime */
+	mov	c4, c30
+	mrs	c5, rcsp_el0
+	blr	c10
+
+	/* Restore return value registers */
+	ldp	c0, c1, [csp], #(CAP_WIDTH * 2)
+TRAMPEND(tramp_return_hook)
+
+PATCH_POINT(tramp_return_hook, function, 1b)
+PATCH_POINT(tramp_return_hook, event, 2b)
+PATCH_POINT(tramp_return_hook, obj, 3b)
+PATCH_POINT(tramp_return_hook, def, 4b)
+
+TRAMP(tramp_return)
+#define	TRUSTED_STACK	csp
+	/* Restore callee-saved registers */
+	ldp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
+	ldp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 10)]
+	ldp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 8)]
+	ldp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 6)]
+	ldp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
+	ldp	c30, c19, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
+	ldr	c12, [TRUSTED_STACK, #(CAP_WIDTH * 1)]
+	ldp	x10, x11, [TRUSTED_STACK], #(CAP_WIDTH * 14)
+
+	/*
+	 * Restore caller's saved rcsp.
+	 */
+	ldr	c13, [c12, #-CAP_WIDTH]
+	scvalue	c14, c12, x11
+	str	c14, [c12, #-CAP_WIDTH]
+
+	/*
+	 * Clear unused return value registers. The registers to clear is
+	 * encoded as follows and stored in the flags of csp:
+	 * - None:	0b00
+	 * - c1 only:	0b01
+	 * - c0 and c1:	0b1x
+	 * Use comparison and csel to avoid branching.
+	 *
+	 * Use subs instead of cmp to clear a register tag.
+	 */
+	gcflgs	x15, TRUSTED_STACK
+	subs	x16, x15, #0b01
+	csel	c1, czr, c1, hs
+	csel	c0, czr, c0, hi
+
+	mov	x9, xzr
+	mov	x8, xzr
+	mov	x7, xzr
+	mov	x6, xzr
+	mov	x5, xzr
+	mov	x4, xzr
+	mov	x3, xzr
+	mov	x2, xzr
+
+	/*
+	 * Clear temporary registers, except
+	 * - c10: Link to previous frame (scalar)
+	 * - c11: Old top of caller's stack (scalar)
+	 * - c12: Bottom of caller's stack
+	 * - c13: Current top of caller's stack
+	 * - c14: Old top of caller's stack
+	 * - c15: Flags of csp (scalar)
+	 * - c16: Comparison result (scalar)
+	 */
+	mov	x17, xzr
+	mov	x18, xzr
+
+	/*
+	 * Restore caller's saved rcsp (has no effect if the caller is
+	 * Executive).
+	 */
+	msr	rcsp_el0, c13
+	retr	c30
+#undef	TRUSTED_STACK
+TRAMPEND(tramp_return)
+#endif

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -1,0 +1,237 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021-2023 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <sys/param.h>
+#include <sys/mman.h>
+
+#include <stdlib.h>
+
+#include "debug.h"
+#include "rtld.h"
+#include "rtld_c18n.h"
+#include "rtld_libc.h"
+#include "rtld_utrace.h"
+
+/*
+ * Trampolines
+ */
+size_t
+tramp_compile(char **entry, const struct tramp_data *data)
+{
+#define IMPORT(template)				\
+	extern const uint32_t tramp_##template[];	\
+	extern const size_t size_tramp_##template
+
+	IMPORT(header);
+	IMPORT(header_hook);
+	IMPORT(save_caller);
+	IMPORT(switch_stack);
+	IMPORT(pre_invoke);
+	IMPORT(clear_mem_args);
+	IMPORT(clear_ret_args_indirect);
+	IMPORT(clear_ret_args);
+	IMPORT(invoke_res);
+	IMPORT(invoke_exe);
+	IMPORT(return_hook);
+	IMPORT(return);
+
+#undef	IMPORT
+
+	uint32_t *buf = (void *)*entry;
+	size_t size = 0;
+	int to_clear;
+	bool executive = cheri_getperm(data->target) & CHERI_PERM_EXECUTIVE;
+	bool hook = ld_compartment_utrace != NULL ||
+	    ld_compartment_overhead != NULL;
+
+#define	COPY(template)					\
+	do {						\
+		buf = mempcpy(buf, tramp_##template,	\
+		    size_tramp_##template);		\
+		size += size_tramp_##template;		\
+	} while(0)
+
+#define	PATCH_POINT(tramp, name) ({					\
+		extern const int32_t patch_tramp_##tramp##_##name;	\
+		&buf[patch_tramp_##tramp##_##name / sizeof(*buf)];	\
+	})
+
+#define PATCH_MOV(tramp, name, value)					\
+	do {								\
+		*PATCH_POINT(tramp, name) |= ((uint16_t)value) << 5;	\
+	} while (0)
+
+#define	PATCH_LDR_IMM(tramp, name, offset)				\
+	do {								\
+		extern const int32_t patch_tramp_##tramp##_##name;	\
+		*PATCH_POINT(tramp, name) |= (roundup2(			\
+		    sizeof(void *) * (offset) -				\
+		    patch_tramp_##tramp##_##name - size,		\
+		    sizeof(void *)) & 0x1ffff0) << 1;			\
+	} while(0)
+
+	COPY(header);
+	*(*(const void ***)entry)++ = data->target;
+
+	if (hook) {
+		COPY(header_hook);
+		PATCH_MOV(header_hook, event, UTRACE_COMPARTMENT_ENTER);
+		PATCH_LDR_IMM(header_hook, target, 0);
+		*(*(const void ***)entry)++ = data->defobj;
+		*(*(const void ***)entry)++ = data->def;
+		*(*(const void ***)entry)++ = _rtld_tramp_hook;
+	}
+
+	COPY(save_caller);
+	PATCH_LDR_IMM(save_caller, target, 0);
+
+	if (!executive) {
+		COPY(switch_stack);
+		PATCH_MOV(switch_stack, cid,
+		    compart_id_to_index(data->defobj->compart_id));
+	}
+
+	COPY(pre_invoke);
+	if (data->sig.valid)
+		PATCH_MOV(pre_invoke, ret_args, data->sig.ret_args);
+
+	if (executive)
+		COPY(invoke_exe);
+	else {
+		if (data->sig.valid) {
+			if (!data->sig.mem_args)
+				COPY(clear_mem_args);
+			if (data->sig.ret_args != INDIRECT)
+				COPY(clear_ret_args_indirect);
+			to_clear = 8 - data->sig.reg_args;
+			buf = mempcpy(buf, tramp_clear_ret_args,
+			    sizeof(*tramp_clear_ret_args) * to_clear);
+			size += sizeof(*tramp_clear_ret_args) * to_clear;
+		}
+		COPY(invoke_res);
+	}
+
+	if (hook) {
+		COPY(return_hook);
+		PATCH_MOV(return_hook, event, UTRACE_COMPARTMENT_LEAVE);
+		PATCH_LDR_IMM(return_hook, obj, 1);
+		PATCH_LDR_IMM(return_hook, def, 2);
+		PATCH_LDR_IMM(return_hook, function, 3);
+	}
+
+	COPY(return);
+
+#undef	COPY
+#undef	PATCH_POINT
+#undef	PATCH_MOV
+#undef	PATCH_LDR_IMM
+
+	return (size);
+}
+
+/*
+ * APIs
+ */
+void *
+_rtld_safebox_code(void *target, struct func_sig sig)
+{
+	const Obj_Entry *obj;
+
+	if (!func_sig_legal(sig)) {
+		_rtld_error(
+		    "_rtld_sandbox_code: Invalid signature "
+		    C18N_SIG_FORMAT_STRING,
+		    C18N_SIG_FORMAT(sig));
+		return (NULL);
+	}
+
+	if ((cheri_getperm(target) & CHERI_PERM_EXECUTIVE) != 0)
+		return (target);
+
+	obj = obj_from_addr(target);
+	if (obj == NULL) {
+		_rtld_error(
+		    "_rtld_sandbox_code: "
+		    "%#p does not belong to any object", target);
+		return (NULL);
+	}
+
+	if (sig.valid) {
+		asm ("chkssu	%0, %0, %1"
+		    : "+C" (target)
+		    : "C" (obj->text_rodata_cap)
+		    : "cc");
+		target = cheri_seal(target,
+		    sealer_tramp + func_sig_to_otype(sig));
+	}
+
+	return (target);
+}
+
+void *
+_rtld_sandbox_code(void *target, struct func_sig sig)
+{
+	const Obj_Entry *obj;
+	void *target_unsealed;
+
+	if (!func_sig_legal(sig)) {
+		_rtld_error(
+		    "_rtld_sandbox_code: Invalid signature "
+		    C18N_SIG_FORMAT_STRING,
+		    C18N_SIG_FORMAT(sig));
+		return (NULL);
+	}
+
+	if ((cheri_getperm(target) & CHERI_PERM_EXECUTIVE) != 0)
+		return (target);
+
+	obj = obj_from_addr(target);
+	if (obj == NULL) {
+		_rtld_error(
+		    "_rtld_sandbox_code: "
+		    "%#p does not belong to any object", target);
+		return (NULL);
+	}
+
+	target_unsealed = cheri_unseal(target, sealer_tramp);
+	if (cheri_gettag(target_unsealed)) {
+		if (sig.valid && cheri_gettype(target) !=
+		    (long)cheri_getbase(sealer_tramp) + func_sig_to_otype(sig))
+			rtld_fatal("Signature mismatch");
+		target = cheri_sealentry(target_unsealed);
+	}
+
+	target = tramp_intern(NULL, &(struct tramp_data) {
+		.target = target,
+		.defobj = obj,
+		.sig = sig
+	});
+
+	return (target);
+}

--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -151,13 +151,21 @@ make_data_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj)
 
 /* TODO: Per-function captable/PLT/FNDESC support */
 #ifdef RTLD_SANDBOX
-#define make_rtld_function_pointer(target_func)	(tramp_pgs_append((target_func), NULL, NULL))
+#define call_init_array_pointer(_obj, _target)				\
+	(((InitArrFunc)tramp_intern(NULL, &(struct tramp_data) {	\
+		.target = (void *)(_target).value,			\
+		.defobj = _obj,						\
+		.sig = (struct func_sig) { .valid = true,		\
+		    .reg_args = 3, .mem_args = false, .ret_args = NONE }\
+	}))(main_argc, main_argv, environ))
 
-#define call_init_array_pointer(obj, target)				\
-	(((InitArrFunc)tramp_pgs_append((void *)(target).value, obj, NULL))(main_argc, main_argv, environ))
-
-#define call_fini_array_pointer(obj, target)				\
-	(((InitFunc)tramp_pgs_append((void *)(target).value, obj, NULL))())
+#define call_fini_array_pointer(_obj, _target)				\
+	(((InitFunc)tramp_intern(NULL, &(struct tramp_data) {		\
+		.target = (void *)(_target).value,			\
+		.defobj = _obj,						\
+		.sig = (struct func_sig) { .valid = true,		\
+		    .reg_args = 0, .mem_args = false, .ret_args = NONE }\
+	}))())
 #else
 #define call_init_array_pointer(obj, target)				\
 	(((InitArrFunc)(target).value)(main_argc, main_argv, environ))
@@ -207,10 +215,6 @@ typedef struct {
 extern void *__tls_get_addr(tls_index *ti);
 
 #define md_abi_variant_hook(x)
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-void *tramp_pgs_append(void *, const Obj_Entry *, const Elf_Sym *);
-#endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
 static inline void

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -315,6 +315,21 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	 *
 	 */
 1:
+#ifdef RTLD_SANDBOX
+	/*
+	 * Caller must be Restricted, so save its rcsp at the bottom of its own
+	 * stack. This step is only needed for _rtld_tlsdesc_dynamic because it
+	 * might call external functions.
+	 *
+	 * For the same reason, the Restricted stack needs to be saved and
+	 * restored upon return.
+	 */
+	mrs	c3, rcsp_el0
+	gclim	x4, c3
+	scvalue	c4, c3, x4
+	str	c3, [c4, #-CAP_WIDTH]
+#endif
+
 	/* Save non-callee-saved capability registers as well as c19 */
 	stp	c29, c30, [csp, #-(10 * 32)]!
 	.cfi_adjust_cfa_offset	10 * 32
@@ -330,7 +345,11 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	stp	c13, c14, [csp, #(6 * 32)]
 	stp	c15, c16, [csp, #(7 * 32)]
 	stp	c17, c18, [csp, #(8 * 32)]
+#ifdef RTLD_SANDBOX
+	stp	c19,  c3, [csp, #(9 * 32)]
+#else
 	str	c19,	  [csp, #(9 * 32)]
+#endif
 	.cfi_rel_offset		 c1, 32
 	.cfi_rel_offset		 c2, 48
 	.cfi_rel_offset		 c5, 64
@@ -359,7 +378,12 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	scbnds	c0, c0, x19
 
 	/* Restore slow path registers */
+#ifdef RTLD_SANDBOX
+	ldp	c19,  c3, [csp, #(9 * 32)]
+	msr	rcsp_el0, c3
+#else
 	ldr	c19,	  [csp, #(9 * 32)]
+#endif
 	ldp	c17, c18, [csp, #(8 * 32)]
 	ldp	c15, c16, [csp, #(7 * 32)]
 	ldp	c13, c14, [csp, #(6 * 32)]

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -74,9 +74,7 @@ ENTRY(.rtld_start)
 	ldr	c2, [csp, #16]			/* Load obj_main */
 	mov	c0, c19				/* Restore aux */
 	mov	csp, c20			/* Restore the stack pointer */
-#ifdef RTLD_SANDBOX
-	blr	c8				/* Jump to the entry point */
-#elif defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+#if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	br	x8				/* Jump to the entry point */
 #else
 	br	c8				/* Jump to the entry point */
@@ -108,28 +106,24 @@ END(.rtld_start)
  */
 ENTRY(_rtld_bind_start)
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	/* Calls to _rtld_bind_start do not go through the trampoline
-	 * because _rtld_bind_start never returns, which would break the
-	 * trampoline's invariant.
-	 * But we still need to manually perform some of the trampoline's
-	 * work, i.e., saving the caller's stack pointer at its bottom.
+	/*
+	 * Maintain consistency of rcsp.
 	 */
 	mrs	c17, rcsp_el0
-	.cfi_def_cfa_register c17
-	.cfi_offset c30, (PTR_WIDTH)
 	gclim	x10, c17
+	sub	x10, x10, #CAP_WIDTH
 	scvalue c10, c17, x10
-	str	c17, [c10, #-PTR_WIDTH]
+	swp	c17, c10, [c10]
 #else
 	mov	PTR(17), PTRN(sp)
 #endif
 
 	/* Save frame pointer and SP */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	stp	PTR(29), PTR(17), [PTRN(sp), #-(PTR_WIDTH * 2)]!
+	stp	PTR(29), PTR(10), [PTRN(sp), #-(PTR_WIDTH * 2)]!
 	mov	PTR(29), PTRN(sp)
 	.cfi_def_cfa PTR(29), (PTR_WIDTH * 2)
-	.cfi_offset PTR(17), -(PTR_WIDTH * 1)
+	.cfi_offset PTR(10), -(PTR_WIDTH * 1)
 #else
 	stp	PTR(29), PTR(30), [PTRN(sp), #-(PTR_WIDTH * 2)]!
 	mov	PTR(29), PTRN(sp)
@@ -192,13 +186,17 @@ ENTRY(_rtld_bind_start)
 
 	/* Restore frame pointer */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	ldp	PTR(29), PTR(17), [PTRN(sp)], #(PTR_WIDTH * 2)
+	ldp	PTR(29), PTR(10), [PTRN(sp)], #(PTR_WIDTH * 2)
 #else
 	ldp	PTR(29), PTR(zr), [PTRN(sp)], #(PTR_WIDTH * 2)
 #endif
 
 	 /* Restore link register saved by the plt code */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	gclim	x17, c10
+	sub	x17, x17, #CAP_WIDTH
+	scvalue	c17, c10, x17
+	swp	c10, c17, [c17]
 	ldp	czr, c30, [c17], #(PTR_WIDTH * 2)
 	msr	rcsp_el0, c17
 #else
@@ -315,21 +313,6 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	 *
 	 */
 1:
-#ifdef RTLD_SANDBOX
-	/*
-	 * Caller must be Restricted, so save its rcsp at the bottom of its own
-	 * stack. This step is only needed for _rtld_tlsdesc_dynamic because it
-	 * might call external functions.
-	 *
-	 * For the same reason, the Restricted stack needs to be saved and
-	 * restored upon return.
-	 */
-	mrs	c3, rcsp_el0
-	gclim	x4, c3
-	scvalue	c4, c3, x4
-	str	c3, [c4, #-CAP_WIDTH]
-#endif
-
 	/* Save non-callee-saved capability registers as well as c19 */
 	stp	c29, c30, [csp, #-(10 * 32)]!
 	.cfi_adjust_cfa_offset	10 * 32
@@ -345,10 +328,18 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	stp	c13, c14, [csp, #(6 * 32)]
 	stp	c15, c16, [csp, #(7 * 32)]
 	stp	c17, c18, [csp, #(8 * 32)]
-#ifdef RTLD_SANDBOX
-	stp	c19,  c3, [csp, #(9 * 32)]
-#else
 	str	c19,	  [csp, #(9 * 32)]
+#if defined(RTLD_SANDBOX)
+	/*
+	 * Maintain consistency of rcsp. This step is only needed for
+	 * _rtld_tlsdesc_dynamic because it might call external functions.
+	 */
+	mrs	c3, rcsp_el0
+	gclim	x4, c3
+	sub	x4, x4, #CAP_WIDTH
+	scvalue	c4, c3, x4
+	swp	c3, c3, [c4]
+	str	c3, [csp, #(9 * 32 + 16)]
 #endif
 	.cfi_rel_offset		 c1, 32
 	.cfi_rel_offset		 c2, 48
@@ -378,12 +369,15 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	scbnds	c0, c0, x19
 
 	/* Restore slow path registers */
-#ifdef RTLD_SANDBOX
-	ldp	c19,  c3, [csp, #(9 * 32)]
+#if defined(RTLD_SANDBOX)
+	ldr	c3, [csp, #(9 * 32 + 16)]
+	gclim	x4, c3
+	sub	x4, x4, #CAP_WIDTH
+	scvalue	c4, c3, x4
+	swp	c3, c3, [c4]
 	msr	rcsp_el0, c3
-#else
-	ldr	c19,	  [csp, #(9 * 32)]
 #endif
+	ldr	c19,	  [csp, #(9 * 32)]
 	ldp	c17, c18, [csp, #(8 * 32)]
 	ldp	c15, c16, [csp, #(7 * 32)]
 	ldp	c13, c14, [csp, #(6 * 32)]
@@ -504,326 +498,3 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	ret
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */
 END(_rtld_tlsdesc_dynamic)
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-ENTRY(_rtld_setjmp)
-	/*
-	 * Before setjmp is called, the top of the Executive stack contains:
-	 * 	-2.	Caller's stack
-	 * 	-1.	Return address
-	 * 	0.	Link to previous frame
-	 * When setjmp is called, the following is pushed to the Executive stack:
-	 * 	1.	Caller's stack
-	 * 	2.	Return address
-	 * 	3.	Link to 0
-	 * setjmp then calls _rtld_setjmp, which pushes the following:
-	 * 	4.	Caller's stack
-	 * 	5.	Return address
-	 * 	6.	Link to 3
-	 * In _rtld_setjmp, we manipulate the stack content to the following:
-	 * 	-5.	Copy of 1
-	 * 	-4.	Copy of 2
-	 * 	-3.	Link to 0
-	 * 	-2.	Caller's stack
-	 * 	-1.	Return address
-	 * 	0.	Link to previous frame
-	 * 	------------------------------
-	 * 	1.	Caller's stack
-	 * 	2.	Return address
-	 * 	3.	Link to 0
-	 * 	------------------------------
-	 * 	4.	Caller's stack
-	 * 	5.	Return address
-	 * 	6.	Link to 3
-	 * To do this, we shift everything from 0 to 6 by 3 positions.
-	 */
-
-#define	SETJMP_SHIFT	3
-	/*
-	 * Move 6 and adjust it's cursor.
-	 * Also adjust csp.
-	 */
-	ldr	c1, [csp], #-(SETJMP_SHIFT * CAP_WIDTH)
-	sub	c1, c1, #(SETJMP_SHIFT * CAP_WIDTH)
-	str	c1, [csp]
-
-	add	c0, csp, #(CAP_WIDTH)
-
-	/* Shift 4 and 5 */
-	ldp	c1, c2, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
-	stp	c1, c2, [c0], #(2 * CAP_WIDTH)
-
-	/* Shift 3 and adjust it's cursor */
-	ldr	c1, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
-	sub	c1, c1, #(SETJMP_SHIFT * CAP_WIDTH)
-	str	c1, [c0], #(CAP_WIDTH)
-
-	/* Shift 1 and 2 */
-	ldp	c1, c2, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
-	stp	c1, c2, [c0], #(2 * CAP_WIDTH)
-
-	/* Shift 0 */
-	ldr	c1, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
-	str	c1, [c0], #(CAP_WIDTH)
-
-	/* Shift -1 and -2 */
-	ldp	c1, c2, [c0, #(SETJMP_SHIFT * CAP_WIDTH)]
-	stp	c1, c2, [c0], #(2 * CAP_WIDTH)
-
-	/* Store -3 */
-	ldr	c1, [c0, #-(2 * SETJMP_SHIFT * CAP_WIDTH)]
-	str	c1, [c0]
-
-	/* Store -4 and -5 */
-	ldp	c1, c2, [c0, #-(2 * SETJMP_SHIFT * CAP_WIDTH - CAP_WIDTH)]
-	stp	c1, c2, [c0, #(CAP_WIDTH)]
-
-	scbnds	c0, c0, #(SETJMP_SHIFT * CAP_WIDTH)
-	/* TODO: seal	c0, c0 */
-
-	ret
-END(_rtld_setjmp)
-
-ENTRY(_rtld_longjmp)
-	/*
-	 * Before longjmp is called, the top of the Executive stack contains:
-	 * 	0.	Link to previous frame
-	 * When longjmp is called, the following is pushed to the Executive stack:
-	 * 	1.	Caller's stack
-	 * 	2.	Return address
-	 * 	3.	Link to 0
-	 * longjmp then calls _rtld_longjmp, which pushes the following:
-	 * 	4.	Caller's stack
-	 * 	5.	Return address
-	 * 	6.	Link to 2
-	 * In _rtld_longjmp, we manipulate the stack content to the following:
-	 * 	-n.	Link to previous frame
-	 * 	------------------------------
-	 * 	...
-	 * 	0.	Link to previous frame
-	 * 	------------------------------
-	 * 	1.	Supplied caller's stack
-	 * 	2.	Supplied return address
-	 * 	3.	Link to supplied Executive stack pointer (-n)
-	 * 	------------------------------
-	 * 	4.	Caller's stack
-	 * 	5.	Return address
-	 * 	6.	Link to 3
-	 * When longjmp makes its final branch, it will go to the returning phase
-	 * of setjmp's trampoline, which unwinds to the frame and PC supplied by 3.
-	 */
-
-	/*
-	 * Check that the supplied buffer is on the current Executive stack.
-	 * c0: Supplied buffer
-	 */
-	chkssu	c0, c0, csp
-	b.pl	1f
-
-	/* Check that the supplied buffer is below the top of the stack */
-	cmp	sp, x0
-	b.hs	1f
-
-	/* Load the link from the supplied buffer */
-	ldr	c2, [c0]
-
-	/*
-	 * Compare its generation counter with that of the capability to the
-	 * supplied buffer.
-	 */
-	gcflgs	x1, c0
-	gcflgs	x3, c2
-	cmp	x1, x3
-	b.ne	1f
-
-	/*
-	 * All sanity checks have passed.
-	 * Locate the frame of the supplied buffer.
-	 * c1: Frame of the supplied buffer
-	 */
-2:	mov	c1, c2
-	ldr	c2, [c2]
-	cmp	x2, x0
-	b.lo	2b
-
-	/*
-	 * Get the previous frame.
-	 * c2: Previous frame
-	 */
-	ldr	c2, [csp]
-
-	/* Unwind the frames */
-	mov	c3, c2
-4:	ldr	c3, [c3]
-	cmp	c3, c1
-	b.eq	3f
-
-	/* Enforce security policy here for each frame being unwound */
-
-	b	4b
-
-3:	ldp	c3, c4, [c0, #(CAP_WIDTH)]
-
-	str	c1, [c2]
-	stp	c3, c4, [c2, #(CAP_WIDTH)]
-
-	ret
-
-	/* TODO: Abort */
-1:	ret
-END(_rtld_longjmp)
-
-#define TRAMP(sym) \
-	.section .rodata; .globl sym; .p2align 4; .type sym,#object; sym:
-
-TRAMP(tramp_template_exe)
-target_cap_exe:
-	.chericap	0
-	.word		0
-
-	/*
-	 * If caller is Restricted, save its rcsp in two places
-	 * 1. The bottom of itself
-	 * 2. The top of the Executive stack
-	 */
-	gcperm	x10, c30
-	tbnz	x10, #1, 1f
-
-	mrs	c10, rcsp_el0
-	gclim	x11, c10
-	scvalue	c11, c10, x11
-	str	c10, [c11, #-CAP_WIDTH]
-	str	c10, [csp, #-CAP_WIDTH]
-
-1:	mov	c10, csp
-	stp	c10, c30, [csp, #-(CAP_WIDTH * 3)]!
-
-	ldr	c10, target_cap_exe
-	blr	c10
-
-	/*
-	 * If caller is Restricted, restore to its saved rcsp
-	 * at the top of the Executive stack
-	 */
-	ldp	c10, c30, [csp]
-	gcperm	x11, c30
-	tbnz	x11, #1, 1f
-
-	ldr	c11, [csp, #(CAP_WIDTH * 2)]
-	msr	rcsp_el0, c11
-
-1:	mov	csp, c10
-	retr	c30
-EEND(tramp_template_exe)
-etramp_template_exe:
-
-TRAMP(tramp_template_res)
-target_cap:
-	.chericap	0
-dst_obj:
-	.word		0
-
-	/*
-	 * If caller is Restricted, save its rcsp in two places
-	 * 1. The bottom of itself
-	 * 2. The top of the Executive stack
-	 */
-	gcperm	x10, c30
-	tbnz	x10, #1, 1f
-
-	mrs	c10, rcsp_el0
-	gclim	x11, c10
-	scvalue	c11, c10, x11
-	str	c10, [c11, #-CAP_WIDTH]
-	str	c10, [csp, #-CAP_WIDTH]
-
-1:	mov	c10, csp
-	stp	c10, c30, [csp, #-(CAP_WIDTH * 3)]!
-
-	/*
-	 * Callee is Restricted, so switch to its saved rcsp
-	 * at the bottom of itself
-	 */
-4:	ldr	w10, dst_obj				/* w10 = index */
-	mrs	c11, ctpidr_el0				/* c11 = table */
-	gclen	x12, c11				/* x12 = len(table) */
-	cmp	x12, x10, lsl #4			/* if (len(table) >= index) */
-	b.ls	2f					/* goto 2f */
-
-	ldr	c12, [c11, w10, uxtw #4]		/* c12 = table[index] */
-	cbz	x12, 2f					/* if (!table[index]) goto 2f */
-
-	ldr	c12, [c12, #-CAP_WIDTH]
-	ldr	c11, target_cap
-
-	/* Push untagged csp to callee's stack to aid stack unwinding */
-	clrtag	c10, csp
-	str	c10, [c12, #-CAP_WIDTH]!
-
-	msr	rcsp_el0, c12
-	blrr	c11
-
-	/*
-	 * Callee's saved rcsp may have changed during the call
-	 * (e.g. because it called into another compartment)
-	 * We restore it to the correct value here
-	 */
-	mrs	c10, rcsp_el0
-
-	/* Pop untagged csp from callee's stack */
-	add	c10, c10, #CAP_WIDTH
-
-	gclim	x11, c10
-	scvalue	c11, c10, x11
-	str	c10, [c11, #-CAP_WIDTH]
-
-	/*
-	 * If caller is Restricted, restore to its saved rcsp
-	 * at the top of the Executive stack
-	 */
-	ldp	c10, c30, [csp]
-	gcperm	x11, c30
-	tbnz	x11, #1, 3f
-
-	ldr	c11, [csp, #(CAP_WIDTH * 2)]
-	msr	rcsp_el0, c11
-
-3:	mov	csp, c10
-	retr	c30
-
-2:	stp	c8, c9, [csp, #-(1 * CAP_WIDTH * 2)]
-	stp	c6, c7, [csp, #-(2 * CAP_WIDTH * 2)]
-	stp	c4, c5, [csp, #-(3 * CAP_WIDTH * 2)]
-	stp	c2, c3, [csp, #-(4 * CAP_WIDTH * 2)]
-	stp	c0, c1, [csp, #-(5 * CAP_WIDTH * 2)]!
-
-	mov	w0, w10					/* w0 = index */
-	mov	c1, c11					/* c1 = table */
-	ldr	c2, target_cap				/* c2 = data */
-
-	ldr	c3, [c11]
-	blr	c3
-
-	ldp	c8, c9, [csp, #(4 * CAP_WIDTH * 2)]
-	ldp	c6, c7, [csp, #(3 * CAP_WIDTH * 2)]
-	ldp	c4, c5, [csp, #(2 * CAP_WIDTH * 2)]
-	ldp	c2, c3, [csp, #(1 * CAP_WIDTH * 2)]
-	ldp	c0, c1, [csp], #(5 * CAP_WIDTH * 2)
-
-	b	4b
-EEND(tramp_template_res)
-etramp_template_res:
-
-	.data
-	.align	3
-	.global	sztramp_template_exe
-	.global	sztramp_template_res
-	.type	sztramp_template_exe,#object
-	.type	sztramp_template_res,#object
-	.size	sztramp_template_exe, 8
-	.size	sztramp_template_res, 8
-sztramp_template_exe:
-	.quad	etramp_template_exe - tramp_template_exe
-sztramp_template_res:
-	.quad	etramp_template_res - tramp_template_res
-#endif

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -35,6 +35,9 @@
 
 #include "debug.h"
 #include "rtld.h"
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#include "rtld_c18n.h"
+#endif
 
 #ifdef RTLD_HAS_CAPRELOCS
 /* The clang-provided header is not warning-clean: */

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -119,6 +119,14 @@ process_r_cheri_capability(Obj_Entry *obj, Elf_Word r_symndx,
 		}
 		/* Remove write permissions and set bounds */
 		symval = make_function_cap_with_addend(def, defobj, addend);
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+		symval = tramp_intern(obj, &(struct tramp_data) {
+			.target = __DECONST(void *, symval),
+			.defobj = defobj,
+			.def = def,
+			.sig = tramp_fetch_sig(obj, r_symndx)
+		});
+#endif
 		if (__predict_false(symval == NULL)) {
 			_rtld_error("Could not create function pointer for %s "
 				    "(in %s)\n",

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -51,6 +51,9 @@
 
 #include "debug.h"
 #include "rtld.h"
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#include "rtld_c18n.h"
+#endif
 
 static Elf_Ehdr *get_elf_header(int, const char *, const struct stat *,
     const char*, Elf_Phdr **phdr);
@@ -423,9 +426,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	obj->tlsinitsize = phtls->p_filesz;
 	obj->tlsinit = mapbase + phtls->p_vaddr;
     }
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-    obj->compart_id = ++compart_max_index;
-#endif
 #ifndef __CHERI_PURE_CAPABILITY__
     obj->stack_flags = stack_flags;
 #endif
@@ -602,10 +602,6 @@ obj_new(void)
     STAILQ_INIT(&obj->dldags);
     STAILQ_INIT(&obj->dagmembers);
     STAILQ_INIT(&obj->names);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-    SLIST_INIT(&obj->stacks);
-    obj->stackslock = lockinfo.lock_create();
-#endif
     return obj;
 }
 

--- a/libexec/rtld-elf/rtld-libc/Makefile.inc
+++ b/libexec/rtld-elf/rtld-libc/Makefile.inc
@@ -67,6 +67,10 @@ _libc_other_objects=sigsetjmp lstat stat fstat fstatat fstatfs syscall \
     __sysctlbyname \
     _sigprocmask _write readlink __realpathat _setjmp setjmp setjmperr
 
+.ifdef RTLD_SANDBOX
+SRCS+=	mempcpy.c
+_libc_other_objects+=thr_exit
+.endif
 
 # Finally add additional architecture-dependent libc dependencies
 .if ${LIBC_ARCH} == "arm"

--- a/libexec/rtld-elf/rtld-libc/rtld_libc.h
+++ b/libexec/rtld-elf/rtld-libc/rtld_libc.h
@@ -52,6 +52,9 @@ int	__sys___getcwd(char *, size_t);
 int	__sys_sigprocmask(int, const sigset_t *, sigset_t *);
 int	__sys_thr_kill(long, int);
 int	__sys_thr_self(long *);
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+void	__sys_thr_exit(long *);
+#endif
 __ssize_t	__sys_pread(int, void *, __size_t, __off_t);
 __ssize_t	__sys_read(int, void *, __size_t);
 __ssize_t	__sys_write(int, const void *, __size_t);

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -862,9 +862,6 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 	dbg("processing main program's program header");
 	assert(aux_info[AT_PHDR] != NULL);
 	phdr = (const Elf_Phdr *) aux_info[AT_PHDR]->a_un.a_ptr;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	phdr = (const Elf_Phdr *) cheri_clearperm(phdr, CHERI_PERM_EXECUTIVE);
-#endif
 	assert(aux_info[AT_PHNUM] != NULL);
 	phnum = aux_info[AT_PHNUM]->a_un.a_val;
 	assert(aux_info[AT_PHENT] != NULL);

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -82,10 +82,6 @@ extern size_t tls_static_space;
 extern Elf_Addr tls_dtv_generation;
 extern int tls_max_index;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-extern uint32_t compart_max_index;
-#endif
-
 extern int npagesizes;
 extern size_t *pagesizes;
 extern size_t page_size;
@@ -140,13 +136,6 @@ typedef struct Struct_Name_Entry {
     STAILQ_ENTRY(Struct_Name_Entry) link;
     char   name[1];
 } Name_Entry;
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-struct Struct_Stack_Entry {
-    SLIST_ENTRY(Struct_Stack_Entry) link;
-    void *stack;
-};
-#endif
 
 /* Lock object */
 typedef struct Struct_LockInfo {
@@ -303,9 +292,8 @@ typedef struct Struct_Obj_Entry {
     int vernum;			/* Number of entries in vertab */
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-    SLIST_HEAD(, Struct_Stack_Entry) stacks; /* List of object's per-thread stacks */
-    void *stackslock;
-    uint32_t compart_id;
+    uint16_t compart_id;
+    const struct func_sig *sigtab;
 #endif
 
     void* init_ptr;		/* Initialization function to call */
@@ -562,11 +550,7 @@ int reloc_iresolve(Obj_Entry *, struct Struct_RtldLockState *);
 int reloc_iresolve_nonplt(Obj_Entry *, struct Struct_RtldLockState *);
 int reloc_gnu_ifunc(Obj_Entry *, int flags, struct Struct_RtldLockState *);
 void ifunc_init(Elf_Auxinfo[__min_size(AT_COUNT)]);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-void init_pltgot(Obj_Entry *, uintptr_t);
-#else
 void init_pltgot(Obj_Entry *);
-#endif
 void allocate_initial_tls(Obj_Entry *);
 
 #if __has_feature(capabilities)

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1,0 +1,1078 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021-2023 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/ktrace.h>
+#include <sys/mman.h>
+#include <sys/sysctl.h>
+
+#include <stdlib.h>
+#include <stdatomic.h>
+
+#include "debug.h"
+#include "rtld.h"
+#include "rtld_c18n.h"
+#include "rtld_libc.h"
+#include "rtld_utrace.h"
+
+/*
+ * Sealers for RTLD privileged information
+ */
+static uintptr_t sealer_jmpbuf;
+
+uintptr_t sealer_pltgot, sealer_tramp;
+
+/* Use utrace() to log compartmentalisation-related events */
+const char *ld_compartment_utrace;
+
+/* Enable compartmentalisation */
+const char *ld_compartment_enable;
+
+/* Simulate overhead during compartment transitions */
+const char *ld_compartment_overhead;
+
+/* Read the .c18n.signature ELF section */
+const char *ld_compartment_sig;
+
+/*
+ * Policies
+ */
+typedef ssize_t string_handle;
+
+struct string_base {
+	char *buf;
+	string_handle size;
+	string_handle capacity;
+};
+
+static string_handle
+string_base_search(const struct string_base *sb, const char *str)
+{
+	const char *cur;
+	string_handle i = 0, s;
+
+	do {
+		s = i;
+		cur = str;
+		while (sb->buf[i] == *cur++)
+			if (sb->buf[i++] == '\0')
+				return (s);
+		while (sb->buf[i] != '\0') ++i;
+	} while (++i < sb->size);
+
+	return (-1);
+}
+
+static char trusted_globals_names[] =
+	"memset\0"
+	"memcpy\0"
+	"mempcpy\0"
+	"memccpy\0"
+	"memchr\0"
+	"memrchr\0"
+	"memmem\0"
+	"memmove\0"
+	"strcpy\0"
+	"strncpy\0"
+	"stpcpy\0"
+	"stpncpy\0"
+	"strcat\0"
+	"strncat\0"
+	"strlcpy\0"
+	"strlcat\0"
+	"strlen\0"
+	"strnlen\0"
+	"strcmp\0"
+	"strncmp\0"
+	"strchr\0"
+	"strrchr\0"
+	"strchrnul\0"
+	"strspn\0"
+	"strcspn\0"
+	"strpbrk\0"
+	"strsep\0"
+	"strstr\0"
+	"strnstr\0"
+
+	"__libc_start1\0"
+	"setjmp\0"
+	"longjmp\0"
+	"_setjmp\0"
+	"_longjmp\0"
+	"sigsetjmp\0"
+	"siglongjmp\0"
+
+	"vfork\0"
+	"rfork\0"
+
+	"_rtld_thread_start";
+
+static const struct string_base trusted_globals = {
+	.buf = trusted_globals_names,
+	.size = sizeof(trusted_globals_names),
+	.capacity = sizeof(trusted_globals_names)
+};
+
+static struct compart rtld_compart = {
+	.name = _BASENAME_RTLD
+};
+
+static struct compart libthr_compart = {
+	.name = "libthr.so.3",
+	.libraries = (const char *[]) {
+		"libc.so.7",
+		"libthr.so.3",
+		NULL
+	}
+};
+
+static struct {
+	const struct compart **data;
+	compart_id_t size;
+	compart_id_t capacity;
+} comparts;
+
+static void
+comparts_data_expand(compart_id_t capacity)
+{
+	const struct compart **data;
+
+	data = realloc(comparts.data, sizeof(*data) * capacity);
+	if (data == NULL)
+		rtld_fatal("realloc failed");
+	comparts.data = data;
+	comparts.capacity = capacity;
+}
+
+static bool
+string_search(const char * const strs[], const char *sym)
+{
+	if (strs != NULL)
+		for (; *strs != NULL; ++strs)
+			if (strcmp(sym, *strs) == 0)
+				return (true);
+	return (false);
+}
+
+static const struct compart * const *
+compart_get_or_create(const char *lib)
+{
+	struct {
+		const char *libraries[2];
+		struct compart com;
+	} *buf;
+
+	for (compart_id_t i = 1; i < comparts.size; ++i)
+		if (string_search(comparts.data[i]->libraries, lib))
+			return (&comparts.data[i]);
+	if (comparts.size == comparts.capacity)
+		comparts_data_expand(comparts.capacity * 2);
+	buf = xmalloc(sizeof(*buf));
+	buf->libraries[0] = lib;
+	buf->libraries[1] = NULL;
+	buf->com = (struct compart) {
+		.name = lib,
+		.libraries = buf->libraries
+	};
+	comparts.data[comparts.size] = &buf->com;
+	return (&comparts.data[comparts.size++]);
+}
+
+compart_id_t
+compart_id_allocate(const char *name)
+{
+	size_t index;
+
+	index = compart_get_or_create(name) - comparts.data;
+	if (index > C18N_COMPARTMENT_ID_MAX)
+		rtld_fatal("Cannot allocate compartment ID");
+
+	return (index);
+}
+
+static bool
+tramp_should_include(const Obj_Entry *reqobj, const struct tramp_data *data)
+{
+	const char *sym;
+
+	if (data->target == NULL)
+		return (false);
+
+	if (reqobj == NULL)
+		return (true);
+
+	if (reqobj->compart_id == data->defobj->compart_id)
+		return (false);
+
+	sym = strtab_value(data->defobj, data->def->st_name);
+
+	if (string_base_search(&trusted_globals, sym) != -1)
+		return (false);
+
+	return (true);
+}
+
+/*
+ * Stack switching
+ */
+#define	C18N_INIT_COMPART_COUNT	8
+
+/*
+ * Set a dummy Restricted stack so that trampolines do not need to test if the
+ * Restricted stack is valid.
+ */
+static void *dummy_stack = &dummy_stack;
+
+static _Atomic(struct stk_table *) free_stk_tables;
+
+static _Atomic(size_t) free_stk_table_cnt;
+
+static void
+push_stk_table(_Atomic(struct stk_table *) *head, struct stk_table *table)
+{
+	struct stk_table **link = &SLIST_NEXT(table, next);
+
+	*link = atomic_load_explicit(head, memory_order_relaxed);
+
+	while (!atomic_compare_exchange_weak_explicit(head, link, table,
+	    /*
+	     * Use release ordering to ensure that table construction happens
+	     * before the push.
+	     */
+	    memory_order_release, memory_order_release));
+}
+
+static struct stk_table *
+pop_stk_table(_Atomic(struct stk_table *) *head)
+{
+	struct stk_table *table, *next;
+
+	table = atomic_load_explicit(head, memory_order_relaxed);
+
+	/* No ABA problem because a stack table is never deallocated */
+	do {
+		next = SLIST_NEXT(table, next);
+	} while (!atomic_compare_exchange_weak_explicit(head, &table, next,
+	    /*
+	     * Use acquire ordering to ensure that the pop happens after table
+	     * construction.
+	     */
+	    memory_order_acquire, memory_order_acquire));
+
+	table->resolver = _rtld_get_rstk;
+
+	return (table);
+}
+
+static struct stk_table *
+stk_table_expand(struct stk_table *table, size_t n_capacity, bool lock)
+{
+	size_t o_capacity;
+	RtldLockState lockstate;
+	bool create = table == NULL;
+
+	if (lock)
+		wlock_acquire(rtld_bind_lock, &lockstate);
+	table = realloc(table, sizeof(*table) +
+	    sizeof(*table->stacks) * n_capacity);
+	if (lock)
+		lock_release(rtld_bind_lock, &lockstate);
+	if (table == NULL)
+		rtld_fatal("realloc failed");
+
+	if (create) {
+		table->resolver = _rtld_get_rstk;
+		o_capacity = 0;
+	} else
+		o_capacity = table->capacity;
+
+	table->capacity =
+	    (cheri_getlen(table) - offsetof(typeof(*table), stacks)) /
+	    sizeof(*table->stacks);
+
+	memset(&table->stacks[o_capacity], 0,
+	    sizeof(*table->stacks) * (table->capacity - o_capacity));
+
+	return (table);
+}
+
+void
+allocate_stk_table(void)
+{
+	size_t cnt;
+
+	/*
+	 * Every call to this function is paired with a call to pop_stk_table
+	 * later. If there are free stacks available, we do not actually
+	 * allocate a new stack but rather decrement the counter to reserve one
+	 * for the later pop.
+	 */
+	cnt = atomic_load_explicit(&free_stk_table_cnt, memory_order_relaxed);
+
+	do {
+		if (cnt == 0) {
+			/*
+			 * Allocate new stack tables to have the same capacity
+			 * as the compartment array.
+			 */
+			push_stk_table(&free_stk_tables,
+			    stk_table_expand(NULL, comparts.capacity, false));
+			break;
+		}
+	} while (!atomic_compare_exchange_weak_explicit(
+	    &free_stk_table_cnt, &cnt, cnt - 1,
+	    /*
+	     * Use acquire ordering to ensure that the pop happens after the
+	     * earlier push.
+	     */
+	    memory_order_acquire, memory_order_acquire));
+}
+
+static void
+free_stk_table(struct stk_table *table)
+{
+	push_stk_table(&free_stk_tables, table);
+	/*
+	 * Use release ordering to ensure that the push happens before the later
+	 * pop.
+	 */
+	atomic_fetch_add_explicit(&free_stk_table_cnt, 1, memory_order_release);
+}
+
+static compart_id_t
+table_index_to_compart_id(unsigned index)
+{
+	struct stk_table dummy;
+
+	return (sizeof(dummy.stacks->bottom) * index / sizeof(*dummy.stacks));
+}
+
+/* Default stack size in libthr */
+#define	C18N_STACK_SIZE	(sizeof(void *) / 4 * 1024 * 1024)
+
+void *get_rstk(unsigned);
+
+void *
+get_rstk(unsigned index)
+{
+	void **stk;
+	size_t capacity, size;
+	compart_id_t cid, cid_off;
+	struct stk_table *table;
+
+	table = stk_table_get();
+
+	cid = table_index_to_compart_id(index);
+	cid_off = cid -
+	    offsetof(typeof(*table), stacks) / sizeof(*table->stacks);
+
+	capacity = table->capacity;
+	if (capacity <= cid_off) {
+		capacity = MAX(capacity * 2, cid_off + 1);
+		table = stk_table_expand(table, capacity, true);
+		stk_table_set(table);
+	}
+	assert(table->stacks[cid_off].bottom == NULL);
+
+	size = C18N_STACK_SIZE;
+	stk = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_STACK, -1, 0);
+	if (stk == MAP_FAILED)
+		rtld_fatal("mmap failed");
+
+	stk = (void **)((char *)stk + size);
+	stk = cheri_clearperm(stk, CHERI_PERM_EXECUTIVE);
+
+	stk[-1] = cheri_clearperm(stk - 1, CHERI_PERM_SW_VMEM);
+	if (ld_compartment_utrace != NULL)
+		*--((uintptr_t **)stk)[-1] = cid;
+
+	table->stacks[cid_off].bottom = stk;
+	table->stacks[cid_off].size = size;
+
+	return (stk);
+}
+
+struct trusted_frame {
+	ptraddr_t next;
+	ptraddr_t o_stack;
+	void **stack;
+	void *ret_addr;
+};
+
+struct jmp_args { void **buf; void *val; };
+
+struct jmp_args _rtld_setjmp_impl(void **, void *, struct trusted_frame *);
+
+struct jmp_args
+_rtld_setjmp_impl(void **buf, void *val, struct trusted_frame *csp)
+{
+	/*
+	 * Before setjmp is called, the top of the Executive stack contains:
+	 * 	0.	Link to previous frame
+	 * setjmp does not push to the Executive stack. When _rtld_setjmp is
+	 * called, the following are pushed to the Executive stack:
+	 * 	1.	Caller's data
+	 * 	2.	Link to 0
+	 * We store a sealed capability to the caller's frame in the jump
+	 * buffer.
+	 */
+
+	*buf++ = cheri_seal(cheri_setaddress(csp, csp->next), sealer_jmpbuf);
+
+	return ((struct jmp_args) { .buf = buf, .val = val });
+}
+
+struct jmp_args _rtld_longjmp_impl(void **, void *, struct trusted_frame *);
+
+struct jmp_args
+_rtld_longjmp_impl(void **buf, void *val, struct trusted_frame *csp)
+{
+	/*
+	 * Before longjmp is called, the top of the Executive stack contains:
+	 * 	0.	Link to previous frame
+	 * longjmp does not push to the Executive stack. When _rtld_longjmp is
+	 * called, the following are pushed to the Executive stack:
+	 * 	1.	Caller's data
+	 * 	2.	Link to 0
+	 * _rtld_longjmp traverses down the Executive stack from 0 and unwinds
+	 * the Restricted stack of each intermediate compartment until reaching
+	 * the target frame.
+	 */
+
+	struct trusted_frame *target, *cur = csp;
+
+	target = cheri_unseal(*buf++, sealer_jmpbuf);
+
+	if (!cheri_is_subset(cur, target) || cur->next > (ptraddr_t)target)
+		rtld_fatal("longjmp: Bad target");
+
+	/*
+	 * Skip the first frame because it will be unwinded when this call
+	 * returns.
+	 */
+	while (cur->next < (ptraddr_t)target) {
+		cur = cheri_setaddress(cur, cur->next);
+		cur->stack[-1] = cheri_setaddress(cur->stack, cur->o_stack);
+	}
+
+	*cur = *csp;
+	csp->next = (ptraddr_t)cur;
+
+	return ((struct jmp_args) { .buf = buf, .val = val });
+}
+
+/*
+ * Trampolines
+ */
+struct tramp_pg {
+	SLIST_ENTRY(tramp_pg) link;
+	_Atomic(size_t) size;
+	size_t capacity;
+	_Alignas(_Alignof(void *)) char trampolines[];
+};
+
+/*
+* 64K is the largest size such that any capability-aligned proper
+* sub-range can be exactly bounded by a Morello capability.
+*/
+#define	C18N_TRAMPOLINE_PAGE_SIZE	64 * 1024
+
+static struct tramp_pg *
+tramp_pg_new(struct tramp_pg *next)
+{
+	size_t capacity = C18N_TRAMPOLINE_PAGE_SIZE;
+	struct tramp_pg *pg;
+
+	pg = mmap(NULL, capacity, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON,
+	    -1, 0);
+	if (pg == MAP_FAILED)
+		rtld_fatal("mmap failed");
+	SLIST_NEXT(pg, link) = next;
+	atomic_store_explicit(&pg->size, 0, memory_order_relaxed);
+	pg->capacity = capacity - offsetof(typeof(*pg), trampolines);
+	return (pg);
+}
+
+static void *
+tramp_pg_push(struct tramp_pg *pg, size_t len)
+{
+	void *tramp;
+	size_t n_size;
+	size_t size = atomic_load_explicit(&pg->size, memory_order_relaxed);
+
+	do {
+		n_size = roundup2(size, _Alignof(void *));
+		tramp = pg->trampolines + n_size;
+		n_size += len;
+		if (n_size > pg->capacity)
+			return (NULL);
+	} while (!atomic_compare_exchange_weak_explicit(&pg->size,
+	    /*
+	     * Relaxed ordering is sufficient because there are no
+	     * side-effects.
+	     */
+	    &size, n_size, memory_order_relaxed, memory_order_relaxed));
+
+	tramp = cheri_setbounds(tramp, len);
+	assert(cheri_gettag(tramp));
+
+	return (tramp);
+}
+
+typedef ssize_t slot_idx_t;
+
+static struct {
+	struct tramp_data *data;
+	struct tramp_map_kv {
+		_Atomic(ptraddr_t) key;
+		_Atomic(slot_idx_t) index;
+	} *map;
+	_Atomic(slot_idx_t) size;
+	_Atomic(slot_idx_t) writers;
+	size_t back;
+	int exp;
+} tramp_table;
+
+static struct {
+	_Atomic(struct tramp_pg *) head;
+	atomic_flag lock;
+} tramp_pgs = {
+	.lock = ATOMIC_FLAG_INIT
+};
+
+static slot_idx_t
+tramp_table_max_load(int exp)
+{
+	/* MAX_LOAD is 37.5% of capacity. */
+	return (3 << (exp - 3));
+}
+
+static void
+tramp_table_expand(int exp)
+{
+	char *buffer;
+	size_t back, map_offset;
+
+	/* The data array only needs to be as large as the MAX_LOAD. */
+	back = sizeof(*tramp_table.data) * tramp_table_max_load(exp);
+	back = map_offset = roundup2(back, _Alignof(typeof(*tramp_table.map)));
+	back += sizeof(*tramp_table.map) << exp;
+
+	buffer = mmap(NULL, back, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0);
+	if (buffer == MAP_FAILED)
+		rtld_fatal("mmap failed");
+
+	if (tramp_table.data != NULL) {
+		memcpy(buffer, tramp_table.data,
+		    sizeof(*tramp_table.data) *
+		    atomic_load_explicit(&tramp_table.size,
+		        memory_order_relaxed));
+		if (munmap(tramp_table.data, tramp_table.back) != 0)
+			rtld_fatal("munmap failed");
+	}
+
+	tramp_table.back = back;
+	tramp_table.exp = exp;
+	tramp_table.data = (void *)buffer;
+	tramp_table.map = (void *)(buffer + map_offset);
+
+	for (size_t i = 0; i < (1 << exp); ++i)
+		tramp_table.map[i] = (struct tramp_map_kv) {
+			.key = 0,
+			.index = -1
+		};
+}
+
+/* Public domain. Taken from https://github.com/skeeto/hash-prospector */
+static uint32_t
+pointer_hash(uint64_t key)
+{
+	uint32_t x = key ^ (key >> 32);
+
+	x ^= x >> 16;
+	x *= 0x21f0aaadU;
+	x ^= x >> 15;
+	x *= 0xd35a2d97U;
+	x ^= x >> 15;
+	return (x);
+}
+
+static slot_idx_t
+next_slot(slot_idx_t slot, uint32_t hash, int exp)
+{
+	uint32_t step, mask;
+
+	step = (hash >> (32 - exp)) | 1;
+	mask = (1 << exp) - 1;
+	return ((slot + step) & mask);
+}
+
+/* Must be called with exclusive access to the table */
+static void
+resize_table(int exp)
+{
+	ptraddr_t key;
+	uint32_t hash;
+	slot_idx_t size, slot;
+
+	assert(0 < exp && exp < 32);
+
+	tramp_table_expand(exp);
+
+	size = atomic_load_explicit(&tramp_table.size, memory_order_relaxed);
+
+	for (slot_idx_t idx = 0; idx < size; ++idx) {
+		key = (ptraddr_t)tramp_table.data[idx].target;
+		hash = pointer_hash(key);
+		slot = hash;
+
+		do {
+			slot = next_slot(slot, hash, exp);
+		} while (atomic_load_explicit(&tramp_table.map[slot].key,
+		    memory_order_relaxed) != 0);
+
+		atomic_store_explicit(&tramp_table.map[slot].key, key,
+		    memory_order_relaxed);
+		atomic_store_explicit(&tramp_table.map[slot].index, idx,
+		    memory_order_relaxed);
+	}
+}
+
+void *
+tramp_hook(int, void *, const Obj_Entry *, const Elf_Sym *, void *, void *);
+
+void *
+tramp_hook(int event, void *target, const Obj_Entry *obj, const Elf_Sym *def,
+    void *link, void *rcsp)
+{
+	Elf_Word sym_num;
+	const char *sym;
+	const char *callee;
+
+	compart_id_t caller_id;
+	const char *caller;
+
+	struct utrace_rtld ut;
+	static const char rtld_utrace_sig[RTLD_UTRACE_SIG_SZ] = RTLD_UTRACE_SIG;
+
+	sym_num = def == NULL ? 0 : def->st_name;
+	sym = def == NULL ? "<unknown>" : strtab_value(obj, def->st_name);
+	callee = comparts.data[obj->compart_id]->name;
+
+	if (cheri_gettag(link) &&
+	    (cheri_getperm(link) & CHERI_PERM_EXECUTIVE) == 0)
+		caller_id = ((uintptr_t *)
+		    cheri_setaddress(rcsp, cheri_gettop(rcsp)))[-2];
+	else
+		caller_id = C18N_RTLD_COMPARTMENT_ID;
+	caller = comparts.data[caller_id]->name;
+
+	if (ld_compartment_utrace != NULL) {
+		memcpy(ut.sig, rtld_utrace_sig, sizeof(ut.sig));
+		ut.event = event;
+		ut.handle = target;
+		ut.mapsize = sym_num;
+		strlcpy(ut.symbol, sym, sizeof(ut.symbol));
+		strlcpy(ut.callee, callee, sizeof(ut.callee));
+		strlcpy(ut.caller, caller, sizeof(ut.caller));
+		utrace(&ut, sizeof(ut));
+	}
+	if (ld_compartment_overhead != NULL)
+		getpid();
+	return (link);
+}
+
+#define	C18N_MAX_TRAMPOLINE_SIZE	768
+
+static void *
+tramp_pgs_append(const struct tramp_data *data)
+{
+	size_t len;
+	/* A capability-aligned buffer large enough to hold a trampoline */
+	_Alignas(_Alignof(void *)) char tmp[C18N_MAX_TRAMPOLINE_SIZE];
+	char *tramp, *entry = tmp;
+	struct tramp_pg *pg;
+
+	/* Fill a temporary buffer with the trampoline and obtain its length */
+	len = tramp_compile(&entry, data);
+
+	pg = atomic_load_explicit(&tramp_pgs.head, memory_order_acquire);
+	tramp = tramp_pg_push(pg, len);
+	if (tramp == NULL) {
+		while (atomic_flag_test_and_set_explicit(&tramp_pgs.lock,
+		    memory_order_acquire));
+		pg = atomic_load_explicit(&tramp_pgs.head,
+		    memory_order_relaxed);
+		tramp = tramp_pg_push(pg, len);
+		if (tramp == NULL) {
+			pg = tramp_pg_new(pg);
+			tramp = tramp_pg_push(pg, len);
+			atomic_store_explicit(&tramp_pgs.head, pg,
+			    memory_order_release);
+		}
+		atomic_flag_clear_explicit(&tramp_pgs.lock,
+		    memory_order_release);
+	}
+	assert(cheri_gettag(tramp));
+
+	entry = tramp + (entry - tmp);
+	memcpy(tramp, tmp, len);
+
+	/*
+	 * Ensure i- and d-cache coherency after writing executable code. The
+	 * __clear_cache procedure rounds the addresses to cache-line-aligned
+	 * addresses. Derive the start/end addresses from pg so that they have
+	 * sufficiently large bounds to contain these rounded addresses.
+	 */
+	__clear_cache(cheri_copyaddress(pg, entry),
+	    cheri_copyaddress(pg, tramp + len));
+
+	entry = cheri_clearperm(entry, FUNC_PTR_REMOVE_PERMS);
+	return (cheri_sealentry(cheri_capmode(entry)));
+}
+
+static bool
+func_sig_equal(struct func_sig lhs, struct func_sig rhs)
+{
+	return (lhs.reg_args == rhs.reg_args &&
+		lhs.mem_args == rhs.mem_args &&
+		lhs.ret_args == rhs.ret_args);
+}
+
+static bool
+func_sig_compatible(struct func_sig lhs, struct func_sig rhs)
+{
+	return (!lhs.valid || !rhs.valid || func_sig_equal(lhs, rhs));
+}
+
+static void *
+tramp_get_entry(const struct tramp_data *found, const struct tramp_data *data)
+{
+	if (!func_sig_compatible(found->sig, data->sig))
+		rtld_fatal(
+		    "Incompatible signatures for function %s: "
+		    "%s requests " C18N_SIG_FORMAT_STRING " but %s provides "
+		    C18N_SIG_FORMAT_STRING,
+		    strtab_value(data->defobj, data->def->st_name),
+		    data->defobj->path, C18N_SIG_FORMAT(data->sig),
+		    found->defobj->path, C18N_SIG_FORMAT(found->sig));
+
+	return (found->entry);
+}
+
+static void *
+tramp_create_entry(struct tramp_data *found, const struct tramp_data *data)
+{
+	struct func_sig sig;
+
+	*found = *data;
+	if (found->def != NULL) {
+		sig = tramp_fetch_sig(found->defobj,
+		    found->def - found->defobj->symtab);
+		if (!found->sig.valid)
+			found->sig = sig;
+		else if (!func_sig_compatible(found->sig, sig))
+			rtld_fatal(
+			    "Incompatible signatures for function %s: "
+			    "requests " C18N_SIG_FORMAT_STRING
+			    " but %s provides " C18N_SIG_FORMAT_STRING,
+			    strtab_value(found->defobj, found->def->st_name),
+			    C18N_SIG_FORMAT(found->sig), found->defobj->path,
+			    C18N_SIG_FORMAT(sig));
+	}
+
+	return (found->entry = tramp_pgs_append(found));
+}
+
+void *
+tramp_intern(const Obj_Entry *reqobj, const struct tramp_data *data)
+{
+	void *entry;
+	RtldLockState lockstate;
+	ptraddr_t target = (ptraddr_t)data->target;
+	const uint32_t hash = pointer_hash(target);
+	slot_idx_t slot, idx, writers;
+	ptraddr_t key;
+	int exp;
+
+	/* reqobj == NULL iff the request is by RTLD */
+	assert((reqobj == NULL || data->def != NULL) &&
+	    data->defobj != NULL && data->entry == NULL &&
+	    func_sig_legal(data->sig));
+
+	if (!tramp_should_include(reqobj, data))
+		return (data->target);
+
+start:
+	slot = hash;
+	rlock_acquire(rtld_tramp_lock, &lockstate);
+	exp = tramp_table.exp;
+	do {
+		slot = next_slot(slot, hash, exp);
+		key = atomic_load_explicit(&tramp_table.map[slot].key,
+		    memory_order_relaxed);
+		if (key != 0)
+			continue;
+
+		/*
+		 * Invariant: tramp_table.size <= tramp_table.writers
+		 *
+		 * This can be shown by observing that every increment in
+		 * tramp_table.size corresponds to an increment in
+		 * tramp_table.writers.
+		 */
+		writers = atomic_fetch_add_explicit(&tramp_table.writers, 1,
+		    memory_order_relaxed);
+
+		/*
+		 * Invariant: tramp_table.size <= writers < tramp_table.writers
+		 */
+		if (writers >= tramp_table_max_load(exp)) {
+			atomic_fetch_sub_explicit(&tramp_table.writers, 1,
+			    memory_order_relaxed);
+			lock_release(rtld_tramp_lock, &lockstate);
+			goto start;
+		}
+
+		/*
+		 * Invariant: writers < MAX_LOAD
+		 *
+		 * Hence tramp_table.size < MAX_LOAD.
+		 *
+		 * Race to acquire the current slot.
+		 */
+		if (atomic_compare_exchange_strong_explicit(
+		    &tramp_table.map[slot].key, &key, target,
+		    memory_order_relaxed, memory_order_relaxed))
+			goto insert;
+		else
+			atomic_fetch_sub_explicit(&tramp_table.writers, 1,
+			    memory_order_relaxed);
+	} while (key != target);
+
+	/*
+	 * Load-acquire the index until it becomes available.
+	 */
+	do
+	        idx = atomic_load_explicit(&tramp_table.map[slot].index,
+	            memory_order_acquire);
+	while (idx == -1);
+
+	entry = tramp_get_entry(&tramp_table.data[idx], data);
+	goto end;
+
+insert:
+	idx = atomic_fetch_add_explicit(&tramp_table.size, 1,
+	    memory_order_relaxed);
+
+	/*
+	 * Invariant: tramp_table.size <= MAX_LOAD
+	 *
+	 * Create the data array entry.
+	 */
+	entry = tramp_create_entry(&tramp_table.data[idx], data);
+
+	/*
+	 * Store-release the index.
+	 */
+	atomic_store_explicit(&tramp_table.map[slot].index, idx,
+	    memory_order_release);
+
+	/*
+	 * If tramp_table.size == MAX_LOAD, resize the table.
+	 */
+	if (idx + 1 == tramp_table_max_load(exp)) {
+
+		/*
+		 * Wait for other readers to complete.
+		 */
+		lock_upgrade(rtld_tramp_lock, &lockstate);
+
+		/*
+		 * There can be no other writer racing with us for the resize.
+		 */
+		resize_table(exp + 1);
+	}
+end:
+	lock_release(rtld_tramp_lock, &lockstate);
+	return (entry);
+}
+
+/*
+ * APIs
+ */
+struct func_sig
+tramp_fetch_sig(const Obj_Entry *obj, unsigned long symnum)
+{
+	if (symnum >= obj->dynsymcount)
+		rtld_fatal("Invalid symbol number %lu for object %s.",
+		    symnum, obj->path);
+
+	if (obj->sigtab == NULL)
+		return ((struct func_sig) {});
+	return (obj->sigtab[symnum]);
+}
+
+void
+tramp_init(void)
+{
+	int exp = 9;
+	uintptr_t sealer;
+
+	/*
+	 * Allocate otypes for RTLD use
+	 */
+	if (sysctlbyname("security.cheri.sealcap", &sealer,
+	    &(size_t) { sizeof(sealer) }, NULL, 0) < 0)
+		rtld_fatal("sysctlbyname failed");
+
+	sealer_pltgot = cheri_setboundsexact(sealer, 1);
+	sealer += 1;
+
+	sealer_jmpbuf = cheri_setboundsexact(sealer, 1);
+	sealer += 1;
+
+	sealer_tramp = cheri_setboundsexact(sealer, C18N_FUNC_SIG_COUNT);
+	sealer += C18N_FUNC_SIG_COUNT;
+
+	/*
+	 * Initialise compartment database
+	 */
+	comparts_data_expand(C18N_INIT_COMPART_COUNT);
+	while (comparts.size < C18N_RTLD_COMPARTMENT_ID)
+		comparts.data[comparts.size++] = NULL;
+	comparts.data[comparts.size++] = &rtld_compart;
+	comparts.data[comparts.size++] = &libthr_compart;
+
+	/*
+	 * Initialise stack table
+	 */
+	stk_table_set(stk_table_expand(NULL, C18N_INIT_COMPART_COUNT, false));
+
+	untrusted_stk_set(&dummy_stack);
+
+	/*
+	 * Initialise trampoline table
+	 */
+	tramp_table_expand(exp);
+
+	atomic_store_explicit(&tramp_pgs.head, tramp_pg_new(NULL),
+	    memory_order_relaxed);
+}
+
+void
+tramp_add_comparts(struct policy *pol)
+{
+	if (pol == NULL)
+		return;
+	comparts_data_expand(comparts.size + pol->count);
+	for (size_t i = 0; i < pol->count; ++i)
+		comparts.data[comparts.size++] = &pol->coms[i];
+}
+
+/*
+ * libthr support
+ */
+static void (*thr_thread_start)(struct pthread *);
+
+void
+_rtld_thread_start_init(void (*p)(struct pthread *))
+{
+	assert((cheri_getperm(p) & CHERI_PERM_EXECUTIVE) == 0);
+	assert(thr_thread_start == NULL);
+	thr_thread_start = tramp_intern(NULL, &(struct tramp_data) {
+		.target = p,
+		.defobj = obj_from_addr(p),
+		.sig = (struct func_sig) {
+			.valid = true,
+			.reg_args = 1, .mem_args = false, .ret_args = NONE
+		}
+	});
+}
+
+void _rtld_thread_start_impl(struct pthread *);
+
+void
+_rtld_thread_start_impl(struct pthread *curthread)
+{
+	stk_table_set(pop_stk_table(&free_stk_tables));
+	untrusted_stk_set(&dummy_stack);
+	thr_thread_start(curthread);
+}
+
+void _rtld_thr_exit_impl(long *);
+
+void
+_rtld_thr_exit_impl(long *state)
+{
+	char *stk;
+	size_t size;
+	struct stk_table *table = stk_table_get();
+
+	for (size_t i = 0; i < table->capacity; ++i) {
+		stk = table->stacks[i].bottom;
+		if (stk != NULL) {
+			size = table->stacks[i].size;
+			if (munmap(stk - size, size) != 0)
+				rtld_fatal("munmap failed");
+			table->stacks[i] = (struct stk_table_stack) {};
+		}
+	}
+
+	free_stk_table(table);
+
+	__sys_thr_exit(state);
+}
+
+static void (*thr_sighandler)(int, siginfo_t *, void *);
+
+void
+_rtld_sighandler_init(void (*p)(int, siginfo_t *, void *))
+{
+	assert((cheri_getperm(p) & CHERI_PERM_EXECUTIVE) == 0);
+	assert(thr_sighandler == NULL);
+	thr_sighandler = tramp_intern(NULL, &(struct tramp_data) {
+		.target = p,
+		.defobj = obj_from_addr(p),
+		.sig = (struct func_sig) {
+			.valid = true,
+			.reg_args = 3, .mem_args = false, .ret_args = NONE
+		}
+	});
+}
+
+void _rtld_sighandler_impl(int, siginfo_t *, void *, ptraddr_t *);
+
+void
+_rtld_sighandler_impl(int sig, siginfo_t *info, void *_ucp, ptraddr_t *frame)
+{
+	ucontext_t *ucp = _ucp;
+
+	*frame = (ptraddr_t)ucp->uc_mcontext.mc_capregs.cap_sp;
+
+	thr_sighandler(sig, info, _ucp);
+}

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -1,0 +1,186 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021-2023 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef RTLD_C18N_H
+#define RTLD_C18N_H
+
+#include <stdint.h>
+
+/*
+ * Global symbols
+ */
+#define	C18N_FUNC_SIG_COUNT	72
+
+extern uintptr_t sealer_pltgot, sealer_tramp;
+extern const char *ld_compartment_utrace;
+extern const char *ld_compartment_enable;
+extern const char *ld_compartment_overhead;
+extern const char *ld_compartment_sig;
+
+void tramp_init(void);
+
+/*
+ * Policies
+ */
+#define	C18N_RTLD_COMPARTMENT_ID	0
+#define	C18N_COMPARTMENT_ID_MAX	(UINT16_MAX >> 1)
+
+typedef uint16_t compart_id_t;
+
+struct compart {
+	/*
+	 * Name of the compartment
+	 */
+	const char *name;
+	/*
+	 * NULL-terminated array of libraries that belong to the compartment
+	 */
+	const char **libraries;
+};
+
+struct policy {
+	struct compart *coms;
+	size_t count;
+};
+
+void tramp_add_comparts(struct policy *);
+compart_id_t compart_id_allocate(const char *);
+
+/*
+ * Stack switching
+ */
+struct stk_table {
+	union {
+		void *(*resolver)(unsigned);
+		SLIST_ENTRY(stk_table) next;
+	};
+	size_t capacity;
+	struct stk_table_stack {
+		void *bottom;
+		size_t size;
+	} stacks[];
+};
+
+struct Struct_Stack_Entry {
+    SLIST_ENTRY(Struct_Stack_Entry) link;
+    void *stack;
+};
+
+void allocate_stk_table(void);
+void *_rtld_get_rstk(unsigned);
+
+static inline unsigned
+compart_id_to_index(compart_id_t cid)
+{
+	struct stk_table dummy;
+
+	return (sizeof(*dummy.stacks) * cid / sizeof(dummy.stacks->bottom));
+}
+
+static inline struct stk_table *
+stk_table_get(void)
+{
+	struct stk_table *table;
+
+	asm ("mrs	%0, ctpidr_el0" : "=C" (table));
+	return (table);
+}
+
+static inline void
+stk_table_set(struct stk_table *table)
+{
+	asm ("msr	ctpidr_el0, %0" :: "C" (table));
+}
+
+static inline void
+untrusted_stk_set(void *sp)
+{
+	asm ("msr	rcsp_el0, %0" :: "C" (sp));
+}
+
+/*
+ * Trampolines
+ */
+#define	DT_CHERI_C18N_SIG	0x60000100	/* function signature (c18n) */
+
+#define	C18N_SIG_FORMAT_STRING	\
+    "(valid = %d, reg_args = %d, mem_args = %d, ret_args = %d)"
+#define	C18N_SIG_FORMAT(sig)	\
+    (sig.valid), (sig.reg_args), (sig.mem_args), (sig.ret_args)
+
+typedef uint8_t func_sig_int;
+
+/* Must not be reordered */
+enum tramp_ret_args {
+	TWO,
+	ONE,
+	NONE,
+	INDIRECT
+};
+
+struct func_sig {
+	unsigned char ret_args : 2; /* enum tramp_ret_args */
+	unsigned char mem_args : 1;
+	unsigned char reg_args : 4;
+	unsigned char valid : 1;
+};
+
+struct tramp_data {
+	void *target;
+	const Obj_Entry *defobj;
+	const Elf_Sym *def;
+	void *entry;
+	struct func_sig sig;
+};
+_Static_assert(sizeof(struct func_sig) == sizeof(func_sig_int),
+    "Unexpected func_sig size");
+
+void *_rtld_tramp_hook(int, void *, const Obj_Entry *, const Elf_Sym *, void *,
+    void *);
+size_t tramp_compile(char **, const struct tramp_data *);
+void *tramp_intern(const Obj_Entry *reqobj, const struct tramp_data *);
+struct func_sig tramp_fetch_sig(const Obj_Entry *, unsigned long);
+
+static inline long
+func_sig_to_otype(struct func_sig sig)
+{
+	return (sig.ret_args | (sig.mem_args << 2) | (sig.reg_args << 3));
+}
+
+static inline bool
+func_sig_legal(struct func_sig sig)
+{
+	return (!sig.valid || sig.reg_args <= 8);
+}
+
+/*
+ * APIs
+ */
+void *_rtld_sandbox_code(void *, struct func_sig);
+void *_rtld_safebox_code(void *, struct func_sig);
+
+#endif

--- a/libexec/rtld-elf/rtld_lock.c
+++ b/libexec/rtld-elf/rtld_lock.c
@@ -66,6 +66,9 @@
 #include "rtld.h"
 #include "rtld_machdep.h"
 #include "rtld_libc.h"
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#include "rtld_c18n.h"
+#endif
 
 void _rtld_thread_init(struct RtldLockInfo *) __exported;
 void _rtld_atfork_pre(int *) __exported;
@@ -424,18 +427,27 @@ _rtld_thread_init(struct RtldLockInfo *pli)
 		}
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 		tmplockinfo = *pli;
-#define wrap_with_trampoline(target) target = tramp_pgs_append(target, obj, NULL)
-		wrap_with_trampoline(tmplockinfo.lock_create);
-		wrap_with_trampoline(tmplockinfo.lock_destroy);
-		wrap_with_trampoline(tmplockinfo.rlock_acquire);
-		wrap_with_trampoline(tmplockinfo.wlock_acquire);
-		wrap_with_trampoline(tmplockinfo.lock_release);
-		wrap_with_trampoline(tmplockinfo.thread_set_flag);
-		wrap_with_trampoline(tmplockinfo.thread_clr_flag);
-		wrap_with_trampoline(tmplockinfo.at_fork);
-		wrap_with_trampoline(tmplockinfo.dlerror_loc);
-		wrap_with_trampoline(tmplockinfo.dlerror_seen);
-#undef wrap_with_trampoline
+#define WRAP(_target, _valid, _reg_args, _mem_args, _ret_args)	\
+	_target = tramp_intern(NULL, &(struct tramp_data) {			\
+		.target = _target,						\
+		.defobj = obj,							\
+		.sig = (struct func_sig) {					\
+			.valid = _valid,					\
+			.reg_args = _reg_args, .mem_args = _mem_args,		\
+			.ret_args = _ret_args					\
+		}								\
+	})
+		WRAP(tmplockinfo.lock_create,		true, 0, false, ONE);
+		WRAP(tmplockinfo.lock_destroy,		true, 1, false, NONE);
+		WRAP(tmplockinfo.rlock_acquire,		true, 1, false, NONE);
+		WRAP(tmplockinfo.wlock_acquire,		true, 1, false, NONE);
+		WRAP(tmplockinfo.lock_release,		true, 1, false, NONE);
+		WRAP(tmplockinfo.thread_set_flag,	true, 1, false, ONE);
+		WRAP(tmplockinfo.thread_clr_flag,	true, 1, false, ONE);
+		WRAP(tmplockinfo.at_fork,		true, 0, false, NONE);
+		WRAP(tmplockinfo.dlerror_loc,		true, 0, false, ONE);
+		WRAP(tmplockinfo.dlerror_seen,		true, 0, false, ONE);
+#undef WRAP
 		pli = &tmplockinfo;
 #endif
 	}

--- a/libexec/rtld-elf/rtld_lock.h
+++ b/libexec/rtld-elf/rtld_lock.h
@@ -30,6 +30,10 @@
 
 #include <sys/cdefs.h>
 
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#include <signal.h>
+#endif
+
 __BEGIN_DECLS
 
 #define	RTLI_VERSION_ONE	0x01
@@ -76,7 +80,7 @@ void _rtld_atfork_post(int *) __exported;
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 void _rtld_thread_start_init(void (*)(struct pthread *));
-void _rtld_sighandler_init(void *);
+void _rtld_sighandler_init(void (*)(int, siginfo_t *, void *));
 #endif
 
 #ifdef IN_RTLD

--- a/libexec/rtld-elf/rtld_utrace.h
+++ b/libexec/rtld-elf/rtld_utrace.h
@@ -44,6 +44,8 @@
 #define	UTRACE_DLSYM_START		11
 #define	UTRACE_DLSYM_STOP		12
 #define	UTRACE_RTLD_ERROR		13
+#define	UTRACE_COMPARTMENT_ENTER	14
+#define	UTRACE_COMPARTMENT_LEAVE	15
 
 #define	RTLD_UTRACE_SIG_SZ		4
 #define	RTLD_UTRACE_SIG			"RTLD"
@@ -55,7 +57,14 @@ struct utrace_rtld {
 	void *mapbase;			/* Used for 'parent' and 'init/fini' */
 	size_t mapsize;
 	int refcnt;			/* Used for 'mode' */
-	char name[MAXPATHLEN];
+	union {
+		char name[MAXPATHLEN];
+		struct {
+			char symbol[MAXPATHLEN / 2];
+			char callee[MAXPATHLEN / 4];
+			char caller[MAXPATHLEN / 4];
+		};
+	};
 };
 
 #endif

--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -31,8 +31,8 @@
 .Nm c18n
 .Nd library-based software compartmentalization
 .Sh DESCRIPTION
-This file contains instructions for using the library-based compartmentalization
-(c18n) prototype.
+This document contains instructions for using the library-based
+compartmentalization (c18n) prototype.
 .Pp
 To launch a dynamically-linked pure-capability application with library-based
 compartmentalization, use the special runtime linker located at
@@ -63,6 +63,11 @@ utility to directly modify the
 .Sy INTERP
 field of an executable, although it is reportedly unreliable at times.
 .Pp
+Environment variables recognized by
+.Xr rtld 1
+should adopt the prefix LD_C18N_ when compartmentalization is enabled.
+For example, LD_LIBRARY_PATH becomes LD_C18N_LIBRARY_PATH.
+.Pp
 Compartmentalization currently depends on modified versions of
 .Lb libc
 and
@@ -71,11 +76,35 @@ These are located in
 .Pa /usr/lib/c18n .
 The modified runtime linker automatically searches from these paths first so
 that modified libraries are used.
+.Ss COMPARTMENT TRANSITION TRACING
+Compartment transitions can be traced with the
+.Xr ktrace 1
+facility.
+To generate a trace, set the environment variable LD_C18N_UTRACE_COMPARTMENT
+and invoke the executable with
+.Xr ktrace 1 .
+.Pp
+.Sy CAUTION:
+Compartment transition tracing is only intended for debugging and analysis
+purposes.
+Turning it on will reduce security.
+.Ss COMPARTMENT TRANSITION OVERHEAD SIMULATION
+To simulate the overhead of making a system call during each compartment
+transition, set the environment variable LD_C18N_COMPARTMENT_OVERHEAD and invoke
+the executable.
+Each compartment transition will then make a
+.Xr getpid 2
+system call.
+.Pp
+.Sy CAUTION:
+Compartment transition overhead simulation is only intended for performance
+analysis purposes.
+Turning it on will reduce security.
 .Sh LIMITATIONS
-This work is of a highly experimental nature.
+This work is of a experimental nature.
 The author has tested it on applications such as
 .Xr tmux 1 ,
-but crashes are likely when running complex pieces of software.
+but instabilities might occur when running complex pieces of software.
 .Pp
 The current prototype only contains a set of
 .Em mechanisms
@@ -89,20 +118,25 @@ For more up-to-date information, visit
 .Lk https://github.com/CTSRD-CHERI/cheripedia/wiki/Library-based-Compartmentalisation .
 .Bl -bullet
 .It
-Functions that take more than 8 arguments (not counting variadic arguments) are
-not expected to work correctly
-.Em when they are called from another library .
-Calling such functions from within the same library is not impacted.
-.It
-Compatibility with C++ software is not expected.
+Calling
+.Xr longjmp 3
+in a signal handler does not work if the
+.Lb libthr
+is not linked to the application.
+This happens in
+.Xr sh 1 ,
+for example.
+A workaround is to PRELOAD
+.Lb libthr .
 .It
 Stack unwinding is not expected to work.
-This includes C++ exceptions and stack tracing in debuggers.
+This includes C++ exceptions, stack tracing in debuggers, and usage of
+.Lb libunwind .
 .It
 .Xr sigaltstack 2
 does not work as expected.
-This impacts some applications that use an alternative stack to handle stack-overflow
-exceptions.
+This impacts some applications that use an alternative stack to handle
+stack-overflow exceptions.
 .It
 .Xr getcontext 3 ,
 .Xr setcontext 3 ,

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -154,6 +154,21 @@ SYSINIT(elf64, SI_SUB_EXEC, SI_ORDER_FIRST,
     (sysinit_cfunc_t)__elfN(insert_brand_entry), &freebsd_brand_info);
 
 #if __has_feature(capabilities)
+static __ElfN(Brandinfo) freebsd_c18n_brand_info = {
+	.brand		= ELFOSABI_FREEBSD,
+	.machine	= EM_AARCH64,
+	.compat_3_brand	= "FreeBSD",
+	.interp_path	= "/libexec/ld-elf-c18n.so.1",
+	.sysvec		= &elf64_freebsd_sysvec,
+	.interp_newpath	= NULL,
+	.brand_note	= &__elfN(freebsd_brandnote),
+	.flags		= BI_CAN_EXEC_DYN | BI_BRAND_NOTE,
+	.header_supported = &elf64c_header_supported,
+};
+
+SYSINIT(elf64_c18n, SI_SUB_EXEC, SI_ORDER_FIRST,
+    (sysinit_cfunc_t)__elfN(insert_brand_entry), &freebsd_c18n_brand_info);
+
 static struct sysentvec elf64cb_freebsd_sysvec = {
 	.sv_size	= SYS_MAXSYSCALL,
 	.sv_table	= sysent,


### PR DESCRIPTION
This PR contains changes pertaining to compartmentalisation that should be included in the autumn 2023 release.

Key changes:
* Support the transition ABI for passing memory arguments.
* Trampolines now clear unused argument registers based on function signature information embedded in the ELF.
* Compartment transition tracing and overhead simulation.
* Allow defining compartments that consist of multiple libraries.
* Support for the benchmark ABI.