### PR TITLE
arm64: Sync rest of VMM code with upstream review

### DIFF
--- a/sys/arm64/vmm/arm64.h
+++ b/sys/arm64/vmm/arm64.h
@@ -1,4 +1,6 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2015 Mihai Carabas <mihai.carabas@gmail.com>
  * All rights reserved.
  *

--- a/sys/arm64/vmm/hyp.h
+++ b/sys/arm64/vmm/hyp.h
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2017 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/sys/arm64/vmm/io/vgic.c
+++ b/sys/arm64/vmm/io/vgic.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2023 Arm Ltd
  *
  * Redistribution and use in source and binary forms, with or without

--- a/sys/arm64/vmm/io/vgic.h
+++ b/sys/arm64/vmm/io/vgic.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2023 Arm Ltd
  *
  * Redistribution and use in source and binary forms, with or without

--- a/sys/arm64/vmm/io/vgic_if.m
+++ b/sys/arm64/vmm/io/vgic_if.m
@@ -1,4 +1,6 @@
 #-
+# SPDX-License-Identifier: BSD-2-Clause
+#
 # Copyright (c) 2023 Arm Ltd
 #
 # Redistribution and use in source and binary forms, with or without

--- a/sys/arm64/vmm/io/vgic_v3.c
+++ b/sys/arm64/vmm/io/vgic_v3.c
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2018 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  * Copyright (C) 2020-2022 Andrew Turner
  * Copyright (C) 2023 Arm Ltd
  *

--- a/sys/arm64/vmm/io/vgic_v3.h
+++ b/sys/arm64/vmm/io/vgic_v3.h
@@ -1,4 +1,6 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2015 Mihai Carabas <mihai.carabas@gmail.com>
  * All rights reserved.
  *

--- a/sys/arm64/vmm/io/vgic_v3_reg.h
+++ b/sys/arm64/vmm/io/vgic_v3_reg.h
@@ -1,4 +1,6 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2018 The FreeBSD Foundation
  *
  * This software was developed by Alexandru Elisei under sponsorship

--- a/sys/arm64/vmm/io/vtimer.c
+++ b/sys/arm64/vmm/io/vtimer.c
@@ -57,7 +57,6 @@
 
 static uint64_t cnthctl_el2_reg;
 static uint32_t tmr_frq;
-static bool have_vtimer = false;
 
 #define timer_condition_met(ctl)	((ctl) & CNTP_CTL_ISTATUS)
 
@@ -69,11 +68,6 @@ vtimer_virtual_timer_intr(void *arg)
 	struct hypctx *hypctx;
 	uint64_t cntpct_el0;
 	uint32_t cntv_ctl;
-
-	/*
-	 * TODO everything here is very strange. The relantionship between the
-	 * hardware value and the value in memory is not clear at all.
-	 */
 
 	hypctx = arm64_get_active_vcpu();
 	cntv_ctl = READ_SPECIALREG(cntv_ctl_el0);
@@ -491,7 +485,6 @@ vtimer_attach(device_t dev)
 	bus_setup_intr(dev, sc->res, INTR_TYPE_CLK, vtimer_virtual_timer_intr,
 	    NULL, NULL, &sc->ihl);
 
-	have_vtimer = true;
 	return (0);
 }
 

--- a/sys/arm64/vmm/io/vtimer.c
+++ b/sys/arm64/vmm/io/vtimer.c
@@ -1,6 +1,7 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 The FreeBSD Foundation
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/sys/arm64/vmm/io/vtimer.h
+++ b/sys/arm64/vmm/io/vtimer.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 The FreeBSD Foundation
  *
  * Redistribution and use in source and binary forms, with or without

--- a/sys/arm64/vmm/mmu.h
+++ b/sys/arm64/vmm/mmu.h
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2017 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  *
  * This software was developed by Alexandru Elisei under sponsorship
  * from the FreeBSD Foundation.

--- a/sys/arm64/vmm/reset.h
+++ b/sys/arm64/vmm/reset.h
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2018 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/sys/arm64/vmm/vmm.c
+++ b/sys/arm64/vmm/vmm.c
@@ -1,4 +1,6 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2015 Mihai Carabas <mihai.carabas@gmail.com>
  * All rights reserved.
  *

