### PR TITLE
libc: Do not override __libc_sigaction to support c18n signal handling

### DIFF
--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -461,4 +461,8 @@ struct _xlocale;
 struct __nl_cat_d *__catopen_l(const char *name, int type,
 	    struct _xlocale *locale);
 
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+int	sigaction_c18n(int, const struct sigaction *, struct sigaction *);
+#endif
+
 #endif /* _LIBC_PRIVATE_H_ */

--- a/lib/libc/sys/interposing_table.c
+++ b/lib/libc/sys/interposing_table.c
@@ -65,7 +65,7 @@ interpos_func_t __libc_interposing[INTERPOS_MAX] = {
 	SLOT_SYS(sendto)
 	SLOT_SYS(setcontext)
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	SLOT_LIBC(sigaction)
+	SLOT(sigaction, sigaction_c18n)
 #else
 	SLOT_SYS(sigaction)
 #endif

--- a/lib/libc/sys/sigaction.c
+++ b/lib/libc/sys/sigaction.c
@@ -34,6 +34,7 @@
 #include "libc_private.h"
 
 __weak_reference(__sys_sigaction, __sigaction);
+__weak_reference(sigaction, __libc_sigaction);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 /*
  * These weak symbols will always be resolved at runtime.
@@ -49,7 +50,7 @@ void _rtld_sigaction_end(int, void *, const struct sigaction *,
     struct sigaction *);
 
 int
-__libc_sigaction(int sig, const struct sigaction *act, struct sigaction *oact)
+sigaction_c18n(int sig, const struct sigaction *act, struct sigaction *oact)
 {
 	int ret;
 	void *context = 0;
@@ -72,8 +73,6 @@ __libc_sigaction(int sig, const struct sigaction *act, struct sigaction *oact)
 
 	return (ret);
 }
-#else
-__weak_reference(sigaction, __libc_sigaction);
 #endif
 
 #pragma weak sigaction


### PR DESCRIPTION
Previously c18n signal handling was supported by overriding __libc_sigaction to call RTLD hooks. However, libthr swaps the default sigaction implementation for its own, yet many libc function continue to call __libc_sigaction instead of the libthr version of sigaction.

This commit creates a new function to be inserted into the interpose table while reverting __libc_sigaction to redirect through the interpose table.