### PR TITLE
share/man: Add mandoc.db files to METALOG

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -40,8 +40,9 @@ distribute:
 	# Avoid installing tests here; "make distribution" will do this and
 	# correctly place them in the right location.
 	${_+_}cd ${.CURDIR} ; ${MAKE} MK_TESTS=no install \
-	    DESTDIR=${DISTDIR}/${DISTRIBUTION}
-	${_+_}cd ${.CURDIR} ; ${MAKE} distribution DESTDIR=${DISTDIR}/${DISTRIBUTION}
+	    DISTBASE=/${DISTRIBUTION} DESTDIR=${DISTDIR}/${DISTRIBUTION}
+	${_+_}cd ${.CURDIR} ; ${MAKE} distribution \
+	    DISTBASE=/${DISTRIBUTION} DESTDIR=${DISTDIR}/${DISTRIBUTION}
 
 .include <bsd.endian.mk>
 

--- a/share/man/Makefile
+++ b/share/man/Makefile
@@ -11,8 +11,16 @@ MAKEWHATIS?=	makewhatis
 makedb:
 .if ${MK_MAN_UTILS} != "no"
 	${MAKEWHATIS} ${DESTDIR}${BINDIR}/man
+.if defined(NO_ROOT) && defined(METALOG)
+	echo ".${DISTBASE}${BINDIR}/man/mandoc.db type=file mode=0644 uname=root gname=wheel" | \
+		cat -l >> ${METALOG}
+.endif
 .if ${MK_OPENSSL} != "no"
 	${MAKEWHATIS} ${DESTDIR}${BINDIR}/openssl/man
+.if defined(NO_ROOT) && defined(METALOG)
+	echo ".${DISTBASE}${BINDIR}/openssl/man/mandoc.db type=file mode=0644 uname=root gname=wheel" | \
+		cat -l >> ${METALOG}
+.endif
 .endif
 .endif
 


### PR DESCRIPTION
Otherwise these are omitted for -DNO_ROOT builds, whether for disk images or dist tarballs.
