### PR TITLE
2024 copyright bump and add missing acks

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -39,7 +39,7 @@ SUCH DAMAGE.
 The compilation of software known as FreeBSD is distributed under the
 following terms:
 
-Copyright (c) 1992-2023 The FreeBSD Project.
+Copyright (c) 1992-2024 The FreeBSD Project.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -18,6 +18,11 @@ Cambridge Computer Laboratory (Department of Computer Science and
 Technology), and Capabilities Limited under Defense Advanced Research
 Projects Agency (DARPA) Contract No. HR001122C0110 ("ETC").
 
+This software was developed by SRI International, the University of
+Cambridge Computer Laboratory (Department of Computer Science and
+Technology), and Capabilities Limited under Defense Advanced Research
+Projects Agency (DARPA) Contract No. HR001122S0003 ("MTSS").
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,8 +1,8 @@
 The compilation of software known as CheriBSD is distributed under the
 following terms:
 
-Copyright 2011-2023 The University of Cambridge.
-Copyright 2012-2023 SRI International.
+Copyright 2011-2024 The University of Cambridge.
+Copyright 2012-2024 SRI International.
 
 This software was developed by SRI International and the University of
 Cambridge Computer Laboratory under DARPA/AFRL contract FA8750-10-C-0237

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -13,6 +13,11 @@ Cambridge Computer Laboratory (Department of Computer Science and
 Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
 DARPA SSITH research programme.
 
+This software was developed by SRI International, the University of
+Cambridge Computer Laboratory (Department of Computer Science and
+Technology), and Capabilities Limited under Defense Advanced Research
+Projects Agency (DARPA) Contract No. HR001122C0110 ("ETC").
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/sys/sys/copyright.h
+++ b/sys/sys/copyright.h
@@ -30,8 +30,8 @@
 /* Add a FreeBSD vendor copyright here - or via CFLAGS */
 #ifndef COPYRIGHT_Vendor
 #define	COPYRIGHT_Vendor \
-	"Copyright 2011-2023 University of Cambridge.\n" \
-	"Copyright 2012-2023 SRI International.\n"
+	"Copyright 2011-2024 University of Cambridge.\n" \
+	"Copyright 2012-2024 SRI International.\n"
 #endif
 
 /* FreeBSD */

--- a/sys/sys/copyright.h
+++ b/sys/sys/copyright.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (C) 1992-2023 The FreeBSD Project. All rights reserved.
+ * Copyright (C) 1992-2024 The FreeBSD Project. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
 
 /* FreeBSD */
 #define COPYRIGHT_FreeBSD \
-	"Copyright (c) 1992-2023 The FreeBSD Project.\n"
+	"Copyright (c) 1992-2024 The FreeBSD Project.\n"
 
 /* Foundation */
 #define	TRADEMARK_Foundation \


### PR DESCRIPTION
I cherry-picked the upstream bump commit for consistency and then bumped our copyrights. Also added ETC and MTSS acks.

A couple things that might want to be addressed separately.
 - CapLtd might want to claim a collective copyright, unsure what dates apply.
 - A more condensed (bulleted?) ack format might be nice since I think we're missing some non-DARPA acks and CPM is coming.


