### PR TITLE
caprevoke: Add ability to enable revocation on every free at run time

### DIFF
--- a/libexec/rc/rc.d/motd
+++ b/libexec/rc/rc.d/motd
@@ -53,6 +53,11 @@ append_perf_warnings()
 		echo -n " CHERI_CAPREVOKE"
 		echo "WARNING: capability revocation enabled by default, this may affect performance" >> $_t
 	fi
+	runtime_revocation_every_free_default=`sysctl -n security.cheri.runtime_revocation_every_free_default 2> /dev/null`
+	if [ "${runtime_revocation_every_free_default}" = "1" ]; then
+		echo -n " REVOKE_EVERY_FREE"
+		echo "WARNING: capability revocation on every free debugging feature enabled by default, expect greatly reduced performance" >> $_t
+	fi
 }
 
 motd_start()

--- a/sys/cheri/cheri_sysctl.c
+++ b/sys/cheri/cheri_sysctl.c
@@ -80,4 +80,13 @@ int security_cheri_runtime_revocation_default = 1;
 SYSCTL_INT(_security_cheri, OID_AUTO, runtime_revocation_default, CTLFLAG_RWTUN,
     &security_cheri_runtime_revocation_default, 0,
     "Userspace runtime revocation default");
+
+/*
+ * Set the default policy for revocation in userspace.  This is used to
+ * compute the revocation policy flag in AT_BSDFLAGS.
+ */
+int security_cheri_runtime_revocation_every_free_default = 0;
+SYSCTL_INT(_security_cheri, OID_AUTO, runtime_revocation_every_free_default,
+    CTLFLAG_RWTUN, &security_cheri_runtime_revocation_every_free_default, 0,
+    "Userspace runtime revocation on every free for debugging default");
 #endif  /* CHERI_CAPREVOKE */

--- a/sys/cheri/revoke_kern.h
+++ b/sys/cheri/revoke_kern.h
@@ -136,6 +136,7 @@ struct cheri_revoke_info_page {
 SYSCTL_DECL(_vm_cheri_revoke);
 
 extern int security_cheri_runtime_revocation_default;
+extern int security_cheri_runtime_revocation_every_free_default;
 #endif
 
 #endif /* !__SYS_CHERI_REVOKE_KERN_H__ */

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1857,6 +1857,15 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 			bsdflags |= ELF_BSDF_CHERI_REVOKE;
 	} else if (security_cheri_runtime_revocation_default != 0)
 		bsdflags |= ELF_BSDF_CHERI_REVOKE;
+	/*
+	 * ELF_BSDF_CHERI_REVOKE tells the runtime whether to enable the
+	 * revoke every free debug policy if revocation is otherwise enabled.
+	 *
+	 * No procctl/ELF note, only system default (and environment variable in
+	 * userspace).
+	 */
+	if (security_cheri_runtime_revocation_every_free_default != 0)
+		bsdflags |= ELF_BSDF_CHERI_REVOKE_EVERY_FREE;
 #endif
 	AUXARGS_ENTRY(pos, AT_BSDFLAGS, bsdflags);
 	AUXARGS_ENTRY(pos, AT_ARGC, imgp->args->argc);

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -1545,6 +1545,7 @@ typedef struct {
 
 #define	ELF_BSDF_SIGFASTBLK	0x0001	/* Kernel supports fast sigblock */
 #define	ELF_BSDF_VMNOOVERCOMMIT	0x0002
+#define	ELF_BSDF_CHERI_REVOKE_EVERY_FREE	0x40000000
 #define	ELF_BSDF_CHERI_REVOKE	0x80000000	/* Process should quarantine */
 
 #endif /* !_SYS_ELF_COMMON_H_ */


### PR DESCRIPTION
This debugging feature will tank performance but is useful in debugging, as UAF bugs are caught on first use rather than at some unknown point in the future as UAR (if at all). The global system default is only meant to be enabled by people wishing to flush out UAFs from CheriBSD; users should instead use the environment variable.

No proccontrol support is provided so as to discourage its use and make it harder for people to accidentally enable not knowing what they're doing.
