### PR TITLE
 c18n: Save caller's stack pointer in trusted frame 

### DIFF
--- a/lib/libsysdecode/utrace.c
+++ b/lib/libsysdecode/utrace.c
@@ -87,6 +87,29 @@ print_utrace_mrs(FILE *fp, void *p)
 	}
 	return (1);
 }
+
+static int
+print_utrace_c18n(FILE *fp, void *p)
+{
+	struct utrace_c18n *ut = p;
+
+	switch (ut->event) {
+	case UTRACE_COMPARTMENT_ENTER:
+		fprintf(fp, "RTLD: c18n: enter %s from %s at [%zu] %s (%02hhx)",
+		    ut->callee, ut->caller, ut->symnum, ut->symbol, ut->fsig);
+		break;
+	case UTRACE_COMPARTMENT_LEAVE:
+		fprintf(fp, "RTLD: c18n: leave %s to %s at [%zu] %s (%02hhx)",
+		    ut->callee, ut->caller, ut->symnum, ut->symbol, ut->fsig);
+		break;
+	default:
+		return (0);
+	}
+	if (ut->verbose)
+		fprintf(fp, "\no_sp = %p, fp = %#p\nn_sp = %#p, csp = %#p\n",
+		    ut->o_sp, ut->fp, ut->n_sp, ut->csp);
+	return (1);
+}
 #endif
 
 #ifdef __LP64__
@@ -200,16 +223,6 @@ print_utrace_rtld(FILE *fp, void *p)
 	case UTRACE_RTLD_ERROR:
 		fprintf(fp, "RTLD: error: %s\n", ut->name);
 		break;
-	case UTRACE_COMPARTMENT_ENTER:
-		fprintf(fp,
-		    "RTLD: c18n: enter %s from %s at [%zu] %s (%p)",
-		    ut->callee, ut->caller, ut->mapsize, ut->symbol, ut->handle);
-		break;
-	case UTRACE_COMPARTMENT_LEAVE:
-		fprintf(fp,
-		    "RTLD: c18n: leave %s to %s at [%zu] %s",
-		    ut->callee, ut->caller, ut->mapsize, ut->symbol);
-		break;
 
 	default:
 		return (0);
@@ -279,10 +292,15 @@ sysdecode_utrace(FILE *fp, void *p, size_t len)
 	static const char rtld_utrace_sig[RTLD_UTRACE_SIG_SZ] = RTLD_UTRACE_SIG;
 #ifdef __CHERI_PURE_CAPABILITY__
 	static const char mrs_utrace_sig[MRS_UTRACE_SIG_SZ] = MRS_UTRACE_SIG;
+	static const char c18n_utrace_sig[C18N_UTRACE_SIG_SZ] = C18N_UTRACE_SIG;
 
 	if (len == sizeof(struct utrace_mrs) && bcmp(p, mrs_utrace_sig,
 	    sizeof(mrs_utrace_sig)) == 0)
 		return (print_utrace_mrs(fp, p));
