### PR TITLE
Export c18n statistics to procstat(1) and file

### DIFF
--- a/lib/libprocstat/Symbol.map
+++ b/lib/libprocstat/Symbol.map
@@ -50,4 +50,6 @@ FBSD_1.7 {
 	 procstat_getquarantining;
 	 procstat_get_revoker_epoch;
 	 procstat_get_revoker_state;
+	 procstat_freec18n;
+	 procstat_getc18n;
 };

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -203,6 +203,7 @@ void	procstat_freeargv(struct procstat *procstat);
 #ifndef ZFS
 void	procstat_freeauxv(struct procstat *procstat, Elf_Auxinfo *auxv);
 #endif
+void	procstat_freec18n(struct procstat *procstat __unused, void *p);
 void	procstat_freeenvv(struct procstat *procstat);
 void	procstat_freegroups(struct procstat *procstat, gid_t *groups);
 void	procstat_freekstack(struct procstat *procstat,
@@ -215,6 +216,8 @@ void	procstat_freeptlwpinfo(struct procstat *procstat,
 void	procstat_freevmmap(struct procstat *procstat,
     struct kinfo_vmentry *vmmap);
 struct advlock_list	*procstat_getadvlock(struct procstat *procstat);
+int	procstat_getc18n(struct procstat *procstat, struct kinfo_proc *kp,
+    void *stats, size_t *maxlen);
 struct filestat_list	*procstat_getfiles(struct procstat *procstat,
     struct kinfo_proc *kp, int mmapped);
 struct kinfo_proc	*procstat_getprocs(struct procstat *procstat,

--- a/libexec/rtld-elf/rtld-libc/Makefile.inc
+++ b/libexec/rtld-elf/rtld-libc/Makefile.inc
@@ -68,7 +68,7 @@ _libc_other_objects=sigsetjmp lstat stat fstat fstatat fstatfs syscall \
     _sigprocmask _write readlink __realpathat _setjmp setjmp setjmperr
 
 .ifdef RTLD_SANDBOX
-_libc_other_objects+=thr_exit
+_libc_other_objects+=thr_exit ftruncate
 .endif
 
 # Finally add additional architecture-dependent libc dependencies

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -404,6 +404,7 @@ enum {
 	LD_COMPARTMENT_OVERHEAD,
 	LD_COMPARTMENT_SIG,
 	LD_COMPARTMENT_UNWIND,
+	LD_COMPARTMENT_STATS,
 #endif
 };
 
@@ -452,6 +453,7 @@ static struct ld_env_var_desc ld_env_vars[] = {
 	LD_ENV_DESC(COMPARTMENT_OVERHEAD, false),
 	LD_ENV_DESC(COMPARTMENT_SIG, false),
 	LD_ENV_DESC(COMPARTMENT_UNWIND, false),
+	LD_ENV_DESC(COMPARTMENT_STATS, false),
 #endif
 };
 
@@ -856,6 +858,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     ld_compartment_overhead = ld_get_env_var(LD_COMPARTMENT_OVERHEAD);
     ld_compartment_sig = ld_get_env_var(LD_COMPARTMENT_SIG);
     ld_compartment_unwind = ld_get_env_var(LD_COMPARTMENT_UNWIND);
+    ld_compartment_stats = ld_get_env_var(LD_COMPARTMENT_STATS);
     /*
      * DISABLE takes precedence over ENABLE.
      */

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -987,7 +987,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
     if (C18N_ENABLED) {
-	c18n_init(&obj_rtld);
+	c18n_init(&obj_rtld, aux_info);
 
 	/*
 	 * Manually register the main object after the policy is loaded.

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -41,6 +41,8 @@ extern const char *ld_compartment_policy;
 extern const char *ld_compartment_overhead;
 extern const char *ld_compartment_sig;
 extern const char *ld_compartment_unwind;
+extern const char *ld_compartment_stats;
+extern struct rtld_c18n_stats *c18n_stats;
 
 /*
  * Policies

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -235,5 +235,5 @@ void *_rtld_tlsdesc_static_c18n(void *);
 void *_rtld_tlsdesc_undef_c18n(void *);
 void *_rtld_tlsdesc_dynamic_c18n(void *);
 
-void c18n_init(Obj_Entry *);
+void c18n_init(Obj_Entry *, Elf_Auxinfo *[]);
 #endif

--- a/sys/amd64/amd64/mem.c
+++ b/sys/amd64/amd64/mem.c
@@ -79,6 +79,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct iovec *iov;
 	void *p;
 	ssize_t orig_resid;
+	vm_prot_t prot;
 	u_long v, vd;
 	u_int c;
 	int error;
@@ -110,8 +111,16 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				break;
 			}
 
-			if (!kernacc((void *)v, c, uio->uio_rw == UIO_READ ?
-			    VM_PROT_READ : VM_PROT_WRITE)) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
+				prot = VM_PROT_READ;
+				break;
+			case UIO_WRITE:
+				prot = VM_PROT_WRITE;
+				break;
+			}
+
+			if (!kernacc((void *)v, c, prot)) {
 				error = EFAULT;
 				break;
 			}

--- a/sys/amd64/amd64/uio_machdep.c
+++ b/sys/amd64/amd64/uio_machdep.c
@@ -97,18 +97,26 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopy(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopy(iov->iov_base, cp, cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/arm/arm/uio_machdep.c
+++ b/sys/arm/arm/uio_machdep.c
@@ -94,20 +94,28 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error) {
 				sf_buf_free(sf);
 				goto out;
 			}
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopy(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopy(iov->iov_base, cp, cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -52,6 +52,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct vm_page m;
 	vm_page_t marr;
 	vm_offset_t off, v;
+	vm_prot_t prot;
 	u_int cnt;
 	int error;
 
@@ -87,8 +88,16 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				break;
 			}
 
-			if (!kernacc((void *)(uintptr_t)v, cnt, uio->uio_rw ==
-			    UIO_READ ? VM_PROT_READ : VM_PROT_WRITE)) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
+				prot = VM_PROT_READ;
+				break;
+			case UIO_WRITE:
+				prot = VM_PROT_WRITE;
+				break;
+			}
+
+			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {
 				error = EFAULT;
 				break;
 			}

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -95,6 +95,11 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			case UIO_WRITE:
 				prot = VM_PROT_WRITE;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 
 			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -6193,7 +6193,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		} else {
 			b_cp = (char *)PHYS_TO_DMAP_LEN(p_b + b_pg_offset, cnt);
 		}
-		bcopy(a_cp, b_cp, cnt);
+		bcopynocap(a_cp, b_cp, cnt);
 		a_offset += cnt;
 		b_offset += cnt;
 		xfersize -= cnt;

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -63,7 +63,8 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 	int save = 0;
 	bool mapped;
 
-	KASSERT(uio->uio_rw == UIO_READ || uio->uio_rw == UIO_WRITE,
+	KASSERT(uio->uio_rw == UIO_READ || uio->uio_rw == UIO_WRITE ||
+	    uio->uio_rw == UIO_READ_CAP || uio->uio_rw == UIO_WRITE_CAP,
 	    ("uiomove_fromphys: mode"));
 	KASSERT(uio->uio_segflg != UIO_USERSPACE || uio->uio_td == curthread,
 	    ("uiomove_fromphys proc"));
@@ -97,6 +98,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		case UIO_USERSPACE:
 			maybe_yield();
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				error = copyoutcap(cp, iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				error = copyincap(iov->iov_base, cp, cnt);
+				break;
+#endif
 			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
 				break;
@@ -109,6 +118,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+#endif
 			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -96,18 +96,26 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/cam/scsi/scsi_target.c
+++ b/sys/cam/scsi/scsi_target.c
@@ -530,10 +530,11 @@ targwrite(struct cdev *dev, struct uio *uio, int ioflag)
 	write_len = error = 0;
 	CAM_DEBUG(softc->path, CAM_DEBUG_PERIPH,
 		  ("write - uio_resid %zd\n", uio->uio_resid));
+	uiomove_enable_cap(uio);
 	while (uio->uio_resid >= sizeof(user_ccb) && error == 0) {
 		union ccb *ccb;
 
-		error = uiomove_cap((caddr_t)&user_ccb, sizeof(user_ccb), uio);
+		error = uiomove((caddr_t)&user_ccb, sizeof(user_ccb), uio);
 		if (error != 0) {
 			CAM_DEBUG(softc->path, CAM_DEBUG_PERIPH,
 				  ("write - uiomove failed (%d)\n", error));
@@ -811,6 +812,7 @@ targread(struct cdev *dev, struct uio *uio, int ioflag)
 	user_queue = &softc->user_ccb_queue;
 	abort_queue = &softc->abort_queue;
 	CAM_DEBUG(softc->path, CAM_DEBUG_PERIPH, ("targread\n"));
+	uiomove_enable_cap(uio);
 
 	/* If no data is available, wait or return immediately */
 	cam_periph_lock(softc->periph);
@@ -850,7 +852,7 @@ targread(struct cdev *dev, struct uio *uio, int ioflag)
 		if (error != 0)
 			goto read_fail;
 		cam_periph_unlock(softc->periph);
-		error = uiomove_cap((caddr_t)&user_ccb, sizeof(user_ccb), uio);
+		error = uiomove((caddr_t)&user_ccb, sizeof(user_ccb), uio);
 		cam_periph_lock(softc->periph);
 		if (error != 0)
 			goto read_fail;
@@ -873,7 +875,7 @@ targread(struct cdev *dev, struct uio *uio, int ioflag)
 			goto read_fail;
 		}
 		cam_periph_unlock(softc->periph);
-		error = uiomove_cap((caddr_t)&user_ccb, sizeof(user_ccb), uio);
+		error = uiomove((caddr_t)&user_ccb, sizeof(user_ccb), uio);
 		cam_periph_lock(softc->periph);
 		if (error != 0)
 			goto read_fail;

--- a/sys/cheri/c18n.h
+++ b/sys/cheri/c18n.h
@@ -1,0 +1,59 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Dapeng Gao
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __SYS_CHERI_C18N_H__
+#define	__SYS_CHERI_C18N_H__
+
+/*
+ * Members fields do not need to be atomic outside of RTLD.
+ */
+#ifndef IN_RTLD
+#define	_Atomic(t)			t
+#endif
+
+#define RTLD_C18N_STATS_VERSION		1
+#define RTLD_C18N_STATS_MAX_SIZE	256
+
+/*
+ * Statistics exposed by RTLD. The version field doubles as a synchronisation
+ * flag where a non-zero value indicates that the other fields have been
+ * initialised.
+ */
+struct rtld_c18n_stats {
+	_Atomic(uint8_t) version;
+	size_t rcs_compart;
+	_Atomic(size_t) rcs_ustack;
+	_Atomic(size_t) rcs_tramp;
+	_Atomic(size_t) rcs_tramp_page;
+	_Atomic(size_t) rcs_bytes_total;
+};
+
+#ifndef IN_RTLD
+#undef _Atomic
+#endif
+
+#endif /* __SYS_CHERI_C18N_H__ */

--- a/sys/cheri/c18n.h
+++ b/sys/cheri/c18n.h
@@ -52,6 +52,19 @@ struct rtld_c18n_stats {
 	_Atomic(size_t) rcs_bytes_total;
 };
 
+/*
+ * The interface provided by the kernel for RTLD to supply compartmentalisation
+ * information. The version field doubles as a synchronisation flag where a
+ * non-zero value indicates that the other fields have been initialised.
+ */
+#define CHERI_C18N_INFO_VERSION		1
+
+struct cheri_c18n_info {
+	_Atomic(uint8_t) version;
+	size_t stats_size;
+	struct rtld_c18n_stats * __kerncap	stats;
+};
+
 #ifndef IN_RTLD
 #undef _Atomic
 #endif

--- a/sys/compat/lindebugfs/lindebugfs.c
+++ b/sys/compat/lindebugfs/lindebugfs.c
@@ -158,6 +158,11 @@ debugfs_fill(PFS_FILL_ARGS)
 			    &off);
 		}
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 
 	if (d->dm_fops->release)

--- a/sys/dev/iicbus/iic.c
+++ b/sys/dev/iicbus/iic.c
@@ -257,6 +257,11 @@ iicuio_move(struct iic_cdevpriv *priv, struct uio *uio, int last)
 			if (error == 0)
 				error = uiomove(buffer, transferred_bytes, uio);
 			break;
+#if __has_feature(capabilities)
+		case UIO_READ_CAP:
+		case UIO_WRITE_CAP:
+			__assert_unreachable();
+#endif
 		}
 	}
 
