### PR TITLE
mmap: deprecate MAP_CHERI_NOSETBOUNDS

### DIFF
--- a/lib/libc/gen/tls_malloc.c
+++ b/lib/libc/gen/tls_malloc.c
@@ -174,23 +174,8 @@ __morepages(int n)
 		caddr_t extra_start = __builtin_align_up(pagepool_start,
 		    pagesz);
 		size_t extra_bytes = pagepool_end - extra_start;
-#ifndef __CHERI_PURE_CAPABILITY__
 		if (munmap(extra_start, extra_bytes) != 0)
 			abort();
-#else
-		/*
-		 * In many cases we could safely unmap part of the end
-		 * (since there's only one pointer to the allocation in
-		 * pagepool_list to be updated), but we need to be careful
-		 * to avoid making the result unrepresentable.  For now,
-		 * just leak the virtual addresses and MAP_GUARD the
-		 * unused pages.
-		 */
-		if (mmap(extra_start, extra_bytes, PROT_NONE,
-		    MAP_FIXED | MAP_GUARD | MAP_CHERI_NOSETBOUNDS, -1, 0)
-		    == MAP_FAILED)
-			abort();
-#endif
 	}
 
 	if ((newpp = mmap(0, size, PROT_READ|PROT_WRITE, MAP_ANON, -1,

--- a/lib/libc/sys/mmap.2
+++ b/lib/libc/sys/mmap.2
@@ -166,9 +166,8 @@ is not representable as a precise capability,
 will fail.
 The
 .Dv MAP_ALIGNED_CHERI
-flag is assumed for CheriABI programs unless
-.Dv MAP_CHERI_NOSETBOUNDS
-is defined.
+flag is assumed for CheriABI programs when address space is being
+reserved.
 On architectures without CHERI support or where all capabilities are
 precise,
 .Dv MAP_ALIGNED_CHERI
@@ -216,15 +215,7 @@ This flag is identical to
 .Dv MAP_ANON
 and is provided for compatibility.
 .It Dv MAP_CHERI_NOSETBOUNDS
-This flag can only be used in combination with
-.Dv MAP_FIXED .
-In CheriABI, do not constrain the alignment of the capability, only
-require that mapping be possible at
-.Fa addr
-and that there be sufficient space in the capability for the request.
-The
-.Dv MAP_CHERI_NOSETBOUNDS
-flag is ignored by non-CheriABI programs.
+This flag is obsolete and should not be used.
 .It Dv MAP_EXCL
 This flag can only be used in combination with
 .Dv MAP_FIXED .
@@ -557,16 +548,6 @@ was specified and
 or
 .Fa size
 was not sufficently aligned for the current architecture.
-.It Bq Er EINVAL
-.Dv MAP_CHERI_NOSETBOUNDS
-was specified, but
-.Dv MAP_FIXED
-was not.
-CheriABI only.
-.It Bq Er EINVAL
-.Dv MAP_CHERI_NOSETBOUNDS
-was specified with an alignment request.
-CheriABI only.
 .It Bq Er EINVAL
 .Dv MAP_GUARD
 was specified, but the

--- a/lib/libc/sys/mmap.2
+++ b/lib/libc/sys/mmap.2
@@ -248,6 +248,14 @@ In contrast, if
 .Dv MAP_EXCL
 is specified, the request will fail if a mapping
 already exists within the range.
+.Pp
+Under CheriABI
+.Dv MAP_FIXED
+may be used with a NULL-derived capability, in which case
+.Dv MAP_EXCL
+is implied, or with a valid capability to an existing mapping.
+The former is allowed for compatability purposes and should be avoided
+in new code.
 .It Dv MAP_GUARD
 Instead of a mapping, create a guard of the specified size.
 Guards allow a process to create reservations in its address space,
@@ -430,6 +438,24 @@ Otherwise, a value of
 is returned and
 .Va errno
 is set to indicate the error.
+.Pp
+Under CheriABI, when a new region of address space is reserved,
+.Nm
+returns a capability with appropriate bounds (padded if required)
+and permissions implied by the
+.Dv PROT_MAX()
+portion of the
+.Fa prot
+argument (or by the passed
+.Dv PROT_*
+flags if no
+.Dv PROT_MAX()
+values are given).
+When the backing store of an existing mapping is updated via the
+.Dv MAP_FIXED
+flag, the passed value of
+.Fa addr
+is returned unmodified.
 .Sh ERRORS
 The
 .Fn mmap

--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -114,26 +114,9 @@ __morepages(int n)
 		caddr_t extra_start = __builtin_align_up(pagepool_start,
 		    _pagesz);
 		size_t extra_bytes = pagepool_end - extra_start;
-#ifndef __CHERI_PURE_CAPABILITY__
 		if (munmap(extra_start, extra_bytes) != 0)
-			error_printf("%s: munmap %p failed\n", __func__, addr);
-#else
-		/*
-		 * XXX: CHERI128: Need to avoid rounding down to an imprecise
-		 * capability.
-		 * In many cases we could safely unmap part of the end
-		 * (since there's only one pointer to the allocation in
-		 * pagepool_list to be updated), but we need to be careful
-		 * to avoid making the result unrepresentable.  For now,
-		 * just leak the virtual addresses and MAP_GUARD the
-		 * unused pages.
-		 */
-		if (mmap(extra_start, extra_bytes, PROT_NONE,
-		    MAP_FIXED | MAP_GUARD | MAP_CHERI_NOSETBOUNDS, -1, 0) ==
-		    MAP_FAILED)
-			error_printf("%s: mmap MAP_GUARD %p failed\n",
-			    __func__, extra_start);
-#endif
+			error_printf("%s: munmap %p failed\n", __func__,
+			    extra_start);
 	}
 
 	if ((newpp = mmap(0, size, PROT_READ|PROT_WRITE, MAP_ANON, -1,

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -120,8 +120,7 @@
 /*
  * CHERI specific flags and alignment constraints.
  *
- * MAP_CHERI_NOSETBOUNDS (requires MAP_FIXED) returns addr unchanged
- * after successful mapping.  CheriABI only.  Reuses MAP_RESERVED0020.
+ * MAP_CHERI_NOSETBOUNDS is obsolete and a no-op.  Reuses MAP_RESERVED0020.
  *
  * MAP_ALIGNED_CHERI returns memory aligned appropriately for the requested
  * length or fails.  Passing an under-rounded length fails.
@@ -129,7 +128,7 @@
  * MAP_ALIGNED_CHERI_SEAL returns memory aligned to allow sealing given the
  * requested length or fails.  Passing an under-rounded length fails.
  */
-#define	MAP_CHERI_NOSETBOUNDS	0x0020		/* Don't alter addr */
+#define	MAP_CHERI_NOSETBOUNDS	0x0020 _Pragma ("GCC warning \"'MAP_CHERI_NOSETBOUNDS' is a deprecated no-op\"")
 #define	MAP_ALIGNED_CHERI	MAP_ALIGNED(2)	/* align for CHERI data */
 #define	MAP_ALIGNED_CHERI_SEAL	MAP_ALIGNED(3)	/* align for sealing on CHERI */
 

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -153,13 +153,10 @@ mmap_retcap(struct thread *td, vm_pointer_t addr,
 	register_t perms, cap_prot;
 
 	/*
-	 * Return the original capability when MAP_CHERI_NOSETBOUNDS is set.
-	 *
-	 * NB: This means no permission changes.
-	 * The assumption is that the larger capability has the correct
-	 * permissions and we're only interested in adjusting page mappings.
+	 * If we're updating the backing store within an existing
+	 * reservation, just return the capability we were passed.
 	 */
-	if (mrp->mr_flags & MAP_CHERI_NOSETBOUNDS)
+	if ((mrp->mr_kern_flags & MAP_RESERVATION_CREATE) == 0)
 		return ((uintcap_t)mrp->mr_source_cap);
 
 	/*


### PR DESCRIPTION
This set of patches makes MAP_CHERI_NOSETBOUNDS a no-op and deprecates it.  Instead, treat MAP_FIXED within an existing reservation as if MAP_CHERI_NOSETBOUNDS was passed and return the `addr` argument unchanged.

I've run into this a couple times while looking at exposing capability load/store page permissions via mmap so I'd like to take the first step before 24.05.

One use remains in the tree in RTLD to allow it to work with older kernels.  For the next release I plan to remove the definition from userspace and then make it an error in the following release.