### PR TITLE
Guard -D_LIBUNWIND_SANDBOX_OTYPES behind an aarch64 check

### DIFF
--- a/lib/libgcc_s/Makefile
+++ b/lib/libgcc_s/Makefile
@@ -53,7 +53,10 @@ SRCS+=		s_logbl.c
 SRCS+=		s_scalbnl.c
 .endif
 
+# LIBUNWIND_SANDBOX_OTYPES is only supported on aarch64 (Morello).
+.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64"
 SYMBOL_MAPS+=	${.CURDIR}/Symbol-c18n.map
 CFLAGS+=	-D_LIBUNWIND_SANDBOX_OTYPES -D_LIBUNWIND_SANDBOX_HARDENED
+.endif
 
 .include <bsd.lib.mk>

--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -29,7 +29,7 @@ MK_UBSAN=	no
 
 .include <bsd.compat.pre.mk>
 
-.if (${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64")
+.if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64"
 RTLD_SANDBOX=
 .endif
 


### PR DESCRIPTION
With recent changes in https://github.com/CTSRD-CHERI/llvm-project/pull/731, we need to guard these libunwind defines behind aarch64 to avoid breaking other archs (like CHERI-RISC-V).