### PR TITLE
kldxref: Properly handle reading strings near the end of an ELF file

### DIFF
--- a/usr.sbin/kldxref/ef.c
+++ b/usr.sbin/kldxref/ef.c
@@ -598,7 +598,6 @@ static int
 ef_seg_read_string(elf_file_t ef, GElf_Addr address, size_t len, char *dest)
 {
 	GElf_Off ofs;
-	int error;
 
 	ofs = ef_get_offset(ef, address);
 	if (ofs == 0) {
@@ -608,13 +607,7 @@ ef_seg_read_string(elf_file_t ef, GElf_Addr address, size_t len, char *dest)
 		return (EFAULT);
 	}
 
-	error = elf_read_raw_data(ef->ef_efile, ofs, dest, len);
-	if (error != 0)
-		return (error);
-	if (strnlen(dest, len) == len)
-		return (EFAULT);
-
-	return (0);
+	return (elf_read_raw_string(ef->ef_efile, ofs, dest, len));
 }
 
 int

--- a/usr.sbin/kldxref/ef.h
+++ b/usr.sbin/kldxref/ef.h
@@ -220,6 +220,10 @@ int	elf_read_raw_data(struct elf_file *efile, off_t offset, void *dst,
 int	elf_read_raw_data_alloc(struct elf_file *efile, off_t offset,
     size_t len, void **out);
 
+/* Reads a single string at the given offset from an ELF file. */
+int	elf_read_raw_string(struct elf_file *efile, off_t offset, char *dst,
+    size_t len);
+
 /*
  * Read relocated data from an ELF file and return it in a
  * dynamically-allocated buffer.  Note that no translation

--- a/usr.sbin/kldxref/ef_obj.c
+++ b/usr.sbin/kldxref/ef_obj.c
@@ -248,7 +248,6 @@ static int
 ef_obj_seg_read_string(elf_file_t ef, GElf_Addr address, size_t len, char *dest)
 {
 	GElf_Off ofs;
-	int error;
 
 	ofs = ef_obj_get_offset(ef, address);
 	if (ofs == 0) {
@@ -258,13 +257,7 @@ ef_obj_seg_read_string(elf_file_t ef, GElf_Addr address, size_t len, char *dest)
 		return (EFAULT);
 	}
 
-	error = elf_read_raw_data(ef->ef_efile, ofs, dest, len);
-	if (error != 0)
-		return (error);
-	if (strnlen(dest, len) == len)
-		return (EFAULT);
-
-	return (0);
+	return (elf_read_raw_string(ef->ef_efile, ofs, dest, len));
 }
 
 int

--- a/usr.sbin/kldxref/elf.c
+++ b/usr.sbin/kldxref/elf.c
@@ -232,6 +232,24 @@ elf_read_raw_data_alloc(struct elf_file *efile, off_t offset, size_t len,
 }
 
 int
+elf_read_raw_string(struct elf_file *efile, off_t offset, char *dst, size_t len)
+{
+	ssize_t nread;
+
+	nread = pread(efile->ef_fd, dst, len, offset);
+	if (nread == -1)
+		return (errno);
+	if (nread == 0)
+		return (EIO);
+
+	/* A short read is ok so long as the data contains a terminator. */
+	if (strnlen(dst, nread) == nread)
+		return (EFAULT);
+
+	return (0);
+}
+
+int
 elf_read_data(struct elf_file *efile, Elf_Type type, off_t offset, size_t len,
     void **out)
 {


### PR DESCRIPTION
If a string is at or near the end of an input file and the amount of
remaining data in the file is smaller than the maximum string size,
the pread(2) system call would return a short read which is treated as
an error.  Instead, add a new helper function for reading a string
which permits short reads so long as the data read from the file
contains a terminated string.

Reported by:	jrtc27
Reviewed by:	jrtc27
Sponsored by:	University of Cambridge, Google, Inc.
Differential Revision:	https://reviews.freebsd.org/D44419

(cherry picked from commit 785600d0fb13d6f0b4595bf4dbbc048113dda71d)
