### PR TITLE
caprevoke fork fixes

### DIFF
--- a/lib/libsysdecode/flags.c
+++ b/lib/libsysdecode/flags.c
@@ -47,6 +47,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/stat.h>
 #include <sys/thr.h>
 #include <sys/umtx.h>
+#include <cheri/revoke.h>
 #include <machine/sysarch.h>
 #include <netinet/in.h>
 #include <netinet/sctp.h>
@@ -241,6 +242,18 @@ sysdecode_cap_fcntlrights(FILE *fp, uint32_t rights, uint32_t *rem)
 {
 
 	return (print_mask_int(fp, capfcntl, rights, rem));
+}
+
+bool
+sysdecode_cr_flags(FILE *fp, int flags, int *rem)
+{
+	return (print_mask_int(fp, cr_flags, flags, rem));
+}
+
+bool
+sysdecode_cr_get_shadow_flags(FILE *fp, int flags, int *rem)
+{
+	return (print_mask_int(fp, cr_get_shadow_flags, flags, rem));
 }
 
 bool

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -94,6 +94,8 @@ gen_table "accessmode"      "[A-Z]_OK[[:space:]]+0?x?[0-9A-Fa-f]+"         "sys/
 gen_table "acltype"         "ACL_TYPE_[A-Z4_]+[[:space:]]+0x[0-9]+"        "sys/acl.h"
 gen_table "atflags"         "AT_[A-Z_]+[[:space:]]+0x[0-9]+"               "sys/fcntl.h"
 gen_table "capfcntl"        "CAP_FCNTL_[A-Z]+[[:space:]]+\(1"              "sys/capsicum.h"
+gen_table "cr_flags" "CHERI_REVOKE_[A-Z_]+[[:space:]]+0x[0-9]+"   "cheri/revoke.h" "CHERI_REVOKE_SHADOW_"
+gen_table "cr_get_shadow_flags" "CHERI_REVOKE_SHADOW_[A-Z]+[[:space:]]+0x[0-9]+" "cheri/revoke.h"
 gen_table "closerangeflags" "CLOSE_RANGE_[A-Z]+[[:space:]]+\([0-9]+<<[0-9]+\)"       "sys/unistd.h"
 gen_table "extattrns"       "EXTATTR_NAMESPACE_[A-Z]+[[:space:]]+0x[0-9]+" "sys/extattr.h"
 gen_table "fadvisebehav"    "POSIX_FADV_[A-Z]+[[:space:]]+[0-9]+"          "sys/fcntl.h"

--- a/lib/libsysdecode/sysdecode.h
+++ b/lib/libsysdecode/sysdecode.h
@@ -53,6 +53,8 @@ const char *sysdecode_atfd(int _fd);
 bool	sysdecode_atflags(FILE *_fp, int _flags, int *_rem);
 bool	sysdecode_cap_fcntlrights(FILE *_fp, uint32_t _rights, uint32_t *_rem);
 void	sysdecode_cap_rights(FILE *_fp, cap_rights_t *_rightsp);
+bool	sysdecode_cr_flags(FILE *_fp, int _flags, int *_rem);
+bool	sysdecode_cr_get_shadow_flags(FILE *_fp, int _flags, int *_rem);
 bool	sysdecode_close_range_flags(FILE *_fp, int _flags, int *_rem);
 const char *sysdecode_cmsg_type(int _cmsg_level, int _cmsg_type);
 const char *sysdecode_extattrnamespace(int _namespace);

--- a/lib/libsysdecode/sysdecode_mask.3
+++ b/lib/libsysdecode/sysdecode_mask.3
@@ -32,6 +32,8 @@
 .Nm sysdecode_accessmode ,
 .Nm sysdecode_atflags ,
 .Nm sysdecode_capfcntlrights ,
+.Nm sysdecode_cr_flags ,
+.Nm sysdecode_cr_get_shadow_flags ,
 .Nm sysdecode_close_range_flags ,
 .Nm sysdecode_fcntl_fileflags ,
 .Nm sysdecode_fileflags ,
@@ -71,6 +73,10 @@
 .Fn sysdecode_atflags "FILE *fp" "int flags" "int *rem"
 .Ft bool
 .Fn sysdecode_cap_fcntlrights "FILE *fp" "uint32_t rights" "uint32_t *rem"
