### PR TITLE
Color format fix

### DIFF
--- a/sys/dev/drm/bridges/tda19988/tda19988.c
+++ b/sys/dev/drm/bridges/tda19988/tda19988.c
@@ -590,11 +590,6 @@ tda19988_start(struct tda19988_softc *sc)
 
 	tda19988_cec_write(sc, TDA_CEC_FRO_IM_CLK_CTRL,
 	    CEC_FRO_IM_CLK_CTRL_GHOST_DIS | CEC_FRO_IM_CLK_CTRL_IMCLK_SEL);
-
-	/* Default values for RGB 4:4:4 mapping */
-	tda19988_reg_write(sc, TDA_VIP_CNTRL_0, 0x23);
-	tda19988_reg_write(sc, TDA_VIP_CNTRL_1, 0x01);
-	tda19988_reg_write(sc, TDA_VIP_CNTRL_2, 0x45);
 }
 
 static int

--- a/sys/dev/drm/komeda/komeda_plane.c
+++ b/sys/dev/drm/komeda/komeda_plane.c
@@ -119,10 +119,7 @@ komeda_convert_format(uint32_t format)
 	case DRM_FORMAT_BGRA8888:
 		return (11);
 	case DRM_FORMAT_XRGB8888:
-	/*
-	 * Documentation states this should be 16, but it works better with 17.
-	 * FALLTHROUGH
-	 */
+		return (16);
 	case DRM_FORMAT_XBGR8888:
 		return (17);
 	case DRM_FORMAT_RGBX8888:


### PR DESCRIPTION
On linux these values come from "platform_data" which is platform-specific. I could not find on which platforms these registers set. On Morello they alter color format.
this is a fix for https://github.com/CTSRD-CHERI/cheribsd/issues/1874