### PR TITLE
Produce a compilation DB for the kernel build.

### DIFF
--- a/sys/conf/kern.post.mk
+++ b/sys/conf/kern.post.mk
@@ -180,6 +180,12 @@ ${KERNEL_KO}.debug: ${FULLKERNEL}
 install.debug reinstall.debug: gdbinit
 	cd ${.CURDIR}; ${MAKE} ${.TARGET:R}
 
+${COMPILATION_DB_FILE}: ${FULLKERNEL}
+	sed -e '1s/^/[/' -e '$$s/,$$/]/' ${COMPILATION_DB_DIR}/*.json > $@
+
+all: ${COMPILATION_DB_FILE}
+
+
 # Install gdbinit files for kernel debugging.
 gdbinit:
 	grep -v '# XXX' ${S}/../tools/debugscripts/dot.gdbinit | \

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -87,6 +87,10 @@ WERROR?=	-Werror
 # default over to -fno-common, making this redundant.
 CFLAGS+=	-fno-common
 
+COMPILATION_DB_FILE?=${.OBJDIR}/compile_commands.json
+COMPILATION_DB_DIR?=${.OBJDIR}/cdb
+CFLAGS.clang+=	-gen-cdb-fragment-path ${COMPILATION_DB_DIR}
+
 # XXX LOCORE means "don't declare C stuff" not "for locore.s".
 ASM_CFLAGS= -x assembler-with-cpp -DLOCORE ${CFLAGS} ${ASM_CFLAGS.${.IMPSRC:T}}
 


### PR DESCRIPTION
Currently this is unconditional, it is certainly possible to add a switch to enable it but the changes are fairly simple and should not impact build speed.