### PR TITLE
[RFC] c18n: New {get,set}context APIs for libunwind

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_ifunc.c
+++ b/bin/cheribsdtest/cheribsdtest_ifunc.c
@@ -27,6 +27,10 @@
 
 #include <machine/ifunc.h>
 
+#ifdef CHERIBSD_DYNAMIC_TESTS
+#include <cheribsdtest_dynamic.h>
+#endif
+
 #include "cheribsdtest.h"
 
 static int
@@ -50,3 +54,17 @@ CHERIBSDTEST(call_ifunc, "Check that IFUNCs can be called")
 
 	cheribsdtest_success();
 }
+
+#ifdef CHERIBSD_DYNAMIC_TESTS
+CHERIBSDTEST(dynamic_ifunc,
+    "Check that IFUNCs can be called from another object")
+{
+	int ret;
+
+	ret = cheribsdtest_dynamic_ifunc();
+	if (ret != 42)
+		cheribsdtest_failure_errx("Returned %d, expected 42", ret);
+
+	cheribsdtest_success();
+}
+#endif

--- a/contrib/subrepo-cheri-libunwind/include/__libunwind_config.h
+++ b/contrib/subrepo-cheri-libunwind/include/__libunwind_config.h
@@ -235,9 +235,4 @@
 # define _LIBUNWIND_HIGHEST_DWARF_REGISTER 287
 #endif // _LIBUNWIND_IS_NATIVE_ONLY
 
-#if defined(_LIBUNWIND_CHERI_C18N_SUPPORT) &&                                  \
-    !defined(_LIBUNWIND_TARGET_AARCH64)
-# error "LIBUNWIND_CHERI_C18N_SUPPORT is only supported on Morello"
-#endif
-
 #endif // ____LIBUNWIND_CONFIG_H__

--- a/contrib/subrepo-cheri-libunwind/src/AddressSpace.hpp
+++ b/contrib/subrepo-cheri-libunwind/src/AddressSpace.hpp
@@ -321,12 +321,6 @@ public:
     return get<v128>(addr);
   }
   capability_t     getCapability(pint_t addr) { return get<capability_t>(addr); }
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(_LIBUNWIND_CHERI_C18N_SUPPORT)
-  static pint_t getUnwindSealer();
-  static bool isValidSealer(pint_t sealer) {
-    return __builtin_cheri_tag_get(sealer);
-  }
-#endif // __CHERI_PURE_CAPABILITY__ && _LIBUNWIND_CHERI_C18N_SUPPORT
   __attribute__((always_inline))
   uintptr_t       getP(pint_t addr);
   uint64_t        getRegister(pint_t addr);
