### PR TITLE
Various bhyve fixes to allow booting Linux

### DIFF
--- a/sys/arm64/vmm/io/vgic.c
+++ b/sys/arm64/vmm/io/vgic.c
@@ -81,6 +81,12 @@ vgic_vmcleanup(struct hyp *hyp)
 	VGIC_VMCLEANUP(vgic_dev, hyp);
 }
 
+int
+vgic_max_cpu_count(struct hyp *hyp)
+{
+	return (VGIC_MAX_CPU_COUNT(vgic_dev, hyp));
+}
+
 bool
 vgic_has_pending_irq(struct hypctx *hypctx)
 {

--- a/sys/arm64/vmm/io/vgic.h
+++ b/sys/arm64/vmm/io/vgic.h
@@ -40,6 +40,7 @@ void vgic_vminit(struct hyp *hyp);
 void vgic_cpuinit(struct hypctx *hypctx);
 void vgic_cpucleanup(struct hypctx *hypctx);
 void vgic_vmcleanup(struct hyp *hyp);
+int vgic_max_cpu_count(struct hyp *hyp);
 bool vgic_has_pending_irq(struct hypctx *hypctx);
 int vgic_inject_irq(struct hyp *hyp, int vcpuid, uint32_t irqid, bool level);
 int vgic_inject_msi(struct hyp *hyp, uint64_t msg, uint64_t addr);

--- a/sys/arm64/vmm/io/vgic_if.m
+++ b/sys/arm64/vmm/io/vgic_if.m
@@ -66,6 +66,11 @@ METHOD void vmcleanup {
 	struct hyp *hyp;
 }
 
+METHOD int max_cpu_count {
+	device_t dev;
+	struct hyp *hyp;
+}
+
 METHOD bool has_pending_irq {
 	device_t dev;
 	struct hypctx *hypctx;

--- a/sys/arm64/vmm/io/vgic_v3.c
+++ b/sys/arm64/vmm/io/vgic_v3.c
@@ -1639,6 +1639,10 @@ redist_read(struct vcpu *vcpu, uint64_t fault_ipa, uintcap_t *rval,
 	/* Find the target vcpu ctx for the access */
 	target_hypctx = hyp->ctx[vcpuid];
 
+	/* Require all vcpus to be initialised */
+	if (target_hypctx == NULL)
+		return (EINVAL);
+
 	/* Check the register is correctly aligned */
 	if ((reg & (size - 1)) != 0)
 		return (EINVAL);
@@ -1696,6 +1700,10 @@ redist_write(struct vcpu *vcpu, uint64_t fault_ipa, uintcap_t wval,
 
 	/* Find the target vcpu ctx for the access */
 	target_hypctx = hyp->ctx[vcpuid];
+
+	/* Require all vcpus to be initialised */
+	if (target_hypctx == NULL)
+		return (EINVAL);
 
 	/* Check the register is correctly aligned */
 	if ((reg & (size - 1)) != 0)

--- a/sys/arm64/vmm/vmm.c
+++ b/sys/arm64/vmm/vmm.c
@@ -414,6 +414,10 @@ vm_alloc_vcpu(struct vm *vm, int vcpuid)
 	if (vcpuid < 0 || vcpuid >= vm_get_maxcpus(vm))
 		return (NULL);
 
+	/* Some interrupt controllers may have a CPU limit */
+	if (vcpuid >= vgic_max_cpu_count(vm->cookie))
+		return (NULL);
+
 	vcpu = atomic_load_ptr(&vm->vcpu[vcpuid]);
 	if (__predict_true(vcpu != NULL))
 		return (vcpu);
@@ -477,7 +481,7 @@ vm_create(const char *name, struct vm **retvm)
 	vm->sockets = 1;
 	vm->cores = 1;			/* XXX backwards compatibility */
 	vm->threads = 1;		/* XXX backwards compatibility */
-	vm->maxcpus = VM_MAXCPU;	/* XXX temp to keep code working */
+	vm->maxcpus = vm_maxcpu;
 
 	vm->vcpu = malloc(sizeof(*vm->vcpu) * vm->maxcpus, M_VMM,
 	    M_WAITOK | M_ZERO);

--- a/sys/arm64/vmm/vmm_instruction_emul.c
+++ b/sys/arm64/vmm/vmm_instruction_emul.c
@@ -66,6 +66,9 @@ vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 		error = vm_get_register(vcpu, vie->reg, &val);
 		if (error)
 			goto out;
+		/* Mask any unneeded bits from the register */
+		if (vie->access_size < 8)
+			val &= (1ul << (vie->access_size * 8)) - 1;
 		error = memwrite(vcpu, gpa, val, vie->access_size, memarg);
 	}
 

--- a/usr.sbin/bhyve/aarch64/fdt.c
+++ b/usr.sbin/bhyve/aarch64/fdt.c
@@ -192,6 +192,7 @@ fdt_add_gic(uint64_t dist_base, uint64_t dist_size,
 	    &prop);
 	SET_PROP_U32(prop, 0, 256);
 	SET_PROP_U32(prop, 1, 64);
+	fdt_property(fdt, "msi-controller", NULL, 0);
 
 	fdt_end_node(fdt);
 


### PR DESCRIPTION
First commit imports https://reviews.freebsd.org/D37428#979293. Later commits fix further issues with it and tweak userspace accordingly.

NB: sysutils/u-boot-bhyve-arm64 needs the following diff:

```diff
diff --git a/sysutils/u-boot-bhyve-arm64/Makefile b/sysutils/u-boot-bhyve-arm64/Makefile
index 5f024f30df6a..2e83ba4946fd 100644
--- a/sysutils/u-boot-bhyve-arm64/Makefile
+++ b/sysutils/u-boot-bhyve-arm64/Makefile
@@ -1,5 +1,7 @@
 MASTERDIR=     ${.CURDIR}/../u-boot-master
 
+U_BOOT_SLAVE_PORTREVISION_2023.07.02=  1
+
 MODEL=         bhyve-arm64
 BOARD_CONFIG=  bhyve_arm64_defconfig
 FAMILY=                bhyve
diff --git a/sysutils/u-boot-bhyve-arm64/files/patch-board_emulation_bhyve-arm_bhyve-arm.c b/sysutils/u-boot-bhyve-arm64/files/patch-board_emulation_bhyve-arm_bhyve-arm.c
index 9cf46325cc08..38ef6709ffcb 100644
--- a/sysutils/u-boot-bhyve-arm64/files/patch-board_emulation_bhyve-arm_bhyve-arm.c
+++ b/sysutils/u-boot-bhyve-arm64/files/patch-board_emulation_bhyve-arm_bhyve-arm.c
@@ -36,7 +36,7 @@
 +              /* GICv3 */
 +              .virt = 0x2f100000UL,
 +              .phys = 0x2f100000UL,
-+              .size = 0x20000UL,
++              .size = 0xf00000UL,
 +              .attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
 +                       PTE_BLOCK_NON_SHARE |
 +                       PTE_BLOCK_PXN | PTE_BLOCK_UXN
```