### PR TITLE
c18n: Create ld-elf64cb-c18n.so.1 for the benchmark ABI

### DIFF
--- a/bin/cheribsdtest/Makefile
+++ b/bin/cheribsdtest/Makefile
@@ -13,7 +13,7 @@ SUBDIR+=	purecap \
 		purecap-dynamic-mt \
 		purecap-mt
 
-.if ${MACHINE_CPUARCH} == "aarch64" && ${MK_LIB64C} == "no"
+.if ${MACHINE_CPUARCH} == "aarch64" && ${MACHINE_ABI:Mpurecap}
 SUBDIR+=	mt-c18n
 .endif
 .endif
@@ -23,6 +23,10 @@ SUBDIR+=	purecap-benchmark \
 		purecap-benchmark-dynamic \
 		purecap-benchmark-dynamic-mt \
 		purecap-benchmark-mt
+
+.if ${MACHINE_CPUARCH} == "aarch64" && ${MACHINE_ABI:Mpurecap}
+SUBDIR+=	benchmark-mt-c18n
+.endif
 .endif
 
 SUBDIR_PARALLEL=

--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -91,7 +91,11 @@ SRCS+=		cheribsdtest_tls_threads.c
 
 .ifdef CHERIBSD_C18N_TESTS
 CFLAGS+=	-DCHERIBSD_C18N_TESTS
+.if ${MACHINE_ABI:Mbenchmark}
+LDFLAGS+=	-Wl,--dynamic-linker=/libexec/ld-elf64cb-c18n.so.1
+.else
 LDFLAGS+=	-Wl,--dynamic-linker=/libexec/ld-elf-c18n.so.1
+.endif
 .endif
 
 .include <bsd.prog.mk>

--- a/bin/cheribsdtest/benchmark-mt-c18n/Makefile
+++ b/bin/cheribsdtest/benchmark-mt-c18n/Makefile
@@ -1,0 +1,9 @@
+.include <src.opts.mk>
+
+PROG=	cheribsdtest-benchmark-mt-c18n
+
+CHERIBSD_DYNAMIC_TESTS=	yes
+CHERIBSD_THREAD_TESTS=	yes
+CHERIBSD_C18N_TESTS=	yes
+
+.include "../Makefile.purecap-benchmark"

--- a/bin/cheribsdtest/cheribsdtest_context.c
+++ b/bin/cheribsdtest/cheribsdtest_context.c
@@ -90,7 +90,7 @@ swapcontext_func(int arg1)
 }
 
 CHERIBSDTEST(swapcontext_basic, "Check that swapcontext works",
-    .ct_xfail_reason = XFAIL_FLAKY_C18N_CONTEXT)
+    .ct_flaky_reason = XFAIL_FLAKY_C18N_CONTEXT)
 {
 	ucontext_t uc, uc_link;
 	int ret;

--- a/bin/cheribsdtest/cheribsdtest_registers.c
+++ b/bin/cheribsdtest/cheribsdtest_registers.c
@@ -172,7 +172,7 @@ check_initreg_code(void * __capability c)
 		    (CHERI_PERMS_SWALL & ~CHERI_PERM_SW_VMEM));
 
 	/* Check that the raw permission bits match the kernel header: */
-#ifdef CHERIBSD_C18N_TESTS
+#if defined(CHERIBSD_C18N_TESTS) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	if (v != (CHERI_CAP_USER_CODE_PERMS & ~CHERI_PERM_EXECUTIVE))
 		cheribsdtest_failure_errx("perms %jx (expected %jx)", v,
 		    (uintmax_t)(CHERI_CAP_USER_CODE_PERMS & ~CHERI_PERM_EXECUTIVE));

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -113,8 +113,10 @@ SUBDIR=	${SUBDIR_BOOTSTRAP} \
 	ncurses \
 	nss_tacplus
 
-.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64" && !defined(COMPAT_LIBCOMPAT)
+.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64"
+.if !defined(COMPAT_LIBCOMPAT) || ${COMPAT_LIBCOMPAT} == "64CB"
 SUBDIR+=	libc_c18n libthr_c18n
+.endif
 .endif
 
 .if !${MACHINE_ABI:Mpurecap}

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -34,12 +34,14 @@
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 .weak _rtld_setjmp;
 LENTRY(_rtld_setjmp)
-	ret
+	/* Should never be called */
+	RETURN
 LEND(_rtld_setjmp)
 
 .weak _rtld_longjmp;
 LENTRY(_rtld_longjmp)
-	ret
+	/* Should never be called */
+	RETURN
 LEND(_rtld_longjmp)
 #endif
 

--- a/lib/libc_c18n/Makefile
+++ b/lib/libc_c18n/Makefile
@@ -1,5 +1,5 @@
 RTLD_SANDBOX=yes
-SHLIBDIR=	/usr/lib/c18n
-LIBDIR=		/usr/lib/c18n
+SHLIBDIR=	/usr/lib${COMPAT_libcompat:U}/c18n
+LIBDIR=		/usr/lib${COMPAT_libcompat:U}/c18n
 
 .include "${SRCTOP}/lib/libc/Makefile"

--- a/lib/libthr_c18n/Makefile
+++ b/lib/libthr_c18n/Makefile
@@ -1,7 +1,7 @@
 RTLD_SANDBOX=
 SHLIB=thr
