### PR TITLE
Fix kernel TLS on CHERI kernels

### DIFF
--- a/sys/netinet/tcp_usrreq.c
+++ b/sys/netinet/tcp_usrreq.c
@@ -1918,7 +1918,7 @@ copyin_tls_enable(struct sockopt *sopt, struct tls_enable *tls)
 	int error;
 
 	if (sopt->sopt_valsize == sizeof(tls_v0)) {
-		error = sooptcopyin(sopt, &tls_v0, sizeof(tls_v0),
+		error = sooptcopyincap(sopt, &tls_v0, sizeof(tls_v0),
 		    sizeof(tls_v0));
 		if (error)
 			return (error);
@@ -1937,7 +1937,7 @@ copyin_tls_enable(struct sockopt *sopt, struct tls_enable *tls)
 		return (0);
 	}
 
-	return (sooptcopyin(sopt, tls, sizeof(*tls), sizeof(*tls)));
+	return (sooptcopyincap(sopt, tls, sizeof(*tls), sizeof(*tls)));
 }
 #endif
 
@@ -2288,13 +2288,7 @@ unlock_and_done:
 #ifdef KERN_TLS
 		case TCP_TXTLS_ENABLE:
 			INP_WUNLOCK(inp);
-#if __has_feature(capabilities)
-			sopt->sopt_dir = SOPT_SETCAP;
-#endif
 			error = copyin_tls_enable(sopt, &tls);
-#if __has_feature(capabilities)
-			sopt->sopt_dir = SOPT_SET;
-#endif
 			if (error)
 				break;
 			error = ktls_enable_tx(so, &tls);
@@ -2311,14 +2305,8 @@ unlock_and_done:
 			break;
 		case TCP_RXTLS_ENABLE:
 			INP_WUNLOCK(inp);
-#if __has_feature(capabilities)
-			sopt->sopt_dir = SOPT_SETCAP;
-#endif
-			error = sooptcopyin(sopt, &tls, sizeof(tls),
+			error = sooptcopyincap(sopt, &tls, sizeof(tls),
 			    sizeof(tls));
-#if __has_feature(capabilities)
-			sopt->sopt_dir = SOPT_SET;
-#endif
 			if (error)
 				break;
 			error = ktls_enable_rx(so, &tls);

--- a/sys/netinet/tcp_usrreq.c
+++ b/sys/netinet/tcp_usrreq.c
@@ -2288,7 +2288,13 @@ unlock_and_done:
 #ifdef KERN_TLS
 		case TCP_TXTLS_ENABLE:
 			INP_WUNLOCK(inp);
+#if __has_feature(capabilities)
+			sopt->sopt_dir = SOPT_SETCAP;
+#endif
 			error = copyin_tls_enable(sopt, &tls);
+#if __has_feature(capabilities)
+			sopt->sopt_dir = SOPT_SET;
+#endif
 			if (error)
 				break;
 			error = ktls_enable_tx(so, &tls);
@@ -2305,8 +2311,14 @@ unlock_and_done:
 			break;
 		case TCP_RXTLS_ENABLE:
 			INP_WUNLOCK(inp);
+#if __has_feature(capabilities)
+			sopt->sopt_dir = SOPT_SETCAP;
+#endif
 			error = sooptcopyin(sopt, &tls, sizeof(tls),
 			    sizeof(tls));
+#if __has_feature(capabilities)
+			sopt->sopt_dir = SOPT_SET;
+#endif
 			if (error)
 				break;
 			error = ktls_enable_rx(so, &tls);

--- a/sys/sys/sockopt.h
+++ b/sys/sys/sockopt.h
@@ -45,10 +45,6 @@ struct socket;
 enum sopt_dir {
 	SOPT_GET,
 	SOPT_SET,
-#if __has_feature(capabilities)
-	SOPT_GETCAP,
-	SOPT_SETCAP,
-#endif
 };
 
 struct	sockopt {
@@ -63,6 +59,12 @@ struct	sockopt {
 int	sosetopt(struct socket *so, struct sockopt *sopt);
 int	sogetopt(struct socket *so, struct sockopt *sopt);
 int	sooptcopyin(struct sockopt *sopt, void *buf, size_t len, size_t minlen);
+#if __has_feature(capabilities)
+int	sooptcopyincap(struct sockopt *sopt, void *buf, size_t len,
+    size_t minlen);
+#else
+#define	sooptcopyincap	sooptcopyin
+#endif
 int	sooptcopyout(struct sockopt *sopt, const void *buf, size_t len);
 int	soopt_getm(struct sockopt *sopt, struct mbuf **mp);
 int	soopt_mcopyin(struct sockopt *sopt, struct mbuf *m);


### PR DESCRIPTION
- **ktls: Use SOPT_SETCAP to fix KTLS socket options for CHERI kernels**
- **sys: Replace SOPT_SET/GETCAP with sooptcopyincap**
