### PR TITLE
realloc fixes

### DIFF
--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1255,11 +1255,6 @@ static void *mrs_realloc(void *ptr, size_t size) {
 	size_t old_size = cheri_getlen(ptr);
 	mrs_debug_printf("mrs_realloc: called ptr %p ptr size %zu new size %zu\n", ptr, old_size, size);
 
-	if (size == 0) {
-		mrs_free(ptr);
-		return NULL;
-	}
-
 	if (ptr == NULL) {
 		return mrs_malloc(size);
 	}

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -339,8 +339,10 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 			return (EPROT);
 		else if ((cheri_getperm(uap->addr) & CHERI_PERM_SW_VMEM))
 			source_cap = uap->addr;
-		else
+		else {
+			SYSERRCAUSE("MAP_FIXED without CHERI_PERM_SW_VMEM");
 			return (EACCES);
+		}
 	} else {
 		if (!cheri_is_null_derived(uap->addr))
 			return (EINVAL);
@@ -366,7 +368,7 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 	    ("td->td_cheri_mmap_cap is untagged!"));
 
 	/*
-	 * If MAP_FIXED is specified, make sure that that the reqested
+	 * If MAP_FIXED is specified, make sure that the requested
 	 * address range fits within the source capability.
 	 */
 	if ((flags & MAP_FIXED) &&

--- a/usr.bin/kdump/kdump.c
+++ b/usr.bin/kdump/kdump.c
@@ -716,6 +716,9 @@ dumpheader(struct ktr_header *kth, u_int sv_flags)
 	case KTR_FAULTEND:
 		type = "PRET";
 		break;
+	case KTR_SYSERRCAUSE:
+		type = "ERR ";
+		break;
 	default:
 		sprintf(unknown, "UNKNOWN(%d)", kth->ktr_type);
 		type = unknown;


### PR DESCRIPTION
- mmap: Add a SYSERRCAUSE for MAP_FIXED without CHERI_PERM_SW_VMEM
- kdump: Handle KTR_SYSERRCAUSE in the record type column
- mrs: For a realloc with a new size of 0 call the underlying malloc
- fixup: mrs: Don't return NULL for a realloc with a new size of zero
