### PR TITLE
Various rtld-elf cleanups

### DIFF
--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -77,8 +77,6 @@ MLINKS?=	rtld.1 ld-elf.so.1.1 \
 		rtld.1 ld.so.1
 
 CFLAGS+=	-fpic -DPIC $(DEBUG)
-# Since we pass -shared, we shouldn't also pass -pie
-MK_PIE:=	no
 
 LDFLAGS+=	-shared -Wl,-Bsymbolic -Wl,-z,defs -nostdlib -e ${RTLD_ENTRY}
 # Pull in the dependencies that we use from libc

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -121,8 +121,6 @@ SRCS+=		rtld_c18n.c rtld_c18n_machdep.c rtld_c18n_asm.S
 .PATH: ${SRCTOP}/lib/libmalloc_simple
 SRCS+=		heap.c malloc.c
 
-CFLAGS+=	-I${SRCTOP}/lib/libc/${RTLD_ARCH}
-
 SIMPLE_PRINTF_PREFIX=rtld
 .include "${SRCTOP}/lib/libsimple_printf/Makefile.inc"
 .endif

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -122,7 +122,6 @@ SRCS+=		rtld_c18n.c rtld_c18n_machdep.c rtld_c18n_asm.S
 SRCS+=		heap.c malloc.c
 
 CFLAGS+=	-I${SRCTOP}/lib/libc/${RTLD_ARCH}
-CXXFLAGS+=	-Wall -Wextra
 
 SIMPLE_PRINTF_PREFIX=rtld
 .include "${SRCTOP}/lib/libsimple_printf/Makefile.inc"

--- a/libexec/rtld-elf/rtld-libc/Makefile.inc
+++ b/libexec/rtld-elf/rtld-libc/Makefile.inc
@@ -120,12 +120,3 @@ rtld_libc.a: ${_libc_pic_path} ${SRCTOP}/libexec/rtld-elf/rtld-libc/Makefile.inc
 CLEANFILES+=rtld_libc.a
 LDADD+=${.OBJDIR}/rtld_libc.a
 beforelinking: rtld_libc.a
-
-# Ensure that we don't end up using unsupported relocations
-.if make(all)
-_building_rtld_flag_supported!=(${LD} --building-freebsd-rtld -v > /dev/null && echo "yes") || echo "no"
-.info "    --building-freebsd-rtld supported: ${_building_rtld_flag_supported}"
-.if ${_building_rtld_flag_supported} != "no"
-LDFLAGS+=	-Wl,--building-freebsd-rtld
-.endif # _building_rtld_flag_supported == yes
-.endif

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -537,7 +537,7 @@ void ifunc_init(Elf_Auxinfo[__min_size(AT_COUNT)]);
 void init_pltgot(Obj_Entry *);
 void allocate_initial_tls(Obj_Entry *);
 
-#if __has_feature(capabilities)
+#ifdef RTLD_HAS_CAPRELOCS
 void process___cap_relocs(Obj_Entry*);
 #endif
 

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -92,19 +92,6 @@ extern char **environ;
 
 struct stat;
 struct Struct_Obj_Entry;
-struct CheriExports;
-struct CheriPlt;
-/* Instead of using void** to get warnings on casts */
-struct CheriCapTableEntry {
-	void *value;
-};
-
-struct CheriCapTableMappingEntry {
-  uint64_t func_start;       // virtual address relative to base address
-  uint64_t func_end;         // virtual address relative to base address
-  uint32_t cap_table_offset; // offset in bytes into captable
-  uint32_t sub_table_size;   // size in bytes of this sub-table
-};
 
 /* Lists of shared objects */
 typedef struct Struct_Objlist_Entry {
@@ -207,9 +194,7 @@ typedef struct Struct_Obj_Entry {
      */
     Elf_Addr text_rodata_start_offset;
     Elf_Addr text_rodata_end_offset;
-    const char* text_rodata_cap;	/* Capability for the executable mapping */
-    struct CheriExports *cheri_exports;	/* Unique thunks for function pointers */
-    struct CheriPlt *cheri_plt_stubs;	/* PLT stubs for external calls */
+    const char *text_rodata_cap;	/* Capability for the executable mapping */
 #endif
     caddr_t relocbase;		/* Relocation constant = mapbase - vaddrbase */
     const Elf_Dyn *dynamic;	/* Dynamic section */


### PR DESCRIPTION
- rtld-elf: Drop redundant downstream MK_PIE override
- rtld-elf: Drop obsolete assignment to CXXFLAGS
- rtld-elf: Drop obsolete libc arch include path addition
- rtld-libc: Stop checking for and trying to use --building-freebsd-rtld
- rtld-elf: GC old unused CHERI-MIPS PLT remnants
- rtld-elf: Sync process___cap_relocs declaration guard with definition
