### PR TITLE
cheribsdtest: Stop passing struct cheri_test

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -366,7 +366,7 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 		}
 
 		/* Run the actual test. */
-		ctp->ct_func(ctp);
+		ctp->ct_func();
 		exit(0);
 	}
 	close(pipefd_stdin[0]);

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -145,7 +145,7 @@ extern struct cheribsdtest_child_state *ccsp;
 struct cheri_test {
 	const char	*ct_name;
 	const char	*ct_desc;
-	void		(*ct_func)(const struct cheri_test *);
+	void		(*ct_func)(void);
 	const char *	(*ct_check_skip)(const char *);
 	const char *	(*ct_check_xfail)(const char *);
 	u_int		 ct_flags;
@@ -159,7 +159,7 @@ struct cheri_test {
 };
 
 #define	_CHERIBSDTEST_DECLARE(func, desc, ...)				\
-	static void func(const struct cheri_test *ctp);			\
+	static void func(void);						\
 	static struct cheri_test __CONCAT(__cheri_test, __LINE__) = {	\
 		.ct_name = #func,					\
 		.ct_desc = (desc),					\
@@ -170,7 +170,7 @@ struct cheri_test {
 
 #define	CHERIBSDTEST(func, desc, ...)					\
 	_CHERIBSDTEST_DECLARE(func, (desc), __VA_ARGS__);		\
-	static void func(const struct cheri_test * __unused ctp)
+	static void func(void)
 
 /*
  * Useful APIs for tests.  These terminate the process returning either

--- a/bin/cheribsdtest/cheribsdtest_sentries.c
+++ b/bin/cheribsdtest/cheribsdtest_sentries.c
@@ -75,7 +75,7 @@ check_fptr(uintptr_t fptr)
 CHERIBSDTEST(sentry_dlsym,
     "Check that a function pointer obtaine dfrom via dlsym is a sentry")
 {
-	unsigned int (*fptr)(unsigned int seconds);
+	double (*fptr)(double);
 	void *handle;
 	const char *libm_so;
 
@@ -96,7 +96,7 @@ CHERIBSDTEST(sentry_dlsym,
 CHERIBSDTEST(sentry_libc,
     "Check that a function pointer from libc is a sentry")
 {
-	unsigned int (*fptr)(unsigned int seconds) = sleep;
+	unsigned int (*fptr)(unsigned int) = sleep;
 
 	check_fptr((uintptr_t)fptr);
 }

--- a/bin/cheribsdtest/cheribsdtest_sentries.c
+++ b/bin/cheribsdtest/cheribsdtest_sentries.c
@@ -104,6 +104,7 @@ CHERIBSDTEST(sentry_libc,
 CHERIBSDTEST(sentry_static,
     "Check that a statically initialized function pointer is a sentry")
 {
+	static unsigned int (*volatile fptr)(unsigned int) = sleep;
 
-	check_fptr((uintptr_t)ctp->ct_func);
+	check_fptr((uintptr_t)fptr);
 }


### PR DESCRIPTION
This has never really been used in a meaningful way, and using it is a
bit dodgy, since it's information the test is telling to the harness
about itself; any information it wants to give itself it can just use
directly rather than looping it through the struct. Other than being
used in sentry_static as a lazy way to get a function pointer, it has
only ever been used for ct_stdin_string/ct_stdout_string, but using
those in particular is even more dodgy, since there's a risk that,
should those values end up corrupted or otherwise wrong, the test uses
that wrong value, rather than the original value it meant, and creates a
circularity in the checking that renders it less meaningful.
