### PR TITLE
uiomove*_cap: Refactor using UIO_READ/WRITE_CAP permissions

### DIFF
--- a/sys/amd64/amd64/mem.c
+++ b/sys/amd64/amd64/mem.c
@@ -79,6 +79,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct iovec *iov;
 	void *p;
 	ssize_t orig_resid;
+	vm_prot_t prot;
 	u_long v, vd;
 	u_int c;
 	int error;
@@ -110,8 +111,16 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				break;
 			}
 
-			if (!kernacc((void *)v, c, uio->uio_rw == UIO_READ ?
-			    VM_PROT_READ : VM_PROT_WRITE)) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
+				prot = VM_PROT_READ;
+				break;
+			case UIO_WRITE:
+				prot = VM_PROT_WRITE;
+				break;
+			}
+
+			if (!kernacc((void *)v, c, prot)) {
 				error = EFAULT;
 				break;
 			}

--- a/sys/amd64/amd64/uio_machdep.c
+++ b/sys/amd64/amd64/uio_machdep.c
@@ -97,18 +97,26 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopy(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopy(iov->iov_base, cp, cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/arm/arm/uio_machdep.c
+++ b/sys/arm/arm/uio_machdep.c
@@ -94,20 +94,28 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error) {
 				sf_buf_free(sf);
 				goto out;
 			}
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopy(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopy(iov->iov_base, cp, cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -52,6 +52,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct vm_page m;
 	vm_page_t marr;
 	vm_offset_t off, v;
+	vm_prot_t prot;
 	u_int cnt;
 	int error;
 
@@ -87,8 +88,16 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				break;
 			}
 
-			if (!kernacc((void *)(uintptr_t)v, cnt, uio->uio_rw ==
-			    UIO_READ ? VM_PROT_READ : VM_PROT_WRITE)) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
+				prot = VM_PROT_READ;
+				break;
+			case UIO_WRITE:
+				prot = VM_PROT_WRITE;
+				break;
+			}
+
+			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {
 				error = EFAULT;
 				break;
 			}

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -95,6 +95,11 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			case UIO_WRITE:
 				prot = VM_PROT_WRITE;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 
 			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -6193,7 +6193,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		} else {
 			b_cp = (char *)PHYS_TO_DMAP_LEN(p_b + b_pg_offset, cnt);
 		}
-		bcopy(a_cp, b_cp, cnt);
+		bcopynocap(a_cp, b_cp, cnt);
 		a_offset += cnt;
 		b_offset += cnt;
 		xfersize -= cnt;

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -63,7 +63,8 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 	int save = 0;
 	bool mapped;
 
