### PR TITLE
CHERI sysctl cleanups

### DIFF
--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -144,10 +144,7 @@ void	cheri_read_tags_page(const void *page, void *tagbuf, bool *hastagsp);
  */
 SYSCTL_DECL(_security_cheri);
 SYSCTL_DECL(_security_cheri_stats);
-extern u_int	security_cheri_debugger_on_sandbox_signal;
 extern u_int	security_cheri_debugger_on_sandbox_syscall;
-extern u_int	security_cheri_debugger_on_sandbox_unwind;
-extern u_int	security_cheri_sandboxed_signals;
 extern u_int	security_cheri_syscall_violations;
 extern u_int	security_cheri_bound_legacy_capabilities;
 extern u_int	cheri_cloadtags_stride;

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -48,7 +48,7 @@ SYSCTL_NODE(_security_cheri, OID_AUTO, stats, CTLFLAG_RD, 0,
 
 /* XXXRW: Should possibly be u_long. */
 u_int	security_cheri_syscall_violations;
-SYSCTL_UINT(_security_cheri, OID_AUTO, syscall_violations, CTLFLAG_RD,
+SYSCTL_UINT(_security_cheri_stats, OID_AUTO, syscall_violations, CTLFLAG_RD,
     &security_cheri_syscall_violations, 0, "Number of system calls blocked");
 
 /*

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -51,28 +51,14 @@ u_int	security_cheri_syscall_violations;
 SYSCTL_UINT(_security_cheri, OID_AUTO, syscall_violations, CTLFLAG_RD,
     &security_cheri_syscall_violations, 0, "Number of system calls blocked");
 
-u_int	security_cheri_sandboxed_signals;
-SYSCTL_UINT(_security_cheri, OID_AUTO, sandboxed_signals, CTLFLAG_RD,
-    &security_cheri_sandboxed_signals, 0, "Number of signals in sandboxes");
-
 /*
  * A set of sysctls that cause the kernel debugger to enter following a policy
  * violation or signal delivery due to CHERI or while in a sandbox.
  */
-u_int	security_cheri_debugger_on_sandbox_signal;
-SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_signal, CTLFLAG_RW,
-    &security_cheri_debugger_on_sandbox_signal, 0,
-    "Enter KDB when a signal is delivered while in a sandbox");
-
 u_int	security_cheri_debugger_on_sandbox_syscall;
 SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_syscall, CTLFLAG_RW,
     &security_cheri_debugger_on_sandbox_syscall, 0,
     "Enter KDB when a syscall is rejected while in a sandbox");
-
-u_int	security_cheri_debugger_on_sandbox_unwind;
-SYSCTL_UINT(_security_cheri, OID_AUTO, debugger_on_sandbox_unwind, CTLFLAG_RW,
-    &security_cheri_debugger_on_sandbox_unwind, 0,
-    "Enter KDB when a sandbox is auto-unwound due to a signal");
 
 u_int	security_cheri_abort_on_memcpy_tag_loss;
 SYSCTL_UINT(_security_cheri, OID_AUTO, abort_on_memcpy_tag_loss,


### PR DESCRIPTION
- sys: Retire stale sysctl nodes.
- cheri_sysctl: Move count of syscall violations under the stats node.
