### PR TITLE
unwind_frame: reject sealed capabilities

### DIFF
--- a/sys/arm64/arm64/unwind.c
+++ b/sys/arm64/arm64/unwind.c
@@ -41,18 +41,15 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 	fp = frame->fp;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (!cheri_can_access((void *)fp, (ptraddr_t)fp, sizeof(fp) * 2,
+	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP))
+		return (false);
+#endif
+
 	if (!__is_aligned(fp, sizeof(fp)) ||
 	    !kstack_contains(td, fp, sizeof(fp) * 2))
 		return (false);
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	if ((ptraddr_t)fp < cheri_getbase(fp) ||
-	    (ptraddr_t)(fp + sizeof(fp) * 2) > cheri_gettop(fp) ||
-	    cheri_gettag(fp) == 0 ||
-	    (cheri_getperm(fp) & (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)) !=
-	    (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP))
-		return (false);
-#endif
 
 	/* FP to previous frame (X29) */
 	frame->fp = ((uintptr_t *)fp)[0];

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -146,6 +146,19 @@ cheri_is_address_inbounds(const void * __capability cap, ptraddr_t addr)
 }
 
 /*
+ * Check if the capability is valid, unsealed, has the given permissions and
+ * grants access to length bytes at address base.
+ */
+static inline bool
+cheri_can_access(const void * __capability cap, ptraddr_t perms, ptraddr_t base,
+    size_t length)
+{
+	return (cheri_gettag(cap) && !cheri_getsealed(cap) &&
+	    (cheri_getperm(cap) & perms) == perms &&
+	    base >= cheri_getbase(cap) && base + length <= cheri_gettop(cap));
+}
+
+/*
  * Two variations on cheri_ptr() based on whether we are looking for a code or
  * data capability.  The compiler's use of CFromPtr will be with respect to
  * $ddc or $pcc depending on the type of the pointer derived, so we need to

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -34,6 +34,9 @@
 
 #include <sys/cdefs.h>
 #include <sys/types.h>
+#if !defined(_KERNEL) && !defined(_STANDALONE)
+#include <stdbool.h>
+#endif
 
 #if __has_feature(capabilities)
 #include <cheri/cherireg.h>	/* Permission definitions. */
@@ -96,11 +99,7 @@
  * Return whether the two pointers are equal, including capability metadata if
  * in purecap mode.
  */
-#ifdef __cplusplus
 static inline bool
-#else
-static inline _Bool
-#endif
 cheri_ptr_equal_exact(void *x, void *y)
 {
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -140,11 +139,7 @@ cheri_ptr_equal_exact(void *x, void *y)
 })
 
 /* Check if the address is between cap.base and cap.top, i.e. in bounds */
-#ifdef __cplusplus
 static inline bool
-#else
-static inline _Bool
-#endif
 cheri_is_address_inbounds(const void * __capability cap, ptraddr_t addr)
 {
 	return (addr >= cheri_getbase(cap) && addr < cheri_gettop(cap));

--- a/sys/riscv/riscv/unwind.c
+++ b/sys/riscv/riscv/unwind.c
@@ -47,18 +47,15 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 	fp = frame->fp;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (!cheri_can_access((void *)fp, (ptraddr_t)fp - sizeof(fp) * 2,
+	    sizeof(fp) * 2, CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP))
+		return (false);
+#endif
+
 	if (!__is_aligned(fp, sizeof(fp)) ||
 	    !kstack_contains(td, fp - sizeof(fp) * 2, sizeof(fp) * 2))
 		return (false);
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	if ((ptraddr_t)(fp - sizeof(fp) * 2) < cheri_getbase(fp) ||
-	    (ptraddr_t)fp > cheri_gettop(fp) ||
-	    cheri_gettag(fp) == 0 ||
-	    (cheri_getperm(fp) & (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)) !=
-	    (CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP))
-		return (false);
-#endif
 
 	frame->sp = fp;
 	frame->fp = ((uintptr_t *)fp)[-2];


### PR DESCRIPTION
The current code was accepting sealed capabilities with as a valid fp
value. This would then trap later when trying to load from the capability.
For RISC-V this actually failed on QEMU while evaluating the expression
`fp - sizeof(fp) * 2` in the kstack_contains() call since QEMU has not yet
been updated to be tag-clearing. I was seeing a boot failure here in the
WITNESS logic which was trying to treat a function pointer to `deadlkres`
as a dereferenceable frame pointer.