@@ -299,6 +304,11 @@ iicuio(struct cdev *dev, struct uio *uio, int ioflag)
 	case UIO_WRITE:
 		addr = priv->addr & ~LSB;
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 
 	error = iicbus_start(parent, addr, 0);

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -987,11 +987,13 @@ unmapped_step:
 		auio.uio_iovcnt = 1;
 	}
 	iostart = auio.uio_offset;
-	if (auio.uio_rw == UIO_READ) {
+	switch (auio.uio_rw) {
+	case UIO_READ:
 		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY);
 		error = VOP_READ(vp, &auio, 0, sc->cred);
 		VOP_UNLOCK(vp);
-	} else {
+		break;
+	case UIO_WRITE:
 		(void) vn_start_write(vp, &mp, V_WAIT);
 		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY);
 		error = VOP_WRITE(vp, &auio, sc->flags & MD_ASYNC ? 0 : IO_SYNC,
@@ -1000,6 +1002,7 @@ unmapped_step:
 		vn_finished_write(mp);
 		if (error == 0)
 			sc->flags &= ~MD_VERIFY;
+		break;
 	}
 
 	/* When MD_CACHE is set, try to avoid double-caching the data. */

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -1003,6 +1003,11 @@ unmapped_step:
 		if (error == 0)
 			sc->flags &= ~MD_VERIFY;
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 
 	/* When MD_CACHE is set, try to avoid double-caching the data. */