+.Ft bool
+.Fn sysdecode_cr_flags "FILE *fp" "int flags" "int *rem"
+.Ft bool
+.Fn sysdecode_cr_get_shadow_flags "FILE *fp" "int flags" "int *rem"
 .Ft bool
 .Fn sysdecode_close_range_flags "FILE *fp" "int flags" "int *rem"
 .Ft bool
@@ -157,11 +163,13 @@ if any bit fields in the value were decoded and
 if no bit fields were decoded.
 .Pp
 Most of these functions decode an argument passed to a system call:
-.Bl -column "Fn sysdecode_flock_operation" "Xr cap_fcntls_limit 2"
+.Bl -column "Fn sysdecode_cr_get_shadow_flags" "Xr cheri_revoke_get_shadow 2"
 .It Sy Function Ta Sy System Call Ta Sy Argument
 .It Fn sysdecode_access_mode Ta Xr access 2 Ta Fa mode
 .It Fn sysdecode_atflags Ta Xr chflagsat 2 , Xr fstatat 2 Ta Fa atflag , Fa flag
 .It Fn sysdecode_cap_fcntlrights Ta Xr cap_fcntls_limit 2 Ta Fa fcntlrights
+.It Fn sysdecode_cr_flags Ta Xr cheri_revoke 2 Ta Fa flags
+.It Fn sysdecode_cr_get_shadow_flags Ta Xr cheri_revoke_shadow 2 Ta Fa flags
 .It Fn sysdecode_fileflags Ta Xr chflags 2 Ta Fa flags
 .It Fn sysdecode_filemode Ta Xr chmod 2 , Xr open 2 Ta mode
 .It Fn sysdecode_flock_operation Ta Xr flock 2 Ta Fa operation

--- a/libexec/rc/rc
+++ b/libexec/rc/rc
@@ -94,7 +94,9 @@ fi
 # Do a first pass to get everything up to $early_late_divider so that
 # we can do a second pass that includes $local_startup directories
 #
-files=`rcorder ${skip} ${skip_firstboot} /etc/rc.d/* 2>/dev/null`
+unset system_rc
+find_system_scripts
+files=`rcorder ${skip} ${skip_firstboot} ${system_rc} 2>/dev/null`
 
 _rc_elem_done=' '
 for _rc_elem in ${files}; do
@@ -106,7 +108,7 @@ for _rc_elem in ${files}; do
 	esac
 done
 
-unset files local_rc
+unset files local_rc system_rc
 
 # Now that disks are mounted, for each dir in $local_startup
 # search for init scripts that use the new rc.d semantics.
@@ -122,7 +124,8 @@ if [ -e ${firstboot_sentinel} ]; then
 	skip_firstboot=""
 fi
 
-files=`rcorder ${skip} ${skip_firstboot} /etc/rc.d/* ${local_rc} 2>/dev/null`
+find_system_scripts
+files=`rcorder ${skip} ${skip_firstboot} ${system_rc} ${local_rc} 2>/dev/null`
 for _rc_elem in ${files}; do
 	case "$_rc_elem_done" in
 	*" $_rc_elem "*)	continue ;;

--- a/libexec/rc/rc.subr
+++ b/libexec/rc/rc.subr
@@ -2108,7 +2108,7 @@ find_local_scripts_new() {
 		if [ -d "${dir}" ]; then
 			for file in `grep -l '^# PROVIDE:' ${dir}/* 2>/dev/null`; do
 				case "$file" in
-				*.sample) ;;
+				*.sample|*.pkgsave) ;;
 				*)	if [ -x "$file" ]; then
 						_add_local_script $file
 					fi
@@ -2116,6 +2116,19 @@ find_local_scripts_new() {
 				esac
 			done
 		fi
+	done
+}
+
+find_system_scripts() {
+	system_rc=''
+	for file in /etc/rc.d/*; do
+		case "${file##*/}" in
+		*.pkgsave) ;;
+		*)	if [ -x "$file" ]; then
+				system_rc="${system_rc} ${file}"
+			fi
+			;;
+		esac
 	done
 }
 

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -5563,7 +5563,7 @@ out:
 				rw_wunlock(lock);
 		}
 	}
-#endif
+#endif /* VM_NRESERVLEVEL > 0 */
 
 	PMAP_UNLOCK(pmap);
 out_unlocked:
@@ -5582,8 +5582,8 @@ out_unlocked:
 
 	return res;
 }
