### PR TITLE
 c18n: Align benchmark ABI protection model to CHERI-RISC-V 

### DIFF
--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -438,7 +438,7 @@ reloc_jmpslots(Obj_Entry *obj, int flags, RtldLockState *lockstate)
 				.target = (void *)target,
 				.defobj = defobj,
 				.def = def,
-				.sig = tramp_fetch_sig(obj,
+				.sig = c18n_fetch_sig(obj,
 				    ELF_R_SYM(rela->r_info))
 			});
 #endif
@@ -592,7 +592,7 @@ reloc_gnu_ifunc(Obj_Entry *obj, int flags,
 				.target = (void *)target,
 				.defobj = defobj,
 				.def = def,
-				.sig = tramp_fetch_sig(obj,
+				.sig = c18n_fetch_sig(obj,
 				    ELF_R_TYPE(rela->r_info))
 			});
 #endif

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -34,14 +34,11 @@ ENTRY(_rtld_setjmp)
 	 * general purpose registers.
 	 */
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c18, rcsp_el0
-#define	TRUSTED_STACK	c18
+	mrs	c2, rcsp_el0
 #else
-#define	TRUSTED_STACK	csp
+	mov	c2, csp
 #endif
-	mov	c2, TRUSTED_STACK
 	b	_rtld_setjmp_impl
-#undef	TRUSTED_STACK
 END(_rtld_setjmp)
 
 ENTRY(_rtld_longjmp)
