### PR TITLE
riscv: Add "capmode" to the list of attributes printed for capabilities.

### DIFF
--- a/lib/libc/cheri/strfcap.3
+++ b/lib/libc/cheri/strfcap.3
@@ -90,7 +90,7 @@ as follows:
 .It Cm \&%a
 is replaced by address of the capability.
 .It Cm \&%A
-is replaced by a textual representation of capablity attributes
+is replaced by a textual representation of capability attributes
 enclosed in parentheses.
 Zero or more of the following attributes are included:
 .Pp
@@ -107,7 +107,7 @@ Executable capability uses capability mode. (RISC-V only)
 .Pp
 If no attributes are present, the field is omitted.
 .It Cm \&%b
-is replaced by the base address of the capablity.
+is replaced by the base address of the capability.
 .It Cm \&%B
 is replaced by the binary representation of the capability (excluding
 the tag) in hexadecimal form.
@@ -211,7 +211,7 @@ Print the number in hexadecimal with lowercase letters.
 Print the number in hexadecimal with uppercase letters.
 .El
 .Pp
-Additionally, an optional decimal string field with may be specifided as
+Additionally, an optional decimal string field with may be specified as
 well as a minimum precision starting with a period
 .Cm \&.
 followed by a decimal digit string.
@@ -228,7 +228,7 @@ The
 function returns the number of characters that would have been printed
 if the
 .Fa size
-were unlimted
+were unlimited
 (not including the trailing
 .Ql \e0
 used to end output to strings).
@@ -244,4 +244,4 @@ contract
 .Pq Do ECATS Dc ,
 as part of the DARPA SSITH research programme.
 .Sh BUGS
-Not all possible erronious input patterns are detected.
+Not all possible erroneous input patterns are detected.

--- a/lib/libc/cheri/strfcap.3
+++ b/lib/libc/cheri/strfcap.3
@@ -36,7 +36,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 17, 2023
+.Dd June 6, 2023
 .Dt STRFCAP 3
 .Os
 .Sh NAME
@@ -101,6 +101,8 @@ Capability's tag is clear.
 Capability is a sealed entry.
 .It sealed
 Capability is sealed but not a sealed entry.
+.It capmode
+Executable capability uses capability mode. (RISC-V only)
 .El
 .Pp
 If no attributes are present, the field is omitted.

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -318,9 +318,9 @@ vfprintf(FILE * __restrict fp, const char * __restrict fmt0, va_list ap)
 #define	BUF	32
 #else
 /* For CHERI we need enough space to print a capability dump:
- * 0x0000007ffffecc10 [rwxRW,0x0000007ffffecc10-0x0000007ffffecc50] (invalid,sealed)
+ * 0x0000007ffffecc10 [rwxRW,0x0000007ffffecc10-0x0000007ffffecc50] (invalid,sealed,capmode)
  *
- * The current maximum length is 81 chars but in case we decide to
+ * The current maximum length is 89 chars but in case we decide to
  * print more info in the future we just use 128 since we have enough
  * stack space here anyway.
 */

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -833,6 +833,10 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			}
 			if (sharpflag) {
 				int orig_dwidth;
+#ifdef CHERI_FLAGS_CAP_MODE
+				bool capmode;
+#endif
+				bool comma, have_attributes, tagged;
 
 				orig_dwidth = dwidth;
 
@@ -897,32 +901,59 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 
 				PCHAR(']');
 
-				/* tag and sealing */
+				/* attributes */
+				tagged = cheri_gettag(cap);
+				have_attributes = !tagged;
+				if (cheri_gettype(cap) != CHERI_OTYPE_UNSEALED)
+					have_attributes = true;
+
+#ifdef CHERI_FLAGS_CAP_MODE
+				capmode = false;
+				if ((cheri_getperm(cap) &
+				    CHERI_PERM_EXECUTE) != 0 &&
+				    cheri_getflags(cap) ==
+				    CHERI_FLAGS_CAP_MODE) {
+					capmode = true;
+					have_attributes = true;
+				}
+#endif
+
+				if (!have_attributes)
+					break;
+
+				comma = false;
+				PCHAR(' ');
+				PCHAR('(');
+
+#define PATTR(str) do {							\
+	if (comma)							\
+		PCHAR(',');						\
+	p = (str);							\
+	while (*p)							\
+		PCHAR(*p++);						\
+	comma = true;							\
+} while (0)
+
+				if (!tagged)
+					PATTR("invalid");
 				switch (cheri_gettype(cap)) {
 				case CHERI_OTYPE_UNSEALED:
-					if (cheri_gettag(cap))
-						p = NULL;
-					else
-						p = "(invalid)";
 					break;
 				case CHERI_OTYPE_SENTRY:
-					if (cheri_gettag(cap))
-						p = "(sentry)";
-					else
-						p = "(invalid,sentry)";
+					PATTR("sentry");
 					break;
 				default:
-					if (cheri_gettag(cap))
-						p = "(sealed)";
-					else
-						p = "(invalid,sealed)";
+					PATTR("sealed");
 					break;
 				}
-				if (p != NULL) {
-					PCHAR(' ');
-					while (*p)
-						PCHAR(*p++);
-				}
+#ifdef __riscv
+				if (capmode)
+					PATTR("capmode");
+#endif
+
+#undef PATRR
+
+				PCHAR(')');
 				break;
 			}
 #else


### PR DESCRIPTION
While here, restructure the printing of capability attributes to make
it easier to extend.
