### PR TITLE
netinet: correct SIOCDIFADDR{,_IN6} calls to use {,in6_}ifreq

### DIFF
--- a/sbin/nos-tun/nos-tun.c
+++ b/sbin/nos-tun/nos-tun.c
@@ -141,7 +141,7 @@ tun_open(char *dev_name, struct sockaddr *ouraddr, char *theiraddr)
    *  when tunN have no addresses, so - log and ignore it.
    *
    */
-  if (ioctl(s, SIOCDIFADDR, &ifra) < 0) {
+  if (ioctl(s, SIOCDIFADDR, &ifrq) < 0) {
     syslog(LOG_ERR,"SIOCDIFADDR - %m");
   }
 
@@ -220,10 +220,8 @@ Finish(int signum)
   /*
    *  Delete addresses for interface
    */
-  bzero(&ifra.ifra_addr, sizeof(ifra.ifra_addr));
-  bzero(&ifra.ifra_broadaddr, sizeof(ifra.ifra_addr));
-  bzero(&ifra.ifra_mask, sizeof(ifra.ifra_addr));
-  if (ioctl(s, SIOCDIFADDR, &ifra) < 0) {
+  bzero(&ifrq.ifr_addr, sizeof(ifrq.ifr_addr));
+  if (ioctl(s, SIOCDIFADDR, &ifrq) < 0) {
     syslog(LOG_ERR,"can't delete interface's addresses - %m");
   }
 closing_fds:

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -1098,12 +1098,10 @@ if_purgeaddrs(struct ifnet *ifp)
 #ifdef INET
 		/* XXX: Ugly!! ad hoc just for INET */
 		if (ifa->ifa_addr->sa_family == AF_INET) {
-			struct ifaliasreq ifr;
+			struct ifreq ifr;
 
 			bzero(&ifr, sizeof(ifr));
-			ifr.ifra_addr = *ifa->ifa_addr;
-			if (ifa->ifa_dstaddr)
-				ifr.ifra_broadaddr = *ifa->ifa_dstaddr;
+			ifr.ifr_addr = *ifa->ifa_addr;
 			if (in_control(NULL, SIOCDIFADDR, (caddr_t)&ifr, ifp,
 			    NULL) == 0)
 				continue;

--- a/sys/netinet/in.c
+++ b/sys/netinet/in.c
@@ -1220,7 +1220,7 @@ in_ifscrub_all(void)
 {
 	struct ifnet *ifp;
 	struct ifaddr *ifa, *nifa;
-	struct ifaliasreq ifr;
+	struct ifreq ifr;
 
 	IFNET_RLOCK();
 	CK_STAILQ_FOREACH(ifp, &V_ifnet, if_link) {
@@ -1235,9 +1235,7 @@ in_ifscrub_all(void)
 			 * cleanly remove addresses and everything attached.
 			 */
 			bzero(&ifr, sizeof(ifr));
-			ifr.ifra_addr = *ifa->ifa_addr;
-			if (ifa->ifa_dstaddr)
-			ifr.ifra_broadaddr = *ifa->ifa_dstaddr;
+			ifr.ifr_addr = *ifa->ifa_addr;
 			(void)in_control(NULL, SIOCDIFADDR, (caddr_t)&ifr,
 			    ifp, NULL);
 		}

--- a/sys/netlink/route/iface.c
+++ b/sys/netlink/route/iface.c
@@ -1194,17 +1194,17 @@ static int
 handle_deladdr_inet(struct nlmsghdr *hdr, struct nl_parsed_ifa *attrs,
     if_t ifp, struct nlpcb *nlp, struct nl_pstate *npt)
 {
-	struct sockaddr_in *addr = (struct sockaddr_in *)attrs->ifa_local;
+	struct sockaddr *addr = attrs->ifa_local;
 
 	if (addr == NULL)
-		addr = (struct sockaddr_in *)attrs->ifa_address;
+		addr = attrs->ifa_address;
 
 	if (addr == NULL) {
 		nlmsg_report_err_msg(npt, "empty IFA_ADDRESS/IFA_LOCAL");
 		return (EINVAL);
 	}
 
-	struct in_aliasreq req = { .ifra_addr = *addr };
+	struct ifreq req = { .ifr_addr = *addr };
 
 	return (in_control_ioctl(SIOCDIFADDR, &req, ifp, nlp_get_cred(nlp)));
 }
@@ -1288,7 +1288,7 @@ handle_deladdr_inet6(struct nlmsghdr *hdr, struct nl_parsed_ifa *attrs,
 		return (EINVAL);
 	}
 
-	struct in6_aliasreq req = { .ifra_addr = *addr };
+	struct in6_ifreq req = { .ifr_addr = *addr };
 
 	return (in6_control_ioctl(SIOCDIFADDR_IN6, &req, ifp, nlp_get_cred(nlp)));
 }


### PR DESCRIPTION
The SIOCDIFADDR{,_IN6} ioctls take an ifreq structure object, not an ifaliasreq/in_aliasreq/in6_aliasreq structure object, as their argument.
    
On CHERI, the incorrect calls using the in6_aliasreq object result in CHERI capability violations. A pointer to the ifra_addr field in in6_aliasreq cast to the ifru_addr union member of in6_ifreq results in bounds being set to the union's larger size. Such bounds exceed the bounds of of in6_aliasreq object and the bounds-setting instruction clears a tag of the object's capability.

Fixes: https://github.com/CTSRD-CHERI/cheribsd/issues/2129