### PR TITLE
cheribsdtest: Add function pointer canonicity tests

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -75,7 +75,8 @@ CFLAGS+=	-DCHERIBSD_DYNAMIC_TESTS
 CFLAGS+=	'-DLIBM_SONAME="libm.so.5"'
 CFLAGS+=	-I${SRCTOP}/lib/libcheribsdtest_dynamic
 LIBADD+=	cheribsdtest_dynamic
-SRCS+=		cheribsdtest_lazy_bind.c
+SRCS+=		cheribsdtest_fptr_canon.c				\
+		cheribsdtest_lazy_bind.c
 .else
 NO_SHARED?=	YES
 .endif

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -151,6 +151,15 @@ extern struct cheribsdtest_child_state *ccsp;
 #endif
 #endif
 
+#ifndef XFAIL_C18N_FPTR_CANON
+#ifdef CHERIBSD_C18N_TESTS
+#define	XFAIL_C18N_FPTR_CANON \
+    "function pointers are currently non-canonical with library-based compartmentalisation"
+#else
+#define	XFAIL_C18N_FPTR_CANON	NULL
+#endif
+#endif
+
 struct cheri_test {
 	const char	*ct_name;
 	const char	*ct_desc;

--- a/bin/cheribsdtest/cheribsdtest_fptr_canon.c
+++ b/bin/cheribsdtest/cheribsdtest_fptr_canon.c
@@ -1,0 +1,87 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Jessica Clarke
+ *
+ * This software was developed by the University of Cambridge Computer
+ * Laboratory (Department of Computer Science and Technology) under Innovate
+ * UK project 105694, "Digital Security by Design (DSbD) Technology Platform
+ * Prototype".
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <dlfcn.h>
+
+#include <cheribsdtest_dynamic.h>
+
+#include "cheribsdtest.h"
+
+CHERIBSDTEST(fptr_canon_cross,
+    "Check that function pointers are canonical across objects",
+    .ct_xfail_reason = XFAIL_C18N_FPTR_CANON)
+{
+	void (* volatile fptr_inside)(void);
+	void (* volatile fptr_outside)(void);
+
+	fptr_inside = cheribsdtest_dynamic_get_dummy_fptr();
+	fptr_outside = &cheribsdtest_dynamic_dummy_func;
+
+	CHERIBSDTEST_VERIFY2(cheri_ptr_equal_exact(fptr_inside, fptr_outside),
+	    "inside %#p differs from outside %#p", fptr_inside, fptr_outside);
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(fptr_canon_dlsym,
+    "Check that function pointers are canonical for dlsym",
+    .ct_xfail_reason = XFAIL_C18N_FPTR_CANON)
+{
+	void (* volatile fptr_inside)(void);
+	void (* volatile fptr_dlsym)(void);
+
+	fptr_inside = cheribsdtest_dynamic_get_dummy_fptr();
+	fptr_dlsym = (void (*)(void))dlsym(RTLD_DEFAULT,
+	    "cheribsdtest_dynamic_dummy_func");
+
+	CHERIBSDTEST_VERIFY2(cheri_ptr_equal_exact(fptr_inside, fptr_dlsym),
+	    "inside %#p differs from dlsym %#p", fptr_inside, fptr_dlsym);
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(fptr_canon_dlfunc,
+    "Check that function pointers are canonical for dlfunc",
+    .ct_xfail_reason = XFAIL_C18N_FPTR_CANON)
+{
+	void (* volatile fptr_inside)(void);
+	void (* volatile fptr_dlfunc)(void);
+
+	fptr_inside = cheribsdtest_dynamic_get_dummy_fptr();
+	fptr_dlfunc = (void (*)(void))dlfunc(RTLD_DEFAULT,
+	    "cheribsdtest_dynamic_dummy_func");
+
+	CHERIBSDTEST_VERIFY2(cheri_ptr_equal_exact(fptr_inside, fptr_dlfunc),
+	    "inside %#p differs from dlfunc %#p", fptr_inside, fptr_dlfunc);
+
+	cheribsdtest_success();
+}

--- a/lib/libcheribsdtest_dynamic/Makefile
+++ b/lib/libcheribsdtest_dynamic/Makefile
@@ -2,6 +2,7 @@ SHLIB=	cheribsdtest_dynamic
 PRIVATELIB=
 MAN=	# No manpage; this is internal.
 
-SRCS=	cheribsdtest_dynamic_identity_cap.c
+SRCS=	cheribsdtest_dynamic_fptr.c					\
+	cheribsdtest_dynamic_identity_cap.c
 
 .include <bsd.lib.mk>

--- a/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_fptr.c
+++ b/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_fptr.c
@@ -1,5 +1,12 @@
 /*-
- * Copyright (c) 2021 Jessica Clarke
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Jessica Clarke
+ *
+ * This software was developed by the University of Cambridge Computer
+ * Laboratory (Department of Computer Science and Technology) under Innovate
+ * UK project 105694, "Digital Security by Design (DSbD) Technology Platform
+ * Prototype".
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +30,17 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _CHERIBSDTEST_DYNAMIC_H_
-#define _CHERIBSDTEST_DYNAMIC_H_
+#include <sys/types.h>
 
-void cheribsdtest_dynamic_dummy_func(void);
-void (*cheribsdtest_dynamic_get_dummy_fptr(void))(void);
+#include "cheribsdtest_dynamic.h"
 
-void * __capability cheribsdtest_dynamic_identity_cap(void * __capability cap);
+void
+cheribsdtest_dynamic_dummy_func(void)
+{
+}
 
-#endif
+void
+(*cheribsdtest_dynamic_get_dummy_fptr(void))(void)
+{
+	return (&cheribsdtest_dynamic_dummy_func);
+}


### PR DESCRIPTION
These reveal the currently-broken c18n implementation.