+
+	if (len == sizeof(struct utrace_c18n) && bcmp(p, c18n_utrace_sig,
+	    sizeof(c18n_utrace_sig)) == 0)
+		return (print_utrace_c18n(fp, p));
 #endif
 
 	if (len == sizeof(struct utrace_rtld) && bcmp(p, rtld_utrace_sig,

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -114,7 +114,11 @@ CFLAGS+=	-I${RTLD_ELF_DIR}/cheri
 .endif
 
 .ifdef RTLD_SANDBOX
-SRCS+=		rtld_c18n.c rtld_c18n_machdep.c rtld_c18n_asm.S
+SRCS+= \
+	rtld_c18n.c \
+	rtld_c18n_policy.S \
+	rtld_c18n_machdep.c \
+	rtld_c18n_asm.S
 .endif
 
 .if ${MACHINE_ABI:Mpurecap}

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -26,6 +26,9 @@
  */
 
 #include <machine/asm.h>
+#define	IN_ASM
+#include "rtld_c18n_machdep.h"
+#undef IN_ASM
 
 ENTRY(_rtld_setjmp)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
@@ -345,7 +348,7 @@ TRAMP(tramp_save_caller)
 	 */
 	gclim	x11, c10
 	scvalue	c18, c10, x11
-	ldr	c17, [c18, #-CAP_WIDTH]
+	ldr	x17, [c18, #-CAP_WIDTH]
 	str	c10, [c18, #-CAP_WIDTH]
 
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
@@ -364,14 +367,15 @@ TRAMP(tramp_save_caller)
 2:	add	x13, x13, #0	/* To be patched at runtime */
 
 	/* Push frame */
-	stp	c29, c30, [TRUSTED_STACK, #-(CAP_WIDTH * 14)]!
+	stp	c29, c30, [TRUSTED_STACK, #-(CAP_WIDTH * C18N_TRUSTED_FRAME_SIZE)]!
 	stp	x12, x13, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
-	stp	c17, c19, [TRUSTED_STACK, #(CAP_WIDTH * 3)]
-	stp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 5)]
-	stp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 7)]
-	stp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 9)]
-	stp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 11)]
-	str	c28, [TRUSTED_STACK, #(CAP_WIDTH * 13)]
+	str	c10, [TRUSTED_STACK, #(CAP_WIDTH * 3)]
+	stp	x17, x12, [TRUSTED_STACK, #(CAP_WIDTH * 4)]
+	stp	c19, c20, [TRUSTED_STACK, #(CAP_WIDTH * 5)]
+	stp	c21, c22, [TRUSTED_STACK, #(CAP_WIDTH * 7)]
+	stp	c23, c24, [TRUSTED_STACK, #(CAP_WIDTH * 9)]
+	stp	c25, c26, [TRUSTED_STACK, #(CAP_WIDTH * 11)]
+	stp	c27, c28, [TRUSTED_STACK, #(CAP_WIDTH * 13)]
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	msr	rcsp_el0, TRUSTED_STACK
 #endif
@@ -435,12 +439,12 @@ TRAMP(tramp_switch_stack)
 	/*
 	 * If the stack table index is out-of-bounds, set it to zero.
 	 */
-	csel	w17, w14, wzr, hi
+	csel	w26, w14, wzr, hi
 	/*
 	 * Load the callee's stack if the stack table index is within bounds.
 	 * Otherwise the resolver will be loaded.
 	 */
-	ldr	c20, [c30, w17, uxtw #4]
+	ldr	c20, [c30, w26, uxtw #4]
 	/*
 	 * If the resolver has been loaded, set the branch target to it.
 	 */
@@ -529,8 +533,8 @@ TRAMP(tramp_invoke_res)
 	mov	x23, xzr
 	mov	x24, xzr
 	mov	x25, xzr
-	mov	x26, xzr
 	/*
+	 * - c26: Stack table index (scalar)
 	 * - c27: Test result (scalar)
 	 * - c28: Permission bits (scalar)
 	 * - c29: Frame pointer (scalar)
@@ -539,13 +543,13 @@ TRAMP(tramp_invoke_res)
 	/*
 	 * Clear temporary registers, except
 	 * - c10: Callee's stack
-	 * - c11: Top of caller's stack (scalar)
-	 * - c12: Link to previous frame (scalar)
-	 * - c13: Number of unused return argument registers (scalar)
+	 * - c11: Limit of caller's stack (scalar)
+	 * - c12: Old trusted stack (scalar)
+	 * - c13: Cookie and number of unused return argument registers (scalar)
 	 * - c14: Callee's compartment ID (scalar)
 	 * - c15: Length of stack table (scalar)
 	 * - c16: Comparison result (scalar)
-	 * - c17: Stack table index (scalar)
+	 * - c17: Old bottom of caller's stack (scalar)
 	 * - c18: CHERI_PERM_EXECUTE (scalar)
 	 */
 
@@ -563,20 +567,20 @@ TRAMP(tramp_pop_frame)
 	/* Restore callee-saved registers */
 	ldp	c29, c30, [TRUSTED_STACK]
 	ldp	x10, x11, [TRUSTED_STACK, #(CAP_WIDTH * 2)]
-	ldp	c12, c19, [TRUSTED_STACK, #(CAP_WIDTH * 3)]
-	ldp	c20, c21, [TRUSTED_STACK, #(CAP_WIDTH * 5)]
-	ldp	c22, c23, [TRUSTED_STACK, #(CAP_WIDTH * 7)]
-	ldp	c24, c25, [TRUSTED_STACK, #(CAP_WIDTH * 9)]
-	ldp	c26, c27, [TRUSTED_STACK, #(CAP_WIDTH * 11)]
-	ldr	c28, [TRUSTED_STACK, #(CAP_WIDTH * 13)]
+	ldp	c15, c12, [TRUSTED_STACK, #(CAP_WIDTH * 3)]
+	ldp	c19, c20, [TRUSTED_STACK, #(CAP_WIDTH * 5)]
+	ldp	c21, c22, [TRUSTED_STACK, #(CAP_WIDTH * 7)]
+	ldp	c23, c24, [TRUSTED_STACK, #(CAP_WIDTH * 9)]
+	ldp	c25, c26, [TRUSTED_STACK, #(CAP_WIDTH * 11)]
+	ldp	c27, c28, [TRUSTED_STACK, #(CAP_WIDTH * 13)]
 
 	/*
 	 * Restore caller's saved rcsp.
 	 */
-	gclim	x13, c12
-	scvalue	c14, c12, x13
-	ldr	c15, [c14, #-CAP_WIDTH]
-	str	c12, [c14, #-CAP_WIDTH]
+	gclim	x13, c15
+	scvalue	c14, c15, x13
+	scvalue	c2, c15, x12
+	str	c2, [c14, #-CAP_WIDTH]
 
 	/*
 	 * Clear unused return value registers. The registers to clear is
@@ -598,7 +602,10 @@ TRAMP(tramp_pop_frame)
 	msr	rcsp_el0, TRUSTED_STACK
 #endif
 
-	mov	x2, xzr
+	/*
+	 * Clear temporary registers, except
+	 * - c2: Old bottom of caller's stack
+	 */
 	mov	x3, xzr
 	mov	x4, xzr
 	mov	x5, xzr
@@ -610,10 +617,10 @@ TRAMP(tramp_pop_frame)
 	/*
 	 * Clear temporary registers, except
 	 * - c10: Link to previous frame (scalar)
-	 * - c11: Number of unused return argument registers (scalar)
-	 * - c12: Old top of caller's stack
-	 * - c13: Bottom of caller's stack (scalar)
-	 * - c14: Bottom of caller's stack
+	 * - c11: Cookie and number of unused return argument registers (scalar)
+	 * - c12: Old bottom of caller's stack (scalar)
+	 * - c13: Limit of caller's stack (scalar)
+	 * - c14: Limit of caller's stack
 	 * - c15: Current top of caller's stack
 	 * - c16: Logical operation result (scalar)
 	 * - c17: Comparison result (scalar)

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -257,7 +257,7 @@ ENTRY(tramp_hook)
 	 * This function is only called from trampolines when tracing
 	 * compartment transitions.
 	 *
-	 * Upon entry, c10-c15 hold the first arguments of tramp_hook.
+	 * Upon entry, c10-c12 hold the first arguments of tramp_hook.
 	 *
 	 * All argument registers must be preserved.
 	 */
@@ -278,9 +278,6 @@ ENTRY(tramp_hook)
 	mov	c0, c10
 	mov	c1, c11
 	mov	c2, c12
-	mov	c3, c13
-	mov	c4, c14
-	mov	c5, c15
 
 	str	c30, [csp, #-CAP_WIDTH]!
 	bl	tramp_hook_impl
@@ -400,25 +397,21 @@ TRAMP(tramp_update_fp_untagged)
 TRAMPEND(tramp_update_fp_untagged)
 
 TRAMP(tramp_call_hook)
-1:	ldr	c18, #0		/* To be patched at runtime */
+1:	ldr	c13, #0		/* To be patched at runtime */
 
-2:	mov	w11, #0		/* To be patched at runtime */
-	mov	c12, c19
-3:	ldr	c13, #0		/* To be patched at runtime */
-4:	ldr	c14, #0		/* To be patched at runtime */
-	mov	c15, c30
-
+2:	mov	w10, #0		/* To be patched at runtime */
+3:	adr	c11, #0		/* To be patched at runtime */
+	mov	c12, TRUSTED_STACK
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	blr	x18
+	blr	x13
 #else
-	blr	c18
+	blr	c13
 #endif
 TRAMPEND(tramp_call_hook)
 
 PATCH_POINT(tramp_call_hook, function, 1b)
 PATCH_POINT(tramp_call_hook, event, 2b)
-PATCH_POINT(tramp_call_hook, obj, 3b)
-PATCH_POINT(tramp_call_hook, def, 4b)
+PATCH_POINT(tramp_call_hook, header, 3b)
 
 TRAMP(tramp_switch_stack)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
@@ -560,7 +553,25 @@ TRAMP(tramp_invoke_res)
 #endif
 TRAMPEND(tramp_invoke_res)
 
-TRAMP(tramp_pop_frame)
+TRAMP(tramp_return_hook)
+1:	ldr	c13, #0			/* To be patched at runtime */
+
+2:	mov	w10, #0			/* To be patched at runtime */
+3:	adr	c11, #0			/* To be patched at runtime */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	mrs	c12, rcsp_el0
+	blr	x13
+#else
+	mov	c12, csp
+	blr	c13
+#endif
+TRAMPEND(tramp_return_hook)
+
+PATCH_POINT(tramp_return_hook, function, 1b)
+PATCH_POINT(tramp_return_hook, event, 2b)
+PATCH_POINT(tramp_return_hook, header, 3b)
+
+TRAMP(tramp_return)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	mrs	TRUSTED_STACK, rcsp_el0
 #endif
@@ -633,38 +644,9 @@ TRAMP(tramp_pop_frame)
 	 */
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	mov	csp, c15
-#else
-	msr	rcsp_el0, c15
-#endif
-TRAMPEND(tramp_pop_frame)
-
-TRAMP(tramp_return)
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	RETURN
 #else
+	msr	rcsp_el0, c15
 	retr	c30
 #endif
 TRAMPEND(tramp_return)
-
-TRAMP(tramp_return_hook)
-	/* Save return value registers */
-1:	ldr	c18, #0			/* To be patched at runtime */
-
-	mov	c10, c15
-2:	mov	w11, #0			/* To be patched at runtime */
-	mov	x12, xzr
-3:	ldr	c13, #0			/* To be patched at runtime */
-4:	ldr	c14, #0			/* To be patched at runtime */
-	mov	c15, c30
-
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	br	x18
-#else
-	br	c18
-#endif
-TRAMPEND(tramp_return_hook)
-
-PATCH_POINT(tramp_return_hook, function, 1b)
-PATCH_POINT(tramp_return_hook, event, 2b)
-PATCH_POINT(tramp_return_hook, obj, 3b)
-PATCH_POINT(tramp_return_hook, def, 4b)

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -157,18 +157,14 @@ tramp_compile(char **entry, const struct tramp_data *data)
 		PATCH_LDR_IMM(call_hook, def, 3);
 	}
 
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	COPY(switch_stack);
-	PATCH_MOV(switch_stack, cid,
-	    compart_id_to_index(executive ? C18N_RTLD_COMPART_ID :
-	        data->defobj->compart_id));
-#else
-	if (!executive) {
+#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	if (!executive)
+#endif
+	{
 		COPY(switch_stack);
 		PATCH_MOV(switch_stack, cid,
-		    compart_id_to_index(data->defobj->compart_id));
+		    cid_to_index(data->defobj->compart_id));
 	}
-#endif
 
 	if (executive)
 		COPY(invoke_exe);

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
@@ -28,20 +28,50 @@
 #ifndef RTLD_C18N_MACHDEP_H
 #define RTLD_C18N_MACHDEP_H
 
+#define	C18N_TRUSTED_FRAME_SIZE		15
+
+#ifndef IN_ASM
 /*
  * Stack unwinding
  */
 struct trusted_frame {
 	void *fp;
 	void *pc;
+	/*
+	 * Address of the next trusted frame
+	 */
 	ptraddr_t next;
+	/*
+	 * Number of return value registers, encoded in enum tramp_ret_args
+	 */
 	uint8_t ret_args : 2;
+	/*
+	 * This field contains the code address in the trampoline that the
+	 * callee should return to. This is only used by unwinders to detect
+	 * compartment boundaries.
+	 */
 	ptraddr_t cookie : 62;
+	/*
+	 * INVARIANT: This field contains the top of the caller's stack when the
+	 * caller made the call.
+	 */
+	void *n_sp;
 	/*
 	 * INVARIANT: This field contains the top of the caller's stack when the
 	 * caller was last entered.
 	 */
-	void *o_sp;
+	ptraddr_t o_sp;
+	/*
+	 * Only used by unwinders
+	 */
+	ptraddr_t csp;
+	/*
+	 * c19 to c28
+	 */
+	void *regs[10];
 };
-
+_Static_assert(
+    sizeof(struct trusted_frame) == sizeof(uintptr_t) * C18N_TRUSTED_FRAME_SIZE,
+    "Unexpected struct trusted_frame size");
+#endif
 #endif

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -52,23 +52,24 @@ ENTRY(.rtld_start)
 #ifdef __CHERI_PURE_CAPABILITY__
 	.cfi_undefined	c30
 	mov	c19, c0				/* Put aux in a callee-saved register */
-#ifdef RTLD_SANDBOX
-	mov	c1, csp
-	sub	csp, csp, #(CAP_WIDTH * 2)
-	bl	c18n_init_rtld_stack
-#endif
-	mov	c20, csp			/* And the stack pointer */
-
-	sub	csp, csp, #32			/* Make room for obj_main & exit proc */
 
 	adrp	c0, _DYNAMIC
 	add	c0, c0, :lo12:_DYNAMIC		/* dynp */
 	mov	c1, c19				/* aux */
 	bl	_rtld_relocate_nonplt_self	/* Relocate ourselves early */
 
+#ifdef RTLD_SANDBOX
+	mov	c1, csp
+	sub	csp, csp, #(CAP_WIDTH * 2)
+	bl	c18n_init_rtld_stack
+#endif
+
 #if __CHERI_CAPABILITY_TABLE__ != 3
 #error "Only the PC-relative ABI is currently supported"
 #endif
+
+	mov	c20, csp			/* Save the stack pointer */
+	sub	csp, csp, #32			/* Make room for obj_main & exit proc */
 
 	mov	c0, c19				/* Restore aux */
 	scbnds	c1, csp, #16			/* exit_proc */

--- a/libexec/rtld-elf/rtld-libc/Makefile.inc
+++ b/libexec/rtld-elf/rtld-libc/Makefile.inc
@@ -68,7 +68,6 @@ _libc_other_objects=sigsetjmp lstat stat fstat fstatat fstatfs syscall \
     _sigprocmask _write readlink __realpathat _setjmp setjmp setjmperr
 
 .ifdef RTLD_SANDBOX
-SRCS+=	mempcpy.c
 _libc_other_objects+=thr_exit
 .endif
 

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -845,6 +845,9 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     ld_utrace = ld_get_env_var(LD_UTRACE);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
     ld_compartment_utrace = ld_get_env_var(LD_UTRACE_COMPARTMENT);
+    if (ld_compartment_utrace != NULL)
+	ld_compartment_utrace_verbose =
+	    strcmp(ld_compartment_utrace, "verbose") == 0;
     ld_compartment_enable = ld_get_env_var(LD_COMPARTMENT_ENABLE);
     ld_compartment_policy = ld_get_env_var(LD_COMPARTMENT_POLICY);
     ld_compartment_overhead = ld_get_env_var(LD_COMPARTMENT_OVERHEAD);

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -797,6 +797,12 @@ _rtld_longjmp_impl(uintptr_t ret, void **buf, struct trusted_frame *csp,
 	do {
 		stk = cheri_setoffset(cur->n_sp, cheri_getlen(cur->n_sp));
 		--stk;
+
+		rtld_require((ptraddr_t)stk->top <= cur->o_sp,
+		    "c18n: Cannot unwind %s from %#p to %p\n"
+		    "csp: %#p -> %#p", comparts.data[stk->compart_id].name,
+		    stk->top, (void *)(uintptr_t)cur->o_sp, csp, target);
+
 		stk->top = cheri_setaddress(cur->n_sp, cur->o_sp);
 		cur = cheri_setaddress(cur, cur->next);
 	} while (cur < target);
@@ -815,6 +821,12 @@ _rtld_longjmp_impl(uintptr_t ret, void **buf, struct trusted_frame *csp,
 	 */
 	stk = cheri_setoffset(rcsp, cheri_getlen(rcsp));
 	--stk;
+
+	rtld_require(rcsp <= stk->top,
+	    "c18n: Cannot complete unwind %s from %#p to %#p\n"
+	    "csp: %#p -> %#p", comparts.data[stk->compart_id].name,
+	    rcsp, stk->top, csp, target);
+
 	csp->n_sp = rcsp;
 	csp->o_sp = (ptraddr_t)stk->top;
 

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -465,6 +465,10 @@ tramp_should_include(const Obj_Entry *reqobj, const struct tramp_data *data)
 struct stk_bottom {
 	compart_id_t compart_id;
 	/*
+	 * Store an integer address of the compartment's name for debuggers.
+	 */
+	ptraddr_t compart_name;
+	/*
 	 * INVARIANT: The bottom of a compartment's stack contains a capability
 	 * to the top of the stack either when the compartment was last entered
 	 * or when it was last exited from, which ever occured later.
@@ -504,6 +508,7 @@ init_compart_stack(void *base, compart_id_t cid)
 	memset(stk, 0, sizeof(*stk));
 	*stk = (struct stk_bottom) {
 		.compart_id = cid,
+		.compart_name = (ptraddr_t)comparts.data[cid].name,
 		.top = cheri_clearperm(stk, CHERI_PERM_SW_VMEM)
 	};
 }

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -567,9 +567,9 @@ _rtld_longjmp_impl(uintptr_t ret, void **buf, struct trusted_frame *csp,
 	 * Unwind each frame before the target frame.
 	 */
 	do {
-		stk = cheri_setoffset(cur->o_sp, cheri_getlen(cur->o_sp));
+		stk = cheri_setoffset(cur->n_sp, cheri_getlen(cur->n_sp));
 		--stk;
-		stk->top = cur->o_sp;
+		stk->top = cheri_setaddress(cur->n_sp, cur->o_sp);
 		cur = cheri_setaddress(cur, cur->next);
 	} while (cur < target);
 
@@ -587,8 +587,8 @@ _rtld_longjmp_impl(uintptr_t ret, void **buf, struct trusted_frame *csp,
 	 */
 	stk = cheri_setoffset(rcsp, cheri_getlen(rcsp));
 	--stk;
-	csp->o_sp = stk->top;
-	stk->top = rcsp;
+	csp->n_sp = rcsp;
+	csp->o_sp = (ptraddr_t)stk->top;
 
 	return ((struct jmp_args) { .ret = ret });
 }

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -36,6 +36,7 @@
  */
 extern uintptr_t sealer_pltgot, sealer_tramp;
 extern const char *ld_compartment_utrace;
+extern bool ld_compartment_utrace_verbose;
 extern const char *ld_compartment_enable;
 extern const char *ld_compartment_policy;
 extern const char *ld_compartment_overhead;

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -180,7 +180,8 @@ struct tramp_data {
 struct tramp_header {
 	void *target;
 	const Obj_Entry *defobj;
-	const Elf_Sym *def;
+	size_t symnum;
+	struct func_sig sig;
 	uint32_t entry[];
 };
 

--- a/libexec/rtld-elf/rtld_c18n_policy.S
+++ b/libexec/rtld-elf/rtld_c18n_policy.S
@@ -1,0 +1,41 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+.section	.rodata
+.globl	c18n_default_policy
+.type	c18n_default_policy,#object
+c18n_default_policy:
+	.incbin "rtld_c18n_policy.txt"
+c18n_default_policy_end:
+.size	c18n_default_policy, . - c18n_default_policy
+
+.globl	c18n_default_policy_size
+.type	c18n_default_policy_size,#object
+.align	3
+c18n_default_policy_size:
+	.quad	c18n_default_policy_end - c18n_default_policy
+.size	c18n_default_policy_size, . - c18n_default_policy_size

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -44,6 +44,16 @@ trust
 	siglongjmp
 	vfork
 	rfork
+	execve
+	fxecve
+	execl
+	execlp
+	execle
+	exect
+	execv
+	execvp
+	execvpe
+	execvP
 	_rtld_thread_start
 
 callee [RTLD]

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -1,0 +1,57 @@
+Version 1
+
+compartment [TCB]
+	libc.so.7
+	libthr.so.3
+
+caller *
+trust
+	memset
+	memcpy
+	mempcpy
+	memccpy
+	memchr
+	memrchr
+	memmem
+	memmove
+	strcpy
+	strncpy
+	stpcpy
+	stpncpy
+	strcat
+	strncat
+	strlcpy
+	strlcat
+	strlen
+	strnlen
+	strcmp
+	strncmp
+	strchr
+	strrchr
+	strchrnul
+	strspn
+	strcspn
+	strpbrk
+	strsep
+	strstr
+	strnstr
+	__libc_start1
+	setjmp
+	longjmp
+	_setjmp
+	_longjmp
+	sigsetjmp
+	siglongjmp
+	vfork
+	rfork
+	_rtld_thread_start
+
+callee [RTLD]
+export to [TCB]
+	_rtld_thread_start_init
+	_rtld_thread_start
+	_rtld_thr_exit
+	_rtld_sighandler_init
+	_rtld_sighandler
+	_rtld_setjmp
+	_rtld_longjmp

--- a/libexec/rtld-elf/rtld_utrace.h
+++ b/libexec/rtld-elf/rtld_utrace.h
@@ -44,8 +44,6 @@
 #define	UTRACE_DLSYM_START		11
 #define	UTRACE_DLSYM_STOP		12
 #define	UTRACE_RTLD_ERROR		13
-#define	UTRACE_COMPARTMENT_ENTER	14
-#define	UTRACE_COMPARTMENT_LEAVE	15
 
 #define	RTLD_UTRACE_SIG_SZ		4
 #define	RTLD_UTRACE_SIG			"RTLD"
@@ -57,14 +55,31 @@ struct utrace_rtld {
 	void *mapbase;			/* Used for 'parent' and 'init/fini' */
 	size_t mapsize;
 	int refcnt;			/* Used for 'mode' */
-	union {
-		char name[MAXPATHLEN];
-		struct {
-			char symbol[MAXPATHLEN / 2];
-			char callee[MAXPATHLEN / 4];
-			char caller[MAXPATHLEN / 4];
-		};
-	};
+	char name[MAXPATHLEN];
 };
+
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	UTRACE_COMPARTMENT_ENTER	1
+#define	UTRACE_COMPARTMENT_LEAVE	2
+
+#define	C18N_UTRACE_SIG_SZ		4
+#define	C18N_UTRACE_SIG			"C18N"
+
+struct utrace_c18n {
+	char sig[C18N_UTRACE_SIG_SZ];
+	uint8_t event;
+	bool verbose;
+	uint8_t fsig;
+	size_t symnum;
+	const void *csp;
+	void *fp;
+	void *pc;
+	void *o_sp;
+	void *n_sp;
+	char symbol[256];
+	char callee[128];
+	char caller[128];
+};
+#endif
 
 #endif


### PR DESCRIPTION
The first commit (5094160ff93673c3f6c68c70b29004546977b638) actually makes the change. The rest of the commits are rebased from #2054.