### PR TITLE
lib: Avoid building libgcc_(eh|s) twice

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -17,8 +17,6 @@ SUBDIR_BOOTSTRAP= \
 	libcompiler_rt \
 	${_libcheribsdtest_dynamic} \
 	${_libclang_rt} \
-	libgcc_eh \
-	libgcc_s \
 	${_libcplusplus} \
 	${_libcxxrt} \
 	libelf \


### PR DESCRIPTION
Commit 47da4fc4f55 ("Remove references to MK_LLVM_LIBUNWIND.") and upstream commit c45018041d5 ("retire the LLVM_LIBUNWIND option") conflicted such that these libraries were listed in both SUBDIR and SUBDIR_BOOTSTRAP.  Remove them from the latter to match upstream.