### PR TITLE
c18n: Set curthread->tcb to real tcb upon thread start 

### DIFF
--- a/lib/libthr/thread/thr_create.c
+++ b/lib/libthr/thread/thr_create.c
@@ -300,6 +300,12 @@ thread_start(struct pthread *curthread)
 	bool restore_sigmask;
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	/*
+	 * At this point, curthread->tcb contains a fake wrapper TCB created by
+	 * RTLD when the thread was created. The real TCB has now been installed
+	 * by RTLD upon thread start, and the struct member should be set to it.
+	 */
+	curthread->tcb = _tcb_get();
 	restore_sigmask = true;
 #else
 	restore_sigmask = curthread->attr.suspend == THR_CREATE_SUSPENDED;

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -6110,6 +6110,12 @@ _rtld_allocate_tls(void *oldtls, size_t tcbsize, size_t tcbalign)
     ret = allocate_tls(globallist_curr(TAILQ_FIRST(&obj_list)), oldtls,
       tcbsize, tcbalign);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+    /*
+     * Create a fake wrapper TCB containing pointers to the real TCB and stack
+     * lookup table. This is passed to the new thread as its initial TCB. Once
+     * the thread starts executing in _rtld_thread_start, it will set the
+     * thread's TCB to the real TCB after installing the stack lookup table.
+     */
     if (C18N_ENABLED)
 	ret = c18n_allocate_tcb(ret);
 #endif


### PR DESCRIPTION
When a pthread is created, RTLD stores in its tcb field a fake tcb-like structure that contains a capability to the actual tcb and a capability to the thread's stack lookup table. This is done so that when the thread is entered, it does not need to create a stack lookup table, which involves a memory allocation that cannot be performed without a stack lookup table in the first place.

This commit fixes a mistake where the tcb field is not restored to the real tcb upon thread entry.