### PR TITLE
c18n: Compartmentalisation policies

### DIFF
--- a/lib/libsysdecode/utrace.c
+++ b/lib/libsysdecode/utrace.c
@@ -87,6 +87,29 @@ print_utrace_mrs(FILE *fp, void *p)
 	}
 	return (1);
 }
+
+static int
+print_utrace_c18n(FILE *fp, void *p)
+{
+	struct utrace_c18n *ut = p;
+
+	switch (ut->event) {
+	case UTRACE_COMPARTMENT_ENTER:
+		fprintf(fp, "RTLD: c18n: enter %s from %s at [%zu] %s (%02hhx)",
+		    ut->callee, ut->caller, ut->symnum, ut->symbol, ut->fsig);
+		break;
+	case UTRACE_COMPARTMENT_LEAVE:
+		fprintf(fp, "RTLD: c18n: leave %s to %s at [%zu] %s (%02hhx)",
+		    ut->callee, ut->caller, ut->symnum, ut->symbol, ut->fsig);
+		break;
+	default:
+		return (0);
+	}
+	if (ut->verbose)
+		fprintf(fp, "\no_sp = %p, fp = %#p\nn_sp = %#p, csp = %#p\n",
+		    ut->o_sp, ut->fp, ut->n_sp, ut->csp);
+	return (1);
+}
 #endif
 
 #ifdef __LP64__
@@ -200,16 +223,6 @@ print_utrace_rtld(FILE *fp, void *p)
 	case UTRACE_RTLD_ERROR:
 		fprintf(fp, "RTLD: error: %s\n", ut->name);
 		break;
-	case UTRACE_COMPARTMENT_ENTER:
-		fprintf(fp,
-		    "RTLD: c18n: enter %s from %s at [%zu] %s (%p)",
-		    ut->callee, ut->caller, ut->mapsize, ut->symbol, ut->handle);
-		break;
-	case UTRACE_COMPARTMENT_LEAVE:
-		fprintf(fp,
-		    "RTLD: c18n: leave %s to %s at [%zu] %s",
-		    ut->callee, ut->caller, ut->mapsize, ut->symbol);
-		break;
 
 	default:
 		return (0);
@@ -279,10 +292,15 @@ sysdecode_utrace(FILE *fp, void *p, size_t len)
 	static const char rtld_utrace_sig[RTLD_UTRACE_SIG_SZ] = RTLD_UTRACE_SIG;
 #ifdef __CHERI_PURE_CAPABILITY__
 	static const char mrs_utrace_sig[MRS_UTRACE_SIG_SZ] = MRS_UTRACE_SIG;
+	static const char c18n_utrace_sig[C18N_UTRACE_SIG_SZ] = C18N_UTRACE_SIG;
 
 	if (len == sizeof(struct utrace_mrs) && bcmp(p, mrs_utrace_sig,
 	    sizeof(mrs_utrace_sig)) == 0)
 		return (print_utrace_mrs(fp, p));
