### PR TITLE
Kernel memory tags via libkvm

### DIFF
--- a/lib/libkvm/kvm.3
+++ b/lib/libkvm/kvm.3
@@ -157,6 +157,7 @@ and
 .Xr kvm_openfiles 3 ,
 .Xr kvm_read 3 ,
 .Xr kvm_read2 3 ,
+.Xr kvm_readcap 3 ,
 .Xr kvm_write 3 ,
 .Xr sysctl 3 ,
 .Xr kmem 4 ,

--- a/lib/libkvm/kvm.h
+++ b/lib/libkvm/kvm.h
@@ -123,6 +123,7 @@ kvm_t	 *kvm_open2
 ssize_t	  kvm_read(kvm_t *, unsigned long, void *, size_t);
 ssize_t	  kvm_read_zpcpu(kvm_t *, unsigned long, void *, size_t, int);
 ssize_t	  kvm_read2(kvm_t *, kvaddr_t, void *, size_t);
+ssize_t   kvm_readcap(kvm_t *, kvaddr_t, void *, size_t);
 ssize_t	  kvm_write(kvm_t *, unsigned long, const void *, size_t);
 kssize_t  kvm_kerndisp(kvm_t *);
 

--- a/lib/libkvm/kvm_read.3
+++ b/lib/libkvm/kvm_read.3
@@ -38,6 +38,7 @@
 .Sh NAME
 .Nm kvm_read ,
 .Nm kvm_read2 ,
+.Nm kvm_readcap ,
 .Nm kvm_write
 .Nd read or write kernel virtual memory
 .Sh LIBRARY
@@ -48,6 +49,8 @@
 .Fn kvm_read "kvm_t *kd" "unsigned long addr" "void *buf" "size_t nbytes"
 .Ft ssize_t
 .Fn kvm_read2 "kvm_t *kd" "kvaddr_t addr" "void *buf" "size_t nbytes"
+.Ft ssize_t
+.Fn kvm_readcap "kvm_t *kd" "kvaddr_t addr" "void *buf" "size_t nbytes"
 .Ft ssize_t
 .Fn kvm_write "kvm_t *kd" "unsigned long addr" "const void *buf" "size_t nbytes"
 .Sh DESCRIPTION
@@ -63,9 +66,10 @@ See
 for information regarding opening kernel virtual memory and crash dumps.
 .Pp
 The
-.Fn kvm_read
+.Fn kvm_read ,
+.Fn kvm_read2 ,
 and
-.Fn kvm_read2
+.Fn kvm_readcap
 functions transfer
 .Fa nbytes
 bytes of data from
@@ -84,13 +88,26 @@ read or write process address spaces.
 .Pp
 The
 .Fn kvm_read2
-function uses a different type
+and
+.Fn kvm_readcap
+functions use a different type
 .Pq Vt kvaddr_t
 for the
 .Fa addr
 argument to allow use of addresses larger than
 .Dv ULONG_MAX
 when examining non-native kernel images.
+.Pp
+.Fn kvm_readcap
+fetches the expanded value of one or more capabilities.
+.Fa addr
+must be aligned to the size of a capability.
+Each capability is stored as a single byte holding the tag followed by
+the capability bytes as would be returned by a corresponding call to
+.Fn kvm_read2 .
+.Fa nbytes must be a multiple of the expanded value size and specifies the
+size of the expanded value buffer,
+not the amount of kernel virtual memory address space.
 .Sh RETURN VALUES
 Upon success, the number of bytes actually transferred is returned.
 Otherwise, -1 is returned.

--- a/sys/sys/memrange.h
+++ b/sys/sys/memrange.h
@@ -7,6 +7,8 @@
 #ifndef _SYS_MEMRANGE_H_
 #define	_SYS_MEMRANGE_H_
 
+#include <sys/ioccom.h>
+
 /* Memory range attributes */
 #define MDF_UNCACHEABLE		(1<<0)	/* region not cached */
 #define MDF_WRITECOMBINE	(1<<1)	/* region supports "write combine" action */

--- a/sys/sys/memrange.h
+++ b/sys/sys/memrange.h
@@ -69,6 +69,14 @@ struct mem_livedump_arg {
 
 #define	MEM_KERNELDUMP	_IOW('m', 53, struct mem_livedump_arg)
 
+struct mem_cheri_cap_arg {
+	ptraddr_t	vaddr;
+	void * __kerncap buf;
+	size_t		len;
+};
+
+#define	MEM_READ_CHERI_CAP	_IOW('m', 100, struct mem_cheri_cap_arg)
+
 #ifdef _KERNEL
 
 MALLOC_DECLARE(M_MEMDESC);


### PR DESCRIPTION
- mem: Add a MEM_READ_CHERI_CAP ioctl similar to PIOD_READ_CHERI_CAP.
- <sys/memrange.h>: Include <sys/ioccom.h>.
- libkvm: Add function to read tagged CHERI capabilities.

Note: This only contains support for live debugging via /dev/kmem.
Crash dumps will need additional changes.
