### PR TITLE
Add CHERI_REPRESENTABLE_ALIGNUP

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_util_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_util_vm.c
@@ -76,7 +76,7 @@ find_address_space_gap(size_t len, size_t align)
 
 	if (align == 0) {
 		len = CHERI_REPRESENTABLE_LENGTH(len);
-		align = CHERI_REPRESENTABLE_ALIGNMENT(len) + 1;
+		align = CHERI_REPRESENTABLE_ALIGNMENT(len);
 	}
 
 	for (u_int i = 1; i < vmcnt; i++) {

--- a/sys/cheri/cheri_exec.c
+++ b/sys/cheri/cheri_exec.c
@@ -73,7 +73,8 @@ cheri_exec_pcc(struct thread *td, struct image_params *imgp)
 
 	code_length = code_end - code_start;
 	/* Check that imgact_elf enforced capability representability. */
-	MPASS(code_start == CHERI_REPRESENTABLE_BASE(code_start, code_length));
+	MPASS(code_start == CHERI_REPRESENTABLE_ALIGN_DOWN(code_start,
+	    code_length));
 	MPASS(code_length == CHERI_REPRESENTABLE_LENGTH(code_length));
 	KASSERT(code_start < code_end, ("%s: truncated PCC", __func__));
 	return (cheri_capability_build_user_code(td, CHERI_CAP_USER_CODE_PERMS,

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -417,6 +417,13 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #define	CHERI_REPRESENTABLE_BASE(base, len) \
 	((base) & CHERI_REPRESENTABLE_ALIGNMENT_MASK(len))
 
+#if __has_feature(capabilities)
+#define	CHERI_REPRESENTABLE_ALIGN_UP(base, len) \
+	__align_up((base), CHERI_REPRESENTABLE_ALIGNMENT(len))
+#else
+#define	CHERI_REPRESENTABLE_ALIGN_UP(base, len) (base)
+#endif
+
 /*
  * In the current encoding sealed and unsealed capabilities have the same
  * alignment constraints.

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -414,7 +414,7 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 /* Provide macros to make it easier to work with the raw CRAM/CRRL results: */
 #define	CHERI_REPRESENTABLE_ALIGNMENT(len) \
 	(~CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) + 1)
-#define	CHERI_REPRESENTABLE_BASE(base, len) \
+#define	CHERI_REPRESENTABLE_ALIGN_DOWN(base, len) \
 	((base) & CHERI_REPRESENTABLE_ALIGNMENT_MASK(len))
 
 #if __has_feature(capabilities)
@@ -423,6 +423,9 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #else
 #define	CHERI_REPRESENTABLE_ALIGN_UP(base, len) (base)
 #endif
+
+/* Backwards compat. */
+#define	CHERI_REPRESENTABLE_BASE	CHERI_REPRESENTABLE_ALIGNMENT_DOWN
 
 /*
  * In the current encoding sealed and unsealed capabilities have the same
@@ -435,7 +438,7 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #define	CHERI_SEALABLE_ALIGNMENT(len)	\
 	CHERI_REPRESENTABLE_ALIGNMENT(len)
 #define	CHERI_SEALABLE_BASE(base, len)	\
-	CHERI_REPRESENTABLE_BASE(base, len)
+	CHERI_REPRESENTABLE_ALIGN_DOWN(base, len)
 
 /* A mask for the lower bits, i.e. the negated alignment mask */
 #define	CHERI_SEAL_ALIGN_MASK(l)	~(CHERI_SEALABLE_ALIGNMENT_MASK(l))

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -608,8 +608,7 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 	 * executable. For RTLD we also align upwards to avoid aligning
 	 * down into the memory region for the main binary.
 	 */
-	reservation = roundup2(reservation,
-	    CHERI_REPRESENTABLE_ALIGNMENT(end - start));
+	reservation = CHERI_REPRESENTABLE_ALIGN_UP(reservation, end - start);
 #endif
 	result = vm_map_reservation_create(map, &reservation, end - start,
 	    PAGE_SIZE, VM_PROT_ALL);

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1126,7 +1126,8 @@ __elfN(enforce_limits)(const struct image_params *imgp, const Elf_Ehdr *hdr,
 	 * Sanity check that the base address was aligned correctly so that we
 	 * can represent a capability spanning the entire executable.
 	 */
-	KASSERT(imgp->start_addr == CHERI_REPRESENTABLE_BASE(imgp->start_addr,
+	KASSERT(imgp->start_addr ==
+	    CHERI_REPRESENTABLE_ALIGN_DOWN(imgp->start_addr,
 	    imgp->end_addr - imgp->start_addr) && imgp->end_addr ==
 	    imgp->start_addr + CHERI_REPRESENTABLE_LENGTH(imgp->end_addr -
 	    imgp->start_addr), ("Image range [%#jx-%#jx] is not representable "
@@ -1250,7 +1251,7 @@ __elfN(load_interp)(struct image_params *imgp, const Elf_Brandinfo *brand_info,
 	error = __elfN(load_file)(imgp->proc, interp, addr, &end_addr, entry);
 done:
 	if (error == 0) {
-		imgp->interp_start = CHERI_REPRESENTABLE_BASE(*addr,
+		imgp->interp_start = CHERI_REPRESENTABLE_ALIGN_DOWN(*addr,
 		    end_addr - *addr);
 		imgp->interp_end = imgp->interp_start +
 		    CHERI_REPRESENTABLE_LENGTH(end_addr - *addr);
@@ -1554,7 +1555,7 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 		goto ret;
 
 	/* Round start/end addresses to representability */
-	imgp->start_addr = CHERI_REPRESENTABLE_BASE(representable_start,
+	imgp->start_addr = CHERI_REPRESENTABLE_ALIGN_DOWN(representable_start,
 	    representable_end - representable_start);
 	imgp->end_addr = imgp->start_addr +
 	    CHERI_REPRESENTABLE_LENGTH(representable_end - representable_start);
@@ -1663,7 +1664,7 @@ prog_cap(struct image_params *imgp, uint64_t perms)
 	 * choosing a sensible start address and length.
 	 */
 	KASSERT(prog_len == CHERI_REPRESENTABLE_LENGTH(prog_len) &&
-	    prog_base == CHERI_REPRESENTABLE_BASE(prog_base, prog_len),
+	    prog_base == CHERI_REPRESENTABLE_ALIGN_DOWN(prog_base, prog_len),
 	    ("program capability [%#jx-%#jx] not representable (length=%#zx)",
 	    (uintmax_t)prog_base, (uintmax_t)imgp->end_addr, prog_len));
 
@@ -1686,7 +1687,8 @@ interp_cap(struct image_params *imgp, Elf_Auxargs *args, uint64_t perms)
 	 * choosing a sensible start address.
 	 */
 	KASSERT(interp_len == CHERI_REPRESENTABLE_LENGTH(interp_len) &&
-	    interp_base == CHERI_REPRESENTABLE_BASE(interp_base, interp_len),
+	    interp_base ==
+	    CHERI_REPRESENTABLE_ALIGN_DOWN(interp_base, interp_len),
 	    ("interp capability [%#jx-%#jx] not representable (length=%#zx)",
 	    (uintmax_t)interp_base, (uintmax_t)imgp->interp_end, interp_len));
 	MPASS(args->base >= interp_base);
@@ -1708,7 +1710,7 @@ timekeep_cap(struct image_params *imgp)
 	    sizeof(struct vdso_timehands) * VDSO_TH_NUM;
 
 	/* These are sub-page so should be representable as-is. */
-	KASSERT(timekeep_base == CHERI_REPRESENTABLE_BASE(timekeep_base,
+	KASSERT(timekeep_base == CHERI_REPRESENTABLE_ALIGN_DOWN(timekeep_base,
 	    timekeep_len), ("timekeep_base needs rounding"));
 	KASSERT(timekeep_len == CHERI_REPRESENTABLE_LENGTH(timekeep_len),
 	    ("timekeep_len needs rounding"));
@@ -2041,7 +2043,8 @@ __elfN(coredump)(struct thread *td, struct vnode *vp, off_t limit, int flags)
 #if __has_feature(capabilities)
 			section_cap = cheri_capability_build_user_data(
 			    CHERI_PERM_LOAD,
-			    CHERI_REPRESENTABLE_BASE(php->p_vaddr, php->p_filesz),
+			    CHERI_REPRESENTABLE_ALIGN_DOWN(php->p_vaddr,
+			    php->p_filesz),
 			    CHERI_REPRESENTABLE_LENGTH(php->p_filesz), 0);
 #else
 			section_cap = (char *)(uintptr_t)php->p_vaddr;

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1263,7 +1263,8 @@ exec_map_stack(struct image_params *imgp)
 		stack_top = sv->sv_usrstack;
 #if __has_feature(capabilities)
 		if (sv->sv_flags & SV_CHERI)
-			stack_top = CHERI_REPRESENTABLE_BASE(stack_top, ssiz);
+			stack_top = CHERI_REPRESENTABLE_ALIGN_DOWN(stack_top,
+			    ssiz);
 #endif
 		stack_addr = stack_top - ssiz;
 		find_space = VMFS_NO_SPACE;
@@ -1315,7 +1316,7 @@ exec_map_stack(struct image_params *imgp)
 		 */
 		strings_size = CHERI_REPRESENTABLE_LENGTH(ARG_MAX + PAGE_SIZE);
 		strings_addr =
-		    CHERI_REPRESENTABLE_BASE(stack_addr - strings_size,
+		    CHERI_REPRESENTABLE_ALIGN_DOWN(stack_addr - strings_size,
 			strings_size);
 		error = vm_mmap_object(map, &strings_addr, 0, strings_size,
 		    VM_PROT_RW_CAP, VM_PROT_RW_CAP, MAP_ANON | MAP_FIXED |

--- a/sys/kern/subr_devmap.c
+++ b/sys/kern/subr_devmap.c
@@ -161,7 +161,7 @@ devmap_add_entry(vm_paddr_t pa, vm_size_t sz)
 	KASSERT(sz == CHERI_REPRESENTABLE_LENGTH(sz),
 	    ("%s: devmap entry is not representable [0x%08jx, 0x%08jx]",
 	    __func__, (uintmax_t)va, (uintmax_t)va + sz));
-	KASSERT(va == CHERI_REPRESENTABLE_BASE(va, sz),
+	KASSERT(va == CHERI_REPRESENTABLE_ALIGN_DOWN(va, sz),
 	    ("%s: devmap entry is not representable [0x%08jx, 0x%08jx]",
 	     __func__, (uintmax_t)va, (uintmax_t)va + sz));
 #endif
@@ -310,8 +310,8 @@ pmap_mapdev(vm_paddr_t pa, vm_size_t size)
 		vm_pointer_t oldva = akva_devmap_vaddr;
 #endif
 		akva_devmap_vaddr -= CHERI_REPRESENTABLE_LENGTH(size);
-		akva_devmap_vaddr = CHERI_REPRESENTABLE_BASE(akva_devmap_vaddr,
-		    size);
+		akva_devmap_vaddr =
+		    CHERI_REPRESENTABLE_ALIGN_DOWN(akva_devmap_vaddr, size);
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr);
 		va = (vm_pointer_t)cheri_setboundsexact(cheri_setaddress(
 		    devmap_capability, akva_devmap_vaddr), size);
@@ -356,8 +356,8 @@ pmap_mapdev_attr(vm_paddr_t pa, vm_size_t size, vm_memattr_t ma)
 		vm_pointer_t oldva = akva_devmap_vaddr;
 #endif
 		akva_devmap_vaddr -= CHERI_REPRESENTABLE_LENGTH(size);
-		akva_devmap_vaddr = CHERI_REPRESENTABLE_BASE(akva_devmap_vaddr,
-		    size);
+		akva_devmap_vaddr =
+		    CHERI_REPRESENTABLE_ALIGN_DOWN(akva_devmap_vaddr, size);
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr);
 		va = (vm_pointer_t)cheri_setboundsexact(cheri_setaddress(
 		    devmap_capability, akva_devmap_vaddr), size);

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -496,7 +496,8 @@ kern_shmat_locked(struct thread *td, int shmid,
 		 * extending before and after the entry to allow arbitrary
 		 * addresses (subject to available space...).
 		 */
-		if (CHERI_REPRESENTABLE_BASE(attach_va, size) != attach_va)
+		if (CHERI_REPRESENTABLE_ALIGN_DOWN(attach_va, size) !=
+		    attach_va)
 			return (EINVAL);
 		if (cheri_gettag(shmaddr)) {
 			int reqperm;

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -448,9 +448,7 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 
 	/* Copy the DTB to KVA space. */
 	dtb_size = fdt_totalsize(rvbp->dtbp_virt);
-#ifdef __CHERI_PURE_CAPABILITY__
-	lastaddr = roundup2(lastaddr, CHERI_REPRESENTABLE_ALIGNMENT(dtb_size));
-#endif
+	lastaddr = CHERI_REPRESENTABLE_ALIGN_UP(lastaddr, dtb_size);
 	lastaddr = roundup(lastaddr, sizeof(int));
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_METADATA | MODINFOMD_DTBP);
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(vm_offset_t));

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -450,9 +450,8 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	dtb_size = fdt_totalsize(rvbp->dtbp_virt);
 #ifdef __CHERI_PURE_CAPABILITY__
 	lastaddr = roundup2(lastaddr, CHERI_REPRESENTABLE_ALIGNMENT(dtb_size));
-#else
-	lastaddr = roundup(lastaddr, sizeof(int));
 #endif
+	lastaddr = roundup(lastaddr, sizeof(int));
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_METADATA | MODINFOMD_DTBP);
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(vm_offset_t));
 	PRELOAD_PUSH_VALUE(vm_offset_t, lastaddr);

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -885,7 +885,7 @@ kmem_init(vm_pointer_t start, vm_pointer_t end)
 	 * for that kva range.
 	 */
 	size = CHERI_REPRESENTABLE_LENGTH((ptraddr_t)start - (ptraddr_t)addr);
-	start = roundup2(start, CHERI_REPRESENTABLE_ALIGNMENT(size));
+	start = CHERI_REPRESENTABLE_ALIGN_UP(start, size);
 	(void)vm_map_reservation_create_locked(kernel_map, &addr, size,
 	    VM_PROT_ALL);
 	(void)vm_map_insert(kernel_map, NULL, 0, addr, start, VM_PROT_ALL,

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5443,8 +5443,7 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	 */
 	user_length = MIN(maxuser - minuser,
 	    VM_MAXUSER_ADDRESS - VM_MINUSER_ADDRESS);
-	padded_minuser = rounddown2(minuser,
-	    CHERI_REPRESENTABLE_ALIGNMENT(user_length));
+	padded_minuser = CHERI_REPRESENTABLE_BASE(minuser, user_length);
 	KASSERT(padded_minuser == minuser || minuser <= PAGE_SIZE,
 	    ("Unrepresentable base for new vmspace"));
 	KASSERT(maxuser - padded_minuser ==

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5443,7 +5443,7 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	 */
 	user_length = MIN(maxuser - minuser,
 	    VM_MAXUSER_ADDRESS - VM_MINUSER_ADDRESS);
-	padded_minuser = CHERI_REPRESENTABLE_BASE(minuser, user_length);
+	padded_minuser = CHERI_REPRESENTABLE_ALIGN_DOWN(minuser, user_length);
 	KASSERT(padded_minuser == minuser || minuser <= PAGE_SIZE,
 	    ("Unrepresentable base for new vmspace"));
 	KASSERT(maxuser - padded_minuser ==


### PR DESCRIPTION
- cheribsdtest: Remove extraneous + 1 from address space gap alignment
- riscv fake_preload_metadata: Always roundup lastaddr for module metadata
- vmspace_exec: Unexpand CHERI_REPRESENTABLE_BASE
- cheric.h: Add a CHERI_REPRESENTABLE_ALIGNUP macro
- sys: Unexpand CHERI_REPRESENTABLE_ALIGNUP in various places
