### PR TITLE
arm64: Make stxr_status an input operand in vm_do_cheri_revoke()

### DIFF
--- a/sys/arm64/arm64/cheri_revoke_machdep.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep.c
@@ -140,9 +140,8 @@ again:
 		 * stxr returns 0 or 1, so use a value of 2
 		 * to indicate that it was not executed.
 		 */
-		stxr_status = 2;
-
 		__asm__ __volatile__ (
+		        "mov %w[stxr_status], #2\n\t"
 #ifndef __CHERI_PURE_CAPABILITY__
 			"bx #4\n\t"
 			".arch_extension c64\n\t"


### PR DESCRIPTION
No test case at the moment, as I've had trouble reproducing this. It's very timing-sensitive. Verified by looking at the disassembly of `vm_cheri_revoke_page_rw()` in kgdb:

```
   0xffff000000a23c70 <+340>:   clrtag  c0, c24
   0xffff000000a23c74 <+344>:   mov     w8, #0x2 <-- this instruction is missing without the patch
   0xffff000000a23c78 <+348>:   ldxr    c1, [c28]
   0xffff000000a23c7c <+352>:   cmp     c1, c24
   0xffff000000a23c80 <+356>:   b.ne    0xffff000000a23c88 <vm_cheri_revoke_page_rw+364>  // b.any
   0xffff000000a23c84 <+360>:   stxr    w8, c0, [c28]
   0xffff000000a23c88 <+364>:   cbz     w8, 0xffff000000a23c18 <vm_cheri_revoke_page_rw+252>
   0xffff000000a23c8c <+368>:   gctag   x9, c1
   0xffff000000a23c90 <+372>:   cbz     x9, 0xffff000000a23c20 <vm_cheri_revoke_page_rw+260>
   0xffff000000a23c94 <+376>:   cmp     w8, #0x1
   0xffff000000a23c98 <+380>:   b.eq    0xffff000000a23c74 <vm_cheri_revoke_page_rw+344>  // b.none
```