### PR TITLE
riscv: Remove old underscore-based kernel configs

### DIFF
--- a/sys/riscv/conf/CHERI_FETT
+++ b/sys/riscv/conf/CHERI_FETT
@@ -1,3 +1,0 @@
-#NO_UNIVERSE
-
-include "CHERI-FETT"

--- a/sys/riscv/conf/CHERI_GFE
+++ b/sys/riscv/conf/CHERI_GFE
@@ -1,3 +1,0 @@
-#NO_UNIVERSE
-
-include "CHERI-GFE"

--- a/sys/riscv/conf/CHERI_QEMU
+++ b/sys/riscv/conf/CHERI_QEMU
@@ -1,3 +1,0 @@
-#NO_UNIVERSE
-
-include "CHERI-QEMU"

--- a/sys/riscv/conf/CHERI_QEMU_MFS_ROOT
+++ b/sys/riscv/conf/CHERI_QEMU_MFS_ROOT
@@ -1,3 +1,0 @@
-#NO_UNIVERSE
-
-include "CHERI-QEMU-MFS-ROOT"

--- a/sys/riscv/conf/CHERI_SPIKE
+++ b/sys/riscv/conf/CHERI_SPIKE
@@ -1,3 +1,0 @@
-#NO_UNIVERSE
-
-include "CHERI-SPIKE"

--- a/sys/riscv/conf/QEMU_MFS_ROOT
+++ b/sys/riscv/conf/QEMU_MFS_ROOT
@@ -1,3 +1,0 @@
-#NO_UNIVERSE
-
-include "QEMU-MFS-ROOT"


### PR DESCRIPTION
These were deprecated in July 2020 so their removal is long overdue.
