### PR TITLE
procstat auxv improvements

### DIFF
--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -2505,7 +2505,7 @@ procstat_getosrel(struct procstat *procstat, struct kinfo_proc *kp, int *osrelp)
 
 #define PROC_AUXV_MAX	256
 
-#if __ELF_WORD_SIZE == 64
+#ifdef PS_ARCH_HAS_FREEBSD32
 static const char *elf32_sv_names[] = {
 	"Linux ELF32",
 	"FreeBSD ELF32",
@@ -2588,7 +2588,7 @@ out:
 	free(auxv32);
 	return (auxv);
 }
-#endif /* __ELF_WORD_SIZE == 64 */
+#endif /* PS_ARCH_HAS_FREEBSD32 */
 
 static Elf_Auxinfo *
 procstat_getauxv_sysctl(pid_t pid, unsigned int *cntp)
@@ -2597,7 +2597,7 @@ procstat_getauxv_sysctl(pid_t pid, unsigned int *cntp)
 	int name[4];
 	size_t len;
 
-#if __ELF_WORD_SIZE == 64
+#ifdef PS_ARCH_HAS_FREEBSD32
 	if (is_elf32_sysctl(pid))
 		return (procstat_getauxv32_sysctl(pid, cntp));
 #endif

--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -2558,8 +2558,8 @@ procstat_getauxv32_sysctl(pid_t pid, unsigned int *cntp)
 			warn("sysctl: kern.proc.auxv: %d: %d", pid, errno);
 		goto out;
 	}
-	count = len / sizeof(Elf_Auxinfo);
-	auxv = malloc(count  * sizeof(Elf_Auxinfo));
+	count = len / sizeof(Elf32_Auxinfo);
+	auxv = malloc(count * sizeof(Elf_Auxinfo));
 	if (auxv == NULL) {
 		warn("malloc(%zu)", count * sizeof(Elf_Auxinfo));
 		goto out;

--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -2538,7 +2538,6 @@ procstat_getauxv32_sysctl(pid_t pid, unsigned int *cntp)
 {
 	Elf_Auxinfo *auxv;
 	Elf32_Auxinfo *auxv32;
-	void *ptr;
 	size_t len;
 	unsigned int i, count;
 	int name[4];
@@ -2572,8 +2571,17 @@ procstat_getauxv32_sysctl(pid_t pid, unsigned int *cntp)
 		 * necessarily true.
 		 */
 		auxv[i].a_type = auxv32[i].a_type;
-		ptr = &auxv32[i].a_un;
-		auxv[i].a_un.a_val = *((uint32_t *)ptr);
+		/*
+		 * Don't sign extend values.  Existing entries are positive
+		 * integers or pointers.  Under freebsd32, programs typically
+		 * have a full [0, 2^32) address space (perhaps minus the last
+		 * page) and treating this as a signed integer would be
+		 * confusing since these are not kernel pointers.
+		 *
+		 * XXX: A more complete translation would be ABI and
+		 * type-aware.
+		 */
+		auxv[i].a_un.a_val = (uint32_t)auxv32[i].a_un.a_val;
 	}
 	*cntp = count;
 out:

--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -2516,7 +2516,7 @@ is_elf32_sysctl(pid_t pid)
 {
 	int error, name[4];
 	size_t len, i;
-	static char sv_name[256];
+	char sv_name[32];
 
 	name[0] = CTL_KERN;
 	name[1] = KERN_PROC;

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -102,6 +102,11 @@
 #define	PS_FST_FFLAG_EXEC	0x2000
 #define	PS_FST_FFLAG_HASLOCK	0x4000
 
+#if !defined(__ILP32__) && !defined(__riscv)
+/* Target architecture supports 32-bit compat */
+#define	PS_ARCH_HAS_FREEBSD32	1
+#endif
+
 struct kinfo_kstack;
 struct kinfo_proc;
 struct kinfo_vmentry;

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 7, 2022
+.Dd October 13, 2023
 .Dt PROCSTAT 1
 .Os
 .Sh NAME
@@ -241,6 +241,12 @@ If the
 flag is passed then extra information is shown.
 .It Ar auxv | Fl x
 Display ELF auxiliary vector for the process.
+.Pp
+If the
+.Fl v
+subcommand option is used and the target process's ABI is a CHERI
+pure-capabilty ABI, then print capability bounds and permissions for
+pointer arguments.
 .It Ar pargs
 Display arguments for the process.
 .It Ar penv

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -89,7 +89,7 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_PLURAL | PS_CMP_SUBSTR | PS_MODE_NO_KINFO_PROC },
 	{ "argument", "arguments", NULL, &procstat_args, &cmdopt_none,
 	    PS_CMP_PLURAL | PS_CMP_SUBSTR },
-	{ "auxv", "auxv", NULL, &procstat_auxv, &cmdopt_none, PS_CMP_NORMAL },
+	{ "auxv", "auxv", "[-v]", &procstat_auxv, &cmdopt_verbose, PS_CMP_NORMAL },
 	{ "basic", "basic", NULL, &procstat_basic, &cmdopt_none,
 	    PS_CMP_NORMAL },
 	{ "binary", "binary", NULL, &procstat_bin, &cmdopt_none,

--- a/usr.bin/procstat/procstat_auxv.c
+++ b/usr.bin/procstat/procstat_auxv.c
@@ -46,6 +46,8 @@
 
 #include <vm/vm.h>
 
+#include <cheri/cheric.h>
+
 #include <err.h>
 #include <errno.h>
 #include <libprocstat.h>
@@ -55,6 +57,20 @@
 #include <string.h>
 
 #include "procstat.h"
+
+static const char *
+fmt_ptr(void *ptr)
+{
+	static char ptrstr[128];
+
+#ifdef __CHERI_PURE_CAPABILITY__
+	if ((procstat_opts & PS_OPT_VERBOSE) != 0)
+		strfcap(ptrstr, sizeof(ptrstr), "%T%C", (uintcap_t)ptr);
+	else
+#endif
+		snprintf(ptrstr, sizeof(ptrstr), "%p", ptr);
+	return (ptrstr);
+}
 
 void
 procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
@@ -87,8 +103,8 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			    prefix, "AT_EXECFD", (long)auxv[i].a_un.a_val);
 			break;
 		case AT_PHDR:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PHDR/%p}\n",
