### PR TITLE
ldconfig: Fix script to always add specified directories

### DIFF
--- a/libexec/rc/rc.d/ldconfig
+++ b/libexec/rc/rc.d/ldconfig
@@ -32,9 +32,7 @@ ldconfig_paths()
 		fi
 	done
 	for _ii in ${_paths} ${_soconf}; do
-		if [ -r "${_ii}" ]; then
-			_ldpaths="${_ldpaths} ${_ii}"
-		fi
+		_ldpaths="${_ldpaths} ${_ii}"
 	done
 
 	echo "${_ldpaths}"


### PR DESCRIPTION
The current ldconfig script does not add a path if it does not exist. However, if a directory is initially non-existent but added later, libraries in that directory will not be searched by the dynamic linker.