### PR TITLE
POSIX shared memory largepage fixes

### DIFF
--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -6333,6 +6333,8 @@ vm_map_reservation_get(vm_map_t map, vm_offset_t start, vm_size_t length,
 	MPASS((map->flags & MAP_RESERVATIONS));
 
 	if (vm_map_lookup_entry(map, start, &entry)) {
+	        if (entry->inheritance == VM_INHERIT_QUARANTINE)
+			return (KERN_NO_SPACE);
 		reservation = entry->reservation;
 		while (entry->end < end) {
 			next_entry = vm_map_entry_succ(entry);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -4791,6 +4791,9 @@ vm_map_remove_locked(vm_map_t map, vm_offset_t start, vm_offset_t end)
 	}
 
 	result = vm_map_delete(map, start, end, true);
+	if (result != KERN_SUCCESS)
+		return (result);
+
 	if (vm_map_reservation_is_unmapped(map, reservation)) {
 #ifdef CHERI_CAPREVOKE
 		if (quarantine_unmapped_reservations &&

--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -1697,10 +1697,14 @@ ATF_TC_BODY(largepage_mprotect, tc)
 		largepage_protect(addr, ps[i], PROT_READ, 0);
 		largepage_protect(addr, ps[0], PROT_NONE, EINVAL);
 		largepage_protect(addr, ps[i], PROT_NONE, 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+		largepage_protect(addr, ps[i], PROT_READ | PROT_WRITE, 0);
+#else
 		largepage_protect(addr, ps[0],
 		    PROT_READ | PROT_WRITE | PROT_EXEC, EINVAL);
 		largepage_protect(addr, ps[i],
 		    PROT_READ | PROT_WRITE | PROT_EXEC, 0);
+#endif
 
 		/* Trigger creation of a mapping and try again. */
 		*(volatile char *)addr = 0;
@@ -1708,10 +1712,14 @@ ATF_TC_BODY(largepage_mprotect, tc)
 		largepage_protect(addr, ps[i], PROT_READ, 0);
 		largepage_protect(addr, ps[0], PROT_NONE, EINVAL);
 		largepage_protect(addr, ps[i], PROT_NONE, 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+		largepage_protect(addr, ps[i], PROT_READ | PROT_WRITE, 0);
+#else
 		largepage_protect(addr, ps[0],
 		    PROT_READ | PROT_WRITE | PROT_EXEC, EINVAL);
 		largepage_protect(addr, ps[i],
 		    PROT_READ | PROT_WRITE | PROT_EXEC, 0);
+#endif
 
 		memset(addr, 0, ps[i]);
 

--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -1408,7 +1408,7 @@ ATF_TC_BODY(largepage_mmap, tc)
 		ATF_REQUIRE(munmap(addr, ps[i] == 0));
 
 		/* Clobber an anonymous mapping with a superpage. */
-		addr1 = mmap(NULL, ps[0], PROT_READ | PROT_WRITE,
+		addr1 = mmap(NULL, ps[i], PROT_READ | PROT_WRITE,
 		    MAP_ANON | MAP_PRIVATE | MAP_ALIGNED(ffsl(ps[i]) - 1), -1,
 		    0);
 		ATF_REQUIRE_MSG(addr1 != MAP_FAILED,


### PR DESCRIPTION
Fix two panics in the large page support triggered by repeated unmaps of the same reservation and trying to map over a quarantined reservation.

Tweak the tests so they all pass. The changes aren't perfect in terms of test coverage, but they are valid for now.