### PR TITLE
arm64: Pass a capability to dma_preread_safe

### DIFF
--- a/sys/arm64/arm64/busdma_bounce.c
+++ b/sys/arm64/arm64/busdma_bounce.c
@@ -975,7 +975,7 @@ bounce_bus_dmamap_unload(bus_dma_tag_t dmat, bus_dmamap_t map)
 }
 
 static void
-dma_preread_safe(vm_offset_t va, vm_size_t size)
+dma_preread_safe(vm_pointer_t va, vm_size_t size)
 {
 	/*
 	 * Write back any partial cachelines immediately before and


### PR DESCRIPTION
When performing DMA on a non cache coherent device we need to ensure the data cache has been invalidated before the device writes to the DMA memory. The helper function that performed this operation took a vm_offset_t, however the cache instructions need a capability.

Change the virtual address argument to a vm_pointer_t to ensure we have a capability.

This fixes CheriBSD on the Morello FVP.