--- a/sys/arm64/vmm/vmm_arm64.c
+++ b/sys/arm64/vmm/vmm_arm64.c
@@ -1002,18 +1002,25 @@ vmmops_gla2gpa(void *vcpui, struct vm_guest_paging *paging, uint64_t gla,
 	 */
 	switch (granule_shift) {
 	case PAGE_SHIFT_4K:
+	case PAGE_SHIFT_16K:
 		/*
 		 * See "Table D8-11 4KB granule, determining stage 1 initial
-		 * lookup level" from the "Arm Architecture Reference Manual
-		 * for A-Profile architecture" revision I.a for the minimum
-		 * and maximum values.
+		 * lookup level" and "Table D8-21 16KB granule, determining
+		 * stage 1 initial lookup level" from the "Arm Architecture
+		 * Reference Manual for A-Profile architecture" revision I.a
+		 * for the minimum and maximum values.
+		 *
+		 * TODO: Support less than 16 when FEAT_LPA2 is implemented
+		 * and TCR_EL1.DS == 1
+		 * TODO: Support more than 39 when FEAT_TTST is implemented
 		 */
 		if (tsz < 16 || tsz > 39) {
 			*is_fault = 1;
 			return (EINVAL);
 		}
 		break;
-	/* TODO: Support non-4k granule */
+	case PAGE_SHIFT_64K:
+	/* TODO: Support 64k granule. It will probably work, but is untested */
 	default:
 		*is_fault = 1;
 		return (EINVAL);
@@ -1048,17 +1055,18 @@ vmmops_gla2gpa(void *vcpui, struct vm_guest_paging *paging, uint64_t gla,
 	for (;levels > 0; levels--) {
 		int idx;
 
-		/* TODO: ptp_hold works on host pages */
-		ptep = ptp_hold(hypctx->vcpu, pte_addr, 1 << granule_shift,
-		    &cookie);
-		if (ptep == NULL) {
-			*is_fault = 1;
-			return (EINVAL);
-		}
 		pte_shift = (levels - 1) * (granule_shift - PTE_SHIFT) +
 		    granule_shift;
 		idx = (gla >> pte_shift) &
 		    ((1ul << (granule_shift - PTE_SHIFT)) - 1);
+		while (idx > PAGE_SIZE / sizeof(pte)) {
+			idx -= PAGE_SIZE / sizeof(pte);
+			pte_addr += PAGE_SIZE;
+		}
+
+		ptep = ptp_hold(hypctx->vcpu, pte_addr, PAGE_SIZE, &cookie);
+		if (ptep == NULL)
+			goto error;
 		pte = ptep[idx];
 
 		/* Calculate the level we are looking at */
@@ -1124,6 +1132,9 @@ done:
 	ptp_release(&cookie);
 	return (0);
 
+error:
+	ptp_release(&cookie);
+	return (EFAULT);
 fault:
 	*is_fault = 1;
 	ptp_release(&cookie);

--- a/sys/arm64/vmm/vmm_call.S
+++ b/sys/arm64/vmm/vmm_call.S
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2017 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  *
  * This software was developed by Alexandru Elisei under sponsorship
  * from the FreeBSD Foundation.

--- a/sys/arm64/vmm/vmm_dev.c
+++ b/sys/arm64/vmm/vmm_dev.c
@@ -1,4 +1,6 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2015 Mihai Carabas <mihai.carabas@gmail.com>
  * All rights reserved.
  *

--- a/sys/arm64/vmm/vmm_hyp.c
+++ b/sys/arm64/vmm/vmm_hyp.c
@@ -625,26 +625,11 @@ vmm_hyp_read_reg(uint64_t reg)
 	return (0);
 }
 
-static bool
-vmm_is_vpipt_cache(void)
-{
-	/* TODO: Implement */
-	return (0);
-}
-
 static int
 vmm_clean_s2_tlbi(void)
 {
 	dsb(ishst);
 	__asm __volatile("tlbi alle1is");
-
-	/*
-	 * If we have a VPIPT icache it will use the VMID to tag cachelines.
-	 * As we are changing the allocated VMIDs we need to invalidate the
-	 * icache lines containing all old values.
-	 */
-	if (vmm_is_vpipt_cache())
-		__asm __volatile("ic ialluis");
 	dsb(ish);
 
 	return (0);

--- a/sys/arm64/vmm/vmm_hyp_exception.S
+++ b/sys/arm64/vmm/vmm_hyp_exception.S
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2017 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  * Copyright (c) 2021 Andrew Turner
  *
  * This software was developed by Alexandru Elisei under sponsorship

--- a/sys/arm64/vmm/vmm_instruction_emul.c
+++ b/sys/arm64/vmm/vmm_instruction_emul.c
@@ -1,4 +1,6 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2015 Mihai Carabas <mihai.carabas@gmail.com>
  * All rights reserved.
  *

--- a/sys/arm64/vmm/vmm_mmu.c
+++ b/sys/arm64/vmm/vmm_mmu.c
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2017 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  *
  * This software was developed by Alexandru Elisei under sponsorship
  * from the FreeBSD Foundation.

--- a/sys/arm64/vmm/vmm_reset.c
+++ b/sys/arm64/vmm/vmm_reset.c
@@ -1,6 +1,7 @@
-/*
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2018 Alexandru Elisei <alexandru.elisei@gmail.com>
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -179,14 +179,14 @@ arm64/vmm/vmm_arm64.c				optional vmm
 arm64/vmm/vmm_reset.c				optional vmm
 arm64/vmm/vmm_call.S				optional vmm
 arm64/vmm/vmm_hyp_exception.S			optional vmm		\
-	compile-with	"${NORMAL_C} -fpie"				\
+	compile-with	"${NORMAL_C:N-fsanitize*:N-mbranch-protection*} -fpie"		\
 	no-obj
 arm64/vmm/vmm_hyp.c				optional vmm		\
-	compile-with	"${NORMAL_C} -fpie"				\
+	compile-with	"${NORMAL_C:N-fsanitize*:N-mbranch-protection*} -fpie"		\
 	no-obj
 vmm_hyp_blob.elf.full				optional vmm		\
 	dependency	"vmm_hyp.o vmm_hyp_exception.o"			\
-	compile-with	"${CC} -o ${.TARGET} ${.ALLSRC} -fPIE -nostdlib -T ${LDSCRIPT} -Wl,--defsym=text_start='0x0'"	\
+	compile-with	"${SYSTEM_LD_BASECMD} -o ${.TARGET} ${.ALLSRC} --defsym=text_start='0x0'"	\
 	no-obj no-implicit-rule
 vmm_hyp_blob.elf				optional vmm		\
 	dependency	"vmm_hyp_blob.elf.full"				\
@@ -199,7 +199,9 @@ vmm_hyp_blob.bin				optional vmm		\
 arm64/vmm/vmm_hyp_el2.S				optional vmm		\
 	dependency	vmm_hyp_blob.bin
 arm64/vmm/vmm_mmu.c				optional vmm
+arm64/vmm/io/vgic.c				optional vmm
 arm64/vmm/io/vgic_v3.c				optional vmm
+arm64/vmm/io/vgic_if.m				optional vmm
 arm64/vmm/io/vtimer.c				optional vmm
 
 crypto/armv8/armv8_crypto.c			optional armv8crypto

--- a/sys/modules/vmm/Makefile
+++ b/sys/modules/vmm/Makefile
@@ -38,15 +38,20 @@ SRCS+=	vmm_hyp_exception.S vmm_hyp.c
 CLEANFILES+=	vmm_hyp_blob.elf.full
 CLEANFILES+=	vmm_hyp_blob.elf vmm_hyp_blob.bin
 
-CFLAGS.vmm_hyp_exception.S += -fpie
-CFLAGS.vmm_hyp.c += -fpie
-vmm_hyp_exception.o:	vmm_hyp_exception.S
+vmm_hyp_exception.o: vmm_hyp_exception.S
+	${CC} -c -x assembler-with-cpp -DLOCORE \
+	    ${CFLAGS:N-fsanitize*:N-mbranch-protection*} \
+	    ${.IMPSRC} -o ${.TARGET} -fpie
+
 vmm_hyp.o: vmm_hyp.c
+	${CC} -c ${CFLAGS:N-fsanitize*:N-mbranch-protection*} \
+	    ${.IMPSRC} -o ${.TARGET} -fpie
 
 vmm_hyp_blob.elf.full:	vmm_hyp_exception.o vmm_hyp.o
-	${CC} -o ${.TARGET} ${.ALLSRC} -fPIE -nostdlib \
-	    -T ${SYSDIR}/conf/ldscript.arm64 \
-	    -Wl,--defsym=text_start='0x0'
+	${LD} -m ${LD_EMULATION} -Bdynamic -T ${SYSDIR}/conf/ldscript.arm64 \
+	${_LDFLAGS} --no-warn-mismatch --warn-common --export-dynamic \
+	--dynamic-linker /red/herring -X -o ${.TARGET} ${.ALLSRC} \
+	--defsym=text_start='0x0'
 
 vmm_hyp_blob.elf:	vmm_hyp_blob.elf.full
 	${OBJCOPY} --strip-debug ${.ALLSRC} ${.TARGET}


### PR DESCRIPTION
- arm64: Sync vmm copyright headers with upstream review
- arm64: Sync vtimer with upstream review
- arm64: Sync vmmops_gla2gpa with upstream review
- arm64: Pull in vmm VPIPT code removal from upstream review
- arm64: Pull in vmm build system fixes from upstream review

"arm64: Sync vmmops_gla2gpa with upstream review" is a possible concern (@markjdb this seems to differ from how you handled the failure in CheriBSD, so would appreciate your review there if you've not already seen the change in the upstream review). The rest should all be very low risk (comments, deleting dead code and build system fixes).
