### PR TITLE
ldconfig -64 fixes

### DIFF
--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -674,7 +674,7 @@ ldconfig_paths="/usr/lib/compat ${_localbase}/lib ${_localbase}/lib/compat/pkg"
 			# shared library search paths
 ldconfig32_paths="/usr/lib32 /usr/lib32/compat"
 			# 32-bit compatibility shared library search paths
-ldconfig64_paths="/usr/local64/lib /usr/local64/lib/compat/pkg"
+ldconfig64_paths="/usr/lib64 /usr/local64/lib /usr/local64/lib/compat/pkg"
 			# 64-bit compatibility shared library search paths
 ldconfig_local_dirs="${_localbase}/libdata/ldconfig"
 			# Local directories with ldconfig configuration files.

--- a/sbin/ldconfig/ldconfig.8
+++ b/sbin/ldconfig/ldconfig.8
@@ -40,7 +40,7 @@
 .Nd configure the dynamic linker search path for shared libraries
 .Sh SYNOPSIS
 .Nm
-.Op Fl 32
+.Op Fl 32 | Fl 64
 .Op Fl Rimrv
 .Op Fl f Ar hints_file
 .Op Ar directory | Ar
@@ -103,6 +103,9 @@ The following options are recognized by
 .It Fl 32
 Generate the hints for 32-bit ABI shared libraries
 on 64-bit systems that support running 32-bit binaries.
+.It Fl 64
+Generate the hints for 64-bit ABI shared libraries
+on CHERI systems that support running 64-bit binaries.
 .It Fl elf
 Ignored for backwards compatibility.
 .It Fl R
@@ -156,6 +159,10 @@ invocations with
 Conventional configuration files containing directory names for
 invocations with
 .Fl 32 .
+.It Pa /var/run/ld-elf64.so.hints
+Conventional configuration files containing directory names for
+invocations with
+.Fl 64 .
 .El
 .Sh SEE ALSO
 .Xr ld 1 ,

--- a/sbin/ldconfig/ldconfig.c
+++ b/sbin/ldconfig/ldconfig.c
@@ -130,7 +130,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: ldconfig [-32] [-elf] [-Rimrv] [-f hints_file] "
+	    "usage: ldconfig [-32|-64] [-elf] [-Rimrv] [-f hints_file] "
 	    "[directory | file ...]\n");
 	exit(1);
 }


### PR DESCRIPTION
- ldconfig: Document -64 in usage and the manual page
- Add /usr/lib64 to default 64-bit ldconfig paths
