### PR TITLE
Do not enforce representability for hybrid binaries in elf imgact.

### DIFF
--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -602,8 +602,9 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	if (hdr->e_type == ET_EXEC && !is_aligned(reservation,
 	    CHERI_REPRESENTABLE_ALIGNMENT(end - start))) {
 		/*
-		 * We can't change the load address for position dependent
-		 *  executables, so we have to give up and report an error.
+		 * We can't change the load address for position
+		 * dependent executables, so we have to give up and
+		 * report an error.
 		 */
 		uprintf("Warning: Attempted to load position-dependent "
 		    "executable with non-representable base: %s\n",
@@ -612,10 +613,10 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	}
 
 	/*
-	 * Note: vm_map_reservation_create aligns down, but we have to align
-	 * upwards here to avoid rounding down to zero for the main executable.
-	 * For RTLD we also align upwards to avoid aligning down into the
-	 * memory region for the main binary.
+	 * Note: vm_map_reservation_create aligns down, but we have to
+	 * align upwards here to avoid rounding down to zero for the main
+	 * executable. For RTLD we also align upwards to avoid aligning
+	 * down into the memory region for the main binary.
 	 */
 	reservation = roundup2(reservation,
 	    CHERI_REPRESENTABLE_ALIGNMENT(end - start));

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -597,7 +597,9 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 		end = MAX(end, seg_addr + seg_size);
 	}
 
-	if (hdr->e_type == ET_EXEC && !is_aligned(start + rbase,
+	reservation = start + rbase;
+#ifdef __ELF_CHERI
+	if (hdr->e_type == ET_EXEC && !is_aligned(reservation,
 	    CHERI_REPRESENTABLE_ALIGNMENT(end - start))) {
 		/*
 		 * We can't change the load address for position dependent
@@ -615,8 +617,9 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	 * For RTLD we also align upwards to avoid aligning down into the
 	 * memory region for the main binary.
 	 */
-	reservation = roundup2(start + rbase,
+	reservation = roundup2(reservation,
 	    CHERI_REPRESENTABLE_ALIGNMENT(end - start));
+#endif
 	result = vm_map_reservation_create(map, &reservation, end - start,
 	    PAGE_SIZE, VM_PROT_ALL);
 	if (result != KERN_SUCCESS)


### PR DESCRIPTION
When loading hybrid position-dependent binaries, we do not care about the representability of the ELF sections. The reservation creation will skip the representability alignment enforcement as well, so avoid complaining about alignment when creating the imgact_capability.

This should fix #1700.