### PR TITLE
depend-cleanup.sh: Fix mismerge in OpenSSL 3.0 code

### DIFF
--- a/tools/build/depend-cleanup.sh
+++ b/tools/build/depend-cleanup.sh
@@ -199,10 +199,11 @@ clean_dep   lib/libc        kqueue1 S
 # 20230623  b077aed33b7b    OpenSSL 3.0 update
 if [ -f "$OBJTOP"/secure/lib/libcrypto/aria.o ]; then
 	echo "Removing old OpenSSL 1.1.1 tree"
-	rm -rf "$OBJTOP"/secure/lib/libcrypto \
-	    "$OBJTOP"/secure/lib/libssl \
-	    "$OBJTOP"/obj-lib32/secure/lib/libcrypto \
-	    "$OBJTOP"/obj-lib32/secure/lib/libssl
+	for libcompat in "" $ALL_libcompats; do
+		dirprfx=${libcompat:+obj-lib${libcompat}/}
+		run rm -rf "$OBJTOP"/${dirprfx}secure/lib/libcrypto \
+		    "$OBJTOP"/${dirprfx}secure/lib/libssl
+	done
 fi
 
 # 20230714  ee8b0c436d72    replace ffs/fls implementations with clang builtins


### PR DESCRIPTION
The multiple libcompat support was added upstream after the OpenSSL 3.0
import, so the initial addition of this code hard-coded lib32 only, and
thus missed lib64 (and lib64c). This effectively reapplies 81805ec30074
("depend-cleanup.sh: Generalise lib32 code and avoid duplication") to
get that missing support.

Fixes:	e99e69227dd5 ("depend-cleanup: apply big hammer for OpenSSL 3.0 update")
