### PR TITLE
arm64: Add credential to vmm cdev object and use for lookup

### DIFF
--- a/sys/arm64/vmm/vmm_dev.c
+++ b/sys/arm64/vmm/vmm_dev.c
@@ -64,6 +64,7 @@ struct devmem_softc {
 struct vmmdev_softc {
 	struct vm	*vm;		/* vm instance cookie */
 	struct cdev	*cdev;
+	struct ucred	*ucred;
 	SLIST_ENTRY(vmmdev_softc) link;
 	SLIST_HEAD(, devmem_softc) devmem;
 	int		flags;
@@ -177,6 +178,12 @@ vmmdev_lookup(const char *name)
 		if (strcmp(name, vm_name(sc->vm)) == 0)
 			break;
 	}
+
+	if (sc == NULL)
+		return (NULL);
+
+	if (cr_cansee(curthread->td_ucred, sc->ucred))
+		return (NULL);
 
 	return (sc);
 }
@@ -774,6 +781,9 @@ vmmdev_destroy(void *arg)
 	if (sc->vm != NULL)
 		vm_destroy(sc->vm);
 
+	if (sc->ucred != NULL)
+		crfree(sc->ucred);
+
 	if ((sc->flags & VSC_LINKED) != 0) {
 		mtx_lock(&vmmdev_mtx);
 		SLIST_REMOVE(&head, sc, vmmdev_softc, link);
@@ -891,6 +901,7 @@ sysctl_vmm_create(SYSCTL_HANDLER_ARGS)
 		goto out;
 
 	sc = malloc(sizeof(struct vmmdev_softc), M_VMMDEV, M_WAITOK | M_ZERO);
+	sc->ucred = crhold(curthread->td_ucred);
 	sc->vm = vm;
 	SLIST_INIT(&sc->devmem);
 
@@ -912,8 +923,8 @@ sysctl_vmm_create(SYSCTL_HANDLER_ARGS)
 		goto out;
 	}
 
-	error = make_dev_p(MAKEDEV_CHECKNAME, &cdev, &vmmdevsw, NULL,
-			   UID_ROOT, GID_WHEEL, 0600, "vmm/%s", buf);
+	error = make_dev_p(MAKEDEV_CHECKNAME, &cdev, &vmmdevsw, sc->ucred,
+	    UID_ROOT, GID_WHEEL, 0600, "vmm/%s", buf);
 	if (error != 0) {
 		vmmdev_destroy(sc);
 		goto out;


### PR DESCRIPTION
Applies a85404906bc8 ("vmm: Add credential to cdev object") to arm64's
outdated fork of amd64's vmm_dev.c, preventing processes in one jail
accessing VMs in another. Patch applies cleanly without any conflicts.
