### PR TITLE
Bump __CheriBSD_version to 20240315

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20230804
+#define __CheriBSD_version 20240315
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,


### PR DESCRIPTION
Bump __CheriBSD_version to the current date to prepare for the next CheriBSD release.