### PR TITLE
Fix coprocess user space switcher for morello

### DIFF
--- a/sys/arm64/cheri/cheri_coaccept.S
+++ b/sys/arm64/cheri/cheri_coaccept.S
@@ -216,10 +216,18 @@ SIGCODE(switcher_coaccept)
 	 */
 	sub	x11, x4, x13
 	cmp	x11, #0
+	mov	x14, x13
 	bge	2f
 	mov	x13, x4
+	mov	x14, x13
 
 2:
+	//If we use this mov instruction instead of the two "mov x14, x13" above
+	//then this function returns '8' even if x13 and x4 contain values
+	//larger than eight. This is an odd bug that cannot be explained by a
+	//flaw in the assembly code. This issue occurs on qemu. I haven't
+	//tested if it can be reproduced on an actual Morello board.
+	//mov	x14, x13
 	add	x13, x13, #-8
 	ldr	x11, [c3, x13]
 	str	x11, [c12, x13]
@@ -234,8 +242,9 @@ SIGCODE(switcher_coaccept)
 	/*
 	 * Return success; clear the carry flag.
 	 */
-	adds	x0, x0, x0
 	mov	x0, 0
+	adds	x0, x0, x0
+	mov	x0, x14
 3:
 	/* Preserve x0, which is our return value. */
 	mov	x1, 0

--- a/sys/arm64/cheri/cheri_coaccept.S
+++ b/sys/arm64/cheri/cheri_coaccept.S
@@ -216,22 +216,16 @@ SIGCODE(switcher_coaccept)
 	 */
 	sub	x11, x4, x13
 	cmp	x11, #0
-	mov	x14, x13
-	bge	2f
+	bge	use_cocall_output_buffer_len
 	mov	x13, x4
-	mov	x14, x13
 
-2:
-	//If we use this mov instruction instead of the two "mov x14, x13" above
-	//then this function returns '8' even if x13 and x4 contain values
-	//larger than eight. This is an odd bug that cannot be explained by a
-	//flaw in the assembly code. This issue occurs on qemu. I haven't
-	//tested if it can be reproduced on an actual Morello board.
-	//mov	x14, x13
+use_cocall_output_buffer_len:
+	mov	x14, x13
+copy_loop:
 	add	x13, x13, #-8
 	ldr	x11, [c3, x13]
 	str	x11, [c12, x13]
-	cbnz	x13, 2b
+	cbnz	x13, copy_loop
 
 	/*
 	 * Zero out the scb_peer_scb variables, releasing the spinlock.

--- a/sys/arm64/cheri/cheri_cocall.S
+++ b/sys/arm64/cheri/cheri_cocall.S
@@ -219,11 +219,19 @@ SIGCODE(switcher_cocall)
 	 */
 	sub	x11, x4, x13
 	cmp	x11, #0
+	mov	x14, x13
 	bge	3f
 	mov	x13, x4
+	mov	x14, x13
 
 CSYM(switcher_cocall_copy_start)
 3:
+	//If we use this mov instruction instead of the two "mov x14, x13" above
+	//then this function returns '8' even if x13 and x4 contain values
+	//larger than eight. This is an odd bug that cannot be explained by a
+	//flaw in the assembly code. This issue occurs on qemu. I haven't
+	//tested if it can be reproduced on an actual Morello board.
+	//mov	x14, x13
 	add	x13, x13, #-8
 	ldr	x11, [c3, x13]
 	str	x11, [c12, x13]
@@ -235,6 +243,7 @@ CSYM(switcher_cocall_copy_end)
 	 */
 	mov	x0, 0
 	adds	x0, x0, x0
+	mov	x0, x14
 4:
 	/* Preserve x0, which is our return value. */
 	mov	x1, 0

--- a/sys/arm64/cheri/cheri_cocall.S
+++ b/sys/arm64/cheri/cheri_cocall.S
@@ -219,23 +219,17 @@ SIGCODE(switcher_cocall)
 	 */
 	sub	x11, x4, x13
 	cmp	x11, #0
-	mov	x14, x13
-	bge	3f
+	bge	use_coaccept_input_buffer_len
 	mov	x13, x4
-	mov	x14, x13
 
+use_coaccept_input_buffer_len:
 CSYM(switcher_cocall_copy_start)
-3:
-	//If we use this mov instruction instead of the two "mov x14, x13" above
-	//then this function returns '8' even if x13 and x4 contain values
-	//larger than eight. This is an odd bug that cannot be explained by a
-	//flaw in the assembly code. This issue occurs on qemu. I haven't
-	//tested if it can be reproduced on an actual Morello board.
-	//mov	x14, x13
+	mov	x14, x13
+copy_loop:
 	add	x13, x13, #-8
 	ldr	x11, [c3, x13]
 	str	x11, [c12, x13]
-	cbnz	x13, 3b
+	cbnz	x13, copy_loop
 CSYM(switcher_cocall_copy_end)
 
 	/*

--- a/sys/cheri/cheri_colocation.c
+++ b/sys/cheri/cheri_colocation.c
@@ -345,9 +345,6 @@ colocation_unborrow(struct thread *td)
 	struct switchercb scb;
 	struct thread *peertd;
 	struct trapframe peertrapframe;
-#ifdef __aarch64__
-	uintcap_t peertpidr;
-#endif
 	bool have_scb;
 
 	have_scb = colocation_fetch_scb(td, &scb);
@@ -393,14 +390,16 @@ colocation_unborrow(struct thread *td)
 		kdb_enter(KDB_WHY_CHERI, "unborrow");
 #endif
 
-
 #ifdef __aarch64__
 	/*
-	 * On aarch64, the TLS pointer is in TPC, not in td_frame.
+	 * Because this thread was borrowed by a callee coprocess this
+	 * register contains the starting address of the thread local storage
+	 * (TLS) of another thread. This overwrites this address with the
+	 * TLS starting address that actually belongs to this thread.
+	 * We have to do this here because the value in this register is written
+	 * to kernel data structures when we execute copark later on.
 	 */
-	peertpidr = peertd->td_pcb->pcb_tpidr_el0;
-	peertd->td_pcb->pcb_tpidr_el0 = td->td_pcb->pcb_tpidr_el0;
-	td->td_pcb->pcb_tpidr_el0 = peertpidr;
+	WRITE_SPECIALREG_CAP(ctpidr_el0, scb.scb_tls);
 #endif
 
 	memcpy(&peertrapframe, peertd->td_frame, sizeof(struct trapframe));
@@ -807,7 +806,6 @@ kern_cogetpid(struct thread *td, pid_t * __capability pidp)
 int
 sys_copark(struct thread *td, struct copark_args *uap)
 {
-
 	return (kern_copark(td));
 }
 


### PR DESCRIPTION
This PR addresses comments by @brooksdavis in https://github.com/CTSRD-CHERI/cheribsd/pull/1757.
After talking to @trasz, I renamed only two labels to reduce the number of merge conflicts that he will have when he'll merge his current work on the user space switcher.