### PR TITLE
sys/sys/systm.h: Drop downstream-only include of machine/pcb.h

### DIFF
--- a/sys/arm64/arm64/freebsd64_machdep.c
+++ b/sys/arm64/arm64/freebsd64_machdep.c
@@ -63,6 +63,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/ucontext.h>
 
 #include <machine/md_var.h>
+#include <machine/pcb.h>
 
 #include <vm/vm.h>
 #include <vm/pmap.h>

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -47,7 +47,6 @@
 #include <sys/stdint.h>		/* for people using printf mainly */
 #include <machine/atomic.h>
 #include <machine/cpufunc.h>
-#include <machine/pcb.h>
 #if __has_feature(capabilities)
 #include <machine/vmparam.h>
 #endif


### PR DESCRIPTION
Upstream doesn't pull it in here; this diff dates back to CHERI-MIPS,
which stored DDC in the PCB and thus __USER_CAP needed its definition.
However, neither Morello nor CHERI-RISC-V get it from the PCB and so do
not need this include (nor is it a generic thing that's needed), so we
should not have this as a downstream diff any more.

This fixes building lib32 libprocstat on amd64. Currently it dies
building zfs_defs.c, since it transitively includes machine/fpu.h via
sys/systm.h and, because it hackily defines _KERNEL, gets kernel
prototypes for things like fpu_save_area_free which reference struct
savefpu, but x86/fpu.h will give the i386 definition, which is a union
not a struct, giving a tag mismatch error. This issue once again
highlights how awful this approach is, and how fragile the whole thing
is when you start modifying system headers. We should probaby invest
efforts in fixing this mess upstream given the continued friction seen
around libprocstat/zfs downstream.