### PR TITLE
morello: Remove deprecated flags from build config.

### DIFF
--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -352,10 +352,7 @@ CCLDFLAGS+=	-fuse-ld=${LD:[1]:S/^ld.//1W}
 
 # Set target-specific linker emulation name.
 LD_EMULATION_aarch64=aarch64elf
-# XXX-AM: This is a workaround for not having full eflag support in morello lld.
-# should be removed as soon as the linker can link in capability mode based on
-# input files eflags instead.
-LD_EMULATION_aarch64c=aarch64elf_cheri
+LD_EMULATION_aarch64c=aarch64elf
 LD_EMULATION_amd64=elf_x86_64_fbsd
 LD_EMULATION_arm=armelf_fbsd
 LD_EMULATION_armv6=armelf_fbsd

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -161,13 +161,6 @@ CFLAGS+=	${GCOV_CFLAGS}
 # the others.
 CFLAGS+=	${CONF_CFLAGS}
 
-# XXX-AM: This is a workaround for not having full eflag support in morello lld.
-# should be removed as soon as the linker can link in capability mode based on
-# input files eflags instead.
-.if ${MACHINE_ARCH:Maarch64*c*}
-LDFLAGS+=	--morello-c64-plt
-.endif
-
 .if defined(LINKER_FEATURES) && ${LINKER_FEATURES:Mbuild-id}
 LDFLAGS+=	--build-id=sha1
 .endif

--- a/sys/conf/kmod.mk
+++ b/sys/conf/kmod.mk
@@ -174,13 +174,6 @@ CFLAGS+=	-fPIC
 LDFLAGS+=	--no-relax
 .endif
 
-# XXX-AM: This is a workaround for not having full eflag support in morello lld.
-# should be removed as soon as the linker can link in capability mode based on
-# input files eflags instead.
-.if ${MACHINE_ARCH:Maarch64*c*}
-LDFLAGS+=	--morello-c64-plt
-.endif
-
 # Temporary workaround for PR 196407, which contains the fascinating details.
 # Don't allow clang to use fpu instructions or registers in kernel modules.
 .if ${MACHINE_CPUARCH} == arm


### PR DESCRIPTION
The kernel build on Morello still uses some options that pre-date support for EFLAGS in Morello lld.