### PR TITLE
cheribsdtest: Improve reason if child unexpectedly dies with a signal

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -430,6 +430,11 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 		 */
 		goto pass;
 	}
+	if (WIFSIGNALED(status)) {
+		snprintf(reason, sizeof(reason), "Child exited with signal %d",
+		    WTERMSIG(status));
+		goto fail;
+	}
 	if (!WIFEXITED(status)) {
 		snprintf(reason, sizeof(reason), "Child exited abnormally");
 		goto fail;


### PR DESCRIPTION
Currently we just use "Child exited abnormally" for when the child process doesn't exit cleanly, which is unhelpful when debugging, so print the signal number instead if it was due to a signal.

Note that tests which deliberately provoke signals still exit cleanly, since the child's test harness will catch the signal, save various parts of the given siginfo_t and exit. This code is only for more catastrophic situations (e.g. signal delivery itself is broken or the child received a fatal signal before even setting up the handler).
