### PR TITLE
caprevoke: fix address space leak, provide quarantine status

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -860,6 +860,12 @@ CHERIBSDTEST(vm_reservation_mmap_after_free_fixed,
     "after the reservation has been deleted")
 {
 	void *map;
+	const volatile struct cheri_revoke_info *cri;
+
+	/* Make sure this process is revoking */
+	CHERIBSDTEST_CHECK_SYSCALL(cheri_revoke_get_shadow(
+	    CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL, __DEQUALIFY(void **, &cri)));
+
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
 
@@ -1945,8 +1951,13 @@ CHERIBSDTEST(revoke_largest_quarantined_reservation,
 	struct procstat *psp;
 	struct kinfo_proc *kipp;
 	struct kinfo_vmentry *kivp;
+	const volatile struct cheri_revoke_info *cri;
 	uint pcnt, vmcnt;
 	bool found_res;
+
+	/* Make sure this process is revoking */
+	CHERIBSDTEST_CHECK_SYSCALL(cheri_revoke_get_shadow(
+	    CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL, __DEQUALIFY(void **, &cri)));
 
 	res = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, res_size, PROT_READ,
 	    MAP_ANON, -1, 0));
@@ -2028,8 +2039,13 @@ CHERIBSDTEST(revoke_merge_quarantined,
 	struct procstat *psp;
 	struct kinfo_proc *kipp;
 	struct kinfo_vmentry *kivp;
+	const volatile struct cheri_revoke_info *cri;
 	uint pcnt, vmcnt;
 	bool found_res[NRES] = {};
+
+	/* Make sure this process is revoking */
+	CHERIBSDTEST_CHECK_SYSCALL(cheri_revoke_get_shadow(
+	    CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL, __DEQUALIFY(void **, &cri)));
 
 	/*
 	 * Create a single large quarantined reservation with three

--- a/lib/libprocstat/Symbol.map
+++ b/lib/libprocstat/Symbol.map
@@ -47,4 +47,7 @@ FBSD_1.6 {
 FBSD_1.7 {
 	 procstat_getadvlock;
 	 procstat_freeadvlock;
+	 procstat_getquarantining;
+	 procstat_get_revoker_epoch;
+	 procstat_get_revoker_state;
 };

--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -2171,6 +2171,117 @@ procstat_getumask(struct procstat *procstat, struct kinfo_proc *kp,
 }
 
 static int
+procstat_getquarantining_sysctl(pid_t pid, int *quarantiningp)
+{
+	int error, name[4];
+	size_t len;
+
+	name[0] = CTL_KERN;
+	name[1] = KERN_PROC;
+	name[2] = KERN_PROC_QUARANTINING;
+	name[3] = pid;
+	len = sizeof(*quarantiningp);
+	error = sysctl(name, nitems(name), quarantiningp, &len, NULL, 0);
+	if (error != 0 && errno != ESRCH)
+		warn("sysctl: kern.proc.quarantining: %d", pid);
+	return (error);
+}
+
+int
+procstat_getquarantining(struct procstat *procstat, struct kinfo_proc *kp,
+    int *quarantiningp)
+{
+	switch (procstat->type) {
+	case PROCSTAT_CORE:
+		warnx("%s: PROCSTAT_CORE not supported", __func__);
+		return (-1);
+	case PROCSTAT_KVM:
+		warnx("%s: PROCSTAT_KVM not supported", __func__);
+		return (-1);
+	case PROCSTAT_SYSCTL:
+		return (procstat_getquarantining_sysctl(kp->ki_pid,
+		    quarantiningp));
+	default:
+		warnx("unknown access method: %d", procstat->type);
+		return (-1);
+	}
+}
+
+static int
+procstat_get_revoker_epoch_sysctl(pid_t pid, uint64_t *revoker_epochp)
+{
+	int error, name[4];
+	size_t len;
+
+	name[0] = CTL_KERN;
+	name[1] = KERN_PROC;
+	name[2] = KERN_PROC_REVOKER_EPOCH;
+	name[3] = pid;
+	len = sizeof(*revoker_epochp);
+	error = sysctl(name, nitems(name), revoker_epochp, &len, NULL, 0);
+	if (error != 0 && errno != ESRCH)
+		warn("sysctl: kern.proc.revoker_epoch: %d", pid);
+	return (error);
+}
+
+int
+procstat_get_revoker_epoch(struct procstat *procstat, struct kinfo_proc *kp,
+    uint64_t *revoker_epochp)
+{
+	switch (procstat->type) {
+	case PROCSTAT_CORE:
+		warnx("%s: PROCSTAT_CORE not supported", __func__);
+		return (-1);
+	case PROCSTAT_KVM:
+		warnx("%s: PROCSTAT_KVM not supported", __func__);
+		return (-1);
+	case PROCSTAT_SYSCTL:
+		return (procstat_get_revoker_epoch_sysctl(kp->ki_pid,
+		    revoker_epochp));
+	default:
+		warnx("unknown access method: %d", procstat->type);
+		return (-1);
+	}
+}
+
+static int
+procstat_get_revoker_state_sysctl(pid_t pid, int *revoker_statep)
+{
+	int error, name[4];
+	size_t len;
+
+	name[0] = CTL_KERN;
+	name[1] = KERN_PROC;
+	name[2] = KERN_PROC_REVOKER_STATE;
+	name[3] = pid;
+	len = sizeof(*revoker_statep);
+	error = sysctl(name, nitems(name), revoker_statep, &len, NULL, 0);
+	if (error != 0 && errno != ESRCH)
+		warn("sysctl: kern.proc.revoker_state: %d", pid);
+	return (error);
+}
+
+int
+procstat_get_revoker_state(struct procstat *procstat, struct kinfo_proc *kp,
+    int *revoker_statep)
+{
+	switch (procstat->type) {
+	case PROCSTAT_CORE:
+		warnx("%s: PROCSTAT_CORE not supported", __func__);
+		return (-1);
+	case PROCSTAT_KVM:
+		warnx("%s: PROCSTAT_KVM not supported", __func__);
+		return (-1);
+	case PROCSTAT_SYSCTL:
+		return (procstat_get_revoker_state_sysctl(kp->ki_pid,
+		    revoker_statep));
+	default:
+		warnx("unknown access method: %d", procstat->type);
+		return (-1);
+	}
+}
+
+static int
 procstat_getrlimit_kvm(kvm_t *kd, struct kinfo_proc *kp, int which,
     struct rlimit* rlimit)
 {

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -218,6 +218,10 @@ int	procstat_get_pipe_info(struct procstat *procstat, struct filestat *fst,
     struct pipestat *pipe, char *errbuf);
 int	procstat_get_pts_info(struct procstat *procstat, struct filestat *fst,
     struct ptsstat *pts, char *errbuf);
+int	procstat_get_revoker_epoch(struct procstat *procstat,
+    struct kinfo_proc *kp, uint64_t *revoker_epoch);
+int	procstat_get_revoker_state(struct procstat *procstat,
+    struct kinfo_proc *kp, int *revoker_state);
 int	procstat_get_sem_info(struct procstat *procstat, struct filestat *fst,
     struct semstat *sem, char *errbuf);
 int	procstat_get_shm_info(struct procstat *procstat, struct filestat *fst,
@@ -244,6 +248,8 @@ int	procstat_getosrel(struct procstat *procstat, struct kinfo_proc *kp,
     int *osrelp);
 int	procstat_getpathname(struct procstat *procstat, struct kinfo_proc *kp,
     char *pathname, size_t maxlen);
+int	procstat_getquarantining(struct procstat *procstat,
+    struct kinfo_proc *kp, int *quarantining);
 int	procstat_getrlimit(struct procstat *procstat, struct kinfo_proc *kp,
     int which, struct rlimit* rlimit);
 int	procstat_getumask(struct procstat *procstat, struct kinfo_proc *kp,

--- a/sys/cheri/revoke_kern.h
+++ b/sys/cheri/revoke_kern.h
@@ -33,6 +33,10 @@
 #ifndef __SYS_CHERI_REVOKE_KERN_H__
 #define	__SYS_CHERI_REVOKE_KERN_H__
 
+#ifndef _KERNEL
+#include <stdbool.h>
+#endif
+
 /*
  * The outermost capability revocation state machine.
  *
@@ -121,6 +125,8 @@ struct cheri_revoke_info_page {
 	 */
 };
 
