### PR TITLE
ldconfig: Restore handling for /etc/ld-elf.so.conf

### DIFF
--- a/libexec/rc/rc.d/ldconfig
+++ b/libexec/rc/rc.d/ldconfig
@@ -30,7 +30,7 @@ ldconfig_paths()
 			fi
 		fi
 	done
-	for _ii in ${_paths} ${_soconf}; do
+	for _ii in ${_paths}; do
 		if [ -r "${_ii}" ]; then
 			_ldpaths="${_ldpaths} ${_ii}"
 		fi
@@ -49,7 +49,7 @@ ldconfig_start()
 	if [ -x "${ldconfig_command}" ]; then
 		_LDC=$(/libexec/ld-elf.so.1 -v | sed -n -e '/^Default lib path /s///p' | tr : ' ')
 		_LDC=$(ldconfig_paths "${ldconfig_local_dirs}" \
-		    "${ldconfig_paths}" "$_LDC")
+		    "${ldconfig_paths} /etc/ld-elf.so.conf" "$_LDC")
 		startmsg 'ELF ldconfig path:' ${_LDC}
 		${ldconfig} -elf ${_ins} ${_LDC}
 


### PR DESCRIPTION
The original change to factor out the ldconfig_paths helper function
accidentally dropped it due to a variable name mismatch (_ldconf vs
_soconf).  As a result, the 4th argument looked unused so I removed
it.  Rather than re-adding the 4th argument to the helper, just
include /etc/ld-elf.so.conf in the list of paths used in the second
for loop.