@@ -50,40 +47,35 @@ ENTRY(_rtld_longjmp)
 	 * the general purpose registers to be restored.
 	 */
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c18, rcsp_el0
-#define	TRUSTED_STACK	c18
+	mrs	c2, rcsp_el0
+#else
+	mov	c2, csp
+#endif
+
+	str	c30, [csp, #-CAP_WIDTH]!
+	bl	_rtld_longjmp_impl
+	ldr	c30, [csp], #CAP_WIDTH
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c10, rcsp_el0
+#define	TRUSTED_STACK	c10
 #else
 #define	TRUSTED_STACK	csp
 #endif
-
-	mov	c2, TRUSTED_STACK
-
-	str	c30, [TRUSTED_STACK, #-CAP_WIDTH]!
+	ldr	x2, [TRUSTED_STACK]
+	scvalue	TRUSTED_STACK, TRUSTED_STACK, x2
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	msr	rcsp_el0, TRUSTED_STACK
 #endif
-
-	bl	_rtld_longjmp_impl
-
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	TRUSTED_STACK, rcsp_el0
-#endif
-	ldr	c30, [TRUSTED_STACK], #CAP_WIDTH
-
-	ldr	x3, [TRUSTED_STACK]
-	scvalue	TRUSTED_STACK, TRUSTED_STACK, x3
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	msr	rcsp_el0, TRUSTED_STACK
-#endif
+#undef	TRUSTED_STACK
 
 	RETURN
-#undef	TRUSTED_STACK
 END(_rtld_longjmp)
 
 ENTRY(_rtld_thread_start)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mov	c10, csp
-	msr	rcsp_el0, c10
+	sub	c10, csp, #CAP_WIDTH
+	str	c10, [csp, #-CAP_WIDTH]!
 #else
 	/*
 	 * Move the Executive mode thread pointer to Restricted mode.
@@ -93,14 +85,6 @@ ENTRY(_rtld_thread_start)
 #endif
 	b	_rtld_thread_start_impl
 END(_rtld_thread_start)
-
-ENTRY(_rtld_thr_exit)
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c10, rcsp_el0
-	mov	csp, c10
-#endif
-	b	_rtld_thr_exit_impl
-END(_rtld_thr_exit)
 
 ENTRY(_rtld_sighandler)
 #ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
@@ -374,6 +358,7 @@ PATCH_POINT(tramp_switch_stack, cid, 1b)
 
 TRAMP(tramp_invoke_exe)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	csp, c17
 	blr	x18
 #else
 	blr	c18

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -137,11 +137,18 @@ tramp_compile(void **entry, const struct tramp_data *data)
 		PATCH_LDR_IMM(call_hook, function, 3);
 	}
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	COPY(switch_stack);
+	PATCH_MOV(switch_stack, cid,
+	    compart_id_to_index(executive ? C18N_RTLD_COMPART_ID :
+	        data->defobj->compart_id));
+#else
 	if (!executive) {
 		COPY(switch_stack);
 		PATCH_MOV(switch_stack, cid,
 		    compart_id_to_index(data->defobj->compart_id));
 	}
+#endif
 
 	if (executive)
 		COPY(invoke_exe);

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -52,6 +52,11 @@ ENTRY(.rtld_start)
 	mov	c19, c0				/* Put aux in a callee-saved register */
 	mov	c20, csp			/* And the stack pointer */
 
+#if defined(RTLD_SANDBOX) && defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+	sub	c20, c20, #CAP_WIDTH
+	str	c20, [csp, #-CAP_WIDTH]!
+#endif
+
 	sub	csp, csp, #32			/* Make room for obj_main & exit proc */
 
 	adrp	c0, _DYNAMIC
@@ -75,11 +80,6 @@ ENTRY(.rtld_start)
 	mov	c0, c19				/* Restore aux */
 	mov	csp, c20			/* Restore the stack pointer */
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mrs	c10, rcsp_el0
-	mov	csp, c10
-	msr	rcsp_el0, c20
-#endif
 	br	x8				/* Jump to the entry point */
 #else
 	br	c8				/* Jump to the entry point */
@@ -110,31 +110,43 @@ END(.rtld_start)
  * x17 = &_rtld_bind_start
  */
 ENTRY(_rtld_bind_start)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 	/*
-	 * Maintain consistency of rcsp.
+	 * Maintain consistency of caller's stack.
 	 */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	c17, csp
+#else
 	mrs	c17, rcsp_el0
+#endif
 	gclim	x10, c17
-	sub	x10, x10, #CAP_WIDTH
 	scvalue c10, c17, x10
-	swp	c17, c10, [c10]
+	ldr	c18, [c10, #-CAP_WIDTH]
+	str	c17, [c10, #-CAP_WIDTH]
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	/*
+	 * Switch to RTLD stack.
+	 */
+	mrs	c10, rctpidr_el0
+	ldr	c10, [c10, #(CAP_WIDTH * 2)]
+	ldr	c10, [c10, #-CAP_WIDTH]
+	mov	csp, c10
+#endif
+
+	/*
+	 * Save old top of caller's stack.
+	 */
+	str	c18, [csp, #-CAP_WIDTH]!
 #else
 	mov	PTR(17), PTRN(sp)
 #endif
 
 	/* Save frame pointer and SP */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	stp	PTR(29), PTR(10), [PTRN(sp), #-(PTR_WIDTH * 2)]!
-	mov	PTR(29), PTRN(sp)
-	.cfi_def_cfa PTR(29), (PTR_WIDTH * 2)
-	.cfi_offset PTR(10), -(PTR_WIDTH * 1)
-#else
 	stp	PTR(29), PTR(30), [PTRN(sp), #-(PTR_WIDTH * 2)]!
 	mov	PTR(29), PTRN(sp)
 	.cfi_def_cfa PTR(29), (PTR_WIDTH * 2)
 	.cfi_offset PTR(30), -(PTR_WIDTH * 1)
-#endif
 	.cfi_offset PTR(29), -(PTR_WIDTH * 2)
 
 	/* Save the arguments */
@@ -190,20 +202,33 @@ ENTRY(_rtld_bind_start)
 	ldp	CAP(0), CAP(1), [PTRN(sp)], #(CAP_WIDTH * 2)
 
 	/* Restore frame pointer */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	ldp	PTR(29), PTR(10), [PTRN(sp)], #(PTR_WIDTH * 2)
-#else
 	ldp	PTR(29), PTR(zr), [PTRN(sp)], #(PTR_WIDTH * 2)
+
+	/* Restore link register saved by the plt code */
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	ldr	c18, [csp], #CAP_WIDTH
+	gclim	x10, c18
+	scvalue	c11, c18, x10
+	ldr	c17, [c11, #-CAP_WIDTH]
+	str	c18, [c11, #-CAP_WIDTH]
+
+	ldp	czr, c30, [c17], #(PTR_WIDTH * 2)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	csp, c17
+#else
+	msr	rcsp_el0, c17
 #endif
 
-	 /* Restore link register saved by the plt code */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	gclim	x17, c10
-	sub	x17, x17, #CAP_WIDTH
-	scvalue	c17, c10, x17
-	swp	c10, c17, [c17]
-	ldp	czr, c30, [c17], #(PTR_WIDTH * 2)
-	msr	rcsp_el0, c17
+	/*
+	 * Clear temporary registers that might contain RTLD-privileged
+	 * capabilities. Typically, the resolver returns a trampoline which will
+	 * clear them, but if the resolved function is trusted, then no such
+	 * clearing would be performed.
+	 */
+	mov	x12, xzr
+	mov	x13, xzr
+	mov	x14, xzr
+	mov	x15, xzr
 #else
 	ldp	PTR(zr), PTR(30), [PTRN(sp)], #(PTR_WIDTH * 2)
 #endif
@@ -336,15 +361,33 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	str	c19,	  [csp, #(9 * 32)]
 #if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	/*
-	 * Maintain consistency of rcsp. This step is only needed for
+	 * Maintain consistency of caller's stack. This step is only needed for
 	 * _rtld_tlsdesc_dynamic because it might call external functions.
 	 */
-	mrs	c3, rcsp_el0
-	gclim	x4, c3
-	sub	x4, x4, #CAP_WIDTH
-	scvalue	c4, c3, x4
-	swp	c3, c3, [c4]
-	str	c3, [csp, #(9 * 32 + 16)]
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	c17, csp
+#else
+	mrs	c17, rcsp_el0
+#endif
+	gclim	x10, c17
+	scvalue	c10, c17, x10
+	ldr	c18, [c10, #-CAP_WIDTH]
+	str	c17, [c10, #-CAP_WIDTH]
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	/*
+	 * Switch to RTLD stack.
+	 */
+	mrs	c10, rctpidr_el0
+	ldr	c10, [c10, #(CAP_WIDTH * 2)]
+	ldr	c10, [c10, #-CAP_WIDTH]
+	mov	csp, c10
+#endif
+
+	/*
+	 * Save old top of caller's stack.
+	 */
+	str	c18, [csp, #-CAP_WIDTH]!
 #endif
 	.cfi_rel_offset		 c1, 32
 	.cfi_rel_offset		 c2, 48
@@ -374,13 +417,18 @@ ENTRY(_rtld_tlsdesc_dynamic)
 	scbnds	c0, c0, x19
 
 	/* Restore slow path registers */
-#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	ldr	c3, [csp, #(9 * 32 + 16)]
-	gclim	x4, c3
-	sub	x4, x4, #CAP_WIDTH
-	scvalue	c4, c3, x4
-	swp	c3, c3, [c4]
-	msr	rcsp_el0, c3
+#ifdef RTLD_SANDBOX
+	ldr	c18, [csp], #CAP_WIDTH
+	gclim	x10, c18
+	scvalue	c11, c18, x10
+	ldr	c17, [c11, #-CAP_WIDTH]
+	str	c18, [c11, #-CAP_WIDTH]
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mov	csp, c17
+#else
+	msr	rcsp_el0, c17
+#endif
 #endif
 	ldr	c19,	  [csp, #(9 * 32)]
 	ldp	c17, c18, [csp, #(8 * 32)]

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -124,7 +124,7 @@ process_r_cheri_capability(Obj_Entry *obj, Elf_Word r_symndx,
 			.target = __DECONST(void *, symval),
 			.defobj = defobj,
 			.def = def,
-			.sig = tramp_fetch_sig(obj, r_symndx)
+			.sig = c18n_fetch_sig(obj, r_symndx)
 		});
 #endif
 		if (__predict_false(symval == NULL)) {

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -998,7 +998,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 	symlook_init(&req, "_rtld_compartments");
 	req.lockstate = &lockstate;
 	if (symlook_obj(&req, obj) == 0)
-	    tramp_add_comparts(make_data_pointer(req.sym_out, req.defobj_out));
+	    c18n_add_comparts(make_data_pointer(req.sym_out, req.defobj_out));
 	break;
     }
 
@@ -1258,7 +1258,7 @@ _rtld_bind(Obj_Entry *obj, Elf_Size reloff)
 	.target = (void *)target,
 	.defobj = defobj,
 	.def = def,
-	.sig = tramp_fetch_sig(obj, ELF_R_SYM(rel->r_info))
+	.sig = c18n_fetch_sig(obj, ELF_R_SYM(rel->r_info))
     });
 #endif
     target = reloc_jmpslot(where, target, defobj, obj, rel);
@@ -2801,8 +2801,8 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
     r_debug.r_ldbase = obj_rtld.relocbase;
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-    obj_rtld.compart_id = C18N_RTLD_COMPARTMENT_ID;
-    tramp_init();
+    obj_rtld.compart_id = C18N_RTLD_COMPART_ID;
+    c18n_init();
 #endif
 }
 

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -694,7 +694,7 @@ tramp_hook(int event, void *target, const Obj_Entry *obj, const Elf_Sym *def,
 		caller_id = ((uintptr_t *)
 		    cheri_setaddress(rcsp, cheri_gettop(rcsp)))[-2];
 	else
-		caller_id = C18N_RTLD_COMPARTMENT_ID;
+		caller_id = C18N_RTLD_COMPART_ID;
 	caller = comparts.data[caller_id]->name;
 
 	if (ld_compartment_utrace != NULL) {
@@ -799,7 +799,7 @@ tramp_create_entry(struct tramp_data *found, const struct tramp_data *data)
 
 	*found = *data;
 	if (found->def != NULL) {
-		sig = tramp_fetch_sig(found->defobj,
+		sig = c18n_fetch_sig(found->defobj,
 		    found->def - found->defobj->symtab);
 		if (!found->sig.valid)
 			found->sig = sig;
@@ -934,7 +934,7 @@ end:
  * APIs
  */
 struct func_sig
-tramp_fetch_sig(const Obj_Entry *obj, unsigned long symnum)
+c18n_fetch_sig(const Obj_Entry *obj, unsigned long symnum)
 {
 	if (symnum >= obj->dynsymcount)
 		rtld_fatal("Invalid symbol number %lu for object %s.",
@@ -946,7 +946,7 @@ tramp_fetch_sig(const Obj_Entry *obj, unsigned long symnum)
 }
 
 void
-tramp_init(void)
+c18n_init(void)
 {
 	int exp = 9;
 	uintptr_t sealer;
@@ -971,7 +971,7 @@ tramp_init(void)
 	 * Initialise compartment database
 	 */
 	comparts_data_expand(C18N_INIT_COMPART_COUNT);
-	while (comparts.size < C18N_RTLD_COMPARTMENT_ID)
+	while (comparts.size < C18N_RTLD_COMPART_ID)
 		comparts.data[comparts.size++] = NULL;
 	comparts.data[comparts.size++] = &rtld_compart;
 	comparts.data[comparts.size++] = &tcb_compart;
@@ -988,7 +988,7 @@ tramp_init(void)
 	 * an execution stack to be used as the trusted stack while RTLD is
 	 * bootstrapping.
 	 */
-	void **stk = get_rstk(compart_id_to_index(C18N_RTLD_COMPARTMENT_ID));
+	void **stk = get_rstk(compart_id_to_index(C18N_RTLD_COMPART_ID));
 	trusted_stk_set(stk[-1]);
 #else
 	untrusted_stk_set(&dummy_stack);
@@ -1004,7 +1004,7 @@ tramp_init(void)
 }
 
 void
-tramp_add_comparts(struct policy *pol)
+c18n_add_comparts(struct policy *pol)
 {
 	if (pol == NULL)
 		return;

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -41,15 +41,15 @@ extern const char *ld_compartment_enable;
 extern const char *ld_compartment_overhead;
 extern const char *ld_compartment_sig;
 
-void tramp_init(void);
+void c18n_init(void);
 
 /*
  * Policies
  */
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-#define	C18N_RTLD_COMPARTMENT_ID	1
+#define	C18N_RTLD_COMPART_ID	1
 #else
-#define	C18N_RTLD_COMPARTMENT_ID	0
+#define	C18N_RTLD_COMPART_ID	0
 #endif
 #define	C18N_COMPARTMENT_ID_MAX	(UINT16_MAX >> 1)
 
@@ -71,7 +71,7 @@ struct policy {
 	size_t count;
 };
 
-void tramp_add_comparts(struct policy *);
+void c18n_add_comparts(struct policy *);
 compart_id_t compart_id_allocate(const char *);
 
 /*
@@ -179,7 +179,7 @@ void *_rtld_tramp_hook(int, void *, const Obj_Entry *, const Elf_Sym *, void *,
     void *);
 size_t tramp_compile(void **, const struct tramp_data *);
 void *tramp_intern(const Obj_Entry *reqobj, const struct tramp_data *);
-struct func_sig tramp_fetch_sig(const Obj_Entry *, unsigned long);
+struct func_sig c18n_fetch_sig(const Obj_Entry *, unsigned long);
 
 static inline long
 func_sig_to_otype(struct func_sig sig)

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -128,6 +128,19 @@ stk_table_set(struct stk_table *table)
 #endif
 }
 
+static inline void *
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+trusted_stk_get(void)
+#else
+untrusted_stk_get(void)
+#endif
+{
+	void *sp;
+
+	asm ("mrs	%0, rcsp_el0" : "=C" (sp));
+	return (sp);
+}
+
 static inline void
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 trusted_stk_set(void *sp)

--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -107,10 +107,12 @@ Environment variables recognized by this variant need to be prefixed with
 LD_64CB_C18N_.
 .Pp
 .Sy NOTE:
-The current implementation is not fully optmized for performance, nor is it
-tested as extensively as the normal variant and may thus contain subtle bugs.
+Because the purecap variant uses some of Morello's architectural features that
+are unavailable under the benchmark ABI, the benchmark ABI variant is not a mere
+translation of the purecap variant but has a slightly different implementation.
+The best effort has been made to ensure that such a divergence does not bias
+performance estimates under almost all circumstances.
 Compartment transition tracing is unreliable under the benchmark ABI.
-Please report any bug to help improve the implementation.
 .Sh LIMITATIONS
 This work is of an experimental nature.
 The author has tested it on applications such as


### PR DESCRIPTION
These are the last c18n commits before switching to the new ABI (#1981).