### PR TITLE
Add pmu-events json for Rainier

### DIFF
--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/branch.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/branch.json
@@ -1,0 +1,22 @@
+[
+    {
+        "ArchStdEvent": "BR_MIS_PRED",
+        "PublicDescription": "Mispredicted or not predicted branch speculatively executed. This event counts any predictable branch instruction which is mispredicted either due to dynamic misprediction or because the MMU is off and the branches are statically predicted not taken"
+    },
+    {
+        "ArchStdEvent": "BR_PRED",
+        "PublicDescription": "Predictable branch speculatively executed. This event counts all predictable branches"
+    },
+    {
+        "ArchStdEvent": "BR_IMMED_SPEC",
+        "PublicDescription": "Branch speculatively executed, immediate branch"
+    },
+    {
+        "ArchStdEvent": "BR_RETURN_SPEC",
+        "PublicDescription": "Branch speculatively executed, procedure return"
+    },
+    {
+        "ArchStdEvent": "BR_INDIRECT_SPEC",
+        "PublicDescription": "Branch speculatively executed, indirect branch"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/bus.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/bus.json
@@ -1,0 +1,34 @@
+[
+    {
+        "ArchStdEvent": "CPU_CYCLES",
+        "PublicDescription": "Cycle"
+    },
+    {
+        "ArchStdEvent": "BUS_ACCESS",
+        "PublicDescription": "Bus access. This event counts for every beat of data transferred over the data channels between the core and the SCU. If both read and write data beats are transferred on a given cycle, this event is counted twice on that cycle. This event counts the sum of BUS_ACCESS_RD and BUS_ACCESS_WR"
+    },
+    {
+        "ArchStdEvent": "BUS_CYCLES",
+        "PublicDescription": "Bus cycles. This event duplicates CPU_CYCLES"
+    },
+    {
+        "ArchStdEvent": "BUS_ACCESS_RD",
+        "PublicDescription": "Bus access read. This event counts for every beat of data transferred over the read data channel between the core and the SCU"
+    },
+    {
+        "ArchStdEvent": "BUS_ACCESS_WR",
+        "PublicDescription": "Bus access write. This event counts for every beat of data transferred over the write data channel between the core and the SCU"
+    },
+    {
+        "PublicDescription": "Bus access, read, valid capability. The counter counts each access counted by BUS_ACCESS_RD where a Capability Tag was set in at least one beat of the access",
+        "EventCode": "0x22D",
+        "EventName": "BUS_ACCESS_RD_CTAG",
+        "BriefDescription": "Bus access, read, valid capability. The counter counts each access counted by BUS_ACCESS_RD where a Capability Tag was set in at least one beat of the access"
+    },
+    {
+        "PublicDescription": "Bus access, write, valid capability. The counter counts each access counted by BUS_ACCESS_WR where a Capability Tag was set in at least one beat of the access",
+        "EventCode": "0x22E",
+        "EventName": "BUS_ACCESS_WR_CTAG",
+        "BriefDescription": "Bus access, write, valid capability. The counter counts each access counted by BUS_ACCESS_WR where a Capability Tag was set in at least one beat of the access"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/cache.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/cache.json
@@ -1,0 +1,280 @@
+[
+    {
+        "ArchStdEvent": "L1I_CACHE_REFILL",
+        "PublicDescription": "L1 instruction cache refill. This event counts any instruction fetch which misses in the cache. The following instructions are not counted:\nCache maintenance instructions.\nNon-cacheable accesses"
+    },
+    {
+        "ArchStdEvent": "L1I_TLB_REFILL",
+        "PublicDescription": "L1 instruction TLB refill. This event counts any refill of the instruction L1 TLB from the L2 TLB. This includes refills that result in a translation fault. The following instructions are not counted:\nTLB maintenance instructions. This event counts regardless of whether the MMU is enabled"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_REFILL",
+        "PublicDescription": "L1 data cache refill. This event counts any load or store operation or page table walk access which causes data to be read from outside the L1, including accesses which do not allocate into L1. The following instructions are not counted:\nCache maintenance instructions and prefetches.\nStores of an entire cache line, even if they make a coherency request outside the L1.\nPartial cache line writes which do not allocate into the L1 cache.\nNon-cacheable accesses. This event counts the sum of L1D_CACHE_REFILL_RD and L1D_CACHE_REFILL_WR"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE",
+        "PublicDescription": "L1 data cache access. This event counts any load or store operation or page table walk access which looks up in the L1 data cache. In particular, any access which could count the L1D_CACHE_REFILL event causes this event to count. The following instructions are not counted:\nCache maintenance instructions and prefetches.\nNon-cacheable accesses. This event counts the sum of L1D_CACHE_RD and L1D_CACHE_WR"
+    },
+    {
+        "ArchStdEvent": "L1D_TLB_REFILL",
+        "PublicDescription": "L1 data TLB refill. This event counts any refill of the data L1 TLB from the L2 TLB. This includes refills that result in a translation fault. The following instructions are not counted:\nTLB maintenance instructions. This event counts regardless of whether the MMU is enabled"
+    },
+    {
+        "ArchStdEvent": "L1I_CACHE",
+        "PublicDescription": "Level 1 instruction cache access or Level 0 Macro-op cache access. This event counts any instruction fetch which accesses the L1 instruction cache or L0 Macro-op cache. The following instructions are not counted:\nCache maintenance instructions.\nNon-cacheable accesses"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_WB",
+        "PublicDescription": "L1 data cache Write-Back. This event counts any write-back of data from the L1 data cache to L2 or L3. This counts both victim line evictions and snoops, including cache maintenance operations. The following instructions are not counted:\nInvalidations which do not result in data being transferred out of the L1.\nFull-line writes which write to L2 without writing L1, such as write streaming mode"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE",
+        "PublicDescription": "L2 data cache access. This event counts any transaction from L1 which looks up in the L2 cache, and any write-back from the L1 to the L2. Snoops from outside the core and cache maintenance operations are not counted"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_REFILL",
+        "PublicDescription": "L2 data cache refill. This event counts any cacheable transaction from L1 which causes data to be read from outside the core. L2 refills caused by stashes into L2 should not be counted"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_WB",
+        "PublicDescription": "L2 data cache write-back. This event counts any write-back of data from the L2 cache to outside the core. This includes snoops to the L2 which return data, regardless of whether they cause an invalidation. Invalidations from the L2 which do not write data outside of the core and snoops which return data from the L1 are not counted"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_ALLOCATE",
+        "PublicDescription": "L2 data cache allocation without refill. This event counts any full cache line write into the L2 cache which does not cause a linefill, including write-backs from L1 to L2 and full-line writes which do not allocate into L1"
+    },
+    {
+        "ArchStdEvent": "L1D_TLB",
+        "PublicDescription": "Level 1 data TLB access. This event counts any load or store operation which accesses the data L1 TLB. If both a load and a store are executed on a cycle, this event counts twice. This event counts regardless of whether the MMU is enabled"
+    },
+    {
+        "ArchStdEvent": "L1I_TLB",
+        "PublicDescription": "Level 1 instruction TLB access. This event counts any instruction fetch which accesses the instruction L1 TLB.This event counts regardless of whether the MMU is enabled"
+    },
+    {
+        "ArchStdEvent": "L3D_CACHE_ALLOCATE",
+        "PublicDescription": "Attributable L3 data or unified cache allocation without refill. This event counts any full cache line write into the L3 cache which does not cause a linefill, including write-backs from L2 to L3 and full-line writes which do not allocate into L2"
+    },
+    {
+        "ArchStdEvent": "L3D_CACHE_REFILL",
+        "PublicDescription": "Attributable Level 3 unified cache refill. This event counts for any cacheable read transaction returning data from the SCU for which the data source was outside the cluster. Transactions such as ReadUnique are counted here as 'read' transactions, even though they can be generated by store instructions"
+    },
+    {
+        "ArchStdEvent": "L3D_CACHE",
+        "PublicDescription": "Attributable Level 3 unified cache access. This event counts for any cacheable read transaction returning data from the SCU, or for any cacheable write to the SCU"
+    },
+    {
+        "ArchStdEvent": "L2D_TLB_REFILL",
+        "PublicDescription": "Attributable L2 data or unified TLB refill. This event counts on any refill of the L2 TLB, caused by either an instruction or data access. This event does not count if the MMU is disabled"
+    },
+    {
+        "ArchStdEvent": "L2D_TLB",
+        "PublicDescription": "Attributable L2 data or unified TLB access. This event counts on any access to the L2 TLB (caused by a refill of any of the L1 TLBs). This event does not count if the MMU is disabled"
+    },
+    {
+        "ArchStdEvent": "DTLB_WALK",
+        "PublicDescription": "Access to data TLB that caused a page table walk. This event counts on any data access which causes L2D_TLB_REFILL to count"
+    },
+    {
+        "ArchStdEvent": "ITLB_WALK",
+        "PublicDescription": "Access to instruction TLB that caused a page table walk. This event counts on any instruction access which causes L2D_TLB_REFILL to count"
+    },
+    {
+        "ArchStdEvent": "LL_CACHE_RD",
+        "PublicDescription": "Last level cache access, read.\nIf CPUECTLR.EXTLLC is set: This event counts any cacheable read transaction which returns a data source of 'interconnect cache'.\nIf CPUECTLR.EXTLLC is not set: This event is a duplicate of the L*D_CACHE_RD event corresponding to the last level of cache implemented - L3D_CACHE_RD if both per-core L2 and cluster L3 are implemented, L2D_CACHE_RD if only one is implemented, or L1D_CACHE_RD if neither is implemented"
+    },
+    {
+        "ArchStdEvent": "LL_CACHE_MISS_RD",
+        "PublicDescription": "Last level cache miss, read.\nIf CPUECTLR.EXTLLC is set: This event counts any cacheable read transaction which returns a data source of 'DRAM', 'remote' or 'inter-cluster peer'.\nIf CPUECTLR.EXTLLC is not set: This event is a duplicate of the L*D_CACHE_REFILL_RD event corresponding to the last level of cache implemented - L3D_CACHE_REFILL_RD if both percore L2 and cluster L3 are implemented, L2D_CACHE_REFILL_RD if only one is implemented, or L1D_CACHE_REFILL_RD if neither is implemented"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_RD",
+        "PublicDescription": "L1 data cache access, read. This event counts any load operation or page table walk access which looks up in the L1 data cache. In particular, any access which could count the L1D_CACHE_REFILL_RD event causes this event to count. The following instructions are not counted:\nCache maintenance instructions and prefetches.\nNon-cacheable accesses"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_WR",
+        "PublicDescription": "L1 data cache access, write. This event counts any store operation which looks up in the L1 data cache. In particular, any access which could count the L1D_CACHE_REFILL_WR event causes this event to count. The following instructions are not counted:\nCache maintenance instructions and prefetches.\nNon-cacheable accesses"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_REFILL_RD",
+        "PublicDescription": "L1 data cache refill, read. This event counts any load operation or page table walk access which causes data to be read from outside the L1, including accesses which do not allocate into L1. The following instructions are not counted:\nCache maintenance instructions and prefetches.\nNon-cacheable accesses"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_REFILL_WR",
+        "PublicDescription": "L1 data cache refill, write. This event counts any store operation which causes data to be read from outside the L1, including accesses which do not allocate into L1. The following instructions are not counted:\nCache maintenance instructions and prefetches.\nStores of an entire cache line, even if they make a coherency request outside the L1.\nPartial cache line writes which do not allocate into the L1 cache.\nNon-cacheable accesses"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_REFILL_INNER",
+        "PublicDescription": "L1 data cache refill, inner. This event counts any L1 D-cache linefill (as counted by L1D_CACHE_REFILL) which hits in the L2 cache, L3 cache or another core in the cluster"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_REFILL_OUTER",
+        "PublicDescription": "L1 data cache refill, outer. This event counts any L1 D-cache linefill (as counted by L1D_CACHE_REFILL) which does not hit in the L2 cache, L3 cache or another core in the cluster, and instead obtains data from outside the cluster"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_WB_VICTIM",
+        "PublicDescription": "L1 data cache write-back, victim"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_WB_CLEAN",
+        "PublicDescription": "L1 data cache write-back cleaning and coherency"
+    },
+    {
+        "ArchStdEvent": "L1D_CACHE_INVAL",
+        "PublicDescription": "L1 data cache invalidate"
+    },
+    {
+        "ArchStdEvent": "L1D_TLB_REFILL_RD",
+        "PublicDescription": "L1 data TLB refill, read"
+    },
+    {
+        "ArchStdEvent": "L1D_TLB_REFILL_WR",
+        "PublicDescription": "L1 data TLB refill, write"
+    },
+    {
+        "ArchStdEvent": "L1D_TLB_RD",
+        "PublicDescription": "L1 data TLB access, read"
+    },
+    {
+        "ArchStdEvent": "L1D_TLB_WR",
+        "PublicDescription": "L1 data TLB access, write"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_RD",
+        "PublicDescription": "L2 data cache access, read. This event counts any read transaction from L1 which looks up in the L2 cache. Snoops from outside the core are not counted"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_WR",
+        "PublicDescription": "L2 data cache access, write. This event counts any write transaction from L1 which looks up in the L2 cache or any write-back from L1 which allocates into the L2 cache. Snoops from outside the core are not counted"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_REFILL_RD",
+        "PublicDescription": "L2 data cache refill, read. This event counts any cacheable read transaction from L1 which causes data to be read from outside the core. L2 refills caused by stashes into L2 should not be counted. Transactions such as ReadUnique are counted here as 'read' transactions, even though they can be generated by store instructions"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_REFILL_WR",
+        "PublicDescription": "L2 data cache refill, write. This event counts any write transaction from L1 which causes data to be read from outside the core. L2 refills caused by stashes into L2 should not be counted. Transactions such as ReadUnique are not counted as write transactions"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_WB_VICTIM",
+        "PublicDescription": "L2 data cache write-back, victim"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_WB_CLEAN",
+        "PublicDescription": "L2 data cache write-back, cleaning and coherency"
+    },
+    {
+        "ArchStdEvent": "L2D_CACHE_INVAL",
+        "PublicDescription": "L2 data cache invalidate"
+    },
+    {
+        "ArchStdEvent": "L2D_TLB_REFILL_RD",
+        "PublicDescription": "L2 data or unified TLB refill, read"
+    },
+    {
+        "ArchStdEvent": "L2D_TLB_REFILL_WR",
+        "PublicDescription": "L2 data or unified TLB refill, write"
+    },
+    {
+        "ArchStdEvent": "L2D_TLB_RD",
+        "PublicDescription": "L2 data or unified TLB access, read"
+    },
+    {
+        "ArchStdEvent": "L2D_TLB_WR",
+        "PublicDescription": "L2 data or unified TLB access, write"
+    },
+    {
+        "ArchStdEvent": "L3D_CACHE_RD",
+        "PublicDescription": "L3 cache read"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache access, read, valid capability. The counter counts each access counted by L1D_CACHE_RD which loaded a valid capability",
+        "EventCode": "0x21C",
+        "EventName": "L1D_CACHE_RD_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache access, read, valid capability. The counter counts each access counted by L1D_CACHE_RD which loaded a valid capability"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache access, write, valid capability. The counter counts each access counted by L1D_CACHE_WR which stored a valid capability",
+        "EventCode": "0x21D",
+        "EventName": "L1D_CACHE_WR_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache access, write, valid capability. The counter counts each access counted by L1D_CACHE_WR which stored a valid capability"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache write-back, valid capability. The counter counts each access counted by L1D_CACHE_WB where at least one valid capability was present in the cache line",
+        "EventCode": "0x21E",
+        "EventName": "L1D_CACHE_WB_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache write-back, valid capability. The counter counts each access counted by L1D_CACHE_WB where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache refill, capability. The counter counts each access counted by L1D_CACHE_REFILL_RD where at least one valid capability was present in the cache line",
+        "EventCode": "0x21F",
+        "EventName": "L1D_CACHE_REFILL_RD_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache refill, capability. The counter counts each access counted by L1D_CACHE_REFILL_RD where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache refill, capability. The counter counts each access counted by L1D_CACHE_REFILL_WR where at least one valid capability was present in the cache line",
+        "EventCode": "0x220",
+        "EventName": "L1D_CACHE_REFILL_WR_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache refill, capability. The counter counts each access counted by L1D_CACHE_REFILL_WR where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache refill, inner, valid capability. The counter counts each access counted by L1D_CACHE_REFILL_INNER where at least one valid capability was present in the cache line",
+        "EventCode": "0x221",
+        "EventName": "L1D_CACHE_REFILL_INNER_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache refill, inner, valid capability. The counter counts each access counted by L1D_CACHE_REFILL_INNER where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache refill, outer, valid capability. The counter counts each access counted by L1D_CACHE_REFILL_OUTER where at least one valid capability was present in the cache line",
+        "EventCode": "0x222",
+        "EventName": "L1D_CACHE_REFILL_OUTER_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache refill, outer, valid capability. The counter counts each access counted by L1D_CACHE_REFILL_OUTER where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache Write-Back, victim, valid capability. The counter counts each access counted by L1D_CACHE_WB_VICTIM where at least one valid capability was present in the cache line",
+        "EventCode": "0x223",
+        "EventName": "L1D_CACHE_WB_VICTIM_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache Write-Back, victim, valid capability. The counter counts each access counted by L1D_CACHE_WB_VICTIM where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 1 data cache Write-Back, cleaning, and coherency, valid capability. The counter counts each access counted by L1D_CACHE_WB_CLEAN where at least one valid capability was present in the cache line",
+        "EventCode": "0x224",
+        "EventName": "L1D_CACHE_WB_CLEAN_CTAG",
+        "BriefDescription": "Attributable Level 1 data cache Write-Back, cleaning, and coherency, valid capability. The counter counts each access counted by L1D_CACHE_WB_CLEAN where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 2 data cache access, read, valid capability. The counter counts each access counted by L2D_CACHE_RD which loaded a valid Capability",
+        "EventCode": "0x226",
+        "EventName": "L2D_CACHE_RD_CTAG",
+        "BriefDescription": "Attributable Level 2 data cache access, read, valid capability. The counter counts each access counted by L2D_CACHE_RD which loaded a valid Capability"
+    },
+    {
+        "PublicDescription": "Attributable Level 2 data cache access, write, valid capability. The counter counts each access counted by L2D_CACHE_WR which stored a valid Capability",
+        "EventCode": "0x227",
+        "EventName": "L2D_CACHE_WR_CTAG",
+        "BriefDescription": "Attributable Level 2 data cache access, write, valid capability. The counter counts each access counted by L2D_CACHE_WR which stored a valid Capability"
+    },
+    {
+        "PublicDescription": "Attributable Level 2 data cache refill, valid capability. The counter counts each access counted by L2D_CACHE_REFILL_RD where at least one valid capability was present in the cache line",
+        "EventCode": "0x228",
+        "EventName": "L2D_CACHE_REFILL_RD_CTAG",
+        "BriefDescription": "Attributable Level 2 data cache refill, valid capability. The counter counts each access counted by L2D_CACHE_REFILL_RD where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 2 data cache Write-Back, victim, valid capability. The counter counts each access counted by L2D_CACHE_WB_VICTIM where at least one valid capability was present in the cache line",
+        "EventCode": "0x22A",
+        "EventName": "L2D_CACHE_WB_VICTIM_CTAG",
+        "BriefDescription": "Attributable Level 2 data cache Write-Back, victim, valid capability. The counter counts each access counted by L2D_CACHE_WB_VICTIM where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 2 data cache Write-Back, cleaning and coherency, valid capability. The counter counts each access counted by L2D_CACHE_WB_CLEAN where at least one valid capability was present in the cache line",
+        "EventCode": "0x22B",
+        "EventName": "L2D_CACHE_WB_CLEAN_CTAG",
+        "BriefDescription": "Attributable Level 2 data cache Write-Back, cleaning and coherency, valid capability. The counter counts each access counted by L2D_CACHE_WB_CLEAN where at least one valid capability was present in the cache line"
+    },
+    {
+        "PublicDescription": "Attributable Level 2 data cache invalidate, valid capability. The counter counts each access counted by L2D_CACHE_INVAL where at least one valid capability was present in the cache line",
+        "EventCode": "0x22C",
+        "EventName": "L2D_CACHE_INVAL_CTAG",
+        "BriefDescription": "Attributable Level 2 data cache invalidate, valid capability. The counter counts each access counted by L2D_CACHE_INVAL where at least one valid capability was present in the cache line"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/exception.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/exception.json
@@ -1,0 +1,62 @@
+[
+    {
+        "ArchStdEvent": "EXC_TAKEN",
+        "PublicDescription": "Exception taken"
+    },
+    {
+        "ArchStdEvent": "MEMORY_ERROR",
+        "PublicDescription": "Local memory error. This event counts any correctable or uncorrectable memory error (ECC or parity) in the protected core RAMs"
+    },
+    {
+        "ArchStdEvent": "EXC_UNDEF",
+        "PublicDescription": "Counts the number of undefined exceptions taken locally"
+    },
+    {
+        "ArchStdEvent": "EXC_SVC",
+        "PublicDescription": "Exception taken locally, Supervisor Call"
+    },
+    {
+        "ArchStdEvent": "EXC_PABORT",
+        "PublicDescription": "Exception taken locally, Instruction Abort"
+    },
+    {
+        "ArchStdEvent": "EXC_DABORT",
+        "PublicDescription": "Exception taken locally, Data Abort and SError"
+    },
+    {
+        "ArchStdEvent": "EXC_IRQ",
+        "PublicDescription": "Exception taken locally, IRQ"
+    },
+    {
+        "ArchStdEvent": "EXC_FIQ",
+        "PublicDescription": "Exception taken locally, FIQ"
+    },
+    {
+        "ArchStdEvent": "EXC_SMC",
+        "PublicDescription": "Exception taken locally, Secure Monitor Call"
+    },
+    {
+        "ArchStdEvent": "EXC_HVC",
+        "PublicDescription": "Exception taken locally, Hypervisor Call"
+    },
+    {
+        "ArchStdEvent": "EXC_TRAP_PABORT",
+        "PublicDescription": "Exception taken, Instruction Abort not taken locally"
+    },
+    {
+        "ArchStdEvent": "EXC_TRAP_DABORT",
+        "PublicDescription": "Exception taken, Data Abort or SError not taken locally"
+    },
+    {
+        "ArchStdEvent": "EXC_TRAP_OTHER",
+        "PublicDescription": "Exception taken, Other traps not taken locally"
+    },
+    {
+        "ArchStdEvent": "EXC_TRAP_IRQ",
+        "PublicDescription": "Exception taken, IRQ not taken locally"
+    },
+    {
+        "ArchStdEvent": "EXC_TRAP_FIQ",
+        "PublicDescription": "Exception taken, FIQ not taken locally"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/instruction.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/instruction.json
@@ -1,0 +1,168 @@
+[
+    {
+        "ArchStdEvent": "SW_INCR",
+        "PublicDescription": "Software increment. Instruction architecturally executed (condition code check pass)"
+    },
+    {
+        "ArchStdEvent": "INST_RETIRED",
+        "PublicDescription": "Instruction architecturally executed. This event counts all retired instructions, including those that fail their condition check"
+    },
+    {
+        "ArchStdEvent": "EXC_RETURN",
+        "PublicDescription": "Instruction architecturally executed, condition code check pass, exception return"
+    },
+    {
+        "ArchStdEvent": "CID_WRITE_RETIRED",
+        "PublicDescription": "Instruction architecturally executed, condition code check pass, write to CONTEXTIDR. This event only counts writes to CONTEXTIDR in AArch32 state, and via the CONTEXTIDR_EL1 mnemonic in AArch64 state. The following instructions are not counted:\nWrites to CONTEXTIDR_EL12 and CONTEXTIDR_EL2"
+    },
+    {
+        "ArchStdEvent": "INST_SPEC",
+        "PublicDescription": "Operation speculatively executed"
+    },
+    {
+        "ArchStdEvent": "TTBR_WRITE_RETIRED",
+        "PublicDescription": "Instruction architecturally executed, condition code check pass, write to TTBR.This event only counts writes to TTBR0/TTBR1 in AArch32 state and TTBR0_EL1/TTBR1_EL1 in AArch64 state. The following instructions are not counted:\nAccesses to TTBR0_EL12/TTBR1_EL12 or TTBR0_EL2/ TTBR1_EL2"
+    },
+    {
+        "ArchStdEvent": "BR_RETIRED",
+        "PublicDescription": "Instruction architecturally executed, branch. This event counts all branches, taken or not. This excludes exception entries, debug entries and CCFAIL branches"
+    },
+    {
+        "ArchStdEvent": "BR_MIS_PRED_RETIRED",
+        "PublicDescription": "Instruction architecturally executed, mispredicted branch. This event counts any branch counted by BR_RETIRED which is not correctly predicted and causes a pipeline flush"
+    },
+    {
+        "ArchStdEvent": "LDREX_SPEC",
+        "PublicDescription": "Exclusive operation speculatively executed, LDREX or LDX"
+    },
+    {
+        "ArchStdEvent": "STREX_PASS_SPEC",
+        "PublicDescription": "Exclusive operation speculatively executed, STREX or STX pass"
+    },
+    {
+        "ArchStdEvent": "STREX_FAIL_SPEC",
+        "PublicDescription": "Exclusive operation speculatively executed, STREX or STX fail"
+    },
+    {
+        "ArchStdEvent": "STREX_SPEC",
+        "PublicDescription": "Exclusive operation speculatively executed, STREX or STX"
+    },
+    {
+        "ArchStdEvent": "LD_SPEC",
+        "PublicDescription": "Operation speculatively executed, load"
+    },
+    {
+        "ArchStdEvent": "ST_SPEC",
+        "PublicDescription": "Operation speculatively executed, store"
+    },
+    {
+        "ArchStdEvent": "LDST_SPEC",
+        "PublicDescription": "Operation speculatively executed, load or store. This event counts the sum of LD_SPEC and ST_SPEC"
+    },
+    {
+        "ArchStdEvent": "DP_SPEC",
+        "PublicDescription": "Operation speculatively executed, integer data-processing"
+    },
+    {
+        "ArchStdEvent": "ASE_SPEC",
+        "PublicDescription": "Operation speculatively executed, Advanced SIMD instruction"
+    },
+    {
+        "ArchStdEvent": "VFP_SPEC",
+        "PublicDescription": "Operation speculatively executed, floating-point instruction"
+    },
+    {
+        "ArchStdEvent": "PC_WRITE_SPEC",
+        "PublicDescription": "Operation speculatively executed, software change of the PC"
+    },
+    {
+        "ArchStdEvent": "CRYPTO_SPEC",
+        "PublicDescription": "Operation speculatively executed, Cryptographic instruction"
+    },
+    {
+        "ArchStdEvent": "ISB_SPEC",
+        "PublicDescription": "Barrier speculatively executed, ISB"
+    },
+    {
+        "ArchStdEvent": "DSB_SPEC",
+        "PublicDescription": "Barrier speculatively executed, DSB"
+    },
+    {
+        "ArchStdEvent": "DMB_SPEC",
+        "PublicDescription": "Barrier speculatively executed, DMB"
+    },
+    {
+        "ArchStdEvent": "RC_LD_SPEC",
+        "PublicDescription": "Release consistency operation speculatively executed, load-acquire"
+    },
+    {
+        "ArchStdEvent": "RC_ST_SPEC",
+        "PublicDescription": "Release consistency operation speculatively executed, store-release"
+    },
+    {
+        "PublicDescription": "Instruction architecturally executed, Write to CID_EL0. The counter counts architecturally executed instructions which write to the Compartment ID Register",
+        "EventCode": "0x208",
+        "EventName": "CID_EL0_WRITE_RETIRED",
+        "BriefDescription": "Instruction architecturally executed, Write to CID_EL0. The counter counts architecturally executed instructions which write to the Compartment ID Register"
+    },
+    {
+        "PublicDescription": "Instruction architecturally executed, Write to DDC_ELx, RDDC_EL0. The counter counts architecturally executed instructions which write to any Default Data Capability",
+        "EventCode": "0x209",
+        "EventName": "DDC_WRITE_RETIRED",
+        "BriefDescription": "Instruction architecturally executed, Write to DDC_ELx, RDDC_EL0. The counter counts architecturally executed instructions which write to any Default Data Capability"
+    },
+    {
+        "PublicDescription": "Read from DDC_ELx, RDDC_EL0, Operations Speculatively Executed. The counter counts speculatively executed operations which read from any Default Data Capability",
+        "EventCode": "0x20A",
+        "EventName": "DDC_READ_SPEC",
+        "BriefDescription": "Read from DDC_ELx, RDDC_EL0, Operations Speculatively Executed. The counter counts speculatively executed operations which read from any Default Data Capability"
+    },
+    {
+        "PublicDescription": "Capability Load Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Capability load instructions",
+        "EventCode": "0x210",
+        "EventName": "CAP_LD_SPEC",
+        "BriefDescription": "Capability Load Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Capability load instructions"
+    },
+    {
+        "PublicDescription": "Capability Store Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Capability store instructions",
+        "EventCode": "0x211",
+        "EventName": "CAP_ST_SPEC",
+        "BriefDescription": "Capability Store Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Capability store instructions"
+    },
+    {
+        "PublicDescription": "Alternate Base Capability Load Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base Capability load instructions",
+        "EventCode": "0x212",
+        "EventName": "CAP_ALT_LD_SPEC",
+        "BriefDescription": "Alternate Base Capability Load Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base Capability load instructions"
+    },
+    {
+        "PublicDescription": "Alternate Base Capability Store Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base Capability store instructions",
+        "EventCode": "0x213",
+        "EventName": "CAP_ALT_ST_SPEC",
+        "BriefDescription": "Alternate Base Capability Store Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base Capability store instructions"
+    },
+    {
+        "PublicDescription": "Alternate Base Load Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base load instructions",
+        "EventCode": "0x214",
+        "EventName": "ALT_LD_SPEC",
+        "BriefDescription": "Alternate Base Load Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base load instructions"
+    },
+    {
+        "PublicDescription": "Alternate Base Store Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base store instructions",
+        "EventCode": "0x215",
+        "EventName": "ALT_ST_SPEC",
+        "BriefDescription": "Alternate Base Store Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Alternate Base store instructions"
+    },
+    {
+        "PublicDescription": "LDCT Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Load Tags instructions",
+        "EventCode": "0x216",
+        "EventName": "LDCT_SPEC",
+        "BriefDescription": "LDCT Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to Load Tags instructions"
+    },
+    {
+        "PublicDescription": "LDCT Instructions When Capability Tags are Zero, Operations Speculatively Executed. The counter counts speculatively executed operations due to Load Capability Tags instructions where the Capability Tags to be loaded are all zero",
+        "EventCode": "0x217",
+        "EventName": "LDCT_NO_CAP_SPEC",
+        "BriefDescription": "LDCT Instructions When Capability Tags are Zero, Operations Speculatively Executed. The counter counts speculatively executed operations due to Load Capability Tags instructions where the Capability Tags to be loaded are all zero"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/memory.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/memory.json
@@ -1,0 +1,30 @@
+[
+    {
+        "ArchStdEvent": "MEM_ACCESS",
+        "PublicDescription": "Data memory access. This event counts memory accesses due to load or store instructions. The following instructions are not counted:\nInstruction fetches.\nCache maintenance instructions.\nTranslation table walks or prefetches. This event counts the sum of MEM_ACCESS_RD and MEM_ACCESS_WR"
+    },
+    {
+        "ArchStdEvent": "REMOTE_ACCESS",
+        "PublicDescription": "Access to another socket in a multi-socket system"
+    },
+    {
+        "ArchStdEvent": "MEM_ACCESS_RD",
+        "PublicDescription": "Data memory access, read. This event counts memory accesses due to load instructions. The following instructions are not counted:\nInstruction fetches.\nCache maintenance instructions.\nTranslation table walks.\nPrefetches"
+    },
+    {
+        "ArchStdEvent": "MEM_ACCESS_WR",
+        "PublicDescription": "Data memory access, write. This event counts memory accesses due to store instructions. The following instructions are not counted:\nInstruction fetches.\nCache maintenance instructions.\nTranslation table walks.\nPrefetches"
+    },
+    {
+        "ArchStdEvent": "UNALIGNED_LD_SPEC",
+        "PublicDescription": "Unaligned access, read"
+    },
+    {
+        "ArchStdEvent": "UNALIGNED_ST_SPEC",
+        "PublicDescription": "Unaligned access, write"
+    },
+    {
+        "ArchStdEvent": "UNALIGNED_LDST_SPEC",
+        "PublicDescription": "Unaligned access"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/other.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/other.json
@@ -1,0 +1,134 @@
+[
+    {
+        "PublicDescription": "Branch mispredict restricted. The counter counts each correction to the predicted program flow that occurs because of a misprediction or no prediction, and relates to switches between Restricted and Executive",
+        "EventCode": "0x200",
+        "EventName": "BR_MIS_PRED_RS",
+        "BriefDescription": "Branch mispredict restricted. The counter counts each correction to the predicted program flow that occurs because of a misprediction or no prediction, and relates to switches between Restricted and Executive"
+    },
+    {
+        "PublicDescription": "Branch mispredict C64. The counter counts each correction to the predicted program flow that occurs because of a misprediction or no prediction, and relates to switches between A64 and C64",
+        "EventCode": "0x201",
+        "EventName": "BR_MIS_PRED_C64",
+        "BriefDescription": "Branch mispredict C64. The counter counts each correction to the predicted program flow that occurs because of a misprediction or no prediction, and relates to switches between A64 and C64"
+    },
+    {
+        "PublicDescription": "Branch mispredict system permission. The counter counts each correction to the predicted program flow that occurs because of a misprediction or no prediction, and relates to System permission",
+        "EventCode": "0x202",
+        "EventName": "BR_MIS_PRED_SYS",
+        "BriefDescription": "Branch mispredict system permission. The counter counts each correction to the predicted program flow that occurs because of a misprediction or no prediction, and relates to System permission"
+    },
+    {
+        "PublicDescription": "PCC register file full. The counter counts every cycle counted by the CPU_CYCLES event on which no operation was issued because the PCC write tracking register file was full",
+        "EventCode": "0x203",
+        "EventName": "PCCRF_FULL",
+        "BriefDescription": "PCC register file full. The counter counts every cycle counted by the CPU_CYCLES event on which no operation was issued because the PCC write tracking register file was full"
+    },
+    {
+        "PublicDescription": "Entry to Executive, Operations Speculatively Executed. The counter counts speculatively executed operations that cause an entry into Executive",
+        "EventCode": "0x204",
+        "EventName": "EXECUTIVE_ENTRY",
+        "BriefDescription": "Entry to Executive, Operations Speculatively Executed. The counter counts speculatively executed operations that cause an entry into Executive"
+    },
+    {
+        "PublicDescription": "Exit from Executive, Operations Speculatively Executed. The counter counts speculatively executed operations that cause an exit from Executive",
+        "EventCode": "0x205",
+        "EventName": "EXECUTIVE_EXIT",
+        "BriefDescription": "Exit from Executive, Operations Speculatively Executed. The counter counts speculatively executed operations that cause an exit from Executive"
+    },
+    {
+        "PublicDescription": "Instructions in A64, Operations Speculatively Executed. The counter counts speculatively executed operations due to all instructions in A64",
+        "EventCode": "0x206",
+        "EventName": "INST_SPEC_A64",
+        "BriefDescription": "Instructions in A64, Operations Speculatively Executed. The counter counts speculatively executed operations due to all instructions in A64"
+    },
+    {
+        "PublicDescription": "Instructions in C64, Operations Speculatively Executed. The counter counts speculatively executed operations due to all instructions in C64",
+        "EventCode": "0x207",
+        "EventName": "INST_SPEC_C64",
+        "BriefDescription": "Instructions in C64, Operations Speculatively Executed. The counter counts speculatively executed operations due to all instructions in C64"
+    },
+    {
+        "PublicDescription": "CVTD Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to the following instructions:\nCVTD (not flag setting): Convert pointer to capability offset from DDC.\nCVTD (flag setting): Convert capability to pointer offset from DDC, setting flags.\nCVTDZ: Convert pointer to capability offset from DDC, with null capability from zero semantics",
+        "EventCode": "0x20B",
+        "EventName": "INST_SPEC_CVTD",
+        "BriefDescription": "CVTD Instructions, Operations Speculatively Executed. The counter counts speculatively executed operations due to the following instructions:\nCVTD (not flag setting): Convert pointer to capability offset from DDC.\nCVTD (flag setting): Convert capability to pointer offset from DDC, setting flags.\nCVTDZ: Convert pointer to capability offset from DDC, with null capability from zero semantics"
+    },
+    {
+        "PublicDescription": "SCBNDS or SCBNDSE Instructions which do not set exact bounds, Operations Speculatively Executed. The counter counts speculatively executed operations due to any of the following instructions not succeeding in setting the requested bounds exactly:\nSCBNDS (register): Set Bounds (register).\nSCBNDS (immediate): Set Bounds (immediate).\nSCBNDSE: Set Bounds Exact",
+        "EventCode": "0x20E",
+        "EventName": "INST_SPEC_SCBNDS_NONEXACT",
+        "BriefDescription": "SCBNDS or SCBNDSE Instructions which do not set exact bounds, Operations Speculatively Executed. The counter counts speculatively executed operations due to any of the following instructions not succeeding in setting the requested bounds exactly:\nSCBNDS (register): Set Bounds (register).\nSCBNDS (immediate): Set Bounds (immediate).\nSCBNDSE: Set Bounds Exact"
+    },
+    {
+        "PublicDescription": "SC set due to CDBM. The counter counts each setting of the permission bit to write Capability Tags to memory in a translation table entry which is due to the CDBM bit being set",
+        "EventCode": "0x20F",
+        "EventName": "CDBM_SET_SC",
+        "BriefDescription": "SC set due to CDBM. The counter counts each setting of the permission bit to write Capability Tags to memory in a translation table entry which is due to the CDBM bit being set"
+    },
+    {
+        "PublicDescription": "Data Cache Zero. The counter counts architecturally executed DC ZVA instructions",
+        "EventCode": "0x218",
+        "EventName": "DC_ZVA_RET",
+        "BriefDescription": "Data Cache Zero. The counter counts architecturally executed DC ZVA instructions"
+    },
+    {
+        "PublicDescription": "Data cache refill due to LDCT, Operations Speculatively Executed. The counter counts each access counted by L1D_CACHE that causes a demand refill of any cache due to execution of an LDCT instruction",
+        "EventCode": "0x21A",
+        "EventName": "LDCT_REFILL",
+        "BriefDescription": "Data cache refill due to LDCT, Operations Speculatively Executed. The counter counts each access counted by L1D_CACHE that causes a demand refill of any cache due to execution of an LDCT instruction"
+    },
+    {
+        "PublicDescription": "Data cache refill due to STCT, Operations Speculatively Executed. The counter counts each access counted by L1D_CACHE that causes a demand refill of any cache due to execution of an STCT instruction",
+        "EventCode": "0x21B",
+        "EventName": "STCT_REFILL",
+        "BriefDescription": "Data cache refill due to STCT, Operations Speculatively Executed. The counter counts each access counted by L1D_CACHE that causes a demand refill of any cache due to execution of an STCT instruction"
+    },
+    {
+        "PublicDescription": "Store of zeros. In combination with the CNT_ST_ZERO_16TH_BYTE, the counter counts the number of bytes written by architecturally executed store instructions, not including DC ZVA where only zeros are stored and not including stores which store 16 bytes of zero",
+        "EventCode": "0x22F",
+        "EventName": "CNT_ST_ZERO_BYTE",
+        "BriefDescription": "Store of zeros. In combination with the CNT_ST_ZERO_16TH_BYTE, the counter counts the number of bytes written by architecturally executed store instructions, not including DC ZVA where only zeros are stored and not including stores which store 16 bytes of zero"
+    },
+    {
+        "PublicDescription": "Store of zeros, 16 byte stores. The counter counts when 16 bytes of zero are written by an architecturally executed store instruction",
+        "EventCode": "0x230",
+        "EventName": "CNT_ST_ZERO_16_BYTES",
+        "BriefDescription": "Store of zeros, 16 byte stores. The counter counts when 16 bytes of zero are written by an architecturally executed store instruction"
+    },
+    {
+        "PublicDescription": "Data memory access, read, valid capability. The counter counts each access counted by MEM_ACCESS_RD where a Capability Tag was set in at least one part of the access",
+        "EventCode": "0x233",
+        "EventName": "MEM_ACCESS_RD_CTAG",
+        "BriefDescription": "Data memory access, read, valid capability. The counter counts each access counted by MEM_ACCESS_RD where a Capability Tag was set in at least one part of the access"
+    },
+    {
+        "PublicDescription": "Data memory access, write, valid capability. The counter counts each access counted by MEM_ACCESS_WR where a Capability Tag was set in at least one part of the access",
+        "EventCode": "0x234",
+        "EventName": "MEM_ACCESS_WR_CTAG",
+        "BriefDescription": "Data memory access, write, valid capability. The counter counts each access counted by MEM_ACCESS_WR where a Capability Tag was set in at least one part of the access"
+    },
+    {
+        "PublicDescription": "Data memory access, read, capability. The counter counts each access counted by MEM_ACCESS_RD due to an instruction which loads a capability. It is not sensitive to the validity of the capability",
+        "EventCode": "0x235",
+        "EventName": "CAP_MEM_ACCESS_RD",
+        "BriefDescription": "Data memory access, read, capability. The counter counts each access counted by MEM_ACCESS_RD due to an instruction which loads a capability. It is not sensitive to the validity of the capability"
+    },
+    {
+        "PublicDescription": "Data memory access, write, capability. The counter counts each access counted by MEM_ACCESS_WR due to an instruction which stores a capability. It is not sensitive to the validity of the capability",
+        "EventCode": "0x236",
+        "EventName": "CAP_MEM_ACCESS_WR",
+        "BriefDescription": "Data memory access, write, capability. The counter counts each access counted by MEM_ACCESS_WR due to an instruction which stores a capability. It is not sensitive to the validity of the capability"
+    },
+    {
+        "PublicDescription": "Instructions in Restricted, Operations Speculatively Executed. The counter counts speculatively executed operations due to all instructions in Restricted",
+        "EventCode": "0x237",
+        "EventName": "INST_SPEC_RESTRICTED",
+        "BriefDescription": "Instructions in Restricted, Operations Speculatively Executed. The counter counts speculatively executed operations due to all instructions in Restricted"
+    },
+    {
+        "PublicDescription": "Load permission cleared, Operations Speculatively Executed. The counter counts speculatively executed operations due to load instructions where the capability tag is cleared due to the operation having been performed without LoadCap permission",
+        "EventCode": "0x238",
+        "EventName": "LD_CAP_PERM_CLR_CTAG",
+        "BriefDescription": "Load permission cleared, Operations Speculatively Executed. The counter counts speculatively executed operations due to load instructions where the capability tag is cleared due to the operation having been performed without LoadCap permission"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/arm/rainier/pipeline.json
+++ b/lib/libpmc/pmu-events/arch/arm64/arm/rainier/pipeline.json
@@ -1,0 +1,10 @@
+[
+    {
+        "ArchStdEvent": "STALL_FRONTEND",
+        "PublicDescription": "No operation issued because of the frontend. The counter counts on any cycle when there are no fetched instructions available to dispatch"
+    },
+    {
+        "ArchStdEvent": "STALL_BACKEND",
+        "PublicDescription": "No operation issued because of the backend. The counter counts on any cycle fetched instructions are not dispatched due to resource constraints"
+    }
+]

--- a/lib/libpmc/pmu-events/arch/arm64/mapfile.csv
+++ b/lib/libpmc/pmu-events/arch/arm64/mapfile.csv
@@ -12,6 +12,7 @@
 #
 #
 #Family-model,Version,Filename,EventType
+0x000000003f0f4120,v1,arm/rainier,core
 0x00000000410fd020,v1,arm/cortex-a34,core
 0x00000000410fd030,v1,arm/cortex-a53,core
 0x00000000420f1000,v1,arm/cortex-a53,core


### PR DESCRIPTION
Generated from https://github.com/ARM-software/data/blob/master/pmu/rainier.json using https://gitlab.arm.com/telemetry-solution/telemetry-solution/-/tree/main/tools/perf_json_generator: `/generate.py <cheribsd>/lib/libpmc --arm-data-path <arm-data> --arm-data-cpus rainier`