### PR TITLE
arm: Always use the virtual timer in userland.

### DIFF
--- a/sys/arm/arm/generic_timer.c
+++ b/sys/arm/arm/generic_timer.c
@@ -112,7 +112,8 @@ struct arm_tmr_softc {
 	uint32_t		clkfreq;
 	int			irq_count;
 	struct eventtimer	et;
-	bool			physical;
+	bool			kern_physical;
+	bool			user_physical;
 };
 
 static struct arm_tmr_softc *arm_tmr_sc = NULL;
@@ -273,7 +274,7 @@ setup_user_access(void *arg __unused)
 	/* Always enable the virtual timer */
 	cntkctl |= GT_CNTKCTL_PL0VCTEN;
 	/* Enable the physical timer if supported */
-	if (arm_tmr_sc->physical) {
+	if (arm_tmr_sc->user_physical) {
 		cntkctl |= GT_CNTKCTL_PL0PCTEN;
 	}
 	set_el1(cntkctl, cntkctl);
@@ -335,7 +336,7 @@ static unsigned
 arm_tmr_get_timecount(struct timecounter *tc)
 {
 
-	return (arm_tmr_sc->get_cntxct(arm_tmr_sc->physical));
+	return (arm_tmr_sc->get_cntxct(arm_tmr_sc->user_physical));
 }
 
 static int
@@ -349,11 +350,11 @@ arm_tmr_start(struct eventtimer *et, sbintime_t first,
 
 	if (first != 0) {
 		counts = ((uint32_t)et->et_frequency * first) >> 32;
-		ctrl = get_ctrl(sc->physical);
+		ctrl = get_ctrl(sc->kern_physical);
 		ctrl &= ~GT_CTRL_INT_MASK;
 		ctrl |= GT_CTRL_ENABLE;
-		set_tval(counts, sc->physical);
-		set_ctrl(ctrl, sc->physical);
+		set_tval(counts, sc->kern_physical);
+		set_ctrl(ctrl, sc->kern_physical);
 		return (0);
 	}
 
@@ -377,7 +378,7 @@ arm_tmr_stop(struct eventtimer *et)
 	struct arm_tmr_softc *sc;
 
 	sc = (struct arm_tmr_softc *)et->et_priv;
-	arm_tmr_disable(sc->physical);
+	arm_tmr_disable(sc->kern_physical);
 
 	return (0);
 }
@@ -389,10 +390,10 @@ arm_tmr_intr(void *arg)
 	int ctrl;
 
 	sc = (struct arm_tmr_softc *)arg;
-	ctrl = get_ctrl(sc->physical);
+	ctrl = get_ctrl(sc->kern_physical);
 	if (ctrl & GT_CTRL_INT_STAT) {
 		ctrl |= GT_CTRL_INT_MASK;
-		set_ctrl(ctrl, sc->physical);
+		set_ctrl(ctrl, sc->kern_physical);
 	}
 
 	if (sc->et.et_active)
@@ -674,6 +675,9 @@ arm_tmr_attach(device_t dev)
 	}
 #endif
 
+	/* Use the virtual timer for userland (and eventcounter). */
+	sc->user_physical = false;
+
 #ifdef __aarch64__
 	/*
 	 * Use the virtual timer when we can't use the hypervisor.
@@ -682,14 +686,14 @@ arm_tmr_attach(device_t dev)
 	 * coordinated with the virtual machine manager.
 	 */
 	if (!HAS_PHYS) {
-		sc->physical = false;
+		sc->kern_physical = false;
 		first_timer = GT_VIRT;
 		last_timer = GT_VIRT;
 	} else
 #endif
 	/* Otherwise set up the secure and non-secure physical timers. */
 	{
-		sc->physical = true;
+		sc->kern_physical = true;
 		first_timer = GT_PHYS_SECURE;
 		last_timer = GT_PHYS_NONSECURE;
 	}
@@ -792,10 +796,10 @@ arm_tmr_do_delay(int usec, void *arg)
 	else
 		counts = usec * counts_per_usec;
 
-	first = sc->get_cntxct(sc->physical);
+	first = sc->get_cntxct(sc->kern_physical);
 
 	while (counts > 0) {
-		last = sc->get_cntxct(sc->physical);
+		last = sc->get_cntxct(sc->kern_physical);
 		counts -= (int32_t)(last - first);
 		first = last;
 	}
@@ -832,7 +836,7 @@ arm_tmr_fill_vdso_timehands(struct vdso_timehands *vdso_th,
 {
 
 	vdso_th->th_algo = VDSO_TH_ALGO_ARM_GENTIM;
-	vdso_th->th_physical = arm_tmr_sc->physical;
+	vdso_th->th_physical = arm_tmr_sc->user_physical;
 	bzero(vdso_th->th_res, sizeof(vdso_th->th_res));
 	return (1);
 }


### PR DESCRIPTION
This broke Morello where ASR is required for the physical timer so init was in a crash/restart loop.

Diagnosed by:	jrtc27