-#endif
-#endif
+#endif /* CHERI_CAPREVOKE */
+#endif /* __has_feature(capabilities) */
 
 /*
  * This code maps large physical mmap regions into the

--- a/sys/arm64/include/pmap.h
+++ b/sys/arm64/include/pmap.h
@@ -188,7 +188,9 @@ extern void (*pmap_invalidate_vpipt_icache)(void);
 static inline int
 pmap_vmspace_copy(pmap_t dst_pmap __unused, pmap_t src_pmap __unused)
 {
-
+#if __has_feature(capabilities)
+	dst_pmap->flags.uclg = src_pmap->flags.uclg;
+#endif
 	return (0);
 }
 

--- a/sys/cheri/revoke.h
+++ b/sys/cheri/revoke.h
@@ -34,7 +34,9 @@
 #ifndef __SYS_CHERI_REVOKE_H__
 #define	__SYS_CHERI_REVOKE_H__
 
+#if __has_feature(capabilities)
 #include <cheri/cherireg.h> /* For CHERI_OTYPE_BITS */
+#endif
 
 typedef uint64_t cheri_revoke_epoch_t;
 #define CHERI_REVOKE_ST_EPOCH_WIDTH	61
@@ -73,6 +75,7 @@ static inline int cheri_revoke_epoch_clears(cheri_revoke_epoch_t now,
 	return cheri_revoke_epoch_ge(now, then + (then & 1) + 2);
 }
 
+#if __has_feature(capabilities)
 /* Returns 1 if cap is revoked, 0 otherwise. */
 static inline int
 cheri_revoke_is_revoked(const void * __capability cap)
@@ -83,6 +86,7 @@ cheri_revoke_is_revoked(const void * __capability cap)
 	return (__builtin_cheri_tag_get(cap) == 0);
 #endif
 }
+#endif
 
 /*************************** SHADOW BITMAP LAYOUT ***************************/
 
@@ -133,8 +137,10 @@ cheri_revoke_is_revoked(const void * __capability cap)
 static const size_t VM_CHERI_REVOKE_GSZ_MEM_NOMAP = sizeof(void * __capability);
 static const size_t VM_CHERI_REVOKE_GSZ_OTYPE = 1;
 
+#if __has_feature(capabilities)
 static const size_t VM_CHERI_REVOKE_BSZ_OTYPE =
   ((1 << CHERI_OTYPE_BITS) / VM_CHERI_REVOKE_GSZ_OTYPE / 8);
+#endif
 
 /*************************** REVOKER CONTROL FLAGS ***************************/
 

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -579,7 +579,9 @@ skip_last_pass:
 	     ((myst == CHERI_REVOKE_ST_SS_LAST) ||
 	      (myst == CHERI_REVOKE_ST_LS_CLOSING))) {
 
-		// XXX Assert all capdirty PTEs have LCLG equal to GCLG
+#ifdef DIAGNOSTIC
+		vm_cheri_assert_consistent_clg(&vm->vm_map);
+#endif
 
 		/* Signal the end of this revocation epoch */
 		epoch++;

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -359,13 +359,13 @@ fast_out:
 		    (flags & CHERI_REVOKE_LAST_NO_EARLY) == 0) {
 			int vmcflags = 0;
 
-			    /* Userspace can ask us to avoid an IPI here */
+			/* Userspace can ask us to avoid an IPI here */
 			vmcflags |= (flags & CHERI_REVOKE_EARLY_SYNC)
-					? VM_CHERI_REVOKE_SYNC_CD : 0;
+			    ? VM_CHERI_REVOKE_SYNC_CD : 0;
 
-			    /* If not first pass, only recently capdirty */
+			/* If not first pass, only recently capdirty */
 			vmcflags |= (entryst == CHERI_REVOKE_ST_SS_INITED)
-					? VM_CHERI_REVOKE_INCREMENTAL : 0;
+			    ? VM_CHERI_REVOKE_INCREMENTAL : 0;
 
 			res = vm_cheri_revoke_pass(&vmcrc, vmcflags);
 

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1201,6 +1201,10 @@ exec_new_vmspace(struct image_params *imgp, struct sysentvec *sv)
 		vmspace = p->p_vmspace;
 		map = &vmspace->vm_map;
 	}
+#ifdef CHERI_CAPREVOKE
+	KASSERT(map->vm_cheri_revoke_st == CHERI_REVOKE_ST_NONE,
+	    ("vm_map still revoking"));
+#endif
 	map->flags |= imgp->map_flags;
 	if (sv->sv_flags & SV_CHERI)
 		map->flags |= MAP_RESERVATIONS;