-	KASSERT(uio->uio_rw == UIO_READ || uio->uio_rw == UIO_WRITE,
+	KASSERT(uio->uio_rw == UIO_READ || uio->uio_rw == UIO_WRITE ||
+	    uio->uio_rw == UIO_READ_CAP || uio->uio_rw == UIO_WRITE_CAP,
 	    ("uiomove_fromphys: mode"));
 	KASSERT(uio->uio_segflg != UIO_USERSPACE || uio->uio_td == curthread,
 	    ("uiomove_fromphys proc"));
@@ -97,6 +98,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		case UIO_USERSPACE:
 			maybe_yield();
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				error = copyoutcap(cp, iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				error = copyincap(iov->iov_base, cp, cnt);
+				break;
+#endif
 			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
 				break;
@@ -109,6 +118,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+#endif
 			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -96,18 +96,26 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/cam/scsi/scsi_target.c
+++ b/sys/cam/scsi/scsi_target.c
@@ -530,10 +530,11 @@ targwrite(struct cdev *dev, struct uio *uio, int ioflag)
 	write_len = error = 0;
 	CAM_DEBUG(softc->path, CAM_DEBUG_PERIPH,
 		  ("write - uio_resid %zd\n", uio->uio_resid));
+	uiomove_enable_cap(uio);
 	while (uio->uio_resid >= sizeof(user_ccb) && error == 0) {
 		union ccb *ccb;
 
-		error = uiomove_cap((caddr_t)&user_ccb, sizeof(user_ccb), uio);
+		error = uiomove((caddr_t)&user_ccb, sizeof(user_ccb), uio);
 		if (error != 0) {
 			CAM_DEBUG(softc->path, CAM_DEBUG_PERIPH,
 				  ("write - uiomove failed (%d)\n", error));
@@ -811,6 +812,7 @@ targread(struct cdev *dev, struct uio *uio, int ioflag)
 	user_queue = &softc->user_ccb_queue;
 	abort_queue = &softc->abort_queue;
 	CAM_DEBUG(softc->path, CAM_DEBUG_PERIPH, ("targread\n"));
+	uiomove_enable_cap(uio);
 
 	/* If no data is available, wait or return immediately */
 	cam_periph_lock(softc->periph);
@@ -850,7 +852,7 @@ targread(struct cdev *dev, struct uio *uio, int ioflag)
 		if (error != 0)
 			goto read_fail;
 		cam_periph_unlock(softc->periph);
-		error = uiomove_cap((caddr_t)&user_ccb, sizeof(user_ccb), uio);
+		error = uiomove((caddr_t)&user_ccb, sizeof(user_ccb), uio);
 		cam_periph_lock(softc->periph);
 		if (error != 0)
 			goto read_fail;
@@ -873,7 +875,7 @@ targread(struct cdev *dev, struct uio *uio, int ioflag)
 			goto read_fail;
 		}
 		cam_periph_unlock(softc->periph);
-		error = uiomove_cap((caddr_t)&user_ccb, sizeof(user_ccb), uio);
+		error = uiomove((caddr_t)&user_ccb, sizeof(user_ccb), uio);
 		cam_periph_lock(softc->periph);
 		if (error != 0)
 			goto read_fail;

--- a/sys/compat/lindebugfs/lindebugfs.c
+++ b/sys/compat/lindebugfs/lindebugfs.c
@@ -158,6 +158,11 @@ debugfs_fill(PFS_FILL_ARGS)
 			    &off);
 		}
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 
 	if (d->dm_fops->release)

--- a/sys/dev/iicbus/iic.c
+++ b/sys/dev/iicbus/iic.c
@@ -257,6 +257,11 @@ iicuio_move(struct iic_cdevpriv *priv, struct uio *uio, int last)
 			if (error == 0)
 				error = uiomove(buffer, transferred_bytes, uio);
 			break;
+#if __has_feature(capabilities)
+		case UIO_READ_CAP:
+		case UIO_WRITE_CAP:
+			__assert_unreachable();
+#endif
 		}
 	}
 
@@ -299,6 +304,11 @@ iicuio(struct cdev *dev, struct uio *uio, int ioflag)
 	case UIO_WRITE:
 		addr = priv->addr & ~LSB;
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 
 	error = iicbus_start(parent, addr, 0);

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -895,23 +895,6 @@ mdstart_vnode(struct md_s *sc, struct bio *bp)
 	int ma_offs, npages;
 	bool mapped;
 
-	switch (bp->bio_cmd) {
-	case BIO_READ:
-		auio.uio_rw = UIO_READ;
-		break;
-	case BIO_WRITE:
-		auio.uio_rw = UIO_WRITE;
-		break;
-	case BIO_FLUSH:
-		break;
-	case BIO_DELETE:
-		if (sc->candelete)
-			break;
-		/* FALLTHROUGH */
-	default:
-		return (EOPNOTSUPP);
-	}
-
 	td = curthread;
 	vp = sc->vnode;
 	piov = NULL;
@@ -928,7 +911,14 @@ mdstart_vnode(struct md_s *sc, struct bio *bp)
 	 * still valid.
 	 */
 
-	if (bp->bio_cmd == BIO_FLUSH) {
+	switch (bp->bio_cmd) {
+	case BIO_READ:
+		auio.uio_rw = UIO_READ;
+		break;
+	case BIO_WRITE:
+		auio.uio_rw = UIO_WRITE;
+		break;
+	case BIO_FLUSH:
 		do {
 			(void)vn_start_write(vp, &mp, V_WAIT);
 			vn_lock(vp, LK_EXCLUSIVE | LK_RETRY);
@@ -937,11 +927,17 @@ mdstart_vnode(struct md_s *sc, struct bio *bp)
 			vn_finished_write(mp);
 		} while (error == ERELOOKUP);
 		return (error);
-	} else if (bp->bio_cmd == BIO_DELETE) {
-		error = vn_deallocate(vp, &off, &len, 0,
-		    sc->flags & MD_ASYNC ? 0 : IO_SYNC, sc->cred, NOCRED);
-		bp->bio_resid = len;
-		return (error);
+	case BIO_DELETE:
+		if (sc->candelete) {
+			error = vn_deallocate(vp, &off, &len, 0,
+			    sc->flags & MD_ASYNC ? 0 : IO_SYNC, sc->cred,
+			    NOCRED);
+			bp->bio_resid = len;
+			return (error);
+		}
+		/* FALLTHROUGH */
+	default:
+		return (EOPNOTSUPP);
 	}
 
 	auio.uio_offset = (vm_ooffset_t)bp->bio_offset;
@@ -987,7 +983,7 @@ unmapped_step:
 		auio.uio_iovcnt = 1;
 	}
 	iostart = auio.uio_offset;
