### PR TITLE
imgact_elf: Enable ELF_IS_CHERI check always

### DIFF
--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -509,12 +509,6 @@ get_elf_header(int fd, const char *path, const struct stat *sbp,
 	if (!check_elf_headers(hdr, path))
 		goto error;
 
-#ifndef ELF_IS_CHERI
-#if __has_feature(capabilities)
-#error "Must have ELF_IS_CHERI for CHERI architectures"
-#endif
-#define ELF_IS_CHERI(hdr) false
-#endif
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (!ELF_IS_CHERI(hdr))
 #else

--- a/sys/sys/elf.h
+++ b/sys/sys/elf.h
@@ -40,4 +40,11 @@
 #include <sys/elf32.h>
 #include <sys/elf64.h>
 
+#ifndef ELF_IS_CHERI
+#if __has_feature(capabilities)
+#error "Must have ELF_IS_CHERI for CHERI architectures"
+#endif
+#define ELF_IS_CHERI(hdr) false
+#endif
+
 #endif /* !_SYS_ELF_H_ */


### PR DESCRIPTION
If an architecture defines ELF_IS_CHERI, always check it in the
non-CHERI case (imgact_elf64.c), not just in CHERI-enabled kernels.
