### PR TITLE
c18n: Improvements and bugfixes

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -365,6 +365,11 @@ TRAMP(tramp_invoke_exe)
 	mov	csp, c17
 	blr	x18
 #else
+	/*
+	 * Save the address of the current frame to c29 so that RTLD functions
+	 * can locate it. c29 will be restored after the function call returns.
+	 */
+	mov	c29, csp
 	blr	c18
 #endif
 TRAMPEND(tramp_invoke_exe)

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -74,8 +74,12 @@ END(_rtld_longjmp)
 
 ENTRY(_rtld_thread_start)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	sub	c10, csp, #CAP_WIDTH
-	str	c10, [csp, #-CAP_WIDTH]!
+	mov	c1, csp
+	sub	csp, csp, #(CAP_WIDTH * 2)
+	/*
+	 * This function MUST preserve the value of c0.
+	 */
+	bl	c18n_init_rtld_stack
 #else
 	/*
 	 * Move the Executive mode thread pointer to Restricted mode.

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -50,12 +50,12 @@ ENTRY(.rtld_start)
 #ifdef __CHERI_PURE_CAPABILITY__
 	.cfi_undefined	c30
 	mov	c19, c0				/* Put aux in a callee-saved register */
-	mov	c20, csp			/* And the stack pointer */
-
 #if defined(RTLD_SANDBOX) && defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	sub	c20, c20, #CAP_WIDTH
-	str	c20, [csp, #-CAP_WIDTH]!
+	mov	c1, csp
+	sub	csp, csp, #(CAP_WIDTH * 2)
+	bl	c18n_init_rtld_stack
 #endif
+	mov	c20, csp			/* And the stack pointer */
 
 	sub	csp, csp, #32			/* Make room for obj_main & exit proc */
 

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1084,6 +1084,23 @@ c18n_add_comparts(struct policy *pol)
 		comparts.data[comparts.size++] = &pol->coms[i];
 }
 
+void *
+c18n_return_address(void)
+{
+	struct trusted_frame *tframe;
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	tframe = trusted_stk_get();
+#else
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wframe-address"
+	tframe = __builtin_frame_address(2);
+#pragma clang diagnostic pop
+#endif
+
+	return (tframe->ret_addr);
+}
+
 /*
  * libthr support
  */

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -526,9 +526,9 @@ struct tramp_pg {
 };
 
 /*
-* 64K is the largest size such that any capability-aligned proper
-* sub-range can be exactly bounded by a Morello capability.
-*/
+ * 64K is the largest size such that any capability-aligned proper
+ * sub-range can be exactly bounded by a Morello capability.
+ */
 #define	C18N_TRAMPOLINE_PAGE_SIZE	64 * 1024
 
 static struct tramp_pg *

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -257,7 +257,42 @@ compart_id_to_stack_index(compart_id_t cid)
 	return (cid - offsetof(typeof(dummy), stacks) / sizeof(*dummy.stacks));
 }
 
+static void init_compart_stack(void **, compart_id_t);
+
+static void
+init_compart_stack(void **stk, compart_id_t cid)
+{
+	/*
+	 * INVARIANT: The bottom of a compartment's stack contains a capability
+	 * to the top of the stack either when the compartment was last entered
+	 * or when it was last exited from, which ever occured later.
+	 */
+	stk[-1] = cheri_clearperm(stk - 1, CHERI_PERM_SW_VMEM);
+	if (
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	    /*
+	     * Do not check whether tracing is enabled if initialising the RTLD
+	     * stack because the global variable might not have been relocated
+	     * yet. This is only needed under the benchmark ABI, which has the
+	     * concept of an RTLD stack.
+	     */
+	    cid == C18N_RTLD_COMPART_ID ||
+#endif
+	    ld_compartment_utrace != NULL)
+		*--((uintptr_t **)stk)[-1] = cid;
+}
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+uintptr_t c18n_init_rtld_stack(uintptr_t, void **);
+
+uintptr_t
+c18n_init_rtld_stack(uintptr_t ret, void **csp)
+{
+	init_compart_stack(csp, C18N_RTLD_COMPART_ID);
+
+	return (ret);
+}
+
 /*
  * Save the initial stack (either at program launch or at thread start) in the
  * stack table.
@@ -415,7 +450,7 @@ void *get_rstk(unsigned);
 void *
 get_rstk(unsigned index)
 {
-	void **stk;
+	void *stk;
 	size_t capacity, size;
 	compart_id_t cid, cid_off;
 	struct stk_table *table;
@@ -435,10 +470,7 @@ get_rstk(unsigned index)
 
 	size = C18N_STACK_SIZE;
 	stk = stk_create(size);
-
-	stk[-1] = cheri_clearperm(stk - 1, CHERI_PERM_SW_VMEM);
-	if (ld_compartment_utrace != NULL)
-		*--((uintptr_t **)stk)[-1] = cid;
+	init_compart_stack(stk, cid);
 
 	table->stacks[cid_off].bottom = stk;
 	table->stacks[cid_off].size = size;
@@ -717,13 +749,22 @@ tramp_hook(int event, void *target, const Obj_Entry *obj, const Elf_Sym *def,
 	sym = def == NULL ? "<unknown>" : strtab_value(obj, def->st_name);
 	callee = comparts.data[obj->compart_id]->name;
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	caller_id =
+	    ((uintptr_t *)cheri_setoffset(rcsp, cheri_getlen(rcsp)))[-2];
+	(void)link;
+#else
 	if (cheri_gettag(link) &&
 	    (cheri_getperm(link) & CHERI_PERM_EXECUTIVE) == 0)
 		caller_id = ((uintptr_t *)
 		    cheri_setoffset(rcsp, cheri_getlen(rcsp)))[-2];
 	else
 		caller_id = C18N_RTLD_COMPART_ID;
-	caller = comparts.data[caller_id]->name;
+#endif
+	if (caller_id < C18N_RTLD_COMPART_ID)
+		caller = "<unknown>";
+	else
+		caller = comparts.data[caller_id]->name;
 
 	if (ld_compartment_utrace != NULL) {
 		memcpy(ut.sig, rtld_utrace_sig, sizeof(ut.sig));

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -212,4 +212,6 @@ func_sig_legal(struct func_sig sig)
 void *_rtld_sandbox_code(void *, struct func_sig);
 void *_rtld_safebox_code(void *, struct func_sig);
 
+void *c18n_return_address(void);
+
 #endif

--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -112,7 +112,6 @@ are unavailable under the benchmark ABI, the benchmark ABI variant is not a mere
 translation of the purecap variant but has a slightly different implementation.
 The best effort has been made to ensure that such a divergence does not bias
 performance estimates under almost all circumstances.
-Compartment transition tracing is unreliable under the benchmark ABI.
 .Sh LIMITATIONS
 This work is of an experimental nature.
 The author has tested it on applications such as


### PR DESCRIPTION
The PR overhauls the protection model used in the benchmark ABI from a rather ad-hoc model to one that logically matches what would be done on CHERI-RISC-V.

It also fixes `dlsym`, which relied on `__builtin_return_address`. The fix for the benchmark ABI is straightforward. But on the purecap ABI with register banking, `__builtin_frame_address(1)` needs to be used which triggers a warning that needs to be explicitly disabled.