@@ -414,24 +408,6 @@ inline uint64_t LocalAddressSpace::getRegister(pint_t addr) {
   return get32(addr);
 #endif
 }
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(_LIBUNWIND_CHERI_C18N_SUPPORT)
-extern "C" {
-/// Call into the RTLD to get a sealer capability. This sealer will be used to
-/// seal information in the unwinding context.
-uintptr_t _rtld_unw_getsealer();
-uintptr_t __rtld_unw_getsealer();
-_LIBUNWIND_HIDDEN uintptr_t __rtld_unw_getsealer() {
-  return (uintptr_t)0;
-}
-_LIBUNWIND_WEAK_ALIAS(__rtld_unw_getsealer, _rtld_unw_getsealer)
-}
-
-/// C++ wrapper for calling into RTLD.
-inline LocalAddressSpace::pint_t LocalAddressSpace::getUnwindSealer() {
-  return _rtld_unw_getsealer();
-}
-#endif // __CHERI_PURE_CAPABILITY__ && _LIBUNWIND_CHERI_C18N_SUPPORT
 
 /// Read a ULEB128 into a 64-bit word.
 inline uint64_t LocalAddressSpace::getULEB128(pint_t &addr, pint_t end) {

--- a/contrib/subrepo-cheri-libunwind/src/CompartmentInfo.hpp
+++ b/contrib/subrepo-cheri-libunwind/src/CompartmentInfo.hpp
@@ -14,20 +14,72 @@
 #define __COMPARTMENT_INFO_HPP__
 
 namespace libunwind {
-class _LIBUNWIND_HIDDEN CompartmentInfo {
-public:
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(_LIBUNWIND_CHERI_C18N_SUPPORT)
-  static CompartmentInfo sThisCompartmentInfo;
-  // Per-architecture trusted stack frame layout.
+
+extern "C" {
+
+struct trusted_frame;
+
+// Must mirror the layout in rtld_c18n_machdep.h
 #if defined(_LIBUNWIND_TARGET_AARCH64)
-  static const uint32_t kNewSPOffset = 12 * sizeof(void *);
-  static const uint32_t kNextOffset = 14 * sizeof(void *);
-  static const uint32_t kCalleeSavedOffset = 2 * sizeof(void *);
-  static const uint32_t kCalleeSavedCount = 10;
-  static const uint32_t kReturnAddressOffset = 15 * sizeof(void *) + 8;
-  static const uint32_t kPCOffset = sizeof(void *);
-#endif // _LIBUNWIND_TARGET_AARCH64
-#endif // __CHERI_PURE_CAPABILITY__ && _LIBUNWIND_CHERI_C18N_SUPPORT
+struct compart_state {
+  void *fp;
+  void *pc;
+  void *regs[10]; // c19 to c28
+  void *sp;
+};
+#else
+# error "LIBUNWIND_CHERI_C18N_SUPPORT is not supported on this target"
+#endif
+
+#pragma weak c18n_is_enabled
+bool c18n_is_enabled(void) {
+  return false;
+};
+
+#pragma weak c18n_is_tramp
+bool c18n_is_tramp(ptraddr_t, struct trusted_frame *);
+
+#pragma weak c18n_pop_trusted_stk
+struct trusted_frame *
+c18n_pop_trusted_stk(struct compart_state *, struct trusted_frame *);
+}
+
+template <typename A, typename R>
+struct CompartmentInfo {
+  typedef typename A::pint_t pint_t;
+
+  static bool isC18NEnabled() {
+    return c18n_is_enabled();
+  }
+
+  static bool isC18NTramp(pint_t pc, pint_t tf) {
+    return c18n_is_tramp(pc, (struct trusted_frame *)tf);
+  }
+
+  static pint_t fillC18NState(R &newRegisters, pint_t tf) {
+    struct compart_state state;
+    tf = (pint_t)c18n_pop_trusted_stk(&state, (struct trusted_frame *)tf);
+
+    newRegisters.setTrustedStack(tf);
+    CHERI_DBG("C18N: SET TRUSTED STACK %#p\n", (void *)tf);
+
+    newRegisters.setFP((pint_t)state.fp);
+    CHERI_DBG("C18N: SET FP %#p\n", state.fp);
+
+    newRegisters.setSP((pint_t)state.sp);
+    CHERI_DBG("C18N: SET SP: %#p\n", state.sp);
+
+    for (size_t i = 0; i < sizeof(state.regs) / sizeof(*state.regs); ++i) {
+      newRegisters.setCapabilityRegister(UNW_ARM64_C19 + i,
+          (pint_t)state.regs[i]);
+      CHERI_DBG("C18N: SET REGISTER: %lu (%s): %#p\n",
+                UNW_ARM64_C19 + i,
+                newRegisters.getRegisterName(UNW_ARM64_C19 + i),
+                state.regs[i]);
+    }
+
+    return (pint_t)state.pc;
+  }
 };
 } // namespace libunwind
 #endif // __COMPARTMENT_INFO_HPP__

--- a/contrib/subrepo-cheri-libunwind/src/UnwindRegistersRestore.S
+++ b/contrib/subrepo-cheri-libunwind/src/UnwindRegistersRestore.S
@@ -714,7 +714,7 @@ DEFINE_LIBUNWIND_FUNCTION(__libunwind_Registers_arm64_jumpto)
 #ifdef __CHERI_PURE_CAPABILITY__
   ldr    c1,      [c0, #0x1f0]  // Pass the target untrusted stack pointer
   ldr    c2,      [c0, #0x210]  // Pass the target trusted stack pointer
-  bl     _rtld_unw_setcontext
+  bl     c18n_unwind_trusted_stk
 
   // skip restore of c0,c1 for now
   ldp    c2, c3,  [c0, #0x020]

--- a/contrib/subrepo-cheri-libunwind/src/UnwindRegistersRestore.S
+++ b/contrib/subrepo-cheri-libunwind/src/UnwindRegistersRestore.S
@@ -704,25 +704,6 @@ Lnovec:
 #elif defined(__aarch64__)
 
 //
-// extern "C" void __rtld_unw_setcontext(void *c0, void *c1,
-//                                       void *rcsp, void **sealed_ecsp);
-//
-#if defined(__CHERI_PURE_CAPABILITY__)
-DEFINE_LIBUNWIND_FUNCTION(__rtld_unw_setcontext)
-  mov    c16, c2
-  ldp    c2, c3,  [c3, #(-0x210 + 0x20)]
-  mov    csp, c16
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-  and    x30, x30, #~1
-  ret    x30
-#else
-  ret
-#endif
-END_LIBUNWIND_FUNCTION(__rtld_unw_setcontext)
-WEAK_ALIAS(__rtld_unw_setcontext, _rtld_unw_setcontext)
-#endif
-
-//
 // extern "C" void __libunwind_Registers_arm64_jumpto(Registers_arm64 *);
 //
 // On entry:
@@ -731,8 +712,12 @@ WEAK_ALIAS(__rtld_unw_setcontext, _rtld_unw_setcontext)
   .p2align 2
 DEFINE_LIBUNWIND_FUNCTION(__libunwind_Registers_arm64_jumpto)
 #ifdef __CHERI_PURE_CAPABILITY__
+  ldr    c1,      [c0, #0x1f0]  // Pass the target untrusted stack pointer
+  ldr    c2,      [c0, #0x210]  // Pass the target trusted stack pointer
+  bl     _rtld_unw_setcontext
+
   // skip restore of c0,c1 for now
-  // also skip restoring c2 and c3 because they will get clobbered later on
+  ldp    c2, c3,  [c0, #0x020]
   ldp    c4, c5,  [c0, #0x040]
   ldp    c6, c7,  [c0, #0x060]
   ldp    c8, c9,  [c0, #0x080]
@@ -772,17 +757,14 @@ DEFINE_LIBUNWIND_FUNCTION(__libunwind_Registers_arm64_jumpto)
   // context struct, because it is allocated on the stack, and an exception
   // could clobber the de-allocated portion of the stack after csp has been
   // restored.
-  ldr    c2,      [c0, #0x1f0]
-  add    c3, c0,  #0x210
-  ldp    c0, c1,  [c0, #0x000]
-  // XXX: variant PCS is not yet supported by rtld, work around it
-  // using a function pointer.
-  adrp   c16,     :got:_rtld_unw_setcontext
-  ldr    c16,     [c16, :got_lo12:_rtld_unw_setcontext]
+  ldr    c16,     [c0, #0x1f0]
+  ldp    c0, c1,  [c0, #0x000]  // restore c0,c1
+  mov    csp,c16                // restore csp
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-  br     x16
+  and    x30, x30, #~1
+  ret    x30                    // jump to pc
 #else
-  br     c16
+  ret                           // jump to pcc
 #endif
 #else
   // skip restore of x0,x1 for now

--- a/contrib/subrepo-cheri-libunwind/src/UnwindRegistersSave.S
+++ b/contrib/subrepo-cheri-libunwind/src/UnwindRegistersSave.S
@@ -838,16 +838,18 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 #elif defined(__aarch64__)
 
 #ifdef __CHERI_PURE_CAPABILITY__
-DEFINE_LIBUNWIND_FUNCTION(__rtld_unw_noop)
+DEFINE_LIBUNWIND_FUNCTION(_c18n_noop)
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
   and    x30, x30, #~1
   ret    x30
 #else
   ret
 #endif
-END_LIBUNWIND_FUNCTION(__rtld_unw_noop)
-WEAK_ALIAS(__rtld_unw_noop, _rtld_unw_getcontext)
-WEAK_ALIAS(__rtld_unw_noop, _rtld_unw_setcontext)
+END_LIBUNWIND_FUNCTION(_c18n_noop)
+// uintptr_t c18n_get_trusted_stk(uintptr_t, struct trusted_frame **);
+WEAK_ALIAS(_c18n_noop, c18n_get_trusted_stk)
+// uintptr_t c18n_unwind_trusted_stk(uintptr_t, void *, struct trusted_frame *);
+WEAK_ALIAS(_c18n_noop, c18n_unwind_trusted_stk)
 #endif
 
 //
@@ -902,7 +904,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
   str    d30,     [c0, #0x0f0]
   str    d31,     [c0, #0x0f8]
   mov    x0, #0                   // return UNW_ESUCCESS
-  b      _rtld_unw_getcontext
+  b      c18n_get_trusted_stk
 #else
   stp    x0, x1,  [x0, #0x000]
   stp    x2, x3,  [x0, #0x010]

--- a/contrib/subrepo-cheri-libunwind/src/UnwindRegistersSave.S
+++ b/contrib/subrepo-cheri-libunwind/src/UnwindRegistersSave.S
@@ -837,13 +837,17 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 #elif defined(__aarch64__)
 
-#if defined(__CHERI_PURE_CAPABILITY__)
-DEFINE_LIBUNWIND_FUNCTION(__rtld_unw_getcontext)
-  mov    c2,      csp
-  str    c2,      [c1]
-  ret    c30
-END_LIBUNWIND_FUNCTION(__rtld_unw_getcontext)
-WEAK_ALIAS(__rtld_unw_getcontext, _rtld_unw_getcontext)
+#ifdef __CHERI_PURE_CAPABILITY__
+DEFINE_LIBUNWIND_FUNCTION(__rtld_unw_noop)
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+  and    x30, x30, #~1
+  ret    x30
+#else
+  ret
+#endif
+END_LIBUNWIND_FUNCTION(__rtld_unw_noop)
+WEAK_ALIAS(__rtld_unw_noop, _rtld_unw_getcontext)
+WEAK_ALIAS(__rtld_unw_noop, _rtld_unw_setcontext)
 #endif
 
 //

--- a/contrib/subrepo-cheri-libunwind/src/libunwind.cpp
+++ b/contrib/subrepo-cheri-libunwind/src/libunwind.cpp
@@ -28,7 +28,6 @@
 
 #if !defined(__USING_SJLJ_EXCEPTIONS__)
 #include "AddressSpace.hpp"
-#include "CompartmentInfo.hpp"
 #include "UnwindCursor.hpp"
 
 
@@ -42,11 +41,6 @@ using namespace libunwind;
 
 /// internal object to represent this processes address space
 LocalAddressSpace LocalAddressSpace::sThisAddressSpace;
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(_LIBUNWIND_CHERI_C18N_SUPPORT)
-/// internal object to represent this processes compartment information
-CompartmentInfo CompartmentInfo::sThisCompartmentInfo;
-#endif // __CHERI_PURE_CAPABILITY__ && _LIBUNWIND_CHERI_C18N_SUPPORT
 
 _LIBUNWIND_EXPORT unw_addr_space_t unw_local_addr_space =
     (unw_addr_space_t)&LocalAddressSpace::sThisAddressSpace;

--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -63,7 +63,7 @@ ENTRY(_setjmp)
 	/*
 	 * Tail-call to save Executive mode state
 	 */
-	b	_rtld_setjmp
+	b	c18n_get_trusted_stk
 #else
 	RETURN
 #endif

--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -81,9 +81,7 @@ ENTRY(_longjmp)
 
 	/* Restore the stack pointer */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c2, c8
-#else
+#if !defined(__CHERI_PURE_CAPABILITY__) || !defined(RTLD_SANDBOX)
 	mov	REGN(sp), REG(8)
 #endif
 
@@ -105,11 +103,12 @@ ENTRY(_longjmp)
 
 	/* Load the return value */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c3, c0
+	ldr	c2, [c0]
 #endif
 	cmp	x1, #0
 	csinc	x0, x1, xzr, ne
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	mov	c1, c8
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -78,7 +78,7 @@ ENTRY(setjmp)
 	/*
 	 * Tail-call to save Executive mode state
 	 */
-	b	_rtld_setjmp
+	b	c18n_get_trusted_stk
 #else
 	RETURN
 #endif
@@ -139,7 +139,7 @@ ENTRY(longjmp)
 	/*
 	 * Tail-call to restore Executive mode state
 	 */
-	b	_rtld_longjmp
+	b	c18n_unwind_trusted_stk
 #else
 	RETURN
 #endif

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -110,9 +110,7 @@ ENTRY(longjmp)
 
 	/* Restore the stack pointer */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c2, c8
-#else
+#if !defined(__CHERI_PURE_CAPABILITY__) || !defined(RTLD_SANDBOX)
 	mov	REGN(sp), REG(8)
 #endif
 
@@ -132,11 +130,12 @@ ENTRY(longjmp)
 
 	/* Load the return value */
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
-	mov	c3, c0
+	ldr	c2, [c0]
 #endif
 	cmp	x1, #0
 	csinc	x0, x1, xzr, ne
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
+	mov	c1, c8
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libcheribsdtest_dynamic/Makefile
+++ b/lib/libcheribsdtest_dynamic/Makefile
@@ -5,4 +5,8 @@ MAN=	# No manpage; this is internal.
 SRCS=	cheribsdtest_dynamic_fptr.c					\
 	cheribsdtest_dynamic_identity_cap.c
 
+.if ${MACHINE_CPUARCH} == "aarch64"
+SRCS+=	cheribsdtest_dynamic_ifunc.c
+.endif
+
 .include <bsd.lib.mk>

--- a/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_ifunc.c
+++ b/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_ifunc.c
@@ -1,5 +1,12 @@
 /*-
- * Copyright (c) 2021 Jessica Clarke
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Dapeng Gao
+ *
+ * This software was developed by the University of Cambridge Computer
+ * Laboratory (Department of Computer Science and Technology) under Innovate
+ * UK project 105694, "Digital Security by Design (DSbD) Technology Platform
+ * Prototype".
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,14 +30,19 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _CHERIBSDTEST_DYNAMIC_H_
-#define _CHERIBSDTEST_DYNAMIC_H_
+#include <sys/types.h>
 
-void cheribsdtest_dynamic_dummy_func(void);
-void (*cheribsdtest_dynamic_get_dummy_fptr(void))(void);
+#include <machine/ifunc.h>
 
-void * __capability cheribsdtest_dynamic_identity_cap(void * __capability cap);
+#include "cheribsdtest_dynamic.h"
 
-int cheribsdtest_dynamic_ifunc(void);
+static int
+cheribsdtest_dynamic_ifunc_impl(void)
+{
+        return (42);
+}
 
-#endif
+DEFINE_UIFUNC(, int, cheribsdtest_dynamic_ifunc, (void))
+{
+	return (cheribsdtest_dynamic_ifunc_impl);
+}

--- a/lib/libgcc_s/Symbol-c18n.map
+++ b/lib/libgcc_s/Symbol-c18n.map
@@ -1,7 +1,5 @@
 FBSDprivate_1.0 {
 	_rtld_unw_getcontext;
 	_rtld_unw_setcontext;
-	_rtld_unw_getcontext_unsealed;
-	_rtld_unw_setcontext_unsealed;
 	_rtld_unw_getsealer;
 };

--- a/lib/libgcc_s/Symbol-c18n.map
+++ b/lib/libgcc_s/Symbol-c18n.map
@@ -1,5 +1,7 @@
 FBSDprivate_1.0 {
-	_rtld_unw_getcontext;
-	_rtld_unw_setcontext;
-	_rtld_unw_getsealer;
+	c18n_get_trusted_stk;
+	c18n_unwind_trusted_stk;
+	c18n_is_enabled;
+	c18n_is_tramp;
+	c18n_pop_trusted_stk;
 };

--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -11,10 +11,6 @@ FBSDprivate_1.0 {
     _rtld_setjmp;
     _rtld_longjmp;
     _rtld_unw_getcontext;
-    _rtld_unw_getcontext_unsealed;
     _rtld_unw_setcontext;
-    _rtld_unw_setcontext_unsealed;
     _rtld_unw_getsealer;
-    _rtld_safebox_code;
-    _rtld_sandbox_code;
 };

--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -8,9 +8,9 @@ FBSDprivate_1.0 {
     _rtld_sighandler;
     _rtld_siginvoke;
     _rtld_sigaction;
-    _rtld_setjmp;
-    _rtld_longjmp;
-    _rtld_unw_getcontext;
-    _rtld_unw_setcontext;
-    _rtld_unw_getsealer;
+    c18n_get_trusted_stk;
+    c18n_unwind_trusted_stk;
+    c18n_is_enabled;
+    c18n_is_tramp;
+    c18n_pop_trusted_stk;
 };

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -154,14 +154,12 @@ ENTRY(create_untrusted_stk)
 	 * callee-saved registers must be cleared.
 	 */
 
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/*
 	 * The execution stack is still the caller's stack. Switch to RTLD's
 	 * stack.
 	 */
 	get_rtld_stk		c10
 	set_untrusted_stk	c10
-#endif
 
 	save_arguments
 

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -35,46 +35,6 @@
  */
 
 /*
- * The _rtld_unw_{get,set}context_epilogue functions are stack unwinding
- * helpers. See the 'Stack unwinding' section in rtld_c18n.c.
- */
-ENTRY(_rtld_unw_getcontext_epilogue)
-	/*
-	 * FIXME: llvm-libunwind specific ABI. This should be better specified.
-	 */
-	mov	c2, csp
-	str	c2, [c1]
-	RETURN
-END(_rtld_unw_getcontext_epilogue)
-
-/*
- * XXX: If compartmentalisation is not enabled, _rtld_unw_setcontext_ptr is NULL
- * and we simply restore a few registers and return via retr (back to Restricted
- * mode). Otherwise, call _rtld_unw_setcontext_impl via a trampoline.
- */
-ENTRY(_rtld_unw_setcontext)
-	ldr	c16, _rtld_unw_setcontext_ptr
-	cbnz	w16, 1f
-	/*
-	 * FIXME: llvm-libunwind specific ABI. This should be better specified.
-	 */
-	mov	c16, c2
-	ldp	c2, c3, [c3, #(-0x210 + 0x20)]
-	mov	csp, c16
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	RETURN
-#else
-	retr	c30
-#endif
-1:
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-	br	x16
-#else
-	br	c16
-#endif
-END(_rtld_unw_setcontext)
-
-/*
  * The _rtld_sighandler function is the actual signal handler passed to the
  * kernel when the user calls sigaction. It dispatches the signal to the
  * appropriate handler registered by the user.

--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -84,18 +84,18 @@ ENTRY(_rtld_sighandler)
 	 * Get the interrupted compartment's current stack top.
 	 */
 	get_untrusted_stk	c3
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/*
 	 * The function is executing on an unknown untrusted stack. Switch to
 	 * RTLD's stack.
 	 */
 	get_rtld_stk		c4
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/*
 	 * Allocate a sigframe on RTLD's stack.
 	 */
 	sub	c4, c4, #SIG_FRAME_SIZE
-	set_untrusted_stk	c4
 #endif
+	set_untrusted_stk	c4
 	b	_rtld_sighandler_impl
 END(_rtld_sighandler)
 

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
@@ -133,7 +133,7 @@ set_untrusted_stk(const void *sp)
 }
 #endif
 
-struct trusted_frame {
+struct compart_state {
 	void *fp;
 	void *pc;
 	/*
@@ -145,38 +145,6 @@ struct trusted_frame {
 	 * caller made the call.
 	 */
 	void *sp;
-	/*
-	 * INVARIANT: This field contains the top of the caller's stack when the
-	 * caller was last entered.
-	 */
-	void *osp;
-	/*
-	 * Address of the previous trusted frame
-	 */
-	struct trusted_frame *previous;
-	/*
-	 * Compartment ID of the caller
-	 */
-	stk_table_index caller;
-	/*
-	 * Zeros
-	 */
-	uint16_t zeros;
-	/*
-	 * Compartment ID of the callee
-	 */
-	stk_table_index callee;
-	/*
-	 * Number of return value registers, encoded in enum tramp_ret_args
-	 */
-	uint8_t ret_args : 2;
-	uint16_t reserved : 14;
-	/*
-	 * This field contains the code address in the trampoline that the
-	 * callee should return to. This is used by trampolines to detect cross-
-	 * compartment tail-calls.
-	 */
-	ptraddr_t landing;
 };
 #endif
 #endif

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
@@ -71,8 +71,8 @@
 .endmacro
 
 .macro	get_rtld_stk		reg
-	mrs	\reg, STACK_TABLE
-	ldr	\reg, [\reg, #STACK_TABLE_RTLD]
+	mrs	STACK_TABLE_C, STACK_TABLE
+	ldr	\reg, [STACK_TABLE_C, #STACK_TABLE_RTLD]
 .endmacro
 
 .macro	update_stk_table	osp, sp, index

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -380,13 +380,11 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	 * get the caller's old stack top.
 	 */
 	update_stk_table	c11, c10, w12
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/*
 	 * Switch to RTLD's stack.
 	 */
 	get_rtld_stk		c10
 	set_untrusted_stk	c10
-#endif
 	/*
 	 * Save caller's old stack top.
 	 */

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -129,18 +129,16 @@ ENTRY(C18N_SYM(_rtld_bind_start))
 	 * get the caller's old stack top.
 	 */
 	update_stk_table	c11, c10, w12
-	mov	c17, c10
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/*
 	 * Switch to RTLD's stack.
 	 */
-	get_rtld_stk		c10
-	set_untrusted_stk	c10
-#endif
+	get_rtld_stk		c12
+	set_untrusted_stk	c12
 	/*
 	 * Save caller's old stack top.
 	 */
 	str	c11, [csp, #-CAP_WIDTH]!
+	mov	c17, c10
 #else
 	mov	PTR(17), PTRN(sp)
 #endif

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -371,7 +371,7 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	stp	c15, c16, [csp, #(7 * 32)]
 	stp	c17, c18, [csp, #(8 * 32)]
 	str	c19,	  [csp, #(9 * 32)]
-#if defined(RTLD_SANDBOX) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+#ifdef RTLD_SANDBOX
 	/*
 	 * Get the caller's current stack top. This step is only needed for
 	 * _rtld_tlsdesc_dynamic because it might call external functions.

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1066,7 +1066,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(RTLD_SANDBOX)
     if (C18N_ENABLED)
-	c18n_init2(&obj_rtld);
+	c18n_init2();
 #endif
 
     /*

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1883,11 +1883,6 @@ _rtld_sighandler_impl(int sig, siginfo_t *info, ucontext_t *ucp, void *nsp)
 
 	info = &sf->sf_si;
 	ucp = &sf->sf_uc;
-#else
-	/*
-	 * Switch to RTLD's stack.
-	 */
-	set_untrusted_stk(table->entries[RTLD_COMPART_ID].stack);
 #endif
 
 	tf = get_trusted_stk();

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -764,17 +764,14 @@ init_stk_table(struct stk_table *table, struct tcb_wrapper *wrap)
 	table->entries[RTLD_COMPART_ID].stack = sp + size;
 
 	/*
-	 * Push a dummy trusted frame indicating that the 'root' compartment
-	 * is RTLD.
+	 * Push a dummy trusted frame indicating that the 'root' compartment is
+	 * RTLD.
 	 */
-	*--tf = (struct trusted_frame) {
-		.callee = cid_to_index(RTLD_COMPART_ID)
-	};
+	tf = push_dummy_rtld_trusted_frame(tf);
 
 	/*
-	 * Install the trusted stack and the stack lookup table.
+	 * Install the stack lookup table.
 	 */
-	set_trusted_stk(tf);
 	set_stk_table(table);
 }
 

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1931,17 +1931,16 @@ _rtld_sighandler_impl(int sig, siginfo_t *info, ucontext_t *ucp, void *nsp)
 	intr = index_to_cid(intr_idx);
 	if (cheri_is_subset(table->meta->compart_stk[intr].begin, nsp))
 		goto found_trusted;
-#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/*
-	 * In the benchmark ABI, lazy binding, thread-local storage, and stack
-	 * resolution all involve switching to RTLD's stack. In this case, nsp
-	 * would refer to RTLD's stack top.
+	 * Lazy binding, thread-local storage, and stack resolution all involve
+	 * switching to RTLD's stack. In this case, nsp would refer to RTLD's
+	 * stack top.
 	 */
 	intr_idx = cid_to_index(RTLD_COMPART_ID);
 	intr = RTLD_COMPART_ID;
 	if (cheri_is_subset(table->meta->compart_stk[intr].begin, nsp))
 		goto found_trusted;
-#else
+#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 found_failed:
 #endif
 	rtld_fdprintf(STDERR_FILENO,

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -118,8 +118,33 @@ struct stk_table {
 
 #define	COMPART_ID_MAX		index_to_cid((stk_table_index) { -1 })
 
+#include "rtld_c18n_machdep.h"
+
 struct tcb *c18n_allocate_tcb(struct tcb *);
 void c18n_free_tcb(void);
+
+/*
+ * When entering the RTLD without a trampoline (e.g., during lazy binding, TLS
+ * lookup, or stack resolution), a dummy trusted frame indicating that the
+ * current compartment is RTLD must be pushed.
+ */
+static inline struct trusted_frame *
+push_dummy_rtld_trusted_frame(struct trusted_frame *tf)
+{
+	*--tf = (struct trusted_frame) {
+		.callee = cid_to_index(RTLD_COMPART_ID)
+	};
+	set_trusted_stk(tf);
+	return (tf);
+}
+
+static inline struct trusted_frame *
+pop_dummy_rtld_trusted_frame(struct trusted_frame *tf)
+{
+	assert(get_trusted_stk() == tf);
+	set_trusted_stk(++tf);
+	return (tf);
+}
 
 /*
  * Trampolines
@@ -205,6 +230,4 @@ void *_rtld_tlsdesc_dynamic_c18n(void *);
 
 void c18n_init(Obj_Entry *, Elf_Auxinfo *[]);
 void c18n_init2(Obj_Entry *);
-
-#include "rtld_c18n_machdep.h"
 #endif

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -229,5 +229,5 @@ void *_rtld_tlsdesc_undef_c18n(void *);
 void *_rtld_tlsdesc_dynamic_c18n(void *);
 
 void c18n_init(Obj_Entry *, Elf_Auxinfo *[]);
-void c18n_init2(Obj_Entry *);
+void c18n_init2(void);
 #endif

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -55,11 +55,15 @@ export to [TCB]
 	_rtld_sighandler
 	_rtld_siginvoke
 	_rtld_sigaction
-	_rtld_setjmp
-	_rtld_longjmp
+
+callee [RTLD]
+export to [TCB]
+export to [libunwind]
+	c18n_get_trusted_stk
+	c18n_unwind_trusted_stk
 
 callee [RTLD]
 export to [libunwind]
-	_rtld_unw_getcontext
-	_rtld_unw_setcontext
-	_rtld_unw_getsealer
+	c18n_is_enabled
+	c18n_is_tramp
+	c18n_pop_trusted_stk


### PR DESCRIPTION
This PR is not intended to be merged but merely to collect feedback.

I changed `_unw_setcontext` to call `_rtld_unw_setcontext` before restoring the registers. Also, `_unw_setcontext` is now marked as a trusted function so no trampoline is involved when entering and exiting it. This ensures that no register is clobbered when setting the context.

Assembly stubs for `_rtld_unw_{get,set}context` in libunwind have been removed. Instead, we make calls to these functions behave like no-ops if they are not defined by RTLD.