### PR TITLE
Minor fixes for release builds

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -1564,7 +1564,7 @@ distributeworld installworld stageworld installsysroot: _installcheck_world .PHO
 	-mkdir ${DESTDIR}/${DISTDIR}/base
 	${_+_}cd ${.CURDIR}/etc; ${CROSSENV} PATH=${TMPPATH:Q} ${MAKE} \
 	    METALOG=${METALOG} ${IMAKE_INSTALL} ${IMAKE_MTREE} \
-	    DISTBASE=/base DESTDIR=${DESTDIR}/${DISTDIR}/base \
+	    DISTBASE=/base DESTDIR=${INSTALL_DDIR}/base \
 	    LOCAL_MTREE=${LOCAL_MTREE:Q} distrib-dirs
 	${INSTALL_SYMLINK} ${INSTALLFLAGS} usr/src/sys ${INSTALL_DDIR}/base/sys
 .endif # make(distributeworld)

--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -1590,7 +1590,7 @@ distributeworld installworld stageworld installsysroot: _installcheck_world .PHO
 	@# the relevant mtree line.
 	cd ${DESTDIR}/${DISTDIR}; \
 	find ./${dist} | ${METALOG_SORT_CMD} -u ${METALOG} - | \
-	awk 'BEGIN { print "#${MTREE_MAGIC}" } !/ type=/ { file = $$1 } / type=/ { if ($$1 == file) { sub(/^\.\/${dist}\//, "./"); print } }' > \
+	awk 'BEGIN { print "#${MTREE_MAGIC}" } !/ type=/ { file = $$1 } / type=/ { if ($$1 == file) { sub(/^\.\/${dist}/, "."); print } }' > \
 	${DESTDIR}/${DISTDIR}/${dist}.meta
 .endfor
 .for dist in ${DEBUG_DISTRIBUTIONS}
@@ -1600,7 +1600,7 @@ distributeworld installworld stageworld installsysroot: _installcheck_world .PHO
 	@# the relevant mtree line.
 	cd ${DESTDIR}/${DISTDIR}; \
 	find ./${dist}/usr/lib/debug | ${METALOG_SORT_CMD} -u ${METALOG} - | \
-	awk 'BEGIN { print "#${MTREE_MAGIC}" } !/ type=/ { file = $$1 } / type=/ { if ($$1 == file) { sub(/^\.\/${dist}\//, "./"); print } }' > \
+	awk 'BEGIN { print "#${MTREE_MAGIC}" } !/ type=/ { file = $$1 } / type=/ { if ($$1 == file) { sub(/^\.\/${dist}/, "."); print } }' > \
 	${DESTDIR}/${DISTDIR}/${dist}.debug.meta
 .endfor
 .endif

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -164,7 +164,6 @@ distrib-dirs: ${MTREES:N/*} distrib-cleanup .PHONY
 	d=${_d}; \
 	test "$$d" = "/" && d=""; \
 	d=${DISTBASE}$$d; \
-	test -d ${DESTDIR}/$$d || mkdir -p ${DESTDIR}/$$d; \
 	${ECHO} "${MTREE_CMD:N-W} -C -f $$m -K all | " \
 	    "sed s#^\.#.$$d# | ${METALOG.add}" ; \
 	${MTREE_FILTER} $$m | \


### PR DESCRIPTION
This fixes two issues:

1. We install an additional empty /base directory
2. We don't install POSIX and en_US.US_ASCII NLS symlinks (which, due to the weird way they're done, actually appear in etcupdate's current tree and thus show as a local diff on a freshly-installed system)
