### PR TITLE
22.12 backports 20230303

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -693,6 +693,18 @@ MKTEMP=${WORLDTMP}/legacy/usr/bin/mktemp
 MKTEMP=mktemp
 .endif
 INSTALLTMP!=	${MKTEMP} -d -u -t install
+
+.if ${.MAKE.OS} == "FreeBSD"
+# When building on FreeBSD we always copy the host tools instead of linking
+# into INSTALLTMP to avoid issues with incompatible libraries (see r364030).
+# Note: we could create links if we don't intend to update the current machine.
+INSTALLTMP_COPY_HOST_TOOL=cp
+.else
+# However, this is not necessary on Linux/macOS. Additionally, copying the host
+# tools to another directory with cp results in AMFI Launch Constraint
+# Violations on macOS Ventura as part of its System Integrity Protection.
+INSTALLTMP_COPY_HOST_TOOL=ln -s
+.endif
 .endif
 
 .if make(stagekernel) || make(distributekernel)
@@ -1486,7 +1498,7 @@ distributeworld installworld stageworld installsysroot: _installcheck_world .PHO
 			fi; \
 		    done); \
 	fi; \
-	cp $$libs $$progs ${INSTALLTMP}
+	${INSTALLTMP_COPY_HOST_TOOL} $$libs $$progs ${INSTALLTMP}
 	cp -R $${PATH_LOCALE:-"/usr/share/locale"} ${INSTALLTMP}/locale
 .if defined(NO_ROOT)
 	-mkdir -p ${METALOG:H}

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -287,34 +287,26 @@ a0dalloc(void *ptr) {
 
 void *
 bootstrap_malloc(size_t size) {
-	bool zero_size;
-
-	zero_size = false;
 	if (unlikely(size == 0)) {
 		size = 1;
-		zero_size = true;
 	}
 	size = ROUND_SIZE(size);
 
-	return BOUND_PTR(a0ialloc(size, false, false), zero_size ? 0 : size);
+	return BOUND_PTR(a0ialloc(size, false, false), size);
 }
 
 void *
 bootstrap_calloc(size_t num, size_t size) {
-	bool zero_size;
 	size_t num_size;
 
-	zero_size = false;
 	num_size = num * size;
 	if (unlikely(num_size == 0)) {
 		assert(num == 0 || size == 0);
-		zero_size = true;
 		num_size = 1;
 	}
 	num_size = ROUND_SIZE(num_size);
 
-	return BOUND_PTR(a0ialloc(num_size, true, false),
-	     zero_size ? 0 : num_size);
+	return BOUND_PTR(a0ialloc(num_size, true, false), num_size);
 }
 
 void
@@ -2280,7 +2272,6 @@ imalloc_init_check(static_opts_t *sopts, dynamic_opts_t *dopts) {
 /* Returns the errno-style error code of the allocation. */
 JEMALLOC_ALWAYS_INLINE int
 imalloc(static_opts_t *sopts, dynamic_opts_t *dopts) {
-	bool zero_size;
 	int ret;
 	size_t size;
 
@@ -2288,10 +2279,6 @@ imalloc(static_opts_t *sopts, dynamic_opts_t *dopts) {
 	 * CHERI: Rounding of allocation size occurs in imalloc_body()
 	 * via compute_size_with_overflow()
 	 */
-	zero_size = false;
-	if (unlikely(dopts->item_size * dopts->num_items == 0)) {
-		zero_size = true;
-	}
 
 	if (tsd_get_allocates() && !imalloc_init_check(sopts, dopts)) {
 		return ENOMEM;
@@ -2316,8 +2303,7 @@ imalloc(static_opts_t *sopts, dynamic_opts_t *dopts) {
 	if (ret == 0) {
 		/* overflow causes imalloc_body to return ENOMEM */
 		(void)compute_size_with_overflow(1, dopts, &size);
-		*dopts->result = BOUND_PTR(*dopts->result,
-		    zero_size ? 0 : size);
+		*dopts->result = BOUND_PTR(*dopts->result, size);
 	}
 	return ret;
 }
@@ -2810,7 +2796,7 @@ je_realloc(void *ptr, size_t arg_size) {
 	check_entry_exit_locking(tsdn);
 
 	LOG("core.realloc.exit", "result: %p", ret);
-	return (BOUND_PTR(ret, arg_size == 0 ? 0 : size));
+	return (BOUND_PTR(ret, size));
 }
 
 JEMALLOC_NOINLINE

--- a/contrib/libpcap/gencode.c
+++ b/contrib/libpcap/gencode.c
@@ -243,6 +243,26 @@ struct chunk {
 	void *m;
 };
 
+/*
+ * A chunk can store any of:
+ *  - a string (guaranteed alignment 1 but present for completeness)
+ *  - a block
+ *  - an slist
+ *  - an arth
+ * For this simple allocator every allocated chunk gets rounded up to the
+ * alignment needed for any chunk.
+ */
+struct chunk_align {
+	char dummy;
+	union {
+		char c;
+		struct block b;
+		struct slist s;
+		struct arth a;
+	} u;
+};
+#define CHUNK_ALIGN (offsetof(struct chunk_align, u))
+
 /* Code generator state */
 
 struct _compiler_state {
@@ -590,13 +610,8 @@ newchunk_nolongjmp(compiler_state_t *cstate, size_t n)
 	int k;
 	size_t size;
 
-#ifndef __NetBSD__
-	/* XXX Round up to nearest long. */
-	n = (n + sizeof(long) - 1) & ~(sizeof(long) - 1);
-#else
-	/* XXX Round up to structure boundary. */
-	n = ALIGN(n);
-#endif
+	/* Round up to chunk alignment. */
+	n = (n + CHUNK_ALIGN - 1) & ~(CHUNK_ALIGN - 1);
 
 	cp = &cstate->chunks[cstate->cur_chunk];
 	if (n > cp->n_left) {

--- a/lib/libc/cheri/Makefile.inc
+++ b/lib/libc/cheri/Makefile.inc
@@ -5,5 +5,6 @@
 .PATH:	${LIBC_SRCTOP}/cheri
 
 SRCS+=strfcap.c
+MAN+=strfcap.3
 
 SYM_MAPS+=${LIBC_SRCTOP}/cheri/Symbol.map

--- a/lib/libc/cheri/strfcap.3
+++ b/lib/libc/cheri/strfcap.3
@@ -36,7 +36,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 8, 2021
+.Dd February 17, 2023
 .Dt STRFCAP 3
 .Os
 .Sh NAME
@@ -189,7 +189,7 @@ the following flags may be used:
 When formatting in hexadecimal,
 .Ql 0x
 (or
-.Ql OX
+.Ql 0X
 for
 .Cm X
 conversions)

--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -45,6 +45,12 @@
     (void * __capability)curthread->td_pcb->pcb_rddc_el0)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
+/* Does the current thread add the base in CToPtr */
+#define __USER_DDC_OFFSET_ENABLED	\
+    (READ_SPECIALREG(cctlr_el0) & CCTLR_DDCBO_MASK)
+#define __USER_PCC_OFFSET_ENABLED	\
+    (READ_SPECIALREG(cctlr_el0) & CCTLR_PCCBO_MASK)
+
 /*
  * Special marker NOPs for the Morello FVP to start / stop region of interest
  * in trace.

--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -40,7 +40,9 @@
 #endif
 
 #ifdef _KERNEL
-#define	__USER_DDC	((void * __capability)curthread->td_frame->tf_ddc)
+#define	__USER_DDC ((cheri_getperm(__USER_PCC) & CHERI_PERM_EXECUTIVE) ? \
+    (void * __capability)curthread->td_frame->tf_ddc :			\
+    (void * __capability)curthread->td_pcb->pcb_rddc_el0)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
 /*

--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -42,7 +42,7 @@
 #ifdef _KERNEL
 #define	__USER_DDC ((cheri_getperm(__USER_PCC) & CHERI_PERM_EXECUTIVE) ? \
     (void * __capability)curthread->td_frame->tf_ddc :			\
-    (void * __capability)curthread->td_pcb->pcb_rddc_el0)
+    (void * __capability)READ_SPECIALREG_CAP(rddc_el0))
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
 /* Does the current thread add the base in CToPtr */

--- a/sys/riscv/include/cheri.h
+++ b/sys/riscv/include/cheri.h
@@ -38,6 +38,10 @@
 #define	__USER_DDC	((void * __capability)curthread->td_frame->tf_ddc)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_sepc)
 
+/* RISC-V always adds the base in CToPtr */
+#define	__USER_DDC_OFFSET_ENABLED	1
+#define	__USER_PCC_OFFSET_ENABLED	1
+
 /*
  * CHERI-RISC-V-specific kernel utility functions.
  */

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -126,7 +126,7 @@ struct ucred;
     ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
-	__builtin_cheri_address_set(NULL, (ptraddr_t)(ptr)) :		\
+	(void * __capability)(uintcap_t)(ptraddr_t)(ptr) :		\
 	(is_offset) ?							\
 	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)) :		\
 	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -122,18 +122,20 @@ struct ucred;
  * Derive out-of-bounds and small values from NULL.  This allows common
  * sentinel values to work.
  */
-#define ___USER_CFROMPTR(ptr, cap)					\
+#define ___USER_CFROMPTR(ptr, cap, is_offset)				\
     ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
-	__builtin_cheri_offset_set(NULL, (ptraddr_t)(ptr)) :		\
-	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)))
+	__builtin_cheri_address_set(NULL, (ptraddr_t)(ptr)) :		\
+	(is_offset) ?							\
+	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)) :		\
+	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))
 
 #define	__USER_CAP_UNBOUND(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_DDC)
+	___USER_CFROMPTR((ptr), __USER_DDC, __USER_DDC_OFFSET_ENABLED)
 
 #define	__USER_CODE_CAP(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_PCC)
+	___USER_CFROMPTR((ptr), __USER_PCC, __USER_PCC_OFFSET_ENABLED)
 
 #define	__USER_CAP(ptr, len)						\
 ({									\


### PR DESCRIPTION
Backport a number of minor fixes (nothing here warrants a point release):
 - Fix __USER_CAP creation from processes in restricted mode (not available by default) and construct capabilities according to the processes DCC offsetting mode.
 - Fix a bug in the strfcap manpage and actually install it
 - Fix builds on macOS Ventura (https://github.com/CTSRD-CHERI/cheribuild/issues/339)
 - Correct an issue with malloc where we returned zero-length capabilities for zero sized requests which could lead to a use-after-free in fairly contrived cases.
 - Correct an alignment issue in libpcap causing issues with wpa_supplicant. Fixes #1637