### PR TITLE
Enable revocation by default

### DIFF
--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -72,11 +72,9 @@ SYSCTL_INT(_security_cheri, OID_AUTO, bound_legacy_capabilities,
 
 #ifdef CHERI_CAPREVOKE
 /*
- * Set (indirectly) the default state of revocation in userspace.
- * Libc/rtld query this sysctl to determined if the revoker should be
- * used by default.  Ultimately, this is purely advisory and exists in
- * the kernel so that the default can impact programs starting from
- * init(8).
+ * Set the default state of revocation in userspace.  This is used to
+ * compute the revocation flags in AT_BSDFLAGS but can be overridden
+ * by elfctl(1) flags and procctl(2).
  */
 int security_cheri_runtime_revocation_default = 0;
 SYSCTL_INT(_security_cheri, OID_AUTO, runtime_revocation_default, CTLFLAG_RWTUN,

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -76,7 +76,7 @@ SYSCTL_INT(_security_cheri, OID_AUTO, bound_legacy_capabilities,
  * compute the revocation flags in AT_BSDFLAGS but can be overridden
  * by elfctl(1) flags and procctl(2).
  */
-int security_cheri_runtime_revocation_default = 0;
+int security_cheri_runtime_revocation_default = 1;
 SYSCTL_INT(_security_cheri, OID_AUTO, runtime_revocation_default, CTLFLAG_RWTUN,
     &security_cheri_runtime_revocation_default, 0,
     "Userspace runtime revocation default");


### PR DESCRIPTION
- Update the comment describing security.cheri.runtime_revocation_default
- Enable revocation by default
