### PR TITLE
Miscellaneous c18n improvements

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -127,6 +127,15 @@ ENTRY(_rtld_dispatch_signal_unsafe)
 	b	dispatch_signal_end
 END(_rtld_dispatch_signal_unsafe)
 
+ENTRY(_rtld_unw_getcontext_epilogue)
+	/*
+	 * FIXME: llvm-libunwind specific ABI. This should be better specified.
+	 */
+	mov	c2, csp
+	str	c2, [c1]
+	RETURN
+END(_rtld_unw_getcontext_epilogue)
+
 ENTRY(_rtld_unw_setcontext_epilogue)
 	/*
 	 * FIXME: llvm-libunwind specific ABI. This should be better specified.


### PR DESCRIPTION
The PR bundles together three minor improvements to c18n.
1. When c18n is disabled, the _rtld_setjmp helper (and its counterparts for libunwind) must not access the trusted stack but should tail-call an epilogue assembly function.
2. Trampoline tables are now allocated with malloc instead of mmap.
3. Block all signals when a new thread is created and only restore the signal mask when the actual thread function is about to be called. This is need for full interrupted safety which will be implemented in the future.