### PR TITLE
caprevoke: Also exclude shadow bitmap from global VM stats

### DIFF
--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -1196,6 +1196,7 @@ vm_map_install_cheri_revoke_shadow(struct vm_map *map, struct sysentvec *sv)
 	 * both large and sparsely mapped.
 	 */
 	vm_object_set_flag(vmo_shadow, OBJ_NOCAP);
+	vm_object_set_flag(vmo_shadow, OBJ_CHERISHADOW);
 
 	vmo_info = vm_object_allocate(OBJT_SWAP, PAGE_SIZE);
 

--- a/sys/vm/vm_meter.c
+++ b/sys/vm/vm_meter.c
@@ -224,9 +224,10 @@ vmtotal(SYSCTL_HANDLER_ARGS)
 		 * this case, the lack of synchronization should not
 		 * impair the accuracy of the reported statistics.
 		 */
-		if ((object->flags & OBJ_FICTITIOUS) != 0) {
+		if ((object->flags & (OBJ_FICTITIOUS | OBJ_CHERISHADOW)) != 0) {
 			/*
-			 * Devices, like /dev/mem, will badly skew our totals.
+			 * Devices, like /dev/mem, will badly skew our totals,
+			 * as will the shadow bitmap.
 			 */
 			continue;
 		}

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -202,6 +202,7 @@ struct vm_object {
 #define	OBJ_HASCAP	0x10000		/* object can store capabilities */
 #define	OBJ_NOCAP	0x20000		/* object and all shadow objects can
 					   not store capabilities */
+#define	OBJ_CHERISHADOW	0x40000		/* object is the shadow bitmap */
 
 /*
  * Helpers to perform conversion between vm_object page indexes and offsets.


### PR DESCRIPTION
Otherwise t_vmshr gives a silly number, and is what pre-3.3.0 htop uses
for shared (magenta in the default colour scheme) memory in its memory
meter. 3.3.0 switches to the more sensible t_rmshr given the bar is
meant to reflect real, not virtual, memory, but we should still report
more useful totals here.
