### PR TITLE
Replace LD_CHERI_ prefix with LD_64C_ for rtld-elf64c

### DIFF
--- a/libexec/rtld-elf/rtld_paths.h
+++ b/libexec/rtld-elf/rtld_paths.h
@@ -50,7 +50,7 @@
 #define	_PATH_LIBMAP_CONF	"/etc/libmap64c.conf"
 #define	_BASENAME_RTLD		_CHERIABI_BASENAME_RTLD
 #define	STANDARD_LIBRARY_PATH	"/lib64c:/usr/lib64c"
-#define	LD_			"LD_CHERI_"
+#define	LD_			"LD_64C_"
 #endif
 
 #ifndef _PATH_ELF32_HINTS

--- a/usr.bin/ldd/ldd.c
+++ b/usr.bin/ldd/ldd.c
@@ -71,14 +71,14 @@ __FBSDID("$FreeBSD$");
 	setenv("LD_" name, value, overwrite);		\
 	setenv("LD_32_" name, value, overwrite);	\
 	setenv("LD_64_" name, value, overwrite);	\
-	setenv("LD_CHERI_" name, value, overwrite);	\
+	setenv("LD_64C_" name, value, overwrite);	\
 } while (0)
 
 #define	LDD_UNSETENV(name) do {		\
 	unsetenv("LD_" name);		\
 	unsetenv("LD_32_" name);	\
 	unsetenv("LD_64_" name);	\
-	unsetenv("LD_CHERI_" name);	\
+	unsetenv("LD_64C_" name);	\
 } while (0)
 
 static int	is_executable(const char *fname, int fd, int *is_shlib,

--- a/usr.bin/stdbuf/stdbuf.c
+++ b/usr.bin/stdbuf/stdbuf.c
@@ -119,15 +119,15 @@ main(int argc, char *argv[])
 	if (i < 0 || putenv(preload1) == -1)
 		warn("Failed to set environment variable: LD_64_PRELOAD");
 
-	preload0 = getenv("LD_CHERI_PRELOAD");
+	preload0 = getenv("LD_64C_PRELOAD");
 	if (preload0 == NULL)
-		i = asprintf(&preload1, "LD_CHERI_PRELOAD=" LIBSTDBUF64C);
+		i = asprintf(&preload1, "LD_64C_PRELOAD=" LIBSTDBUF64C);
 	else
-		i = asprintf(&preload1, "LD_CHERI_PRELOAD=%s:%s", preload0,
+		i = asprintf(&preload1, "LD_64C_PRELOAD=%s:%s", preload0,
 		    LIBSTDBUF64C);
 
 	if (i < 0 || putenv(preload1) == -1)
-		warn("Failed to set environment variable: LD_CHERI_PRELOAD");
+		warn("Failed to set environment variable: LD_64C_PRELOAD");
 
 	execvp(argv[0], argv);
 	err(2, "%s", argv[0]);

--- a/usr.bin/stdbuf/stdbuf.c
+++ b/usr.bin/stdbuf/stdbuf.c
@@ -36,7 +36,7 @@
 #define	LIBSTDBUF	"/usr/lib/libstdbuf.so"
 #define	LIBSTDBUF32	"/usr/lib32/libstdbuf.so"
 #define	LIBSTDBUF64	"/usr/lib64/libstdbuf.so"
-#define	LIBSTDBUFCHERI	"/usr/lib64c/libstdbuf.so"
+#define	LIBSTDBUF64C	"/usr/lib64c/libstdbuf.so"
 
 extern char *__progname;
 
@@ -121,10 +121,10 @@ main(int argc, char *argv[])
 
 	preload0 = getenv("LD_CHERI_PRELOAD");
 	if (preload0 == NULL)
-		i = asprintf(&preload1, "LD_CHERI_PRELOAD=" LIBSTDBUFCHERI);
+		i = asprintf(&preload1, "LD_CHERI_PRELOAD=" LIBSTDBUF64C);
 	else
 		i = asprintf(&preload1, "LD_CHERI_PRELOAD=%s:%s", preload0,
-		    LIBSTDBUFCHERI);
+		    LIBSTDBUF64C);
 
 	if (i < 0 || putenv(preload1) == -1)
 		warn("Failed to set environment variable: LD_CHERI_PRELOAD");


### PR DESCRIPTION
This at last finishes the multi-year transition from libcheri to lib64c, now that cheribuild should be able to handle both.