--- a/sys/fs/procfs/procfs_osrel.c
+++ b/sys/fs/procfs/procfs_osrel.c
@@ -45,9 +45,11 @@ procfs_doosrel(PFS_FILL_ARGS)
 
 	if (uio == NULL)
 		return (EOPNOTSUPP);
-	if (uio->uio_rw == UIO_READ) {
+	switch (uio->uio_rw) {
+	case UIO_READ:
 		sbuf_printf(sb, "%d\n", p->p_osrel);
-	} else {
+		break;
+	case UIO_WRITE:
 		sbuf_trim(sb);
 		sbuf_finish(sb);
 		pp = sbuf_data(sb);
@@ -62,6 +64,7 @@ procfs_doosrel(PFS_FILL_ARGS)
 			osrel = ov;
 		}
 		p->p_osrel = osrel;
+		break;
 	}
 	return (0);
 }

--- a/sys/fs/procfs/procfs_osrel.c
+++ b/sys/fs/procfs/procfs_osrel.c
@@ -65,6 +65,11 @@ procfs_doosrel(PFS_FILL_ARGS)
 		}
 		p->p_osrel = osrel;
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 	return (0);
 }

--- a/sys/i386/i386/uio_machdep.c
+++ b/sys/i386/i386/uio_machdep.c
@@ -94,10 +94,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error) {
 				sf_buf_free(sf);
 				sched_unpin();
@@ -105,10 +109,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			}
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopy(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopy(iov->iov_base, cp, cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1912,6 +1912,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	AUXARGS_ENTRY(pos, AT_USRSTACKBASE, round_page(vmspace->vm_stacktop));
 	stacksz = imgp->proc->p_limit->pl_rlimit[RLIMIT_STACK].rlim_cur;
 	AUXARGS_ENTRY(pos, AT_USRSTACKLIM, stacksz);
+	AUXARGS_ENTRY_PTR(pos, AT_CHERI_C18N, imgp->c18n_info);
 	AUXARGS_ENTRY(pos, AT_NULL, 0);
 
 	free(imgp->auxargs, M_TEMP);

--- a/sys/kern/kern_physio.c
+++ b/sys/kern/kern_physio.c
@@ -127,6 +127,11 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 				    uio->uio_iov[i].iov_len);
 				racct_add_force(curproc, RACCT_WRITEIOPS, 1);
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 			PROC_UNLOCK(curproc);
 		}
