### PR TITLE
cheribsdtest: Add test for cross-object IFUNC invocation

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_ifunc.c
+++ b/bin/cheribsdtest/cheribsdtest_ifunc.c
@@ -27,6 +27,10 @@
 
 #include <machine/ifunc.h>
 
+#ifdef CHERIBSD_DYNAMIC_TESTS
+#include <cheribsdtest_dynamic.h>
+#endif
+
 #include "cheribsdtest.h"
 
 static int
@@ -50,3 +54,17 @@ CHERIBSDTEST(call_ifunc, "Check that IFUNCs can be called")
 
 	cheribsdtest_success();
 }
+
+#ifdef CHERIBSD_DYNAMIC_TESTS
+CHERIBSDTEST(dynamic_ifunc,
+    "Check that IFUNCs can be called from another object")
+{
+	int ret;
+
+	ret = cheribsdtest_dynamic_ifunc();
+	if (ret != 42)
+		cheribsdtest_failure_errx("Returned %d, expected 42", ret);
+
+	cheribsdtest_success();
+}
+#endif

--- a/lib/libcheribsdtest_dynamic/Makefile
+++ b/lib/libcheribsdtest_dynamic/Makefile
@@ -5,4 +5,8 @@ MAN=	# No manpage; this is internal.
 SRCS=	cheribsdtest_dynamic_fptr.c					\
 	cheribsdtest_dynamic_identity_cap.c
 
+.if ${MACHINE_CPUARCH} == "aarch64"
+SRCS+=	cheribsdtest_dynamic_ifunc.c
+.endif
+
 .include <bsd.lib.mk>

--- a/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_ifunc.c
+++ b/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_ifunc.c
@@ -1,5 +1,12 @@
 /*-
- * Copyright (c) 2021 Jessica Clarke
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Dapeng Gao
+ *
+ * This software was developed by the University of Cambridge Computer
+ * Laboratory (Department of Computer Science and Technology) under Innovate
+ * UK project 105694, "Digital Security by Design (DSbD) Technology Platform
+ * Prototype".
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,14 +30,19 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _CHERIBSDTEST_DYNAMIC_H_
-#define _CHERIBSDTEST_DYNAMIC_H_
+#include <sys/types.h>
 
-void cheribsdtest_dynamic_dummy_func(void);
-void (*cheribsdtest_dynamic_get_dummy_fptr(void))(void);
+#include <machine/ifunc.h>
 
-void * __capability cheribsdtest_dynamic_identity_cap(void * __capability cap);
+#include "cheribsdtest_dynamic.h"
 
-int cheribsdtest_dynamic_ifunc(void);
+static int
+cheribsdtest_dynamic_ifunc_impl(void)
+{
+        return (42);
+}
 
-#endif
+DEFINE_UIFUNC(, int, cheribsdtest_dynamic_ifunc, (void))
+{
+	return (cheribsdtest_dynamic_ifunc_impl);
+}


### PR DESCRIPTION
This is known to fail for the current `dev` and is fixed in #2134.