### PR TITLE
mmap: complete removal of MAP_CHERI_NOSETBOUNDS

### DIFF
--- a/lib/libsys/mmap.2
+++ b/lib/libsys/mmap.2
@@ -214,8 +214,6 @@ argument must be 0.
 This flag is identical to
 .Dv MAP_ANON
 and is provided for compatibility.
-.It Dv MAP_CHERI_NOSETBOUNDS
-This flag is obsolete and should not be used.
 .It Dv MAP_EXCL
 This flag can only be used in combination with
 .Dv MAP_FIXED .

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -155,7 +155,7 @@ gen_table "vmresult"        "KERN_[A-Z_]+[[:space:]]+[0-9]+"               "vm/v
 gen_table "wait6opt"        "W[A-Z]+[[:space:]]+[0-9]+"                    "sys/wait.h"
 gen_table "seekwhence"      "SEEK_[A-Z]+[[:space:]]+[0-9]+"                "sys/unistd.h"
 gen_table "fcntlcmd"        "F_[A-Z0-9_]+[[:space:]]+[0-9]+[[:space:]]+"   "sys/fcntl.h"	"F_CANCEL|F_..LCK"
-gen_table "mmapflags"       "MAP_[2-3A-Z_]+[[:space:]]+0x[0-9A-Fa-f]+"     "sys/mman.h"	"MAP_CHERI_NOSETBOUNDS|MAP_RESERVATION_CREATE"
+gen_table "mmapflags"       "MAP_[2-3A-Z_]+[[:space:]]+0x[0-9A-Fa-f]+"     "sys/mman.h"	"MAP_RESERVATION_CREATE"
 gen_table "rtpriofuncs"     "RTP_[A-Z]+[[:space:]]+[0-9]+"                 "sys/rtprio.h"
 gen_table "msgflags"        "MSG_[A-Z_]+[[:space:]]+0x[0-9]+"              "sys/socket.h"	"MSG_SOCALLBCK|MSG_MORETOCOME|MSG_TLSAPPDATA"
 gen_table "sigcode"         "SI_[A-Z]+[[:space:]]+0(x[0-9abcdef]+)?"       "sys/signal.h"

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -304,12 +304,7 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	data_vlimit = rtld_round_page(segs[i]->p_vaddr + segs[i]->p_filesz);
 	data_addr = mapbase + (data_vaddr - base_vaddr);
 	data_prot = convert_prot(segs[i]->p_flags);
-	/*
-	 * Set MAP_CHERI_NOSETBOUNDS to avoid the need for a precisely
-	 * representable region. We already have a valid capability and only
-	 * want to check if mapping from the file (MAP_ANON for bss) succeeded.
-	 */
-	data_flags = convert_flags(segs[i]->p_flags) | MAP_FIXED | MAP_CHERI_NOSETBOUNDS;
+	data_flags = convert_flags(segs[i]->p_flags) | MAP_FIXED;
 	dbg("Mapping %s PT_LOAD(%d) with flags 0x%x at %p", path, i,
 	    segs[i]->p_flags, data_addr, data_vlimit);
 

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -120,15 +120,12 @@
 /*
  * CHERI specific flags and alignment constraints.
  *
- * MAP_CHERI_NOSETBOUNDS is obsolete and a no-op.  Reuses MAP_RESERVED0020.
- *
  * MAP_ALIGNED_CHERI returns memory aligned appropriately for the requested
  * length or fails.  Passing an under-rounded length fails.
  *
  * MAP_ALIGNED_CHERI_SEAL returns memory aligned to allow sealing given the
  * requested length or fails.  Passing an under-rounded length fails.
  */
-#define	MAP_CHERI_NOSETBOUNDS	0x0020 _Pragma ("GCC warning \"'MAP_CHERI_NOSETBOUNDS' is a deprecated no-op\"")
 #define	MAP_ALIGNED_CHERI	MAP_ALIGNED(2)	/* align for CHERI data */
 #define	MAP_ALIGNED_CHERI_SEAL	MAP_ALIGNED(3)	/* align for sealing on CHERI */
 

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -325,12 +325,6 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 		if (flags & MAP_FIXED)
 			flags |= MAP_EXCL;
 
-		if (flags & MAP_CHERI_NOSETBOUNDS) {
-			SYSERRCAUSE("MAP_CHERI_NOSETBOUNDS without a valid "
-			    "addr capability");
-			return (EINVAL);
-		}
-
 		source_cap = userspace_root_cap;
 	}
 	KASSERT(cheri_gettag(source_cap),
@@ -493,8 +487,7 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 	/*
 	 * Ignore old flags that used to be defined but did not do anything.
 	 */
-	if (!SV_CURPROC_FLAG(SV_CHERI))
-		flags &= ~(MAP_RESERVED0020 | MAP_RESERVED0040);
+	flags &= ~(MAP_RESERVED0020 | MAP_RESERVED0040);
 
 	/*
 	 * Enforce the constraints.
@@ -537,8 +530,7 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 	unsigned int extra_flags =
 	    (flags & ~(MAP_SHARED | MAP_PRIVATE | MAP_FIXED | MAP_HASSEMAPHORE |
 	    MAP_STACK | MAP_NOSYNC | MAP_ANON | MAP_EXCL | MAP_NOCORE |
-	    MAP_PREFAULT_READ | MAP_GUARD | MAP_32BIT | MAP_CHERI_NOSETBOUNDS |
-	    MAP_ALIGNMENT_MASK));
+	    MAP_PREFAULT_READ | MAP_GUARD | MAP_32BIT | MAP_ALIGNMENT_MASK));
 	if (extra_flags != 0) {
 		SYSERRCAUSE("%s: Unhandled flag(s) 0x%x", __func__,
 		    extra_flags);
@@ -561,7 +553,7 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 	}
 	if ((flags & MAP_GUARD) != 0 && (prot != PROT_NONE || fd != -1 ||
 	    pos != 0 || (flags & ~(MAP_FIXED | MAP_GUARD | MAP_EXCL |
-	    MAP_CHERI_NOSETBOUNDS | MAP_RESERVATION_CREATE |
+	    MAP_RESERVATION_CREATE |
 	    MAP_32BIT | MAP_ALIGNMENT_MASK)) != 0)) {
 		SYSERRCAUSE("%s: Invalid arguments with MAP_GUARD", __func__);
 		return (EINVAL);


### PR DESCRIPTION
This completes the removal started in f918bdbcd8af.  After this commit:
 - Rtld will require a kernel were MAP_CHERI_NOSETBOUNDS is a no-op (24.05 release or any kernel after f918bdbcd8af).
 - The kernel completely ignores MAP_CHERI_NOSETBOUNDS so old binaries relying on MAP_CHERI_NOSETBOUNDS should still work (so long as it does not also rely on the bounding behavior).
 - Software depending on MAP_CHERI_NOSETBOUNDS will no longer compile.