### PR TITLE
caprevoke fixes and cleanup

### DIFF
--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -351,9 +351,6 @@ static enum vm_cro_at
 vm_cheri_revoke_object_at(const struct vm_cheri_revoke_cookie *crc, int flags,
     vm_map_entry_t entry, vm_offset_t ioff, vm_offset_t *ooff, int *vmres)
 {
-#ifdef INVARIANTS
-	vm_page_astate_t mas;
-#endif
 	CHERI_REVOKE_STATS_FOR(crst, crc);
 	vm_map_t map = crc->map;
 	vm_object_t obj = entry->object.vm_object;
@@ -668,10 +665,8 @@ ok:
 		mxbusy = false;
 	}
 
-	mas = vm_page_astate_load(m);
-	KASSERT((mas.flags & PGA_CAPDIRTY) == 0 ||
-	    (flags & VM_CHERI_REVOKE_BARRIERED) == 0,
-	    ("Capdirty page after visit with world stopped?"));
+	KASSERT((vm_page_astate_load(m).flags & PGA_CAPDIRTY) == 0,
+	    ("Capdirty page after visit?"));
 #endif
 
 	*ooff = ioff + PAGE_SIZE;

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -922,7 +922,7 @@ vm_map_install_cheri_revoke_shadow(struct vm_map *map, struct sysentvec *sv)
 	vm_offset_t start_addr = sv->sv_cheri_revoke_shadow_base;
 	vm_offset_t end_addr = start_addr + sv->sv_cheri_revoke_shadow_length;
 
-	vmo_shadow = vm_object_allocate(OBJT_DEFAULT, end_addr - start_addr);
+	vmo_shadow = vm_object_allocate(OBJT_SWAP, end_addr - start_addr);
 	/*
 	 * The shadow bitmap can never contain capabilities so mark it as
 	 * such to ensure it doesn't need to be scanned for them (e.g.,
@@ -931,7 +931,7 @@ vm_map_install_cheri_revoke_shadow(struct vm_map *map, struct sysentvec *sv)
 	 */
 	vm_object_set_flag(vmo_shadow, OBJ_NOCAP);
 
-	vmo_info = vm_object_allocate(OBJT_DEFAULT, PAGE_SIZE);
+	vmo_info = vm_object_allocate(OBJT_SWAP, PAGE_SIZE);
 
 	vm_map_lock(map);
 

--- a/sys/vm/vm_cheri_revoke.h
+++ b/sys/vm/vm_cheri_revoke.h
@@ -101,9 +101,6 @@ void vm_cheri_revoke_info_page(struct vm_map *map, struct sysentvec *,
 enum {
 	/* Set externally, checked per page */
 	VM_CHERI_REVOKE_BARRIERED   = 0x01, /* world is stopped (debug) */
-
-	/* Set internally, checked per page */
-	VM_CHERI_REVOKE_QUICK_SUCCESSOR = 0x02,
 };
 
 int vm_cheri_revoke_pass(const struct vm_cheri_revoke_cookie *, int);

--- a/sys/vm/vm_cheri_revoke.h
+++ b/sys/vm/vm_cheri_revoke.h
@@ -98,11 +98,6 @@ void vm_cheri_revoke_cookie_rele(struct vm_cheri_revoke_cookie *cookie);
 void vm_cheri_revoke_info_page(struct vm_map *map, struct sysentvec *,
     struct cheri_revoke_info_page * __capability *);
 
-enum {
-	/* Set externally, checked per page */
-	VM_CHERI_REVOKE_BARRIERED   = 0x01, /* world is stopped (debug) */
-};
-
 int vm_cheri_revoke_pass(const struct vm_cheri_revoke_cookie *, int);
 
 void vm_cheri_assert_consistent_clg(struct vm_map *map);

--- a/sys/vm/vm_object.c
+++ b/sys/vm/vm_object.c
@@ -1939,6 +1939,9 @@ vm_object_collapse(vm_object_t object)
 		    ("vm_object_collapse: Backing object already collapsing."));
 		KASSERT((object->flags & (OBJ_COLLAPSING | OBJ_DEAD)) == 0,
 		    ("vm_object_collapse: object is already collapsing."));
+		KASSERT((object->flags & OBJ_HASCAP) != 0 ||
+		    (backing_object->flags & OBJ_HASCAP) == 0,
+		    ("vm_object_collapse: shadow does not bear capabilities"));
 
 		/*
 		 * We know that we can either collapse the backing object if

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -202,7 +202,8 @@ struct vm_object {
 #define	OBJ_PAGERPRIV1	0x4000		/* Pager private */
 #define	OBJ_PAGERPRIV2	0x8000		/* Pager private */
 #define	OBJ_HASCAP	0x10000		/* object can store capabilities */
-#define	OBJ_NOCAP	0x20000		/* object can not store capabilities */
+#define	OBJ_NOCAP	0x20000		/* object and allow shadow objects can
+					   not store capabilities */
 
 /*
  * Helpers to perform conversion between vm_object page indexes and offsets.


### PR DESCRIPTION
Fix a couple of problems with `VM_CHERI_REVOKE_QUICK_SUCCESSOR` and perform assorted cleanup.