### PR TITLE
Revert "Check that perl is available before using it."

### DIFF
--- a/tests/sys/acl/00.sh
+++ b/tests/sys/acl/00.sh
@@ -47,10 +47,6 @@ if [ ! -c /dev/mdctl ]; then
 	echo "1..0 # SKIP no /dev/mdctl to create md devices"
 	exit 0
 fi
-if [ -z "$(which perl)" ]; then
-	echo "1..0 # SKIP perl must be installed"
-	exit 0
-fi
 
 echo "1..4"
 

--- a/tests/sys/acl/01.sh
+++ b/tests/sys/acl/01.sh
@@ -49,10 +49,6 @@ if [ ! -c /dev/mdctl ]; then
 	echo "1..0 # SKIP no /dev/mdctl to create md devices"
 	exit 0
 fi
-if [ -z "$(which perl)" ]; then
-	echo "1..0 # SKIP perl must be installed"
-	exit 0
-fi
 
 echo "1..4"
 

--- a/tests/sys/acl/02.sh
+++ b/tests/sys/acl/02.sh
@@ -47,10 +47,6 @@ if [ ! -c /dev/mdctl ]; then
 	echo "1..0 # SKIP no /dev/mdctl to create md devices"
 	exit 0
 fi
-if [ -z "$(which perl)" ]; then
-	echo "1..0 # SKIP perl must be installed"
-	exit 0
-fi
 
 echo "1..4"
 

--- a/tests/sys/acl/03.sh
+++ b/tests/sys/acl/03.sh
@@ -44,10 +44,6 @@ if [ ! -c /dev/mdctl ]; then
 	echo "1..0 # SKIP no /dev/mdctl to create md devices"
 	exit 0
 fi
-if [ -z "$(which perl)" ]; then
-	echo "1..0 # SKIP perl must be installed"
-	exit 0
-fi
 
 echo "1..5"
 

--- a/tests/sys/acl/04.sh
+++ b/tests/sys/acl/04.sh
@@ -41,10 +41,6 @@ if [ ! -c /dev/mdctl ]; then
 	echo "1..0 # SKIP no /dev/mdctl to create md devices"
 	exit 0
 fi
-if [ -z "$(which perl)" ]; then
-	echo "1..0 # SKIP perl must be installed"
-	exit 0
-fi
 
 echo "1..3"
 


### PR DESCRIPTION
This was fixed upstream by making perl a requirement in the test
metadata in commit 1fe8c3077f04e1c570ad12ea120e15b9c9acbb93.

This reverts commit d88a4595aba0d62c4f40f2bfbf650107c0c45e7b.