-	if (auio.uio_rw == UIO_READ) {
+	if (bp->bio_cmd == BIO_READ) {
 		vn_lock(vp, LK_EXCLUSIVE | LK_RETRY);
 		error = VOP_READ(vp, &auio, 0, sc->cred);
 		VOP_UNLOCK(vp);

--- a/sys/fs/procfs/procfs_osrel.c
+++ b/sys/fs/procfs/procfs_osrel.c
@@ -45,9 +45,11 @@ procfs_doosrel(PFS_FILL_ARGS)
 
 	if (uio == NULL)
 		return (EOPNOTSUPP);
-	if (uio->uio_rw == UIO_READ) {
+	switch (uio->uio_rw) {
+	case UIO_READ:
 		sbuf_printf(sb, "%d\n", p->p_osrel);
-	} else {
+		break;
+	case UIO_WRITE:
 		sbuf_trim(sb);
 		sbuf_finish(sb);
 		pp = sbuf_data(sb);
@@ -62,6 +64,7 @@ procfs_doosrel(PFS_FILL_ARGS)
 			osrel = ov;
 		}
 		p->p_osrel = osrel;
+		break;
 	}
 	return (0);
 }

--- a/sys/fs/procfs/procfs_osrel.c
+++ b/sys/fs/procfs/procfs_osrel.c
@@ -65,6 +65,11 @@ procfs_doosrel(PFS_FILL_ARGS)
 		}
 		p->p_osrel = osrel;
 		break;
+#if __has_feature(capabilities)
+	case UIO_READ_CAP:
+	case UIO_WRITE_CAP:
+		__assert_unreachable();
+#endif
 	}
 	return (0);
 }

--- a/sys/i386/i386/uio_machdep.c
+++ b/sys/i386/i386/uio_machdep.c
@@ -94,10 +94,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error) {
 				sf_buf_free(sf);
 				sched_unpin();
@@ -105,10 +109,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			}
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopy(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopy(iov->iov_base, cp, cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/kern/kern_physio.c
+++ b/sys/kern/kern_physio.c
@@ -127,6 +127,11 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 				    uio->uio_iov[i].iov_len);
 				racct_add_force(curproc, RACCT_WRITEIOPS, 1);
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 			PROC_UNLOCK(curproc);
 		}
@@ -143,6 +148,11 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 				bp->bio_cmd = BIO_WRITE;
 				curthread->td_ru.ru_oublock++;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 			bp->bio_offset = uio->uio_offset;
 			base = uio->uio_iov[i].iov_base;

--- a/sys/kern/kern_physio.c
+++ b/sys/kern/kern_physio.c
@@ -116,14 +116,17 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 #ifdef RACCT
 		if (racct_enable) {
 			PROC_LOCK(curproc);
-			if (uio->uio_rw == UIO_READ) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				racct_add_force(curproc, RACCT_READBPS,
 				    uio->uio_iov[i].iov_len);
 				racct_add_force(curproc, RACCT_READIOPS, 1);
-			} else {
+				break;
+			case UIO_WRITE:
 				racct_add_force(curproc, RACCT_WRITEBPS,
 				    uio->uio_iov[i].iov_len);
 				racct_add_force(curproc, RACCT_WRITEIOPS, 1);
+				break;
 			}
 			PROC_UNLOCK(curproc);
 		}
@@ -131,12 +134,15 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 
 		while (uio->uio_iov[i].iov_len) {
 			g_reset_bio(bp);
-			if (uio->uio_rw == UIO_READ) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bp->bio_cmd = BIO_READ;
 				curthread->td_ru.ru_inblock++;
-			} else {
+				break;
+			case UIO_WRITE:
 				bp->bio_cmd = BIO_WRITE;
 				curthread->td_ru.ru_oublock++;
+				break;
 			}
 			bp->bio_offset = uio->uio_offset;
 			base = uio->uio_iov[i].iov_base;

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -1259,12 +1259,15 @@ vn_io_fault_doio(struct vn_io_fault_args *args, struct uio *uio,
 		    uio, args->cred, args->flags, td);
 		break;
 	case VN_IO_FAULT_VOP:
