### PR TITLE
Sync with upstreamed -DNO_ROOT realinstall parallel fix

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -499,7 +499,6 @@ SUBDIR+=	tools/cheribsdbox
 # installed.
 .if make(installworld) || make(install) || make(installsysroot)
 SUBDIR+=.WAIT
-SUBDIR_INSTALL_USE_DEPENDS=
 .endif
 .if !defined(SYSROOT_ONLY)
 SUBDIR+=etc

--- a/libexec/Makefile
+++ b/libexec/Makefile
@@ -88,17 +88,10 @@ _rtld-elf=	rtld-elf rtld-elf-debug
 .if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64"
 SUBDIR+=	rtld-elf-c18n rtld-elf64cb-c18n
 .endif
-# rtld.1 needs to be installed before the cross-dir MLINKS can work.
-SUBDIR_INSTALL_USE_DEPENDS=
-SUBDIR_DEPEND_rtld-elf-c18n=	rtld-elf
-SUBDIR_DEPEND_rtld-elf64cb-c18n=	rtld-elf
-SUBDIR_DEPEND_rtld-elf-debug=	rtld-elf
 .for LIBCOMPAT libcompat in ${_ALL_LIBCOMPATS_libcompats}
 SUBDIR.${MK_LIB${LIBCOMPAT}}+=	rtld-elf${libcompat}
-SUBDIR_DEPEND_rtld-elf${libcompat}=	rtld-elf
 .if exists(${.CURDIR}/rtld-elf${libcompat}-debug)
 SUBDIR.${MK_LIB${LIBCOMPAT}}+=	rtld-elf${libcompat}-debug
-SUBDIR_DEPEND_rtld-elf${libcompat}-debug=	rtld-elf
 .endif
 .endfor
 .endif

--- a/share/mk/bsd.subdir.mk
+++ b/share/mk/bsd.subdir.mk
@@ -56,11 +56,6 @@ STANDALONE_SUBDIR_TARGETS+= \
 		installconfig installdirs installincludes installfiles print-dir \
 		maninstall manlint obj objlink
 
-# It is safe to install in parallel when staging.
-.if (defined(NO_ROOT) || !empty(SYSROOT)) && !defined(SUBDIR_INSTALL_USE_DEPENDS)
-STANDALONE_SUBDIR_TARGETS+= realinstall
-.endif
-
 .include <bsd.init.mk>
 
 .if ${MK_META_MODE} == "yes"


### PR DESCRIPTION
- bsd.subdir.mk: Drop broken optimisation for realinstall parallelisation
- Revert "Makefile.inc1: Ensure etc installs last for -DNO_ROOT"
- Revert "Fix parallel install of some rtld manpages."
