### PR TITLE
c18n: Change trusted frame layout for better unwinding

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -262,7 +262,7 @@ END(tramp_hook)
  * defined to describe them.
  */
 #define TRAMP(sym)							\
-	.section .rodata; .globl sym; .align 4; .type sym,#object; sym:
+	.section .rodata; .globl sym; .type sym,#object; sym:
 
 #define TRAMPEND(sym)							\
 	end_##sym:							\
@@ -272,7 +272,7 @@ END(tramp_hook)
 	.quad	end_##sym - sym
 
 #define	PATCH_POINT(tramp, name, label)					\
-	.section .rodata; .globl patch_##tramp##_##name; .align 3;	\
+	.section .rodata; .globl patch_##tramp##_##name; .align 2;	\
 	.type patch_##tramp##_##name,#object;				\
 	.size patch_##tramp##_##name, 4; patch_##tramp##_##name:	\
 	.word	label - end_##tramp

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -277,6 +277,14 @@ END(tramp_hook)
 	.size patch_##tramp##_##name, 4; patch_##tramp##_##name:	\
 	.word	label - end_##tramp
 
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+#define	TRUSTED_STACK	c18
+#define	TRUSTED_STACK_X	x18
+#else
+#define	TRUSTED_STACK	csp
+#define	TRUSTED_STACK_X	sp
+#endif
+
 TRAMP(tramp_save_caller)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	mov	c10, csp
