### PR TITLE
Re-enable ping tests for purecap

### DIFF
--- a/sbin/ping/Makefile
+++ b/sbin/ping/Makefile
@@ -36,8 +36,7 @@ LIBADD+=	ipsec
 
 CFLAGS+=	-Wno-error=unused-but-set-variable
 
-# Doesn't link reliably with CheriABI
-#HAS_TESTS=
-#SUBDIR.${MK_TESTS}+= tests
+HAS_TESTS=
+SUBDIR.${MK_TESTS}+= tests
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
- Revert "Disable tests for now."
- ping: Fix a mostly harmless buffer overflow in -S parsing in main
