### PR TITLE
mrs: Make thread safe and related cleanups

### DIFF
--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -356,17 +356,12 @@ static void mrs_printf(char *fmt, ...)
 	mrs_unlock(&printf_lock);
 }
 
-#define mrs_printcap(name, cap) \
-	mrs_printf("capability %s: v:%u s:%u p:%08lx b:%016lx l:%016lx, o:%lx t:%ld\n", (name), cheri_gettag((cap)), cheri_getsealed((cap)), cheri_getperm((cap)), cheri_getbase((cap)), cheri_getlen((cap)), cheri_getoffset((cap)), cheri_gettype((cap)))
-
 /* debugging */
 
 #ifdef DEBUG
 #define mrs_debug_printf(fmt, ...) mrs_printf(fmt, ##__VA_ARGS__)
-#define mrs_debug_printcap(name, cap) mrs_printcap(name, cap)
 #else /* DEBUG */
 #define mrs_debug_printf(fmt, ...)
-#define mrs_debug_printcap(name, cap)
 #endif /* !DEBUG */
 
 #define	MRS_UTRACE_ENV	"_MRS_UTRACE"
@@ -501,8 +496,7 @@ static inline void quarantine_insert(struct mrs_quarantine *quarantine, void *pt
 #if 0
 	if (quarantine->size > allocated_size) {
 		mrs_printf("fatal error: quarantine size %zu exceeded allocated_size %zu "
-		    "inserting the following cap\n", quarantine->size, allocated_size);
-		mrs_printcap("inserted", ptr);
+		    "inserting %#p\n", quarantine->size, allocated_size, ptr);
 		exit(7);
 	}
 #endif
@@ -536,7 +530,7 @@ static inline void *validate_freed_pointer(void *ptr) {
 		mrs_debug_printf("validate_freed_pointer: not allocated by underlying allocator\n");
 		return NULL;
 	}
-	/*mrs_debug_printcap("freed underlying allocation", underlying_allocation);*/
+	/*mrs_debug_printf("freed underlying allocation %#p\n", underlying_allocation);*/
 
 #ifdef JUST_BOOKKEEPING
 	REAL(free)(ptr);
@@ -1123,8 +1117,8 @@ static void *mrs_malloc(size_t size) {
 
 	increment_allocated_size(allocated_region);
 
-	/*mrs_debug_printf("mrs_malloc: called size 0x%zx\n", size);*/
-	/*mrs_debug_printcap("allocation", allocated_region);*/
+	/*mrs_debug_printf("mrs_malloc: called size 0x%zx, allocation %#p\n",
+	    size, allocated_region);*/
 
 	MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, allocated_region);
 	return allocated_region;

--- a/lib/libc/stdlib/malloc/mrs/mrs_utrace.h
+++ b/lib/libc/stdlib/malloc/mrs/mrs_utrace.h
@@ -1,0 +1,58 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 SRI International
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. HR001122S0003 ("MTSS").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __MRS_UTRACE_H__
+#define	__MRS_UTRACE_H__
+
+#define	UTRACE_MRS_MALLOC		1
+#define	UTRACE_MRS_CALLOC		2
+#define	UTRACE_MRS_POSIX_MEMALIGN	3
+#define	UTRACE_MRS_ALIGNED_ALLOC	4
+#define	UTRACE_MRS_REALLOC		5
+#define	UTRACE_MRS_FREE			6
+#define	UTRACE_MRS_QUARANTINE_INSERT	7
+#define	UTRACE_MRS_MALLOC_REVOKE	8
+#define	UTRACE_MRS_QUARANTINE_FLUSH	9
+
+#define	MRS_UTRACE_SIG_SZ		4
+#define	MRS_UTRACE_SIG			"MRS "
+
+struct utrace_mrs {
+	char sig[MRS_UTRACE_SIG_SZ];
+	int event;
+	size_t s;			/* size input arg */
+	void *p;			/* pointer input arg */
+	void *r;			/* pointer return value */
+	size_t n;			/* alignment/number input arg */
+};
+
+#endif /* !__MRS_UTRACE_H__ */

--- a/lib/libsysdecode/Makefile
+++ b/lib/libsysdecode/Makefile
@@ -13,6 +13,7 @@ INCS=	sysdecode.h
 CFLAGS+= -I${.OBJDIR}
 CFLAGS+= -I${SRCTOP}/sys
 CFLAGS+= -I${SRCTOP}/libexec/rtld-elf
+CFLAGS+= -I${SRCTOP}/lib/libc/stdlib/malloc/mrs
 
 MAN=	sysdecode.3 \
 	sysdecode_abi_to_freebsd_errno.3 \


### PR DESCRIPTION
- mrs: Add utrace(2) events
- mrs: Use %#p instead of mrs_printcap
- mrs: Various style fixes, no functional change
- mrs: Apply recent realloc fixes to mrs_rallocx
- mrs: Make thread safe
