### PR TITLE
iwlwifi

### DIFF
--- a/sys/compat/linuxkpi/common/include/linux/mm.h
+++ b/sys/compat/linuxkpi/common/include/linux/mm.h
@@ -252,17 +252,17 @@ get_page(struct vm_page *page)
 }
 
 extern long
-get_user_pages(unsigned long start, unsigned long nr_pages,
+get_user_pages(void * __capability start, unsigned long nr_pages,
     int gup_flags, struct page **,
     struct vm_area_struct **);
 
 extern int
-__get_user_pages_fast(unsigned long start, int nr_pages, int write,
+__get_user_pages_fast(void * __capability start, int nr_pages, int write,
     struct page **);
 
 extern long
 get_user_pages_remote(struct task_struct *, struct mm_struct *,
-    unsigned long start, unsigned long nr_pages,
+    void * __capability start, unsigned long nr_pages,
     int gup_flags, struct page **,
     struct vm_area_struct **);
 

--- a/sys/compat/linuxkpi/common/include/linux/xarray.h
+++ b/sys/compat/linuxkpi/common/include/linux/xarray.h
@@ -100,9 +100,9 @@ xa_init(struct xarray *xa)
 }
 
 static inline void *
-xa_mk_value(unsigned long v)
+xa_mk_value(uintptr_t v)
 {
-	unsigned long r = (v << 1) | 1;
+	uintptr_t r = (v << 1) | 1;
 
 	return ((void *)r);
 }
@@ -110,15 +110,15 @@ xa_mk_value(unsigned long v)
 static inline bool
 xa_is_value(const void *e)
 {
-	unsigned long v = (unsigned long)e;
+	uintptr_t v = (uintptr_t)e;
 
 	return (v & 1);
 }
 
-static inline unsigned long
+static inline uintptr_t
 xa_to_value(const void *e)
 {
-	unsigned long v = (unsigned long)e;
+	uintptr_t v = (uintptr_t)e;
 
 	return (v >> 1);
 }

--- a/sys/compat/linuxkpi/common/include/net/mac80211.h
+++ b/sys/compat/linuxkpi/common/include/net/mac80211.h
@@ -744,7 +744,7 @@ struct ieee80211_tx_info {
 			uint8_t				antenna;
 			uint16_t			tx_time;
 			bool				is_valid_ack_signal;
-			void				*status_driver_data[16 / sizeof(void *)];		/* XXX TODO */
+			void				*status_driver_data[2];		/* XXX TODO */
 		} status;
 #define	IEEE80211_TX_INFO_DRIVER_DATA_SIZE	(5 * sizeof(void *))			/* XXX TODO 5? */
 		void					*driver_data[IEEE80211_TX_INFO_DRIVER_DATA_SIZE / sizeof(void *)];

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -1768,7 +1768,7 @@ linux_file_mmap_sub(struct thread *td, vm_size_t objsize, vm_prot_t prot,
 }
 
 static int
-linux_file_mmap(struct file *fp, vm_map_t map, vm_offset_t *addr,
+linux_file_mmap(struct file *fp, vm_map_t map, vm_pointer_t *addr,
     vm_offset_t max_addr, vm_size_t size, vm_prot_t prot,
     vm_prot_t cap_maxprot, int flags, vm_ooffset_t foff, struct thread *td)
 {
@@ -1993,7 +1993,7 @@ iounmap(void *addr)
 void *
 vmap(struct page **pages, unsigned int count, unsigned long flags, int prot)
 {
-	vm_offset_t off;
+	vm_pointer_t off;
 	size_t size;
 
 	size = count * PAGE_SIZE;
@@ -2014,8 +2014,8 @@ vunmap(void *addr)
 	vmmap = vmmap_remove(addr);
 	if (vmmap == NULL)
 		return;
-	pmap_qremove((vm_offset_t)addr, vmmap->vm_size / PAGE_SIZE);
-	kva_free((vm_offset_t)addr, vmmap->vm_size);
+	pmap_qremove((vm_pointer_t)addr, vmmap->vm_size / PAGE_SIZE);
+	kva_free((vm_pointer_t)addr, vmmap->vm_size);
 	kfree(vmmap);
 }
 
@@ -2822,7 +2822,9 @@ SYSUNINIT(linux_compat, SI_SUB_DRIVERS, SI_ORDER_SECOND, linux_compat_uninit, NU
  * used. Assert these types have the same size, else some parts of the
  * LinuxKPI may not work like expected:
  */
+#if !__has_feature(capabilities)
 CTASSERT(sizeof(unsigned long) == sizeof(uintptr_t));
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20221129,

--- a/sys/compat/linuxkpi/common/src/linux_page.c
+++ b/sys/compat/linuxkpi/common/src/linux_page.c
@@ -190,8 +190,8 @@ linux_free_kmem(vm_pointer_t addr, unsigned int order)
 }
 
 static int
-linux_get_user_pages_internal(vm_map_t map, unsigned long start, int nr_pages,
-    int write, struct page **pages)
+linux_get_user_pages_internal(vm_map_t map, void * __capability start,
+    int nr_pages, int write, struct page **pages)
 {
 	vm_prot_t prot;
 	size_t len;
@@ -199,30 +199,38 @@ linux_get_user_pages_internal(vm_map_t map, unsigned long start, int nr_pages,
 
 	prot = write ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
 	len = ptoa((vm_offset_t)nr_pages);
-	count = vm_fault_quick_hold_pages(map, (void *)(uintptr_t)start, len, prot, pages, nr_pages);
+	count = vm_fault_quick_hold_pages(map, start, len, prot, pages, nr_pages);
 	return (count == -1 ? -EFAULT : nr_pages);
 }
 
 int
-__get_user_pages_fast(unsigned long start, int nr_pages, int write,
+__get_user_pages_fast(void * __capability addr, int nr_pages, int write,
     struct page **pages)
 {
 	vm_map_t map;
 	vm_page_t *mp;
+	vm_offset_t start;
 	vm_offset_t va;
 	vm_offset_t end;
+	vm_size_t len;
 	vm_prot_t prot;
 	int count;
 
 	if (nr_pages == 0 || in_interrupt())
 		return (0);
 
+	prot = write ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
+	len = ptoa((vm_offset_t)nr_pages);
+#if __has_feature(capabilities)
+	if (!__CAP_CHECK(addr, len) || !vm_cap_allows_prot(addr, prot))
+		return (-1);
+#endif
 	MPASS(pages != NULL);
 	map = &curthread->td_proc->p_vmspace->vm_map;
-	end = start + ptoa((vm_offset_t)nr_pages);
+	start = (__cheri_addr vm_offset_t)addr;
+	end = start + len;
 	if (!vm_map_range_valid(map, start, end))
 		return (-EINVAL);
-	prot = write ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
 	for (count = 0, mp = pages, va = start; va < end;
 	    mp++, va += PAGE_SIZE, count++) {
 		*mp = pmap_extract_and_hold(map->pmap, va, prot);
@@ -248,7 +256,7 @@ __get_user_pages_fast(unsigned long start, int nr_pages, int write,
 
 long
 get_user_pages_remote(struct task_struct *task, struct mm_struct *mm,
-    unsigned long start, unsigned long nr_pages, int gup_flags,
+    void * __capability start, unsigned long nr_pages, int gup_flags,
     struct page **pages, struct vm_area_struct **vmas)
 {
 	vm_map_t map;
@@ -259,7 +267,7 @@ get_user_pages_remote(struct task_struct *task, struct mm_struct *mm,
 }
 
 long
-get_user_pages(unsigned long start, unsigned long nr_pages, int gup_flags,
+get_user_pages(void * __capability start, unsigned long nr_pages, int gup_flags,
     struct page **pages, struct vm_area_struct **vmas)
 {
 	vm_map_t map;

--- a/sys/compat/linuxkpi/common/src/linux_skbuff.c
+++ b/sys/compat/linuxkpi/common/src/linux_skbuff.c
@@ -283,7 +283,7 @@ DB_SHOW_COMMAND(skb, db_show_skb)
 			return;
 	}
 
-	skb = (struct sk_buff *)addr;
+	skb = DB_DATA_PTR(addr, struct sk_buff);
 
 	db_printf("skb %p\n", skb);
 	db_printf("\tnext %p prev %p\n", skb->next, skb->prev);

--- a/sys/contrib/dev/iwlwifi/fw/error-dump.h
+++ b/sys/contrib/dev/iwlwifi/fw/error-dump.h
@@ -259,7 +259,7 @@ struct iwl_fw_ini_dump_entry {
 	struct list_head list;
 	u32 size;
 	u8 data[];
-} __packed;
+};
 
 /**
  * struct iwl_fw_error_dump_file - header of dump file

--- a/sys/contrib/dev/iwlwifi/iwl-trans.h
+++ b/sys/contrib/dev/iwlwifi/iwl-trans.h
@@ -252,7 +252,7 @@ struct iwl_rx_cmd_buffer {
 
 static inline void *rxb_addr(struct iwl_rx_cmd_buffer *r)
 {
-	return (void *)((unsigned long)page_address(r->_page) + r->_offset);
+	return (char *)page_address(r->_page) + r->_offset;
 }
 
 static inline int rxb_offset(struct iwl_rx_cmd_buffer *r)

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -213,8 +213,8 @@ SUBDIR=	\
 	libiconv \
 	libmchain \
 	lindebugfs \
-	${_linuxkpi} \
-	${_linuxkpi_wlan} \
+	linuxkpi \
+	linuxkpi_wlan \
 	${_lio} \
 	lpt \
 	${_mac_biba} \
@@ -529,11 +529,9 @@ _ipoib=		ipoib
 _iser=		iser
 .endif
 _ipmi=		ipmi
-.if !${MACHINE_CPU:Mcheri}
 _iwlwifi=	iwlwifi
 .if ${MK_SOURCELESS_UCODE} != "no"
 _iwlwififw=	iwlwififw
-.endif
 .endif
 _mlx4=		mlx4
 _mlx5=		mlx5
@@ -866,11 +864,6 @@ _bcm283x_pwm=  bcm283x_pwm
 # LLVM 10 crashes when building if_malo_pci.c, fixed in LLVM11:
 # https://bugs.llvm.org/show_bug.cgi?id=44351
 _malo=	malo
-.endif
-
-.if !${MACHINE_CPU:Mcheri}
-_linuxkpi=	linuxkpi
-_linuxkpi_wlan=	linuxkpi_wlan
 .endif
 
 # Some of these work in hybrid kernels but we disable them for consistency


### PR DESCRIPTION
The hybrid kernel panics for me when trying to use a PCI-express wifi adapter in a Morello box, but it's probably good to keep compile coverage over these bits.

```
panic: lkpi_sta_auth_to_scan: lsta 0xffffa000067e7800 state not NONE: 0, nstate 1 arg 1
...
panic() at panic+0x60
lkpi_sta_auth_to_scan() at lkpi_sta_auth_to_scan+0x294
lkpi_iv_newstate() at lkpi_iv_newstate+0x1b8
ieee80211_newstate_cb() at ieee80211_newstate_cb+0x140
taskqueue_run_locked() at taskqueue_run_locked+0x17c
taskqueue_thread_loop() at taskqueue_thread_loop+0xc8
fork_exit() at fork_exit+0x74
fork_trampoline() at fork_trampoline+0x10
```

In the purecap kernel the driver panics when being kldloaded due to dpcpu nonsense.