### PR TITLE
Add a pkg repository with CheriABI debug packages

### DIFF
--- a/usr.sbin/pkg/CheriBSD-debug.conf
+++ b/usr.sbin/pkg/CheriBSD-debug.conf
@@ -1,0 +1,15 @@
+#
+# To enable this repository, instead of modifying this file,
+# create a /usr/local/etc/pkg/repos/CheriBSD-debug.conf file:
+#
+#   mkdir -p /usr/local/etc/pkg/repos
+#   echo "CheriBSD-debug: { enabled: yes }" > /usr/local/etc/pkg/repos/CheriBSD-debug.conf
+#
+
+CheriBSD-debug: {
+  url: "http://pkg.CheriBSD.org/${ABI}-debug",
+  mirror_type: "none",
+  signature_type: "fingerprints",
+  fingerprints: "/usr/share/keys/pkg",
+  enabled: no
+}

--- a/usr.sbin/pkg/CheriBSD.conf
+++ b/usr.sbin/pkg/CheriBSD.conf
@@ -11,5 +11,6 @@ CheriBSD: {
   mirror_type: "none",
   signature_type: "fingerprints",
   fingerprints: "/usr/share/keys/pkg",
-  enabled: yes
+  enabled: yes,
+  priority: 1
 }

--- a/usr.sbin/pkg/Makefile
+++ b/usr.sbin/pkg/Makefile
@@ -3,9 +3,12 @@
 
 PACKAGE=	pkg-bootstrap
 
-PKGCONF?=	CheriBSD.conf
-CONFS=		${PKGCONF}
-CONFSNAME_${PKGCONF}=	${PKGCONF:C/\.conf.+$/.conf/}
+CONFS=		CheriBSD.conf
+.if ${MACHINE_ABI:Mpurecap} && !defined(PKG_SUFFIX)
+# Install a configuration file for a pkg repository with debug packages for use
+# with the default package manager only if the world is compiled for CheriABI.
+CONFS+=		CheriBSD-debug.conf
+.endif
 CONFSDIR=	/etc/pkg${PKG_SUFFIX}
 CONFSMODE=	644
 PROG?=	pkg${PKG_SUFFIX}


### PR DESCRIPTION
* Only for pkg64c, install a separate pkg repository file with the CheriBSD-debug repository definition that is disabled by default, and that can be enabled in /usr/local/etc/pkg/repos as advised in the configuration file itself;
* Increase the priority of the CheriBSD repository so that pkg64c commands consider it before the CheriBSD-debug repository;
* Remove unnecessary logic in Makefile that is specific to upstream and maps branch-specific configuration file names to their configuration names.

The CheriBSD-debug repository is disabled by default not to confuse users. If it was enabled `pkg64c search` would list packages twice, once for CheriBSD and once for CheriBSD-debug. Hence, it is better to disable it and document in the Getting Started with CheriBSD guide how to make use of CheriBSD-debug.