@@ -143,6 +148,11 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 				bp->bio_cmd = BIO_WRITE;
 				curthread->td_ru.ru_oublock++;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 			bp->bio_offset = uio->uio_offset;
 			base = uio->uio_iov[i].iov_base;

--- a/sys/kern/kern_physio.c
+++ b/sys/kern/kern_physio.c
@@ -116,14 +116,17 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 #ifdef RACCT
 		if (racct_enable) {
 			PROC_LOCK(curproc);
-			if (uio->uio_rw == UIO_READ) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				racct_add_force(curproc, RACCT_READBPS,
 				    uio->uio_iov[i].iov_len);
 				racct_add_force(curproc, RACCT_READIOPS, 1);
-			} else {
+				break;
+			case UIO_WRITE:
 				racct_add_force(curproc, RACCT_WRITEBPS,
 				    uio->uio_iov[i].iov_len);
 				racct_add_force(curproc, RACCT_WRITEIOPS, 1);
+				break;
 			}
 			PROC_UNLOCK(curproc);
 		}
@@ -131,12 +134,15 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 
 		while (uio->uio_iov[i].iov_len) {
 			g_reset_bio(bp);
-			if (uio->uio_rw == UIO_READ) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bp->bio_cmd = BIO_READ;
 				curthread->td_ru.ru_inblock++;
-			} else {
+				break;
+			case UIO_WRITE:
 				bp->bio_cmd = BIO_WRITE;
 				curthread->td_ru.ru_oublock++;
+				break;
 			}
 			bp->bio_offset = uio->uio_offset;
 			base = uio->uio_iov[i].iov_base;

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -493,6 +493,14 @@ proc_readmem(struct thread *td, struct proc *p, vm_offset_t va, void *buf,
 }
 
 ssize_t
