### PR TITLE
Enable -morello-bounded-memargs=caller-only for Morello purecap userland

### DIFF
--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -331,7 +331,7 @@ MACHINE_CPU += riscv
 .if ${MACHINE_CPUARCH} == "aarch64"
 . if ${MACHINE_CPU:Mcheri}
 CFLAGS+=	-march=morello
-CFLAGS+=	-Xclang -morello-vararg=new
+CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs=caller-only
 LDFLAGS+=	-march=morello
 . endif
 

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -145,7 +145,7 @@ INLINE_LIMIT?=	8000
 
 .if ${MACHINE_CPU:Mcheri}
 CFLAGS+=	-march=morello
-CFLAGS+=	-Xclang -morello-vararg=new
+CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs=caller-only
 .endif
 
 .if ${MACHINE_ARCH:Maarch*c*}


### PR DESCRIPTION
And enable `-morello-bounded-memargs` for the kernel.

This is the first phase of the ABI switch whose end goal is to enable `-morello-bounded-memargs` for all purecap code. Supercedes #1695.