### PR TITLE
sys/signal.h: Simplify __SIGHANDLER_CONSTANT by using __kintcap_t

### DIFF
--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -105,19 +105,11 @@ typedef	__uintmax_t		uintmax_t;
 #define	_UINTMAX_T_DECLARED
 #endif
 #ifndef _KINTCAP_T_DECLARED
-#ifdef _KERNEL
-typedef	__intcap_t		kintcap_t;
-#else
-typedef	__intptr_t		kintcap_t;
-#endif
+typedef	__kintcap_t		kintcap_t;
 #define	_KINTCAP_T_DECLARED
 #endif
 #ifndef _KUINTCAP_T_DECLARED
-#ifdef _KERNEL
-typedef	__uintcap_t		kuintcap_t;
-#else
-typedef	__uintptr_t		kuintcap_t;
-#endif
+typedef	__kuintcap_t		kuintcap_t;
 #define	_KUINTCAP_T_DECLARED
 #endif
 #ifndef _KUINT64CAP_T_DECLARED

--- a/sys/sys/_types.h
+++ b/sys/sys/_types.h
@@ -171,8 +171,10 @@ typedef	__uintptr_t	__uintcap_t;
 #endif
 
 #ifdef _KERNEL
+typedef	__intcap_t	__kintcap_t;
 typedef	__uintcap_t	__kuintcap_t;
 #else
+typedef	__intptr_t	__kintcap_t;
 typedef	__uintptr_t	__kuintcap_t;
 #endif
 

--- a/sys/sys/_types.h
+++ b/sys/sys/_types.h
@@ -171,9 +171,9 @@ typedef	__uintptr_t	__uintcap_t;
 #endif
 
 #ifdef _KERNEL
-typedef __uintcap_t	__kuintcap_t;
+typedef	__uintcap_t	__kuintcap_t;
 #else
-typedef __uintptr_t	__kuintcap_t;
+typedef	__uintptr_t	__kuintcap_t;
 #endif
 
 /*

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -137,20 +137,14 @@ typedef	__uid_t		uid_t;
 #define	SIGRTMIN	65
 #define	SIGRTMAX	126
 
-#ifdef _KERNEL
-#if !__has_feature(capabilities)
-#define	__intcap_t __intptr_t
-#endif
 /*
- * In the kernel we need to cast to __intcap_t since we are assigning to a
- * capability. If we did this in hybrid userspace we would generate a CToPtr
- * which causes all of the SIG_* constants to evaluate to 0.
+ * In a hybrid kernel we need to cast via __intcap_t since we are assigning to
+ * a capability and would otherwise get a CFromPtr rather than a null-derived
+ * capability. In all other cases the inner __kintcap_t cast is unnecessary but
+ * harmless. This is a workaround for what is really a hybrid C "spec" bug.
  */
 #define __SIGHANDLER_CONSTANT(value)	\
-    ((__sighandler_t * __kerncap)(__intcap_t)value)
-#else
-#define __SIGHANDLER_CONSTANT(value) ((__sighandler_t *)(__intptr_t)value)
-#endif
+    ((__sighandler_t * __kerncap)(__kintcap_t)value)
 #define	SIG_DFL		__SIGHANDLER_CONSTANT(0)
 #define	SIG_IGN		__SIGHANDLER_CONSTANT(1)
 #define	SIG_ERR		__SIGHANDLER_CONSTANT(-1)


### PR DESCRIPTION
Also update the comment here to clarify what exactly is going on (the
talk about CToPtr in particular is a bit confusing, really it's saying
why we use __intptr_t rather than __intcap_t for hybrid userspace, but
the latter would be a bit stupid to use anyway).