-		if (uio->uio_rw == UIO_READ) {
+		switch (uio->uio_rw) {
+		case UIO_READ:
 			error = VOP_READ(args->args.vop_args.vp, uio,
 			    args->flags, args->cred);
-		} else if (uio->uio_rw == UIO_WRITE) {
+			break;
+		case UIO_WRITE:
 			error = VOP_WRITE(args->args.vop_args.vp, uio,
 			    args->flags, args->cred);
+			break;
 		}
 		break;
 	default:

--- a/sys/powerpc/powerpc/uio_machdep.c
+++ b/sys/powerpc/powerpc/uio_machdep.c
@@ -100,20 +100,28 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 			case UIO_USERSPACE:
 				maybe_yield();
-				if (uio->uio_rw == UIO_READ)
+				switch (uio->uio_rw) {
+				case UIO_READ:
 					error = copyout(cp, iov->iov_base, cnt);
-				else
+					break;
+				case UIO_WRITE:
 					error = copyin(iov->iov_base, cp, cnt);
+					break;
+				}
 				if (error) {
 					sf_buf_free(sf);
 					goto out;
 				}
 				break;
 			case UIO_SYSSPACE:
-				if (uio->uio_rw == UIO_READ)
+				switch (uio->uio_rw) {
+				case UIO_READ:
 					bcopy(cp, iov->iov_base, cnt);
-				else
+					break;
+				case UIO_WRITE:
 					bcopy(iov->iov_base, cp, cnt);
+					break;
+				}
 				break;
 			case UIO_NOCOPY:
 				break;

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -102,6 +102,11 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			case UIO_WRITE:
 				prot = VM_PROT_WRITE;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 
 			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -55,6 +55,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 	struct iovec *iov;
 	struct vm_page m;
 	vm_page_t marr;
+	vm_prot_t prot;
 	u_int cnt;
 	int error;
 
@@ -94,8 +95,16 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				break;
 			}
 
-			if (!kernacc((void *)(uintptr_t)v, cnt, uio->uio_rw ==
-			    UIO_READ ? VM_PROT_READ : VM_PROT_WRITE)) {
+			switch (uio->uio_rw) {
+			case UIO_READ:
+				prot = VM_PROT_READ;
+				break;
+			case UIO_WRITE:
+				prot = VM_PROT_WRITE;
+				break;
+			}
+
+			if (!kernacc((void *)(uintptr_t)v, cnt, prot)) {
 				error = EFAULT;
 				break;
 			}

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -4367,9 +4367,15 @@ pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 
 int unmapped_buf_allowed = 1;
 
+#if __has_feature(capabilities)
+static void
+_pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize, bool clear_tags)
+#else
 void
 pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
     vm_offset_t b_offset, int xfersize)
+#endif
 {
 	void *a_cp, *b_cp;
 	vm_page_t m_a, m_b;
@@ -4396,12 +4402,33 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		} else {
 			b_cp = (char *)PHYS_TO_DMAP_LEN(p_b + b_pg_offset, cnt);
 		}
-		bcopynocap(a_cp, b_cp, cnt);
+#if __has_feature(capabilities)
+		if (clear_tags)
+			bcopynocap(a_cp, b_cp, cnt);
+		else
+#endif
+			bcopy(a_cp, b_cp, cnt);
 		a_offset += cnt;
 		b_offset += cnt;
 		xfersize -= cnt;
 	}
 }
