### PR TITLE
procstat(1) support for per-process compartment statistics

### DIFF
--- a/lib/libprocstat/Symbol.map
+++ b/lib/libprocstat/Symbol.map
@@ -50,4 +50,6 @@ FBSD_1.7 {
 	 procstat_getquarantining;
 	 procstat_get_revoker_epoch;
 	 procstat_get_revoker_state;
+	 procstat_freec18n;
+	 procstat_getc18n;
 };

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -203,6 +203,7 @@ void	procstat_freeargv(struct procstat *procstat);
 #ifndef ZFS
 void	procstat_freeauxv(struct procstat *procstat, Elf_Auxinfo *auxv);
 #endif
+void	procstat_freec18n(struct procstat *procstat __unused, void *p);
 void	procstat_freeenvv(struct procstat *procstat);
 void	procstat_freegroups(struct procstat *procstat, gid_t *groups);
 void	procstat_freekstack(struct procstat *procstat,
@@ -215,6 +216,8 @@ void	procstat_freeptlwpinfo(struct procstat *procstat,
 void	procstat_freevmmap(struct procstat *procstat,
     struct kinfo_vmentry *vmmap);
 struct advlock_list	*procstat_getadvlock(struct procstat *procstat);
+int	procstat_getc18n(struct procstat *procstat, struct kinfo_proc *kp,
+    void **pp, size_t *lenp);
 struct filestat_list	*procstat_getfiles(struct procstat *procstat,
     struct kinfo_proc *kp, int mmapped);
 struct kinfo_proc	*procstat_getprocs(struct procstat *procstat,

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -147,6 +147,9 @@ SUBDIR.${MK_TESTS}+= tests
 # libcompiler_rt on some architectures.
 LIBADD+=	compiler_rt
 
+# Install one public header, used by procstat(1).
+INCS=	rtld_c18n_public.h
+
 .include <bsd.prog.mk>
 ${PROG_FULL}:	${VERSION_MAP}
 .include <bsd.symver.mk>

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -70,6 +70,7 @@
 #include "rtld_libc.h"
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
 #include "rtld_c18n.h"
+#include "rtld_c18n_public.h"
 #endif
 
 /* Types. */
@@ -90,6 +91,9 @@ typedef void * (*path_enum_proc) (const char *path, size_t len, void *arg);
 extern struct r_debug r_debug; /* For GDB */
 extern int _thread_autoinit_dummy_decl;
 extern void (*__cleanup)(void);
+#ifdef __CHERI_PURE_CAPABILITY__
+extern struct rtld_c18n_stats rtld_c18n_stats;
+#endif
 
 struct dlerror_save {
 	int seen;
@@ -637,6 +641,12 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     for (i = 0;  i < AT_COUNT;  i++)
 	aux_info[i] = NULL;
     for (auxp = aux;  auxp->a_type != AT_NULL;  auxp++) {
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (auxp->a_type == AT_C18N)
+	    auxp->a_un.a_ptr = &rtld_c18n_stats;
+	if (auxp->a_type == AT_C18NLEN)
+	    auxp->a_un.a_val = sizeof(rtld_c18n_stats);
+#endif
 	if (auxp->a_type < AT_COUNT)
 	    aux_info[auxp->a_type] = auxp;
 #ifdef __powerpc__

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1566,6 +1566,9 @@ c18n_init(void)
 			.reg_args = 3, .mem_args = false, .ret_args = NONE
 		}
 	});
+
+	/* Preinitialize to 1 to take into account the program binary. */
+	rtld_c18n_stats.rcs_compartments = 1;
 }
 
 /*

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 #include "rtld_c18n_machdep.h"
+#include "rtld_c18n_public.h"
 
 /*
  * Global symbols
@@ -45,6 +46,8 @@ extern const char *ld_compartment_policy;
 extern const char *ld_compartment_overhead;
 extern const char *ld_compartment_sig;
 extern const char *ld_compartment_unwind;
+
+extern struct rtld_c18n_stats rtld_c18n_stats;
 
 /*
  * Policies

--- a/libexec/rtld-elf/rtld_c18n_public.h
+++ b/libexec/rtld-elf/rtld_c18n_public.h
@@ -1,0 +1,44 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef RTLD_C18N_STATS_H
+#define RTLD_C18N_STATS_H
+
+struct rtld_c18n_stats {
+	long	rcs_compartments;
+	long	rcs_stacks;
+	long	rcs_trampolines;
+	long	rcs_tramppages;
+	long	rcs_tramptable;
+};
+
+#endif

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1912,6 +1912,8 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	AUXARGS_ENTRY(pos, AT_USRSTACKBASE, round_page(vmspace->vm_stacktop));
 	stacksz = imgp->proc->p_limit->pl_rlimit[RLIMIT_STACK].rlim_cur;
 	AUXARGS_ENTRY(pos, AT_USRSTACKLIM, stacksz);
+	AUXARGS_ENTRY_PTR(pos, AT_C18N, NULL);
+	AUXARGS_ENTRY(pos, AT_C18NLEN, 0);
 	AUXARGS_ENTRY(pos, AT_NULL, 0);
 
 	free(imgp->auxargs, M_TEMP);

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -1011,8 +1011,10 @@ typedef struct {
 #define	AT_KPRELOAD	34	/* Base of vdso, preloaded by rtld */
 #define	AT_USRSTACKBASE	35	/* Top of user stack */
 #define	AT_USRSTACKLIM	36	/* Grow limit of user stack */
+#define	AT_C18N		37	/* Location of C18N block (opaque to kernel) */
+#define	AT_C18NLEN	38	/* Length of C18N block */
 
-#define	AT_COUNT	37	/* Count of defined aux entry types. */
+#define	AT_COUNT	39	/* Count of defined aux entry types. */
 
 /*
  * Relocation types.

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1022,6 +1022,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_ARND		37	/* int: from arc4rand() */
 #define	KERN_MAXPHYS		38	/* int: MAXPHYS value */
 #define	KERN_LOCKF		39	/* struct: lockf reports */
+
 /*
  * KERN_PROC subtypes
  */
@@ -1064,6 +1065,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_PROC_QUARANTINING	46	/* is this process quarantining? */
 #define	KERN_PROC_REVOKER_STATE	47	/* revoker state */
 #define	KERN_PROC_REVOKER_EPOCH	48	/* revoker epoch */
+#define	KERN_PROC_C18N		49	/* c18n stats */
 
 /*
  * KERN_IPC identifiers

--- a/usr.bin/procstat/Makefile
+++ b/usr.bin/procstat/Makefile
@@ -9,6 +9,7 @@ SRCS=	procstat.c		\
 	procstat_auxv.c		\
 	procstat_basic.c	\
 	procstat_bin.c		\
+	procstat_c18n.c		\
 	procstat_cheri.c	\
 	procstat_cred.c		\
 	procstat_cs.c		\

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -169,6 +169,8 @@ Substring commands are accepted.
 Display command line arguments for the process.
 .Pp
 Substring commands are accepted.
+.It Ar c18n
+Display CHERI compartmentalization information about a process.
 .It Ar cheri
 Display CHERI-specific information about the process.
 If the
@@ -297,6 +299,26 @@ command
 .It ARGS
 command line arguments (if available)
 .El
+.Ss Compartmentalization information
+Display CHERI compartmentalization information for a process (see
+.Xr c18n 7 ) :
+.Pp
+.Bl -tag -width TRMPTBL -compact
+.It PID
+process ID
+.It COMM
+command
+.It COMP
+number of compartments
+.It STKS
+number of compartment stacks
+.It TRAMPS
+number of initialized trampolines
+.It TRPGS
+number of pages mapped for trampolines
+.It TRMPTBL
+size of the trampoline table in bytes
+.El
 .Ss CHERI information
 Display the process ID, command, and CHERI-specific information:
 .Pp
@@ -313,6 +335,10 @@ quarantining status
 in-kernel revoker state
 .It EPOCH
 in-kernel revoker epoch
+.It C18N
+number of
+.Xr c18n 7
+compartments
 .El
 .Pp
 The following values indicate the support for CHERI in the process ABI:
@@ -915,6 +941,7 @@ procstat: procstat_getprocs()
 .Xr sctp 4 ,
 .Xr tcp 4 ,
 .Xr udp 4 ,
+.Xr c18n 7 ,
 .Xr stack 9
 .Sh AUTHORS
 .An Robert N M Watson Aq Mt rwatson@FreeBSD.org .

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -93,6 +93,8 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_NORMAL },
 	{ "binary", "binary", NULL, &procstat_bin, &cmdopt_none,
 	    PS_CMP_SUBSTR },
+	{ "c18n", "c18n", NULL, &procstat_c18n, &cmdopt_none,
+	    PS_CMP_NORMAL },
 	{ "cheri", "cheri", "[-v]", &procstat_cheri, &cmdopt_verbose,
 	    PS_CMP_NORMAL },
 	{ "cpuset", "cs", NULL, &procstat_cs, &cmdopt_cpuset, PS_CMP_NORMAL },

--- a/usr.bin/procstat/procstat.h
+++ b/usr.bin/procstat/procstat.h
@@ -60,6 +60,7 @@ void	procstat_args(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_auxv(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_basic(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_bin(struct procstat *prstat, struct kinfo_proc *kipp);
+void	procstat_c18n(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cheri(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cred(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cs(struct procstat *prstat, struct kinfo_proc *kipp);

--- a/usr.bin/procstat/procstat_auxv.c
+++ b/usr.bin/procstat/procstat_auxv.c
@@ -284,6 +284,18 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			    prefix, "AT_USRSTACKLIM", auxv[i].a_un.a_val);
 			break;
 #endif
+#ifdef AT_C18N
+		case AT_C18N:
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_C18N/%s}\n",
+			    prefix, "AT_C18N", fmt_ptr(auxv[i].a_un.a_ptr));
+			break;
+#endif
+#ifdef AT_C18NLEN
+		case AT_C18NLEN:
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_C18NLEN/%ld}\n",
+			    prefix, "AT_C18NLEN", (long)auxv[i].a_un.a_val);
+			break;
+#endif
 		default:
 			xo_emit("{dw:/%s}{Lw:/%16ld/%ld}{:UNKNOWN/%#lx}\n",
 			    prefix, auxv[i].a_type, auxv[i].a_un.a_val);

--- a/usr.bin/procstat/procstat_c18n.c
+++ b/usr.bin/procstat/procstat_c18n.c
@@ -1,0 +1,79 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/user.h>
+
+#include <cheri/revoke.h>
+#include <cheri/revoke_kern.h>
+
+#include <err.h>
+#include <libprocstat.h>
+#include <string.h>
+#include <rtld_c18n_public.h>
+
+#include "procstat.h"
+
+void
+procstat_c18n(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	struct rtld_c18n_stats *rcsp;
+	size_t len;
+
+	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
+		xo_emit("{T:/%5s %-19s %5s %5s %6s %5s %7s}\n",
+			    "PID", "COMM", "COMP", "STKS", "TRAMPS", "TRPGS", "TRMPTBL");
+	}
+
+	if (procstat_getc18n(procstat, kipp, (void **)&rcsp, &len) < 0)
+		return;
+	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
+	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
+	if (rcsp == NULL || len < sizeof(*rcsp)) {
+		xo_emit(" {:compartments/%5s/%s}", "-");
+		xo_emit(" {:stacks/%5s/%s}", "-");
+		xo_emit(" {:trampolines/%6s/%s}", "-");
+		xo_emit(" {:tramppages/%5s/%s}", "-");
+		xo_emit(" {:tramptable/%7s/%s}", "-");
+	} else {
+		xo_emit(" {:compartments/%5lu/%lu}", rcsp->rcs_compartments);
+		xo_emit(" {:stacks/%5lu/%lu}", rcsp->rcs_compartments);
+		xo_emit(" {:trampolines/%6lju/%lu}", rcsp->rcs_trampolines);
+		xo_emit(" {:tramppages/%5d/%d}", rcsp->rcs_tramppages);
+		xo_emit(" {:tramptable/%7d/%d}", rcsp->rcs_tramptable);
+	}
+	xo_emit("\n");
+
+	procstat_freec18n(procstat, rcsp);
+}

--- a/usr.bin/procstat/procstat_cheri.c
+++ b/usr.bin/procstat/procstat_cheri.c
@@ -88,7 +88,7 @@ procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit(" {:revoker_epoch/%34s/%s}", abi_cheri == 'P' ?
 		    get_revoker_epoch(procstat, kipp) : "-");
 	}
-	xo_emit(" {:compartments/%s/%s}", get_c18n(procstat, kipp));
+	xo_emit(" {:compartments/%5s/%s}", get_c18n(procstat, kipp));
 	xo_emit("\n");
 }
 
@@ -192,6 +192,8 @@ get_c18n(struct procstat *procstat, struct kinfo_proc *kipp)
 	if (procstat_getc18n(procstat, kipp, (void **)&rcsp, &len) < 0) {
 		if (errno != ESRCH && errno != EPERM && errno != ENOEXEC)
 			warn("procstat_get_c18n");
+		snprintf(c18n_buf, sizeof(c18n_buf), "-");
+	} else if (len < sizeof(*rcsp)) {
 		snprintf(c18n_buf, sizeof(c18n_buf), "-");
 	} else {
 		snprintf(c18n_buf, sizeof(c18n_buf), "%5lu",

--- a/usr.bin/procstat/procstat_cheri.c
+++ b/usr.bin/procstat/procstat_cheri.c
@@ -2,11 +2,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2023 SRI International
+ * Copyright (c) 2024 Capabilities Limited
  *
  * This software was developed by SRI International, the University of
  * Cambridge Computer Laboratory (Department of Computer Science and
  * Technology), and Capabilities Limited under Defense Advanced Research
  * Projects Agency (DARPA) Contract No. HR001123C0031 ("MTSS").
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +46,7 @@
 
 #include <err.h>
 #include <libprocstat.h>
+#include <rtld_c18n_public.h>
 #include <string.h>
 
 #include "procstat.h"
@@ -51,6 +58,8 @@ static const char *get_revoker_epoch(struct procstat *procstat,
     struct kinfo_proc *kipp);
 static const char *get_revoker_state(struct procstat *procstat,
     struct kinfo_proc *kipp);
+static const char *get_c18n(struct procstat *procstat,
+    struct kinfo_proc *kipp);
 
 void
 procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
@@ -59,11 +68,12 @@ procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
 
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
 		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
-			xo_emit("{T:/%5s %-19s %c %4s}\n",
-			    "PID", "COMM", 'C', "QUAR");
+			xo_emit("{T:/%5s %-19s %c %4s %5s}\n",
+			    "PID", "COMM", 'C', "QUAR", "C18N");
 		else
-			xo_emit("{T:/%5s %-19s %c %4s %7s %34s}\n",
-			    "PID", "COMM", 'C', "QUAR", "RSTATE", "EPOCH");
+			xo_emit("{T:/%5s %-19s %c %4s %7s %34s %5s}\n",
+			    "PID", "COMM", 'C', "QUAR", "RSTATE", "EPOCH",
+			    "C18N");
 	}
 
 	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
@@ -78,6 +88,7 @@ procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit(" {:revoker_epoch/%34s/%s}", abi_cheri == 'P' ?
 		    get_revoker_epoch(procstat, kipp) : "-");
 	}
+	xo_emit(" {:compartments/%s/%s}", get_c18n(procstat, kipp));
 	xo_emit("\n");
 }
 
@@ -169,4 +180,22 @@ get_revoker_state(struct procstat *procstat, struct kinfo_proc *kipp)
 	} else {
 		return ("-");
 	}
+}
+
+static const char *
+get_c18n(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	static char c18n_buf[6];
+	struct rtld_c18n_stats *rcsp;
+	size_t len;
+
+	if (procstat_getc18n(procstat, kipp, (void **)&rcsp, &len) < 0) {
+		if (errno != ESRCH && errno != EPERM && errno != ENOEXEC)
+			warn("procstat_get_c18n");
+		snprintf(c18n_buf, sizeof(c18n_buf), "-");
+	} else {
+		snprintf(c18n_buf, sizeof(c18n_buf), "%5lu",
+		    rcsp->rcs_compartments);
+	}
+	return (c18n_buf);
 }


### PR DESCRIPTION
This change introduces experimental support for `procstat(1)` to display information on c18n statistics for each processes. A number of parts come together to support this:

- Two new ELF auxarg types are added, `AT_C18N` (pointer to per-process c18n exported state) and `AT_C18NLEN` (size of per-process c18n exported state). These default to `NULL` and 0 respectively, but may be updated by the process dynamically.
- The kernel adds a new `kern.proc.c18n` sysctl, which allows retrieving c18n exported state from a target process. In general, this is a lot like `kern.proc.auxv` and the other `sysctl` MIB entries used by `procstat(1)` already.
- `rtld-elf` has a new `struct rtld_c18n_stats` structure, defined in a new header `rtld_c18n_public.h`, which contains an initial set of statistics of interest, including number of compartments, number of stacks, number of initialised trampolines, and also information on memory commitment to trampolines.
- `rtld-elf` implements a global instance of `struct c18n_stats` and, during startup updates the ELF auxiliary arguments to point at it. The c18n code number atomically updates various fields in the structure as sundry slow-path operations are performed. There is no support (currently) for fast-path operations such as domain switch counters.
- `libprocstat(3)` implements `procstat_getc18n(3)` and `procstat_freec18n(3)` APIs. These are not yet documented, but grab the c18n exported state from a target process using the new `sysctl`, and provide it back to the caller.
- `procstat(1)` implements an additional column in the `cheri` output, `C18N`, which lists a count of compartments in each process.
- `procstat(1)` implements a new mode `c18n` that includes the full set of c18n stats fields for each process.

As a result, it’s now possible to easily look at the number of compartments in a process, as well as comment on some other behavioural aspects, when giving demos.

This isn’t yet a pull request, as various aspects (including overall approach) need discussing. We might for example, want the stacks block to me more overtly a variable-length array of {type, value} a la auxargs.