### PR TITLE
libsysdecode: Don't handle MAP_CHERI_NOSETBOUNDS

### DIFF
--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -155,7 +155,7 @@ gen_table "vmresult"        "KERN_[A-Z_]+[[:space:]]+[0-9]+"               "vm/v
 gen_table "wait6opt"        "W[A-Z]+[[:space:]]+[0-9]+"                    "sys/wait.h"
 gen_table "seekwhence"      "SEEK_[A-Z]+[[:space:]]+[0-9]+"                "sys/unistd.h"
 gen_table "fcntlcmd"        "F_[A-Z0-9_]+[[:space:]]+[0-9]+[[:space:]]+"   "sys/fcntl.h"	"F_CANCEL|F_..LCK"
-gen_table "mmapflags"       "MAP_[2-3A-Z_]+[[:space:]]+0x[0-9A-Fa-f]+"     "sys/mman.h"	"MAP_RESERVATION_CREATE"
+gen_table "mmapflags"       "MAP_[2-3A-Z_]+[[:space:]]+0x[0-9A-Fa-f]+"     "sys/mman.h"	"MAP_CHERI_NOSETBOUNDS|MAP_RESERVATION_CREATE"
 gen_table "rtpriofuncs"     "RTP_[A-Z]+[[:space:]]+[0-9]+"                 "sys/rtprio.h"
 gen_table "msgflags"        "MSG_[A-Z_]+[[:space:]]+0x[0-9]+"              "sys/socket.h"	"MSG_SOCALLBCK|MSG_MORETOCOME|MSG_TLSAPPDATA"
 gen_table "sigcode"         "SI_[A-Z]+[[:space:]]+0(x[0-9abcdef]+)?"       "sys/signal.h"


### PR DESCRIPTION
Expanding the macro produces warnings so stop doing it.  There aren't enough users to worry about the loss of decoding at this point.