+
+#if __has_feature(capabilities)
+void
+pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize)
+{
+	_pmap_copy_pages(ma, a_offset, mb, b_offset, xfersize, true);
+}
+
+void
+pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
+    vm_offset_t b_offset, int xfersize)
+{
+	_pmap_copy_pages(ma, a_offset, mb, b_offset, xfersize, false);
+}
+#endif
 
 vm_pointer_t
 pmap_quick_enter_page(vm_page_t m)

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -97,6 +97,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		case UIO_USERSPACE:
 			maybe_yield();
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				error = copyoutcap(cp, iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				error = copyincap(iov->iov_base, cp, cnt);
+				break;
+#endif
 			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
 				break;
@@ -109,6 +117,14 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			break;
 		case UIO_SYSSPACE:
 			switch (uio->uio_rw) {
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+				bcopy_c(PTR2CAP(cp), iov->iov_base, cnt);
+				break;
+			case UIO_WRITE_CAP:
+				bcopy_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+#endif
 			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -96,18 +96,26 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 		switch (uio->uio_segflg) {
 		case UIO_USERSPACE:
 			maybe_yield();
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				error = copyout(cp, iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				error = copyin(iov->iov_base, cp, cnt);
+				break;
+			}
 			if (error)
 				goto out;
 			break;
 		case UIO_SYSSPACE:
-			if (uio->uio_rw == UIO_READ)
+			switch (uio->uio_rw) {
+			case UIO_READ:
 				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
-			else
+				break;
+			case UIO_WRITE:
 				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				break;
+			}
 			break;
 		case UIO_NOCOPY:
 			break;

--- a/sys/sys/_uio.h
+++ b/sys/sys/_uio.h
@@ -35,7 +35,14 @@
 #if __BSD_VISIBLE
 enum uio_rw {
 	UIO_READ,
-	UIO_WRITE
+	UIO_WRITE,
+#if __has_feature(capabilities)
+	UIO_READ_CAP,
+	UIO_WRITE_CAP
+#else
+	UIO_READ_CAP = UIO_READ,
+	UIO_WRITE_CAP = UIO_WRITE
+#endif
 };
 
 /* Segment flag values. */

--- a/sys/sys/uio.h
+++ b/sys/sys/uio.h
@@ -84,6 +84,25 @@ struct uio {
 	};
 } __aligned(sizeof(void * __capability));
 
+#if __has_feature(capabilities)
+static __inline void
+uiomove_enable_cap(struct uio *uio)
+{
+	switch (uio->uio_rw) {
+	case UIO_READ:
+		uio->uio_rw = UIO_READ_CAP;
+		break;
+	case UIO_WRITE:
+		uio->uio_rw = UIO_WRITE_CAP;
+		break;
+	default:
+		break;
+	}
+}
+#else
+#define	uiomove_enable_cap(uio)
+#endif
+
 /*
  * Limits
  *
@@ -117,7 +136,6 @@ int	physcopyin_vlist(struct bus_dma_segment *src, off_t offset,
 int	physcopyout_vlist(vm_paddr_t src, struct bus_dma_segment *dst,
 	    off_t offset, size_t len);
 int	uiomove(void *cp, int n, struct uio *uio);
-int	uiomove_cap(void *cp, int n, struct uio *uio);
 int	uiomove_frombuf(void *buf, int buflen, struct uio *uio);
 int	uiomove_fromphys(struct vm_page *ma[], vm_offset_t offset, int n,
 	    struct uio *uio);

--- a/sys/ufs/ffs/ffs_suspend.c
+++ b/sys/ufs/ffs/ffs_suspend.c
@@ -156,6 +156,11 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 				if (error != 0)
 					goto out;
 				break;
+#if __has_feature(capabilities)
+			case UIO_READ_CAP:
+			case UIO_WRITE_CAP:
+				__assert_unreachable();
+#endif
 			}
 			IOVEC_ADVANCE(&uio->uio_iov[i], len);
 			uio->uio_resid -= len;

--- a/sys/ufs/ffs/ffs_suspend.c
+++ b/sys/ufs/ffs/ffs_suspend.c
@@ -138,7 +138,8 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 			    NOCRED, &bp);
 			if (error != 0)
 				goto out;
-			if (uio->uio_rw == UIO_WRITE) {
+			switch (uio->uio_rw) {
+			case UIO_WRITE:
 				error = copyin(base, bp->b_data, len);
 				if (error != 0) {
 					bp->b_flags |= B_INVAL | B_NOCACHE;
@@ -148,11 +149,13 @@ ffs_susp_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 				error = bwrite(bp);
 				if (error != 0)
 					goto out;
-			} else {
+				break;
+			case UIO_READ:
 				error = copyout(bp->b_data, base, len);
 				brelse(bp);
 				if (error != 0)
 					goto out;
+				break;
 			}
 			IOVEC_ADVANCE(&uio->uio_iov[i], len);
 			uio->uio_resid -= len;

--- a/sys/vm/pmap.h
+++ b/sys/vm/pmap.h
@@ -150,6 +150,10 @@ void		 pmap_copy_page_tags(vm_page_t, vm_page_t);
 #endif
 void		 pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset,
 		    vm_page_t mb[], vm_offset_t b_offset, int xfersize);
+#if __has_feature(capabilities)
+void		 pmap_copy_pages_tags(vm_page_t ma[], vm_offset_t a_offset,
+		    vm_page_t mb[], vm_offset_t b_offset, int xfersize);
+#endif
 
 /*
  * CHERI capability revocation imposes the following novel demand on pmap_enter


### PR DESCRIPTION
This approach is more orthogonal and permits using capability copies
with uiomove_frompyhs or higher level APIs like proc_rwmem without
requiring additional *_cap wrapper routines.
