### PR TITLE
Capability injection via ptrace

### DIFF
--- a/bin/cheribsdtest/arm64/cheribsdtest_md.h
+++ b/bin/cheribsdtest/arm64/cheribsdtest_md.h
@@ -56,4 +56,6 @@
 #define	TLS_EXACT_BOUNDS
 #endif
 
+#define	CAPREG_PCC(capreg)	((capreg)->celr)
+
 #endif /* !_CHERIBSDTEST_H_ */

--- a/bin/cheribsdtest/cheribsdtest_ptrace.c
+++ b/bin/cheribsdtest/cheribsdtest_ptrace.c
@@ -34,10 +34,12 @@
 #error "This code requires a CHERI-aware compiler"
 #endif
 
+#include <sys/mman.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -200,6 +202,58 @@ CHERIBSDTEST(ptrace_readcap_pageend,
 	memcpy(&cap, &capbuf[1], sizeof(cap));
 	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(pp[last_index]),
 	    cap), "Mismatch in non-tag bits of first capability");
+
+	finish_child(pid);
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(ptrace_writecap, "Basic tests of PIOD_WRITE_CHERI_CAP")
+{
+	struct capreg capreg;
+	struct ptrace_io_desc piod;
+	pid_t pid;
+	int fd;
+	uintcap_t *map, pp[2];
+	char capbuf[2][sizeof(uintcap_t) + 1];
+
+	fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
+	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
+
+	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
+	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+
+	pid = fork_child();
+
+	/* Fetch the capability registers of the child. */
+	CHERIBSDTEST_CHECK_SYSCALL(ptrace(PT_GETCAPREGS, pid, (caddr_t)&capreg,
+	    0));
+
+	/* Write a modified PCC with a small offset. */
+	pp[0] = CAPREG_PCC(&capreg) + 16;
+	pp[1] = 42;
+
+	capbuf[0][0] = 1;
+	memcpy(&capbuf[0][1], &pp[0], sizeof(pp[0]));
+	capbuf[1][0] = 0;
+	memcpy(&capbuf[1][1], &pp[1], sizeof(pp[1]));
+
+	piod.piod_op = PIOD_WRITE_CHERI_CAP;
+	piod.piod_offs = map;
+	piod.piod_addr = capbuf;
+	piod.piod_len = sizeof(capbuf);
+	CHERIBSDTEST_CHECK_SYSCALL(ptrace(PT_IO, pid, (caddr_t)&piod, 0));
+
+	CHERIBSDTEST_VERIFY(piod.piod_len == sizeof(capbuf));
+
+	CHERIBSDTEST_VERIFY2(cheri_gettag(map[0]) == 1,
+	    "Tag not set in first injected capability");
+	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(map[0]), pp[0]),
+	    "Mismatch in non-tag bits of first capability");
+	CHERIBSDTEST_VERIFY2(cheri_gettag(map[1]) == 0,
+	    "Tag set in second injected capability");
+	CHERIBSDTEST_VERIFY2(cheri_equal_exact(map[1], pp[1]),
+	    "Mismatch in non-tag bits of second capability");
 
 	finish_child(pid);
 

--- a/bin/cheribsdtest/riscv/cheribsdtest_md.h
+++ b/bin/cheribsdtest/riscv/cheribsdtest_md.h
@@ -48,4 +48,6 @@
 #define	XFAIL_VARARG_BOUNDS	"varargs bounds known to be unimplemented"
 #endif
 
+#define	CAPREG_PCC(capreg)	((capreg)->sepcc)
+
 #endif /* !_CHERIBSDTEST_H_ */

