### PR TITLE
c18n: Augment dummy stack to contain full metadata

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -171,7 +171,8 @@ ENTRY(allocate_rstk)
 	 */
 
 #ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	adr	c20, (dummy_stack + CAP_WIDTH * 2)
+	gclim	x20, csp
+	scvalue	c20, csp, x20
 #endif
 	ldr	c20, [c20, #-CAP_WIDTH]
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI


### PR DESCRIPTION
Previously, the dummy stack used to fill the Restricted stack pointer when running Executive mode code is just a capability pointing to itself. This commit augments the dummy stack to contain full metadata like all other Restricted stacks.