### PR TITLE
Update capability tag reading via ptrace() for async revocation

### DIFF
--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -516,7 +516,8 @@ proc_read_cheri_tags_page(vm_map_t map, vm_offset_t va, void *tagbuf,
 	 * Fault in the next page, but only if it already exists.  If
 	 * the page doesn't exist, fill the tag buffer with zeroes.
 	 */
-	error = vm_fault(map, va, VM_PROT_READ, VM_FAULT_NOFILL, &m);
+	error = vm_fault(map, va, VM_PROT_READ,
+	    VM_FAULT_NOFILL | VM_FAULT_NOPMAP, &m);
 	if (error == KERN_PAGE_NOT_FILLED) {
 		memset(tagbuf, 0, TAG_BYTES_PER_PAGE);
 		*hastagsp = false;


### PR DESCRIPTION
I got a `panic: cheri revoke does not support foreign maps (yet)` running GDB on `chericat`. This fix merges the tweak from ebc253e0464f87220085b303a5427fad91cd1d90 into `proc_read_cheri_tags_page()`, which seems to resolve the issue here. But definitely wants review by @markjdb. When ready, this change will want to go into the demo branch also.