### PR TITLE
i386 kernel build fixes

### DIFF
--- a/sys/dev/mthca/mthca_memfree.c
+++ b/sys/dev/mthca/mthca_memfree.c
@@ -471,7 +471,7 @@ int mthca_map_user_db(struct mthca_dev *dev, struct mthca_uar *uar,
 		goto out;
 	}
 
-	ret = get_user_pages(uaddr & PAGE_MASK, 1, FOLL_WRITE, pages, NULL);
+	ret = get_user_pages((void *)(uintptr_t)(uaddr & PAGE_MASK), 1, FOLL_WRITE, pages, NULL);
 	if (ret < 0)
 		goto out;
 

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -670,7 +670,7 @@ proc_write_cheri_cap_page(struct proc *p, vm_map_t map, vm_offset_t va,
 	if (error != KERN_SUCCESS)
 		return (EFAULT);
 
-	dst = (uintcap_t *)PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m)) + pageoff /
+	dst = (uintcap_t *)PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(m)) + pageoff /
 	    sizeof(uintcap_t);
 	while (todo > 0) {
 		error = uiomove(capbuf, sizeof(capbuf), uio);

--- a/sys/ofed/drivers/infiniband/core/ib_umem.c
+++ b/sys/ofed/drivers/infiniband/core/ib_umem.c
@@ -180,7 +180,7 @@ struct ib_umem *ib_umem_get(struct ib_ucontext *context, unsigned long addr,
 	sg_list_start = umem->sg_head.sgl;
 
 	while (npages) {
-		ret = get_user_pages(cur_base,
+		ret = get_user_pages((void *)cur_base,
 				     min_t(unsigned long, npages,
 					   PAGE_SIZE / sizeof (struct page *)),
 				     gup_flags, page_list, vma_list);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -2015,7 +2015,7 @@ vm_map_findspace(vm_map_t map, vm_offset_t start, vm_size_t length)
 	VM_MAP_ASSERT_LOCKED(map);
 	KASSERT((map->flags & MAP_RESERVATIONS) == 0 ||
 	    length == CHERI_REPRESENTABLE_LENGTH(length),
-	    ("%s: imprecise length %#lx", __func__, length));
+	    ("%s: imprecise length %#jx", __func__, (uintmax_t)length));
 
 	/*
 	 * Request must fit within min/max VM address and must avoid
@@ -6190,7 +6190,7 @@ _vm_map_assert_consistent(vm_map_t map, int check)
 		    (entry->eflags & MAP_ENTRY_UNMAPPED) != 0),
 		    ("map %p prev->start %jx, start %jx, reservation %jx, "
 		    "both MAP_ENTRY_UNMAPPED", map, (uintmax_t)prev->start,
-		    (uintmax_t)entry->start, entry->reservation));
+		    (uintmax_t)entry->start, (uintmax_t)entry->reservation));
 		cur = map->root;
 		lbound = ubound = header;
 		for (;;) {

--- a/sys/vm/vm_param.h
+++ b/sys/vm/vm_param.h
@@ -135,7 +135,6 @@ struct xswdev {
 #endif
 #define PHYS_AVAIL_COUNT        (PHYS_AVAIL_ENTRIES + 2)
 
-#if PMAP_HAS_DMAP
 /*
  * Check that a physical address range completely lies within the direct map.
  */
@@ -145,22 +144,21 @@ struct xswdev {
 #define	PHYS_TO_DMAP_PAGE(pa)						\
 ({									\
 	KASSERT(is_aligned(pa, PAGE_SIZE),				\
-	    ("%s: PA is not page aligned, PA: 0x%lx", __func__,		\
-	    (vm_paddr_t)(pa)));						\
+	    ("%s: PA is not page aligned, PA: 0x%jx", __func__,		\
+	    (uintmax_t)(pa)));						\
 	cheri_kern_setboundsexact(PHYS_TO_DMAP(pa), PAGE_SIZE);		\
 })
 
 #define	PHYS_TO_DMAP_LEN(pa, len)					\
 ({									\
 	KASSERT(PHYS_SZ_IN_DMAP(pa, len),				\
-	    ("%s: PA region is outside of dmap, PA: [0x%lx, 0x%lx)",	\
-	    __func__, (vm_paddr_t)(pa), (vm_paddr_t)((pa) + (len))));	\
+	    ("%s: PA region is outside of dmap, PA: [0x%jx, 0x%jx)",	\
+	    __func__, (uintmax_t)(pa), (uintmax_t)((pa) + (len))));	\
 	KASSERT(trunc_page(pa) == trunc_page((pa) + (len) - 1),		\
-	    ("%s: PA chunk crosses page boundary, PA: [0x%lx, 0x%lx)",	\
-	    __func__, (vm_paddr_t)(pa), (vm_paddr_t)((pa) + (len))));	\
+	    ("%s: PA chunk crosses page boundary, PA: [0x%jx, 0x%jx)",	\
+	    __func__, (uintmax_t)(pa), (uintmax_t)((pa) + (len))));	\
 	cheri_kern_setboundsexact(PHYS_TO_DMAP(pa), (len));		\
 })
-#endif
 
 #ifndef ASSEMBLER
 #ifdef _KERNEL


### PR DESCRIPTION
- Enable common PMAP macros on all platforms.
- vm: Update a few printf formats to uintmax_t to pacify 32-bit build.
- proc_cheri_cap_page: Use PHYS_TO_DMAP_PAGE.
- OFED: Fix a few places that use get_user_pages.
