### PR TITLE
Fix panic when starting sddm after caprevoke merge

### DIFF
--- a/sys/arm64/arm64/exec_machdep.c
+++ b/sys/arm64/arm64/exec_machdep.c
@@ -945,7 +945,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	onstack = sigonstack(tf->tf_sp);
 
 	CTR4(KTR_SIG, "sendsig: td=%p (%s) catcher=%p sig=%d", td, p->p_comm,
-	    catcher, sig);
+	    (__cheri_fromcap void *)catcher, sig);
 
 	/* Allocate and validate space for the signal handler context. */
 	if ((td->td_pflags & TDP_ALTSTACK) != 0 && !onstack &&
@@ -977,7 +977,8 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	/* Copy the sigframe out to the user's stack. */
 	if (copyoutcap(&frame, fp, sizeof(*fp)) != 0) {
 		/* Process has trashed its stack. Kill it. */
-		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td, fp);
+		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td,
+		    (__cheri_fromcap void *)fp);
 		PROC_LOCK(p);
 		sigexit(td, SIGILL);
 	}

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -1527,24 +1527,27 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 				p->p_ptevents |= PTRACE_SCE;
 				CTR4(KTR_PTRACE,
 		    "PT_TO_SCE: pid %d, events = %#x, PC = %#lx, sig = %d",
-				    p->p_pid, p->p_ptevents, (u_long)addr, data);
+				    p->p_pid, p->p_ptevents,
+				    (__cheri_addr u_long)addr, data);
 				break;
 			case PT_TO_SCX:
 				p->p_ptevents |= PTRACE_SCX;
 				CTR4(KTR_PTRACE,
 		    "PT_TO_SCX: pid %d, events = %#x, PC = %#lx, sig = %d",
-				    p->p_pid, p->p_ptevents, (u_long)addr, data);
+				    p->p_pid, p->p_ptevents,
+				    (__cheri_addr u_long)addr, data);
 				break;
 			case PT_SYSCALL:
 				p->p_ptevents |= PTRACE_SYSCALL;
 				CTR4(KTR_PTRACE,
 		    "PT_SYSCALL: pid %d, events = %#x, PC = %#lx, sig = %d",
-				    p->p_pid, p->p_ptevents, (u_long)addr, data);
+				    p->p_pid, p->p_ptevents,
+				    (__cheri_addr u_long)addr, data);
 				break;
 			case PT_CONTINUE:
 				CTR3(KTR_PTRACE,
 				    "PT_CONTINUE: pid %d, PC = %#lx, sig = %d",
-				    p->p_pid, (u_long)addr, data);
+				    p->p_pid, (__cheri_addr u_long)addr, data);
 				break;
 			}
 			break;
@@ -1645,7 +1648,7 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 			error = ENOMEM;
 		else
 			CTR3(KTR_PTRACE, "PT_WRITE: pid %d: %lx <= %#x",
-			    p->p_pid, (u_long)addr, data);
+			    p->p_pid, (__cheri_addr u_long)addr, data);
 		PROC_LOCK(p);
 		break;
 
@@ -1658,7 +1661,7 @@ kern_ptrace(struct thread *td, int req, pid_t pid, void * __capability addr, int
 			error = ENOMEM;
 		else
 			CTR3(KTR_PTRACE, "PT_READ: pid %d: %lx >= %#x",
-			    p->p_pid, (u_long)addr, tmp);
+			    p->p_pid, (__cheri_addr u_long)addr, tmp);
 		td->td_retval[0] = tmp;
 		PROC_LOCK(p);
 		break;

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -454,7 +454,7 @@ kern_nmount(struct thread *td, struct iovec * __capability iovp, u_int iovcnt,
 
 	AUDIT_ARG_FFLAGS(flags);
 	CTR4(KTR_VFS, "%s: iovp %#lx with iovcnt %d and flags %d", __func__,
-	    iovp, (u_long)iovcnt, flags);
+	    (__cheri_fromcap void *)iovp, (u_long)iovcnt, flags);
 
 	/*
 	 * Filter out MNT_ROOTFS.  We do not want clients of nmount() in

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -398,7 +398,11 @@ struct thread {
 
 struct thread0_storage {
 	struct thread t0st_thread;
+#ifdef __CHERI_PURE_CAPABILITY__
+	uint64_t t0st_sched[11];
+#else
 	uint64_t t0st_sched[10];
+#endif
 } __no_subobject_bounds;
 
 struct mtx *thread_lock_block(struct thread *);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -219,7 +219,7 @@ quarantine_cmp(struct vm_map_entry *e1, struct vm_map_entry *e2)
 	KASSERT(e1->reservation != e2->reservation,
 	    ("two quarantined entries %p %p with the same reservation %zu",
 	     e1, e2, e1->reservation));
-	return (e1->reservation > e2->reservation ? -1 : 0);
+	return (e1->reservation > e2->reservation ? -1 : 1);
 }
 
 RB_GENERATE_STATIC(vm_map_quarantine, vm_map_entry, quarantine, quarantine_cmp)

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -2883,6 +2883,10 @@ vm_map_entry_clone(vm_map_t map, vm_map_entry_t entry)
 	vm_map_entry_t new_entry;
 
 	VM_MAP_ASSERT_LOCKED(map);
+#ifdef CHERI_CAPREVOKE
+	KASSERT(entry->inheritance != VM_INHERIT_QUARANTINE,
+	    ("%s: cloning quarantine map entry", __func__));
+#endif
 
 	/*
 	 * Create a backing object now, if none exists, so that more individual

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -1639,9 +1639,8 @@ vm_map_entry_quarantine(vm_map_t map, vm_map_entry_t entry)
 
 	KASSERT((entry->eflags & MAP_ENTRY_UNMAPPED) != 0,
 	    ("Can only quarantine unmappled pages %x\n", entry->eflags));
-	CTR3(KTR_VM,
-	    __func__ ": map %p, nentries %d, entry %p", map, map->nentries,
-	    entry);
+	CTR(KTR_VM, "%s: map %p, nentries %d, entry %p", __func__, map,
+	    map->nentries, entry);
 	VM_MAP_ASSERT_LOCKED(map);
 	entry->inheritance = VM_INHERIT_QUARANTINE;
 	RB_INSERT(vm_map_quarantine, &map->quarantine, entry);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -1597,8 +1597,8 @@ vm_map_entry_unlink(vm_map_t map, vm_map_entry_t entry,
 		rlist->offset = root->offset;
 		/*
 		 * Either both are part of the same reservation or they
-		 * are quarantined, adjacent neighbors being combined
-		 * and thus will take on the previous entries's resevation.
+		 * are adjacent quarantined neighbors being combined
+		 * and thus will take on the previous entry's reservation.
 		 */
 		rlist->reservation = root->reservation;
 	}


### PR DESCRIPTION
- sys: Various fixes for KTR traces for hybrid kernels
- Fix quarantine_cmp to not return equal
- vm_map_entry_unlink: Cleanup a comment
- vm_map_entry_clone: Assert against cloning quarantine entries
- vm_map: Move quarantine RB_REINSERT into vm_map_merge_entries
- purecap: Grow the size of tst0_sched for purecap kernels
