### PR TITLE
Reduce cheribsdtest verbosity

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -91,9 +91,10 @@ static int fast_tests_only;
 static int qtrace;
 static int qtrace_user_mode_only;
 static int sleep_after_test;
-static int verbose;
 static int coredump_enabled;
 static int debugger_enabled;
+
+int verbose;
 
 static void
 usage(void)

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -41,34 +41,6 @@
 
 #include "cheribsdtest_md.h"
 
-#define	CHERI_CAP_PRINT(cap) do {					\
-	printf("tag %ju s %ju perms %08jx type %016jx\n",		\
-	    (uintmax_t)cheri_gettag(cap),				\
-	    (uintmax_t)cheri_getsealed(cap),				\
-	    (uintmax_t)cheri_getperm(cap),				\
-	    (uintmax_t)cheri_gettype(cap));				\
-	printf("\tbase %016jx length %016jx\n",				\
-	    (uintmax_t)cheri_getbase(cap),				\
-	    (uintmax_t)cheri_getlen(cap));				\
-} while (0)
-
-#define	CHERI_CAPREG_PRINT(crn) do {					\
-	void * __capability cap;						\
-	if (crn == 0)							\
-		cap = cheri_getdefault();				\
-	else								\
-		cap = cheri_getreg(crn);				\
-	printf("C%u ", crn);						\
-	CHERI_CAP_PRINT(cap);						\
-} while (0)
-
-#define	CHERI_PCC_PRINT() do {						\
-	void * __capability cap;						\
-	cap = cheri_getpcc();						\
-	printf("PCC ");							\
-	CHERI_CAP_PRINT(cap);						\
-} while (0)
-
 /*
  * Convert a pointer to a null-derived void * with the same address. This is
  * useful for getting the correct value for ccs_si_addr_expected.

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -75,6 +75,8 @@
  */
 #define	NULL_DERIVED_VOIDP(x) ((void *)(uintptr_t)(ptraddr_t)(x))
 
+extern int verbose;
+
 /*
  * Shared memory interface between tests and the test controller process.
  */

--- a/bin/cheribsdtest/cheribsdtest_registers.c
+++ b/bin/cheribsdtest/cheribsdtest_registers.c
@@ -76,8 +76,6 @@ check_initreg_code(void * __capability c)
 {
 	uintmax_t v;
 
-	fprintf(stderr, "c %#lp\n", c);
-
 #if defined(__CHERI_PURE_CAPABILITY__)
 	/*
 	 * Dynamically linked pure-capability code should have a program

--- a/bin/cheribsdtest/cheribsdtest_syscall.c
+++ b/bin/cheribsdtest/cheribsdtest_syscall.c
@@ -64,24 +64,8 @@
 
 CHERIBSDTEST(sig_dfl_neq_ign, "Test SIG_DFL != SIG_IGN")
 {
-	void * __capability sic = (__cheri_tocap void * __capability)SIG_IGN;
-
-	/*
-	 * This may appear redundant, but it tickles some of the optimizers
-	 * differently than the condition below, which, apparently, can get
-	 * constant-folded and DCE'd, while this does not.
-	 */
-	int eq = (SIG_IGN == SIG_DFL);
-
-	fprintf(stderr, "sic %#lp\n", sic);
-	fprintf(stderr, "IGN=%ld(%p) DFL=%ld(%p) EQ=%d(%d)\n",
-		(long)SIG_IGN, SIG_IGN,
-		(long)SIG_DFL, SIG_DFL, SIG_IGN == SIG_DFL, eq);
-
 	if (SIG_IGN == SIG_DFL)
 		cheribsdtest_failure_errx("SIG_{IGN,DFL} conflated");
-	else if (eq)
-		cheribsdtest_failure_errx("SIG_{IGN,DFL} somewhat conflated?");
 	else
 		cheribsdtest_success();
 }

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -358,8 +358,6 @@ CHERIBSDTEST(vm_cap_share_fd_kqueue,
 		CHERIBSDTEST_VERIFY2(oke.ident == 0x2BAD, "Bad identifier from kqueue");
 		CHERIBSDTEST_VERIFY2(oke.filter == EVFILT_USER, "Bad filter from kqueue");
 
-		fprintf(stderr, "oke.udata %#lp\n", oke.udata);
-
 		exit(cheri_gettag(oke.udata));
 	} else {
 		int res;
@@ -428,8 +426,6 @@ CHERIBSDTEST(vm_cap_share_sigaction,
 
 		/* Read it again and check that we get the same value back. */
 		CHERIBSDTEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
-		fprintf(stderr, "child value read from sigaction(): ");
-		fprintf(stderr, "sa.sa_handler %#lp\n", sa.sa_handler);
 		CHERIBSDTEST_CHECK_EQ_CAP(sa.sa_handler, passme);
 
 		exit(0);
@@ -442,8 +438,6 @@ CHERIBSDTEST(vm_cap_share_sigaction,
 		sa.sa_flags = 1;
 
 		CHERIBSDTEST_CHECK_SYSCALL(__sys_sigaction(SIGUSR1, NULL, &sa));
-		fprintf(stderr, "parent sa read from sigaction(): ");
-		fprintf(stderr, "sa.sa_handler %#lp\n", sa.sa_handler);
 
 		/* Flags should be zero on read */
 		CHERIBSDTEST_CHECK_EQ_LONG(sa.sa_flags, 0);

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -199,9 +199,8 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 						0));
 		c = *map;
 
-		fprintf(stderr, "rx cap: v:%lu b:%016jx l:%016zx o:%jx\n",
-			(unsigned long)cheri_gettag(c), cheri_getbase(c),
-			cheri_getlen(c), cheri_getoffset(c));
+		if (verbose)
+			fprintf(stderr, "rx cap: %#lp\n", c);
 
 		tag = cheri_gettag(c);
 		CHERIBSDTEST_VERIFY2(tag == 0, "tag read");
@@ -235,9 +234,8 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 		c = *map;
 		CHERIBSDTEST_VERIFY2(cheri_gettag(c) != 0, "tag written");
 
-		fprintf(stderr, "tx cap: v:%lu b:%016jx l:%016zx o:%jx\n",
-			(unsigned long)cheri_gettag(c), cheri_getbase(c),
-			cheri_getlen(c), cheri_getoffset(c));
+		if (verbose)
+			fprintf(stderr, "tx cap: %#lp\n", c);
 
 		CHERIBSDTEST_CHECK_SYSCALL(munmap(map, getpagesize()));
 

--- a/share/examples/cheribsdtest/run-many
+++ b/share/examples/cheribsdtest/run-many
@@ -70,5 +70,5 @@ for suffix in $suffixes; do
 	echo
 	echo $prog
 	echo $prog | sed 's/./-/g'
-	$prog -a | grep -v '^\(TEST\|X\?\(PASS\|FAIL\)\):' || :
+	$prog -a | grep -v '^\(TEST\|X\?\(PASS\|FAIL\)\|SKIP\):' || :
 done


### PR DESCRIPTION
- cheribsdtest: Remove the sig_dfl_neq_ign test
- cheribsdtest: Trim some spurious debug printfs.
- cheribsdtest: Export verbose flag so tests can use it
- cheribsdtest: Move debug printfs conditional on verbose
- cheribsdtest: Remove some stale macros for printing capabilities
- run-many: Hide SKIP test results
