### PR TITLE
caprevoke: actually revoke unmapped entries

### DIFF
--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -520,8 +520,6 @@ fast_out:
 		break;
 	}
 
-	vm_map_entry_end_revocation(&vm->vm_map);
-
 	PROC_LOCK(td->td_proc);
 	_PRELE(td->td_proc);
 	if ((td->td_proc->p_flag & P_HADTHREADS) != 0) {
@@ -588,6 +586,8 @@ skip_last_pass:
 		crepochs.dequeue = epoch;
 		vm_cheri_revoke_publish_epochs(info_page, &crepochs);
 		entryst = CHERI_REVOKE_ST_NONE;
+
+		vm_map_entry_end_revocation(&vm->vm_map);
 	}
 
 	vm_map_lock(vmm);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -4768,10 +4768,20 @@ vm_map_clear(vm_map_t map)
 	int result;
 
 	vm_map_lock(map);
-	result = vm_map_delete(map, vm_map_min(map), vm_map_max(map), false);
 #ifdef CHERI_CAPREVOKE
+	/*
+	 * vm_map_clear() is the ultimate revocation (no mappings means
+	 * no capabilities).  Clear revocation state.
+	 */
 	map->vm_cheri_revoke_st = CHERI_REVOKE_ST_NONE;
+	/* quarantine is drained below. */
+	map->rev_entry = NULL;
+#ifdef CHERI_CAPREVOKE_STATS
+	memset(&map->vm_cheri_revoke_stats, 0,
+	    sizeof(map->vm_cheri_revoke_stats));
 #endif
+#endif
+	result = vm_map_delete(map, vm_map_min(map), vm_map_max(map), false);
 	vm_map_unlock(map);
 
 	return (result);


### PR DESCRIPTION
In working on #1743 I discovered that I was the unmapped entry that was being revoked too early resulting in it never being removed except perhaps in the most accidental fashion. Fixing this turned up a bug when exiting a process that was in the load-side INITED state as we'd hit an assert when trying to unlink the entry being removed.