### PR TITLE
Stop disabling linker warnings for netlink

### DIFF
--- a/libexec/tftp-proxy/Makefile
+++ b/libexec/tftp-proxy/Makefile
@@ -8,9 +8,6 @@ MAN=	tftp-proxy.8
 CFLAGS+= -I${SRCTOP}/lib/libpfctl -I${OBJTOP}/lib/libpfctl
 LIBADD= pfctl
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
-
 WARNS?=	3
 
 .include <bsd.prog.mk>

--- a/rescue/rescue/Makefile
+++ b/rescue/rescue/Makefile
@@ -253,9 +253,6 @@ CRUNCH_ALIAS_chown= chgrp
 
 CRUNCH_LIBS+=		${OBJTOP}/lib/libifconfig/libifconfig.a
 CRUNCH_BUILDOPTS+=	CRUNCH_CFLAGS+=-I${OBJTOP}/lib/libifconfig
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-# >>> defined in libifconfig_carp.c (libifconfig_carp.o:(.rodata+0x1E2C70)
-LD_FATAL_WARNINGS=	no
 
 CRUNCH_LIBS_ifconfig+=	${LIBNV}
 

--- a/sbin/ifconfig/Makefile
+++ b/sbin/ifconfig/Makefile
@@ -76,10 +76,6 @@ SRCS+=	ifconfig_netlink.c
 CFLAGS+=-DWITHOUT_NETLINK
 .endif
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-# >>> defined in libifconfig_carp.c (libifconfig_carp.pieo:(.rodata+0x8A10)
-LD_FATAL_WARNINGS=no
-
 MAN=	ifconfig.8
 
 CFLAGS+= -Wall -Wmissing-prototypes -Wcast-qual -Wwrite-strings -Wnested-externs

--- a/sbin/pfctl/Makefile
+++ b/sbin/pfctl/Makefile
@@ -29,9 +29,6 @@ YFLAGS=
 
 LIBADD=	m md pfctl
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
-
 HAS_TESTS=
 SUBDIR.${MK_TESTS}+= tests
 

--- a/sbin/route/Makefile
+++ b/sbin/route/Makefile
@@ -20,9 +20,6 @@ CFLAGS+= -I.
 
 .if ${MK_NETLINK_SUPPORT} != "no"
 SRCS+= route_netlink.c
-
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
 .else
 CFLAGS+=-DWITHOUT_NETLINK
 .endif

