### PR TITLE
sysv_msg: Fix a typo when freeing a msghdr.

### DIFF
--- a/sys/kern/sysv_msg.c
+++ b/sys/kern/sysv_msg.c
@@ -429,7 +429,7 @@ msg_freehdr(struct msg *msghdr)
 	}
 	if (msghdr->msg_spot != -1)
 		panic("msghdr->msg_spot != -1");
-	TAILQ_INSERT_HEAD(&free_msghdrs, msghdrs, msg_queue);
+	TAILQ_INSERT_HEAD(&free_msghdrs, msghdr, msg_queue);
 #ifdef MAC
 	mac_sysvmsg_cleanup(msghdr);
 #endif


### PR DESCRIPTION
Free the msghdr in question, not the first msghdr in the global
msghdrs array.  This corrupted the free_msghdrs list resulting in
panics during the kyua tests.

Fixes:		9bada506e46f sysvmsg: switch message queues to TAILQs