+#ifdef _KERNEL
 SYSCTL_DECL(_vm_cheri_revoke);
+#endif
 
 #endif

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -571,6 +571,9 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 		return (EINVAL);
 	}
 
+	if (!cheri_gettag(cres))
+		return (EINVAL);
+
 	error = copyoutcap(&cres, shadow, sizeof(cres));
 
 	return (error);

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -148,6 +148,58 @@ static SYSCTL_NODE(_kern_proc, KERN_PROC_QUARANTINING, quarantining,
     CTLFLAG_RD | CTLFLAG_MPSAFE, sysctl_kern_proc_quarantining,
     "is this process quarantining for temporal safety");
 
+static int
+sysctl_kern_proc_revoker_state(SYSCTL_HANDLER_ARGS)
+{
+	struct vmspace *vm;
+	int *name = (int *)arg1;
+	u_int namelen = arg2;
+	struct proc *p;
+	int error = 0;
+	pid_t pid;
+	int state;
+
+	if (namelen != 1)
+		return (EINVAL);
+
+	pid = (pid_t)name[0];
+	if (pid == curproc->p_pid || pid == 0) {
+		if (SV_CURPROC_FLAG(SV_CHERI))
+			state = cheri_revoke_st_get_state(
+			    curproc->p_vmspace->vm_map.vm_cheri_revoke_st);
+		else
+			state = -1;
+
+		goto out;
+	}
+
+	error = pget(pid, PGET_WANTREAD, &p);
+	if (error != 0)
+		return (error);
+
+	if (SV_PROC_FLAG(p, SV_CHERI)) {
+		vm = vmspace_acquire_ref(p);
+		if (vm == NULL)
+			error = ESRCH;
+		else {
+			state = cheri_revoke_st_get_state(
+			    vm->vm_map.vm_cheri_revoke_st);
+			vmspace_free(vm);
+		}
+	} else
+		state = -1;
+
+	PRELE(p);
+out:
+	if (error == 0)
+		error = SYSCTL_OUT(req, &state, sizeof(state));
+	return (error);
+}
+
+static SYSCTL_NODE(_kern_proc, KERN_PROC_REVOKER_STATE, revoker_state,
+    CTLFLAG_RD | CTLFLAG_MPSAFE, sysctl_kern_proc_revoker_state,
+    "state of the in-kernel revoker");
+
 #ifdef CHERI_CAPREVOKE_STATS
 /* Here seems about as good a place as any */
 _Static_assert(sizeof(struct cheri_revoke_stats) ==

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -95,6 +95,59 @@ cheri_revoke_fini(struct cheri_revoke_syscall_info * __capability crsi,
 	return (res3);
 }
 
+static int
+sysctl_kern_proc_quarantining(SYSCTL_HANDLER_ARGS)
+{
+	struct vmspace *vm;
+	int *name = (int *)arg1;
+	u_int namelen = arg2;
+	struct proc *p;
+	int error = 0;
+	pid_t pid;
+	int is_quarantining;
+
+	if (namelen != 1)
+		return (EINVAL);
+
+	pid = (pid_t)name[0];
+	if (pid == curproc->p_pid || pid == 0) {
+		if (SV_CURPROC_FLAG(SV_CHERI))
+			is_quarantining = curproc->p_vmspace->
+			    vm_map.vm_cheri_revoke_quarantining;
+		else
+			is_quarantining = -1;
+
+		goto out;
+	}
+
+	error = pget(pid, PGET_WANTREAD, &p);
+	if (error != 0)
+		return (error);
+
+	if (SV_PROC_FLAG(p, SV_CHERI)) {
+		vm = vmspace_acquire_ref(p);
+		if (vm == NULL)
+			error = ESRCH;
+		else {
+			is_quarantining =
+			     vm->vm_map.vm_cheri_revoke_quarantining;
+			vmspace_free(vm);
+		}
+	} else
+		is_quarantining = -1;
+
+	PRELE(p);
+out:
+	if (error == 0)
+		error = SYSCTL_OUT(req, &is_quarantining,
+		    sizeof(is_quarantining));
+	return (error);
+}
+
+static SYSCTL_NODE(_kern_proc, KERN_PROC_QUARANTINING, quarantining,
+    CTLFLAG_RD | CTLFLAG_MPSAFE, sysctl_kern_proc_quarantining,
+    "is this process quarantining for temporal safety");
+
 #ifdef CHERI_CAPREVOKE_STATS
 /* Here seems about as good a place as any */
 _Static_assert(sizeof(struct cheri_revoke_stats) ==

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1059,6 +1059,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 
 #define	KERN_PROC_QUARANTINING	46	/* is this process quarantining? */
 #define	KERN_PROC_REVOKER_STATE	47	/* revoker state */
+#define	KERN_PROC_REVOKER_EPOCH	48	/* revoker epoch */
 
 /*
  * KERN_IPC identifiers

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1057,6 +1057,8 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_PROC_SIGFASTBLK	44	/* address of fastsigblk magic word */
 #define	KERN_PROC_VM_LAYOUT	45	/* virtual address space layout info */
 
+#define	KERN_PROC_QUARANTINING	46	/* is this process quarantining? */
+
 /*
  * KERN_IPC identifiers
  */

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1058,6 +1058,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_PROC_VM_LAYOUT	45	/* virtual address space layout info */
 
 #define	KERN_PROC_QUARANTINING	46	/* is this process quarantining? */
+#define	KERN_PROC_REVOKER_STATE	47	/* revoker state */
 
 /*
  * KERN_IPC identifiers

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -252,6 +252,7 @@ struct vm_map {
 	 * Tree of map entries awaiting revocation, ordered by size and
 	 * virtual address.
 	 */
+	bool vm_cheri_revoke_quarantining;	/* map is quarantining */
 	RB_HEAD(vm_map_quarantine, vm_map_entry) quarantine;
 	struct vm_map_entry *rev_entry;	/* entry being revoked */
 #ifdef CHERI_CAPREVOKE_STATS

--- a/usr.bin/procstat/Makefile
+++ b/usr.bin/procstat/Makefile
@@ -9,6 +9,7 @@ SRCS=	procstat.c		\
 	procstat_auxv.c		\
 	procstat_basic.c	\
 	procstat_bin.c		\
+	procstat_cheri.c	\
 	procstat_cred.c		\
 	procstat_cs.c		\
 	procstat_files.c	\

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -169,6 +169,11 @@ Substring commands are accepted.
 Display command line arguments for the process.
 .Pp
 Substring commands are accepted.
+.It Ar cheri
+Display CHERI-specific information about the process.
+If the
+.Fl v
+flag is passed then extra information is shown.
 .It Ar environment | Fl e
 Display environment variables for the process.
 .Pp
@@ -285,6 +290,58 @@ process ID
 command
 .It ARGS
 command line arguments (if available)
+.El
+.Ss CHERI information
+Display the process ID, command, and CHERI-specific information:
+.Pp
+.Bl -tag -width "RSTATE" -compact
+.It PID
+process ID
+.It COMM
+command
+.It C
+CHERI support in the process ABI
+.It QUAR
+quarantining status
+.It RSTATE
+in-kernel revoker state
+.It EPOCH
+in-kernel revoker epoch
+.El
+.Pp
+The following values indicate the support for CHERI in the process ABI:
+.Pp
+.Bl -tag -width XX -compact
+.It H
+hybrid ABI with integer system call arguments
+.It P
+pure-capability ABI with capability system call arguments
+.It !
+CHERI not supported
+.It ?
+Unknown ABI
+.El
+.Pp
+The following quarantining status types may be displayed:
+.Pp
+.Bl -tag -width nosup -compact
+.It yes
+address space is quarantining fully unmapped reservations
+.It no
+address space is not quarantining fully unmapped reservations
+.El
+.Pp
+The following revoker state values may be displayed:
+.Pp
+.Bl -tag -width initing -compact
+.It none
+revoker not active
+.It initint
+revoker being initialized
+.It inited
+revoker initialized, epoch open
+.It closing
+revoker finishing an epoch
 .El
 .Ss Environment Variables
 Display the process ID, command, and environment variables:

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -126,7 +126,7 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_PLURAL },
 	{ "tsignal", "thread_signals", "[-n]", &procstat_threads_sigs,
 	    &cmdopt_signals, PS_CMP_PLURAL | PS_CMP_SUBSTR },
-	{ "vm", "vm", NULL, &procstat_vm, &cmdopt_verbose, PS_CMP_NORMAL }
+	{ "vm", "vm", "[-v]", &procstat_vm, &cmdopt_verbose, PS_CMP_NORMAL }
 };
 
 static void

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -94,6 +94,8 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_NORMAL },
 	{ "binary", "binary", NULL, &procstat_bin, &cmdopt_none,
 	    PS_CMP_SUBSTR },
