### PR TITLE
libsimple_printf: Catch up with INIT_ALL option

### DIFF
--- a/lib/libsimple_printf/Makefile
+++ b/lib/libsimple_printf/Makefile
@@ -2,8 +2,7 @@
 
 .include <src.opts.mk>
 MK_SSP=	no
-MK_INIT_ALL_ZERO=	no
-MK_INIT_ALL_PATTERN=	no
+OPT_INIT_ALL=	none
 
 PACKAGE=lib${LIB}
 LIB=	simple_printf


### PR DESCRIPTION
It's now a "single" option rather than a pair of incompatible options.

As mentioned in https://github.com/CTSRD-CHERI/cheribsd/pull/2046#issuecomment-1998234008 merge this on it's own.