+proc_readmem_cap(struct thread *td, struct proc *p, vm_offset_t va, void *buf,
+    size_t len)
+{
+
+	return (proc_iop(td, p, va, buf, len, UIO_READ_CAP));
+}
+
+ssize_t
 proc_writemem(struct thread *td, struct proc *p, vm_offset_t va, void *buf,
     size_t len)
 {

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1259,12 +1259,15 @@ vn_io_fault_doio(struct vn_io_fault_args *args, struct uio *uio,
 		    uio, args->cred, args->flags, td);
 		break;
 	case VN_IO_FAULT_VOP:
-		if (uio->uio_rw == UIO_READ) {
+		switch (uio->uio_rw) {
+		case UIO_READ:
 			error = VOP_READ(args->args.vop_args.vp, uio,
 			    args->flags, args->cred);
-		} else if (uio->uio_rw == UIO_WRITE) {
+			break;
+		case UIO_WRITE:
 			error = VOP_WRITE(args->args.vop_args.vp, uio,
 			    args->flags, args->cred);
+			break;
 		}
 		break;
 	default:

--- a/sys/powerpc/powerpc/uio_machdep.c
+++ b/sys/powerpc/powerpc/uio_machdep.c
@@ -100,20 +100,28 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 			case UIO_USERSPACE:
 				maybe_yield();
-				if (uio->uio_rw == UIO_READ)
+				switch (uio->uio_rw) {
+				case UIO_READ:
 					error = copyout(cp, iov->iov_base, cnt);
-				else
+					break;
+				case UIO_WRITE:
 					error = copyin(iov->iov_base, cp, cnt);
+					break;
+				}
 				if (error) {
 					sf_buf_free(sf);
 					goto out;
 				}
 				break;
 			case UIO_SYSSPACE:
-				if (uio->uio_rw == UIO_READ)
+				switch (uio->uio_rw) {
+				case UIO_READ:
 					bcopy(cp, iov->iov_base, cnt);
-				else
+					break;
+				case UIO_WRITE:
 					bcopy(iov->iov_base, cp, cnt);
+					break;
+				}
 				break;
 			case UIO_NOCOPY:
 				break;

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -102,6 +102,11 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			case UIO_WRITE:
 				prot = VM_PROT_WRITE;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 
 			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -55,6 +55,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct iovec *iov;
 	struct vm_page m;
 	vm_page_t marr;
+	vm_prot_t prot;
 	u_int cnt;
 	int error;
 
@@ -94,8 +95,16 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				break;
 			}
 
-			if (!kernacc((void *)(uintptr_t)v, cnt, uio->uio_rw ==
-			    UIO_READ ? VM_PROT_READ : VM_PROT_WRITE)) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
+				prot = VM_PROT_READ;
+				break;
+			case UIO_WRITE:
+				prot = VM_PROT_WRITE;
+				break;
+			}
+
+			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {
 				error = EFAULT;
 				break;
 			}

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -4367,9 +4367,15 @@ pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 
 int unmapped_buf_allowed = 1;
 
+#if __has_feature(capabilities)
+static void
+_pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize, bool clear_tags)
+#else
 void
 pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
     vm_offset_t b_offset, int xfersize)
+#endif
 {
 	void *a_cp, *b_cp;
 	vm_page_t m_a, m_b;
@@ -4396,12 +4402,33 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		} else {
 			b_cp = (char *)PHYS_TO_DMAP_LEN(p_b + b_pg_offset, cnt);
 		}
-		bcopynocap(a_cp, b_cp, cnt);
+#if __has_feature(capabilities)
+		if (clear_tags)
+			bcopynocap(a_cp, b_cp, cnt);
+		else
+#endif
+			bcopy(a_cp, b_cp, cnt);
 		a_offset += cnt;
 		b_offset += cnt;
 		xfersize -= cnt;
 	}
 }
