### PR TITLE
arm64: Switch to final ABI for passing memory arguments

### DIFF
--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -60,7 +60,6 @@ ENTRY(_setjmp)
 #endif
 	mov	x0, #0
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	x9, xzr
 	/*
 	 * Tail-call to save Executive mode state
 	 */
@@ -112,7 +111,6 @@ ENTRY(_longjmp)
 	csinc	x0, x1, xzr, ne
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 	mov	c1, c4
-	mov	x9, xzr
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -84,7 +84,6 @@ ENTRY(setjmp)
 #endif
 	mov	x0, #0
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	x9, xzr
 	/*
 	 * Tail-call to save Executive mode state
 	 */
@@ -148,7 +147,6 @@ ENTRY(longjmp)
 	csinc	x0, x1, xzr, ne
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 	mov	c1, c4
-	mov	x9, xzr
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -389,28 +389,6 @@ TRAMP(tramp_switch_stack)
 	blr	[c30, #0]			/* allocate_rstk() */
 #endif
 3:	ldr	c17, [c17, #-CAP_WIDTH]
-
-	/* Move the c9 buffer to the target stack */
-	cbz	x9, 6f
-	gclen	x11, c9
-	add	c30, c9, x11
-	lsr	x11, x11, #4
-	tst	x30, #0xf
-	b.eq	5f
-
-	orr	x12, x30, #0xfffffffffffffff0
-	add	c17, c17, x12
-7:	ldrb	w12, [c30, #-1]!
-	strb	w12, [c17, #-1]!
-	tst	x30, #0xf
-	b.ne	7b
-
-4:	cbz	x11, 6f
-5:	ldr	c12, [c30, #-CAP_WIDTH]!
-	str	c12, [c17, #-CAP_WIDTH]!
-	sub	x11, x11, #1
-	b	4b
-6:
 TRAMPEND(tramp_switch_stack)
 
 PATCH_POINT(tramp_switch_stack, cid, 1b)

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -334,7 +334,7 @@ MACHINE_CPU += riscv
 .if ${MACHINE_CPUARCH} == "aarch64"
 . if ${MACHINE_CPU:Mcheri}
 CFLAGS+=	-march=morello
-CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs=caller-only
+CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs
 LDFLAGS+=	-march=morello
 . endif
 

--- a/sys/arm64/arm64/exec_machdep.c
+++ b/sys/arm64/arm64/exec_machdep.c
@@ -1008,7 +1008,6 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	tf->tf_x[8] = (uintcap_t)catcher;
 	tf->tf_sp = (uintcap_t)fp;
 #if __has_feature(capabilities)
-	tf->tf_x[9] = 0;
 	trapframe_set_elr(tf, (uintcap_t)p->p_md.md_sigcode);
 #else
 	tf->tf_elr = (register_t)PROC_SIGCODE(p);

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -147,7 +147,7 @@ INLINE_LIMIT?=	8000
 
 .if ${MACHINE_CPU:Mcheri}
 CFLAGS+=	-march=morello
-CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs=caller-only
+CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs
 .endif
 
 .if ${MACHINE_ARCH:Maarch*c*}

--- a/sys/dev/psci/smccc_arm64.S
+++ b/sys/dev/psci/smccc_arm64.S
@@ -95,6 +95,7 @@
 ENTRY(arm_smccc_\insn)
 #ifdef __CHERI_PURE_CAPABILITY__
 	save_registers
+	str	PTR(9), [PTRN(sp), #-PTR_WIDTH]!
 #endif
 #if __has_feature(capabilities)
 	reset_ddc_el0
@@ -104,9 +105,12 @@ ENTRY(arm_smccc_\insn)
 	restore_ddc_el0
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
+	ldr	PTR(9), [PTRN(sp)], #PTR_WIDTH
 	restore_registers
-#endif
+	ldr	PTR(4), [PTR(9)]
+#else
 	ldr	PTR(4), [PTRN(sp)]
+#endif
 	cbz	x4, 1f
 	stp	PTR(0), PTR(1), [PTR(4), #(2 * PTR_WIDTH) * 0]
 	stp	PTR(2), PTR(3), [PTR(4), #(2 * PTR_WIDTH) * 1]


### PR DESCRIPTION
This completes the ABI transition started by
cb987198fe2cf46c10317423b8a917dbf2ec3a6a. We set
-morello-bounded-memargs when building both the kernel and purecap userland.

This also reverts commit a81684622828b38239c1102fe9dc34e55653d39b, which is only applicable to the transition ABI.