### PR TITLE
Disable pkg repository mirroring

### DIFF
--- a/usr.sbin/pkg/CheriBSD.conf
+++ b/usr.sbin/pkg/CheriBSD.conf
@@ -7,8 +7,8 @@
 #
 
 CheriBSD: {
-  url: "pkg+http://pkg.CheriBSD.org/${ABI}",
-  mirror_type: "srv",
+  url: "http://pkg.CheriBSD.org/${ABI}",
+  mirror_type: "none",
   signature_type: "fingerprints",
   fingerprints: "/usr/share/keys/pkg",
   enabled: yes


### PR DESCRIPTION
Change the mirror type to "none" to match the reality as we don't provide mirroring, and don't use the "pkg+http://" URL scheme that libfetch(3) disallows when not using mirroring.

A package repository with a mirror type set to "srv" must point at an URL that includes a domain with SRV records in its DNS entry. pkg 1.18.4 from CheriBSD 22.12 doesn't verify that but pkg 1.20.5 or later scheduled for the next CheriBSD release will do. Note that this change is compatible with both 1.18.4 and 1.20.5 pkg versions so we don't have to synchronize merging this commit with packages for the next release.