### PR TITLE
bsd.lib.mk: Use correct debug directory for lib64cb

### DIFF
--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -258,7 +258,7 @@ SHLIB_NAME_FULL=${SHLIB_NAME}.full
 # Use ${DEBUGDIR} for base system debug files, else .debug subdirectory
 .if ${_SHLIBDIR} == "/boot" ||\
     ${SHLIBDIR:C%/lib(/.*)?$%/lib%} == "/lib" ||\
-    ${SHLIBDIR:C%/usr/(tests/)?lib(32|64|64c|exec)?(/.*)?%/usr/lib%} == "/usr/lib"
+    ${SHLIBDIR:C%/usr/(tests/)?lib(32|64|64c|64cb|exec)?(/.*)?%/usr/lib%} == "/usr/lib"
 DEBUGFILEDIR=${DEBUGDIR}${_SHLIBDIR}
 .else
 DEBUGFILEDIR=${_SHLIBDIR}/.debug


### PR DESCRIPTION
Due to not containing a literal lib32 or lib64 this slipped through the
cracks when generalising the build system to not hard-code the set of
libcompats everywhere. For now just fix it up manually rather than try
and generalise this one, which should be done later upstream.

Fixes:	3215005566be ("arm64: Add new lib64cb libcompat for purecap benchmark ABI")
