### PR TITLE
truss support for benchmark ABI

### DIFF
--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -127,6 +127,9 @@ static struct procabi linux32 = {
 static struct procabi_table abis[] = {
 #if __has_feature(capabilities)
 	{ "FreeBSD ELF64C", &freebsd },
+#if defined(__aarch64__)
+	{ "FreeBSD ELF64CB", &freebsd },
+#endif
 	{ "FreeBSD ELF64", &freebsd64 },
 	{ "FreeBSD ELF32", &freebsd32 },
 #elif __SIZEOF_POINTER__ == 4


### PR DESCRIPTION
Syscalls are unchanged between CheriABI and the benchmark ABI, but the emul string differs.

Found by grep while working on #1873 