### PR TITLE
adding fork-exec functionality

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -14,6 +14,7 @@ SRCS+=	cheribsdtest_bounds_globals.c					\
 	cheribsdtest_fs.c						\
 	cheribsdtest_kbounce.c						\
 	cheribsdtest_ipc.c						\
+	cheribsdtest_internal.c 					\
 	cheribsdtest_local_global.c					\
 	cheribsdtest_longjmp.c						\
 	cheribsdtest_printf.c						\

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -37,6 +37,7 @@
 #endif
 
 #include <sys/param.h>
+#include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/sysctl.h>
@@ -59,6 +60,7 @@
 #include <fnmatch.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <spawn.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -87,6 +89,7 @@ static const struct cheri_test *running_test;
 static int tests_run, tests_skipped;
 static int tests_failed, tests_passed, tests_xfailed, tests_xpassed;
 static int expected_failures;
+static int is_execed_child;
 static int list;
 static int run_all;
 static int fast_tests_only;
@@ -97,6 +100,8 @@ static int coredump_enabled;
 static int debugger_enabled;
 
 int verbose;
+
+extern char **environ;
 
 static void
 usage(void)
@@ -623,6 +628,103 @@ cheribsdtest_run_test_name(const char *name)
 	errx(EX_USAGE, "unknown test: %s", name);
 }
 
