### PR TITLE
Fix freebsdNN compat for [u]intptr_t syscall arguments

### DIFF
--- a/sys/compat/freebsd32/freebsd32_proto.h
+++ b/sys/compat/freebsd32/freebsd32_proto.h
@@ -89,7 +89,7 @@ struct freebsd32_getitimer_args {
 struct freebsd32_fcntl_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char arg_l_[PADL_(intptr_t)]; intptr_t arg; char arg_r_[PADR_(intptr_t)];
+	char arg_l_[PADL_(intptr32_t)]; intptr32_t arg; char arg_r_[PADR_(intptr32_t)];
 };
 struct freebsd32_select_args {
 	char nd_l_[PADL_(int)]; int nd; char nd_r_[PADR_(int)];

--- a/sys/compat/freebsd32/freebsd32_systrace_args.c
+++ b/sys/compat/freebsd32/freebsd32_systrace_args.c
@@ -527,7 +527,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct freebsd32_fcntl_args *p = params;
 		iarg[a++] = p->fd; /* int */
 		iarg[a++] = p->cmd; /* int */
-		uarg[a++] = (intptr_t)p->arg; /* intptr_t */
+		uarg[a++] = (intptr_t)p->arg; /* intptr32_t */
 		*n_args = 3;
 		break;
 	}
@@ -3381,8 +3381,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[a++] = p->pid1; /* pid_t */
 		iarg[a++] = p->pid2; /* pid_t */
 		iarg[a++] = p->type; /* int */
-		uarg[a++] = (intptr_t)p->idx1; /* uintptr_t */
-		uarg[a++] = (intptr_t)p->idx2; /* uintptr_t */
+		uarg[a++] = (intptr_t)p->idx1; /* uintptr32_t */
+		uarg[a++] = (intptr_t)p->idx2; /* uintptr32_t */
 		*n_args = 5;
 		break;
 	}
@@ -4192,7 +4192,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "intptr_t";
+			p = "intptr32_t";
 			break;
 		default:
 			break;
@@ -9141,10 +9141,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "uintptr_t";
+			p = "uintptr32_t";
 			break;
 		case 4:
-			p = "uintptr_t";
+			p = "uintptr32_t";
 			break;
 		default:
 			break;

--- a/sys/compat/freebsd32/syscalls.conf
+++ b/sys/compat/freebsd32/syscalls.conf
@@ -14,6 +14,7 @@ abi_long="int32_t"
 abi_u_long="uint32_t"
 abi_semid_t="int32_t"
 abi_size_t="uint32_t"
+abi_intptr_t="intptr32_t"
 abi_ptr_array_t="uint32_t"
 abi_headers="#include <compat/freebsd32/freebsd32_proto.h>"
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -1179,7 +1179,7 @@ freebsd64_fcntl(struct thread *td, struct freebsd64_fcntl_args *uap)
 	case F_SETLK:
 	case F_SETLKW:
 	case F_SETLK_REMOTE:
-		arg = (intcap_t)__USER_CAP_UNBOUND((void *)uap->arg);
+		arg = (intcap_t)__USER_CAP_UNBOUND(uap->arg);
 		break;
 	default:
 		arg = (intcap_t)uap->arg;

