### PR TITLE
Jenkinsfile: Enable building lib32 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -288,6 +288,7 @@ selectedArchitectures.each { suffix ->
                 '--cheribsd/default-kernel-abi=hybrid',
                 '--keep-install-dir',
                 '--install-prefix=/rootfs',
+                '--cheribsd/build-lib32',
                 '--cheribsd/build-tests',
                 '--cheribsd/build-bench-kernels',
                 '--cheribsd/with-manpages',


### PR DESCRIPTION
These add a bit to the build time, but we want to check that we're not regressing the lib32 build as has happened in the past. We may wish to flip the default in cheribuild (or remove the option entirely) at some point in the future once we don't need to support versions where the build is broken.