### PR TITLE
c18n: Allow GDB to access compartment data

### DIFF
--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -1,4 +1,6 @@
 FBSDprivate_1.0 {
+    r_debug_comparts_state;
+    _compart_size;
     _rtld_thread_start_init;
     _rtld_thread_start;
     _rtld_thr_exit;

--- a/sys/sys/link_elf.h
+++ b/sys/sys/link_elf.h
@@ -74,6 +74,14 @@ struct r_debug {
 		RT_DELETE			/* removing a shared library */
 	}		r_state;
 	void		*r_ldbase;		/* Base address of rtld */
+#if defined(IN_RTLD) && defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	enum {
+		RCT_CONSISTENT,			/* vector is stable */
+		RCT_ADD,			/* adding a compartment */
+	}		r_comparts_state;
+	int		r_comparts_size;
+	void		*r_comparts;		/* struct compart [] */
+#endif
 };
 
 #define	R_DEBUG_VERSION		1


### PR DESCRIPTION
Extend struct r_debug to contain a pointer to RTLD's array of compartments and count of elements.  Export the size of struct compart so a debugger can walk the array.