### PR TITLE
rc.conf: add /usr/local64cb to rc.d search paths

### DIFF
--- a/libexec/rc/rc.conf
+++ b/libexec/rc/rc.conf
@@ -67,7 +67,8 @@ var_run_autosave="NO" 	# Only restore /var/run structure at shutdown/reboot
 			# manually save the /var/run mtree
 var_run_mtree="/var/db/mtree/BSD.var-run.mtree"
 			# Where to save /var/run mtree
-local_startup="${_localbase}/etc/rc.d /usr/local64/etc/rc.d" # startup script dirs.
+local_startup="${_localbase}/etc/rc.d /usr/local64cb/etc/rc.d /usr/local64/etc/rc.d"
+			# startup script dirs.
 script_name_sep=" "	# Change if your startup scripts' names contain spaces
 rc_conf_files="/etc/rc.conf /etc/rc.conf.local"
 


### PR DESCRIPTION
The order of search paths matches the order of directories in the default value of the PATH environment variable.