### PR TITLE
Fix ipcs and ipcrm

### DIFF
--- a/sys/kern/sysv_msg.c
+++ b/sys/kern/sysv_msg.c
@@ -633,10 +633,6 @@ kern_msgctl(struct thread *td, int msqid, int cmd, struct msqid_ds *msqbuf)
 		*msqbuf = msqkptr->u;
 		if (td->td_ucred->cr_prison != msqkptr->cred->cr_prison)
 			msqbuf->msg_perm.key = IPC_PRIVATE;
-
-		KASSERT(msqbuf->__msg_first == NULL &&
-		    msqbuf->__msg_last == NULL,
-		    ("Nothing should set __msg_first or __msg_last"));
 		break;
 
 	default:
@@ -1715,8 +1711,7 @@ freebsd7_freebsd32_msgctl(struct thread *td,
 		if (error)
 			return (error);
 		freebsd32_ipcperm_old_in(&msqbuf32.msg_perm, &msqbuf.msg_perm);
-		PTRIN_CP(msqbuf32, msqbuf, __msg_first);
-		PTRIN_CP(msqbuf32, msqbuf, __msg_last);
+		bzero(&msqbuf, sizeof(msqbuf));
 		CP(msqbuf32, msqbuf, msg_cbytes);
 		CP(msqbuf32, msqbuf, msg_qnum);
 		CP(msqbuf32, msqbuf, msg_qbytes);
@@ -1732,8 +1727,7 @@ freebsd7_freebsd32_msgctl(struct thread *td,
 	if (uap->cmd == IPC_STAT) {
 		bzero(&msqbuf32, sizeof(msqbuf32));
 		freebsd32_ipcperm_old_out(&msqbuf.msg_perm, &msqbuf32.msg_perm);
-		PTROUT_CP(msqbuf, msqbuf32, __msg_first);
-		PTROUT_CP(msqbuf, msqbuf32, __msg_last);
+		/* Don't copy unused __msg_* */
 		CP(msqbuf, msqbuf32, msg_cbytes);
 		CP(msqbuf, msqbuf32, msg_qnum);
 		CP(msqbuf, msqbuf32, msg_qbytes);
@@ -1760,8 +1754,7 @@ freebsd32_msgctl(struct thread *td, struct freebsd32_msgctl_args *uap)
 		if (error)
 			return (error);
 		freebsd32_ipcperm_in(&msqbuf32.msg_perm, &msqbuf.msg_perm);
-		PTRIN_CP(msqbuf32, msqbuf, __msg_first);
-		PTRIN_CP(msqbuf32, msqbuf, __msg_last);
+		bzero(&msqbuf, sizeof(msqbuf));
 		CP(msqbuf32, msqbuf, msg_cbytes);
 		CP(msqbuf32, msqbuf, msg_qnum);
 		CP(msqbuf32, msqbuf, msg_qbytes);
@@ -1775,9 +1768,9 @@ freebsd32_msgctl(struct thread *td, struct freebsd32_msgctl_args *uap)
 	if (error)
 		return (error);
 	if (uap->cmd == IPC_STAT) {
+		bzero(&msqbuf32, sizeof(msqbuf32));
 		freebsd32_ipcperm_out(&msqbuf.msg_perm, &msqbuf32.msg_perm);
-		PTROUT_CP(msqbuf, msqbuf32, __msg_first);
-		PTROUT_CP(msqbuf, msqbuf32, __msg_last);
+		/* Don't copy unused __msg_* */
 		CP(msqbuf, msqbuf32, msg_cbytes);
 		CP(msqbuf, msqbuf32, msg_qnum);
 		CP(msqbuf, msqbuf32, msg_qbytes);
@@ -1866,8 +1859,7 @@ freebsd7_freebsd64_msgctl(struct thread *td,
 		if (error)
 			return (error);
 		ipcperm_old2new(&msqbuf64.msg_perm, &msqbuf.msg_perm);
-		msqbuf.__msg_first = NULL;	/* Unused */
-		msqbuf.__msg_last = NULL;	/* Unused */
+		bzero(&msqbuf, sizeof(msqbuf));
 		CP(msqbuf64, msqbuf, msg_cbytes);
 		CP(msqbuf64, msqbuf, msg_qnum);
 		CP(msqbuf64, msqbuf, msg_qbytes);
@@ -1912,8 +1904,7 @@ freebsd64_msgctl(struct thread *td, struct freebsd64_msgctl_args *uap)
 		if (error)
 			return (error);
 		CP(msqbuf64, msqbuf, msg_perm);
-		msqbuf.__msg_first = NULL;	/* Unused */
-		msqbuf.__msg_last = NULL;	/* Unused */
+		bzero(&msqbuf, sizeof(msqbuf));
 		CP(msqbuf64, msqbuf, msg_cbytes);
 		CP(msqbuf64, msqbuf, msg_qnum);
 		CP(msqbuf64, msqbuf, msg_qbytes);
@@ -2032,8 +2023,7 @@ freebsd7_msgctl(struct thread *td, struct freebsd7_msgctl_args *uap)
 		if (error)
 			return (error);
 		ipcperm_old2new(&msqold.msg_perm, &msqbuf.msg_perm);
-		CP(msqold, msqbuf, __msg_first);
-		CP(msqold, msqbuf, __msg_last);
+		bzero(&msqbuf, sizeof(msqbuf));
 		CP(msqold, msqbuf, msg_cbytes);
 		CP(msqold, msqbuf, msg_qnum);
 		CP(msqold, msqbuf, msg_qbytes);
@@ -2049,8 +2039,7 @@ freebsd7_msgctl(struct thread *td, struct freebsd7_msgctl_args *uap)
 	if (uap->cmd == IPC_STAT) {
 		bzero(&msqold, sizeof(msqold));
 		ipcperm_new2old(&msqbuf.msg_perm, &msqold.msg_perm);
-		CP(msqbuf, msqold, __msg_first);
-		CP(msqbuf, msqold, __msg_last);
+		/* Don't copy unused __msg_* */
 		CP(msqbuf, msqold, msg_cbytes);
 		CP(msqbuf, msqold, msg_qnum);
 		CP(msqbuf, msqold, msg_qbytes);

--- a/sys/kern/sysv_sem.c
+++ b/sys/kern/sysv_sem.c
@@ -1553,6 +1553,7 @@ sysctl_sema(SYSCTL_HANDLER_ARGS)
 {
 	struct prison *pr, *rpr;
 	struct semid_kernel tsemak;
+	struct semid_kernel_sysctl tsemak_u;
 #ifdef COMPAT_FREEBSD32
 	struct semid_kernel32 tsemak32;
 #endif
@@ -1595,7 +1596,7 @@ sysctl_sema(SYSCTL_HANDLER_ARGS)
 		if (!SV_CURPROC_FLAG(SV_CHERI)) {
 			bzero(&tsemak64, sizeof(tsemak64));
 			CP(tsemak, tsemak64, u.sem_perm);
-			/* Don't copy u.sem_base */
+			/* Don't copy u.__sem_base */
 			CP(tsemak, tsemak64, u.sem_nsems);
 			CP(tsemak, tsemak64, u.sem_otime);
 			CP(tsemak, tsemak64, u.sem_ctime);
@@ -1605,11 +1606,15 @@ sysctl_sema(SYSCTL_HANDLER_ARGS)
 		} else
 #endif
 		{
-			tsemak.u.__sem_base = NULL;
-			tsemak.label = NULL;
-			tsemak.cred = NULL;
-			outaddr = &tsemak;
-			outsize = sizeof(tsemak);
+			bzero(&tsemak_u, sizeof(tsemak_u));
+			CP(tsemak, tsemak_u, u.sem_perm);
+			/* Don't copy u.__sem_base */
+			CP(tsemak, tsemak_u, u.sem_nsems);
+			CP(tsemak, tsemak_u, u.sem_otime);
+			CP(tsemak, tsemak_u, u.sem_ctime);
+			/* Don't copy label or cred */
+			outaddr = &tsemak_u;
+			outsize = sizeof(tsemak_u);
 		}
 		error = SYSCTL_OUT(req, outaddr, outsize);
 		if (error != 0)

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -1222,16 +1222,11 @@ shmunload(void)
 	return (0);
 }
 
-struct shmid_kernel_user {
-	struct shmid_ds u;
-	void * __capability kernel_bits[3];	/* Keep these NULL */
-};
-
 static int
 sysctl_shmsegs(SYSCTL_HANDLER_ARGS)
 {
 	struct shmid_kernel tshmseg;
-	struct shmid_kernel_user tshmseg_u;
+	struct shmid_kernel_sysctl tshmseg_u;
 #ifdef COMPAT_FREEBSD32
 	struct shmid_kernel32 tshmseg32;
 #endif

--- a/sys/sys/msg.h
+++ b/sys/sys/msg.h
@@ -67,8 +67,8 @@ typedef	__time_t	time_t;
     defined(COMPAT_FREEBSD6) || defined(COMPAT_FREEBSD7)
 struct msqid_ds_old {
 	struct	ipc_perm_old msg_perm;	/* msg queue permission bits */
-	struct	msg *__msg_first;	/* first message in the queue */
-	struct	msg *__msg_last;	/* last message in the queue */
+	struct	msg *__msg_first;	/* unused */
+	struct	msg *__msg_last;	/* unused */
 	msglen_t msg_cbytes;	/* number of bytes in use on the queue */
 	msgqnum_t msg_qnum;	/* number of msgs in the queue */
 	msglen_t msg_qbytes;	/* max # of bytes on the queue */
@@ -92,8 +92,8 @@ struct msqid_ds_old {
 
 struct msqid_ds {
 	struct	ipc_perm msg_perm;	/* msg queue permission bits */
-	void * __kerncap __msg_first;	/* unused */
-	void * __kerncap __msg_last;	/* unused */
+	void * __kerncap __msg_first __attribute__((deprecated));
+	void * __kerncap __msg_last __attribute__((deprecated));
 	msglen_t msg_cbytes;	/* number of bytes in use on the queue */
 	msgqnum_t msg_qnum;	/* number of msgs in the queue */
 	msglen_t msg_qbytes;	/* max # of bytes on the queue */

--- a/sys/sys/msg.h
+++ b/sys/sys/msg.h
@@ -29,6 +29,9 @@
 #define	_WANT_SYSVIPC_INTERNALS
 #endif
 #include <sys/ipc.h>
+#if defined(_KERNEL) || defined(_WANT_SYSVMSG_INTERNALS)
+#include <sys/queue.h>
+#endif
 
 /*
  * The MSG_NOERROR identifier value, the msqid_ds struct and the msg struct
@@ -103,7 +106,7 @@ struct msqid_ds {
 
 #ifdef _KERNEL
 struct msg {
-	struct	msg *msg_next;  /* next msg in the chain */
+	TAILQ_ENTRY(msg) msg_queue;
 	long	msg_type; 	/* type of this message */
 				/* >0 -> type of this message */
 				/* 0 -> free header */
@@ -146,8 +149,7 @@ struct msqid_kernel_kvm {
 	struct	msqid_ds u;
 	struct	label *label;	/* MAC label */
 	struct	ucred *cred;	/* creator's credentials */
-	struct	msg *first_msg;
-	struct	msg *last_msg;
+	TAILQ_HEAD(, msg) queue;
 };
 
 /*

--- a/sys/sys/msg.h
+++ b/sys/sys/msg.h
@@ -134,19 +134,36 @@ struct msginfo {
 };
 
 /*
- * Kernel wrapper for the user-level structure.
+ * Kernel wrapper for struct msqid_ds.  This is used internally and exposed
+ * via kvm(3).  If this changes, consumers such as usr.bin/ipcs/ipc.c must
+ * be updated.  This struct ABI is unstable.
  */
+#ifdef _KERNEL
 struct msqid_kernel {
-	/*
-	 * Data structure exposed to user space.
-	 */
+#else
+struct msqid_kernel_kvm {
+#endif
 	struct	msqid_ds u;
-
-	/*
-	 * Kernel-private components of the message queue.
-	 */
 	struct	label *label;	/* MAC label */
 	struct	ucred *cred;	/* creator's credentials */
+};
+
+/*
+ * This is the public interface to msqid_ds via the kern.ipc.msqids sysctl.
+ * This struct ABI is stable.
+ *
+ * HISTORY: when kern.ipc.msqids was created, it exposed the internal
+ * kernel struct to match the existing kvm interface.  This defeated the
+ * purpose of having a kernel wrapper so they are now decoupled.
+ */
+#ifdef _KERNEL
+struct msqid_kernel_sysctl {
+#else
+struct msqid_kernel {
+#endif
+	struct  msqid_ds u;
+	void * __kerncap label;	/* Always NULL */
+	void * __kerncap cred;	/* Always NULL */
 };
 #endif
 

--- a/sys/sys/msg.h
+++ b/sys/sys/msg.h
@@ -89,8 +89,8 @@ struct msqid_ds_old {
 
 struct msqid_ds {
 	struct	ipc_perm msg_perm;	/* msg queue permission bits */
-	struct	msg *__msg_first;	/* first message in the queue */
-	struct	msg *__msg_last;	/* last message in the queue */
+	void * __kerncap __msg_first;	/* unused */
+	void * __kerncap __msg_last;	/* unused */
 	msglen_t msg_cbytes;	/* number of bytes in use on the queue */
 	msgqnum_t msg_qnum;	/* number of msgs in the queue */
 	msglen_t msg_qbytes;	/* max # of bytes on the queue */
@@ -146,6 +146,8 @@ struct msqid_kernel_kvm {
 	struct	msqid_ds u;
 	struct	label *label;	/* MAC label */
 	struct	ucred *cred;	/* creator's credentials */
+	struct	msg *first_msg;
+	struct	msg *last_msg;
 };
 
 /*

--- a/sys/sys/sem.h
+++ b/sys/sys/sem.h
@@ -122,12 +122,39 @@ struct seminfo {
 };
 
 /*
- * Kernel wrapper for the user-level structure
+ * Kernel wrapper for struct semid_ds.  This is used internally and exposed
+ * via kvm(3).  If this changes, consumers such as usr.bin/ipcs/ipc.c must
+ * be updated.
+ *
+ * This struct ABI is unstable.
  */
+#ifdef _KERNEL
 struct semid_kernel {
+#else
+struct semid_kernel_kvm {
+#endif
 	struct	semid_ds u;
 	struct	label *label;	/* MAC framework label */
 	struct	ucred *cred;	/* creator's credentials */
+};
+
+/*
+ * This is the public interface to semid_ds via the kern.ipc.sema sysctl.
+ *
+ * This struct ABI is stable.
+ *
+ * HISTORY: when kern.ipc.sema was created, it exposed the internal
+ * kernel struct to match the existing kvm interface.  This defeated the
+ * purpose of having a kernel wrapper so they are now decoupled.
+ */
+#ifdef _KERNEL
+struct semid_kernel_sysctl {
+#else
+struct semid_kernel {
+#endif
+	struct semid_ds u;
+	void * __kerncap label;	/* Always NULL */
+	void * __kerncap cred;	/* Always NULL */
 };
 
 /* internal "mode" bits */

--- a/usr.bin/ipcs/ipc.c
+++ b/usr.bin/ipcs/ipc.c
@@ -58,6 +58,17 @@ struct msqid_kernel	*msqids;
 struct shminfo		shminfo;
 struct shmid_kernel	*shmsegs;
 
+/*
+ * If any of these asserts fail, the kget code will need to be updated
+ * to translate from the _kernel_kvm version to _kernel.
+ */
+_Static_assert(sizeof(struct semid_kernel) == sizeof(struct semid_kernel_kvm),
+    "In-kernel struct semid_kernel ABI has changed");
+_Static_assert(sizeof(struct msqid_kernel) == sizeof(struct msqid_kernel_kvm),
+    "In-kernel struct msqid_kernel ABI has changed");
+_Static_assert(sizeof(struct shmid_kernel) == sizeof(struct shmid_kernel_kvm),
+    "In-kernel struct shmid_kernel ABI has changed");
+
 struct nlist symbols[] = {
 	{ .n_name = "sema" },
 	{ .n_name = "seminfo" },

--- a/usr.bin/ipcs/ipc.c
+++ b/usr.bin/ipcs/ipc.c
@@ -47,6 +47,8 @@ __FBSDID("$FreeBSD$");
 #include <kvm.h>
 #include <nlist.h>
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "ipc.h"
 
@@ -64,8 +66,6 @@ struct shmid_kernel	*shmsegs;
  */
 _Static_assert(sizeof(struct semid_kernel) == sizeof(struct semid_kernel_kvm),
     "In-kernel struct semid_kernel ABI has changed");
-_Static_assert(sizeof(struct msqid_kernel) == sizeof(struct msqid_kernel_kvm),
-    "In-kernel struct msqid_kernel ABI has changed");
 _Static_assert(sizeof(struct shmid_kernel) == sizeof(struct shmid_kernel_kvm),
     "In-kernel struct shmid_kernel ABI has changed");
 
@@ -141,8 +141,10 @@ kget(int idx, void *addr, size_t size)
 {
 	const char *symn;		/* symbol name */
 	size_t tsiz;
-	int rv;
+	int rv, nentries;
 	unsigned long kaddr;
+	struct msqid_kernel *msqids_kernel;
+	struct msqid_kernel_kvm *msqids_kernel_kvm;
 	const char *sym2sysctl[] = {	/* symbol to sysctl name table */
 		"kern.ipc.sema",
 		"kern.ipc.seminfo",
@@ -169,6 +171,13 @@ kget(int idx, void *addr, size_t size)
 			rv = kvm_read(kd, symbols[idx].n_value,
 			    &msqids, tsiz);
 			kaddr = (u_long)msqids;
+
+			memset(addr, 0, size);
+			nentries = size / sizeof(struct msqid_kernel);
+			msqids_kernel = addr;
+			size = nentries * sizeof(struct msqid_kernel_kvm);
+			if ((addr = malloc(size)) == NULL)
+				err(1, "malloc");
 			break;
 		case X_SHMSEGS:
 			tsiz = sizeof(shmsegs);
@@ -191,6 +200,20 @@ kget(int idx, void *addr, size_t size)
 			errx(1, "%s: %s", symn, kvm_geterr(kd));
 		if ((unsigned)kvm_read(kd, kaddr, addr, size) != size)
 			errx(1, "%s: %s", symn, kvm_geterr(kd));
+
+		switch (idx) {
+		case X_MSQIDS:
+			msqids_kernel_kvm = addr;
+			for (int i = 0; i < nentries; i++) {
+				/*
+				 * struct msqid_ds is the same in both.
+				 * Other members were zeroed with the
+				 * memset above.
+				 */
+				msqids_kernel[i].u = msqids_kernel_kvm[i].u;
+			}
+			free(msqids_kernel_kvm);
+		}
 	} else {
 		switch (idx) {
 		case X_SHMINFO:


### PR DESCRIPTION
Correct ABi mismatches between the hybrid kernel and purecap binaries in the SysV semaphore and message queue ABIs by adopting the previously applied fix to sysvshm. While doing so, improve the declarations to the structs in the ABI so all the right things are visible in kernel and userspace. 