-			    prefix, "AT_PHDR", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PHDR/%s}\n",
+			    prefix, "AT_PHDR", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 		case AT_PHENT:
 			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PHENT/%ld}\n",
@@ -103,16 +119,16 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			    prefix, "AT_PAGESZ", (long)auxv[i].a_un.a_val);
 			break;
 		case AT_BASE:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_BASE/%p}\n",
-			    prefix, "AT_BASE", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_BASE/%s}\n",
+			    prefix, "AT_BASE", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 		case AT_FLAGS:
 			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_FLAGS/%#lx}\n",
 			    prefix, "AT_FLAGS", (u_long)auxv[i].a_un.a_val);
 			break;
 		case AT_ENTRY:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_ENTRY/%p}\n",
-			    prefix, "AT_ENTRY", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_ENTRY/%s}\n",
+			    prefix, "AT_ENTRY", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #ifdef AT_NOTELF
 		case AT_NOTELF:
@@ -145,12 +161,12 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			break;
 #endif
 		case AT_EXECPATH:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_EXECPATH/%p}\n",
-			    prefix, "AT_EXECPATH", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_EXECPATH/%s}\n",
+			    prefix, "AT_EXECPATH", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 		case AT_CANARY:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_CANARY/%p}\n",
-			    prefix, "AT_CANARY", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_CANARY/%s}\n",
+			    prefix, "AT_CANARY", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 		case AT_CANARYLEN:
 			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_CANARYLEN/%ld}\n",
@@ -165,8 +181,8 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			    prefix, "AT_NCPUS", (long)auxv[i].a_un.a_val);
 			break;
 		case AT_PAGESIZES:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PAGESIZES/%p}\n",
-			    prefix, "AT_PAGESIZES", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PAGESIZES/%s}\n",
+			    prefix, "AT_PAGESIZES", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 		case AT_PAGESIZESLEN:
 			xo_emit("{dw:/%s}{Lw:/%-16s/%s}"
@@ -185,8 +201,8 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			break;
 #ifdef AT_TIMEKEEP
 		case AT_TIMEKEEP:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_TIMEKEEP/%p}\n",
-			    prefix, "AT_TIMEKEEP", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_TIMEKEEP/%s}\n",
+			    prefix, "AT_TIMEKEEP", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
 #ifdef AT_EHDRFLAGS
@@ -221,8 +237,8 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 #endif
 #ifdef AT_ARGV
 		case AT_ARGV:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_ARGV/%p}\n",
-			    prefix, "AT_ARGV", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_ARGV/%s}\n",
+			    prefix, "AT_ARGV", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
 #ifdef AT_ENVC
@@ -233,26 +249,26 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 #endif
 #ifdef AT_ENVV
 		case AT_ENVV:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_ENVV/%p}\n",
-			    prefix, "AT_ENVV", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_ENVV/%s}\n",
+			    prefix, "AT_ENVV", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
 #ifdef AT_PS_STRINGS
 		case AT_PS_STRINGS:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PS_STRINGS/%p}\n",
-			    prefix, "AT_PS_STRINGS", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_PS_STRINGS/%s}\n",
+			    prefix, "AT_PS_STRINGS", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
 #ifdef AT_FXRNG
 		case AT_FXRNG:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_FXRNG/%p}\n",
-			    prefix, "AT_FXRNG", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_FXRNG/%s}\n",
+			    prefix, "AT_FXRNG", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
 #ifdef AT_KPRELOAD
 		case AT_KPRELOAD:
-			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_KPRELOAD/%p}\n",
-			    prefix, "AT_KPRELOAD", auxv[i].a_un.a_ptr);
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_KPRELOAD/%s}\n",
+			    prefix, "AT_KPRELOAD", fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
 #ifdef AT_USRSTACKBASE

--- a/usr.bin/procstat/procstat_auxv.c
+++ b/usr.bin/procstat/procstat_auxv.c
@@ -64,16 +64,16 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 	static char prefix[256];
 
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0)
-		xo_emit("{T:/%5s %-16s %-16s %-16s}\n", "PID", "COMM", "AUXV",
+		xo_emit("{T:/%5s %-19s %-16s %-16s}\n", "PID", "COMM", "AUXV",
 		    "VALUE");
 
 	auxv = procstat_getauxv(procstat, kipp, &count);
 	if (auxv == NULL)
 		return;
-        snprintf(prefix, sizeof(prefix), "%5d %-16s", kipp->ki_pid,
-            kipp->ki_comm);
+	snprintf(prefix, sizeof(prefix), "%5d %-19s", kipp->ki_pid,
+	    kipp->ki_comm);
 
-	xo_emit("{e:process_id/%5d/%d}{e:command/%-16s/%s}", kipp->ki_pid,
+	xo_emit("{e:process_id/%5d/%d}{e:command/%-19s/%s}", kipp->ki_pid,
 	    kipp->ki_comm);
 
 	for (i = 0; i < count; i++) {


### PR DESCRIPTION
Add support for printing auxv arguments as capabilities. Along the way make some fixes to the 32-bit compat code, fix support for hybrid ABIs, and improve the readability of output with wide commands.