--- a/lib/libc/sys/ptrace.2
+++ b/lib/libc/sys/ptrace.2
@@ -408,6 +408,7 @@ struct ptrace_io_desc {
 #define PIOD_WRITE_I	4	/* Write to I space */
 #define PIOD_READ_CHERI_TAGS	5	/* Read packed memory tags */
 #define	PIOD_READ_CHERI_CAP	7	/* Read CHERI capabilities */
+#define	PIOD_WRITE_CHERI_CAP	8	/* Write CHERI capabilities */
 .Ed
 .Pp
 The
@@ -439,6 +440,19 @@ The address must be aligned to the size of a capability.
 Each capability is stored as a single byte holding the tag followed by
 the capability bytes as would be returned by a corresponding call using
 .Dv PIOD_READ_D .
+.Fa piod_len
+must be a multiple of the expanded value size and specifies the size of
+the expanded value buffer,
+not the amount of target address space.
+.Pp
+.Dv PIOD_WRITE_CHERI_CAP
+stores one or more capabilities starting at the virtual address
+.Fa piod_offs
+in the traced process's address space.
+The address must be aligned to the size of a capability.
+Each capability must be provided in the same expanded format returned by
+.Dv PIOD_READ_CHERI_CAP :
+a single byte holding the tag followed by the capability bytes.
 .Fa piod_len
 must be a multiple of the expanded value size and specifies the size of
 the expanded value buffer,

--- a/lib/libc/sys/ptrace.2
+++ b/lib/libc/sys/ptrace.2
@@ -190,6 +190,56 @@ In this case requests return
 .Xr EPERM
 error.
 .El
+.Sh INJECTING CHERI CAPABILITIES
+.Pp
+Some requests such as
+.Dv PT_SETCAPREGS
+and
+.Dv PT_IO
+can inject tagged CHERI capabilities into the target process.
+The tag for these capabilities is stored separately from the rest of the
+capability,
+so the kernel must derive the requested capability from an existing
+capability.
+There are multiple classes of capabilities the kernel can use as the
+root for deriving a requested capability.
+The kernel will attempt to derive requested capabilities from all of
+the levels less than or equal to the current value of the
+.Dv security.cheri.ptrace_caps
+sysctl.
+The following levels are available:
+.Bl -tag
+.It 0
+Any tagged, unsealed capability in a user register of any thread in the
+target process can be used as a root.
+In addition, tagged and sealed capabilities equal to an existing user
+register of any thread in the target process can be injected.
+Sentry capabilities can be injected if they can be derived from an
+existing executable capability in a user register.
+.It 1
+Capabilities corresponding to any existing reservations in the address
+space of the target process can be used as root.
+Sentry capabilities can be injected if they can be derived from an
+executable mapping in the address space.
+.It 2
+A capability spanning the entire user address space can be used as the root.
+This permits injecting arbitrary
+.Pq forged
+user capabilities,
+including capabilities sealed with an arbitrary user object type.
+.El
+.Pp
+If a requested capability cannot be derived,
+the operation will fail with
+.Er EPROT .
+The
+.Dv security.cheri.stats.untagged_ptrace_caps
+sysctl counts the number of capability injection attempts which failed.
+.Pp
+The
+.Dv security.cheri.stats.forged_ptrace_caps
+sysctl counts the number of forged injected capabilities
+.Pq derived at level 2 .
 .Sh TRACING EVENTS
 .Pp
 Each traced process has a tracing event mask.
@@ -1463,6 +1513,12 @@ cannot return the pathname of the backing object because the buffer is not big
 enough.
 .Fa pve_pathlen
 holds the minimum buffer size required on return.
+.El
+.It Bq Er EPROT
+.Bl -bullet -compact
+.It
+A request attempted to inject a tagged CHERI capability that could not be
+derived.
 .El
 .El
 .Sh SEE ALSO

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -140,6 +140,15 @@ void	cheri_otype_free(otype_t);
 void	cheri_read_tags_page(const void *page, void *tagbuf, bool *hastagsp);
 
 /*
+ * Functions to derive capabilities for ptrace.
+ */
+struct proc;
+bool	ptrace_derive_cap(struct proc *p, uintcap_t in, uintcap_t *out);
+bool	ptrace_derive_capreg_td(struct thread *td, uintcap_t in,
+    uintcap_t *out);
+bool	vm_derive_capreg(struct proc *p, uintcap_t in, uintcap_t *out);
+
+/*
  * Global sysctl definitions.
  */
 SYSCTL_DECL(_security_cheri);

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -647,6 +647,80 @@ proc_read_cheri_cap(struct proc *p, struct uio *uio)
 	}
 	return (error);
 }