+
+	if (len == sizeof(struct utrace_c18n) && bcmp(p, c18n_utrace_sig,
+	    sizeof(c18n_utrace_sig)) == 0)
+		return (print_utrace_c18n(fp, p));
 #endif
 
 	if (len == sizeof(struct utrace_rtld) && bcmp(p, rtld_utrace_sig,

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -114,7 +114,11 @@ CFLAGS+=	-I${RTLD_ELF_DIR}/cheri
 .endif
 
 .ifdef RTLD_SANDBOX
-SRCS+=		rtld_c18n.c rtld_c18n_machdep.c rtld_c18n_asm.S
+SRCS+= \
+	rtld_c18n.c \
+	rtld_c18n_policy.S \
+	rtld_c18n_machdep.c \
+	rtld_c18n_asm.S
 .endif
 
 .if ${MACHINE_ABI:Mpurecap}

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -257,7 +257,7 @@ ENTRY(tramp_hook)
 	 * This function is only called from trampolines when tracing
 	 * compartment transitions.
 	 *
-	 * Upon entry, c10-c15 hold the first arguments of tramp_hook.
+	 * Upon entry, c10-c12 hold the first arguments of tramp_hook.
 	 *
 	 * All argument registers must be preserved.
 	 */
@@ -278,9 +278,6 @@ ENTRY(tramp_hook)
 	mov	c0, c10
 	mov	c1, c11
 	mov	c2, c12
-	mov	c3, c13
-	mov	c4, c14
-	mov	c5, c15
 
 	str	c30, [csp, #-CAP_WIDTH]!
 	bl	tramp_hook_impl
@@ -400,25 +397,21 @@ TRAMP(tramp_update_fp_untagged)
 TRAMPEND(tramp_update_fp_untagged)
 
 TRAMP(tramp_call_hook)
-1:	ldr	c18, #0		/* To be patched at runtime */
+1:	ldr	c13, #0		/* To be patched at runtime */
 
-2:	mov	w11, #0		/* To be patched at runtime */
-	mov	c12, c19
-3:	ldr	c13, #0		/* To be patched at runtime */
-4:	ldr	c14, #0		/* To be patched at runtime */
-	mov	c15, c30
-
+2:	mov	w10, #0		/* To be patched at runtime */
+3:	adr	c11, #0		/* To be patched at runtime */
+	mov	c12, TRUSTED_STACK
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	blr	x18
+	blr	x13
 #else
-	blr	c18
+	blr	c13
 #endif
 TRAMPEND(tramp_call_hook)
 
 PATCH_POINT(tramp_call_hook, function, 1b)
 PATCH_POINT(tramp_call_hook, event, 2b)
-PATCH_POINT(tramp_call_hook, obj, 3b)
-PATCH_POINT(tramp_call_hook, def, 4b)
+PATCH_POINT(tramp_call_hook, header, 3b)
 
 TRAMP(tramp_switch_stack)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
@@ -560,7 +553,25 @@ TRAMP(tramp_invoke_res)
 #endif
 TRAMPEND(tramp_invoke_res)
 
-TRAMP(tramp_pop_frame)
+TRAMP(tramp_return_hook)
+1:	ldr	c13, #0			/* To be patched at runtime */
+
+2:	mov	w10, #0			/* To be patched at runtime */
+3:	adr	c11, #0			/* To be patched at runtime */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c12, rcsp_el0
+	blr	x13
+#else
+	mov	c12, csp
+	blr	c13
+#endif
+TRAMPEND(tramp_return_hook)
+
+PATCH_POINT(tramp_return_hook, function, 1b)
+PATCH_POINT(tramp_return_hook, event, 2b)
+PATCH_POINT(tramp_return_hook, header, 3b)
+
+TRAMP(tramp_return)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	mrs	TRUSTED_STACK, rcsp_el0
 #endif
@@ -633,38 +644,9 @@ TRAMP(tramp_pop_frame)
 	 */
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	mov	csp, c15
-#else
-	msr	rcsp_el0, c15
-#endif
-TRAMPEND(tramp_pop_frame)
-
-TRAMP(tramp_return)
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	RETURN
 #else
+	msr	rcsp_el0, c15
 	retr	c30
 #endif
 TRAMPEND(tramp_return)
-
-TRAMP(tramp_return_hook)
-	/* Save return value registers */
-1:	ldr	c18, #0			/* To be patched at runtime */
-
-	mov	c10, c15
-2:	mov	w11, #0			/* To be patched at runtime */
-	mov	x12, xzr
-3:	ldr	c13, #0			/* To be patched at runtime */
-4:	ldr	c14, #0			/* To be patched at runtime */
-	mov	c15, c30
-
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	br	x18
-#else
-	br	c18
-#endif
-TRAMPEND(tramp_return_hook)
-
-PATCH_POINT(tramp_return_hook, function, 1b)
-PATCH_POINT(tramp_return_hook, event, 2b)
-PATCH_POINT(tramp_return_hook, obj, 3b)
-PATCH_POINT(tramp_return_hook, def, 4b)

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -157,18 +157,14 @@ tramp_compile(char **entry, const struct tramp_data *data)
 		PATCH_LDR_IMM(call_hook, def, 3);
 	}
 
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	COPY(switch_stack);
-	PATCH_MOV(switch_stack, cid,
-	    compart_id_to_index(executive ? C18N_RTLD_COMPART_ID :
-	        data->defobj->compart_id));
-#else
-	if (!executive) {
+#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	if (!executive)
+#endif
+	{
 		COPY(switch_stack);
 		PATCH_MOV(switch_stack, cid,
-		    compart_id_to_index(data->defobj->compart_id));
+		    cid_to_index(data->defobj->compart_id));
 	}
-#endif
 
 	if (executive)
 		COPY(invoke_exe);

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -52,23 +52,24 @@ ENTRY(.rtld_start)
 #ifdef __CHERI_PURE_CAPABILITY__
 	.cfi_undefined	c30
 	mov	c19, c0				/* Put aux in a callee-saved register */
-#ifdef RTLD_SANDBOX
-	mov	c1, csp
-	sub	csp, csp, #(CAP_WIDTH * 2)
-	bl	c18n_init_rtld_stack
-#endif
-	mov	c20, csp			/* And the stack pointer */
-
-	sub	csp, csp, #32			/* Make room for obj_main & exit proc */
 
 	adrp	c0, _DYNAMIC
 	add	c0, c0, :lo12:_DYNAMIC		/* dynp */
 	mov	c1, c19				/* aux */
 	bl	_rtld_relocate_nonplt_self	/* Relocate ourselves early */
 
+#ifdef RTLD_SANDBOX
+	mov	c1, csp
+	sub	csp, csp, #(CAP_WIDTH * 2)
+	bl	c18n_init_rtld_stack
+#endif
+
 #if __CHERI_CAPABILITY_TABLE__ != 3
 #error "Only the PC-relative ABI is currently supported"
 #endif
+
+	mov	c20, csp			/* Save the stack pointer */
+	sub	csp, csp, #32			/* Make room for obj_main & exit proc */
 
 	mov	c0, c19				/* Restore aux */
 	scbnds	c1, csp, #16			/* exit_proc */

--- a/libexec/rtld-elf/rtld-libc/Makefile.inc
+++ b/libexec/rtld-elf/rtld-libc/Makefile.inc
@@ -68,7 +68,6 @@ _libc_other_objects=sigsetjmp lstat stat fstat fstatat fstatfs syscall \
     _sigprocmask _write readlink __realpathat _setjmp setjmp setjmperr
 
 .ifdef RTLD_SANDBOX
-SRCS+=	mempcpy.c
 _libc_other_objects+=thr_exit
 .endif
 

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -845,6 +845,9 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     ld_utrace = ld_get_env_var(LD_UTRACE);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
     ld_compartment_utrace = ld_get_env_var(LD_UTRACE_COMPARTMENT);
+    if (ld_compartment_utrace != NULL)
+	ld_compartment_utrace_verbose =
+	    strcmp(ld_compartment_utrace, "verbose") == 0;
     ld_compartment_enable = ld_get_env_var(LD_COMPARTMENT_ENABLE);
     ld_compartment_policy = ld_get_env_var(LD_COMPARTMENT_POLICY);
     ld_compartment_overhead = ld_get_env_var(LD_COMPARTMENT_OVERHEAD);

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -797,6 +797,12 @@ _rtld_longjmp_impl(uintptr_t ret, void **buf, struct trusted_frame *csp,
 	do {
 		stk = cheri_setoffset(cur->n_sp, cheri_getlen(cur->n_sp));
 		--stk;
+
+		rtld_require((ptraddr_t)stk->top <= cur->o_sp,
+		    "c18n: Cannot unwind %s from %#p to %p\n"
+		    "csp: %#p -> %#p", comparts.data[stk->compart_id].name,
+		    stk->top, (void *)(uintptr_t)cur->o_sp, csp, target);
+
 		stk->top = cheri_setaddress(cur->n_sp, cur->o_sp);
 		cur = cheri_setaddress(cur, cur->next);
 	} while (cur < target);
@@ -815,6 +821,12 @@ _rtld_longjmp_impl(uintptr_t ret, void **buf, struct trusted_frame *csp,
 	 */
 	stk = cheri_setoffset(rcsp, cheri_getlen(rcsp));
 	--stk;
+
+	rtld_require(rcsp <= stk->top,
+	    "c18n: Cannot complete unwind %s from %#p to %#p\n"
+	    "csp: %#p -> %#p", comparts.data[stk->compart_id].name,
+	    rcsp, stk->top, csp, target);
+
 	csp->n_sp = rcsp;
 	csp->o_sp = (ptraddr_t)stk->top;
 

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -465,6 +465,10 @@ tramp_should_include(const Obj_Entry *reqobj, const struct tramp_data *data)
 struct stk_bottom {
 	compart_id_t compart_id;
 	/*
+	 * Store an integer address of the compartment's name for debuggers.
+	 */
+	ptraddr_t compart_name;
+	/*
 	 * INVARIANT: The bottom of a compartment's stack contains a capability
 	 * to the top of the stack either when the compartment was last entered
 	 * or when it was last exited from, which ever occured later.
@@ -504,6 +508,7 @@ init_compart_stack(void *base, compart_id_t cid)
 	memset(stk, 0, sizeof(*stk));
 	*stk = (struct stk_bottom) {
 		.compart_id = cid,
+		.compart_name = (ptraddr_t)comparts.data[cid].name,
 		.top = cheri_clearperm(stk, CHERI_PERM_SW_VMEM)
 	};
 }

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -36,6 +36,7 @@
  */
 extern uintptr_t sealer_pltgot, sealer_tramp;
 extern const char *ld_compartment_utrace;
+extern bool ld_compartment_utrace_verbose;
 extern const char *ld_compartment_enable;
 extern const char *ld_compartment_policy;
 extern const char *ld_compartment_overhead;

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -180,7 +180,8 @@ struct tramp_data {
 struct tramp_header {
 	void *target;
 	const Obj_Entry *defobj;
-	const Elf_Sym *def;
+	size_t symnum;
+	struct func_sig sig;
 	uint32_t entry[];
 };
 

--- a/libexec/rtld-elf/rtld_c18n_policy.S
+++ b/libexec/rtld-elf/rtld_c18n_policy.S
@@ -1,0 +1,41 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+.section	.rodata
+.globl	c18n_default_policy
+.type	c18n_default_policy,#object
+c18n_default_policy:
+	.incbin "rtld_c18n_policy.txt"
+c18n_default_policy_end:
+.size	c18n_default_policy, . - c18n_default_policy
+
+.globl	c18n_default_policy_size
+.type	c18n_default_policy_size,#object
+.align	3
+c18n_default_policy_size:
+	.quad	c18n_default_policy_end - c18n_default_policy
+.size	c18n_default_policy_size, . - c18n_default_policy_size

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -44,6 +44,16 @@ trust
 	siglongjmp
 	vfork
 	rfork
+	execve
+	fxecve
+	execl
+	execlp
+	execle
+	exect
+	execv
+	execvp
+	execvpe
+	execvP
 	_rtld_thread_start
 
 callee [RTLD]

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -1,0 +1,57 @@
+Version 1
+
+compartment [TCB]
+	libc.so.7
+	libthr.so.3
+
+caller *
+trust
+	memset
+	memcpy
+	mempcpy
+	memccpy
+	memchr
+	memrchr
+	memmem
+	memmove
+	strcpy
+	strncpy
+	stpcpy
+	stpncpy
+	strcat
+	strncat
+	strlcpy
+	strlcat
+	strlen
+	strnlen
+	strcmp
+	strncmp
+	strchr
+	strrchr
+	strchrnul
+	strspn
+	strcspn
+	strpbrk
+	strsep
+	strstr
+	strnstr
+	__libc_start1
+	setjmp
+	longjmp
+	_setjmp
+	_longjmp
+	sigsetjmp
+	siglongjmp
+	vfork
+	rfork
+	_rtld_thread_start
+
+callee [RTLD]
+export to [TCB]
+	_rtld_thread_start_init
+	_rtld_thread_start
+	_rtld_thr_exit
+	_rtld_sighandler_init
+	_rtld_sighandler
+	_rtld_setjmp
+	_rtld_longjmp

--- a/libexec/rtld-elf/rtld_utrace.h
+++ b/libexec/rtld-elf/rtld_utrace.h
@@ -44,8 +44,6 @@
 #define	UTRACE_DLSYM_START		11
 #define	UTRACE_DLSYM_STOP		12
 #define	UTRACE_RTLD_ERROR		13
-#define	UTRACE_COMPARTMENT_ENTER	14
-#define	UTRACE_COMPARTMENT_LEAVE	15
 
 #define	RTLD_UTRACE_SIG_SZ		4
 #define	RTLD_UTRACE_SIG			"RTLD"
@@ -57,14 +55,31 @@ struct utrace_rtld {
 	void *mapbase;			/* Used for 'parent' and 'init/fini' */
 	size_t mapsize;
 	int refcnt;			/* Used for 'mode' */
-	union {
-		char name[MAXPATHLEN];
-		struct {
-			char symbol[MAXPATHLEN / 2];
-			char callee[MAXPATHLEN / 4];
-			char caller[MAXPATHLEN / 4];
-		};
-	};
+	char name[MAXPATHLEN];
 };
+
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	UTRACE_COMPARTMENT_ENTER	1
+#define	UTRACE_COMPARTMENT_LEAVE	2
+
+#define	C18N_UTRACE_SIG_SZ		4
+#define	C18N_UTRACE_SIG			"C18N"
+
+struct utrace_c18n {
+	char sig[C18N_UTRACE_SIG_SZ];
+	uint8_t event;
+	bool verbose;
+	uint8_t fsig;
+	size_t symnum;
+	const void *csp;
+	void *fp;
+	void *pc;
+	void *o_sp;
+	void *n_sp;
+	char symbol[256];
+	char callee[128];
+	char caller[128];
+};
+#endif
 
 #endif


### PR DESCRIPTION
Implements a compartmentalisation policy format. Fixes a bug that causes vfork to corrupt stack state. Improves trampoline generation code. Adds an option to output verbose utrace information.