+
+#if __has_feature(capabilities)
+void
+pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize)
+{
+	_pmap_copy_pages(ma, a_offset, mb, b_offset, xfersize, true);
+}
+
+void
+pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize)
+{
+	_pmap_copy_pages(ma, a_offset, mb, b_offset, xfersize, false);
+}
+#endif
 
 vm_pointer_t
 pmap_quick_enter_page(vm_page_t m)

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -97,6 +97,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		case UIO_USERSPACE:
 			maybe_yield();
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				error = copyoutcap(cp, iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				error = copyincap(iov->iov_base, cp, cnt);
+				break;
+#endif
 			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
 				break;
@@ -109,6 +117,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+#endif
 			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -96,18 +96,26 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/sys/_uio.h
+++ b/sys/sys/_uio.h
@@ -35,7 +35,14 @@
 #if __BSD_VISIBLE
 enum uio_rw {
 	UIO_READ,
-	UIO_WRITE
+	UIO_WRITE,
+#if __has_feature(capabilities)
+	UIO_READ_CAP,
+	UIO_WRITE_CAP
+#else
+	UIO_READ_CAP = UIO_READ,
+	UIO_WRITE_CAP = UIO_WRITE
+#endif
 };
 
 /* Segment flag values. */

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -1011,8 +1011,9 @@ typedef struct {
 #define	AT_KPRELOAD	34	/* Base of vdso, preloaded by rtld */
 #define	AT_USRSTACKBASE	35	/* Top of user stack */
 #define	AT_USRSTACKLIM	36	/* Grow limit of user stack */
+#define	AT_CHERI_C18N	37	/* Compartment info block */
 
-#define	AT_COUNT	37	/* Count of defined aux entry types. */
+#define	AT_COUNT	38	/* Count of defined aux entry types. */
 
 /*
  * Relocation types.

--- a/sys/sys/imgact.h
+++ b/sys/sys/imgact.h
@@ -86,6 +86,7 @@ struct image_params {
 	int canarylen;
 	void * __capability pagesizes;
 	int pagesizeslen;
+	struct cheri_c18n_info * __kerncap c18n_info;
 	void * __capability stack;
 	vm_prot_t stack_prot;
 	u_long stack_sz;

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -784,6 +784,7 @@ struct proc {
 
 	TAILQ_HEAD(, kq_timer_cb_data)	p_kqtim_stop;	/* (c) */
 	LIST_ENTRY(proc) p_jaillist;	/* (d) Jail process linkage. */
+	struct cheri_c18n_info	*p_c18n_info;	/* (x) Compartment info block */
 };
 
 #define	p_session	p_pgrp->pg_session

--- a/sys/sys/ptrace.h
+++ b/sys/sys/ptrace.h
@@ -264,6 +264,8 @@ int	proc_sstep(struct thread *_td);
 int	proc_rwmem(struct proc *_p, struct uio *_uio);
 ssize_t	proc_readmem(struct thread *_td, struct proc *_p, vm_offset_t _va,
 	    void *_buf, size_t _len);
+ssize_t	proc_readmem_cap(struct thread *_td, struct proc *_p, vm_offset_t _va,
+	    void *_buf, size_t _len);
 ssize_t	proc_writemem(struct thread *_td, struct proc *_p, vm_offset_t _va,
 	    void *_buf, size_t _len);
 #if __has_feature(capabilities)

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1064,6 +1064,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_PROC_QUARANTINING	46	/* is this process quarantining? */
 #define	KERN_PROC_REVOKER_STATE	47	/* revoker state */
 #define	KERN_PROC_REVOKER_EPOCH	48	/* revoker epoch */
+#define	KERN_PROC_C18N		49	/* compartmentalisation statistics */
 
 /*
  * KERN_IPC identifiers

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -84,6 +84,25 @@ struct uio {
 	};
 } __aligned(sizeof(void * __capability));
 
+#if __has_feature(capabilities)
+static __inline void
+uiomove_enable_cap(struct uio *uio)
+{
+	switch (uio->uio_rw) {
+	case UIO_READ:
+		uio->uio_rw = UIO_READ_CAP;
+		break;
+	case UIO_WRITE:
+		uio->uio_rw = UIO_WRITE_CAP;
+		break;
+	default:
+		break;
+	}
+}
+#else
+#define	uiomove_enable_cap(uio)
+#endif
+
 /*
  * Limits
  *
@@ -117,7 +136,6 @@ int	physcopyin_vlist(struct bus_dma_segment *src, off_t offset,
 int	physcopyout_vlist(vm_paddr_t src, struct bus_dma_segment *dst,
 	    off_t offset, size_t len);
 int	uiomove(void *cp, int n, struct uio *uio);
-int	uiomove_cap(void *cp, int n, struct uio *uio);
 int	uiomove_frombuf(void *buf, int buflen, struct uio *uio);
 int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 	    struct uio *uio);

--- a/sys/ufs/ffs/ffs_suspend.c
+++ b/sys/ufs/ffs/ffs_suspend.c
@@ -156,6 +156,11 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 				if (error != 0)
 					goto out;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 			IOVEC_ADVANCE(&uio->uio_iov[i], len);
 			uio->uio_resid -= len;

--- a/sys/ufs/ffs/ffs_suspend.c
+++ b/sys/ufs/ffs/ffs_suspend.c
@@ -138,7 +138,8 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 			    NOCRED, &bp);
 			if (error != 0)
 				goto out;
-			if (uio->uio_rw == UIO_WRITE) {
+			switch (uio->uio_rw) {
+			case UIO_WRITE:
 				error = copyin(base, bp->b_data, len);
 				if (error != 0) {
 					bp->b_flags |= B_INVAL | B_NOCACHE;
@@ -148,11 +149,13 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 				error = bwrite(bp);
 				if (error != 0)
 					goto out;
-			} else {
+				break;
+			case UIO_READ:
 				error = copyout(bp->b_data, base, len);
 				brelse(bp);
 				if (error != 0)
 					goto out;
+				break;
 			}
 			IOVEC_ADVANCE(&uio->uio_iov[i], len);
 			uio->uio_resid -= len;

--- a/sys/vm/pmap.h
+++ b/sys/vm/pmap.h
@@ -150,6 +150,10 @@ void		 pmap_copy_page_tags(vm_page_t, vm_page_t);
 #endif
 void		 pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset,
 		    vm_page_t mb[], vm_offset_t b_offset, int xfersize);
+#if __has_feature(capabilities)
+void		 pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset,
+		    vm_page_t mb[], vm_offset_t b_offset, int xfersize);
+#endif
 
 /*
  * CHERI capability revocation imposes the following novel demand on pmap_enter

--- a/usr.bin/procstat/Makefile
+++ b/usr.bin/procstat/Makefile
@@ -9,6 +9,7 @@ SRCS=	procstat.c		\
 	procstat_auxv.c		\
 	procstat_basic.c	\
 	procstat_bin.c		\
+	procstat_c18n.c		\
 	procstat_cheri.c	\
 	procstat_cred.c		\
 	procstat_cs.c		\

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -169,6 +169,8 @@ Substring commands are accepted.
 Display command line arguments for the process.
 .Pp
 Substring commands are accepted.
+.It Ar c18n
+Display CHERI compartmentalization information about a process.
 .It Ar cheri
 Display CHERI-specific information about the process.
 If the
@@ -297,6 +299,29 @@ command
 .It ARGS
 command line arguments (if available)
 .El
+.Ss Compartmentalization information
+Display CHERI compartmentalization information for a process (see
+.Xr c18n 7 ) :
+.Pp
+.Bl -tag -width TRMPTBL -compact
+.It PID
+process ID
+.It COMM
+command
+.It COMP
+number of compartments
+.It STKS
+number of compartment stacks
+.It TRMPS
+number of initialized trampolines
+.It TRPGS
+number of pages mapped for trampolines
+.It MEM
+total size of
+.Xr c18n 7
+data structures (including stack lookup tables, trampoline lookup tables, etc.,
+but excluding execution stacks and trampolines which have dedicated counters)
+.El
 .Ss CHERI information
 Display the process ID, command, and CHERI-specific information:
 .Pp
@@ -313,6 +338,10 @@ quarantining status
 in-kernel revoker state
 .It EPOCH
 in-kernel revoker epoch
+.It C18N
+number of
+.Xr c18n 7
+compartments
 .El
 .Pp
 The following values indicate the support for CHERI in the process ABI:
@@ -915,6 +944,7 @@ procstat: procstat_getprocs()
 .Xr sctp 4 ,
 .Xr tcp 4 ,
 .Xr udp 4 ,
+.Xr c18n 7 ,
 .Xr stack 9
 .Sh AUTHORS
 .An Robert N M Watson Aq Mt rwatson@FreeBSD.org .

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -93,6 +93,8 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_NORMAL },
 	{ "binary", "binary", NULL, &procstat_bin, &cmdopt_none,
 	    PS_CMP_SUBSTR },
+	{ "c18n", "c18n", NULL, &procstat_c18n, &cmdopt_none,
+	    PS_CMP_NORMAL },
 	{ "cheri", "cheri", "[-v]", &procstat_cheri, &cmdopt_verbose,
 	    PS_CMP_NORMAL },
 	{ "cpuset", "cs", NULL, &procstat_cs, &cmdopt_cpuset, PS_CMP_NORMAL },

--- a/usr.bin/procstat/procstat.h
+++ b/usr.bin/procstat/procstat.h
@@ -60,6 +60,7 @@ void	procstat_args(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_auxv(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_basic(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_bin(struct procstat *prstat, struct kinfo_proc *kipp);
+void	procstat_c18n(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cheri(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cred(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cs(struct procstat *prstat, struct kinfo_proc *kipp);

--- a/usr.bin/procstat/procstat_auxv.c
+++ b/usr.bin/procstat/procstat_auxv.c
@@ -284,6 +284,12 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			    prefix, "AT_USRSTACKLIM", auxv[i].a_un.a_val);
 			break;
 #endif
+#ifdef AT_CHERI_C18N
+		case AT_CHERI_C18N:
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_CHERI_C18N/%s}\n",
+			    prefix, "AT_CHERI_C18N", fmt_ptr(auxv[i].a_un.a_ptr));
+			break;
+#endif
 		default:
 			xo_emit("{dw:/%s}{Lw:/%16ld/%ld}{:UNKNOWN/%#lx}\n",
 			    prefix, auxv[i].a_type, auxv[i].a_un.a_val);

--- a/usr.bin/procstat/procstat_c18n.c
+++ b/usr.bin/procstat/procstat_c18n.c
@@ -1,0 +1,80 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/user.h>
+
+#include <cheri/c18n.h>
+
+#include <err.h>
+#include <libprocstat.h>
+
+#include "procstat.h"
+
+void
+procstat_c18n(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	/*
+	 * Use a large buffer as backing storage so that future versions of the
+	 * statistics structure remain compatible.
+	 */
+	struct rtld_c18n_stats *rcs;
+	size_t len = RTLD_C18N_STATS_MAX_SIZE;
+	_Alignas(_Alignof(*rcs)) char buf[RTLD_C18N_STATS_MAX_SIZE];
+	int error;
+
+	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
+		xo_emit("{T:/%5s %-19s %5s %5s %6s %5s %5s}\n",
+		    "PID", "COMM", "COMP", "STKS", "TRMPS", "TRPGS", "MEM");
+	}
+
+	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
+	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
+
+	error = procstat_getc18n(procstat, kipp, buf, &len);
+	if (error != 0 || len < sizeof(*rcs)) {
+		xo_emit(" {:compartments/%5s/%s}", "-");
+		xo_emit(" {:stacks/%5s/%s}", "-");
+		xo_emit(" {:trampolines/%6s/%s}", "-");
+		xo_emit(" {:tramppages/%5s/%s}", "-");
+		xo_emit(" {:memory/%5s/%s}", "-");
+	} else {
+		rcs = (struct rtld_c18n_stats *)buf;
+		xo_emit(" {:compartments/%5zu/%zu}", rcs->rcs_compart);
+		xo_emit(" {:stacks/%5zu/%zu}", rcs->rcs_ustack);
+		xo_emit(" {:trampolines/%6zu/%zu}", rcs->rcs_tramp);
+		xo_emit(" {:tramppages/%5zu/%zu}", rcs->rcs_tramp_page);
+		xo_emit(" {[:5}{h,hn-decimal:memory/%zu/%zu}{]:}",
+		    rcs->rcs_bytes_total);
+	}
+	xo_emit("\n");
+}


### PR DESCRIPTION
This PR modifies #2080 to export a slightly different set of statistics:
* Number of compartments
* Number of compartment stacks
* Number of trampolines
* Number of trampoline pages
* Memory space taken up by c18n data structures

It allows exposes environment variable `LD_COMPART_STATS` that allows a struct containing the above statistics to be exported to a file.