### PR TITLE
kldxref: Handle R_RISCV_CHERI_CAPABILITY

### DIFF
--- a/usr.sbin/kldxref/ef_riscv.c
+++ b/usr.sbin/kldxref/ef_riscv.c
@@ -77,7 +77,8 @@ ef_riscv_reloc(struct elf_file *ef, const void *reldata, Elf_Type reltype,
 		le64enc(where, addr);
 		break;
 	case R_RISCV_CHERI_CAPABILITY:
-		warnx("unhandled R_RISCV_CHERI_CAPABILITY relocation");
+		addr = EF_SYMADDR(ef, symidx) + addend;
+		le64enc(where, addr);
 		break;
 	default:
 		warnx("unhandled relocation type %d", (int)rtype);


### PR DESCRIPTION
As with R_MORELLO_CAPINIT only the address is output.