--- a/sys/compat/freebsd64/freebsd64_proto.h
+++ b/sys/compat/freebsd64/freebsd64_proto.h
@@ -234,7 +234,7 @@ struct freebsd64_cheri_cidcap_alloc_args {
 struct freebsd64_fcntl_args {
 	char fd_l_[PADL_(int)]; int fd; char fd_r_[PADR_(int)];
 	char cmd_l_[PADL_(int)]; int cmd; char cmd_r_[PADR_(int)];
-	char arg_l_[PADL_(intptr_t)]; intptr_t arg; char arg_r_[PADR_(intptr_t)];
+	char arg_l_[PADL_(intptr64_t)]; intptr64_t arg; char arg_r_[PADR_(intptr64_t)];
 };
 struct freebsd64_select_args {
 	char nd_l_[PADL_(int)]; int nd; char nd_r_[PADR_(int)];
@@ -1513,8 +1513,8 @@ struct freebsd64_kcmp_args {
 	char pid1_l_[PADL_(pid_t)]; pid_t pid1; char pid1_r_[PADR_(pid_t)];
 	char pid2_l_[PADL_(pid_t)]; pid_t pid2; char pid2_r_[PADR_(pid_t)];
 	char type_l_[PADL_(int)]; int type; char type_r_[PADR_(int)];
-	char idx1_l_[PADL_(uintptr_t)]; uintptr_t idx1; char idx1_r_[PADR_(uintptr_t)];
-	char idx2_l_[PADL_(uintptr_t)]; uintptr_t idx2; char idx2_r_[PADR_(uintptr_t)];
+	char idx1_l_[PADL_(uintptr64_t)]; uintptr64_t idx1; char idx1_r_[PADR_(uintptr64_t)];
+	char idx2_l_[PADL_(uintptr64_t)]; uintptr64_t idx2; char idx2_r_[PADR_(uintptr64_t)];
 };
 int	freebsd64_read(struct thread *, struct freebsd64_read_args *);
 int	freebsd64_write(struct thread *, struct freebsd64_write_args *);

--- a/sys/compat/freebsd64/freebsd64_systrace_args.c
+++ b/sys/compat/freebsd64/freebsd64_systrace_args.c
@@ -531,7 +531,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		struct freebsd64_fcntl_args *p = params;
 		iarg[a++] = p->fd; /* int */
 		iarg[a++] = p->cmd; /* int */
-		uarg[a++] = (intptr_t)p->arg; /* intptr_t */
+		uarg[a++] = (intptr_t)p->arg; /* intptr64_t */
 		*n_args = 3;
 		break;
 	}
@@ -3475,8 +3475,8 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 		iarg[a++] = p->pid1; /* pid_t */
 		iarg[a++] = p->pid2; /* pid_t */
 		iarg[a++] = p->type; /* int */
-		uarg[a++] = (intptr_t)p->idx1; /* uintptr_t */
-		uarg[a++] = (intptr_t)p->idx2; /* uintptr_t */
+		uarg[a++] = (intptr_t)p->idx1; /* uintptr64_t */
+		uarg[a++] = (intptr_t)p->idx2; /* uintptr64_t */
 		*n_args = 5;
 		break;
 	}
@@ -4296,7 +4296,7 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 2:
-			p = "intptr_t";
+			p = "intptr64_t";
 			break;
 		default:
 			break;
@@ -9303,10 +9303,10 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "int";
 			break;
 		case 3:
-			p = "uintptr_t";
+			p = "uintptr64_t";
 			break;
 		case 4:
-			p = "uintptr_t";
+			p = "uintptr64_t";
 			break;
 		default:
 			break;

--- a/sys/compat/freebsd64/syscalls.conf
+++ b/sys/compat/freebsd64/syscalls.conf
@@ -13,6 +13,7 @@ systrace="freebsd64_systrace_args.c"
 abi_flags="pointer_args|pointer_size"
 abi_func_prefix="freebsd64_"
 abi_type_suffix="64"
+abi_intptr_t="intptr64_t"
 abi_headers="#include <compat/freebsd64/freebsd64_proto.h>"
 # amd64 is the oldest surviving 64-bit platform.  Support appeared in 5.1.
 mincompat="5"

--- a/sys/sys/types.h
+++ b/sys/sys/types.h
@@ -300,6 +300,16 @@ typedef	__uint64_t	uoff_t;
 typedef	char		vm_memattr_t;	/* memory attribute codes */
 typedef	struct vm_page	*vm_page_t;
 
+#ifdef COMPAT_FREEBSD32
+typedef	__int32_t	intptr32_t;
+typedef	__uint32_t	uintptr32_t;
+#endif
+
+#ifdef COMPAT_FREEBSD64
+typedef	__int64_t	intptr64_t;
+typedef	__uint64_t	uintptr64_t;
+#endif
+
 #define offsetof(type, field) __offsetof(type, field)
 #endif /* _KERNEL */
 


### PR DESCRIPTION
- **freebsd64_fcntl: Remove unnecessary cast**
- **freebsd32/64: Map [u]intptr_t syscall arguments to [u]intXX_t**
- **sysent: Regen**
