### PR TITLE
Clean up assembly that computes the return values of coaccept and cocall

### DIFF
--- a/sys/arm64/cheri/cheri_coaccept.S
+++ b/sys/arm64/cheri/cheri_coaccept.S
@@ -216,22 +216,16 @@ SIGCODE(switcher_coaccept)
 	 */
 	sub	x11, x4, x13
 	cmp	x11, #0
-	mov	x14, x13
-	bge	2f
+	bge	use_cocall_output_buffer_len
 	mov	x13, x4
+use_cocall_output_buffer_len:
 	mov	x14, x13
 
-2:
-	//If we use this mov instruction instead of the two "mov x14, x13" above
-	//then this function returns '8' even if x13 and x4 contain values
-	//larger than eight. This is an odd bug that cannot be explained by a
-	//flaw in the assembly code. This issue occurs on qemu. I haven't
-	//tested if it can be reproduced on an actual Morello board.
-	//mov	x14, x13
+copy_loop:
 	add	x13, x13, #-8
 	ldr	x11, [c3, x13]
 	str	x11, [c12, x13]
-	cbnz	x13, 2b
+	cbnz	x13, copy_loop
 
 	/*
 	 * Zero out the scb_peer_scb variables, releasing the spinlock.

--- a/sys/arm64/cheri/cheri_coaccept.S
+++ b/sys/arm64/cheri/cheri_coaccept.S
@@ -148,7 +148,7 @@ SIGCODE(switcher_coaccept)
 	str	x11, SCB_BORROWER_TD(c29)
 	b	5f
 4:
-	str	czr, SCB_BORROWER_TD(c8)
+	str	xzr, SCB_BORROWER_TD(c8)
 5:
 
 	/*

--- a/sys/arm64/cheri/cheri_cocall.S
+++ b/sys/arm64/cheri/cheri_cocall.S
@@ -145,7 +145,7 @@ SIGCODE(switcher_cocall)
 	str	x12, SCB_BORROWER_TD(c29)
 	b	6f
 5:
-	str	czr, SCB_BORROWER_TD(c8)
+	str	xzr, SCB_BORROWER_TD(c8)
 6:
 
 	/*

--- a/sys/arm64/cheri/cheri_cocall.S
+++ b/sys/arm64/cheri/cheri_cocall.S
@@ -219,23 +219,17 @@ SIGCODE(switcher_cocall)
 	 */
 	sub	x11, x4, x13
 	cmp	x11, #0
-	mov	x14, x13
-	bge	3f
+	bge	use_coaccept_input_buffer_len
 	mov	x13, x4
+use_coaccept_input_buffer_len:
 	mov	x14, x13
 
 CSYM(switcher_cocall_copy_start)
-3:
-	//If we use this mov instruction instead of the two "mov x14, x13" above
-	//then this function returns '8' even if x13 and x4 contain values
-	//larger than eight. This is an odd bug that cannot be explained by a
-	//flaw in the assembly code. This issue occurs on qemu. I haven't
-	//tested if it can be reproduced on an actual Morello board.
-	//mov	x14, x13
+copy_loop:
 	add	x13, x13, #-8
 	ldr	x11, [c3, x13]
 	str	x11, [c12, x13]
-	cbnz	x13, 3b
+	cbnz	x13, copy_loop
 CSYM(switcher_cocall_copy_end)
 
 	/*


### PR DESCRIPTION
This PR addresses comments by @brooksdavis in https://github.com/CTSRD-CHERI/cheribsd/pull/1757.
After talking to @trasz, I renamed only two labels to reduce the number of merge conflicts that he'll have when he merges his current work on the user space switcher.