### PR TITLE
sys/malloc.h: Pass correct type in free_c

### DIFF
--- a/sys/sys/malloc.h
+++ b/sys/sys/malloc.h
@@ -280,7 +280,7 @@ static inline void
 free_c(void * __capability addr, struct malloc_type *type)
 {
 
-	free((__cheri_fromcap void *)addr, M_IOV);
+	free((__cheri_fromcap void *)addr, type);
 }
 
 static inline void * __capability


### PR DESCRIPTION
Fixes:	2a2d2282513c ("Split userspace and kernel iovec types.")
