### PR TITLE
CheriBSD fails to build on recent glibc versions.

### DIFF
--- a/tools/build/cross-build/include/linux/fts.h
+++ b/tools/build/cross-build/include/linux/fts.h
@@ -1,0 +1,10 @@
+
+#pragma once
+
+#include_next<fts.h>
+
+#ifdef __GLIBC__
+#define fts_open(path_argv, options, compar)				\
+	fts_open(path_argv, options,					\
+	    (int (*)(const FTSENT **, const FTSENT **))compar)
+#endif

--- a/tools/build/cross-build/include/linux/string.h
+++ b/tools/build/cross-build/include/linux/string.h
@@ -46,9 +46,13 @@
 
 #include <sys/cdefs.h>
 
+#ifndef __THROW
+#define	__THROW
+#endif
+
 __BEGIN_DECLS
-size_t strlcpy(char *dst, const char *src, size_t siz);
-size_t strlcat(char *dst, const char *src, size_t siz);
+size_t strlcpy(char *dst, const char *src, size_t siz) __THROW;
+size_t strlcat(char *dst, const char *src, size_t siz) __THROW;
 char *strnstr(const char *str, const char *find, size_t str_len);
 void strmode(mode_t mode, char *str);
 


### PR DESCRIPTION
This adds a __THROW annotation to string.h functions.
The signature of `fts_open()` appear to have changed. This fix is messy, I'd prefer to patch it in a different way, maybe directly at the places where fts_open is used?