### PR TITLE
mrs: alignment changes and cleanups

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -100,11 +100,6 @@ static int sleep_after_test;
 static int coredump_enabled;
 static int debugger_enabled;
 
-#ifdef __CHERI_PURE_CAPABILITY__
-/* Ask MRS to quarantine despite the system default. */
-const int malloc_revocation = MR_ENABLE;
-#endif
-
 int verbose;
 
 extern char **environ;

--- a/contrib/jemalloc/include/jemalloc/internal/sc.h
+++ b/contrib/jemalloc/include/jemalloc/internal/sc.h
@@ -169,16 +169,7 @@
  * Size class N + (1 << SC_LG_NGROUP) twice the size of size class N.
  */
 #define SC_LG_NGROUP 2
-#ifdef MALLOC_REVOCATION_SHIM
-/*
- * If we're going to revoke malloced pointers, we need to ensure
- * that we only give out allocations of at least 16 bytes so we don't
- * mistakenly revoke an adjacent, active allocation.
- */
-#define SC_LG_TINY_MIN 4
-#else
 #define SC_LG_TINY_MIN 3
-#endif
 
 #if SC_LG_TINY_MIN == 0
 /* The div module doesn't support division by 1, which this would require. */

--- a/include/malloc_np.h
+++ b/include/malloc_np.h
@@ -70,17 +70,6 @@ struct extent_hooks_s {
 	extent_merge_t		*merge;
 };
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#define	MR_SYSTEM_DEFAULT	0x0
-#define	MR_DISABLE		0x1
-#define	MR_ENABLE		0x2
-#define	_MR_FORCED		0x4
-#define	MR_DISABLE_FORCED	(MR_DISABLE | _MR_FORCED)
-#define	MR_ENABLE_FORCED	(MR_ENABLE | _MR_FORCED)
-
-extern const int malloc_revocation;
-#endif
-
 __MyBool malloc_is_revoking(void);
 
 size_t	malloc_usable_size(const void *ptr);

--- a/lib/libc/stdlib/malloc/mrs/Makefile.inc
+++ b/lib/libc/stdlib/malloc/mrs/Makefile.inc
@@ -15,7 +15,4 @@ MLINKS+= \
 
 CFLAGS.mrs.c+=-Wno-error=gnu-folding-constant
 
-# Allow quarantine to be enabled/disabled during program startup
-CFLAGS.mrs.c+=	-DOPTIONAL_QUARANTINING
-
 CFLAGS.mrs.c+=	-DMRS_REAL_PREFIX=${MRS_REAL_PREFIX}

--- a/lib/libc/stdlib/malloc/mrs/mrs.3
+++ b/lib/libc/stdlib/malloc/mrs/mrs.3
@@ -56,8 +56,6 @@
 .In malloc_np.h
 .Ft bool
 .Fn malloc_is_revoking "void"
-.Vt const int
-.Va malloc_revocation ;
 .Sh DESCRIPTION
 The Malloc Revocation Shim (MRS) extends a CHERI-aware malloc implemention
 with revocation support, providing heap temporal safety.
@@ -107,10 +105,7 @@ starts up, an array of parameters are evaluated to determine if free'd
 objects should be quarantined and revoked or if the underlying
 implementations should be exposed directly.
 .Nm
-considers two sources of information:
-.Bl -bullet
-.It
-The
+considers the
 .Dv ELF_BSDF_CHERI_REVOKE
 and
 .Dv ELF_BSDF_CHERI_REVOKE_FORCED
@@ -122,32 +117,6 @@ administratively configured preferences
 .Dv ELF_BSDF_CHERI_REVOKE_FORCED
 is set)
 or system-wide defaults.
-.It
-.Sy For stically linked programs,
-the value of the
-.Va malloc_revocation
-variable.
-.Va malloc_revocation
-is a weak symbol in libc which can be provided by the program to override
-the system default or prevent administrative overrides.
-If it is set to one of
-.Dv MR_ENABLE
-or
-.Dv MR_DISABLE
-then it overrides the system default, but usually configured
-preferences expressed by
-.Dv AT_BSDFLAGS
-take precedence.
-If it is set to one of
-.Dv MR_ENABLE_FORCED
-or
-.Dv MR_DISABLE_FORCED
-then
-.Dv AT_BSDFLAGS
-is ignored.
-.Pp
-.Sy This does not work for dynamically linked programs.
-.El
 .Pp
 .\" XXX: this is not tied to mrs and probably belongs somewhere else
 The kernel considers the following factors in order of decreasing precedence
@@ -234,28 +203,11 @@ This capability will not be revoked and thus can be stored in the quarantine
 structure.
 This interface must not be exported outside the implementation.
 .Sh EXAMPLES
-If a program linked with
-.Nm
-allocator wishes to use revocation even if the system-wide default is to
-disable it, the programmer can add the following global declaration:
-.Pp
-.Dl const int malloc_revocation = MR_ENABLED;
-.Pp
-Note that even if
-.Dv MR_ENABLED_FORCED
-is used, revocation depends on the kernel providing support and
-.Nm
-may silently not use revocation if it is not supported.
-.Pp
 To alter a binary to disable use of revocation, use:
 .Pp
 .Dl elfctl -e +nocherirevoke <program>
 .Pp
-To override the system default and binary settings (other than
-.Va malloc_revocation
-being set to
-.Dv MR_ENABLE_FORCED )
-run the program as follows:
+To override the system default and binary settings run the program as follows:
 .Pp
 .Dl proccontrol -m cherirevoke -s enable <program>
 .Sh SEE ALSO

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1248,44 +1248,6 @@ mrs_malloc(size_t size)
 
 	void *allocated_region;
 
