### PR TITLE
Disable warnings triggered in libc++15 with Clang 16

### DIFF
--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -257,6 +257,14 @@ CWARNFLAGS+=	-Wno-system-headers
 CWARNFLAGS+=	-Wno-error=pass-failed
 .endif
 
+.if ${COMPILER_TYPE} == "clang" && ${COMPILER_VERSION} >= 160000
+# Work around warnings in libc++15 when built with Clang 16+.
+# This has to be here rather than scoped to libc++ since it is
+# triggered in headers used by (almost) all C++ programs.
+# FIXME: Remove this once libc++ has been upgraded.
+CXXWARNFLAGS+=-Wno-keyword-compat
+.endif
+
 # How to handle FreeBSD custom printf format specifiers.
 .if ${COMPILER_TYPE} == "clang" || \
     (${COMPILER_TYPE} == "gcc" && ${COMPILER_VERSION} >= 120100)


### PR DESCRIPTION
After upgrading LLVM we get the following error:
`keyword '__make_signed' will be made available as an identifier for the remainder of the translation unit [-Werror,-Wkeyword-compat]` This will be fixed once libc++ is upgraded to version 16, but this commit can be cherry-picked back to older release branches.