### PR TITLE
Revoke fixes from Robert's demo box

### DIFF
--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -301,9 +301,6 @@ kern_cheri_revoke(struct thread *td, int flags,
 		if (!vmm->vm_cheri_revoke_quarantining)
 			vmm->vm_cheri_revoke_quarantining = true;
 
-		epoch = cheri_revoke_st_get_epoch(vmm->vm_cheri_revoke_st);
-		entryst = cheri_revoke_st_get_state(vmm->vm_cheri_revoke_st);
-
 		if ((flags & (fast_out_flags | CHERI_REVOKE_LAST_PASS)) ==
 		    fast_out_flags) {
 			/* Apparently they really just wanted the time. */
@@ -311,6 +308,9 @@ kern_cheri_revoke(struct thread *td, int flags,
 		}
 
 reentry:
+		epoch = cheri_revoke_st_get_epoch(vmm->vm_cheri_revoke_st);
+		entryst = cheri_revoke_st_get_state(vmm->vm_cheri_revoke_st);
+
 		if (cheri_revoke_epoch_clears(epoch, start_epoch)) {
 			/*
 			 * An entire epoch has come and gone since the
@@ -392,8 +392,6 @@ fast_out:
 				return (ires);
 			}
 
-			epoch = cheri_revoke_st_get_epoch(
-			    vmm->vm_cheri_revoke_st);
 			goto reentry;
 		}
 

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -4739,9 +4739,6 @@ vm_map_delete(vm_map_t map, vm_offset_t start, vm_offset_t end,
 			cloned_entry->end = entry->end;
 			cloned_entry->reservation = entry->reservation;
 			cloned_entry->next_read = entry->start;
-
-			/* XXX: Is this the right max-prot to use? */
-			cloned_entry->max_protection = entry->max_protection;
 		}
 
 		/*


### PR DESCRIPTION
- vm_map_delete: Leave max_prot for unmapped reservations as VM_PROT_NONE
- kern_cheri_revoke: Reload entryst after sleeping