-#if 0
-	/*
-	 * Ensure that all allocations less than the shadow bitmap
-	 * granule size are aligned to that granule size, so that no
-	 * two allocations will be governed by the same shadow bit.
-	 * Allocators may implement alignment incorrectly, this
-	 * doesn't allow UAF bugs but may cause faults.
-	 */
-	if (size < CAPREVOKE_BITMAP_ALIGNMENT) {
-		/*
-		 * Use posix_memalign because unlike aligned_alloc it
-		 * does not require size to be an integer multiple of
-		 * alignment.
-		 */
-		if (REAL(posix_memalign)(&allocated_region,
-		    CAPREVOKE_BITMAP_ALIGNMENT, size)) {
-			mrs_debug_printf("mrs_malloc: error aligning allocation of size less than the shadow bitmap granule\n");
-			MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, NULL);
-			return (NULL);
-		}
-	} else {
-		/*
-		 * Currently, sizeof(void *) ==
-		 * CAPREVOKE_BITMAP_ALIGNMENT == 16, which means that
-		 * if size >= CAPREVOKE_BITMAP_ALIGNMENT it should be
-		 * aligned to a multiple of CAPREVOKE_BITMAP_ALIGNMENT
-		 * (because it is possible to store a pointer in the
-		 * allocation and thus the alignment is guaranteed by
-		 * malloc).
-		 */
-		allocated_region = REAL(malloc)(size);
-		if (allocated_region == NULL) {
-			MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0,
-			    allocated_region);
-			return (allocated_region);
-		}
-	}
-#endif
 	/*
 	 * Round up here to make sure there is only one allocation per
 	 * granule without requiring modifications to the underlying
@@ -1365,45 +1327,6 @@ mrs_calloc(size_t number, size_t size)
 
 	void *allocated_region;
 
-#if 0
-	/*
-	 * Ensure that all allocations less than the shadow bitmap
-	 * granule size are aligned to that granule size, so that no
-	 * two allocations will be governed by the same shadow bit.
-	 * Allocators may implement alignment incorrectly, this
-	 * doesn't allow UAF bugs but may cause faults.
-	 */
-	if (size < CAPREVOKE_BITMAP_ALIGNMENT) {
-		/*
-		 * Use posix_memalign because unlike aligned_alloc it
-		 * does not require size to be an integer multiple of
-		 * alignment.
-		 */
-		if (REAL(posix_memalign)(&allocated_region,
-		    CAPREVOKE_BITMAP_ALIGNMENT, number * size)) {
-			mrs_debug_printf("mrs_calloc: error aligning allocation of size less than the shadow bitmap granule\n");
-			MRS_UTRACE(UTRACE_MRS_CALLOC, NULL, size, number, NULL);
-			return (NULL);
-		}
-		memset(allocated_region, 0, cheri_getlen(allocated_region));
-	} else {
-		/*
-		 * Currently, sizeof(void *) ==
-		 * CAPREVOKE_BITMAP_ALIGNMENT == 16, which means that
-		 * if size >= CAPREVOKE_BITMAP_ALIGNMENT it should be
-		 * aligned to a multiple of CAPREVOKE_BITMAP_ALIGNMENT
-		 * (because it is possible to store a pointer in the
-		 * allocation and thus the alignment is guaranteed by
-		 * calloc).
-		 */
-		allocated_region = REAL(calloc)(number, size);
-		if (allocated_region == NULL) {
-			MRS_UTRACE(UTRACE_MRS_CALLOC, NULL, size, number,
-			    allocated_region);
-			return (allocated_region);
-		}
-	}
-#endif
 	/*
 	 * Round up here to make sure there is only one allocation per
 	 * granule without requiring modifications to the underlying

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -313,8 +313,6 @@ static struct mrs_quarantine application_quarantine;
 static struct mrs_quarantine offload_quarantine;
 #endif /* OFFLOAD_QUARANTINE */
 
-static void *mrs_calloc_bootstrap(size_t number, size_t size);
-
 static inline __attribute__((always_inline)) void
 mrs_puts(const char *p)
 {
@@ -1247,28 +1245,6 @@ mrs_malloc(size_t size)
 
 	MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, allocated_region);
 	return (allocated_region);
-}
-
-/*
- * calloc is used to bootstrap various system libraries so is called before
- * even the constructor function of this library.  Before the initializer is
- * called and REAL(calloc) is set appropriately, use this bootstrap function to
- * serve allocations.
- */
-static void *
-mrs_calloc_bootstrap(size_t number, size_t size)
-{
-	const size_t BOOTSTRAP_CALLOC_SIZE = 1024 * 1024 * 4;
-	static char mem[BOOTSTRAP_CALLOC_SIZE] __attribute((aligned(16))) = {0};
-	static size_t offset = 0;
-
-	size_t old_offset = offset;
-	offset += (number * size);
-	if (offset > BOOTSTRAP_CALLOC_SIZE) {
-		mrs_puts("mrs_calloc_bootstrap: ran out of memory\n");
-		exit(7);
-	}
-	return (&mem[old_offset]);
 }
 
 void *

--- a/libexec/malloc_is_revoking/malloc_is_revoking.c
+++ b/libexec/malloc_is_revoking/malloc_is_revoking.c
@@ -33,9 +33,6 @@
 #include <stdlib.h>
 #include <malloc_np.h>
 
-/* Ignore the system default.  In the steady state if will be enabled. */
-const int malloc_revocation = MR_ENABLE;
-
 int
 main(void)
 {


### PR DESCRIPTION
- Move the responsibility for alignment of small allocations into MRS
- remove OPTIONAL_QUARANTINING ifdef
- tidy JUST_INTERPOSE definition now that OPTIONAL_QUARANTINING isn't optional
- GC some unused bits