### PR TITLE
Makefile.inc1: Support building with macOS Ventura's AMFI Launch Constraints

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -693,6 +693,18 @@ MKTEMP=${WORLDTMP}/legacy/usr/bin/mktemp
 MKTEMP=mktemp
 .endif
 INSTALLTMP!=	${MKTEMP} -d -u -t install
+
+.if ${.MAKE.OS} == "FreeBSD"
+# When building on FreeBSD we always copy the host tools instead of linking
+# into INSTALLTMP to avoid issues with incompatible libraries (see r364030).
+# Note: we could create links if we don't intend to update the current machine.
+INSTALLTMP_COPY_HOST_TOOL=cp
+.else
+# However, this is not necessary on Linux/macOS. Additionally, copying the host
+# tools to another directory with cp results in AMFI Launch Constraint
+# Violations on macOS Ventura as part of its System Integrity Protection.
+INSTALLTMP_COPY_HOST_TOOL=ln -s
+.endif
 .endif
 
 .if make(stagekernel) || make(distributekernel)
@@ -1485,7 +1497,7 @@ distributeworld installworld stageworld installsysroot: _installcheck_world .PHO
 			fi; \
 		    done); \
 	fi; \
-	cp $$libs $$progs ${INSTALLTMP}
+	${INSTALLTMP_COPY_HOST_TOOL} $$libs $$progs ${INSTALLTMP}
 	cp -R $${PATH_LOCALE:-"/usr/share/locale"} ${INSTALLTMP}/locale
 .if defined(NO_ROOT)
 	-mkdir -p ${METALOG:H}


### PR DESCRIPTION
As of macOS Ventura, Apple-signed binaries cannot be run if copied away from their system location. This security feature doesn't really make sense for boring things like sh(1), more so for applications with special entitlements, but it's universally present, and results in the following error:

  >>> Install check world
  bmake[2]: "/Users/Jess/cheri/freebsd/Makefile.inc1" line 572: warning: "MAKEFLAGS= CPUTYPE=dummy /Users/Jess/cheri/build/freebsd-riscv64-build/bmake-install/bin/bmake -f /dev/null  -m /Users/Jess/cheri/freebsd/share/mk MK_AUTO_OBJ=no -V CPUTYPE" exited on a signal
  bmake[2]: "/Users/Jess/cheri/freebsd/Makefile.inc1" line 575: CPUTYPE global should be set with ?=.

As with host-symlinks, we don't actually need to copy the files on macOS, since we're not updating the current machine, so copy its approach and just symlink them instead.

MFC after:	1 week

(cherry picked from commit dda4d97289f17aa8b2bbfd8d63a746b3a7836fd5)