-SHLIBDIR=	/usr/lib/c18n
-LIBDIR=		/usr/lib/c18n
+SHLIBDIR=	/usr/lib${COMPAT_libcompat:U}/c18n
+LIBDIR=		/usr/lib${COMPAT_libcompat:U}/c18n
 LIB=
 
 MK_TESTS=no

--- a/libexec/Makefile
+++ b/libexec/Makefile
@@ -86,11 +86,12 @@ _tftp-proxy=	tftp-proxy
 .if !defined(NO_PIC) && !defined(NO_RTLD)
 _rtld-elf=	rtld-elf rtld-elf-debug
 .if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64"
-SUBDIR+=	rtld-elf-c18n
+SUBDIR+=	rtld-elf-c18n rtld-elf64cb-c18n
 .endif
 # rtld.1 needs to be installed before the cross-dir MLINKS can work.
 SUBDIR_INSTALL_USE_DEPENDS=
 SUBDIR_DEPEND_rtld-elf-c18n=	rtld-elf
+SUBDIR_DEPEND_rtld-elf64cb-c18n=	rtld-elf
 SUBDIR_DEPEND_rtld-elf-debug=	rtld-elf
 .for LIBCOMPAT libcompat in ${_ALL_LIBCOMPATS_libcompats}
 SUBDIR.${MK_LIB${LIBCOMPAT}}+=	rtld-elf${libcompat}

--- a/libexec/rc/rc.d/ldconfig
+++ b/libexec/rc/rc.d/ldconfig
@@ -65,6 +65,10 @@ ldconfig_start()
 			    "${ldconfig64cb_paths}" "" "")
 			startmsg 'Benchmark ABI ldconfig path:' ${_LDC}
 			${ldconfig} -f /var/run/ld-elf64cb.so.hints ${_ins} ${_LDC}
+
+			_LDC="/usr/lib64cb/c18n ${_LDC}"
+			startmsg 'Library-based compartmentalization (benchmark ABI) ldconfig path:' ${_LDC}
+			${ldconfig} -f /var/run/ld-elf64cb-c18n.so.hints ${_ins} ${_LDC}
 			;&
 			# FALLTHROUGH
 		riscv64c)

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -81,14 +81,23 @@ END(_rtld_sighandler)
 
 ENTRY(_rtld_get_rstk)
 	/*
-	 * This function MUST preserve all caller-saved registers except:
-	 * - c11: Target restricted stack
-	 * - c18: Will be overwritten later in the trampoline
+	 * NON-STANDARD CALLING CONVENTION
+	 *
+	 * This function is only called from trampolines when lazily allocating
+	 * a restricted stack for the callee compartment.
+	 *
+	 * Upon entry, w14 holds the compartment ID of the callee compartment.
+	 *
+	 * Upon return, c17 holds the allocated stack.
+	 *
+	 * All caller-saved registers must be preserved except c17.
 	 */
