### PR TITLE
libunwind: fix an unused variable diagnostic

### DIFF
--- a/contrib/subrepo-cheri-libunwind/src/UnwindLevel1.c
+++ b/contrib/subrepo-cheri-libunwind/src/UnwindLevel1.c
@@ -44,7 +44,11 @@
 // directly jump to __libunwind_Registerts_x86/x86_64_jumpto instead of using
 // a regular function call to avoid pushing to CET shadow stack again.
 #if !defined(_LIBUNWIND_USE_CET)
-#define __unw_phase2_resume(cursor, fn) __unw_resume((cursor))
+#define __unw_phase2_resume(cursor, fn)                                        \
+  do {                                                                         \
+    (void)fn;                                                                  \
+    __unw_resume((cursor));                                                    \
+  } while (0)
 #elif defined(_LIBUNWIND_TARGET_I386)
 #define __unw_phase2_resume(cursor, fn)                                        \
   do {                                                                         \


### PR DESCRIPTION
This pulls in the upstream fix:
https://github.com/llvm/llvm-project/commit/575a1d48e781a03a1bb892ff52e16ee0485d0a34