--- a/sys/riscv/include/pmap.h
+++ b/sys/riscv/include/pmap.h
@@ -175,7 +175,9 @@ int	pmap_fault(pmap_t, vm_offset_t, vm_prot_t);
 static inline int
 pmap_vmspace_copy(pmap_t dst_pmap __unused, pmap_t src_pmap __unused)
 {
-
+#if __has_feature(capabilities)
+	dst_pmap->flags.uclg = src_pmap->flags.uclg;
+#endif
 	return (0);
 }
 

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -4110,7 +4110,7 @@ out:
 				rw_wunlock(lock);
 		}
 	}
-#endif
+#endif /* VM_NRESERVLEVEL > 0 */
 
 	PMAP_UNLOCK(pmap);
 out_unlocked:
@@ -4126,8 +4126,8 @@ out_unlocked:
 
 	return res;
 }
-#endif
-#endif
+#endif /* CHERI_CAPREVOKE */
+#endif /* __has_feature(capabilities) */
 
 /*
  * This code maps large physical mmap regions into the

--- a/sys/vm/pmap.h
+++ b/sys/vm/pmap.h
@@ -142,6 +142,7 @@ enum pmap_caploadgen_res {
 int		 pmap_caploadgen_update(pmap_t, vm_offset_t, vm_page_t *,
 		    int flags);
 void		 pmap_caploadgen_next(pmap_t pmap);
+void		 pmap_assert_consistent_clg(pmap_t, vm_offset_t);
 #endif
 void		 pmap_clear_modify(vm_page_t m);
 void		 pmap_copy(pmap_t, pmap_t, vm_offset_t, vm_size_t, vm_offset_t);

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -873,6 +873,28 @@ out:
 	return res;
 }
 
+void
+vm_cheri_assert_consistent_clg(struct vm_map *map)
+{
+	pmap_t pmap = map->pmap;
+	vm_map_entry_t entry;
+	vm_offset_t addr;
+
+	/* Called with map lock held */
+
+	VM_MAP_ENTRY_FOREACH(entry, map) {
+		if ((entry->max_protection & VM_PROT_READ_CAP) == 0 ||
+		    entry->object.vm_object == NULL) {
+			continue;
+		}
+
+		for (addr = entry->start; addr < entry->end;
+		    addr += pagesizes[0]) {
+			pmap_assert_consistent_clg(pmap, addr);
+		}
+	}
+}
+
 /*
  * XXX Should this encapsulate a barrier around epochs and stat collection and
  * all that?  I don't think there are any meaningful races around epoch close,

--- a/sys/vm/vm_cheri_revoke.h
+++ b/sys/vm/vm_cheri_revoke.h
@@ -114,6 +114,8 @@ enum {
 
 int vm_cheri_revoke_pass(const struct vm_cheri_revoke_cookie *, int);
 
+void vm_cheri_assert_consistent_clg(struct vm_map *map);
+
 /*  Shadow region installation into vm map */
 int vm_map_install_cheri_revoke_shadow(struct vm_map *map, struct sysentvec *);
 

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -4769,6 +4769,9 @@ vm_map_clear(vm_map_t map)
 
 	vm_map_lock(map);
 	result = vm_map_delete(map, vm_map_min(map), vm_map_max(map), false);
+#ifdef CHERI_CAPREVOKE
+	map->vm_cheri_revoke_st = CHERI_REVOKE_ST_NONE;
+#endif
 	vm_map_unlock(map);
 
 	return (result);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5060,7 +5060,6 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 	vm2->vm_map.vm_cheri_revoke_st = vm1->vm_map.vm_cheri_revoke_st;
 #endif
 
