### PR TITLE
stdint.h: define PTRADDR_MAX

### DIFF
--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -124,6 +124,9 @@ typedef	__ptraddr_t		ptraddr_t;
 #define	_PTRADDR_T_DECLARED
 #endif
 
+/* Limits of ptraddr_t. */
+#define	PTRADDR_MAX		SIZE_MAX
+
 #ifndef _VADDR_T_DECLARED
 __attribute__((__deprecated__("use ptraddr_t instead")))
 typedef	ptraddr_t		vaddr_t;


### PR DESCRIPTION
In the interest of diff reduction, centrally define it to SIZE_MAX since they are the same on all practical architectures rather than editing each machine/_stdint.h as per standard practice.

Fixes:	#1793