### PR TITLE
examples: Add a new /usr/share/examples/cheribsdtest/run-many

### DIFF
--- a/etc/mtree/BSD.usr.dist
+++ b/etc/mtree/BSD.usr.dist
@@ -273,6 +273,8 @@
             ..
             bsdconfig
             ..
+            cheribsdtest
+            ..
             csh
             ..
             diskless

--- a/share/examples/Makefile
+++ b/share/examples/Makefile
@@ -72,6 +72,10 @@ SE_BOOTFORTH= \
 	menuconf.4th \
 	screen.4th
 
+.if ${MK_CHERI} != "no"
+SUBDIR+=	cheribsdtest
+.endif
+
 SE_DIRS+=	csh
 SE_CSH=	dot.cshrc
 

--- a/share/examples/cheribsdtest/Makefile
+++ b/share/examples/cheribsdtest/Makefile
@@ -1,0 +1,7 @@
+PACKAGE=examples
+
+BINDIR=	${SHAREDIR}/examples/cheribsdtest
+
+SCRIPTS=	run-many
+
+.include <bsd.prog.mk>

--- a/share/examples/cheribsdtest/run-many
+++ b/share/examples/cheribsdtest/run-many
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2023 Jessica Clarke <jrtc27@FreeBSD.org>
+#
+# This software was developed by the University of Cambridge Computer
+# Laboratory (Department of Computer Science and Technology) under Innovate
+# UK project 105694, "Digital Security by Design (DSbD) Technology Platform
+# Prototype".
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+set -e
+set -u
+
+if [ $# -eq 0 ]; then
+	set -- hybrid purecap
+
+	case `uname -p` in
+	aarch64c)
+		set -- "$@" c18n
+		;;
+	esac
+fi
+
+if [ $1 = "-h" ]; then
+	echo >&2 "Usage: $0 [ABI] ..."
+	exit
+fi
+
+suffixes=
+for abi in "$@"; do
+	case "$abi" in
+	c18n)
+		suffixes="$suffixes mt-c18n"
+		;;
+	*)
+		for dyn in '' -dynamic; do
+			for mt in '' -mt; do
+				suffixes="$suffixes $abi$dyn$mt"
+			done
+		done
+		;;
+	esac
+done
+
+for suffix in $suffixes; do
+	prog=cheribsdtest-$suffix
+	echo
+	echo $prog
+	echo $prog | sed 's/./-/g'
+	$prog -a | grep -v '^\(TEST\|X\?\(PASS\|FAIL\)\):' || :
+done


### PR DESCRIPTION
This lets you easily run multiple cheribsdtest variants in sequence, filtering out the verbose logging for each test, printing just the summary lines at the end, as a useful tool for local testing. It is only intended for humans and should not be extended for use in automated environments; those should be using cheribuild or another similar tool to do things properly.
