### PR TITLE
Allow to enable emulation of cntfrq_el0 access.

### DIFF
--- a/sys/arm64/include/armreg.h
+++ b/sys/arm64/include/armreg.h
@@ -153,6 +153,14 @@
 #define	CNTPCT_EL0_CRm		0
 #define	CNTPCT_EL0_op2		1
 
+/* CNTFRQ_EL0 */
+#define	CNTFRQ_EL0		MRS_REG(CNTFRQ_EL0)
+#define	CNTFRQ_EL0_op0		3
+#define	CNTFRQ_EL0_op1		3
+#define	CNTFRQ_EL0_CRn		14
+#define	CNTFRQ_EL0_CRm		0
+#define	CNTFRQ_EL0_op2		0
+
 /* CPACR_EL1 */
 #define	CPACR_ZEN_MASK		(0x3 << 16)
 #define	 CPACR_ZEN_TRAP_ALL1	(0x0 << 16) /* Traps from EL0 and EL1 */


### PR DESCRIPTION
This works around the need to expose the physical counter to userland and any restriction on the System Register Access permission.

Also added a tunable to switch the `sc->user_physical` which is always false for now. Not sure whether it may be useful for testing, so I left it in but I can yank it out.