+
 	stp	c18, c30, [csp, #-(CAP_WIDTH * 2)]!
-	stp	c15, c16, [csp, #-(CAP_WIDTH * 2)]!
-	stp	c13, c14, [csp, #-(CAP_WIDTH * 2)]!
-	stp	c10, c12, [csp, #-(CAP_WIDTH * 2)]!
+	str	c16, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c14, c15, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c12, c13, [csp, #-(CAP_WIDTH * 2)]!
+	stp	c10, c11, [csp, #-(CAP_WIDTH * 2)]!
 	stp	c8, c9, [csp, #-(CAP_WIDTH * 2)]!
 	stp	c6, c7, [csp, #-(CAP_WIDTH * 2)]!
 	stp	c4, c5, [csp, #-(CAP_WIDTH * 2)]!
@@ -101,35 +110,61 @@ ENTRY(_rtld_get_rstk)
 
 	mov	w0, w14					/* w0 = cid */
 	bl	get_rstk
-	mov	c11, c0
+	mov	c17, c0
 
 	ldp	q6, q7, [csp, #(16 * 6)]
 	ldp	q4, q5, [csp, #(16 * 4)]
 	ldp	q2, q3, [csp, #(16 * 2)]
 	ldp	q0, q1, [csp], #(16 * 8)
-	ldp	c18, c30, [csp, #(CAP_WIDTH * 16)]
-	ldp	c15, c16, [csp, #(CAP_WIDTH * 14)]
-	ldp	c13, c14, [csp, #(CAP_WIDTH * 12)]
-	ldp	c10, c12, [csp, #(CAP_WIDTH * 10)]
+	ldp	c18, c30, [csp, #(CAP_WIDTH * 18)]
+	ldr	c16, [csp, #(CAP_WIDTH * 16)]
+	ldp	c14, c15, [csp, #(CAP_WIDTH * 14)]
+	ldp	c12, c13, [csp, #(CAP_WIDTH * 12)]
+	ldp	c10, c11, [csp, #(CAP_WIDTH * 10)]
 	ldp	c8, c9, [csp, #(CAP_WIDTH * 8)]
 	ldp	c6, c7, [csp, #(CAP_WIDTH * 6)]
 	ldp	c4, c5, [csp, #(CAP_WIDTH * 4)]
 	ldp	c2, c3, [csp, #(CAP_WIDTH * 2)]
-	ldp	c0, c1, [csp], #(CAP_WIDTH * 18)
+	ldp	c0, c1, [csp], #(CAP_WIDTH * 20)
 
 	RETURN
 END(_rtld_get_rstk)
 
 ENTRY(_rtld_tramp_hook)
+	/*
+	 * NON-STANDARD CALLING CONVENTION
+	 *
+	 * This function is only called from trampolines when tracing
+	 * compartment transitions.
+	 *
+	 * Upon entry, c10-c14 hold the first arguments of tramp_hook.
+	 *
+	 * All argument registers must be preserved.
+	 */
+
+	/* Save argument registers */
+	stp	c0, c1, [csp, #-(CAP_WIDTH * 10)]!
+	stp	c2, c3, [csp, #(CAP_WIDTH * 2)]
+	stp	c4, c5, [csp, #(CAP_WIDTH * 4)]
+	stp	c6, c7, [csp, #(CAP_WIDTH * 6)]
+	stp	c8, c9, [csp, #(CAP_WIDTH * 8)]
+
 	/* Save floating point registers */
 	stp	q0, q1, [csp, #-(16 * 8)]!
 	stp	q2, q3, [csp, #(16 * 2)]
 	stp	q4, q5, [csp, #(16 * 4)]
 	stp	q6, q7, [csp, #(16 * 6)]
 
-	str	c30, [csp, #-CAP_WIDTH]!
+	mov	c0, c10
+	mov	c1, c11
+	mov	c2, c12
+	mov	c3, c13
+	mov	c4, c14
+	mrs	c5, rcsp_el0
+
+	stp	c18, c30, [csp, #-(CAP_WIDTH * 2)]!
 	bl	tramp_hook
-	ldr	c30, [csp], #CAP_WIDTH
+	ldp	c18, c30, [csp], #(CAP_WIDTH * 2)
 
 	/* Restore floating point registers */
 	ldp	q6, q7, [csp, #(16 * 6)]
@@ -137,7 +172,14 @@ ENTRY(_rtld_tramp_hook)
 	ldp	q2, q3, [csp, #(16 * 2)]
 	ldp	q0, q1, [csp], #(16 * 8)
 
-	RETURN
+	/* Restore argument registers */
+	ldp	c8, c9, [csp, #(CAP_WIDTH * 8)]
+	ldp	c6, c7, [csp, #(CAP_WIDTH * 6)]
+	ldp	c4, c5, [csp, #(CAP_WIDTH * 4)]
+	ldp	c2, c3, [csp, #(CAP_WIDTH * 2)]
+	ldp	c0, c1, [csp], #(CAP_WIDTH * 10)
+
+	retr	c30
 END(_rtld_tramp_hook)
 
 /*
@@ -160,47 +202,6 @@ END(_rtld_tramp_hook)
 	.size patch_##tramp##_##name, 4; patch_##tramp##_##name:	\
 	.word	label - end_##tramp
 
-TRAMP(tramp_header)
-tramp_header_target:
-	.chericap	0
-TRAMPEND(tramp_header)
-
-TRAMP(tramp_header_hook)
-tramp_header_hook_obj:
-	.chericap	0
-tramp_header_hook_def:
-	.chericap	0
-tramp_header_hook_function:
-	.chericap	0
-	/* Save argument registers */
-	stp	c0, c1, [csp, #-(CAP_WIDTH * 10)]!
-	stp	c2, c3, [csp, #(CAP_WIDTH * 2)]
-	stp	c4, c5, [csp, #(CAP_WIDTH * 4)]
-	stp	c6, c7, [csp, #(CAP_WIDTH * 6)]
-	stp	c8, c9, [csp, #(CAP_WIDTH * 8)]
-
-	ldr	c10, tramp_header_hook_function
-
-1:	mov	w0, #0		/* To be patched at runtime */
-2:	ldr	c1, #0		/* To be patched at runtime */
-	ldr	c2, tramp_header_hook_obj
-	ldr	c3, tramp_header_hook_def
-	mov	c4, c30
-	mrs	c5, rcsp_el0
-	blr	c10
-	mov	c30, c0
-
-	/* Restore argument registers */
-	ldp	c8, c9, [csp, #(CAP_WIDTH * 8)]
-	ldp	c6, c7, [csp, #(CAP_WIDTH * 6)]
-	ldp	c4, c5, [csp, #(CAP_WIDTH * 4)]
-	ldp	c2, c3, [csp, #(CAP_WIDTH * 2)]
-	ldp	c0, c1, [csp], #(CAP_WIDTH * 10)
-TRAMPEND(tramp_header_hook)
-
-PATCH_POINT(tramp_header_hook, event, 1b)
-PATCH_POINT(tramp_header_hook, target, 2b)
-
 TRAMP(tramp_save_caller)
 1:	ldr	c18, #0		/* To be patched at runtime */
 	mrs	c17, rcsp_el0
@@ -214,11 +215,11 @@ TRAMP(tramp_save_caller)
 	 */
 	gclim	x11, c17
 	scvalue	c16, c17, x11
-	ldr	x13, [c16, #-CAP_WIDTH]
+	ldr	x12, [c16, #-CAP_WIDTH]
 	str	c17, [c16, #-CAP_WIDTH]
 
 	/* Push frame */
-	stp	x10, x13, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
+	stp	x10, x12, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
 	str	c16, [TRUSTED_STACK, #(CAP_WIDTH * 1)]
 	stp	c30, c19, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
 	stp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
@@ -226,10 +227,35 @@ TRAMP(tramp_save_caller)
 	stp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 8)]
 	stp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 10)]
 	stp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
+
+	/*
+	 * Save the number of unused return value registers in the flags of csp.
+	 */
+2:	movz	x13, #0		/* To be patched at runtime */
+	scflgs	TRUSTED_STACK, TRUSTED_STACK, x13
 #undef	TRUSTED_STACK
 TRAMPEND(tramp_save_caller)
 
 PATCH_POINT(tramp_save_caller, target, 1b)
+PATCH_POINT(tramp_save_caller, ret_args, 2b)
+
+TRAMP(tramp_call_hook)
+1:	ldr	c17, #0		/* To be patched at runtime */
+
+2:	mov	w10, #0		/* To be patched at runtime */
+3:	ldr	c11, #0		/* To be patched at runtime */
+4:	ldr	c12, #0		/* To be patched at runtime */
+5:	ldr	c13, #0		/* To be patched at runtime */
+	mov	c14, c30
+
+	blr	c17
+TRAMPEND(tramp_call_hook)
+
+PATCH_POINT(tramp_call_hook, function, 1b)
+PATCH_POINT(tramp_call_hook, event, 2b)
+PATCH_POINT(tramp_call_hook, target, 3b)
+PATCH_POINT(tramp_call_hook, obj, 4b)
+PATCH_POINT(tramp_call_hook, def, 5b)
 
 TRAMP(tramp_switch_stack)
 	mrs	c30, ctpidr_el0		/* c30 = table */
@@ -244,8 +270,8 @@ TRAMP(tramp_switch_stack)
 	 */
 	subs	x16, x15, x14, lsl #4		/* if (len(table) <= cid) */
 	b.ls	2f				/* goto 2f */
-	ldr	c11, [c30, w14, uxtw #4]	/* c11 = table[cid] */
-	cbnz	x11, 3f
+	ldr	c17, [c30, w14, uxtw #4]	/* c17 = table[cid] */
+	cbnz	x17, 3f
 
 	/*
 	 * Call get_rstk(), which may invoke Restricted code (e.g. locking
@@ -254,44 +280,32 @@ TRAMP(tramp_switch_stack)
 	 */
 2:
 	blr	[c30, #0]			/* get_rstk() */
-3:	ldr	c11, [c11, #-CAP_WIDTH]
+3:	ldr	c17, [c17, #-CAP_WIDTH]
 
 	/* Move the c9 buffer to the target stack */
 	cbz	x9, 6f
-	gclen	x16, c9
-	add	c17, c9, x16
-	lsr	x16, x16, #4
-	tst	x17, #0xf
+	gclen	x11, c9
+	add	c30, c9, x11
+	lsr	x11, x11, #4
+	tst	x30, #0xf
 	b.eq	5f
 
-	orr	x30, x17, #0xfffffffffffffff0
-	add	c11, c11, x30
-7:	ldrb	w30, [c17, #-1]!
-	strb	w30, [c11, #-1]!
-	tst	x17, #0xf
+	orr	x12, x30, #0xfffffffffffffff0
+	add	c17, c17, x12
+7:	ldrb	w12, [c30, #-1]!
+	strb	w12, [c17, #-1]!
+	tst	x30, #0xf
 	b.ne	7b
 
-4:	cbz	x16, 6f
-5:	ldr	c30, [c17, #-CAP_WIDTH]!
-	str	c30, [c11, #-CAP_WIDTH]!
-	sub	x16, x16, #1
+4:	cbz	x11, 6f
+5:	ldr	c12, [c30, #-CAP_WIDTH]!
+	str	c12, [c17, #-CAP_WIDTH]!
+	sub	x11, x11, #1
 	b	4b
 6:
 TRAMPEND(tramp_switch_stack)
 
 PATCH_POINT(tramp_switch_stack, cid, 1b)
-
-TRAMP(tramp_pre_invoke)
-#define	TRUSTED_STACK	csp
-	/*
-	 * Save the number of unused return value registers in the flags of csp.
-	 */
-1:	movz	x17, #0		/* To be patched at runtime */
-	scflgs	TRUSTED_STACK, TRUSTED_STACK, x17
-#undef	TRUSTED_STACK
-TRAMPEND(tramp_pre_invoke)
-
-PATCH_POINT(tramp_pre_invoke, ret_args, 1b)
 
 TRAMP(tramp_invoke_exe)
 	blr	c18
@@ -333,44 +347,21 @@ TRAMP(tramp_invoke_res)
 	/*
 	 * Clear temporary registers, except
 	 * - c10: Link to previous frame (scalar)
-	 * - c11: Callee's stack
-	 * - c12: Tag of csp (scalar)
-	 * - c13: Old top of caller's stack (scalar)
+	 * - c11: Top of caller's stack (scalar)
+	 * - c12: Old top of caller's stack (scalar)
+	 * - c13: Flags of csp (scalar)
 	 * - c14: Callee's compartment ID (scalar)
 	 * - c15: Length of stack table (scalar)
 	 * - c16: Comparison result (scalar)
-	 * - c17: Flags of csp (scalar)
+	 * - c17: Callee's stack
 	 * - c18: Callee's code
 	 */
 
-	msr	rcsp_el0, c11
+	msr	rcsp_el0, c17
 	blrr	c18
 TRAMPEND(tramp_invoke_res)
 
-TRAMP(tramp_return_hook)
-	/* Save return value registers */
-	stp	c0, c1, [csp, #-(CAP_WIDTH * 2)]!
-
-1:	ldr	c10, #0			/* To be patched at runtime */
-
-2:	mov	w0, #0			/* To be patched at runtime */
-	mov	x1, xzr
-3:	ldr	c2, #0			/* To be patched at runtime */
-4:	ldr	c3, #0			/* To be patched at runtime */
-	mov	c4, c30
-	mrs	c5, rcsp_el0
-	blr	c10
-
-	/* Restore return value registers */
-	ldp	c0, c1, [csp], #(CAP_WIDTH * 2)
-TRAMPEND(tramp_return_hook)
-
-PATCH_POINT(tramp_return_hook, function, 1b)
-PATCH_POINT(tramp_return_hook, event, 2b)
-PATCH_POINT(tramp_return_hook, obj, 3b)
-PATCH_POINT(tramp_return_hook, def, 4b)
-
-TRAMP(tramp_return)
+TRAMP(tramp_pop_frame)
 #define	TRUSTED_STACK	csp
 	/* Restore callee-saved registers */
 	ldp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
@@ -431,7 +422,28 @@ TRAMP(tramp_return)
 	 * Executive).
 	 */
 	msr	rcsp_el0, c13
-	retr	c30
 #undef	TRUSTED_STACK
+TRAMPEND(tramp_pop_frame)
+
+TRAMP(tramp_return)
+	retr	c30
 TRAMPEND(tramp_return)
+
+TRAMP(tramp_return_hook)
+	/* Save return value registers */
+1:	ldr	c18, #0			/* To be patched at runtime */
+
+2:	mov	w10, #0			/* To be patched at runtime */
+	mov	x11, xzr
+3:	ldr	c12, #0			/* To be patched at runtime */
+4:	ldr	c13, #0			/* To be patched at runtime */
+	mov	c14, c30
+
+	br	c18
+TRAMPEND(tramp_return_hook)
+
+PATCH_POINT(tramp_return_hook, function, 1b)
+PATCH_POINT(tramp_return_hook, event, 2b)
+PATCH_POINT(tramp_return_hook, obj, 3b)
+PATCH_POINT(tramp_return_hook, def, 4b)
 #endif

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -33,7 +33,12 @@ ENTRY(_rtld_setjmp)
 	 * This function MUST update c0 to point at the buffer that saves the
 	 * general purpose registers.
 	 */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c18, rcsp_el0
+#define	TRUSTED_STACK	c18
+#else
 #define	TRUSTED_STACK	csp
+#endif
 	mov	c2, TRUSTED_STACK
 	b	_rtld_setjmp_impl
 #undef	TRUSTED_STACK
@@ -44,38 +49,63 @@ ENTRY(_rtld_longjmp)
 	 * This function MUST preserve the value of x1 and update c0 to point at
 	 * the general purpose registers to be restored.
 	 */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c18, rcsp_el0
+#define	TRUSTED_STACK	c18
+#else
 #define	TRUSTED_STACK	csp
+#endif
 
 	mov	c2, TRUSTED_STACK
 
 	str	c30, [TRUSTED_STACK, #-CAP_WIDTH]!
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	msr	rcsp_el0, TRUSTED_STACK
+#endif
 
 	bl	_rtld_longjmp_impl
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	TRUSTED_STACK, rcsp_el0
+#endif
 	ldr	c30, [TRUSTED_STACK], #CAP_WIDTH
 
 	ldr	x3, [TRUSTED_STACK]
 	scvalue	TRUSTED_STACK, TRUSTED_STACK, x3
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	msr	rcsp_el0, TRUSTED_STACK
+#endif
 
 	RETURN
 #undef	TRUSTED_STACK
 END(_rtld_longjmp)
 
 ENTRY(_rtld_thread_start)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	c10, csp
+	msr	rcsp_el0, c10
+#else
 	/*
 	 * Move the Executive mode thread pointer to Restricted mode.
 	 */
 	mrs	c10, ctpidr_el0
 	msr	rctpidr_el0, c10
+#endif
 	b	_rtld_thread_start_impl
 END(_rtld_thread_start)
 
 ENTRY(_rtld_thr_exit)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c10, rcsp_el0
+	mov	csp, c10
+#endif
 	b	_rtld_thr_exit_impl
 END(_rtld_thr_exit)
 
 ENTRY(_rtld_sighandler)
+#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	mov	c3, csp
+#endif
 	b	_rtld_sighandler_impl
 END(_rtld_sighandler)
 
@@ -160,7 +190,11 @@ ENTRY(_rtld_tramp_hook)
 	mov	c2, c12
 	mov	c3, c13
 	mov	c4, c14
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	c5, csp
+#else
 	mrs	c5, rcsp_el0
+#endif
 
 	stp	c18, c30, [csp, #-(CAP_WIDTH * 2)]!
 	bl	tramp_hook
@@ -179,7 +213,11 @@ ENTRY(_rtld_tramp_hook)
 	ldp	c2, c3, [csp, #(CAP_WIDTH * 2)]
 	ldp	c0, c1, [csp], #(CAP_WIDTH * 10)
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	RETURN
+#else
 	retr	c30
+#endif
 END(_rtld_tramp_hook)
 
 /*
@@ -204,9 +242,15 @@ END(_rtld_tramp_hook)
 
 TRAMP(tramp_save_caller)
 1:	ldr	c18, #0		/* To be patched at runtime */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	c17, csp
+	mrs	c10, rcsp_el0
+#define	TRUSTED_STACK	c10
+#else
 	mrs	c17, rcsp_el0
 	mov	x10, sp
 #define	TRUSTED_STACK	csp
+#endif
 
 	/*
 	 * Maintain consistency of rcsp by saving it at the bottom of itself.
@@ -219,7 +263,12 @@ TRAMP(tramp_save_caller)
 	str	c17, [c16, #-CAP_WIDTH]
 
 	/* Push frame */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	x11, x10
+	stp	x11, x12, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
+#else
 	stp	x10, x12, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
+#endif
 	str	c16, [TRUSTED_STACK, #(CAP_WIDTH * 1)]
 	stp	c30, c19, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
 	stp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
@@ -233,6 +282,9 @@ TRAMP(tramp_save_caller)
 	 */
 2:	movz	x13, #0		/* To be patched at runtime */
 	scflgs	TRUSTED_STACK, TRUSTED_STACK, x13
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	msr	rcsp_el0, TRUSTED_STACK
+#endif
 #undef	TRUSTED_STACK
 TRAMPEND(tramp_save_caller)
 
@@ -248,7 +300,11 @@ TRAMP(tramp_call_hook)
 5:	ldr	c13, #0		/* To be patched at runtime */
 	mov	c14, c30
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	blr	x17
+#else
 	blr	c17
+#endif
 TRAMPEND(tramp_call_hook)
 
 PATCH_POINT(tramp_call_hook, function, 1b)
@@ -258,7 +314,11 @@ PATCH_POINT(tramp_call_hook, obj, 4b)
 PATCH_POINT(tramp_call_hook, def, 5b)
 
 TRAMP(tramp_switch_stack)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c30, rctpidr_el0	/* c30 = table */
+#else
 	mrs	c30, ctpidr_el0		/* c30 = table */
+#endif
 1:	movz	w14, #0		/* w14 = cid, to be patched at runtime */
 	gclen	x15, c30	/* x15 = len(table) */
 
@@ -279,7 +339,12 @@ TRAMP(tramp_switch_stack)
 	 * implications of re-entrancy must be carefully addressed.
 	 */
 2:
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	ldr	c11, [c30]
+	blr	x11
+#else
 	blr	[c30, #0]			/* get_rstk() */
+#endif
 3:	ldr	c17, [c17, #-CAP_WIDTH]
 
 	/* Move the c9 buffer to the target stack */
@@ -308,7 +373,11 @@ TRAMPEND(tramp_switch_stack)
 PATCH_POINT(tramp_switch_stack, cid, 1b)
 
 TRAMP(tramp_invoke_exe)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	blr	x18
+#else
 	blr	c18
+#endif
 TRAMPEND(tramp_invoke_exe)
 
 TRAMP(tramp_clear_mem_args)
@@ -357,12 +426,22 @@ TRAMP(tramp_invoke_res)
 	 * - c18: Callee's code
 	 */
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	csp, c17
+	blr	x18
+#else
 	msr	rcsp_el0, c17
 	blrr	c18
+#endif
 TRAMPEND(tramp_invoke_res)
 
 TRAMP(tramp_pop_frame)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c18, rcsp_el0
+#define	TRUSTED_STACK	c18
+#else
 #define	TRUSTED_STACK	csp
+#endif
 	/* Restore callee-saved registers */
 	ldp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
 	ldp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 10)]
@@ -404,6 +483,10 @@ TRAMP(tramp_pop_frame)
 	mov	x3, xzr
 	mov	x2, xzr
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	msr	rcsp_el0, TRUSTED_STACK
+#endif
+
 	/*
 	 * Clear temporary registers, except
 	 * - c10: Link to previous frame (scalar)
@@ -421,12 +504,20 @@ TRAMP(tramp_pop_frame)
 	 * Restore caller's saved rcsp (has no effect if the caller is
 	 * Executive).
 	 */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	csp, c13
+#else
 	msr	rcsp_el0, c13
+#endif
 #undef	TRUSTED_STACK
 TRAMPEND(tramp_pop_frame)
 
 TRAMP(tramp_return)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	RETURN
+#else
 	retr	c30
+#endif
 TRAMPEND(tramp_return)
 
 TRAMP(tramp_return_hook)
@@ -439,7 +530,11 @@ TRAMP(tramp_return_hook)
 4:	ldr	c13, #0			/* To be patched at runtime */
 	mov	c14, c30
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	br	x18
+#else
 	br	c18
+#endif
 TRAMPEND(tramp_return_hook)
 
 PATCH_POINT(tramp_return_hook, function, 1b)

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -75,6 +75,11 @@ ENTRY(.rtld_start)
 	mov	c0, c19				/* Restore aux */
 	mov	csp, c20			/* Restore the stack pointer */
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	mrs	c10, rcsp_el0
+	mov	csp, c10
+	msr	rcsp_el0, c20
+#endif
 	br	x8				/* Jump to the entry point */
 #else
 	br	c8				/* Jump to the entry point */
@@ -105,7 +110,7 @@ END(.rtld_start)
  * x17 = &_rtld_bind_start
  */
 ENTRY(_rtld_bind_start)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	/*
 	 * Maintain consistency of rcsp.
 	 */
@@ -119,7 +124,7 @@ ENTRY(_rtld_bind_start)
 #endif
 
 	/* Save frame pointer and SP */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	stp	PTR(29), PTR(10), [PTRN(sp), #-(PTR_WIDTH * 2)]!
 	mov	PTR(29), PTRN(sp)
 	.cfi_def_cfa PTR(29), (PTR_WIDTH * 2)
@@ -185,14 +190,14 @@ ENTRY(_rtld_bind_start)
 	ldp	CAP(0), CAP(1), [PTRN(sp)], #(CAP_WIDTH * 2)
 
 	/* Restore frame pointer */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	ldp	PTR(29), PTR(10), [PTRN(sp)], #(PTR_WIDTH * 2)
 #else
 	ldp	PTR(29), PTR(zr), [PTRN(sp)], #(PTR_WIDTH * 2)
 #endif
 
 	 /* Restore link register saved by the plt code */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	gclim	x17, c10
 	sub	x17, x17, #CAP_WIDTH
 	scvalue	c17, c10, x17
@@ -204,10 +209,10 @@ ENTRY(_rtld_bind_start)
 #endif
 
 	/* Call into the correct function */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	brr	PTR(16)
-#elif defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+#if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	br	x16
+#elif defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	brr	PTR(16)
 #else
 	br	PTR(16)
 #endif
@@ -228,7 +233,7 @@ ENTRY(_rtld_tlsdesc_static)
 	ldp	x0, x1, [c0, #16]
 	add	c0, c2, x0
 	scbnds	c0, c0, x1
-#ifdef RTLD_SANDBOX
+#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	retr	c30
 #else
 	RETURN
@@ -247,7 +252,7 @@ END(_rtld_tlsdesc_static)
 ENTRY(_rtld_tlsdesc_undef)
 #ifdef __CHERI_PURE_CAPABILITY__
 	ldr	x0, [c0, #16]
-#ifdef RTLD_SANDBOX
+#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	retr	c30
 #else
 	RETURN
@@ -300,7 +305,7 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	/* Restore registers and return */
 	ldp	 c3,  c4, [csp], #32
 	.cfi_adjust_cfa_offset 	-2 * 16
-#ifdef RTLD_SANDBOX
+#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	retr	c30
 #else
 	RETURN
@@ -329,7 +334,7 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	stp	c15, c16, [csp, #(7 * 32)]
 	stp	c17, c18, [csp, #(8 * 32)]
 	str	c19,	  [csp, #(9 * 32)]
-#if defined(RTLD_SANDBOX)
+#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	/*
 	 * Maintain consistency of rcsp. This step is only needed for
 	 * _rtld_tlsdesc_dynamic because it might call external functions.
@@ -369,7 +374,7 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	scbnds	c0, c0, x19
 
 	/* Restore slow path registers */
-#if defined(RTLD_SANDBOX)
+#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	ldr	c3, [csp, #(9 * 32 + 16)]
 	gclim	x4, c3
 	sub	x4, x4, #CAP_WIDTH
@@ -394,7 +399,7 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	/* Restore fast path registers and return */
 	ldp	 c3,  c4, [csp], #32
 	.cfi_adjust_cfa_offset 	-2 * 16
-#ifdef RTLD_SANDBOX
+#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	retr	c30
 #else
 	RETURN

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -161,7 +161,7 @@ _Static_assert(sizeof(struct func_sig) == sizeof(func_sig_int),
 
 void *_rtld_tramp_hook(int, void *, const Obj_Entry *, const Elf_Sym *, void *,
     void *);
-size_t tramp_compile(char **, const struct tramp_data *);
+size_t tramp_compile(void **, const struct tramp_data *);
 void *tramp_intern(const Obj_Entry *reqobj, const struct tramp_data *);
 struct func_sig tramp_fetch_sig(const Obj_Entry *, unsigned long);
 

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -46,7 +46,11 @@ void tramp_init(void);
 /*
  * Policies
  */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+#define	C18N_RTLD_COMPARTMENT_ID	1
+#else
 #define	C18N_RTLD_COMPARTMENT_ID	0
+#endif
 #define	C18N_COMPARTMENT_ID_MAX	(UINT16_MAX >> 1)
 
 typedef uint16_t compart_id_t;
@@ -106,18 +110,30 @@ stk_table_get(void)
 {
 	struct stk_table *table;
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	asm ("mrs	%0, rctpidr_el0" : "=C" (table));
+#else
 	asm ("mrs	%0, ctpidr_el0" : "=C" (table));
+#endif
 	return (table);
 }
 
 static inline void
 stk_table_set(struct stk_table *table)
 {
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	asm ("msr	rctpidr_el0, %0" :: "C" (table));
+#else
 	asm ("msr	ctpidr_el0, %0" :: "C" (table));
+#endif
 }
 
 static inline void
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+trusted_stk_set(void *sp)
+#else
 untrusted_stk_set(void *sp)
+#endif
 {
 	asm ("msr	rcsp_el0, %0" :: "C" (sp));
 }

--- a/libexec/rtld-elf64cb-c18n/Makefile
+++ b/libexec/rtld-elf64cb-c18n/Makefile
@@ -1,0 +1,11 @@
+NEED_COMPAT=	64CB
+.include <bsd.compat.mk>
+
+PROG=	ld-elf64cb-c18n.so.1
+MAN=
+MLINKS=	rtld.1 ld-elf64cb-c18n.so.1.1
+
+RTLD_SANDBOX=
+
+.PATH:  ${SRCTOP}/libexec/rtld-elf
+.include "${SRCTOP}/libexec/rtld-elf/Makefile"

--- a/share/examples/cheribsdtest/run-many
+++ b/share/examples/cheribsdtest/run-many
@@ -45,7 +45,7 @@ if [ $# -eq 0 ]; then
 
 	case `uname -p` in
 	aarch64c)
-		set -- "$@" c18n
+		set -- "$@" c18n benchmark-c18n
 		;;
 	esac
 fi
@@ -58,8 +58,8 @@ fi
 suffixes=
 for abi in "$@"; do
 	case "$abi" in
-	c18n)
-		suffixes="$suffixes mt-c18n"
+	c18n|benchmark-c18n)
+		suffixes="$suffixes ${abi%c18n}mt-c18n"
 		;;
 	*)
 		for dyn in '' -dynamic; do

--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -65,7 +65,7 @@ field of an executable, although it is reportedly unreliable at times.
 .Pp
 Environment variables recognized by
 .Xr rtld 1
-should adopt the prefix LD_C18N_ when compartmentalization is enabled.
+adopt the prefix LD_C18N_ when compartmentalization is enabled.
 For example, LD_LIBRARY_PATH becomes LD_C18N_LIBRARY_PATH.
 .Pp
 Compartmentalization currently depends on modified versions of
@@ -100,18 +100,28 @@ system call.
 Compartment transition overhead simulation is only intended for performance
 analysis purposes.
 Turning it on will reduce security.
+.Ss BENCHMARK ABI VARIANT
+A variant of the runtime linker that uses the benchmark ABI is provided at
+.Pa /libexec/ld-elf64cb-c18n.so.1 .
+Environment variables recognized by this variant need to be prefixed with
+LD_64CB_C18N_.
+.Pp
+.Sy NOTE:
+The current implementation is not fully optmized for performance, nor is it
+tested as extensively as the normal variant and may thus contain subtle bugs.
+Compartment transition tracing is unreliable under the benchmark ABI.
+Please report any bug to help improve the implementation.
 .Sh LIMITATIONS
-This work is of a experimental nature.
+This work is of an experimental nature.
 The author has tested it on applications such as
 .Xr tmux 1 ,
 but instabilities might occur when running complex pieces of software.
 .Pp
-The current prototype only contains a set of
-.Em mechanisms
-for implementing library-based compartmentalization.
-No
-.Em policy
-has been enforced yet.
+Importantly, this prototype
+.Em does not
+provide complete isolation between compartments.
+For example, they are allowed to make arbitrary system calls to obtain
+privileges.
 .Pp
 Below is a list of known limitations and problems.
 For more up-to-date information, visit

--- a/sys/arm64/include/tls.h
+++ b/sys/arm64/include/tls.h
@@ -45,7 +45,7 @@ static __inline void
 _tcb_set(struct tcb *tcb)
 {
 #ifdef __CHERI_PURE_CAPABILITY__
-#if defined(IN_RTLD) && defined(RTLD_SANDBOX)
+#if defined(IN_RTLD) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	__asm __volatile("msr	rctpidr_el0, %0" :: "C" (tcb));
 #else
 	__asm __volatile("msr	ctpidr_el0, %0" :: "C" (tcb));
@@ -61,7 +61,7 @@ _tcb_get(void)
 	struct tcb *tcb;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#if defined(IN_RTLD) && defined(RTLD_SANDBOX)
+#if defined(IN_RTLD) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	__asm __volatile("mrs	%0, rctpidr_el0" : "=C" (tcb));
 #else
 	__asm __volatile("mrs	%0, ctpidr_el0" : "=C" (tcb));

--- a/usr.bin/ldd/ldd.c
+++ b/usr.bin/ldd/ldd.c
@@ -72,6 +72,7 @@
 	setenv("LD_64C_" name, value, overwrite);	\
 	setenv("LD_64CB_" name, value, overwrite);	\
 	setenv("LD_C18N_" name, value, overwrite);	\
+	setenv("LD_64CB_C18N_" name, value, overwrite);	\
 } while (0)
 
 #define	LDD_UNSETENV(name) do {		\
@@ -81,6 +82,7 @@
 	unsetenv("LD_64C_" name);	\
 	unsetenv("LD_64CB_" name);	\
 	unsetenv("LD_C18N_" name);	\
+	unsetenv("LD_64CB_C18N_" name);	\
 } while (0)
 
 static int	is_executable(const char *fname, int fd, int *is_shlib,

--- a/usr.bin/stdbuf/stdbuf.c
+++ b/usr.bin/stdbuf/stdbuf.c
@@ -109,6 +109,7 @@ main(int argc, char *argv[])
 	appendenv("LD_64C_PRELOAD", LIBSTDBUF64C);
 	appendenv("LD_64CB_PRELOAD", LIBSTDBUF64CB);
 	appendenv("LD_C18N_PRELOAD", LIBSTDBUF);
+	appendenv("LD_64CB_C18N_PRELOAD", LIBSTDBUF64CB);
 
 	execvp(argv[0], argv);
 	err(2, "%s", argv[0]);


### PR DESCRIPTION
This PR adds the benchmark ABI-variant of the compartmentalising dynamic linker.