### PR TITLE
arm64: Inherit C64 in child across fork

### DIFF
--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -121,7 +121,11 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	bcopy(td1->td_frame, tf, sizeof(*tf));
 	tf->tf_x[0] = 0;
 	tf->tf_x[1] = 0;
-	tf->tf_spsr = td1->td_frame->tf_spsr & (PSR_M_32 | PSR_DAIF);
+	tf->tf_spsr = td1->td_frame->tf_spsr & (PSR_M_32 | PSR_DAIF
+#if __has_feature(capabilities)
+	    | PSR_C64
+#endif
+	    );
 
 	td2->td_frame = tf;
 


### PR DESCRIPTION
Because Morello awkwardly puts the encoding mode in SPSR rather than CELR, we need to explicitly copy it over to the child's trapframe otherwise we'll lose the state and end up back in A64. In practice, this currently doesn't matter, since the success path doesn't have any mode-dependent instructions and terminates in a ret, which will get the right mode from c30, and the error path (which does have mode-dependent instructions behind a direct branch to cerror) can never be reached in the child, only the parent. However, this is still wrong, and will matter in the Morello benchmark ABI, where fork will return with an integer ret x30 and thus stay in A64.
