### PR TITLE
Prepare for tag clearing CHERI-RISC-V implementations

### DIFF
--- a/sys/riscv/cheri/cheri_debug.c
+++ b/sys/riscv/cheri/cheri_debug.c
@@ -56,8 +56,10 @@ DB_SHOW_COMMAND(scr, ddb_dump_scr)
 	uint64_t sccsr;
 
 	sccsr = csr_read(sccsr);
-	db_printf("sccsr: %s, %s\n", sccsr & SCCSR_E ? "enabled" : "disabled",
-	    sccsr & SCCSR_D ? "dirty" : "clean");
+	db_printf("sccsr: %s, %s, %s semantics\n",
+	    sccsr & SCCSR_E ? "enabled" : "disabled",
+	    sccsr & SCCSR_D ? "dirty" : "clean",
+	    sccsr & SCCSR_TAG_CLEARING ? "tag-clearing" : "trapping");
 
 	db_printf("ddc: %#.16lp\n",  scr_read(ddc));
 	db_printf("pcc: %#.16lp\n",  scr_read(pcc));

--- a/sys/riscv/cheri/cheri_debug.c
+++ b/sys/riscv/cheri/cheri_debug.c
@@ -56,9 +56,8 @@ DB_SHOW_COMMAND(scr, ddb_dump_scr)
 	uint64_t sccsr;
 
 	sccsr = csr_read(sccsr);
-	db_printf("sccsr: %s, %s, %s semantics\n",
+	db_printf("sccsr: %s, %s semantics\n",
 	    sccsr & SCCSR_E ? "enabled" : "disabled",
-	    sccsr & SCCSR_D ? "dirty" : "clean",
 	    sccsr & SCCSR_TAG_CLEARING ? "tag-clearing" : "trapping");
 
 	db_printf("ddc: %#.16lp\n",  scr_read(ddc));

--- a/sys/riscv/include/riscvreg.h
+++ b/sys/riscv/include/riscvreg.h
@@ -165,7 +165,6 @@
 
 #if __has_feature(capabilities)
 #define	SCCSR_E			(1 << 0)
-#define	SCCSR_D			(1 << 1)
 #define	SCCSR_TAG_CLEARING	(1 << 31)
 #define	TVAL_CAP_CAUSE_SHIFT	0
 #define	TVAL_CAP_CAUSE_MASK	(0x1f << TVAL_CAP_CAUSE_SHIFT)

--- a/sys/riscv/include/riscvreg.h
+++ b/sys/riscv/include/riscvreg.h
@@ -166,6 +166,7 @@
 #if __has_feature(capabilities)
 #define	SCCSR_E			(1 << 0)
 #define	SCCSR_D			(1 << 1)
+#define	SCCSR_TAG_CLEARING	(1 << 31)
 #define	TVAL_CAP_CAUSE_SHIFT	0
 #define	TVAL_CAP_CAUSE_MASK	(0x1f << TVAL_CAP_CAUSE_SHIFT)
 #define	TVAL_CAP_CAUSE(tval)						\

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -653,6 +653,22 @@ initriscv(struct riscv_bootparams *rvbp)
 
 	cninit();
 
+#if __has_feature(capabilities)
+	/*
+	 * Now that printf() is ready, we check for the required CHERI features
+	 * needed to run this version of CheriBSD to detect incompatible (old)
+	 * implementations instead of failing with obscure errors later on.
+	 * TODO: we should do this earlier since this check may actually be
+	 * too late to print a helpful error message. Once moved earlier, we
+	 * could use SBI print calls to output the error instead of printf.
+	 */
+	if ((csr_read(sccsr) & SCCSR_TAG_CLEARING) == 0) {
+		printf("WARNING: CHERI implementation raises exceptions on "
+		       "invalid operations. This is no longer supported and "
+		       "will become a hard error soon\n");
+	}
+#endif
+
 	/*
 	 * Dump the boot metadata. We have to wait for cninit() since console
 	 * output is required. If it's grossly incorrect the kernel will never


### PR DESCRIPTION
Currently a tag clearing implementation will fail two of the cheribsdtests. This commit adds support for the new "tag clearing semantics" feature bit (https://github.com/CTSRD-CHERI/sail-cheri-riscv/pull/74) that will be added to QEMU as well to allow all tests to pass with a tag clearing QEMU.

In the future we can change this warning message into a hard panic().