### PR TITLE
Don't create the shadows bitmap with OBJ_HASCAP

### DIFF
--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2908,6 +2908,8 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 				if (tobj != obj && tobj != lobj)
 					VM_OBJECT_RUNLOCK(tobj);
 			}
+			if ((obj->flags & OBJ_HASCAP) != 0)
+				kve->kve_flags |= KVME_FLAG_HASCAP;
 		} else {
 			lobj = NULL;
 		}

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -515,6 +515,7 @@ struct kinfo_lockf {
 #define	KVME_FLAG_USER_WIRED	0x00000040
 #define	KVME_FLAG_GUARD		0x00000080
 #define	KVME_FLAG_UNMAPPED	0x00000100
+#define	KVME_FLAG_HASCAP	0x00000200
 
 #if defined(__amd64__)
 #define	KINFO_OVMENTRY_SIZE	1168

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -933,6 +933,14 @@ vm_map_install_cheri_revoke_shadow(struct vm_map *map, struct sysentvec *sv)
 	vm_offset_t end_addr = start_addr + sv->sv_cheri_revoke_shadow_length;
 
 	vmo_shadow = vm_object_allocate(OBJT_DEFAULT, end_addr - start_addr);
+	/*
+	 * The shadow bitmap can never contain capabilities so mark it as
+	 * such to ensure it doesn't need to be scanned for them (e.g.,
+	 * by userspace programs examining capabilities via ptrace) as it is
+	 * both large and sparsely mapped.
+	 */
+	vm_object_set_flag(vmo_shadow, OBJ_NOCAP);
+
 	vmo_info = vm_object_allocate(OBJT_DEFAULT, PAGE_SIZE);
 
 	vm_map_lock(map);

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -1294,11 +1294,15 @@ vm_fault_cow(struct faultstate *fs)
 		 * an assertion that the source page has no tags
 		 * instead if OBJ_HASCAP is not set.
 		 *
+		 * XXXBD: it is no longer the case that the all anonymous
+		 * objects are OBJ_HASCAP as OBJ_NOCAP supresses the addition
+		 * of OBJ_HASCAP
+		 *
 		 * Preserve tags if the source page contains tags.
 		 * The destination page will always belong to a
 		 * tag-bearing VM object.
 		 */
-		KASSERT(fs->first_object->flags & OBJ_HASCAP,
+		KASSERT(fs->first_object->flags & (OBJ_HASCAP | OBJ_NOCAP),
 		    ("%s: destination object %p doesn't have OBJ_HASCAP",
 		    __func__, fs->first_object));
 		if (fs->object->flags & OBJ_HASCAP) {

--- a/sys/vm/vm_object.c
+++ b/sys/vm/vm_object.c
@@ -464,6 +464,7 @@ vm_object_allocate_anon(vm_pindex_t size, vm_object_t backing_object,
     struct ucred *cred, vm_size_t charge)
 {
 	vm_object_t handle, object;
+	int capflag = OBJ_HASCAP;
 
 	if (backing_object == NULL)
 		handle = NULL;
@@ -471,9 +472,12 @@ vm_object_allocate_anon(vm_pindex_t size, vm_object_t backing_object,
 		handle = backing_object->handle;
 	else
 		handle = backing_object;
+	if (backing_object != NULL &&
+	    (backing_object->flags & OBJ_NOCAP) != 0)
+		capflag = OBJ_NOCAP;
 	object = uma_zalloc(obj_zone, M_WAITOK);
 	_vm_object_allocate(OBJT_SWAP, size,
-	    OBJ_ANON | OBJ_ONEMAPPING | OBJ_HASCAP | OBJ_SWAP, object, handle);
+	    OBJ_ANON | OBJ_ONEMAPPING | capflag | OBJ_SWAP, object, handle);
 	object->cred = cred;
 	object->charge = cred != NULL ? charge : 0;
 	return (object);

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -202,6 +202,7 @@ struct vm_object {
 #define	OBJ_PAGERPRIV1	0x4000		/* Pager private */
 #define	OBJ_PAGERPRIV2	0x8000		/* Pager private */
 #define	OBJ_HASCAP	0x10000		/* object can store capabilities */
+#define	OBJ_NOCAP	0x20000		/* object can not store capabilities */
 
 /*
  * Helpers to perform conversion between vm_object page indexes and offsets.

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -777,6 +777,8 @@ The following mapping flags may be displayed:
 .Bl -tag -width X -compact
 .It C
 copy-on-write
+.It c
+object can hold capabilities
 .It G
 guard mapping
 .It u

--- a/usr.bin/procstat/procstat_vm.c
+++ b/usr.bin/procstat/procstat_vm.c
@@ -57,11 +57,11 @@ procstat_vm(struct procstat *procstat, struct kinfo_proc *kipp)
 #endif
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
 		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
-			xo_emit("{T:/%5s %*s %*s %-5s %4s %4s %3s %3s %-5s %-2s %-s}\n",
+			xo_emit("{T:/%5s %*s %*s %-5s %4s %4s %3s %3s %-6s %-2s %-s}\n",
 			    "PID", ptrwidth, "START", ptrwidth, "END", "PRT",
 			    "RES", "PRES", "REF", "SHD", "FLAG", "TP", "PATH");
 		else
-			xo_emit("{T:/%5s %*s %*s %*s %-5s %4s %4s %3s %3s %-5s %-2s %-s}\n",
+			xo_emit("{T:/%5s %*s %*s %*s %-5s %4s %4s %3s %3s %-6s %-2s %-s}\n",
 			    "PID", ptrwidth, "START", ptrwidth, "END",
 			    ptrwidth, "RESERV", "PRT",
 			    "RES", "PRES", "REF", "SHD", "FLAG", "TP", "PATH");
@@ -134,8 +134,10 @@ procstat_vm(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit("{d:grows_down/%-1s}", kve->kve_flags &
 		    KVME_FLAG_GROWS_UP ? "U" : kve->kve_flags &
 		    KVME_FLAG_GROWS_DOWN ? "D" : "-");
-		xo_emit("{d:wired/%-1s} ", kve->kve_flags &
+		xo_emit("{d:wired/%-1s}", kve->kve_flags &
 		    KVME_FLAG_USER_WIRED ? "W" : "-");
+		xo_emit("{d:hascap/%-1s} ", kve->kve_flags &
+		    KVME_FLAG_HASCAP ? "c" : "-");
 		xo_open_container("kve_flags");
 		xo_emit("{en:copy_on_write/%s}", kve->kve_flags &
 		    KVME_FLAG_COW ? "true" : "false");
@@ -153,6 +155,8 @@ procstat_vm(struct procstat *procstat, struct kinfo_proc *kipp)
 		    KVME_FLAG_GROWS_DOWN ? "true" : "false");
 		xo_emit("{en:wired/%s}", kve->kve_flags &
 		    KVME_FLAG_USER_WIRED ? "true" : "false");
+		xo_emit("{en:hascap/%s}", kve->kve_flags &
+		    KVME_FLAG_HASCAP ? "true" : "false");
 		xo_close_container("kve_flags");
 		switch (kve->kve_type) {
 		case KVME_TYPE_NONE:


### PR DESCRIPTION
This set of changes exposes the OBJ_HASCAP flag of vm mapping to the user via procstat and then alters the creation of the underlying object to suppressing setting of OBJ_HASCAP when mappings are touched via faults.

I'm not really convinced by either the `OBJT_CHERI_SHADOW` psuedo type in creation or the revocation-specific `OBJ_CHERI_SHADOW` flag as APIs, but they seem to work. Suggestions from those more familiar with this code would be most welcome.