### PR TITLE
Revert "Explicitly clear a pointer to the next free block."

### DIFF
--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -337,21 +337,6 @@ __tls_malloc(size_t nbytes)
 	op = SLIST_FIRST(bucketp);
 	SLIST_REMOVE_HEAD(bucketp, ov_next);
 	TLS_MALLOC_UNLOCK;
-	/*
-	 * XXXQEMU: Clear the overhead struct to remove any capability
-	 * permissions in ov_real_allocation.
-	 *
-	 * Based on a tag and permissions of ov_real_allocation, find_overhead()
-	 * determines if an allocation is aligned. The QEMU user mode for
-	 * CheriABI doesn't implement tagged memory and find_overhead() might
-	 * incorrectly assume the allocation is aligned because of a
-	 * non-cleared tag. Having the permissions cleared, find_overhead()
-	 * behaves as expected under the user mode.
-	 *
-	 * This is a workaround and should be reverted once the user mode
-	 * implements tagged memory.
-	 */
-	memset(op, 0, sizeof(*op));
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
 	return (op + 1);

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -311,21 +311,6 @@ __simple_malloc_unaligned(size_t nbytes)
 	/* remove from linked list */
 	op = SLIST_FIRST(bucketp);
 	SLIST_REMOVE_HEAD(bucketp, ov_next);
-	/*
-	 * XXXQEMU: Clear the overhead struct to remove any capability
-	 * permissions in ov_real_allocation.
-	 *
-	 * Based on a tag and permissions of ov_real_allocation, find_overhead()
-	 * determines if an allocation is aligned. The QEMU user mode for
-	 * CheriABI doesn't implement tagged memory and find_overhead() might
-	 * incorrectly assume the allocation is aligned because of a
-	 * non-cleared tag. Having the permissions cleared, find_overhead()
-	 * behaves as expected under the user mode.
-	 *
-	 * This is a workaround and should be reverted once the user mode
-	 * implements tagged memory.
-	 */
-	memset(op, 0, sizeof(*op));
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
 	return (op + 1);

--- a/libexec/rtld-elf/rtld_malloc.c
+++ b/libexec/rtld-elf/rtld_malloc.c
@@ -150,21 +150,6 @@ __crt_malloc(size_t nbytes)
 	}
 	/* remove from linked list */
   	nextf[bucket] = op->ov_next;
-	/*
-	 * XXXQEMU: Set an ov_next capability to a NULL capability, clearing any
-	 * permissions.
-	 *
-	 * Based on a tag and permissions of ov_next, find_overhead() determines
-	 * if an allocation is aligned. The QEMU user mode for CheriABI doesn't
-	 * implement tagged memory and find_overhead() might incorrectly assume
-	 * the allocation is aligned because of a non-cleared tag. Having the
-	 * permissions cleared, find_overhead() behaves as expected under the
-	 * user mode.
-	 *
-	 * This is a workaround and should be reverted once the user mode
-	 * implements tagged memory.
-	 */
-	op->ov_next = NULL;
 	op->ov_magic = MAGIC;
 	op->ov_index = bucket;
   	return ((char *)(op + 1));


### PR DESCRIPTION
QEMU CheriABI user mode implements tagged memory now.

This reverts commit 11e986fc851036a52bd3dd8413172a5646e69ee0 and fixes https://github.com/CTSRD-CHERI/cheribsd/issues/1755.