### PR TITLE
Add missing void to function signatures

### DIFF
--- a/sys/arm64/arm64/cheri_revoke_machdep.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep.c
@@ -197,14 +197,14 @@ again:
 }
 
 static inline void
-enable_user_memory_access()
+enable_user_memory_access(void)
 {
 	/* Set PSTATE.PAN to 0 */
 	__asm __volatile("msr pan, #0");
 }
 
 static inline void
-disable_user_memory_access()
+disable_user_memory_access(void)
 {
 	/* Set PSTATE.PAN to 1 */
 	__asm __volatile("msr pan, #1");

--- a/sys/riscv/riscv/cheri_revoke_machdep.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep.c
@@ -177,7 +177,7 @@ again:
 }
 
 static inline void
-enable_user_memory_access()
+enable_user_memory_access(void)
 {
 	uint64_t tmp;
 
@@ -194,7 +194,7 @@ enable_user_memory_access()
 }
 
 static inline void
-disable_user_memory_access()
+disable_user_memory_access(void)
 {
 	uint64_t tmp;
 


### PR DESCRIPTION
This is required to avoid -Werror build failures with LLVM 15