+
+static int
+proc_write_cheri_cap_page(struct proc *p, vm_map_t map, vm_offset_t va,
+    struct uio *uio)
+{
+	char capbuf[sizeof(uintcap_t) + 1];
+	uintcap_t *dst, cap;
+	vm_page_t m;
+	u_int pageoff, todo;
+	int error;
+
+	KASSERT(is_aligned(va, sizeof(uintcap_t)),
+	    ("%s: user address %lx is not capability-aligned", __func__, va));
+	pageoff = va & PAGE_MASK;
+	todo = (PAGE_SIZE - pageoff) / sizeof(uintcap_t) *
+	    (sizeof(uintcap_t) + 1);
+	todo = MIN(todo, uio->uio_resid);
+	va = trunc_page(va);
+
+	error = vm_fault(map, va, VM_PROT_WRITE | VM_PROT_WRITE_CAP, 0, &m);
+	if (error != KERN_SUCCESS)
+		return (EFAULT);
+
+	dst = (uintcap_t *)PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m)) + pageoff /
+	    sizeof(uintcap_t);
+	while (todo > 0) {
+		error = uiomove(capbuf, sizeof(capbuf), uio);
+		if (error != 0)
+			break;
+
+		memcpy(&cap, capbuf + 1, sizeof(cap));
+		if (capbuf[0] != 0) {
+			if (!ptrace_derive_cap(p, cap, dst)) {
+				error = EPROT;
+				break;
+			}
+		} else
+			*dst = cap;
+
+		todo -= sizeof(capbuf);
+		dst++;
+	}
+
+	vm_page_unwire(m, PQ_ACTIVE);
+	return (error);
+}
+
+static int
+proc_write_cheri_cap(struct proc *p, struct uio *uio)
+{
+	vm_map_t map = &p->p_vmspace->vm_map;
+	vm_offset_t va;
+	int error;
+
+	/*
+	 * Can't reuse uio_offset directly as uiomove increments it
+	 * based on the expanded capability size.
+	 */
+	va = uio->uio_offset;
+	if (!is_aligned(va, sizeof(uintcap_t)))
+		return (EINVAL);
+
+	if (uio->uio_resid % (sizeof(uintcap_t) + 1) != 0)
+		return (EINVAL);
+
+	error = 0;
+	while (uio->uio_resid > 0) {
+		error = proc_write_cheri_cap_page(p, map, va, uio);
+		if (error != 0)
+			break;
+		va = trunc_page(va) + PAGE_SIZE;
+	}
+	return (error);
+}
 #endif
 
 static int
@@ -1631,6 +1705,17 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 			uio.uio_rw = UIO_READ;
 			PROC_UNLOCK(p);
 			error = proc_read_cheri_cap(p, &uio);
+			piod->piod_len -= uio.uio_resid;
+			PROC_LOCK(p);
+			goto out;
+		case PIOD_WRITE_CHERI_CAP:
+			CTR3(KTR_PTRACE,
+			    "PT_IO: pid %d: WRITE_CHERI_CAP (%p, %#x)",
+			    p->p_pid, (uintptr_t)uio.uio_offset, uio.uio_resid);
+			td2->td_dbgflags |= TDB_USERWR;
+			uio.uio_rw = UIO_WRITE;
+			PROC_UNLOCK(p);
+			error = proc_write_cheri_cap(p, &uio);
 			piod->piod_len -= uio.uio_resid;
 			PROC_LOCK(p);
 			goto out;

--- a/sys/riscv/include/cheric.h
+++ b/sys/riscv/include/cheric.h
@@ -37,4 +37,12 @@
 #define	cheri_capmode(cap)	cheri_setflags(cap, CHERI_FLAGS_CAP_MODE)
 #endif
 
+#ifdef _KERNEL
+/* XXX: Convert faulting CBuildCap into tag-stripping. */
+extern void * __capability cheri_buildcap_safe(void * __capability, intcap_t);
+
+#undef cheri_buildcap
+#define	cheri_buildcap(x, y)	cheri_buildcap_safe((x), (y))
+#endif
+
 #endif /* !_MACHINE_CHERIC_H_ */

--- a/sys/riscv/riscv/support.S
+++ b/sys/riscv/riscv/support.S
@@ -466,6 +466,42 @@ ENTRY(sucap)
 END(sucap)
 #endif
 
