### PR TITLE
caprevoke: Don't revoke by default

### DIFF
--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -975,6 +975,12 @@ static void init(void) {
 			quarantining = true;
 		}
 	}
+	if (!quarantining)
+#if defined(PRINT_CAPREVOKE) || defined(PRINT_CAPREVOKE_MRS) || defined(PRINT_STATS)
+		goto nosys;
+#else
+		return;
+#endif
 #endif /* OPTIONAL_QUARANTINING */
 
 	if (cheri_revoke_get_shadow(CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL,

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -78,7 +78,7 @@ SYSCTL_INT(_security_cheri, OID_AUTO, bound_legacy_capabilities,
  * the kernel so that the default can impact programs starting from
  * init(8).
  */
-static int runtime_default = 1;
+static int runtime_quarantine_default = 0;
 SYSCTL_INT(_security_cheri, OID_AUTO, runtime_quarantine_default, CTLFLAG_RWTUN,
-    &runtime_default, 0, "Userspace runtime quarantine default");
+    &runtime_quarantine_default, 0, "Userspace runtime quarantine default");
 #endif  /* CHERI_CAPREVOKE */


### PR DESCRIPTION
We're seeing apparent UAF issues in the installer where they are annoying to debug so try disabling quarantine for now.