### PR TITLE
openzfs: Account for padding in itx_t for purecap

### DIFF
--- a/sys/contrib/subrepo-openzfs/module/zfs/zil.c
+++ b/sys/contrib/subrepo-openzfs/module/zfs/zil.c
@@ -2351,7 +2351,8 @@ zil_itx_create(uint64_t txtype, size_t olrsize)
 	itx_t *itx;
 
 	ASSERT3U(olrsize, >=, sizeof (lr_t));
-	lrsize = P2ROUNDUP_TYPED(olrsize, sizeof (uint64_t), size_t);
+	lrsize = MAX(olrsize, sizeof (itx_t) - offsetof(itx_t, itx_lr));
+	lrsize = P2ROUNDUP_TYPED(lrsize, sizeof (uint64_t), size_t);
 	ASSERT3U(lrsize, >=, olrsize);
 	itxsize = offsetof(itx_t, itx_lr) + lrsize;
 


### PR DESCRIPTION
The current struct layout for purecap means there is 8 bytes of padding
at the end of itx_t after the lr_t itx_lr member, and so if olrsize is
exactly sizeof(lr_t) we underallocate by this amount, risking bounds
faults but also the assertions in zil_itx_clone and zil_itx_destroy that
itx_size is at least sizeof(itx_t). Thus, round up lrsize to ensure it
at least covers any padding. It may also be valid to leave lrsize, i.e.
itx_lr.lrc_reclen, as the unpadded value but pad itx_size, however more
assertions would need to be changed for that and it's unclear if any of
the code actually relies on the correspondence between them. Since the
code already rounds up the requested size to a multiple of 8 it's likely
safer to just round it up some more.