+static void
+cheribsdtest_run_child(struct cheri_test *ctp)
+{
+	if (ctp->ct_child_func == NULL)
+		errx(EX_SOFTWARE, "%s has no child function", ctp->ct_name);
+	ctp->ct_child_func();
+	errx(EX_SOFTWARE, "%s child function returned", ctp->ct_name);
+}
+
+static void
+cheribsdtest_run_child_name(const char *name)
+{
+	struct cheri_test **ctpp, *ctp;
+
+	SET_FOREACH(ctpp, cheri_tests_set) {
+		ctp = *ctpp;
+		if (strcmp(name, ctp->ct_name) == 0) {
+			cheribsdtest_run_child(ctp);
+		}
+	}
+	errx(EX_USAGE, "unknown test: %s", name);
+}
+
+static char **
+mk_exec_args(const struct cheri_test *ctp)
+{
+	char *execpath;
+	char const **exec_args;
+	int argc = 0, error;
+
+	execpath = malloc(MAXPATHLEN);
+	if (execpath == NULL)
+		err(EX_OSERR, "malloc");
+	exec_args = calloc(5, sizeof(*exec_args));
+	if (exec_args == NULL)
+		err(EX_OSERR, "calloc");
+
+	/*
+	 * XXX: This won't work for direct exec as an rtld argument.
+	 * (e.g., /libexec/ld-elf.so.1 /bin/cheribsdtest-purecap-dynamic)
+	 * If this becomes an issue we could alter rtld to update
+	 * AT_EXECPATH or add some sort of coexeve_self(3) implemented
+	 * by rtld for dynamic binaries and libc for static.
+	 */
+	error = elf_aux_info(AT_EXECPATH, execpath, MAXPATHLEN);
+	if (error != 0)
+		errx(EX_OSERR, "elf_aux_info: %s", strerror(error));
+	exec_args[argc++] = execpath;
+	exec_args[argc++] = "-E";
+	if (coredump_enabled)
+		exec_args[argc++] = "-c";
+	if (verbose)
+		exec_args[argc++] = "-v";
+	exec_args[argc++] = ctp->ct_name;
+	exec_args[argc++] = NULL;
+
+	return (__DECONST(char **, exec_args));
+}
+
+pid_t
+cheribsdtest_spawn_child(enum spawn_child_mode mode)
+{
+	char **exec_args;
+	int error;
+	pid_t pid;
+
+	exec_args = mk_exec_args(running_test);
+
+	switch (mode) {
+		case SC_MODE_POSIX_SPAWN:
+			error = posix_spawn(&pid, exec_args[0],
+				NULL, NULL, exec_args, environ);
+			if (error != 0)
+				pid = -1;
+			break;
+		case SC_MODE_FORK:
+			pid = fork();
+			break;
+		case SC_MODE_RFORK:
+			pid = rfork(RFPROC);
+			break;
+		case SC_MODE_VFORK:
+			pid = vfork();
+			break;
+		default:
+			errno = EDOOFUS;
+			pid = -1;
+			break;
+	}
+
+	if (pid == -1)
+		err(EX_OSERR, "%s: fork/spawn error (mode = %d)", __func__, mode);
+	if (mode != SC_MODE_POSIX_SPAWN && pid == 0)
+		execve(exec_args[0], exec_args, NULL);
+	return (pid);
+}
+
 __noinline void *
 cheribsdtest_memcpy(void *dst, const void *src, size_t n)
 {
@@ -651,7 +753,7 @@ main(int argc, char *argv[])
 	argc = xo_parse_args(argc, argv);
 	if (argc < 0)
 		errx(1, "xo_parse_args failed\n");
-	while ((opt = getopt(argc, argv, "acdfglQqsuvx")) != -1) {
+	while ((opt = getopt(argc, argv, "acdEfglQqsuvx")) != -1) {
 		switch (opt) {
 		case 'a':
 			run_all = 1;
@@ -661,6 +763,9 @@ main(int argc, char *argv[])
 			break;
 		case 'd':
 			debugger_enabled = 1;
+			break;
+		case 'E':
+			is_execed_child = 1;
 			break;
 		case 'f':
 			fast_tests_only = 1;
@@ -704,6 +809,16 @@ main(int argc, char *argv[])
 	}
 	argc -= optind;
 	argv += optind;
+	if (is_execed_child) {
+		if (run_all || glob || list) {
+			warnx("-E is incompatible with -a, -g, and -l");
+			usage();
+		}
+		if (argc != 1) {
+			warnx("-E requires exactly one test argument");
+			usage();
+		}
+	}
 	if (run_all && list) {
 		warnx("-a and -l are incompatible");
 		usage();
@@ -740,6 +855,12 @@ main(int argc, char *argv[])
 	stack.ss_flags = 0;
 	if (sigaltstack(&stack, NULL) < 0)
 		err(EX_OSERR, "sigaltstack");
+
+	/*
+	 * We've been execed so look up our child function and run it.
+	 */
+	if (is_execed_child)
+		cheribsdtest_run_child_name(argv[0]);
 
 	/*
 	 * Allocate a page shared with children processes to return success/

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -146,6 +146,7 @@ struct cheri_test {
 	const char	*ct_name;
 	const char	*ct_desc;
 	void		(*ct_func)(void);
+	void		(*ct_child_func)(void);
 	const char *	(*ct_check_skip)(const char *);
 	const char *	(*ct_check_xfail)(const char *);
 	u_int		 ct_flags;
@@ -171,6 +172,14 @@ struct cheri_test {
 #define	CHERIBSDTEST(func, desc, ...)					\
 	_CHERIBSDTEST_DECLARE(func, (desc), __VA_ARGS__);		\
 	static void func(void)
+
+/* Enum for different modes of spawning a child process */
+enum spawn_child_mode {
+	SC_MODE_POSIX_SPAWN,
+	SC_MODE_FORK,
+	SC_MODE_VFORK,
+	SC_MODE_RFORK,
+};
 
 /*
  * Useful APIs for tests.  These terminate the process returning either
@@ -305,5 +314,11 @@ extern void *cheribsdtest_memcpy(void *dst, const void *src, size_t n);
 extern void *cheribsdtest_memmove(void *dst, const void *src, size_t n);
 
 extern ptraddr_t find_address_space_gap(size_t len, size_t align);
+
+/*
+ * Spawn a new copy of cheribsdtest and run the test's associated child
+ * function.
+ */
+extern pid_t cheribsdtest_spawn_child(enum spawn_child_mode mode);
 
 #endif /* !_CHERIBSDTEST_H_ */

--- a/bin/cheribsdtest/cheribsdtest_internal.c
+++ b/bin/cheribsdtest/cheribsdtest_internal.c
@@ -1,0 +1,122 @@
+/*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
+* Copyright (c) 2023 SRI International
+*
+* This software was developed by SRI International, the University of
+* Cambridge Computer Laboratory (Department of Computer Science and
+* Technology), and Capabilities Limited under Defense Advanced Research
+* Projects Agency (DARPA) Contract No. HR001122S0003 ("MTSS").
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+
+#include <sys/cdefs.h>
+
+#if !__has_feature(capabilities)
+#error "This code requires a CHERI-aware compiler"
+#endif
+
+#include <sys/wait.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "cheribsdtest.h"
+
+static void
+exec_child_cf(void)
+{
+	if (verbose)
+		fprintf(stderr, "in child function\n");
+
+	exit(0);
+}
+
+CHERIBSDTEST(internal_spawn_child_posix_spawn,
+    "check that directly spawning a child process with posix_spawn runs properly",
+    .ct_child_func = exec_child_cf)
+{
+	int res;
+	pid_t pid;
+
+	pid = cheribsdtest_spawn_child(SC_MODE_POSIX_SPAWN);
+
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	if (res != 0)
+		cheribsdtest_failure_errx("Bad child process exit");
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(internal_spawn_child_fork,
+    "check that directly spawning a child process with fork runs properly",
+    .ct_child_func = exec_child_cf)
+{
+	int res;
+	pid_t pid;
+
+	pid = cheribsdtest_spawn_child(SC_MODE_FORK);
+
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	if (res != 0)
+		cheribsdtest_failure_errx("Bad child process exit");
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(internal_spawn_child_vfork,
+    "check that directly spawning a child process with vfork runs properly",
+    .ct_child_func = exec_child_cf)
+{
+	int res;
+	pid_t pid;
+
+	pid = cheribsdtest_spawn_child(SC_MODE_VFORK);
+
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	if (res != 0)
+		cheribsdtest_failure_errx("Bad child process exit");
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(internal_spawn_child_rfork,
+    "check that directly spawning a child process with rfork runs properly",
+    .ct_child_func = exec_child_cf)
+{
+	int res;
+	pid_t pid;
+
+	pid = cheribsdtest_spawn_child(SC_MODE_RFORK);
+
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	if (res != 0)
+		cheribsdtest_failure_errx("Bad child process exit");
+
+	cheribsdtest_success();
+}


### PR DESCRIPTION
Adding ability to run a function in an execve()-d child process, allowing tests to fork and exec a child running the test-specific function.