### PR TITLE
Add auto-truncate to bsddialog and use for bsdinstall

### DIFF
--- a/contrib/bsddialog/bsddialog.c
+++ b/contrib/bsddialog/bsddialog.c
@@ -47,6 +47,7 @@ enum OPTS {
 	ALTERNATE_SCREEN = '?' + 1,
 	AND_DIALOG,
 	ASCII_LINES,
+	AUTO_TRUNCATE,
 	BACKTITLE,
 	BEGIN_X,
 	BEGIN_Y,
@@ -82,6 +83,7 @@ enum OPTS {
 	ITEM_PREFIX,
 	LOAD_THEME,
 	MAX_INPUT,
+	NO_AUTO_TRUNCATE,
 	NO_CANCEL,
 	NO_DESCRIPTIONS,
 	NO_LINES,
@@ -140,6 +142,7 @@ static struct option longopts[] = {
 	{"and-dialog",        no_argument,       NULL, AND_DIALOG},
 	{"and-widget",        no_argument,       NULL, AND_DIALOG},
 	{"ascii-lines",       no_argument,       NULL, ASCII_LINES},
+	{"auto-truncate",     no_argument,       NULL, AUTO_TRUNCATE},
 	{"backtitle",         required_argument, NULL, BACKTITLE},
 	{"begin-x",           required_argument, NULL, BEGIN_X},
 	{"begin-y",           required_argument, NULL, BEGIN_Y},
@@ -180,6 +183,7 @@ static struct option longopts[] = {
 	{"keep-tite",         no_argument,       NULL, ALTERNATE_SCREEN},
 	{"load-theme",        required_argument, NULL, LOAD_THEME},
 	{"max-input",         required_argument, NULL, MAX_INPUT},
+	{"no-auto-truncate",  no_argument,       NULL, NO_AUTO_TRUNCATE},
 	{"no-cancel",         no_argument,       NULL, NO_CANCEL},
 	{"nocancel",          no_argument,       NULL, NO_CANCEL},
 	{"no-descriptions",   no_argument,       NULL, NO_DESCRIPTIONS},
@@ -496,6 +500,9 @@ static int parseargs(int argc, char **argv, struct bsddialog_conf *conf)
 		case ASCII_LINES:
 			conf->ascii_lines = true;
 			break;
+		case AUTO_TRUNCATE:
+			conf->auto_truncate = true;
+			break;
 		case BACKTITLE:
 			backtitle_opt = optarg;
 			if (conf->y == BSDDIALOG_CENTER)
@@ -610,6 +617,9 @@ static int parseargs(int argc, char **argv, struct bsddialog_conf *conf)
 			break;
 		case MAX_INPUT:
 			max_input_form_opt = (u_int)strtoul(optarg, NULL, 10);
+			break;
+		case NO_AUTO_TRUNCATE:
+			conf->auto_truncate = false;
 			break;
 		case NO_CANCEL:
 			conf->button.without_cancel = true;

--- a/contrib/bsddialog/lib/bsddialog.h
+++ b/contrib/bsddialog/lib/bsddialog.h
@@ -73,6 +73,7 @@
 
 struct bsddialog_conf {
 	bool ascii_lines;
+	bool auto_truncate;
 	unsigned int auto_minheight;
 	unsigned int auto_minwidth;
 	unsigned int auto_topmargin;

--- a/contrib/bsddialog/lib/lib_util.c
+++ b/contrib/bsddialog/lib/lib_util.c
@@ -143,6 +143,31 @@ unsigned int strcols(const char *mbstring)
 	return (ncol);
 }
 
+char *strcolseek(const char *mbstring, unsigned int ncol)
+{
+	int w;
+	size_t charlen, mb_cur_max;
+	wchar_t wch;
+	mbstate_t mbs;
+
+	mb_cur_max = MB_CUR_MAX;
+	memset(&mbs, 0, sizeof(mbs));
+	while ((charlen = mbrlen(mbstring, mb_cur_max, &mbs)) != 0 &&
+	    charlen != (size_t)-1 && charlen != (size_t)-2) {
+		if (mbtowc(&wch, mbstring, mb_cur_max) < 0)
+			return (NULL);
+		w = (wch == L'\t') ? TABSIZE : wcwidth(wch);
+		if (w < 0)
+			w = 0;
+		if (ncol < (unsigned int)w)
+			return (__DECONST(char *, mbstring));
+		ncol -= w;
+		mbstring += charlen;
+	}
+
+	return (NULL);
+}
+
 /* Clear */
 int hide_widget(int y, int x, int h, int w, bool withshadow)
 {

--- a/contrib/bsddialog/lib/lib_util.h
+++ b/contrib/bsddialog/lib/lib_util.h
@@ -48,6 +48,7 @@ extern bool hastermcolors;
 
 /* unicode */
 unsigned int strcols(const char *mbstring);
+char *strcolseek(const char *mbstring, unsigned int ncol);
 int str_props(const char *mbstring, unsigned int *cols, bool *has_multi_col);
 void mvwaddwch(WINDOW *w, int y, int x, wchar_t wch);
 wchar_t* alloc_mbstows(const char *mbstring);

--- a/usr.sbin/bsdinstall/distextract/distextract.c
+++ b/usr.sbin/bsdinstall/distextract/distextract.c
@@ -140,6 +140,7 @@ main(void)
 
 	conf.title = "Archive Extraction";
 	conf.auto_minwidth = 40;
+	conf.auto_truncate = true;
 	pvconf.callback	= extract_files;
 	pvconf.refresh = 1;
 	pvconf.fmtbottomstr = "%10lli files read @ %'9.1f files/sec.";

--- a/usr.sbin/bsdinstall/scripts/checksum
+++ b/usr.sbin/bsdinstall/scripts/checksum
@@ -30,14 +30,20 @@ test -f $BSDINSTALL_DISTDIR/MANIFEST || exit 0
 BSDCFG_SHARE="/usr/share/bsdconfig"
 . $BSDCFG_SHARE/common.subr || exit 1
 
+dist_to_statusvar()
+{
+	printf 'status_'
+	echo "$1" | sed 's/_/__/g;s/\./_dot_/g;s/-/_dash_/g'
+}
+
 percentage=0
 for dist in $DISTRIBUTIONS; do
-	distname=$(basename $dist .txz)
-	eval "status_$distname=-8"
+	statusvar=$(dist_to_statusvar $dist)
+	eval "$statusvar=-8"
 
 	items=""
 	for i in $DISTRIBUTIONS; do
-		items="$items $i `eval echo \\\${status_$(basename $i .txz):--11}`"
+		items="$items $i `eval echo \\\${$(dist_to_statusvar $i):--11}`"
 	done
 	bsddialog --backtitle "$OSNAME Installer" --title "Checksum Verification" \
 	    --mixedgauge "\nVerifying checksums of selected distributions.\n" \
@@ -57,13 +63,13 @@ for dist in $DISTRIBUTIONS; do
 	CK_VALID=$?
 	if [ $CK_VALID -le 1 ]; then
 		if [ $CK_VALID -eq 0 ]; then
-			eval "status_$distname=-3"
+			eval "$statusvar=-3"
 		else
-			eval "status_$distname=-7"
+			eval "$statusvar=-7"
 		fi
 		percentage=$(echo $percentage + 100/`echo $DISTRIBUTIONS | wc -w` | bc)
 	else
-		eval "status_$distname=-2"
+		eval "$statusvar=-2"
 		case $(/bin/freebsd-version -u) in
 		*-ALPHA*|*-CURRENT|*-STABLE|*-PRERELEASE)
 			bsddialog --backtitle "$OSNAME Installer" --title "Error" \

--- a/usr.sbin/bsdinstall/scripts/checksum
+++ b/usr.sbin/bsdinstall/scripts/checksum
@@ -46,6 +46,7 @@ for dist in $DISTRIBUTIONS; do
 		items="$items $i `eval echo \\\${$(dist_to_statusvar $i):--11}`"
 	done
 	bsddialog --backtitle "$OSNAME Installer" --title "Checksum Verification" \
+	    --auto-truncate \
 	    --mixedgauge "\nVerifying checksums of selected distributions.\n" \
 	    0 0 $percentage  -- $items
 


### PR DESCRIPTION
- bsdinstall: Encode dists to valid variable names in checksum script
- bsddialog: Optionally truncate long mixedgauge labels and screens
- bsdinstall: Enable bsddialog auto-truncate for distextract and checksum
