### PR TITLE
caprevoke: style(9) improvements

### DIFF
--- a/sys/arm64/arm64/cheri_revoke_machdep.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep.c
@@ -179,8 +179,8 @@ again:
 			 * nor 1, which means that the stxr wasn't executed and
 			 * so the capability at cutp has changed.
 			 */
-			*res |= VM_CHERI_REVOKE_PAGE_DIRTY
-				| VM_CHERI_REVOKE_PAGE_HASCAPS ;
+			*res |= VM_CHERI_REVOKE_PAGE_DIRTY |
+			    VM_CHERI_REVOKE_PAGE_HASCAPS;
 		}
 	} else {
 		CHERI_REVOKE_STATS_BUMP(crst, caps_found);
@@ -241,6 +241,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 
 	for (; cheri_getaddress(mvu) < mve; mvu++) {
 		uintcap_t cut = *mvu;
+
 		if (cheri_gettag(cut)) {
 			if (cb(&res, crc, crshadow, ctp, mvu, cut, start, end))
 				goto out;
@@ -279,7 +280,7 @@ vm_cheri_revoke_test(const struct vm_cheri_revoke_cookie *crc, uintcap_t cut)
 		disable_user_memory_access();
 		curthread->td_pcb->pcb_onfault = 0;
 #endif
-		return res;
+		return (res);
 	}
 
 	return (0);
@@ -349,15 +350,15 @@ vm_cheri_revoke_page_ro_adapt(int *res,
 
 	/* If the thing has no permissions, we don't need to scan it later */
 	if ((cheri_gettag(cut) == 0) || (cheri_getperm(cut) == 0))
-		return 0;
+		return (0);
 
 	*res |= VM_CHERI_REVOKE_PAGE_HASCAPS;
 
 	if (ctp(crshadow, cut, cheri_getperm(cut), start, end)) {
 		*res |= VM_CHERI_REVOKE_PAGE_DIRTY;
 
-		/* One dirty answer is as good as any other; stop eary */
-		return 1;
+		/* One dirty answer is as good as any other; stop early */
+		return (1);
 	}
 
 	return (0);

--- a/sys/arm64/arm64/cheri_revoke_machdep_tests.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep_tests.c
@@ -54,9 +54,8 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 
 	ptraddr_t va = cheri_getbase(cut);
 
-	bmloc = crshadow
-	    - VM_CHERI_REVOKE_BSZ_OTYPE
-	    - (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
+	bmloc = crshadow - VM_CHERI_REVOKE_BSZ_OTYPE -
+	    (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
 
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
 	bmbits = *bmloc;
@@ -85,7 +84,7 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 /* Check the fine-grained NOMAP bitmap */
 static inline unsigned long
 vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
-			    uintcap_t cut)
+    uintcap_t cut)
 {
 	uint8_t bmbits;
 	const uint8_t * __capability bmloc;
@@ -144,8 +143,7 @@ vm_cheri_revoke_test_just_mem(const uint8_t * __capability crshadow,
 
 static unsigned long
 vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms,
-		      vm_offset_t start, vm_offset_t end)
+    uintcap_t cut, unsigned long perms, vm_offset_t start, vm_offset_t end)
 {
 	/*
 	 * Most capabilities are memory capabilities, most are unrevoked,
@@ -166,8 +164,7 @@ vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
 
 static unsigned long
 vm_cheri_revoke_test_mem_fine_range(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms,
-		      vm_offset_t start, vm_offset_t end)
+    uintcap_t cut, unsigned long perms, vm_offset_t start, vm_offset_t end)
 {
 	/*
 	 * Only check the capability if it has some memory permissions.
@@ -177,16 +174,13 @@ vm_cheri_revoke_test_mem_fine_range(const uint8_t * __capability crshadow,
 			return (1);
 
 		if ((perms & CHERI_PERM_SW_VMEM) == 0) {
-			return vm_cheri_revoke_test_mem_nomap(crshadow, cut);
+			return (vm_cheri_revoke_test_mem_nomap(crshadow, cut));
 		}
 	}
 
 	return (0);
 }
 
-/*
- *
- */
 void
 vm_cheri_revoke_set_test(vm_map_t map, int flags)
 {

--- a/sys/riscv/riscv/cheri_revoke_machdep.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep.c
@@ -159,8 +159,8 @@ again:
 			goto again;
 		} else {
 			/* An unexpected capability */
-			*res |= VM_CHERI_REVOKE_PAGE_DIRTY
-				| VM_CHERI_REVOKE_PAGE_HASCAPS ;
+			*res |= VM_CHERI_REVOKE_PAGE_DIRTY |
+			    VM_CHERI_REVOKE_PAGE_HASCAPS;
 		}
 	} else {
 		CHERI_REVOKE_STATS_BUMP(crst, caps_found);
@@ -215,10 +215,8 @@ uint8_t cloadtags_stride;
 SYSCTL_U8(_vm, OID_AUTO, cloadtags_stride, 0, &cloadtags_stride, 0, "XXX");
 
 static void
-measure_cloadtags_stride(void *ignored)
+measure_cloadtags_stride(void *ignored __unused)
 {
-	(void)ignored;
-
 	/* A 256-byte cache-line is probably beyond the pale, so use that */
 	void * __capability buf[16] __attribute__((aligned(256)));
 	int i;
@@ -322,6 +320,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 	/* And the last line */
 	{
 		uintcap_t * __capability mvt = mvu;
+
 		for (; tags != 0; (tags >>= 1), mvt += 1) {
 			if (!(tags & 1))
 				continue;
@@ -336,6 +335,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 
 	for (; cheri_getaddress(mvu) < mve; mvu++) {
 		uintcap_t cut = *mvu;
+
 		if (cheri_gettag(cut)) {
 			if (cb(&res, crc, crshadow, ctp, mvu, cut, start, end))
 				goto out;
@@ -431,14 +431,12 @@ static inline int
 vm_cheri_revoke_page_ro_adapt(int *res,
     const struct vm_cheri_revoke_cookie *vmcrc,
     const uint8_t * __capability crshadow, vm_cheri_revoke_test_fn ctp,
-    uintcap_t * __capability cutp, uintcap_t cut, vm_offset_t start,
+    uintcap_t * __capability cutp __unused, uintcap_t cut, vm_offset_t start,
     vm_offset_t end)
 {
-	(void)cutp;
-
 	/* If the thing has no permissions, we don't need to scan it later */
 	if ((cheri_gettag(cut) == 0) || (cheri_getperm(cut) == 0))
-		return 0;
+		return (0);
 
 	*res |= VM_CHERI_REVOKE_PAGE_HASCAPS;
 
@@ -446,7 +444,7 @@ vm_cheri_revoke_page_ro_adapt(int *res,
 		*res |= VM_CHERI_REVOKE_PAGE_DIRTY;
 
 		/* One dirty answer is as good as any other; stop eary */
-		return 1;
+		return (1);
 	}
 
 	return (0);

--- a/sys/riscv/riscv/cheri_revoke_machdep_tests.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep_tests.c
@@ -54,9 +54,8 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 
 	ptraddr_t va = cheri_getbase(cut);
 
-	bmloc = crshadow
-	    - VM_CHERI_REVOKE_BSZ_OTYPE
-	    - (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
+	bmloc = crshadow - VM_CHERI_REVOKE_BSZ_OTYPE -
+	    (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
 
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
 	/* XXX This is terribly, terribly unsafe and should go away. */
@@ -167,8 +166,7 @@ vm_cheri_revoke_test_just_mem_fine(const uint8_t * __capability crshadow,
 
 static unsigned long
 vm_cheri_revoke_test_mem_fine_range(const uint8_t * __capability crshadow,
-		      uintcap_t cut, unsigned long perms,
-		      vm_offset_t start, vm_offset_t end)
+    uintcap_t cut, unsigned long perms, vm_offset_t start, vm_offset_t end)
 {
 	/*
 	 * Only check the capability if it has some memory permissions.
@@ -185,9 +183,6 @@ vm_cheri_revoke_test_mem_fine_range(const uint8_t * __capability crshadow,
 	return (0);
 }
 
-/*
- *
- */
 void
 vm_cheri_revoke_set_test(vm_map_t map, int flags)
 {
@@ -218,5 +213,3 @@ vm_cheri_revoke_set_test(vm_map_t map, int flags)
 		panic("Bad cheri_revoke cookie flags 0x%x\n", flags);
 	}
 }
-
-


### PR DESCRIPTION
Assorted style fixes plus some typo fixes and comment cleanups:
 - indentation of continued statements
 - contine lines after operators not before
 - return values in ()
 - use __unused rather than (void) casts
 - prefer `(flags & FLAG) != 0` to `!!(flags & FLAG)`
 - use C-style comments
 - declare more varables at the tops of blocks
 - space after switch keyword