### PR TITLE
Restrict some cap permissions in purecap kernels

### DIFF
--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -307,7 +307,6 @@ virtdone:
 	/*
 	 * Convert modulep into a capability
 	 * XXX-AM: can we set bounds on this?
-	 * TODO: clear perms
 	 */
 	cvtd	c19, x19
 #endif

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -403,7 +403,7 @@ init_proc0(vm_pointer_t kstack)
 
 	/* XXX-AM: We need to set bounds on pcb and kstack here as in MIPS */
 	proc_linkup0(&proc0, &thread0);
-	thread0.td_kstack = kstack;
+	thread0.td_kstack = cheri_kern_andperm(kstack, CHERI_PERMS_KERNEL_DATA);
 	thread0.td_kstack_pages = kstack_pages;
 #if defined(PERTHREAD_SSP)
 	thread0.td_md.md_canary = boot_canary;

--- a/sys/arm64/arm64/machdep_boot.c
+++ b/sys/arm64/arm64/machdep_boot.c
@@ -181,6 +181,8 @@ linux_parse_boot_param(struct arm64_bootparams *abp)
 		return (0);
 	/* Test if modulep point to valid DTB. */
 	dtb_ptr = (struct fdt_header *)abp->modulep;
+	dtb_ptr = cheri_kern_andperm(dtb_ptr,
+	    CHERI_PERMS_KERNEL_RODATA & CHERI_PERMS_KERNEL_DATA_NOCAP);
 	if (fdt_check_header(dtb_ptr) != 0)
 		return (0);
 	dtb_size = fdt_totalsize(dtb_ptr);
@@ -204,6 +206,8 @@ freebsd_parse_boot_param(struct arm64_bootparams *abp)
 		return (0);
 
 	preload_metadata = (caddr_t)(uintptr_t)(abp->modulep);
+	preload_metadata = cheri_kern_andperm(preload_metadata,
+	    CHERI_PERMS_KERNEL_RODATA & CHERI_PERMS_KERNEL_DATA_NOCAP);
 	kmdp = preload_search_by_type("elf kernel");
 	if (kmdp == NULL)
 		return (0);


### PR DESCRIPTION
- Morello: Restrict perms on thread0's stack to CHERI_PERMS_KERNEL_DATA
- Morello: Reduce perms on the modulep pointer passed from locore
- purecap kernel: Restrict permissions on kmem capabilities
