### PR TITLE
thr_init: Fix __thr_get_main_stack_base for purecap

### DIFF
--- a/lib/libthr/thread/thr_init.c
+++ b/lib/libthr/thread/thr_init.c
@@ -465,7 +465,7 @@ __thr_get_main_stack_base(char **base)
 	 * there.
 	 */
 	char *sp = (char *)cheri_getstack();
-	*base = sp + cheri_getlen(sp);
+	*base = cheri_setoffset(sp, cheri_getlen(sp));
 	return (true);
 #else
 	size_t len;


### PR DESCRIPTION
The current stack pointer will have a very big non-zero offset at the
point this is called, so adding on the length will take it way beyond
the real "base" (top) of the stack. This greatly confused WebKit, since
it would very easily observe during its evaluation loop that the
difference between the current stack pointer and this claimed base was
bigger than the (correct) reported stack size, and thus conclude that
the stack had overflowed and throw an exception (helpfully with no
message).

Fixes:	31044f68ee91 ("libthr: Always define usrtack from the main thread's stack pointer.")