+#if __has_feature(capabilities)
+/*
+ * cheri_buildcap_safe failed, return untagged input
+ */
+ENTRY(cbuildcap_fault)
+#ifdef __CHERI_PURE_CAPABILITY__
+	SET_FAULT_HANDLER(cnull, ca1)	/* Reset the handler function */
+#else
+	SET_FAULT_HANDLER(x0, a1)	/* Reset the handler function */
+#endif
+	ccleartag ca0, ca1
+	RETURN
+END(cbuildcap_fault)
+
+/*
+ * void * __capability cheri_buildcap_safe(volatile void * __capability,
+ *	intcap_t)
+ */
+ENTRY(cheri_buildcap_safe)
+#ifdef __CHERI_PURE_CAPABILITY__
+	clgc	ca6, cbuildcap_fault	/* Load the fault handler */
+	SET_FAULT_HANDLER(ca6, ca2)	/* And set it */
+#else
+	la	a6, cbuildcap_fault	/* Load the fault handler */
+	SET_FAULT_HANDLER(a6, a2)	/* And set it */
+#endif
+	cbuildcap ca0, ca0, ca1
+#ifdef __CHERI_PURE_CAPABILITY__
+	SET_FAULT_HANDLER(cnull, ca2)	/* Reset the fault handler */
+#else
+	SET_FAULT_HANDLER(x0, a2)	/* Reset the fault handler */
+#endif
+	RETURN
+END(cheri_buildcap_safe)
+#endif
+
 ENTRY(setjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Store the stack pointer */

--- a/sys/sys/ptrace.h
+++ b/sys/sys/ptrace.h
@@ -122,6 +122,7 @@ struct ptrace_io_desc {
 #define PIOD_WRITE_I	4	/* Write to I space */
 #define	PIOD_READ_CHERI_TAGS	5	/* Read packed memory tags */
 #define	PIOD_READ_CHERI_CAP	7	/* Read CHERI capabilities */
+#define	PIOD_WRITE_CHERI_CAP	8	/* Write CHERI capabilities */
 
 /* Argument structure for PT_LWPINFO. */
 struct ptrace_lwpinfo {

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -514,6 +514,7 @@ int vm_map_reservation_create_locked(vm_map_t, vm_pointer_t *, vm_size_t, vm_pro
 int vm_map_reservation_get(vm_map_t, vm_offset_t, vm_size_t, vm_offset_t *);
 #if __has_feature(capabilities)
 int vm_map_prot2perms(vm_prot_t prot);
+void * __capability vm_map_reservation_cap(vm_map_t, vm_offset_t);
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
 vm_pointer_t _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -2178,6 +2178,41 @@ vm_mmap_to_errno(int rv)
 		return (EINVAL);
 	}
 }
+
+#if __has_feature(capabilities)
+bool
+vm_derive_capreg(struct proc *p, uintcap_t in, uintcap_t *out)
+{
+	void * __capability cap;
+	vm_map_t map;
+	int otype;
+
+	/* The only sealed caps supported for this are sentries. */
+	otype = cheri_gettype(in);
+	switch (otype) {
+	case CHERI_OTYPE_UNSEALED:
+	case CHERI_OTYPE_SENTRY:
+		break;
+	default:
+		return (0);
+	}
+
+	map = &p->p_vmspace->vm_map;
+	cap = vm_map_reservation_cap(map, (vm_offset_t)in);
+
+	cap = cheri_buildcap(cap, in);
+#ifdef __aarch64__
+	/* Morello requires explicit sealing for entry. */
+	if (otype == CHERI_OTYPE_SENTRY)
+		cap = cheri_sealentry(cap);
+#endif
+	if (cheri_gettag(cap)) {
+		*out = (uintcap_t)cap;
+		return (true);
+	}
+	return (false);
+}
+#endif
 // CHERI CHANGES START
 // {
 //   "updated": 20230509,


### PR DESCRIPTION
- sys: Add helper functions for injecting capabilities via ptrace().
- riscv: Add a pcb_onfault wrapper around CBuildCap.
- riscv: Support PT_SETCAPREGS.
- arm64: Support PT_SETCAPREGS.
- ptrace: Add PIOD_WRITE_CHERI_CAP mode for PT_IO.
- ptrace.2: Document the policy knob for CHERI capability injection.
