### PR TITLE
Bump __CheriBSD_version to 20240617

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20240315
+#define __CheriBSD_version 20240617
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,


### PR DESCRIPTION
Bump __CheriBSD_version to the current date to prepare for the next CheriBSD release.

Note that we have already bumped __CheriBSD_version after 23.11 but we want to update it again in case there are dev users who should upgrade packages after the next package repositories' build.