### PR TITLE
csu: Add missing .cfi_undefined directives

### DIFF
--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -76,6 +76,7 @@ _start(void *auxv,
 	void (*cleanup)(void),			/* from shared loader */
 	struct Struct_Obj_Entry *obj)		/* from shared loader */
 {
+	__asm__ volatile(".cfi_undefined c30");
 	int argc = 0;
 	char **argv = NULL;
 	char **env = NULL;

--- a/lib/csu/riscv/crt1_c.c
+++ b/lib/csu/riscv/crt1_c.c
@@ -57,6 +57,7 @@ void __start(int argc, char **argv, char **env, void (*cleanup)(void)) __dead2;
 void
 __start(int argc, char **argv, char **env, void (*cleanup)(void))
 {
+	__asm__ volatile(".cfi_undefined ra");
 #ifdef SHOULD_PROCESS_CAP_RELOCS
 	/*
 	 * Initialize __cap_relocs for static executables. The run-time linker

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -76,6 +76,7 @@ _start(void *auxv,
 	void (*cleanup)(void),			/* from shared loader */
 	struct Struct_Obj_Entry *obj)		/* from shared loader */
 {
+	__asm__ volatile(".cfi_undefined cra");
 	int argc = 0;
 	char **argv = NULL;
 	char **env = NULL;


### PR DESCRIPTION
Without these libunwind attempts to unwind beyond _start which results in nonsense infinite backtraces. Found this by running the libunwind tests for RISCV and noticed that purecap was also missing these directives:
```
starting test1
Frame 1: _Z9backtracei+0x2e
Frame 2: _Z5test1i+0x40
Frame 3: main+0x28
Frame 4: __libc_start1+0x76
Frame 5: __start+0x18
Frame 6: _start+0x22
Frame 7: _Z9backtracei+0x2e
Frame 8: _start+0x22
Frame 9: _Z9backtracei+0x2e
Frame 10: _start+0x22
....
```

For RISC-V I added the directive to the C function rather than the assembly one but I could also add it to _start instead.