### PR TITLE
arm64: Clear c9 before invoking sigcode on Morello

### DIFF
--- a/sys/arm64/arm64/exec_machdep.c
+++ b/sys/arm64/arm64/exec_machdep.c
@@ -1009,6 +1009,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	tf->tf_x[8] = (uintcap_t)catcher;
 	tf->tf_sp = (uintcap_t)fp;
 #if __has_feature(capabilities)
+	tf->tf_x[9] = 0;
 	trapframe_set_elr(tf, (uintcap_t)p->p_md.md_sigcode);
 #else
 	tf->tf_elr = (register_t)PROC_SIGCODE(p);


### PR DESCRIPTION
This follows the transitional memory-argument ABI used release 23.11 and will be removed once the ABI transition completes.