### PR TITLE
Make sure that the iovec array in struct uio is representable.

### DIFF
--- a/sys/cddl/compat/opensolaris/kern/opensolaris_uio.c
+++ b/sys/cddl/compat/opensolaris/kern/opensolaris_uio.c
@@ -68,7 +68,7 @@ uiocopy(void *p, size_t n, enum uio_rw rw, struct uio *uio, size_t *cbytes)
 	error = vn_io_fault_uiomove(p, n, uio_clone);
 	*cbytes = uio->uio_resid - uio_clone->uio_resid;
 	if (uio_clone != &small_uio_clone)
-		free(uio_clone, M_IOV);
+		freeuio(uio_clone);
 	return (error);
 }
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -410,7 +410,6 @@ freebsd64_copyinuio(const struct iovec * __capability cb_arg, u_int iovcnt,
 		IOVEC_INIT_C(&iov[i], __USER_CAP(iov64.iov_base, iov64.iov_len),
 		    iov64.iov_len);
 	}
-	uio->uio_iov = iov;
 	uio->uio_iovcnt = iovcnt;
 	uio->uio_segflg = UIO_USERSPACE;
 	uio->uio_offset = -1;

--- a/sys/compat/linux/linux_file.c
+++ b/sys/compat/linux/linux_file.c
@@ -1040,7 +1040,7 @@ linux_preadv(struct thread *td, struct linux_preadv_args *uap)
 	if (error != 0)
 		return (error);
 	error = kern_preadv(td, uap->fd, auio, offset);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 
@@ -1067,7 +1067,7 @@ linux_pwritev(struct thread *td, struct linux_pwritev_args *uap)
 	if (error != 0)
 		return (error);
 	error = kern_pwritev(td, uap->fd, auio, offset);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (linux_enobufs2eagain(td, uap->fd, error));
 }
 
