### PR TITLE
Merge FreeBSD 2023-11-08 security advisories

### DIFF
--- a/lib/libc/stdio/fflush.c
+++ b/lib/libc/stdio/fflush.c
@@ -103,11 +103,11 @@ __weak_reference(__fflush, fflush_unlocked);
 int
 __sflush(FILE *fp)
 {
-	unsigned char *p, *old_p;
-	int n, t, old_w;
+	unsigned char *p;
+	int n, f, t;
 
-	t = fp->_flags;
-	if ((t & __SWR) == 0)
+	f = fp->_flags;
+	if ((f & __SWR) == 0)
 		return (0);
 
 	if ((p = fp->_bf._base) == NULL)
@@ -119,26 +119,19 @@ __sflush(FILE *fp)
 	 * Set these immediately to avoid problems with longjmp and to allow
 	 * exchange buffering (via setvbuf) in user write function.
 	 */
-	old_p = fp->_p;
 	fp->_p = p;
-	old_w = fp->_w;
-	fp->_w = t & (__SLBF|__SNBF) ? 0 : fp->_bf._size;
+	fp->_w = f & (__SLBF|__SNBF) ? 0 : fp->_bf._size;
 
 	for (; n > 0; n -= t, p += t) {
 		t = _swrite(fp, (char *)p, n);
 		if (t <= 0) {
-			/* Reset _p and _w. */
-			if (p > fp->_p) {
+			if (p > fp->_p)
 				/* Some was written. */
 				memmove(fp->_p, p, n);
-				fp->_p += n;
-				if ((fp->_flags & (__SLBF | __SNBF)) == 0)
-					fp->_w -= n;
-			/* conditional to handle setvbuf */
-			} else if (p == fp->_p && errno == EINTR) {
-				fp->_p = old_p;
-				fp->_w = old_w;
-			}
+			/* Reset _p and _w. */
+			fp->_p += n;
+			if ((fp->_flags & __SNBF) == 0)
+				fp->_w -= n;
 			fp->_flags |= __SERR;
 			return (EOF);
 		}

--- a/lib/libc/stdio/fvwrite.c
+++ b/lib/libc/stdio/fvwrite.c
@@ -36,7 +36,6 @@
 static char sccsid[] = "@(#)fvwrite.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -53,7 +52,6 @@ int
 __sfvwrite(FILE *fp, struct __suio *uio)
 {
 	size_t len;
-	unsigned char *old_p;
 	char *p;
 	struct __siov *iov;
 	int w, s;
@@ -137,12 +135,8 @@ __sfvwrite(FILE *fp, struct __suio *uio)
 				COPY(w);
 				/* fp->_w -= w; */ /* unneeded */
 				fp->_p += w;
-				old_p = fp->_p;
-				if (__fflush(fp) == EOF) {
-					if (old_p == fp->_p && errno == EINTR)
-						fp->_p -= w;
+				if (__fflush(fp))
 					goto err;
-				}
 			} else if (len >= (w = fp->_bf._size)) {
 				/* write directly */
 				w = _swrite(fp, p, w);
@@ -181,12 +175,8 @@ __sfvwrite(FILE *fp, struct __suio *uio)
 				COPY(w);
 				/* fp->_w -= w; */
 				fp->_p += w;
-				old_p = fp->_p;
-				if (__fflush(fp) == EOF) {
-					if (old_p == fp->_p && errno == EINTR)
-						fp->_p -= w;
+				if (__fflush(fp))
 					goto err;
-				}
 			} else if (s >= (w = fp->_bf._size)) {
 				w = _swrite(fp, p, w);
 				if (w <= 0)

--- a/lib/libc/stdio/wbuf.c
+++ b/lib/libc/stdio/wbuf.c
@@ -50,7 +50,6 @@ static char sccsid[] = "@(#)wbuf.c	8.1 (Berkeley) 6/4/93";
 int
 __swbuf(int c, FILE *fp)
 {
-	unsigned char *old_p;
 	int n;
 
 	/*
@@ -86,15 +85,8 @@ __swbuf(int c, FILE *fp)
 	}
 	fp->_w--;
 	*fp->_p++ = c;
-	old_p = fp->_p;
-	if (++n == fp->_bf._size || (fp->_flags & __SLBF && c == '\n')) {
-		if (__fflush(fp) != 0) {
-			if (fp->_p == old_p && errno == EINTR) {
-				fp->_p--;
-				fp->_w++;
-			}
+	if (++n == fp->_bf._size || (fp->_flags & __SLBF && c == '\n'))
+		if (__fflush(fp) != 0)
 			return (EOF);
-		}
-	}
 	return (c);
 }

--- a/lib/libcasper/services/cap_net/cap_net.c
+++ b/lib/libcasper/services/cap_net/cap_net.c
@@ -1232,7 +1232,7 @@ verify_name2addr_newlimits(const nvlist_t *oldlimits,
 	oldfunclimits = NULL;
 	if (oldlimits != NULL) {
 		oldfunclimits = dnvlist_get_nvlist(oldlimits,
-		    LIMIT_NV_ADDR2NAME, NULL);
+		    LIMIT_NV_NAME2ADDR, NULL);
 	}
 
 	cookie = NULL;

--- a/lib/libcasper/services/cap_net/tests/net_test.c
+++ b/lib/libcasper/services/cap_net/tests/net_test.c
@@ -783,6 +783,18 @@ ATF_TC_BODY(capnet__limits_name2addr_hosts, tc)
 	limit = cap_net_limit_init(capnet, CAPNET_NAME2ADDR);
 	ATF_REQUIRE(cap_net_limit(limit) != 0);
 
+	/* Try to extend the limit. */
+	limit = cap_net_limit_init(capnet, CAPNET_NAME2ADDR);
+	ATF_REQUIRE(limit != NULL);
+	cap_net_limit_name2addr(limit, TEST_DOMAIN_1, NULL);
+	ATF_REQUIRE(cap_net_limit(limit) != 0);
+
+	limit = cap_net_limit_init(capnet, CAPNET_NAME2ADDR);
+	ATF_REQUIRE(limit != NULL);
+	cap_net_limit_name2addr(limit, TEST_DOMAIN_0, NULL);
+	cap_net_limit_name2addr(limit, TEST_DOMAIN_1, NULL);
+	ATF_REQUIRE(cap_net_limit(limit) != 0);
+
 	cap_close(capnet);
 }
 

--- a/sys/netpfil/pf/if_pfsync.c
+++ b/sys/netpfil/pf/if_pfsync.c
@@ -1775,6 +1775,7 @@ pfsync_sendout(int schedswi, int c)
 	struct pf_kstate *st, *st_next;
 	struct pfsync_upd_req_item *ur;
 	struct pfsync_bucket *b = &sc->sc_buckets[c];
+	size_t len;
 	int aflen, offset, count = 0;
 	enum pfsync_q_id q;
 
@@ -1795,7 +1796,9 @@ pfsync_sendout(int schedswi, int c)
 		return;
 	}
 	m->m_data += max_linkhdr;
-	m->m_len = m->m_pkthdr.len = b->b_len;
+	bzero(m->m_data, b->b_len);
+
+	len = b->b_len;
 
 	/* build the ip header */
 	switch (sc->sc_sync_peer.ss_family) {
@@ -1808,7 +1811,8 @@ pfsync_sendout(int schedswi, int c)
 		bcopy(&sc->sc_template.ipv4, ip, sizeof(*ip));
 		aflen = offset = sizeof(*ip);
 
-		ip->ip_len = htons(m->m_pkthdr.len);
+		len -= sizeof(union inet_template) - sizeof(struct ip);
+		ip->ip_len = htons(len);
 		ip_fillid(ip);
 		break;
 	    }
@@ -1822,7 +1826,8 @@ pfsync_sendout(int schedswi, int c)
 		bcopy(&sc->sc_template.ipv6, ip6, sizeof(*ip6));
 		aflen = offset = sizeof(*ip6);
 
-		ip6->ip6_plen = htons(m->m_pkthdr.len);
+		len -= sizeof(union inet_template) - sizeof(struct ip6_hdr);
+		ip6->ip6_plen = htons(len);
 		break;
 		}
 #endif
@@ -1830,14 +1835,14 @@ pfsync_sendout(int schedswi, int c)
 		m_freem(m);
 		return;
 	}
