### PR TITLE
Remove thread guard pages and executable stacks entirely on purecap

### DIFF
--- a/lib/libc/gen/elf_utils.c
+++ b/lib/libc/gen/elf_utils.c
@@ -39,7 +39,9 @@
 #include "libc_private.h"
 #include "static_tls.h"
 
+#ifndef __CHERI_PURE_CAPABILITY__
 void __pthread_map_stacks_exec(void);
+#endif
 void __pthread_distribute_static_tls(size_t, void *, size_t, size_t);
 
 int
@@ -73,6 +75,7 @@ __elf_phdr_match_addr(struct dl_phdr_info *phdr_info, void *addr)
 	return (i != phdr_info->dlpi_phnum);
 }
 
+#ifndef __CHERI_PURE_CAPABILITY__
 void
 __libc_map_stacks_exec(void)
 {
@@ -104,6 +107,7 @@ __pthread_map_stacks_exec(void)
 
 	((void (*)(void))__libc_interposing[INTERPOS_map_stacks_exec])();
 }
+#endif
 
 void
 __libc_distribute_static_tls(size_t offset, void *src, size_t len,

--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -444,7 +444,9 @@ int _elf_aux_info(int aux, void *buf, int buflen);
 struct dl_phdr_info;
 int __elf_phdr_match_addr(struct dl_phdr_info *, void *);
 void __init_elf_aux_vector(void);
+#ifndef __CHERI_PURE_CAPABILITY__
 void __libc_map_stacks_exec(void);
+#endif
 void __libc_distribute_static_tls(__size_t, void *, __size_t, __size_t);
 __uintptr_t __libc_static_tls_base(__size_t);
 

--- a/lib/libc/sys/interposing_table.c
+++ b/lib/libc/sys/interposing_table.c
@@ -89,8 +89,10 @@ interpos_func_t __libc_interposing[INTERPOS_MAX] = {
 	SLOT_SYS(kevent)
 	SLOT_SYS(wait6)
 	SLOT_SYS(ppoll)
+#ifndef __CHERI_PURE_CAPABILITY__
 #ifndef INTERPOS_SYSCALLS_ONLY
 	SLOT_LIBC(map_stacks_exec)
+#endif
 #endif
 	SLOT_SYS(fdatasync)
 	SLOT_SYS(clock_nanosleep)

--- a/lib/libthr/thread/thr_attr.c
+++ b/lib/libthr/thread/thr_attr.c
@@ -461,11 +461,13 @@ _thr_attr_setguardsize(pthread_attr_t *attr, size_t guardsize __unused)
 	/* Check for invalid arguments. */
 	if (attr == NULL || *attr == NULL)
 		ret = EINVAL;
+#ifdef __CHERI_PURE_CAPABILITY__
+	else if (guardsize != 0)
+		ret = EINVAL;
+#endif
 	else {
-#ifndef __CHERI_PURE_CAPABILITY__
 		/* Save the stack size. */
 		(*attr)->guardsize_attr = guardsize;
-#endif
 		ret = 0;
 	}
 	return (ret);

--- a/lib/libthr/thread/thr_create.c
+++ b/lib/libthr/thread/thr_create.c
@@ -158,12 +158,14 @@ _pthread_create(pthread_t * __restrict thread,
 	new_thread->refcount = 1;
 	_thr_link(curthread, new_thread);
 
+#ifndef __CHERI_PURE_CAPABILITY__
 	/*
 	 * Handle the race between __pthread_map_stacks_exec and
 	 * thread linkage.
 	 */
 	if (old_stack_prot != _rtld_get_stack_prot())
 		_thr_stack_fix_protection(new_thread);
+#endif
 
 	/* Return thread pointer eariler so that new thread can use it. */
 	(*thread) = new_thread;

--- a/lib/libthr/thread/thr_private.h
+++ b/lib/libthr/thread/thr_private.h
@@ -996,7 +996,9 @@ struct dl_phdr_info;
 void __pthread_cxa_finalize(struct dl_phdr_info *phdr_info);
 void _thr_tsd_unload(struct dl_phdr_info *phdr_info) __hidden;
 void _thr_sigact_unload(struct dl_phdr_info *phdr_info) __hidden;
+#ifndef __CHERI_PURE_CAPABILITY__
 void _thr_stack_fix_protection(struct pthread *thrd);
+#endif
 void __pthread_distribute_static_tls(size_t offset, void *src, size_t len,
     size_t total_len);
 

--- a/lib/libthr/thread/thr_stack.c
+++ b/lib/libthr/thread/thr_stack.c
@@ -157,6 +157,7 @@ round_up(size_t size)
 	return size;
 }
 
+#ifndef __CHERI_PURE_CAPABILITY__
 void
 _thr_stack_fix_protection(struct pthread *thrd)
 {
@@ -203,6 +204,7 @@ __thr_map_stacks_exec(void)
 		_thr_stack_fix_protection(thrd);
 	THREAD_LIST_UNLOCK(curthread);
 }
+#endif
 
 int
 _thr_stack_alloc(struct pthread_attr *attr)

--- a/lib/libthr/thread/thr_syscalls.c
+++ b/lib/libthr/thread/thr_syscalls.c
@@ -680,7 +680,9 @@ __thr_interpose_libc(void)
 	SLOT(kevent);
 	SLOT(wait6);
 	SLOT(ppoll);
+#ifndef __CHERI_PURE_CAPABILITY__
 	SLOT(map_stacks_exec);
+#endif
 	SLOT(fdatasync);
 	SLOT(clock_nanosleep);
 	SLOT(pdfork);

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -140,7 +140,9 @@ static int load_needed_objects(Obj_Entry *, int);
 static int load_preload_objects(const char *, bool);
 static int load_kpreload(const void *addr);
 static Obj_Entry *load_object(const char *, int fd, const Obj_Entry *, int);
+#ifndef __CHERI_PURE_CAPABILITY__
 static void map_stacks_exec(RtldLockState *);
+#endif
 static int obj_disable_relro(Obj_Entry *);
 static int obj_enforce_relro(Obj_Entry *);
 static void objlist_call_fini(Objlist *, Obj_Entry *, RtldLockState *);
@@ -284,8 +286,12 @@ static int osreldate;
 size_t *pagesizes;
 size_t page_size;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+static int stack_prot = PROT_READ | PROT_WRITE;
+#else
 static int stack_prot = PROT_READ | PROT_WRITE | PROT_EXEC;
 static int max_stack_flags;
+#endif
 
 /*
  * Global declarations normally provided by crt1.  The dynamic linker is
@@ -851,7 +857,9 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 	close(fd);
 	if (obj_main == NULL)
 	    rtld_die();
+#ifndef __CHERI_PURE_CAPABILITY__
 	max_stack_flags = obj_main->stack_flags;
+#endif
     } else {				/* Main program already loaded. */
 	dbg("processing main program's program header");
 	assert(aux_info[AT_PHDR] != NULL);
@@ -1050,12 +1058,12 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 
     r_debug_state(NULL, &obj_main->linkmap); /* say hello to gdb! */
 
-    map_stacks_exec(NULL);
-
 #ifdef __CHERI_PURE_CAPABILITY__
     /* old crt does not exist for CheriABI */
     obj_main->crt_no_init = true;
 #else
+    map_stacks_exec(NULL);
+
     if (!obj_main->crt_no_init) {
 	/*
 	 * Make sure we don't call the main program's init and fini
@@ -1818,6 +1826,7 @@ digest_phdr(const Elf_Phdr *phdr, int phnum, dlfunc_t entry, const char *path)
 	obj->relocbase = __DECONST(char *, phdr) - ph->p_vaddr;
 	break;
     }
+
 #ifdef __CHERI_PURE_CAPABILITY__
     /*
      * Position dependent binaries can cause relocbase to be unrepresentable.
@@ -1834,9 +1843,9 @@ digest_phdr(const Elf_Phdr *phdr, int phnum, dlfunc_t entry, const char *path)
 	    "relocation base (" PTR_FMT ")", path, obj->relocbase);
 	return NULL;
     }
-#endif
-
+#else
     obj->stack_flags = PF_X | PF_R | PF_W;
+#endif
 
     for (ph = phdr;  ph < phlimit;  ph++) {
 	switch (ph->p_type) {
@@ -1880,7 +1889,15 @@ digest_phdr(const Elf_Phdr *phdr, int phnum, dlfunc_t entry, const char *path)
 	    break;
 
 	case PT_GNU_STACK:
+#ifdef __CHERI_PURE_CAPABILITY__
+	    if ((ph->p_flags & PF_X) != 0) {
+		_rtld_error("%s: PF_X in PT_GNU_STACK", path);
+		obj_free(obj);
+		return (NULL);
+	    }
+#else
 	    obj->stack_flags = ph->p_flags;
+#endif
 	    break;
 
 	case PT_GNU_RELRO:
@@ -2549,12 +2566,20 @@ parse_rtld_phdr(Obj_Entry *obj)
 	const Elf_Phdr *ph;
 	Elf_Note *note_start, *note_end;
 
+#ifndef __CHERI_PURE_CAPABILITY__
 	obj->stack_flags = PF_X | PF_R | PF_W;
+#endif
 	for (ph = obj->phdr;  (const char *)ph < (const char *)obj->phdr +
 	    obj->phsize; ph++) {
 		switch (ph->p_type) {
 		case PT_GNU_STACK:
+#ifdef __CHERI_PURE_CAPABILITY__
+			if ((ph->p_flags & PF_X) != 0)
+				rtld_fatal("%s: PF_X in PT_GNU_STACK",
+				    obj->path);
+#else
 			obj->stack_flags = ph->p_flags;
+#endif
 			break;
 		case PT_GNU_RELRO:
 			obj->relro_page = obj->relocbase +
@@ -3104,7 +3129,9 @@ do_load_object(int fd, const char *name, char *path, struct stat *sbp,
     obj_count++;
     obj_loads++;
     linkmap_add(obj);	/* for GDB & dlinfo() */
+#ifndef __CHERI_PURE_CAPABILITY__
     max_stack_flags |= obj->stack_flags;
+#endif
 
     dbg("  %p .. %p: %s", obj->mapbase,
          obj->mapbase + obj->mapsize - 1, obj->path);
@@ -3146,7 +3173,15 @@ load_kpreload(const void *addr)
 			break;
 		case PT_GNU_STACK:
 			/* Absense of PT_GNU_STACK implies stack_flags == 0. */
+#ifdef __CHERI_PURE_CAPABILITY__
+			if ((phdr->p_flags & PF_X) != 0) {
+				_rtld_error("%s: PF_X in PT_GNU_STACK", kname);
+				obj_free(obj);
+				return (-1);
+			}
+#else
 			obj->stack_flags = phdr->p_flags;
+#endif
 			break;
 		case PT_LOAD:
 			if (seg0 == NULL || seg0->p_vaddr > phdr->p_vaddr)
@@ -3186,7 +3221,9 @@ load_kpreload(const void *addr)
 	obj_count++;
 	obj_loads++;
 	linkmap_add(obj);	/* for GDB & dlinfo() */
+#ifndef __CHERI_PURE_CAPABILITY__
 	max_stack_flags |= obj->stack_flags;
+#endif
 
 	LD_UTRACE(UTRACE_LOAD_OBJECT, obj, obj->mapbase, 0, 0, obj->path);
 	return (0);
@@ -4126,7 +4163,9 @@ dlopen_object(const char *name, int fd, Obj_Entry *refobj, int lo_flags,
     GDB_STATE(RT_CONSISTENT,obj ? &obj->linkmap : NULL);
 
     if ((lo_flags & RTLD_LO_EARLY) == 0) {
+#ifndef __CHERI_PURE_CAPABILITY__
 	map_stacks_exec(lockstate);
+#endif
 	if (obj != NULL)
 	    distribute_static_tls(&initlist, lockstate);
     }
@@ -6211,6 +6250,7 @@ obj_enforce_relro(Obj_Entry *obj)
 	return (obj_remap_relro(obj, PROT_READ));
 }
 
+#ifndef __CHERI_PURE_CAPABILITY__
 static void
 map_stacks_exec(RtldLockState *lockstate)
 {
@@ -6225,6 +6265,7 @@ map_stacks_exec(RtldLockState *lockstate)
 		thr_map_stacks_exec();
 	}
 }
+#endif
 
 static void
 distribute_static_tls(Objlist *list, RtldLockState *lockstate)

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -230,7 +230,9 @@ typedef struct Struct_Obj_Entry {
     const Elf_Phdr *phdr;	/* Program header if it is mapped, else NULL */
     size_t phsize;		/* Size of program header in bytes */
     const char *interp;		/* Pathname of the interpreter, if any */
+#ifndef __CHERI_PURE_CAPABILITY__
     Elf_Word stack_flags;
+#endif
 
     /* TLS information */
     int tlsindex;		/* Index in DTV for this module */


### PR DESCRIPTION
This does add several new #ifdefs that could increase the chance for conflicts in the future.  It might be nice if we could have an upstream macro in rtld to request building a version that doesn't support binaries that request executable stacks as that would make the upstream diff a bit less painful.