@@ -1874,7 +1874,7 @@ linux_writev(struct thread *td, struct linux_writev_args *args)
 	if (error != 0)
 		return (error);
 	error = kern_writev(td, args->fd, auio);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (linux_enobufs2eagain(td, args->fd, error));
 }
 // CHERI CHANGES START

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -542,7 +542,7 @@ user_jail_set(struct thread *td, struct iovec * __capability iovp,
 	if (error)
 		return (error);
 	error = kern_jail_set(td, auio, flags);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 
@@ -2283,7 +2283,7 @@ user_jail_get(struct thread *td, struct iovec * __capability iovp,
 	error = kern_jail_get(td, auio, flags);
 	if (error == 0)
 		error = updateiov_f(auio, iovp);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 

--- a/sys/kern/kern_ktrace.c
+++ b/sys/kern/kern_ktrace.c
@@ -788,7 +788,7 @@ ktrgenio(int fd, enum uio_rw rw, struct uio *uio, int error)
 	char *buf;
 
 	if (error) {
-		free(uio, M_IOV);
+		freeuio(uio);
 		return;
 	}
 	uio->uio_offset = 0;
@@ -796,7 +796,7 @@ ktrgenio(int fd, enum uio_rw rw, struct uio *uio, int error)
 	datalen = MIN(uio->uio_resid, ktr_geniosize);
 	buf = malloc(datalen, M_KTRACE, M_WAITOK);
 	error = uiomove(buf, datalen, uio);
-	free(uio, M_IOV);
+	freeuio(uio);
 	if (error) {
 		free(buf, M_KTRACE);
 		return;

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1343,8 +1343,8 @@ kern_sendfile(struct thread *td, int fd, int s, off_t offset, size_t nbytes,
 		copyout(&sbytes, usbytes, sizeof(off_t));
 
 out:
-	free(hdr_uio, M_IOV);
-	free(trl_uio, M_IOV);
+	freeuio(hdr_uio);
+	freeuio(trl_uio);
 	return (error);
 }
 

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -392,7 +392,7 @@ log_console(struct uio *uio)
 		msglogstr(consbuffer, pri, /*filter_cr*/ 1);
 	}
 	msgbuftrigger = 1;
-	free(uio, M_IOV);
+	freeuio(uio);
 	free(consbuffer, M_TEMP);
 }
 

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -408,21 +408,20 @@ copyinuio(const struct iovec * __capability iovp, u_int iovcnt,
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
 	iovlen = iovcnt * sizeof(struct iovec);
-	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
-	iov = (struct iovec *)(uio + 1);
+	uio = allocuio(iovcnt);
+	iov = uio->uio_iov;
 	error = copyincap(iovp, iov, iovlen);
 	if (error != 0) {
-		free(uio, M_IOV);
+		freeuio(uio);
 		return (error);
 	}
-	uio->uio_iov = cheri_kern_setbounds(iov, iovlen);
 	uio->uio_iovcnt = iovcnt;
 	uio->uio_segflg = UIO_USERSPACE;
 	uio->uio_offset = -1;
 	uio->uio_resid = 0;
 	for (i = 0; i < iovcnt; i++) {
 		if (iov->iov_len > IOSIZE_MAX - uio->uio_resid) {
-			free(uio, M_IOV);
+			freeuio(uio);
 			return (EINVAL);
 		}
 		uio->uio_resid += iov->iov_len;
@@ -450,15 +449,38 @@ updateiov(const struct uio *uiop, struct iovec * __capability iovp)
 }
 
 struct uio *
-cloneuio(struct uio *uiop)
+allocuio(u_int iovcnt)
 {
 	struct uio *uio;
 	int iovlen;
 
-	iovlen = uiop->uio_iovcnt * sizeof(struct iovec);
+	KASSERT(iovcnt <= UIO_MAXIOV,
+	    ("Requested %u iovecs exceed UIO_MAXIOV", iovcnt));
+	iovlen = iovcnt * sizeof(struct iovec);
 	uio = malloc(iovlen + sizeof(*uio), M_IOV, M_WAITOK);
-	*uio = *uiop;
 	uio->uio_iov = (struct iovec *)(uio + 1);
+
+	return (uio);
+}
+
+void
+freeuio(struct uio *uio)
+{
+	free(uio, M_IOV);
+}
+
+struct uio *
+cloneuio(struct uio *uiop)
+{
+	struct iovec *iov;
+	struct uio *uio;
+	int iovlen;
+
+	iovlen = uiop->uio_iovcnt * sizeof(struct iovec);
+	uio = allocuio(iovcnt);
+	iov = uio->uio_iov;
+	*uio = *uiop;
+	uio->uio_iov = iov;
 	bcopy(uiop->uio_iov, uio->uio_iov, iovlen);
 	return (uio);
 }

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -386,7 +386,7 @@ copyiniov(const struct iovec* __capability iovp, u_int iovcnt, struct iovec **io
 	*iov = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (error);
-	iovlen = iovcnt * sizeof (struct iovec);
+	iovlen = iovcnt * sizeof(struct iovec);
 	iovs = malloc(iovlen, M_IOV, M_WAITOK);
 	error = copyincap(iovp, iovs, iovlen);
 	if (error != 0)
@@ -407,7 +407,7 @@ copyinuio(const struct iovec * __capability iovp, u_int iovcnt,
 	*uiop = NULL;
 	if (iovcnt > UIO_MAXIOV)
 		return (EINVAL);
-	iovlen = iovcnt * sizeof (struct iovec);
+	iovlen = iovcnt * sizeof(struct iovec);
 	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
 	iov = (struct iovec *)(uio + 1);
 	error = copyincap(iovp, iov, iovlen);
@@ -455,8 +455,8 @@ cloneuio(struct uio *uiop)
 	struct uio *uio;
 	int iovlen;
 
-	iovlen = uiop->uio_iovcnt * sizeof (struct iovec);
-	uio = malloc(iovlen + sizeof *uio, M_IOV, M_WAITOK);
+	iovlen = uiop->uio_iovcnt * sizeof(struct iovec);
+	uio = malloc(iovlen + sizeof(*uio), M_IOV, M_WAITOK);
 	*uio = *uiop;
 	uio->uio_iov = (struct iovec *)(uio + 1);
 	bcopy(uiop->uio_iov, uio->uio_iov, iovlen);

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -282,7 +282,7 @@ user_readv(struct thread *td, int fd, struct iovec * __capability iovp,
 	if (error)
 		return (error);
 	error = kern_readv(td, fd, auio);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 
@@ -330,7 +330,7 @@ user_preadv(struct thread *td, int fd, struct iovec * __capability iovp,
 	if (error)
 		return (error);
 	error = kern_preadv(td, fd, auio, offset);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 
@@ -507,7 +507,7 @@ user_writev(struct thread *td, int fd, struct iovec * __capability iovp,
 	if (error)
 		return (error);
 	error = kern_writev(td, fd, auio);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 
@@ -555,7 +555,7 @@ user_pwritev(struct thread *td, int fd, struct iovec * __capability iovp,
 	if (error)
 		return (error);
 	error = kern_pwritev(td, fd, auio, offset);
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1467,7 +1467,7 @@ aiocb_free_kaiocb(struct kaiocb *kjob)
 		return;
 	if (refcount_release(&kjob->refcount)) {
 		if (kjob->uiop != &kjob->uio)
-			free(kjob->uiop, M_IOV);
+			freeuio(kjob->uiop);
 		uma_zfree(aiocb_zone, kjob);
 	}
 }
@@ -1788,7 +1788,7 @@ err3:
 	knlist_delete(&job->klist, curthread, 0);
 err2:
 	if (job->uiop != &job->uio)
-		free(job->uiop, M_IOV);
+		freeuio(job->uiop);
 	uma_zfree(aiocb_zone, job);
 err1:
 	ops->store_error(ujob, error);

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -483,7 +483,7 @@ kern_nmount(struct thread *td, struct iovec * __capability iovp, u_int iovcnt,
 	}
 	error = vfs_donmount(td, flags, auio);
 
-	free(auio, M_IOV);
+	freeuio(auio);
 	return (error);
 }
 

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1428,7 +1428,7 @@ vn_io_fault1(struct vnode *vp, struct uio *uio, struct vn_io_fault_args *args,
 	td->td_ma_cnt = prev_td_ma_cnt;
 	curthread_pflags_restore(saveheld);
 out:
-	free(uio_clone, M_IOV);
+	freeuio(uio_clone);
 	return (error);
 }
 

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -78,6 +78,8 @@ struct vm_object;
 struct vm_page;
 struct bus_dma_segment;
 
+struct uio *allocuio(u_int iovcnt);
+void	freeuio(struct uio *uio);
 struct uio *cloneuio(struct uio *uiop);
 int	copyiniov(const struct iovec * __capability iovp, u_int iovcnt,
 	    struct iovec **iov, int error);


### PR DESCRIPTION
There is a trade-off between having an possibly imprecise sub-allocation for the iovec array and using two different malloc()/free() calls for the uio and iovec arrays.
Note that, without explicitly modifying the uio free() code paths, the struct uio can not have tight bounds, because the call to free() requires a capability with the same bounds returned by malloc().

This patch abstracts away the uio allocation using the `allocuio()` and `freeuio()` functions.
Introduce a new UMA zone to allocate `struct uio`. The `struct uio` is modified to include an embedded small iovec array that is meant to satisfy the majority of iovec array allocations without the need for a dedicated external allocation. When the iovec array is larger than the embedded array, allocate a larger chunk of memory using kernel malloc with the `M_IOV` malloc type.
Currently, the uio zone ctor and dtor always create and destroy the external iovec array. We could be smarter and let the buffers hang around in the UMA cache, but it's unclear to me whether this yields a meaningful benefit.