### PR TITLE
rtld-elf: Fix cheri tests

### DIFF
--- a/libexec/rtld-elf/tests/Makefile
+++ b/libexec/rtld-elf/tests/Makefile
@@ -18,7 +18,7 @@ SRCS.$t=	$t.c common.c
 WARNS?=		3
 
 .if ${MACHINE_ABI:Mpurecap}
-SUBDIR+=	cheri
+TESTS_SUBDIRS+=	cheri
 .endif
 
 .include <bsd.test.mk>

--- a/libexec/rtld-elf/tests/cheri/Makefile
+++ b/libexec/rtld-elf/tests/cheri/Makefile
@@ -1,3 +1,5 @@
+TESTSDIR?=	${TESTSBASE}/libexec/rtld-elf/cheri
+
 TESTS_SUBDIRS+=	abi-mismatch
 
 .include <bsd.test.mk>

--- a/libexec/rtld-elf/tests/cheri/abi-mismatch/dlopen-hybrid/dlopen-hybrid.c
+++ b/libexec/rtld-elf/tests/cheri/abi-mismatch/dlopen-hybrid/dlopen-hybrid.c
@@ -66,22 +66,9 @@ ATF_TC_BODY(dlopen_hybrid, tc)
 	test_dlopen_success("libbasic_hybrid.so.0", "hybrid", true);
 }
 
-ATF_TC(dlopen_nocheri);
-ATF_TC_HEAD(dlopen_nocheri, tc)
-{
-	atf_tc_set_md_var(tc, "descr",
-	    "Check that we can dlopen() a non-CHERI library from a hybrid binary");
-}
-ATF_TC_BODY(dlopen_nocheri, tc)
-{
-	test_dlopen_success("libbasic_nocheri.so.0", "not CHERI", true);
-}
-
-
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, dlopen_purecap_fail);
 	ATF_TP_ADD_TC(tp, dlopen_hybrid);
-	ATF_TP_ADD_TC(tp, dlopen_nocheri);
 	return atf_no_error();
 }

--- a/libexec/rtld-elf/tests/cheri/abi-mismatch/dlopen-purecap/dlopen-purecap.c
+++ b/libexec/rtld-elf/tests/cheri/abi-mismatch/dlopen-purecap/dlopen-purecap.c
@@ -67,36 +67,9 @@ ATF_TC_BODY(dlopen_hybrid_fail, tc)
 	test_dlopen_failure("libbasic_hybrid.so.0", error_msg);
 }
 
-ATF_TC(dlopen_nocheri_fail);
-ATF_TC_HEAD(dlopen_nocheri_fail, tc)
-{
-	atf_tc_set_md_var(tc, "descr",
-	    "Check that dlopen() of a non-CHERI library from a purecap binary fails");
-}
-ATF_TC_BODY(dlopen_nocheri_fail, tc)
-{
-	char error_msg[PATH_MAX];
-	const char* exedir = get_executable_dir();
-
-#if defined(__riscv) || (__aarch64__)
-	/*
-	 * RISC-V has no CHERI vs non-CHERI distinction in its flags (just like all
-	 * extensions other than C, which influences linker relaxation). We
-	 * therefore fall back on it not being purecap.
-	 */
-	snprintf(error_msg, sizeof(error_msg),
-	    "%s/%s: cannot load %s/../%s since it is not CheriABI",
-	    exedir, "dlopen-purecap", exedir, "libbasic_nocheri.so.0");
-#else
-#error "Unknown architecture"
-#endif
-	test_dlopen_failure("libbasic_nocheri.so.0", error_msg);
-}
-
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, dlopen_purecap);
 	ATF_TP_ADD_TC(tp, dlopen_hybrid_fail);
-	ATF_TP_ADD_TC(tp, dlopen_nocheri_fail);
 	return atf_no_error();
 }


### PR DESCRIPTION
- rtld-elf: Set proper TESTSDIR for tests/cheri and use TESTS_SUBDIRS
- rtld-elf: Drop dlopen_nocheri tests