+	m->m_len = m->m_pkthdr.len = len;
 
 	/* build the pfsync header */
 	ph = (struct pfsync_header *)(m->m_data + offset);
-	bzero(ph, sizeof(*ph));
 	offset += sizeof(*ph);
 
 	ph->version = PFSYNC_VERSION;
-	ph->len = htons(b->b_len - aflen);
+	ph->len = htons(len - aflen);
 	bcopy(V_pf_status.pf_chksum, ph->pfcksum, PF_MD5_DIGEST_LENGTH);
 
 	/* walk the queues */
@@ -1865,7 +1870,6 @@ pfsync_sendout(int schedswi, int c)
 		}
 		TAILQ_INIT(&b->b_qs[q]);
 
-		bzero(subh, sizeof(*subh));
 		subh->action = pfsync_qs[q].action;
 		subh->count = htons(count);
 		V_pfsyncstats.pfsyncs_oacts[pfsync_qs[q].action] += count;
@@ -1886,7 +1890,6 @@ pfsync_sendout(int schedswi, int c)
 			count++;
 		}
 
-		bzero(subh, sizeof(*subh));
 		subh->action = PFSYNC_ACT_UPD_REQ;
 		subh->count = htons(count);
 		V_pfsyncstats.pfsyncs_oacts[PFSYNC_ACT_UPD_REQ] += count;
@@ -1903,7 +1906,6 @@ pfsync_sendout(int schedswi, int c)
 	subh = (struct pfsync_subheader *)(m->m_data + offset);
 	offset += sizeof(*subh);
 
-	bzero(subh, sizeof(*subh));
 	subh->action = PFSYNC_ACT_EOF;
 	subh->count = htons(1);
 	V_pfsyncstats.pfsyncs_oacts[PFSYNC_ACT_EOF]++;
@@ -1911,10 +1913,10 @@ pfsync_sendout(int schedswi, int c)
 	/* we're done, let's put it on the wire */
 	if (ifp->if_bpf) {
 		m->m_data += aflen;
-		m->m_len = m->m_pkthdr.len = b->b_len - aflen;
+		m->m_len = m->m_pkthdr.len = len - aflen;
 		BPF_MTAP(ifp, m);
 		m->m_data -= aflen;
-		m->m_len = m->m_pkthdr.len = b->b_len;
+		m->m_len = m->m_pkthdr.len = len;
 	}
 
 	if (sc->sc_sync_if == NULL) {


### PR DESCRIPTION
- [FreeBSD-SA-23:15.stdio](https://www.freebsd.org/security/advisories/FreeBSD-SA-23:15.stdio.asc)
- [FreeBSD-SA-23:16.cap_net](https://www.freebsd.org/security/advisories/FreeBSD-SA-23:16.cap_net.asc)
- pfsync: Avoid transmitting uninitialized bytes in pfsync_sendout() (uninitialized data leak, no SA)