### PR TITLE
arm64 purecap kernel panic fixes

### DIFF
--- a/sys/arm64/arm64/db_trace.c
+++ b/sys/arm64/arm64/db_trace.c
@@ -94,6 +94,14 @@ db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 			struct trapframe *tf;
 
 			tf = (struct trapframe *)(uintptr_t)frame->fp - 1;
+#ifdef __CHERI_PURE_CAPABILITY__
+			if (!cheri_can_access(tf,
+			    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
+			    (ptraddr_t)tf, sizeof(*tf))) {
+				db_printf("--- invalid trapframe %#p\n", tf);
+				break;
+			}
+#endif
 			if (!kstack_contains(td, (vm_offset_t)tf,
 			    sizeof(*tf))) {
 				db_printf("--- invalid trapframe %p\n", tf);

--- a/sys/arm64/arm64/exception.S
+++ b/sys/arm64/arm64/exception.S
@@ -81,7 +81,7 @@ __FBSDID("$FreeBSD$");
 .endm
 
 .macro	save_registers el
-	add	x29, sp, #(TF_SIZE)
+	add	PTR(29), PTRN(sp), #(TF_SIZE)
 .if \el == 0
 #if defined(PERTHREAD_SSP)
 	/* Load the SSP canary to sp_el0 */

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -380,11 +380,14 @@ makectx(struct trapframe *tf, struct pcb *pcb)
 {
 	int i;
 
-	for (i = 0; i < nitems(pcb->pcb_x); i++)
-		pcb->pcb_x[i] = tf->tf_x[i + PCB_X_START];
-
 	/* NB: pcb_x[PCB_LR] is the PC, see PC_REGS() in db_machdep.h */
-	pcb->pcb_x[PCB_LR] = tf->tf_elr;
+	for (i = 0; i < nitems(pcb->pcb_x); i++) {
+		if (i == PCB_LR)
+			pcb->pcb_x[i] = tf->tf_elr;
+		else
+			pcb->pcb_x[i] = tf->tf_x[i + PCB_X_START];
+	}
+
 	pcb->pcb_sp = tf->tf_sp;
 }
 

--- a/sys/riscv/riscv/db_trace.c
+++ b/sys/riscv/riscv/db_trace.c
@@ -86,6 +86,14 @@ db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 			struct trapframe *tf;
 
 			tf = (struct trapframe *)(uintptr_t)frame->sp;
+#ifdef __CHERI_PURE_CAPABILITY__
+			if (!cheri_can_access(tf,
+			    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
+			    (ptraddr_t)tf, sizeof(*tf))) {
+				db_printf("--- invalid trapframe %#p\n", tf);
+				break;
+			}
+#endif
 			if (!kstack_contains(td, (vm_offset_t)tf,
 			    sizeof(*tf))) {
 				db_printf("--- invalid trapframe %p\n", tf);


### PR DESCRIPTION
- arm64 db_trace: Use cheri_can_access for trapframes.
- arm64: Fix the pseudo FP (c29) for kernel exceptions for purecap.
- arm64 makectx: Fix overflow of tf_x array
