### PR TITLE
c18n, libgcc_s: Support a c18n-aware libunwind.

### DIFF
--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -82,7 +82,7 @@ ENTRY(_longjmp)
 	/* Restore the stack pointer */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c3, c8
+	mov	c2, c8
 #else
 	mov	REGN(sp), REG(8)
 #endif
@@ -105,12 +105,11 @@ ENTRY(_longjmp)
 
 	/* Load the return value */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c4, c0
+	mov	c3, c0
 #endif
 	cmp	x1, #0
 	csinc	x0, x1, xzr, ne
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c1, c4
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -111,7 +111,7 @@ ENTRY(longjmp)
 	/* Restore the stack pointer */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c3, c8
+	mov	c2, c8
 #else
 	mov	REGN(sp), REG(8)
 #endif
@@ -132,12 +132,11 @@ ENTRY(longjmp)
 
 	/* Load the return value */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c4, c0
+	mov	c3, c0
 #endif
 	cmp	x1, #0
 	csinc	x0, x1, xzr, ne
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c1, c4
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libgcc_s/Makefile
+++ b/lib/libgcc_s/Makefile
@@ -53,4 +53,7 @@ SRCS+=		s_logbl.c
 SRCS+=		s_scalbnl.c
 .endif
 
+SYMBOL_MAPS+=	${.CURDIR}/Symbol-c18n.map
+CFLAGS+=	-D_LIBUNWIND_SANDBOX_OTYPES -D_LIBUNWIND_SANDBOX_HARDENED
+
 .include <bsd.lib.mk>

--- a/lib/libgcc_s/Symbol-c18n.map
+++ b/lib/libgcc_s/Symbol-c18n.map
@@ -1,0 +1,7 @@
+FBSDprivate_1.0 {
+	_rtld_unw_getcontext;
+	_rtld_unw_setcontext;
+	_rtld_unw_getcontext_unsealed;
+	_rtld_unw_setcontext_unsealed;
+	_rtld_unw_getsealer;
+};

--- a/lib/libgcc_s/Versions.def
+++ b/lib/libgcc_s/Versions.def
@@ -31,3 +31,6 @@ GCC_4.3.0 {
 
 GCC_4.6.0 {
 } GCC_4.3.0;
+
+FBSDprivate_1.0 {
+} GCC_4.6.0;

--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -9,6 +9,11 @@ FBSDprivate_1.0 {
     _rtld_sighandler;
     _rtld_setjmp;
     _rtld_longjmp;
+    _rtld_unw_getcontext;
+    _rtld_unw_getcontext_unsealed;
+    _rtld_unw_setcontext;
+    _rtld_unw_setcontext_unsealed;
+    _rtld_unw_getsealer;
     _rtld_safebox_code;
     _rtld_sandbox_code;
 };

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -127,6 +127,16 @@ ENTRY(_rtld_dispatch_signal_unsafe)
 	b	dispatch_signal_end
 END(_rtld_dispatch_signal_unsafe)
 
+ENTRY(_rtld_unw_setcontext_epilogue)
+	/*
+	 * FIXME: llvm-libunwind specific ABI. This should be better specified.
+	 */
+	mov	c16, c2
+	ldp	c2, c3, [c3, #(-0x210 + 0x20)]
+	mov	csp, c16
+	RETURN
+END(_rtld_unw_setcontext_epilogue)
+
 ENTRY(allocate_rstk)
 	/*
 	 * NON-STANDARD CALLING CONVENTION

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -30,32 +30,6 @@
 #include "rtld_c18n_machdep.h"
 #undef IN_ASM
 
-ENTRY(_rtld_setjmp)
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c2, rcsp_el0
-#else
-	mov	c2, csp
-#endif
-	/*
-	 * This function MUST preserve the value of c0 and clear unused return
-	 * value registers.
-	 */
-	b	_rtld_setjmp_impl
-END(_rtld_setjmp)
-
-ENTRY(_rtld_longjmp)
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c2, rcsp_el0
-#else
-	mov	c2, csp
-#endif
-	/*
-	 * This function MUST preserve the value of c0 and clear unused return
-	 * value registers.
-	 */
-	b	_rtld_longjmp_impl
-END(_rtld_longjmp)
-
 ENTRY(_rtld_thread_start)
 	mov	c1, csp
 	sub	csp, csp, #(CAP_WIDTH * 2)

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -37,11 +37,10 @@ trust
 	strnstr
 	__libc_start1
 	setjmp
-	longjmp
 	_setjmp
-	_longjmp
 	sigsetjmp
-	siglongjmp
+	unw_getcontext
+	unw_getcontext_unsealed
 	_rtld_thread_start
 
 callee [RTLD]

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -4,6 +4,9 @@ compartment [TCB]
 	libc.so.7
 	libthr.so.3
 
+compartment [libunwind]
+	libgcc_s.so.1
+
 caller *
 trust
 	memset
@@ -52,3 +55,11 @@ export to [TCB]
 	_rtld_sighandler
 	_rtld_setjmp
 	_rtld_longjmp
+
+callee [RTLD]
+export to [libunwind]
+	_rtld_unw_getcontext
+	_rtld_unw_getcontext_unsealed
+	_rtld_unw_setcontext
+	_rtld_unw_setcontext_unsealed
+	_rtld_unw_getsealer


### PR DESCRIPTION
These 2 commits are bundled together with https://github.com/CTSRD-CHERI/llvm-project/pull/731 into https://github.com/CTSRD-CHERI/cheribsd/pull/2003 for easy testing. There is currently a lot of code duplication across `longjmp`, resume and unsealed resume, and I'm not too sure how to eliminate it since we're in a context where we can't perform a function call, so any function would have to be always inlined (while the compiler supports this, I'm not sure if it's good practice here?). I also wanted to avoid making *too* much of it a macro so that debugging of these functions doesn't become painful.