--- a/sys/netlink/netlink_snl.h
+++ b/sys/netlink/netlink_snl.h
@@ -181,6 +181,18 @@ static const struct snl_hdr_parser _name = {				\
 #define	SNL_DECLARE_PARSER(_name, _t, _fp, _np)				\
 	SNL_DECLARE_PARSER_EXT(_name, sizeof(_t), 0, _fp, _np, NULL)
 
+#define	SNL_DECLARE_FIELD_PARSER_EXT(_name, _sz_h_in, _sz_out, _fp, _cb) \
+static const struct snl_hdr_parser _name = {				\
+	.in_hdr_size = _sz_h_in,					\
+	.out_size = _sz_out,						\
+	.fp = &((_fp)[0]),						\
+	.fp_size = NL_ARRAY_LEN(_fp),					\
+	.cb_post = _cb,							\
+}
+
+#define	SNL_DECLARE_FIELD_PARSER(_name, _t, _fp)			\
+	SNL_DECLARE_FIELD_PARSER_EXT(_name, sizeof(_t), 0, _fp, NULL)
+
 #define	SNL_DECLARE_ATTR_PARSER_EXT(_name, _sz_out, _np, _cb)		\
 static const struct snl_hdr_parser _name = {				\
 	.out_size = _sz_out,						\
@@ -917,14 +929,12 @@ SNL_DECLARE_PARSER(snl_errmsg_parser, struct nlmsgerr, nlf_p_errmsg, nla_p_errms
 
 #define	_IN(_field)	offsetof(struct nlmsgerr, _field)
 #define	_OUT(_field)	offsetof(struct snl_errmsg_data, _field)
-static const struct snl_attr_parser nla_p_donemsg[] = {};
-
 static const struct snl_field_parser nlf_p_donemsg[] = {
 	{ .off_in = _IN(error), .off_out = _OUT(error), .cb = snl_field_get_uint32 },
 };
 #undef _IN
 #undef _OUT
-SNL_DECLARE_PARSER(snl_donemsg_parser, struct nlmsgerr, nlf_p_donemsg, nla_p_donemsg);
+SNL_DECLARE_FIELD_PARSER(snl_donemsg_parser, struct nlmsgerr, nlf_p_donemsg);
 
 static inline bool
 snl_parse_errmsg(struct snl_state *ss, struct nlmsghdr *hdr, struct snl_errmsg_data *e)

--- a/tools/cheribsdbox/Makefile
+++ b/tools/cheribsdbox/Makefile
@@ -83,10 +83,6 @@ CRUNCH_LIBS+=	-lsysdecode
 CRUNCH_LIBS+=	-l80211
 CRUNCH_LIBS+=		${CRUNCH_OBJTOP}/lib/libifconfig/libifconfig.a
 CRUNCH_BUILDOPTS+=	CRUNCH_CFLAGS+=-I${CRUNCH_OBJTOP}/lib/libifconfig
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-# >>> defined in libifconfig_carp.c (libifconfig_carp.o:(.rodata+0xE76D0)
-LD_FATAL_WARNINGS=no
-
 # needed by fetch:
 CRUNCH_LIBS+= -lfetch
 # devinfo

--- a/usr.bin/genl/Makefile
+++ b/usr.bin/genl/Makefile
@@ -1,6 +1,3 @@
 PROG=	genl
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=	no
-
 .include <bsd.prog.mk>

--- a/usr.bin/netstat/Makefile
+++ b/usr.bin/netstat/Makefile
@@ -56,10 +56,6 @@ BINGRP=	kmem
 BINMODE=2555
 LIBADD=	kvm memstat xo util
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-# >>> defined in route_netlink.c (route_netlink.o:(.rodata+0xDAC0))
-LD_FATAL_WARNINGS=no
-
 .if ${MK_NETGRAPH_SUPPORT} != "no"
 SRCS+=	netgraph.c
 LIBADD+=	netgraph

--- a/usr.sbin/arp/Makefile
+++ b/usr.sbin/arp/Makefile
@@ -10,9 +10,6 @@ SRCS=	arp.c
 
 .if ${MK_NETLINK_SUPPORT} != "no"
 SRCS+=	arp_netlink.c
-
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
 .else
 CFLAGS+=-DWITHOUT_NETLINK
 .endif

--- a/usr.sbin/authpf/Makefile
+++ b/usr.sbin/authpf/Makefile
@@ -15,9 +15,6 @@ CFLAGS+= -I${SRCTOP}/lib/libpfctl -I${OBJTOP}/lib/libpfctl
 
 LIBADD=	m util pfctl
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
-
 WARNS?=	3
 
 LINKS=	${BINDIR}/authpf ${BINDIR}/authpf-noip

--- a/usr.sbin/ftp-proxy/Makefile
+++ b/usr.sbin/ftp-proxy/Makefile
@@ -12,9 +12,6 @@ CFLAGS+= -I${SRCTOP}/lib/libpfctl -I${OBJTOP}/lib/libpfctl
 
 LIBADD=	event1 pfctl
 
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
-
 WARNS?=	3
 
 .include <bsd.prog.mk>

--- a/usr.sbin/ndp/Makefile
+++ b/usr.sbin/ndp/Makefile
@@ -30,9 +30,6 @@ CFLAGS+=	-DDRAFT_IETF_6MAN_IPV6ONLY_FLAG
 
 .if ${MK_NETLINK_SUPPORT} != "no"
 SRCS+=	ndp_netlink.c
-
-# ld.lld: error: could not determine size of cap reloc against local object nla_p_donemsg
-LD_FATAL_WARNINGS=no
 .else
 CFLAGS+=-DWITHOUT_NETLINK
 .endif


### PR DESCRIPTION
- netlink: Don't use a zero-length array
- Re-enable fatal linker warnings for programs using netlink