+	{ "cheri", "cheri", "[-v]", &procstat_cheri, &cmdopt_verbose,
+	    PS_CMP_NORMAL },
 	{ "cpuset", "cs", NULL, &procstat_cs, &cmdopt_cpuset, PS_CMP_NORMAL },
 	{ "cs", "cs", NULL, &procstat_cs, &cmdopt_cpuset, PS_CMP_NORMAL },
 	{ "credential", "credentials", NULL, &procstat_cred, &cmdopt_none,

--- a/usr.bin/procstat/procstat.h
+++ b/usr.bin/procstat/procstat.h
@@ -60,6 +60,7 @@ void	procstat_args(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_auxv(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_basic(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_bin(struct procstat *prstat, struct kinfo_proc *kipp);
+void	procstat_cheri(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cred(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cs(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_env(struct procstat *prstat, struct kinfo_proc *kipp);

--- a/usr.bin/procstat/procstat_cheri.c
+++ b/usr.bin/procstat/procstat_cheri.c
@@ -1,0 +1,176 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 SRI International
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. HR001122S0003 ("MTSS").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/user.h>
+
+#include <cheri/revoke.h>
+#include <cheri/revoke_kern.h>
+
+#include <err.h>
+#include <libprocstat.h>
+#include <string.h>
+
+#include "procstat.h"
+
+static char get_abi_cheri(struct kinfo_proc *kipp);
+static const char *get_quarantining(struct procstat *procstat,
+    struct kinfo_proc *kipp);
+static const char *get_revoker_epoch(struct procstat *procstat,
+    struct kinfo_proc *kipp);
+static const char *get_revoker_state(struct procstat *procstat,
+    struct kinfo_proc *kipp);
+
+void
+procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	char abi_cheri;
+
+	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
+		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
+			xo_emit("{T:/%5s %-19s %c %4s %7s}\n",
+			    "PID", "COMM", 'C', "QUAR", "RSTATE");
+		else
+			xo_emit("{T:/%5s %-19s %c %4s %7s %34s}\n",
+			    "PID", "COMM", 'C', "QUAR", "RSTATE", "EPOCH");
+	}
+
+	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
+	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
+	abi_cheri = get_abi_cheri(kipp);
+	xo_emit(" {:abi_cheri_support/%c/%c}", abi_cheri);
+	/* Don't print CHERI-specific things for non-CheriABI ABIs */
+	switch (abi_cheri) {
+	case 'P':
+		xo_emit(" {:quarantining/%4s}",
+		    get_quarantining(procstat, kipp));
+		xo_emit(" {:revoker_state/%7s}",
+		    get_revoker_state(procstat, kipp));
+		if ((procstat_opts & PS_OPT_VERBOSE) != 0)
+			xo_emit(" {:revoker_epoch/%34s}",
+			    get_revoker_epoch(procstat, kipp));
+		break;
+	}
+	xo_emit("\n");
+}
+
+static struct {
+	const char *emul;
+	char abi;
+} abis[] = {
+	{ "FreeBSD ELF64C", 'P' },
+	{ "FreeBSD ELF64CB", 'P' },
+	{ "FreeBSD ELF64", 'H' },
+	{ "FreeBSD ELF32", '!' },
+	{ "Linux ELF64", '!' },
+	{ "Linux ELF32", '!' },
+};
+
+static char
+get_abi_cheri(struct kinfo_proc *kipp)
+{
+	for (size_t i = 0; i < nitems(abis); i++)
+		if (strcmp(abis[i].emul, kipp->ki_emul) == 0)
+			return (abis[i].abi);
+	return ('?');
+}
+
+static const char *
+get_quarantining(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	int quarantining;
+
+	if (procstat_getquarantining(procstat, kipp, &quarantining) == 0) {
+		switch (quarantining) {
+		case 0:
+			return ("no");
+		case 1:
+			return ("yes");
+		case -1:
+			return ("!");
+		default:
+			warnx("%s: unknown quarantining status", __func__);
+			return ("?");
+		}
+	} else {
+		return ("-");
+	}
+}
+
+static const char *
+get_revoker_epoch(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	uint64_t epoch;
+	static char revoker_epoch_buf[2*16 + 2 + 1]; /* 0x + number + NUL */
+
+	if (procstat_get_revoker_epoch(procstat, kipp, &epoch) == 0) {
+		switch (epoch) {
+		case (uint64_t)-1:
+			return ("na");
+		default:
+			snprintf(revoker_epoch_buf, sizeof(revoker_epoch_buf),
+			    "%#jx", (uintmax_t)epoch);
+			return (revoker_epoch_buf);
+		}
+	} else {
+		return ("-");
+	}
+
+}
+
+static const char *
+get_revoker_state(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	int state;
+
+	if (procstat_get_revoker_state(procstat, kipp, &state) == 0) {
+		switch (state) {
+		case CHERI_REVOKE_ST_NONE:
+			return ("none");
+		case CHERI_REVOKE_ST_INITING:
+			return ("initing");
+		case CHERI_REVOKE_ST_INITED:
+			return ("inited");
+		case CHERI_REVOKE_ST_CLOSING:
+			return ("closing");
+		case -1:
+			return ("!");
+		default:
+			warnx("%s: unknown quarantining status", __func__);
+			return ("?");
+		}
+	} else {
+		return ("-");
+	}
+}


### PR DESCRIPTION
Delay quarantine of unmapped regions until after a revocation syscall has been made (typically early in libc startup).

Expose quarantine status via sysctl and a new `procstat cheri` subcommand.