### PR TITLE
c18n: Make _rtld_unw_setcontext callable via function pointer

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -47,15 +47,32 @@ ENTRY(_rtld_unw_getcontext_epilogue)
 	RETURN
 END(_rtld_unw_getcontext_epilogue)
 
-ENTRY(_rtld_unw_setcontext_epilogue)
+/*
+ * XXX: If compartmentalisation is not enabled, _rtld_unw_setcontext_ptr is NULL
+ * and we simply restore a few registers and return via retr (back to Restricted
+ * mode). Otherwise, call _rtld_unw_setcontext_impl via a trampoline.
+ */
+ENTRY(_rtld_unw_setcontext)
+	ldr	c16, _rtld_unw_setcontext_ptr
+	cbnz	w16, 1f
 	/*
 	 * FIXME: llvm-libunwind specific ABI. This should be better specified.
 	 */
 	mov	c16, c2
 	ldp	c2, c3, [c3, #(-0x210 + 0x20)]
 	mov	csp, c16
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	RETURN
-END(_rtld_unw_setcontext_epilogue)
+#else
+	retr	c30
+#endif
+1:
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	br	x16
+#else
+	br	c16
+#endif
+END(_rtld_unw_setcontext)
 
 /*
  * The _rtld_sighandler function is the actual signal handler passed to the

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1066,7 +1066,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
     if (C18N_ENABLED)
-	c18n_init2();
+	c18n_init2(&obj_rtld);
 #endif
 
     /*

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -204,7 +204,7 @@ void *_rtld_tlsdesc_undef_c18n(void *);
 void *_rtld_tlsdesc_dynamic_c18n(void *);
 
 void c18n_init(Obj_Entry *, Elf_Auxinfo *[]);
-void c18n_init2(void);
+void c18n_init2(Obj_Entry *);
 
 #include "rtld_c18n_machdep.h"
 #endif

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -43,7 +43,6 @@ trust
 	_setjmp
 	sigsetjmp
 	unw_getcontext
-	unw_getcontext_unsealed
 	_rtld_thread_start
 	_rtld_sighandler
 
@@ -62,7 +61,5 @@ export to [TCB]
 callee [RTLD]
 export to [libunwind]
 	_rtld_unw_getcontext
-	_rtld_unw_getcontext_unsealed
 	_rtld_unw_setcontext
-	_rtld_unw_setcontext_unsealed
 	_rtld_unw_getsealer


### PR DESCRIPTION
So that no lazy binding happens during the call, which might clobber registers when c18n is disabled. (Registers are always clobbered when c18n is enabled due to the use of trampolines.)

Also remove _rtld_unw_*_unsealed as they are no longer used by libunwind.