### PR TITLE
Makefile.inc1: Ensure etc installs last for -DNO_ROOT

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -499,6 +499,7 @@ SUBDIR+=	tools/cheribsdbox
 # installed.
 .if make(installworld) || make(install) || make(installsysroot)
 SUBDIR+=.WAIT
+SUBDIR_INSTALL_USE_DEPENDS=
 .endif
 .if !defined(SYSROOT_ONLY)
 SUBDIR+=etc


### PR DESCRIPTION
Otherwise makewhatis can be run too early for -DNO_ROOT builds. This
makes use of the CheriBSD-specific SUBDIR_INSTALL_USE_DEPENDS option
until the dodginess has been resolved upstream, as is already done for
libexec's installing of libcompat rtld-elf variants.
