### PR TITLE
Fix bootstrapping on macOS with Clang 16 / Apple Clang 15

### DIFF
--- a/contrib/mandoc/config.h
+++ b/contrib/mandoc/config.h
@@ -13,7 +13,7 @@
 #define HAVE_ENDIAN 0
 #define HAVE_ERR 1
 #define HAVE_FTS 1
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || defined(__APPLE__)
 #define HAVE_FTS_COMPARE_CONST 0
 #else
 #define HAVE_FTS_COMPARE_CONST 1

--- a/lib/libpmc/pmu-events/jevents.c
+++ b/lib/libpmc/pmu-events/jevents.c
@@ -1355,7 +1355,7 @@ err_out:
 #include <fts.h>
 
 static int
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || defined(__APPLE__)
 fts_compare(const FTSENT **a, const FTSENT **b)
 #else
 fts_compare(const FTSENT * const *a, const FTSENT * const *b)

--- a/usr.sbin/kldxref/kldxref.c
+++ b/usr.sbin/kldxref/kldxref.c
@@ -748,7 +748,7 @@ usage(void)
 }
 
 static int
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || defined(__APPLE__)
 compare(const FTSENT **a, const FTSENT **b)
 #else
 compare(const FTSENT *const *a, const FTSENT *const *b)


### PR DESCRIPTION
macOS, like Linux, does not include an outer const qualifier for its
fts_open callback arguments, so -Wincompatible-function-pointer-types
also picks this up and breaks the build now Clang 16 makes it an error
by default. Extend the existing Linux support to fix this.
