### PR TITLE
procstat cheri improvements

### DIFF
--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -2182,7 +2182,8 @@ procstat_getquarantining_sysctl(pid_t pid, int *quarantiningp)
 	name[3] = pid;
 	len = sizeof(*quarantiningp);
 	error = sysctl(name, nitems(name), quarantiningp, &len, NULL, 0);
-	if (error != 0 && errno != ESRCH && feature_present("cheri_revoke"))
+	if (error != 0 && errno != ESRCH && errno != EPERM &&
+	    feature_present("cheri_revoke"))
 		warn("sysctl: kern.proc.quarantining: %d", pid);
 	return (error);
 }
@@ -2219,7 +2220,8 @@ procstat_get_revoker_epoch_sysctl(pid_t pid, uint64_t *revoker_epochp)
 	name[3] = pid;
 	len = sizeof(*revoker_epochp);
 	error = sysctl(name, nitems(name), revoker_epochp, &len, NULL, 0);
-	if (error != 0 && errno != ESRCH && feature_present("cheri_revoke"))
+	if (error != 0 && errno != ESRCH && errno != EPERM &&
+	    feature_present("cheri_revoke"))
 		warn("sysctl: kern.proc.revoker_epoch: %d", pid);
 	return (error);
 }
@@ -2256,7 +2258,8 @@ procstat_get_revoker_state_sysctl(pid_t pid, int *revoker_statep)
 	name[3] = pid;
 	len = sizeof(*revoker_statep);
 	error = sysctl(name, nitems(name), revoker_statep, &len, NULL, 0);
-	if (error != 0 && errno != ESRCH && feature_present("cheri_revoke"))
+	if (error != 0 && errno != ESRCH && errno != EPERM &&
+	    feature_present("cheri_revoke"))
 		warn("sysctl: kern.proc.revoker_state: %d", pid);
 	return (error);
 }

--- a/usr.bin/procstat/procstat_cheri.c
+++ b/usr.bin/procstat/procstat_cheri.c
@@ -59,8 +59,8 @@ procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
 
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
 		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
-			xo_emit("{T:/%5s %-19s %c %4s %7s}\n",
-			    "PID", "COMM", 'C', "QUAR", "RSTATE");
+			xo_emit("{T:/%5s %-19s %c %4s}\n",
+			    "PID", "COMM", 'C', "QUAR");
 		else
 			xo_emit("{T:/%5s %-19s %c %4s %7s %34s}\n",
 			    "PID", "COMM", 'C', "QUAR", "RSTATE", "EPOCH");
@@ -70,17 +70,13 @@ procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
 	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
 	abi_cheri = get_abi_cheri(kipp);
 	xo_emit(" {:abi_cheri_support/%c/%c}", abi_cheri);
-	/* Don't print CHERI-specific things for non-CheriABI ABIs */
-	switch (abi_cheri) {
-	case 'P':
-		xo_emit(" {:quarantining/%4s}",
-		    get_quarantining(procstat, kipp));
-		xo_emit(" {:revoker_state/%7s}",
-		    get_revoker_state(procstat, kipp));
-		if ((procstat_opts & PS_OPT_VERBOSE) != 0)
-			xo_emit(" {:revoker_epoch/%34s}",
-			    get_revoker_epoch(procstat, kipp));
-		break;
+	xo_emit(" {:quarantining/%4s/%s}", abi_cheri == 'P' ?
+	    get_quarantining(procstat, kipp) : "-");
+	if ((procstat_opts & PS_OPT_VERBOSE) != 0) {
+		xo_emit(" {:revoker_state/%7s/%s}", abi_cheri == 'P' ?
+		    get_revoker_state(procstat, kipp) : "-");
+		xo_emit(" {:revoker_epoch/%34s/%s}", abi_cheri == 'P' ?
+		    get_revoker_epoch(procstat, kipp) : "-");
 	}
 	xo_emit("\n");
 }


### PR DESCRIPTION
Tweak output to include `-` in columns were the data is meaningless and don't warn on EPERM in libprocstat