### PR TITLE
morello: Disable libssl ASM optimisation in the base system.

### DIFF
--- a/secure/lib/libcrypto/Makefile.common
+++ b/secure/lib/libcrypto/Makefile.common
@@ -10,7 +10,7 @@ CFLAGS+=	-DB_ENDIAN
 .ifndef WITHOUT_AUTO_ASM
 .if ${MACHINE_CPUARCH} == "aarch64" || ${MACHINE_CPUARCH} == "amd64" || \
     ${MACHINE_CPUARCH} == "arm" || ${MACHINE_CPUARCH} == "i386"
-.if !${MACHINE_ARCH:Maarch64*c*}
+.if !${MACHINE_ARCH:Maarch64*}
 ASM_${MACHINE_CPUARCH}=
 .endif
 .elif ${MACHINE_ARCH} == "powerpc" || ${MACHINE_ARCH} == "powerpc64" || \


### PR DESCRIPTION
The hybrid ABI libssl uses optimised assembly implementations for crypto functions. This is a problem for benchmarks because we don't currently have pure-capability variants of these functions. This patch temporarily disables ASM optimisations on AArch64, so that we maintain the same behaviour on all ABIs.