### PR TITLE
git subrepo pull contrib/subrepo-cheri-libunwind

### DIFF
--- a/contrib/subrepo-cheri-libunwind/.gitrepo
+++ b/contrib/subrepo-cheri-libunwind/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/CTSRD-CHERI/libunwind.git
 	branch = monorepo-mirror
-	commit = f259b9f6514777f6668b8dd0cfc4481a9a9cb149
+	commit = 00c1abba9013886b55b9ad93c2700277c4f25cfa
 	parent = 62cf0bc0c803707ae44438a51196756b5de444bf
 	method = rebase
-	cmdver = 0.4.6
+	cmdver = 0.4.1

--- a/contrib/subrepo-cheri-libunwind/src/AddressSpace.hpp
+++ b/contrib/subrepo-cheri-libunwind/src/AddressSpace.hpp
@@ -847,17 +847,18 @@ inline bool LocalAddressSpace::findUnwindSections(pc_t targetAddr,
     return true;
   }
 #elif defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND) && defined(_LIBUNWIND_IS_BAREMETAL)
+  (void)targetAddr;
   info.dso_base = 0;
   // Bare metal is statically linked, so no need to ask the dynamic loader
   info.dwarf_section_length = (size_t)(&__eh_frame_end - &__eh_frame_start);
-  info.dwarf_section =        (uintptr_t)(&__eh_frame_start);
+  info.set_dwarf_section((uintptr_t)(&__eh_frame_start));
   _LIBUNWIND_TRACE_UNWINDING("findUnwindSections: section %p length %p",
-                             (void *)info.dwarf_section, (void *)info.dwarf_section_length);
+                             (void *)info.dwarf_section(), (void *)info.dwarf_section_length);
 #if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
-  info.dwarf_index_section =        (uintptr_t)(&__eh_frame_hdr_start);
+  info.set_dwarf_index_section((uintptr_t)(&__eh_frame_hdr_start));
   info.dwarf_index_section_length = (size_t)(&__eh_frame_hdr_end - &__eh_frame_hdr_start);
   _LIBUNWIND_TRACE_UNWINDING("findUnwindSections: index section %p length %p",
-                             (void *)info.dwarf_index_section, (void *)info.dwarf_index_section_length);
+                             (void *)info.dwarf_index_section(), (void *)info.dwarf_index_section_length);
 #endif
   if (info.dwarf_section_length)
     return true;

--- a/contrib/subrepo-cheri-libunwind/src/DwarfInstructions.hpp
+++ b/contrib/subrepo-cheri-libunwind/src/DwarfInstructions.hpp
@@ -84,7 +84,7 @@ private:
       *success = false;
       return (pint_t)-1;
     }
-    if (!is_pointer_in_bounds(result)) {
+    if (!is_pointer_in_bounds(result, true)) {
       _LIBUNWIND_LOG("evaluated out-of-bounds/invalid CFA "
                      "expression for pc %#tx: " _LIBUNWIND_FMT_PTR "\n",
                      (ptrdiff_t)pc.address(), (void *)result);

--- a/contrib/subrepo-cheri-libunwind/src/config.h
+++ b/contrib/subrepo-cheri-libunwind/src/config.h
@@ -194,23 +194,26 @@
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-static inline bool is_pointer_in_bounds(uintptr_t value) {
+static inline bool is_pointer_in_bounds(uintptr_t value, bool include_top) {
   ptraddr_t addr = (ptraddr_t)value;
   ptraddr_t base = __builtin_cheri_base_get(value);
   ptraddr_t top = base + __builtin_cheri_length_get(value);
-  return __builtin_cheri_tag_get(value) && addr >= base && addr < top;
+  return __builtin_cheri_tag_get(value) && addr >= base &&
+         (include_top ? addr <= top : addr < top);
 }
 
 static inline uintptr_t assert_pointer_in_bounds(uintptr_t value) {
-  if (!is_pointer_in_bounds(value)) {
+  // XXX: Should some callers include the top?
+  if (!is_pointer_in_bounds(value, false)) {
     _LIBUNWIND_ABORT_FMT(
         "Out-of-bounds/invalid value used: " _LIBUNWIND_FMT_PTR, (void *)value);
   }
   return value;
 }
 #else
-static inline bool is_pointer_in_bounds(uintptr_t value) {
+static inline bool is_pointer_in_bounds(uintptr_t value, bool include_top) {
   (void)value;
+  (void)include_top;
   return true;
 }
 static inline uintptr_t assert_pointer_in_bounds(uintptr_t value) {


### PR DESCRIPTION
```
subrepo:
  subdir:   "contrib/subrepo-cheri-libunwind"
  merged:   "a11aebfb1a54"
upstream:
  origin:   "https://github.com/CTSRD-CHERI/libunwind.git"
  branch:   "monorepo-mirror"
  commit:   "00c1abba9013"
git-subrepo:
  version:  "0.4.1"
  origin:   "https://github.com/ingydotnet/git-subrepo.git"
  commit:   "1f13869"
```

NB: Incorporates the following commits:

```
commit 049700932e2f0fd301feee43db660c38a0be389d
Author: Jessica Clarke <jrtc27@jrtc27.com>
Date:   Thu Nov 30 23:37:02 2023 +0000

    [libunwind] Don't skip unwinding last frame in call stack

    Having the CFA be exactly at the capability top is expected at the top
    of the call stack on secondary threads, so fix this off-by-one error
    such that those frames are not skipped, only ones where the CFA is
    strictly out-of-bounds.

    This is a targeted fix solely for DwarfInstructions::getCFA; it is
    highly likely that some of the calls to assert_pointer_in_bounds are
    overly strict. It's also likely some are overly weak since, if in
    bounds, they probably want more than a single byte, but that's less of
    a concern, since these are just to aid in catching nonsense states
    early rather than crashing in a confusing manner later.

commit e0146d0ef2efd23282acc05f823bdae5710735fb
Author: Jessica Clarke <jrtc27@jrtc27.com>
Date:   Thu Nov 30 18:09:30 2023 +0000

    [libunwind] Add support for Morello pure-capability benchmark ABI

    Extracted from my prior CheriBSD commit.

commit 2da4fc28b2f7dc12db2f262769864187c6863f8d
Author: Alex Richardson <Alexander.Richardson@cl.cam.ac.uk>
Date:   Wed Sep 13 16:01:41 2023 -0700

    [libunwind] Fix baremetal build
```
