### PR TITLE
mrs: handle empty quarantine

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -30,6 +30,7 @@ SRCS+=	cheribsdtest_bounds_globals.c					\
 .if ${MACHINE_ABI:Mpurecap}
 SRCS+=	cheribsdtest_bounds_subobject.c					\
 	cheribsdtest_bounds_varargs.c					\
+	cheribsdtest_malloc.c						\
 	cheribsdtest_sentries.c
 .endif
 

--- a/bin/cheribsdtest/cheribsdtest_malloc.c
+++ b/bin/cheribsdtest/cheribsdtest_malloc.c
@@ -1,0 +1,73 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 SRI International
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. HR001122S0003 ("MTSS").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#include "cheribsdtest.h"
+
+bool malloc_is_quarantining(void);
+
+static const char *
+skip_malloc_not_quarantining(const char *name __unused)
+{
+	if (malloc_is_quarantining())
+		return (NULL);
+	return ("malloc is not quarantining");
+}
+
+CHERIBSDTEST(malloc_revoke_basic,
+    "verify that a free'd pointer is revoked by malloc_revoke",
+    .ct_check_skip = skip_malloc_not_quarantining)
+{
+	volatile void *ptr __unused;
+
+	ptr = malloc(1);
+
+	free(__DEVOLATILE(void *, ptr));
+
+	malloc_revoke();
+
+	/* XXX: ask kernel what the revocation method is? */
+	CHERIBSDTEST_VERIFY2(!cheri_gettag(ptr),
+	    "free'd pointer not revoked %#lp", ptr);
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(malloc_revoke_twice, "revoke twice back to back",
+    .ct_check_skip = skip_malloc_not_quarantining)
+{
+	malloc_revoke();
+	malloc_revoke();
+
+	cheribsdtest_success();
+}

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -754,17 +754,19 @@ static inline void quarantine_flush(struct mrs_quarantine *quarantine) {
 		prev = iter;
 	}
 
-	/* free the quarantined descriptors */
-	prev->next = free_descriptor_slabs;
+	if (prev != NULL) {
+		/* free the quarantined descriptors */
+		prev->next = free_descriptor_slabs;
 #ifdef OFFLOAD_QUARANTINE
-	while (!atomic_compare_exchange_weak(&free_descriptor_slabs, &prev->next, quarantine->list));
+		while (!atomic_compare_exchange_weak(&free_descriptor_slabs, &prev->next, quarantine->list));
 #else /* OFFLOAD_QUARANTINE */
-	free_descriptor_slabs = quarantine->list;
+		free_descriptor_slabs = quarantine->list;
 #endif /* !OFFLOAD_QUARANTINE */
 
-	quarantine->list = NULL;
-	allocated_size -= quarantine->size;
-	quarantine->size = 0;
+		quarantine->list = NULL;
+		allocated_size -= quarantine->size;
+		quarantine->size = 0;
+	}
 	mrs_debug_printf("quarantine_flush: flushed, allocated_size %zu quarantine->size %zu\n", allocated_size, quarantine->size);
 }
 


### PR DESCRIPTION
Add a test for calling malloc_revoke() with an empty quarantine in mrs and fix a crash when that happens.

Fixes: #1875