### PR TITLE
mincore: adjust capability requirements

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -60,6 +60,82 @@
 
 #include "cheribsdtest.h"
 
+#define	MINCORE_PAGES	3
+
+CHERIBSDTEST(cheriabi_mincore,
+    "Test CheriABI mincore() with various permissions and bounds")
+{
+	char *pages, *cap;
+	size_t page_sz = getpagesize();
+	size_t pages_len = page_sz * MINCORE_PAGES;
+	char vec[MINCORE_PAGES];
+
+	pages = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, pages_len,
+	    PROT_MAX(PROT_READ | PROT_WRITE | PROT_EXEC) | PROT_NONE,
+	    MAP_ANON | MAP_PRIVATE, -1, 0));
+
+	cap = pages;
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
+	    "whole allocation from mmap");
+
+	/*
+	 * mincore(2) requires minimal permissions, the capability just
+	 * needs to be a memory capabilty that can do something useful.
+	 */
+
+	/* No VMEM */
+	cap = cheri_andperm(pages, ~CHERI_PERM_SW_VMEM);
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
+	    "whole allocation from mmap without VMEM perm");
+
+	/* Execute-only */
+	cap = cheri_andperm(pages, CHERI_PERM_EXECUTE | CHERI_PERM_GLOBAL);
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
+	    "whole allocation from mmap with only CHERI_PERM_EXECUTE");
+
+	/* Read-only */
+	cap = cheri_andperm(pages, CHERI_PERM_LOAD | CHERI_PERM_GLOBAL);
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
+	    "whole allocation from mmap with only CHERI_PERM_LOAD");
+
+	/* Write-only */
+	cap = cheri_andperm(pages, CHERI_PERM_STORE | CHERI_PERM_GLOBAL);
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
+	    "whole allocation from mmap with only CHERI_PERM_STORE");
+
+	/*
+	 * mincore(2) needs to work even if the page isn't fully covered.
+	 * Restrict bounds to cover a single byte of the first and last
+	 * pages.
+	 */
+	cap = trunc_page(cheri_setbounds(pages + page_sz - 1,
+	    pages_len - 2 * (PAGE_SIZE - 1)));
+
+	/* The whole thing */
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
+	    "whole allocation with reduced bounds");
+
+	/* 1st page */
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, page_sz, vec),
+	    "first page (last byte inbounds)");
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap + page_sz, page_sz, vec),
+	    "second page (all in bounds)");
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap + pages_len - page_sz,
+	    page_sz, vec), "last page (first byte in bounds)");
+
+#ifdef __FreeBSD__
+	/*
+	 * FreeBSD (nonportably) allows under-aligned address and length.
+	 */
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cheri_setoffset(cap, 0), 1, vec),
+	    "last byte of first page");
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cheri_setoffset(cap, 0),
+	    cheri_getlen(cap), vec), "whole in-bounds region");
+#endif
+
+	cheribsdtest_success();
+}
+
 CHERIBSDTEST(cheriabi_mmap_unrepresentable,
     "Test CheriABI mmap() with unrepresentable lengths")
 {

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -1272,19 +1272,43 @@ struct mincore_args {
 int
 sys_mincore(struct thread *td, struct mincore_args *uap)
 {
+	uintcap_t addr = (uintcap_t)uap->addr;
 
 #if __has_feature(capabilities)
+	vm_offset_t range_bottom_page = trunc_page(addr);
+	vm_offset_t range_top_page = round_page(addr + uap->len);
+	vm_offset_t cap_bottom_page = trunc_page(cheri_getbase(addr));
+	vm_offset_t cap_top_page = round_page(cheri_gettop(addr));
+
 	/*
-	 * Since this is a read-only query that does not modify any mappings
-	 * or raise faults, we do not require the cap to cover
-	 * the full page, just to overlap at least part of the page.
+	 * mincore(2) is a read-only, metadata operation.  Require that
+	 * the capabilty be valid and unsealed, have at least one of
+	 * execute, load, or store permissions (it's a memory capability
+	 * with permision to do *something*) and that it cover at least
+	 * one byte of every page whose status is requested.
+	 *
+	 * Note that we don't require the address to be in bounds as
+	 * portable callers will round down to page alignment.  Likewise,
+	 * we don't require that the page have the CHERI_PERM_SW_VMEM
+	 * as we're not manipulating or accessing memory and it needs to
+	 * work on stacks and malloced memory.
+	 *
+	 * XXX: disallowing sealed capabilities means users can't call
+	 * mincore() on function pointers, but that seems unlikely to
+	 * be useful and isn't portable as there's no way to round them
+	 * down without stripping the tag.
 	 */
-	if (__CAP_CHECK(uap->addr, uap->len) == 0)
+	if (!cheri_gettag(addr) || cheri_getsealed(addr) ||
+	    (cheri_getperm(addr) &
+	    (CHERI_PERM_EXECUTE | CHERI_PERM_LOAD | CHERI_PERM_STORE)) == 0 ||
+	    range_bottom_page < cap_bottom_page ||
+	    range_bottom_page >= cap_top_page ||
+	    range_top_page <= cap_bottom_page ||
+	    range_top_page > cap_top_page)
 		return (EPROT);
 #endif
 
-	return (kern_mincore(td, (uintptr_t)(uintcap_t)uap->addr, uap->len,
-	    uap->vec));
+	return (kern_mincore(td, (uintptr_t)addr, uap->len, uap->vec));
 }
 
 int


### PR DESCRIPTION
Relax the requirement of mincore's addr argument.  Because mincore only reads metadata about page status, require that it be a memory capability that can do something (tagged, unsealed, and have at least one of load, store, or execute permissions) and that if cover some part of each page for which metadata is retrieved.

Fixes #1806