@@ -295,13 +303,9 @@ TRAMP(tramp_save_caller)
 	str	c10, [c18, #-CAP_WIDTH]
 
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c18, rcsp_el0
-#define	TRUSTED_STACK	c18
-	mov	x12, x18
-#else
-	mov	x12, sp
-#define	TRUSTED_STACK	csp
+	mrs	TRUSTED_STACK, rcsp_el0
 #endif
+	mov	x12, TRUSTED_STACK_X
 
 	/*
 	 * Save the address that the callee should return to.
@@ -314,18 +318,17 @@ TRAMP(tramp_save_caller)
 2:	add	x13, x13, #0	/* To be patched at runtime */
 
 	/* Push frame */
-	stp	x12, x13, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
-	str	c17, [TRUSTED_STACK, #(CAP_WIDTH * 1)]
-	stp	c30, c19, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
-	stp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
-	stp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 6)]
-	stp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 8)]
-	stp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 10)]
-	stp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
+	stp	c29, c30, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
+	stp	x12, x13, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
+	stp	c17, c19, [TRUSTED_STACK, #(CAP_WIDTH * 3)]
+	stp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 5)]
+	stp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 7)]
+	stp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 9)]
+	stp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 11)]
+	str	c28, [TRUSTED_STACK, #(CAP_WIDTH * 13)]
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	msr	rcsp_el0, TRUSTED_STACK
 #endif
-#undef	TRUSTED_STACK
 
 3:	ldr	c19, #0		/* To be patched at runtime */
 TRAMPEND(tramp_save_caller)
@@ -333,6 +336,18 @@ TRAMPEND(tramp_save_caller)
 PATCH_POINT(tramp_save_caller, cookie, 1b)
 PATCH_POINT(tramp_save_caller, ret_args, 2b)
 PATCH_POINT(tramp_save_caller, target, 3b)
+
+/*
+ * Save the address of the current frame to c29 so that unwinders can locate it.
+ * When transitioning to Restricted mode code, its tag must be cleared.
+ */
+TRAMP(tramp_update_fp)
+	mov	c29, TRUSTED_STACK
+TRAMPEND(tramp_update_fp)
+
+TRAMP(tramp_update_fp_untagged)
+	mov	x29, TRUSTED_STACK_X
+TRAMPEND(tramp_update_fp_untagged)
 
 TRAMP(tramp_call_hook)
 1:	ldr	c18, #0		/* To be patched at runtime */
@@ -398,12 +413,6 @@ TRAMP(tramp_invoke_exe)
 	blr	x19
 #else
 	/*
-	 * Save the address of the current frame to c29 so that RTLD functions
-	 * can locate it. c29 will be restored after the function call returns.
-	 */
-	mov	c29, csp
-
-	/*
 	 * Set the Restricted stack to a dummy stack located at the bottom of
 	 * the trusted stack.
 	 */
@@ -449,7 +458,9 @@ TRAMP(tramp_invoke_res)
 	mov	x26, xzr
 	mov	x27, xzr
 	mov	x28, xzr
-	mov	x29, xzr
+	/*
+	 * - c29: Frame pointer (scalar)
+	 */
 
 	/*
 	 * Clear temporary registers, except
@@ -477,20 +488,17 @@ TRAMPEND(tramp_invoke_res)
 
 TRAMP(tramp_pop_frame)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	mrs	c18, rcsp_el0
-#define	TRUSTED_STACK	c18
-#else
-#define	TRUSTED_STACK	csp
+	mrs	TRUSTED_STACK, rcsp_el0
 #endif
 	/* Restore callee-saved registers */
-	ldp	x10, x11, [TRUSTED_STACK]
-	ldr	c12, [TRUSTED_STACK, #(CAP_WIDTH * 1)]
-	ldp	c30, c19, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
-	ldp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
-	ldp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 6)]
-	ldp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 8)]
-	ldp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 10)]
-	ldp	c28, c29, [TRUSTED_STACK, #(CAP_WIDTH * 12)]
+	ldp	c29, c30, [TRUSTED_STACK]
+	ldp	x10, x11, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
+	ldp	c12, c19, [TRUSTED_STACK, #(CAP_WIDTH * 3)]
+	ldp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 5)]
+	ldp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 7)]
+	ldp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 9)]
+	ldp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 11)]
+	ldr	c28, [TRUSTED_STACK, #(CAP_WIDTH * 13)]
 
 	/*
 	 * Restore caller's saved rcsp.
@@ -519,7 +527,6 @@ TRAMP(tramp_pop_frame)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	msr	rcsp_el0, TRUSTED_STACK
 #endif
-#undef	TRUSTED_STACK
 
 	mov	x2, xzr
 	mov	x3, xzr

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -49,6 +49,8 @@ tramp_compile(struct tramp_header **entry, const struct tramp_data *data)
 	extern const size_t size_tramp_##template
 
 	IMPORT(save_caller);
+	IMPORT(update_fp);
+	IMPORT(update_fp_untagged);
 	IMPORT(call_hook);
 	IMPORT(switch_stack);
 	IMPORT(invoke_exe);
@@ -141,6 +143,11 @@ tramp_compile(struct tramp_header **entry, const struct tramp_data *data)
 	PATCH_LDR_IMM(save_caller, target, hook ? 1 : 0);
 	if (data->sig.valid)
 		PATCH_ADD(save_caller, ret_args, data->sig.ret_args);
+
+	if (executive || ld_compartment_unwind != NULL)
+		COPY(update_fp);
+	else
+		COPY(update_fp_untagged);
 
 	if (hook) {
 		COPY(call_hook);

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -42,7 +42,7 @@
  * Trampolines
  */
 size_t
-tramp_compile(struct tramp_header **entry, const struct tramp_data *data)
+tramp_compile(char **entry, const struct tramp_data *data)
 {
 #define IMPORT(template)				\
 	extern const uint32_t tramp_##template[];	\

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
@@ -1,0 +1,47 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef RTLD_C18N_MACHDEP_H
+#define RTLD_C18N_MACHDEP_H
+
+/*
+ * Stack unwinding
+ */
+struct trusted_frame {
+	void *fp;
+	void *pc;
+	ptraddr_t next;
+	uint8_t ret_args : 2;
+	ptraddr_t cookie : 62;
+	/*
+	 * INVARIANT: This field contains the top of the caller's stack when the
+	 * caller was last entered.
+	 */
+	void *o_sp;
+};
+
+#endif

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -401,6 +401,7 @@ enum {
 	LD_COMPARTMENT_ENABLE,
 	LD_COMPARTMENT_OVERHEAD,
 	LD_COMPARTMENT_SIG,
+	LD_COMPARTMENT_UNWIND,
 #endif
 };
 
@@ -446,6 +447,7 @@ static struct ld_env_var_desc ld_env_vars[] = {
 	LD_ENV_DESC(COMPARTMENT_ENABLE, false),
 	LD_ENV_DESC(COMPARTMENT_OVERHEAD, false),
 	LD_ENV_DESC(COMPARTMENT_SIG, false),
+	LD_ENV_DESC(COMPARTMENT_UNWIND, false),
 #endif
 };
 
@@ -844,6 +846,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     ld_compartment_enable = ld_get_env_var(LD_COMPARTMENT_ENABLE);
     ld_compartment_overhead = ld_get_env_var(LD_COMPARTMENT_OVERHEAD);
     ld_compartment_sig = ld_get_env_var(LD_COMPARTMENT_SIG);
+    ld_compartment_unwind = ld_get_env_var(LD_COMPARTMENT_UNWIND);
 #endif
 
     set_ld_elf_hints_path();

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -193,7 +193,7 @@ struct tramp_header {
 
 void *tramp_hook(void *, int, void *, const Obj_Entry *, const Elf_Sym *,
     void *);
-size_t tramp_compile(struct tramp_header **, const struct tramp_data *);
+size_t tramp_compile(char **, const struct tramp_data *);
 void *tramp_intern(const Obj_Entry *reqobj, const struct tramp_data *);
 
 struct func_sig sigtab_get(const Obj_Entry *, unsigned long);

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -29,6 +29,7 @@
 #define RTLD_C18N_H
 
 #include <stdint.h>
+#include "rtld_c18n_machdep.h"
 
 /*
  * Global symbols
@@ -38,6 +39,7 @@ extern const char *ld_compartment_utrace;
 extern const char *ld_compartment_enable;
 extern const char *ld_compartment_overhead;
 extern const char *ld_compartment_sig;
+extern const char *ld_compartment_unwind;
 
 /*
  * Policies


### PR DESCRIPTION
Put the frame pointer (c29 as provided by the caller of the trampoline) and the return address (c30) together. This layout complies with the AArch64 ABI and enables privileged unwinders (e.g. the kernel) to walk through the trusted frame transparently.