### PR TITLE
Introduce and fix non-CHERI tinderbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,10 @@ worlds: .PHONY
 # powerpcspe excluded from main list until clang fixed
 EXTRA_ARCHES_powerpc=	powerpcspe
 .endif
+.if defined(NO_CHERI_TARGETS)
+CHERI_ARCHES_arm64=
+CHERI_ARCHES_riscv=
+.endif
 TARGETS?= ${TARGET_MACHINE_LIST}
 _UNIVERSE_TARGETS=	${TARGETS}
 .for target in ${TARGETS}
@@ -744,6 +748,9 @@ _THINNER=cat
 _THINNER=grep 'LINT' || true
 .else
 _THINNER=xargs grep -L "^.NO_UNIVERSE" || true
+.endif
+.if defined(NO_CHERI_KERNELS)
+_THINNER:=grep -v 'CHERI\|MORELLO' | ${_THINNER}
 .endif
 KERNCONFS!=	cd ${KERNSRCDIR}/${TARGET}/conf && \
 		find [[:upper:][:digit:]]*[[:upper:][:digit:]] \

--- a/lib/libc/gen/setjmperr.c
+++ b/lib/libc/gen/setjmperr.c
@@ -45,7 +45,7 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 #include "un-namespace.h"
 
-__attribute__((visibility("protected"))) void
+void
 longjmperror(void)
 {
 #define	ERRMSG	"longjmp botch.\n"

--- a/lib/libc/net/getaddrinfo.c
+++ b/lib/libc/net/getaddrinfo.c
@@ -1834,7 +1834,7 @@ addrinfo_marshal_func(char *buffer, size_t *buffer_size, void *retval,
 
 	memcpy(p, &ai_size, sizeof(size_t));
 	p += sizeof(size_t);
-	p = _ALIGN(p);
+	p = (char *)_ALIGN(p);
 	for (cai = ai; cai != NULL; cai = cai->ai_next) {
 		memcpy(p, cai, sizeof(struct addrinfo));
 		p += sizeof(struct addrinfo);
@@ -1850,7 +1850,7 @@ addrinfo_marshal_func(char *buffer, size_t *buffer_size, void *retval,
 			memcpy(p, cai->ai_canonname, size);
 			p += size;
 		}
-		p = _ALIGN(p);
+		p = (char *)_ALIGN(p);
 	}
 
 	return (NS_SUCCESS);
@@ -1868,7 +1868,7 @@ addrinfo_unmarshal_func(char *buffer, size_t buffer_size, void *retval,
 	p = buffer;
 	memcpy(&ai_size, p, sizeof(size_t));
 	p += sizeof(size_t);
-	p = _ALIGN(p);
+	p = (char *)_ALIGN(p);
 
 	result = NULL;
 	lasts = NULL;
@@ -1904,7 +1904,7 @@ addrinfo_unmarshal_func(char *buffer, size_t buffer_size, void *retval,
 			lasts->ai_next = sentinel;
 			lasts = sentinel;
 		}
-		p = _ALIGN(p);
+		p = (char *)_ALIGN(p);
 	}
 
 	*((struct addrinfo **)retval) = result;

--- a/lib/libc/riscv/SYS.h
+++ b/lib/libc/riscv/SYS.h
@@ -79,7 +79,7 @@ ENTRY(__sys_##name);						\
 	_SYSCALL(name);						\
 	bnez	t0, 1f; 					\
 	RETURN;							\
-1:	ASM_LOCAL_TAILCALL(t1, cerror);				\
+1:	_TAIL	cerror@plt;					\
 END(__sys_##name)
 
 #define	RSYSCALL(name)						\
@@ -89,7 +89,7 @@ ENTRY(__sys_##name);						\
 	_SYSCALL(name);						\
 	bnez	t0, 1f; 					\
 	RETURN;							\
-1:	ASM_LOCAL_TAILCALL(t1, cerror);				\
+1:	_TAIL	cerror@plt;					\
 END(__sys_##name)
 
 /* Do a system call where the _x() is also custom (e.g. fcntl, ioctl) */
@@ -98,5 +98,5 @@ ENTRY(__sys_##name);						\
 	_SYSCALL(name);						\
 	bnez	t0, 1f; 					\
 	RETURN;							\
-1:	ASM_LOCAL_TAILCALL(t1, cerror);				\
+1:	_TAIL	cerror@plt;					\
 END(__sys_##name)

--- a/lib/libc/riscv/SYS.h
+++ b/lib/libc/riscv/SYS.h
@@ -42,29 +42,6 @@
 	li	t0, SYS_ ## name;				\
 	ecall
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#define _GET_FNPTR(outreg, function)	\
-	clgc CAPABILITY_REG(outreg), _C_LABEL(function)
-#define _GET_LOCAL_FNPTR(outreg, function)	\
-	cllc CAPABILITY_REG(outreg), _C_LABEL(function)
-#define _CALL_FNPTR(reg)	cjalr CAPABILITY_REG(reg)
-#define _TAILCALL_FNPTR(reg)	cjr CAPABILITY_REG(reg)
-#else
-#define _GET_LOCAL_FNPTR(outreg, function)	\
-	lla outreg, _C_LABEL(function)
-#define _GET_FNPTR(outreg, function)	\
-	la outreg, _C_LABEL(function)
-#define _CALL_FNPTR(reg)	jalr reg
-#define _TAILCALL_FNPTR(reg)	jr reg
-#endif
-
-#define ASM_LOCAL_TAILCALL(tmpreg, function)				\
-	_GET_LOCAL_FNPTR(tmpreg, function);				\
-	_TAILCALL_FNPTR(tmpreg)
-#define ASM_LOCAL_CALL(tmpreg, function)				\
-	_GET_LOCAL_FNPTR(tmpreg, function);				\
-	_CALL_FNPTR(tmpreg)
-
 #define	SYSCALL(name)						\
 ENTRY(__sys_##name);						\
 	WEAK_REFERENCE(__sys_##name, name);			\

--- a/lib/libc/riscv/sys/cerror.S
+++ b/lib/libc/riscv/sys/cerror.S
@@ -44,7 +44,7 @@ ENTRY(cerror)
 	cincoffset	csp, csp, -FRAME_SIZE
 	csc	cra, SPILLSLOT_RA(csp)
 	csd	a0, SPILLSLOT_ERRNO(csp)	# spill new errno value
-	ASM_LOCAL_CALL(t1, __error)		# locate address of errno (in ca0)
+	ccall	_C_LABEL(__error)		# locate address of errno (in ca0)
 	cld	a1, SPILLSLOT_ERRNO(csp)	# re-load new errno value
 	csw	a1, 0(ca0)			# update errno value
 	clc	cra, SPILLSLOT_RA(csp)

--- a/lib/libc/riscv/sys/vfork.S
+++ b/lib/libc/riscv/sys/vfork.S
@@ -48,5 +48,5 @@ ENTRY(__sys_vfork)
 	MOVE_REG(ra, a2)
 
 	RETURN
-1:	ASM_LOCAL_TAILCALL(t1, cerror)
+1:	_TAIL	cerror@plt
 END(__sys_vfork)

--- a/lib/libc/stdlib/abort.c
+++ b/lib/libc/stdlib/abort.c
@@ -45,7 +45,7 @@ __FBSDID("$FreeBSD$");
 
 #include "libc_private.h"
 
-__attribute__((visibility("protected"))) void
+void
 abort(void)
 {
 	struct sigaction act;

--- a/lib/libc/sys/__error.c
+++ b/lib/libc/sys/__error.c
@@ -54,7 +54,7 @@ __set_error_selector(int *(*arg)(void))
 	__error_selector = arg;
 }
 
-__attribute__((visibility("protected"))) int *
+int *
 __error(void)
 {
 

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -273,7 +273,7 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 #endif
     }
 
-    dbg("Allocating entire object: mmap(" PTR_FMT ", 0x%lx, 0x%x, 0x%x, -1, 0)",
+    dbg("Allocating entire object: mmap(" PTR_FMT ", 0x%zx, 0x%x, 0x%x, -1, 0)",
 	    base_addr, mapsize, PROT_NONE | PROT_MAX(_PROT_ALL), base_flags);
     mapbase = mmap(base_addr, mapsize, PROT_NONE | PROT_MAX(_PROT_ALL),
 	base_flags, -1, 0);

--- a/libexec/rtld-elf/riscv/rtld_start.S
+++ b/libexec/rtld-elf/riscv/rtld_start.S
@@ -37,7 +37,6 @@ __FBSDID("$FreeBSD$");
 
 #ifdef __CHERI_PURE_CAPABILITY__
 #include <machine/riscvreg.h>
-#include "SYS.h"
 #endif
 
 /*
@@ -66,7 +65,7 @@ ENTRY(.rtld_start)
 
 	cllc	ca0, _DYNAMIC				/* dynp */
 	cmove	ca1, cs0				/* aux */
-	ASM_LOCAL_CALL(ra, _rtld_relocate_nonplt_self)	/* Relocate ourselves early, including __cap_relocs */
+	cjal	_rtld_relocate_nonplt_self		/* Relocate ourselves early, including __cap_relocs */
 
 #if __CHERI_CAPABILITY_TABLE__ != 3
 	/* TODO: CGP for PLT and FNDESC ABIs */
@@ -77,7 +76,7 @@ ENTRY(.rtld_start)
 	csetbounds	ca1, csp, CLEN			/* exit_proc */
 	cincoffset	ca2, csp, CLEN
 	csetbounds	ca2, ca2, CLEN			/* obj_main */
-	ASM_LOCAL_CALL(ra, _rtld)			/* Call the loader */
+	cjal	_rtld					/* Call the loader */
 	cmove	ct0, ca0				/* Backup the entry point */
 
 	clc	ca1, (CLEN * 0)(csp)			/* Load cleanup */

--- a/share/mk/sys.machine.mk
+++ b/share/mk/sys.machine.mk
@@ -6,10 +6,13 @@ TARGET_MACHINE_LIST?= amd64 arm arm64 i386 powerpc riscv
 
 MACHINE_ARCH_host?= ${_HOST_ARCH}
 
+CHERI_ARCHES_arm64?= aarch64c
+CHERI_ARCHES_riscv?= riscv64c
+
 MACHINE_ARCH_LIST_arm?= armv6 armv7
-MACHINE_ARCH_LIST_arm64?= aarch64 aarch64c
+MACHINE_ARCH_LIST_arm64?= aarch64 ${CHERI_ARCHES_arm64}
 MACHINE_ARCH_LIST_powerpc?= powerpc powerpc64 powerpc64le ${EXTRA_ARCHES_powerpc}
-MACHINE_ARCH_LIST_riscv?= riscv64 riscv64c
+MACHINE_ARCH_LIST_riscv?= riscv64 ${CHERI_ARCHES_riscv}
 
 .for m in ${TARGET_MACHINE_LIST}
 MACHINE_ARCH_LIST_$m?= $m

--- a/stand/efi/loader/arch/arm/start.S
+++ b/stand/efi/loader/arch/arm/start.S
@@ -140,6 +140,7 @@ section_table:
 _end_header:
 
 	.text
+	.globl	_start
 _start:
 	/* Save the boot params to the stack */
 	push	{r0, r1}

--- a/sys/arm/arm/elf_machdep.c
+++ b/sys/arm/arm/elf_machdep.c
@@ -185,7 +185,7 @@ store_ptr(Elf_Addr *where, Elf_Addr val)
 
 /* Process one elf relocation with addend. */
 static int
-elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
+elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
     int type, int local, elf_lookup_fn lookup)
 {
 	Elf_Addr *where;
@@ -217,7 +217,7 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 
 	if (local) {
 		if (rtype == R_ARM_RELATIVE) {	/* A + B */
-			addr = elf_relocaddr(lf, relocbase + addend);
+			addr = elf_relocaddr(lf, (Elf_Addr)relocbase + addend);
 			if (load_ptr(where) != addr)
 				store_ptr(where, addr);
 		}
@@ -264,7 +264,7 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 }
 
 int
-elf_reloc(linker_file_t lf, Elf_Addr relocbase, const void *data, int type,
+elf_reloc(linker_file_t lf, char *relocbase, const void *data, int type,
     elf_lookup_fn lookup)
 {
 
@@ -272,7 +272,7 @@ elf_reloc(linker_file_t lf, Elf_Addr relocbase, const void *data, int type,
 }
 
 int
-elf_reloc_local(linker_file_t lf, Elf_Addr relocbase, const void *data,
+elf_reloc_local(linker_file_t lf, char *relocbase, const void *data,
     int type, elf_lookup_fn lookup)
 {
 

--- a/sys/arm/arm/minidump_machdep.c
+++ b/sys/arm/arm/minidump_machdep.c
@@ -223,7 +223,7 @@ cpu_minidumpsys(struct dumperinfo *di, const struct minidumpstate *state)
 	if (error != 0)
 		goto fail;
 
-	printf("Physical memory: %u MB\n", ptoa((uintmax_t)physmem) / 1048576);
+	printf("Physical memory: %ju MB\n", ptoa((uintmax_t)physmem) / 1048576);
 	printf("Dumping %llu MB:", (long long)dumpsize >> 20);
 
 	/* Dump my header */

--- a/sys/arm64/conf/GENERIC-MFS-ROOT
+++ b/sys/arm64/conf/GENERIC-MFS-ROOT
@@ -18,6 +18,8 @@
 #
 # $FreeBSD$
 
+#NO_UNIVERSE
+
 include GENERIC
 include	"std.MFS-ROOT"
 

--- a/sys/arm64/conf/GENERIC-MORELLO-MFS-ROOT
+++ b/sys/arm64/conf/GENERIC-MORELLO-MFS-ROOT
@@ -18,6 +18,8 @@
 #
 # $FreeBSD$
 
+#NO_UNIVERSE
+
 include GENERIC-MORELLO
 include	"std.MFS-ROOT"
 

--- a/sys/arm64/conf/GENERIC-MORELLO-PURECAP-MFS-ROOT
+++ b/sys/arm64/conf/GENERIC-MORELLO-PURECAP-MFS-ROOT
@@ -19,6 +19,8 @@
 #
 # $FreeBSD$
 
+#NO_UNIVERSE
+
 include GENERIC-MORELLO-PURECAP
 include	"std.MFS-ROOT"
 

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -99,9 +99,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/ktrace.h>
 #endif
 
-#ifdef INET
 #include <netinet/in.h>
-#endif
 
 #include <vm/vm.h>
 #include <vm/vm_param.h>

--- a/sys/compat/linuxkpi/common/include/linux/module.h
+++ b/sys/compat/linuxkpi/common/include/linux/module.h
@@ -75,7 +75,8 @@ _module_run(void *arg)
 	long offset;
 
 	pc = (caddr_t)arg;
-	if (linker_search_symbol_name(pc, name, sizeof(name), &offset) != 0)
+	if (linker_search_symbol_name((ptraddr_t)pc, name, sizeof(name),
+	    &offset) != 0)
 		printf("Running ??? (%p)\n", pc);
 	else
 		printf("Running %s (%p)\n", name, pc);

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -392,8 +392,6 @@ cheri/cheri_usercap.c			optional cpu_cheri
 # dtrace specific
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c	optional dtrace compile-with "${DTRACE_C}" \
 							warning "kernel contains CDDL licensed DTRACE"
-cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c	optional dtrace_fasttrap | dtraceall compile-with "${FASTTRAP_C}"
-cddl/contrib/opensolaris/common/unicode/u8_textprep.c   optional dtrace_fasttrap | dtraceall compile-with "${FASTTRAP_C}"
 cddl/contrib/opensolaris/uts/common/dtrace/dtrace_xoroshiro128_plus.c	optional dtrace compile-with "${DTRACE_C}"
 cddl/dev/dtmalloc/dtmalloc.c		optional dtmalloc        | dtraceall compile-with "${CDDL_C}"
 cddl/dev/profile/profile.c		optional dtrace_profile  | dtraceall compile-with "${CDDL_C}"

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -274,10 +274,13 @@ ZFS_CFLAGS+= -DBITS_PER_LONG=32
 ZFS_CFLAGS+= -DBITS_PER_LONG=64
 .endif
 
+.if ${MACHINE_ABI:Mpurecap}
+ZFS_CFLAGS+=	-Xclang -cheri-bounds=conservative
+.endif
 
 ZFS_ASM_CFLAGS= -x assembler-with-cpp -DLOCORE ${ZFS_CFLAGS}
-ZFS_C=		${CC} -c ${ZFS_CFLAGS} -Xclang -cheri-bounds=conservative ${WERROR} ${.IMPSRC}
-ZFS_RPC_C=	${CC} -c ${ZFS_CFLAGS} -DHAVE_RPC_TYPES -Xclang -cheri-bounds=conservative ${WERROR} ${.IMPSRC}
+ZFS_C=		${CC} -c ${ZFS_CFLAGS} ${WERROR} ${.IMPSRC}
+ZFS_RPC_C=	${CC} -c ${ZFS_CFLAGS} -DHAVE_RPC_TYPES ${WERROR} ${.IMPSRC}
 ZFS_S=		${CC} -c ${ZFS_ASM_CFLAGS} ${WERROR} ${.IMPSRC}
 
 # ATH driver

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -310,15 +310,6 @@ FBT_CFLAGS+=	-I$S/cddl/dev/fbt/x86
 .endif
 FBT_C=		${CC} -c ${FBT_CFLAGS}		${WERROR} ${.IMPSRC}
 
-# Special flags for managing the compat compiles for DTrace/fasttrap
-FASTTRAP_CFLAGS=	-DBUILDING_DTRACE -nostdinc \
-	-I$S/cddl/contrib/opensolaris/uts/${MACHINE_CPUARCH} \
-	-I$S/cddl/contrib/opensolaris/uts/common/sys \
-	-I$S/cddl/compat/opensolaris \
-	-I$S/cddl/contrib/opensolaris/uts/common \
-	-I$S ${CDDL_CFLAGS}
-FASTTRAP_C=		${CC} -c ${FASTTRAP_CFLAGS}		${WERROR} ${PROF} ${.IMPSRC}
-
 .if ${MK_CTF} != "no"
 NORMAL_CTFCONVERT=	${CTFCONVERT} ${CTFFLAGS} ${.TARGET}
 .elif ${MAKE_VERSION} >= 5201111300

--- a/sys/i386/i386/machdep.c
+++ b/sys/i386/i386/machdep.c
@@ -1708,7 +1708,7 @@ i386_setup_lcall_gate(void)
 	u_int lcall_addr;
 
 	sv = &elf32_freebsd_sysvec;
-	lcall_addr = (uintptr_t)sv->sv_usrstack - sv->ps_strings_sz -
+	lcall_addr = (uintptr_t)sv->sv_usrstack - sv->sv_psstringssz -
 	    sz_lcall_tramp;
 
 	bzero(&desc, sizeof(desc));

--- a/sys/kern/subr_devmap.c
+++ b/sys/kern/subr_devmap.c
@@ -165,8 +165,10 @@ devmap_add_entry(vm_paddr_t pa, vm_size_t sz)
 	    ("%s: devmap entry is not representable [0x%08jx, 0x%08jx]",
 	     __func__, (uintmax_t)va, (uintmax_t)va + sz));
 #endif
+#ifndef __arm__
 	KASSERT(va >= VM_MAX_KERNEL_ADDRESS - PMAP_MAPDEV_EARLY_SIZE,
 	    ("%s: early devmap too small", __func__));
+#endif
 	akva_devmap_vaddr = va;
 
 	m = &akva_devmap_entries[akva_devmap_idx++];

--- a/sys/kern/subr_msan.c
+++ b/sys/kern/subr_msan.c
@@ -196,7 +196,7 @@ kmsan_report_hook(const void *addr, size_t size, size_t off, const char *hook)
 	kmsan_md_orig_decode(*orig, &type, &ptr);
 	typename = kmsan_orig_name(type);
 
-	if (linker_ddb_search_symbol_name((caddr_t)ptr, buf,
+	if (linker_ddb_search_symbol_name((ptraddr_t)ptr, buf,
 	    sizeof(buf), &foff) == 0) {
 		REPORT("MSan: Uninitialized %s memory in %s, "
 		    "offset %zu/%zu, addr %p, from %s+%#lx",
@@ -248,7 +248,7 @@ kmsan_report_inline(msan_orig_t orig, unsigned long pc)
 	kmsan_md_orig_decode(orig, &type, &ptr);
 	typename = kmsan_orig_name(type);
 
-	if (linker_ddb_search_symbol_name((caddr_t)ptr, buf,
+	if (linker_ddb_search_symbol_name((ptraddr_t)ptr, buf,
 	    sizeof(buf), &foff) == 0) {
 		REPORT("MSan: Uninitialized %s memory from %s+%#lx",
 		    typename, buf, foff);

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -351,7 +351,7 @@ kern_shmdt_locked(struct thread *td, const void * __capability shmaddr)
 {
 	struct proc *p = td->td_proc;
 	struct shmmap_state *shmmap_s;
-	static struct shmid_kernel *shmseg;
+	static struct shmid_kernel *shmseg __unused;
 #ifdef MAC
 	int error;
 #endif

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -864,7 +864,8 @@ osend(struct thread *td, struct osend_args *uap)
 	msg.msg_namelen = 0;
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
-	IOVEC_INIT_C(&aiov, uap->buf, uap->len);
+	IOVEC_INIT_C(&aiov, __DECONST_CAP(void * __capability, uap->buf),
+	    uap->len);
 	msg.msg_control = 0;
 	msg.msg_flags = 0;
 	return (user_sendit(td, uap->s, &msg, uap->flags));

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -5134,7 +5134,6 @@ user_copy_file_range(struct thread *td, int infd,
 //   "target_type": "kernel",
 //   "changes": [
 //     "iovec-macros",
-//     "kiovec_t",
 //     "user_capabilities",
 //     "ctoptr"
 //   ]

--- a/sys/netinet/in_pcb.h
+++ b/sys/netinet/in_pcb.h
@@ -287,7 +287,7 @@ struct xinpcb {
 	uint8_t		inp_ip_p;		/* (n) */
 	uint8_t		inp_ip_minttl;		/* (n) */
 	int8_t		inp_spare8[4];
-};
+} __aligned(8);
 
 struct xinpgen {
 	ksize_t	xig_len;	/* length of this structure */
@@ -296,7 +296,7 @@ struct xinpgen {
 	inp_gen_t	xig_gen;	/* generation count at this time */
 	so_gen_t	xig_sogen;	/* socket generation count this time */
 	uint64_t	_xig_spare64[4];
-} __aligned(sizeof(void *));
+} __aligned(8);
 
 struct sockopt_parameters {
 	struct in_conninfo sop_inc;

--- a/sys/netinet/ip_fw.h
+++ b/sys/netinet/ip_fw.h
@@ -30,6 +30,8 @@
 #ifndef _IPFW2_H
 #define _IPFW2_H
 
+#include <sys/param.h>
+
 /*
  * The default rule number.  By the design of ip_fw, the default rule
  * is the last one, so its number can also serve as the highest number
@@ -744,13 +746,7 @@ struct _ipfw_dyn_rule {
 	u_int16_t	dyn_type;	/* rule type			*/
 	u_int16_t	count;		/* refcount			*/
 	u_int16_t	kidx;		/* index of named object */
-} __packed
-#ifndef __CHERI_PURE_CAPABILITY__
-__aligned(8)
-#else
-__aligned(sizeof(void *))
-#endif
-;
+} __packed __aligned(MAX(8, sizeof(void *)));
 
 /*
  * Definitions for IP option names.

--- a/sys/netlink/route/iface.c
+++ b/sys/netlink/route/iface.c
@@ -1238,7 +1238,9 @@ rtnl_handle_addr(struct nlmsghdr *hdr, struct nlpcb *nlp, struct nl_pstate *npt)
 		return (ENOENT);
 	}
 
+#if defined(INET) || defined(INET6)
 	bool new = hdr->nlmsg_type == NL_RTM_NEWADDR;
+#endif
 
 	/*
 	 * TODO: Properly handle NLM_F_CREATE / NLM_F_EXCL.

--- a/sys/ofed/drivers/infiniband/ulp/sdp/sdp.h
+++ b/sys/ofed/drivers/infiniband/ulp/sdp/sdp.h
@@ -670,7 +670,7 @@ void sdp_handle_sendsm(struct sdp_sock *ssk, u32 mseq_ack);
 void sdp_handle_rdma_read_compl(struct sdp_sock *ssk, u32 mseq_ack,
 		u32 bytes_completed);
 int sdp_handle_rdma_read_cqe(struct sdp_sock *ssk);
-int sdp_rdma_to_iovec(struct socket *sk, kivec_t *iov, struct mbuf *mb,
+int sdp_rdma_to_iovec(struct socket *sk, struct iovec *iov, struct mbuf *mb,
 		unsigned long *used);
 int sdp_post_rdma_rd_compl(struct sdp_sock *ssk,
 		struct rx_srcavail_state *rx_sa);

--- a/sys/powerpc/include/vmparam.h
+++ b/sys/powerpc/include/vmparam.h
@@ -321,7 +321,6 @@ extern	int vm_level_0_order;
 #define DMAP_TO_PHYS(x) ({						\
 	KASSERT(hw_direct_map, ("Direct map not provided by PMAP"));	\
 	(x) &~ DMAP_BASE_ADDRESS; })
-#define	PHYS_TO_DMAP_PAGE(x) PHYS_TO_DMAP(x)
 
 /*
  * No non-transparent large page support in the pmap.

--- a/sys/powerpc/powerpc/elf32_machdep.c
+++ b/sys/powerpc/powerpc/elf32_machdep.c
@@ -236,7 +236,7 @@ elf_is_ifunc_reloc(Elf_Size r_info)
 
 /* Process one elf relocation with addend. */
 static int
-elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
+elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
     int type, int local, elf_lookup_fn lookup)
 {
 	Elf_Addr *where;
@@ -253,8 +253,8 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 		break;
 	case ELF_RELOC_RELA:
 		rela = (const Elf_Rela *)data;
-		where = (Elf_Addr *) ((uintptr_t)relocbase + rela->r_offset);
-		hwhere = (Elf_Half *) ((uintptr_t)relocbase + rela->r_offset);
+		where = (Elf_Addr *) (relocbase + rela->r_offset);
+		hwhere = (Elf_Half *) (relocbase + rela->r_offset);
 		addend = rela->r_addend;
 		rtype = ELF_R_TYPE(rela->r_info);
 		symidx = ELF_R_SYM(rela->r_info);
@@ -283,8 +283,9 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 		 * (i.e. .rodata) in rela, where in reality they
 		 * are relative to relocbase. Detect this condition.
 		 */
-		if (addr > relocbase && addr <= (relocbase + addend))
-			addr = relocbase;
+		if (addr > (Elf_Addr)relocbase &&
+		    addr <= ((Elf_Addr)relocbase + addend))
+			addr = (Elf_Addr)relocbase;
 		addr = elf_relocaddr(lf, addr + addend);
 		*hwhere = addr & 0xffff;
 		break;
@@ -298,15 +299,16 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 		 * (i.e. .rodata) in rela, where in reality they
 		 * are relative to relocbase. Detect this condition.
 		 */
-		if (addr > relocbase && addr <= (relocbase + addend))
-			addr = relocbase;
+		if (addr > (Elf_Addr)relocbase &&
+		    addr <= ((Elf_Addr)relocbase + addend))
+			addr = (Elf_Addr)relocbase;
 		addr = elf_relocaddr(lf, addr + addend);
 		*hwhere = ((addr >> 16) + ((addr & 0x8000) ? 1 : 0))
 		    & 0xffff;
 		break;
 
 	case R_PPC_RELATIVE: /* word32 B + A */
-		*where = elf_relocaddr(lf, relocbase + addend);
+		*where = elf_relocaddr(lf, (Elf_Addr)relocbase + addend);
 		break;
 
 	case R_PPC_JMP_SLOT: /* PLT jump slot entry */
@@ -324,7 +326,7 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 		break;
 
 	case R_PPC_IRELATIVE:
-		addr = relocbase + addend;
+		addr = (Elf_Addr)relocbase + addend;
 		val = ((Elf32_Addr (*)(void))addr)();
 		if (*where != val)
 			*where = val;
@@ -372,7 +374,7 @@ elf_reloc_self(Elf_Dyn *dynp, Elf_Addr relocbase)
 }
 
 int
-elf_reloc(linker_file_t lf, Elf_Addr relocbase, const void *data, int type,
+elf_reloc(linker_file_t lf, char *relocbase, const void *data, int type,
     elf_lookup_fn lookup)
 {
 
@@ -380,7 +382,7 @@ elf_reloc(linker_file_t lf, Elf_Addr relocbase, const void *data, int type,
 }
 
 int
-elf_reloc_local(linker_file_t lf, Elf_Addr relocbase, const void *data,
+elf_reloc_local(linker_file_t lf, char *relocbase, const void *data,
     int type, elf_lookup_fn lookup)
 {
 

--- a/sys/powerpc/powerpc/elf64_machdep.c
+++ b/sys/powerpc/powerpc/elf64_machdep.c
@@ -326,7 +326,7 @@ elf_is_ifunc_reloc(Elf_Size r_info)
 
 /* Process one elf relocation with addend. */
 static int
-elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
+elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
     int type, int local, elf_lookup_fn lookup)
 {
 	Elf_Addr *where;
@@ -364,7 +364,7 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 		break;
 
 	case R_PPC_RELATIVE:	/* doubleword64 B + A */
-		*where = elf_relocaddr(lf, relocbase + addend);
+		*where = elf_relocaddr(lf, (Elf_Addr)relocbase + addend);
 		break;
 
 	case R_PPC_JMP_SLOT:	/* function descriptor copy */
@@ -378,7 +378,7 @@ elf_reloc_internal(linker_file_t lf, Elf_Addr relocbase, const void *data,
 		break;
 
 	case R_PPC_IRELATIVE:
-		addr = relocbase + addend;
+		addr = (Elf_Addr)relocbase + addend;
 		val = ((Elf64_Addr (*)(void))addr)();
 		if (*where != val)
 			*where = val;
@@ -426,7 +426,7 @@ elf_reloc_self(Elf_Dyn *dynp, Elf_Addr relocbase)
 }
 
 int
-elf_reloc(linker_file_t lf, Elf_Addr relocbase, const void *data, int type,
+elf_reloc(linker_file_t lf, char *relocbase, const void *data, int type,
     elf_lookup_fn lookup)
 {
 
@@ -434,7 +434,7 @@ elf_reloc(linker_file_t lf, Elf_Addr relocbase, const void *data, int type,
 }
 
 int
-elf_reloc_local(linker_file_t lf, Elf_Addr relocbase, const void *data,
+elf_reloc_local(linker_file_t lf, char *relocbase, const void *data,
     int type, elf_lookup_fn lookup)
 {
 

--- a/sys/riscv/include/asm.h
+++ b/sys/riscv/include/asm.h
@@ -79,12 +79,16 @@
 	csrc	sstatus, tmp
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#define CAPABILITY_REG(reg)	c##reg
-#define MOVE_REG(dst, src)	cmove CAPABILITY_REG(dst), CAPABILITY_REG(src)
-#define RETURN	cret
+#define	CAPABILITY_REG(reg)	c##reg
+#define	MOVE_REG(dst, src)	cmove CAPABILITY_REG(dst), CAPABILITY_REG(src)
+#define	_CALL	ccall
+#define	_TAIL	ctail
+#define	RETURN	cret
 #else
-#define MOVE_REG(dst, src)	mv dst, src
-#define RETURN	ret
+#define	MOVE_REG(dst, src)	mv dst, src
+#define	_CALL	call
+#define	_TAIL	tail
+#define	RETURN	ret
 #endif
 
 #endif /* _MACHINE_ASM_H_ */

--- a/sys/sys/unpcb.h
+++ b/sys/sys/unpcb.h
@@ -167,14 +167,14 @@ struct xunpcb {
 		char	xu_dummy2[256];
 	};
 	struct xsocket	xu_socket;
-} __aligned(MAX(8, sizeof(void *)));
+} __aligned(8);
 
 struct xunpgen {
 	ksize_t	xug_len;
 	u_int	xug_count;
 	unp_gen_t xug_gen;
 	so_gen_t xug_sogen;
-} __aligned(sizeof(void *));	/* Followed by struct xunpcb */
+} __aligned(8);
 #endif /* _SYS_SOCKETVAR_H_ */
 
 #if defined(_KERNEL)

--- a/sys/ufs/ufs/ufs_extattr.c
+++ b/sys/ufs/ufs/ufs_extattr.c
@@ -887,7 +887,7 @@ ufs_extattr_get(struct vnode *vp, int attrnamespace, const char *name,
 	 * how much.
 	 */
 	bzero(&ueh, sizeof(struct ufs_extattr_header));
-	IOVEC_INIT_OBJ(&local_aiov, &ueh);
+	IOVEC_INIT_OBJ(&local_aiov, ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_READ;
@@ -1090,7 +1090,7 @@ ufs_extattr_set(struct vnode *vp, int attrnamespace, const char *name,
 	ueh.ueh_len = uio->uio_resid;
 	ueh.ueh_flags = UFS_EXTATTR_ATTR_FLAG_INUSE;
 	ueh.ueh_i_gen = ip->i_gen;
-	IOVEC_INIT_OBJ(&local_aiov, &ueh);
+	IOVEC_INIT_OBJ(&local_aiov, ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_WRITE;
@@ -1187,7 +1187,7 @@ ufs_extattr_rm(struct vnode *vp, int attrnamespace, const char *name,
 	 */
 	bzero(&ueh, sizeof(struct ufs_extattr_header));
 
-	IOVEC_INIT_OBJ(&local_aiov, &ueh);
+	IOVEC_INIT_OBJ(&local_aiov, ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_READ;
@@ -1232,7 +1232,7 @@ ufs_extattr_rm(struct vnode *vp, int attrnamespace, const char *name,
 	ueh.ueh_flags = 0;
 	ueh.ueh_len = 0;
 
-	IOVEC_INIT_OBJ(&local_aiov, &ueh);
+	IOVEC_INIT_OBJ(&local_aiov, ueh);
 	local_aio.uio_iov = &local_aiov;
 	local_aio.uio_iovcnt = 1;
 	local_aio.uio_rw = UIO_WRITE;

--- a/sys/vm/memguard.c
+++ b/sys/vm/memguard.c
@@ -260,7 +260,7 @@ v2sizep(vm_pointer_t va)
 
 	pa = pmap_kextract(va);
 	if (pa == 0)
-		panic("MemGuard detected double-free of %#p", (void *)va);
+		panic("MemGuard detected double-free of %p", (void *)va);
 	p = PHYS_TO_VM_PAGE(pa);
 	KASSERT(vm_page_wired(p) && p->a.queue == PQ_NONE,
 	    ("MEMGUARD: Expected wired page %p in vtomgfifo!", p));


### PR DESCRIPTION
Mostly non-CHERI fixes, with the exception of some CHERI-RISC-V changes motivated by removing some broken hacks in libc that break i386 specifically. See the individual commit messages for details.