### PR TITLE
Backport #1798 and #1799 to 22.12

### DIFF
--- a/lib/libc/gen/lockf.c
+++ b/lib/libc/gen/lockf.c
@@ -44,11 +44,13 @@ int
 lockf(int filedes, int function, off_t size)
 {
 	struct flock fl;
+	intptr_t flip;
 	int cmd;
 
 	fl.l_start = 0;
 	fl.l_len = size;
 	fl.l_whence = SEEK_CUR;
+	flip = (intptr_t)&fl;
 
 	switch (function) {
 	case F_ULOCK:
@@ -65,8 +67,8 @@ lockf(int filedes, int function, off_t size)
 		break;
 	case F_TEST:
 		fl.l_type = F_WRLCK;
-		if (((int (*)(int, int, ...))
-		    __libc_interposing[INTERPOS_fcntl])(filedes, F_GETLK, &fl)
+		if (((int (*)(int, int, intptr_t))
+		    __libc_interposing[INTERPOS_fcntl])(filedes, F_GETLK, flip)
 		    == -1)
 			return (-1);
 		if (fl.l_type == F_UNLCK || (fl.l_sysid == 0 &&
@@ -81,6 +83,6 @@ lockf(int filedes, int function, off_t size)
 		/* NOTREACHED */
 	}
 
-	return (((int (*)(int, int, ...))
-	    __libc_interposing[INTERPOS_fcntl])(filedes, cmd, &fl));
+	return (((int (*)(int, int, intptr_t))
+	    __libc_interposing[INTERPOS_fcntl])(filedes, cmd, flip));
 }

--- a/usr.sbin/bsdinstall/scripts/auto
+++ b/usr.sbin/bsdinstall/scripts/auto
@@ -49,7 +49,7 @@ msg_auto_zfs="Auto (ZFS)"
 case `uname -p` in
 aarch64*c*|riscv*c*)
 	msg_auto_zfs_desc="EXPERIMENTAL Guided Root-on-ZFS"
-	msg_auto_zfs_help="ZFS is Alpha quality and the pure-capability kernel (non-default) does not support it as a root FS. See the release notes for caveats."
+	msg_auto_zfs_help="ZFS is Alpha quality. See the release notes for caveats."
 	;;
 *)
 	msg_auto_zfs_desc="Guided Root-on-ZFS"


### PR DESCRIPTION
- lockf: Use correct calling convention for fcntl syscall
- bsdinstall: Drop obsolete warning about root-on-ZFS for purecap kernels