-	/* XXX NWF This should copy across the CLG? */
 	error = pmap_vmspace_copy(new_map->pmap, old_map->pmap);
 	if (error != 0) {
 		sx_xunlock(&old_map->lock);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -107,6 +107,7 @@ __FBSDID("$FreeBSD$");
 
 #ifdef CHERI_CAPREVOKE
 #include <cheri/revoke.h>
+#include <vm/vm_cheri_revoke.h>
 #endif
 
 /*
@@ -5252,6 +5253,9 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 #endif
 		}
 	}
+#if defined(CHERI_CAPREVOKE) && defined(DIAGNOSTIC)
+	vm_cheri_assert_consistent_clg(new_map);
+#endif
 	/*
 	 * Use inlined vm_map_unlock() to postpone handling the deferred
 	 * map entries, which cannot be done until both old_map and

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5250,6 +5250,13 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 			new_entry->cred = NULL;
 
 			vm_map_entry_link(new_map, new_entry);
+			/*
+			 * Install as rev_entry if required before adding
+			 * to the quarantine list so we don't get merged
+			 * with a newly quarantined neighbor.
+			 */
+			if (old_entry == old_map->rev_entry)
+				new_map->rev_entry = new_entry;
 			vm_map_entry_quarantine(new_map, new_entry);
 			vmspace_map_entry_forked(vm1, vm2, new_entry);
 

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5062,6 +5062,7 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 	 * XXX NWF We should probably go around again to force the epoch closed.
 	 */
 	vm2->vm_map.vm_cheri_revoke_st = vm1->vm_map.vm_cheri_revoke_st;
+	vm2->vm_map.vm_cheri_revoke_test = vm1->vm_map.vm_cheri_revoke_test;
 #endif
 
 	error = pmap_vmspace_copy(new_map->pmap, old_map->pmap);

--- a/usr.bin/kdump/kdump.c
+++ b/usr.bin/kdump/kdump.c
@@ -1609,6 +1609,23 @@ ktrsyscall_freebsd(struct ktr_syscall *ktr, register_t **resip,
 				narg--;
 				c = ',';
 				break;
+			case SYS_cheri_revoke:
+				putchar('(');
+				print_mask_arg(sysdecode_cr_flags, *ip);
+				ip++;
+				narg--;
+				c = ',';
+				/* XXX: don't need to print the rest? */
+				break;
+			case SYS_cheri_revoke_get_shadow:
+				putchar('(');
+				print_mask_arg(sysdecode_cr_get_shadow_flags,
+				    *ip);
+				ip++;
+				narg--;
+				c = ',';
+				/* XXX: don't need to print the rest? */
+				break;
 			}
 			switch (ktr->ktr_code) {
 			case SYS_chflagsat:

--- a/usr.bin/truss/syscall.h
+++ b/usr.bin/truss/syscall.h
@@ -91,6 +91,8 @@ enum Argtype {
 	Atfd,
 	Atflags,
 	CapFcntlRights,
+	CheriRevokeFlags,
+	CheriRevokeGetShadowFlags,
 	Closerangeflags,
 	Extattrnamespace,
 	Fadvice,

--- a/usr.bin/truss/syscalls.c
+++ b/usr.bin/truss/syscalls.c
@@ -170,6 +170,11 @@ static const struct syscall_decode decoded_syscalls[] = {
 	  .args = { { Int, 0 }, { CapRights, 1 } } },
 	{ .name = "chdir", .ret_type = 1, .nargs = 1,
 	  .args = { { Name, 0 } } },
+	{ .name = "cheri_revoke", .ret_type = 1, .nargs = 3,
+	  .args = { { CheriRevokeFlags, 0 }, { Quad, 1 }, { Ptr | OUT, 2} } },
+	{ .name = "cheri_revoke_get_shadow", .ret_type = 1, .nargs = 3,
+	  .args = { { CheriRevokeGetShadowFlags, 0 }, { Ptr, 1 },
+		    {  Ptr | OUT, 2} } },
 	{ .name = "chflags", .ret_type = 1, .nargs = 2,
 	  .args = { { Name | IN, 0 }, { FileFlags, 1 } } },
 	{ .name = "chflagsat", .ret_type = 1, .nargs = 4,
@@ -2445,6 +2450,13 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 		print_mask_arg32(sysdecode_cap_fcntlrights, fp, rights);
 		break;
 	}
+	case CheriRevokeFlags:
+		print_mask_arg(sysdecode_cr_flags, fp, args[sc->offset]);
+		break;
+	case CheriRevokeGetShadowFlags:
+		print_mask_arg(sysdecode_cr_get_shadow_flags, fp,
+		    args[sc->offset]);
+		break;
 	case Fadvice:
 		print_integer_arg(sysdecode_fadvice, fp, args[sc->offset]);
 		break;


### PR DESCRIPTION
Fix/work around some issues present in the caprevoke tree.

- The first change is a cherry pick of a change that for reasons I don't fully understand triggers other issues: panic on Morello due to calling a NULL revocation test function and hang in rccorder (the change should cause a significant increase in the malloc/free calls as I believe the append pattern in the sh is basically realloc repeatedly.)
- The first vmspace_fork() fix addresses the NULL pointer dereference.
- The second I noticed while fixing the first.
- Finally, I disable the rcorder use that causes hangs as it's quite hard to debug during boot.  More investigation required.

