### PR TITLE
Package manager configuration for demo-2024-06

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20240315
+#define __CheriBSD_version 20240607
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,

--- a/usr.sbin/pkg/CheriBSD-debug.conf
+++ b/usr.sbin/pkg/CheriBSD-debug.conf
@@ -7,7 +7,7 @@
 #
 
 CheriBSD-debug: {
-  url: "http://pkg.CheriBSD.org/${ABI}-debug",
+  url: "http://pkg.CheriBSD.org/demo-2024-06/${ABI}-debug",
   mirror_type: "none",
   signature_type: "fingerprints",
   fingerprints: "/usr/share/keys/pkg",

--- a/usr.sbin/pkg/CheriBSD.conf
+++ b/usr.sbin/pkg/CheriBSD.conf
@@ -7,7 +7,7 @@
 #
 
 CheriBSD: {
-  url: "http://pkg.CheriBSD.org/${ABI}",
+  url: "http://pkg.CheriBSD.org/demo-2024-06/${ABI}",
   mirror_type: "none",
   signature_type: "fingerprints",
   fingerprints: "/usr/share/keys/pkg",

--- a/usr.sbin/pkg/config.c
+++ b/usr.sbin/pkg/config.c
@@ -63,7 +63,7 @@ static struct config_entry c[] = {
 	[PACKAGESITE] = {
 		PKG_CONFIG_STRING,
 		"PACKAGESITE",
-		URL_SCHEME_PREFIX "http://pkg.CheriBSD.org/${ABI}",
+		URL_SCHEME_PREFIX "http://pkg.CheriBSD.org/demo-2024-06/${ABI}",
 		NULL,
 		NULL,
 		false,


### PR DESCRIPTION
**NOTE: this is not ready to be merged until we have packages deployed.**

We need to use a custom compiler to build packages for the demonstration branch with c18n support for function pointers. Not to confuse these packages with production packages for releases and the dev branch, the packages for this branch will be stored in a separate subdirectory.

"[DO NOT MERGE]" headlines should be kept after these commits are merged into `demo-2024-06`. We don't want them to be merged into dev.