### PR TITLE
Fix warnings in purecap pmcstat

### DIFF
--- a/lib/libpmcstat/libpmcstat.h
+++ b/lib/libpmcstat/libpmcstat.h
@@ -178,10 +178,10 @@ struct pmcstat_image {
 	 * Executables have pi_start and pi_end; these are zero
 	 * for shared libraries.
 	 */
-	uintfptr_t	pi_start;	/* start address (inclusive) */
-	uintfptr_t	pi_end;		/* end address (exclusive) */
-	uintfptr_t	pi_entry;	/* entry address */
-	uintfptr_t	pi_vaddr;	/* virtual address where loaded */
+	ptraddr_t	pi_start;	/* start address (inclusive) */
+	ptraddr_t	pi_end;		/* end address (exclusive) */
+	ptraddr_t	pi_entry;	/* entry address */
+	ptraddr_t	pi_vaddr;	/* virtual address where loaded */
 	int		pi_isdynamic;	/* whether a dynamic object */
 	int		pi_iskernelmodule;
 	pmcstat_interned_string pi_dynlinkerpath; /* path in .interp */
@@ -226,8 +226,8 @@ struct pmcstat_string {
  */
 struct pmcstat_pcmap {
 	TAILQ_ENTRY(pmcstat_pcmap) ppm_next;
-	uintfptr_t	ppm_lowpc;
-	uintfptr_t	ppm_highpc;
+	ptraddr_t	ppm_lowpc;
+	ptraddr_t	ppm_highpc;
 	struct pmcstat_image *ppm_image;
 };
 
@@ -247,7 +247,7 @@ struct pmcstat_process {
 	LIST_ENTRY(pmcstat_process) pp_next;	/* hash-next */
 	pid_t			pp_pid;		/* associated pid */
 	int			pp_isactive;	/* whether active */
-	uintfptr_t		pp_entryaddr;	/* entry address */
+	ptraddr_t		pp_entryaddr;	/* entry address */
 	TAILQ_HEAD(,pmcstat_pcmap) pp_map;	/* address range map */
 };
 extern LIST_HEAD(pmcstat_process_hash_list, pmcstat_process) pmcstat_process_hash[PMCSTAT_NHASH];
@@ -281,7 +281,7 @@ struct pmc_plugins {
 	/* sample processing */
 	void (*pl_process)(struct pmcstat_process *pp,
 	    struct pmcstat_pmcrecord *pmcr, uint32_t nsamples,
-	    uintfptr_t *cc, int usermode, uint32_t cpu);
+	    ptraddr_t *cc, int usermode, uint32_t cpu);
 
 	/* image */
 	void (*pl_initimage)(struct pmcstat_image *pi);
@@ -317,7 +317,7 @@ struct pmcstat_stats {
 __BEGIN_DECLS
 int pmcstat_symbol_compare(const void *a, const void *b);
 struct pmcstat_symbol *pmcstat_symbol_search(struct pmcstat_image *image,
-    uintfptr_t addr);
+    ptraddr_t addr);
 void pmcstat_image_add_symbols(struct pmcstat_image *image, Elf *e,
     Elf_Scn *scn, GElf_Shdr *sh);
 
@@ -339,7 +339,7 @@ void pmcstat_process_elf_exec(struct pmcstat_process *_pp,
     struct pmcstat_stats *pmcstat_stats);
 
 void pmcstat_image_link(struct pmcstat_process *_pp,
-    struct pmcstat_image *_i, uintfptr_t _lpc);
+    struct pmcstat_image *_i, ptraddr_t _lpc);
 
 void pmcstat_process_aout_exec(struct pmcstat_process *_pp,
     struct pmcstat_image *_image, uintptr_t _baseaddr);
@@ -350,7 +350,7 @@ void pmcstat_process_exec(struct pmcstat_process *_pp,
 void pmcstat_image_determine_type(struct pmcstat_image *_image, struct pmcstat_args *args);
 void pmcstat_image_get_aout_params(struct pmcstat_image *_image, struct pmcstat_args *args);
 struct pmcstat_pcmap *pmcstat_process_find_map(struct pmcstat_process *_p,
-    uintfptr_t _pc);
+    ptraddr_t _pc);
 void pmcstat_initialize_logging(struct pmcstat_process **pmcstat_kernproc,
     struct pmcstat_args *args, struct pmc_plugins *plugins,
     int *pmcstat_npmcs, int *pmcstat_mergepmc);

--- a/lib/libpmcstat/libpmcstat_image.c
+++ b/lib/libpmcstat/libpmcstat_image.c
@@ -181,10 +181,10 @@ pmcstat_image_add_symbols(struct pmcstat_image *image, Elf *e,
 
 void
 pmcstat_image_link(struct pmcstat_process *pp, struct pmcstat_image *image,
-    uintfptr_t start)
+    ptraddr_t start)
 {
 	struct pmcstat_pcmap *pcm, *pcmnew;
-	uintfptr_t offset;
+	ptraddr_t offset;
 #ifdef __powerpc__
 	unsigned long kernbase;
 	size_t kernbase_len;
@@ -304,7 +304,7 @@ pmcstat_image_get_elf_params(struct pmcstat_image *image,
 	const char *path, *elfbase;
 	char *p, *endp;
 	bool first_exec_segment;
-	uintfptr_t minva, maxva;
+	ptraddr_t minva, maxva;
 	Elf *e;
 	Elf_Scn *scn;
 	GElf_Ehdr eh;
@@ -315,8 +315,8 @@ pmcstat_image_get_elf_params(struct pmcstat_image *image,
 
 	assert(image->pi_type == PMCSTAT_IMAGE_UNKNOWN);
 
-	image->pi_start = minva = ~(uintfptr_t) 0;
-	image->pi_end = maxva = (uintfptr_t) 0;
+	image->pi_start = minva = ~(ptraddr_t) 0;
+	image->pi_end = maxva = (ptraddr_t) 0;
 	image->pi_type = image_type = PMCSTAT_IMAGE_INDETERMINABLE;
 	image->pi_isdynamic = 0;
 	image->pi_dynlinkerpath = NULL;

--- a/lib/libpmcstat/libpmcstat_logging.c
+++ b/lib/libpmcstat/libpmcstat_logging.c
@@ -117,8 +117,8 @@ pmcstat_pmcid_add(pmc_id_t pmcid, pmcstat_interned_string ps,
  */
 
 static void
-pmcstat_image_unmap(struct pmcstat_process *pp, uintfptr_t start,
-    uintfptr_t end)
+pmcstat_image_unmap(struct pmcstat_process *pp, ptraddr_t start,
+    ptraddr_t end)
 {
 	struct pmcstat_pcmap *pcm, *pcmtmp, *pcmnew;
 

--- a/lib/libpmcstat/libpmcstat_process.c
+++ b/lib/libpmcstat/libpmcstat_process.c
@@ -189,7 +189,7 @@ pmcstat_process_exec(struct pmcstat_process *pp,
  */
 
 struct pmcstat_pcmap *
-pmcstat_process_find_map(struct pmcstat_process *p, uintfptr_t pc)
+pmcstat_process_find_map(struct pmcstat_process *p, ptraddr_t pc)
 {
 	struct pmcstat_pcmap *ppm;
 

--- a/lib/libpmcstat/libpmcstat_symbol.c
+++ b/lib/libpmcstat/libpmcstat_symbol.c
@@ -128,7 +128,7 @@ pmcstat_symbol_compare(const void *a, const void *b)
  */
 
 struct pmcstat_symbol *
-pmcstat_symbol_search(struct pmcstat_image *image, uintfptr_t addr)
+pmcstat_symbol_search(struct pmcstat_image *image, ptraddr_t addr)
 {
 	struct pmcstat_symbol sym;
 

--- a/sys/sys/pmckern.h
+++ b/sys/sys/pmckern.h
@@ -74,17 +74,17 @@ typedef enum ring_type {
 
 struct pmckern_procexec {
 	int		pm_credentialschanged;
-	uintptr_t	pm_baseaddr;
-	uintptr_t	pm_dynaddr;
+	ptraddr_t	pm_baseaddr;
+	ptraddr_t	pm_dynaddr;
 };
 
 struct pmckern_map_in {
 	void		*pm_file;	/* filename or vnode pointer */
-	uintfptr_t	pm_address;	/* address object is loaded at */
+	ptraddr_t	pm_address;	/* address object is loaded at */
 };
 
 struct pmckern_map_out {
-	uintfptr_t	pm_address;	/* start address of region */
+	ptraddr_t	pm_address;	/* start address of region */
 	size_t		pm_size;	/* size of unmapped region */
 };
 

--- a/usr.sbin/pmc/Makefile
+++ b/usr.sbin/pmc/Makefile
@@ -6,9 +6,6 @@ CXXSTD= c++14
 CWARNFLAGS.gcc+= -Wno-redundant-decls
 CFLAGS+= -I${SRCTOP}/lib/libpmcstat
 
-# XXX: not at all purecap clean
-MK_WERROR=	no
-
 LIBADD=	pmc m pmcstat elf
 
 SRCS=	pmc.c pmc_util.c cmd_pmc_stat.c \

--- a/usr.sbin/pmcstat/Makefile
+++ b/usr.sbin/pmcstat/Makefile
@@ -1,9 +1,6 @@
 #
 #
 
-# XXX: not at all purecap clean
-MK_WERROR=	no
-
 PROG_CXX=	pmcstat
 MAN=	pmcstat.8
 

--- a/usr.sbin/pmcstat/pmcpl_annotate.c
+++ b/usr.sbin/pmcstat/pmcpl_annotate.c
@@ -87,11 +87,11 @@
 
 void
 pmcpl_annotate_process(struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu)
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu)
 {
 	struct pmcstat_pcmap *map;
 	struct pmcstat_symbol *sym;
-	uintfptr_t newpc;
+	ptraddr_t newpc;
 	struct pmcstat_image *image;
 
 	(void) pmcr; (void) nsamples; (void) usermode; (void) cpu;

--- a/usr.sbin/pmcstat/pmcpl_annotate.h
+++ b/usr.sbin/pmcstat/pmcpl_annotate.h
@@ -36,6 +36,6 @@
 /* Function prototypes */
 void pmcpl_annotate_process(
     struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu);
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu);
 
 #endif	/* _PMCSTAT_PL_ANNOTATE_H_ */

--- a/usr.sbin/pmcstat/pmcpl_annotate_cg.c
+++ b/usr.sbin/pmcstat/pmcpl_annotate_cg.c
@@ -90,11 +90,11 @@
 
 void
 pmcpl_annotate_cg_process(struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu)
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu)
 {
 	struct pmcstat_pcmap *map;
 	struct pmcstat_symbol *sym;
-	uintfptr_t newpc;
+	ptraddr_t newpc;
 	struct pmcstat_image *image;
 	int i;
 	char filename[PATH_MAX], funcname[PATH_MAX];

--- a/usr.sbin/pmcstat/pmcpl_annotate_cg.h
+++ b/usr.sbin/pmcstat/pmcpl_annotate_cg.h
@@ -39,6 +39,6 @@
 /* Function prototypes */
 void pmcpl_annotate_cg_process(
     struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu);
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu);
 
 #endif	/* _PMCSTAT_PL_ANNOTATE_CG_H_ */

--- a/usr.sbin/pmcstat/pmcpl_callgraph.c
+++ b/usr.sbin/pmcstat/pmcpl_callgraph.c
@@ -101,7 +101,7 @@ int pmcstat_cgnode_hash_count;
 static pmcstat_interned_string pmcstat_previous_filename_printed;
 
 static struct pmcstat_cgnode *
-pmcstat_cgnode_allocate(struct pmcstat_image *image, uintfptr_t pc)
+pmcstat_cgnode_allocate(struct pmcstat_image *image, ptraddr_t pc)
 {
 	struct pmcstat_cgnode *cg;
 
@@ -138,14 +138,14 @@ pmcstat_cgnode_free(struct pmcstat_cgnode *cg)
  */
 static struct pmcstat_cgnode *
 pmcstat_cgnode_hash_lookup_pc(struct pmcstat_process *pp, pmc_id_t pmcid,
-    uintfptr_t pc, int usermode)
+    ptraddr_t pc, int usermode)
 {
 	struct pmcstat_pcmap *ppm;
 	struct pmcstat_symbol *sym;
 	struct pmcstat_image *image;
 	struct pmcstat_cgnode *cg;
 	struct pmcstat_cgnode_hash *h;
-	uintfptr_t loadaddress;
+	ptraddr_t loadaddress;
 	unsigned int i, hash;
 
 	ppm = pmcstat_process_find_map(usermode ? pp : pmcstat_kernproc, pc);
@@ -168,7 +168,7 @@ pmcstat_cgnode_hash_lookup_pc(struct pmcstat_process *pp, pmc_id_t pmcid,
 			pmcstat_stats.ps_samples_unknown_function++;
 	}
 
-	for (hash = i = 0; i < sizeof(uintfptr_t); i++)
+	for (hash = i = 0; i < sizeof(ptraddr_t); i++)
 		hash += (pc >> i) & 0xFF;
 
 	hash &= PMCSTAT_HASH_MASK;
@@ -232,7 +232,7 @@ pmcstat_cgnode_compare(const void *a, const void *b)
 
 static struct pmcstat_cgnode *
 pmcstat_cgnode_find(struct pmcstat_cgnode *parent, struct pmcstat_image *image,
-    uintfptr_t pcoffset)
+    ptraddr_t pcoffset)
 {
 	struct pmcstat_cgnode *child;
 
@@ -336,9 +336,9 @@ pmcstat_cgnode_print(struct pmcstat_cgnode *cg, int depth, uint32_t total)
 
 void
 pmcpl_cg_process(struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu)
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu)
 {
-	uintfptr_t pc, loadaddress;
+	ptraddr_t pc, loadaddress;
 	uint32_t n;
 	struct pmcstat_image *image;
 	struct pmcstat_pcmap *ppm;

--- a/usr.sbin/pmcstat/pmcpl_callgraph.h
+++ b/usr.sbin/pmcstat/pmcpl_callgraph.h
@@ -39,7 +39,7 @@
 
 struct pmcstat_cgnode {
 	struct pmcstat_image	*pcg_image;
-	uintfptr_t		pcg_func;
+	ptraddr_t		pcg_func;
 	uint32_t		pcg_count;
 	uint32_t		pcg_nchildren;
 	LIST_ENTRY(pmcstat_cgnode) pcg_sibling;
@@ -59,7 +59,7 @@ int pmcpl_cg_init(void);
 void pmcpl_cg_shutdown(FILE *mf);
 void pmcpl_cg_process(
     struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu);
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu);
 int pmcpl_cg_topkeypress(int c, void *w);
 void pmcpl_cg_topdisplay(void);
 void pmcpl_cg_configure(char *opt);

--- a/usr.sbin/pmcstat/pmcpl_calltree.c
+++ b/usr.sbin/pmcstat/pmcpl_calltree.c
@@ -98,7 +98,7 @@ struct pmcpl_ct_arc {
 };
 
 struct pmcpl_ct_instr {
-	uintfptr_t		pctf_func;
+	ptraddr_t		pctf_func;
 	struct pmcpl_ct_sample	pctf_samples;
 };
 
@@ -107,7 +107,7 @@ struct pmcpl_ct_instr {
  */
 struct pmcpl_ct_node {
 	struct pmcstat_image	*pct_image;
-	uintfptr_t		pct_func;
+	ptraddr_t		pct_func;
 
 	struct pmcstat_symbol	*pct_sym;
 	pmcstat_interned_string	pct_ifl;
@@ -280,7 +280,7 @@ pmcpl_ct_instr_grow(int cursize, int *maxsize, struct pmcpl_ct_instr **items)
 
 static void
 pmcpl_ct_instr_add(struct pmcpl_ct_node *ct, int pmcin,
-    uintfptr_t pc, unsigned v)
+    ptraddr_t pc, unsigned v)
 {
 	int i;
 	struct pmcpl_ct_instr *in;
@@ -670,7 +670,7 @@ pmcpl_ct_node_update(struct pmcpl_ct_node *parent,
  */
 
 static struct pmcpl_ct_node *
-pmcpl_ct_node_hash_lookup(struct pmcstat_image *image, uintfptr_t pc,
+pmcpl_ct_node_hash_lookup(struct pmcstat_image *image, ptraddr_t pc,
     struct pmcstat_symbol *sym, char *fl, char *fn)
 {
 	int i;
@@ -687,7 +687,7 @@ pmcpl_ct_node_hash_lookup(struct pmcstat_image *image, uintfptr_t pc,
 		ifn = 0;
 	}
 
-	for (hash = i = 0; i < (int)sizeof(uintfptr_t); i++)
+	for (hash = i = 0; i < (int)sizeof(ptraddr_t); i++)
 		hash += (pc >> i) & 0xFF;
 
 	hash &= PMCSTAT_HASH_MASK;
@@ -735,10 +735,10 @@ pmcpl_ct_node_hash_lookup(struct pmcstat_image *image, uintfptr_t pc,
 
 void
 pmcpl_ct_process(struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu)
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu)
 {
 	int i, n, pmcin;
-	uintfptr_t pc, loadaddress;
+	ptraddr_t pc, loadaddress;
 	struct pmcstat_image *image;
 	struct pmcstat_symbol *sym;
 	struct pmcstat_pcmap *ppm[PMC_CALLCHAIN_DEPTH_MAX];
@@ -835,11 +835,11 @@ pmcpl_ct_process(struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
  */
 
 static void
-pmcpl_ct_node_printchild(struct pmcpl_ct_node *ct, uintfptr_t paddr,
+pmcpl_ct_node_printchild(struct pmcpl_ct_node *ct, ptraddr_t paddr,
     int pline)
 {
 	int i, j, line;
-	uintfptr_t addr;
+	ptraddr_t addr;
 	struct pmcpl_ct_node *child;
 	char sourcefile[PATH_MAX];
 	char funcname[PATH_MAX];
@@ -904,7 +904,7 @@ static void
 pmcpl_ct_node_printself(struct pmcpl_ct_node *ct)
 {
 	int i, j, fline, line;
-	uintfptr_t faddr, addr;
+	ptraddr_t faddr, addr;
 	char sourcefile[PATH_MAX];
 	char funcname[PATH_MAX];
 
@@ -1036,7 +1036,7 @@ _pmcpl_ct_expand_inline(struct pmcpl_ct_node *ct)
 {
 	int i, j;
 	unsigned fline, line, v;
-	uintfptr_t faddr, addr, pc;
+	ptraddr_t faddr, addr, pc;
 	char sourcefile[PATH_MAX];
 	char ffuncname[PATH_MAX], funcname[PATH_MAX];
 	char buffer[PATH_MAX];

--- a/usr.sbin/pmcstat/pmcpl_calltree.h
+++ b/usr.sbin/pmcstat/pmcpl_calltree.h
@@ -34,7 +34,7 @@ int pmcpl_ct_init(void);
 void pmcpl_ct_shutdown(FILE *mf);
 void pmcpl_ct_process(
     struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu);
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu);
 int pmcpl_ct_topkeypress(int c, void *w);
 void pmcpl_ct_topdisplay(void);
 int pmcpl_ct_configure(char *opt);

--- a/usr.sbin/pmcstat/pmcpl_gprof.c
+++ b/usr.sbin/pmcstat/pmcpl_gprof.c
@@ -409,12 +409,12 @@ pmcpl_gmon_newpmc(pmcstat_interned_string ps, struct pmcstat_pmcrecord *pr)
 
 void
 pmcpl_gmon_process(struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu)
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu)
 {
 	struct pmcstat_pcmap *map;
 	struct pmcstat_image *image;
 	struct pmcstat_gmonfile *pgf;
-	uintfptr_t bucket;
+	ptraddr_t bucket;
 	HISTCOUNTER *hc;
 	WIDEHISTCOUNTER *whc;
 	pmc_id_t pmcid;

--- a/usr.sbin/pmcstat/pmcpl_gprof.h
+++ b/usr.sbin/pmcstat/pmcpl_gprof.h
@@ -38,7 +38,7 @@
 void pmcpl_gmon_shutdown(FILE *mf);
 void pmcpl_gmon_process(
     struct pmcstat_process *pp, struct pmcstat_pmcrecord *pmcr,
-    uint32_t nsamples, uintfptr_t *cc, int usermode, uint32_t cpu);
+    uint32_t nsamples, ptraddr_t *cc, int usermode, uint32_t cpu);
 void pmcpl_gmon_initimage(struct pmcstat_image *pi);
 void pmcpl_gmon_shutdownimage(struct pmcstat_image *pi);
 void pmcpl_gmon_newpmc(pmcstat_interned_string ps,

--- a/usr.sbin/pmcstat/pmcstat_log.c
+++ b/usr.sbin/pmcstat/pmcstat_log.c
@@ -245,7 +245,7 @@ pmcstat_stats_reset(int reset_global)
  * Resolve file name and line number for the given address.
  */
 int
-pmcstat_image_addr2line(struct pmcstat_image *image, uintfptr_t addr,
+pmcstat_image_addr2line(struct pmcstat_image *image, ptraddr_t addr,
     char *sourcefile, size_t sourcefile_len, unsigned *sourceline,
     char *funcname, size_t funcname_len)
 {

--- a/usr.sbin/pmcstat/pmcstat_log.h
+++ b/usr.sbin/pmcstat/pmcstat_log.h
@@ -50,7 +50,7 @@ extern int pmcstat_pmcinfilter; /* PMC index displayed. */
 const char *pmcstat_pmcid_to_name(pmc_id_t _pmcid);
 const char *pmcstat_pmcindex_to_name(int pmcin);
 struct pmcstat_pmcrecord *pmcstat_pmcindex_to_pmcr(int pmcin);
-int pmcstat_image_addr2line(struct pmcstat_image *image, uintfptr_t addr,
+int pmcstat_image_addr2line(struct pmcstat_image *image, ptraddr_t addr,
     char *sourcefile, size_t sourcefile_len, unsigned *sourceline,
     char *funcname, size_t funcname_len);
 


### PR DESCRIPTION
- **hwpmc: Use ptraddr_t instead of uintfptr_t**
- **pmc,pmcstat: Re-enable -Werror**
