### PR TITLE
Fix DMAP capability bounds in pmap_zero_page_area.

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -5471,7 +5471,7 @@ pmap_zero_page(vm_page_t m)
 void
 pmap_zero_page_area(vm_page_t m, int off, int size)
 {
-	vm_pointer_t va = PHYS_TO_DMAP_LEN(VM_PAGE_TO_PHYS(m), size);
+	vm_pointer_t va = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(m));
 
 	if (off == 0 && size == PAGE_SIZE)
 		pagezero((void *)va);

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -3686,7 +3686,7 @@ pmap_zero_page(vm_page_t m)
 void
 pmap_zero_page_area(vm_page_t m, int off, int size)
 {
-	vm_pointer_t va = PHYS_TO_DMAP_LEN(VM_PAGE_TO_PHYS(m), size);
+	vm_pointer_t va = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(m));
 
 	if (off == 0 && size == PAGE_SIZE)
 		pagezero((void *)va);


### PR DESCRIPTION
Always use a capability with full page bounds when zeroing a subpage region.