### PR TITLE
Fix mmap(2) with MAP_GUARD for hybrid ABI

### DIFF
--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -2149,7 +2149,7 @@ vm_mmap_object(vm_map_t map, vm_pointer_t *addr, vm_offset_t max_addr,
 	} else {
 		if (max_addr != 0 && *addr + size > max_addr)
 			return (ENOMEM);
-		if (docow & MAP_GUARD)
+		if (docow & MAP_CREATE_GUARD)
 			maxprot = PROT_NONE;
 		if ((flags & MAP_RESERVATION_CREATE) != 0)
 			reservp = addr;


### PR DESCRIPTION
The copy-on-write flag for the MAP_GUARD vm_map operation is spelled MAP_CREATE_GUARD.

With the incorrect MAP_GUARD usage, an mmap(2) call with MAP_GUARD in a hybrid ABI process failed as a result of vm_map_insert1() returning KERN_INVALID_ARGUMENT when the maximum permissions are not VM_PROT_NONE.