### PR TITLE
Remove MAP_ALIGNED_CHERI

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -815,13 +815,6 @@ CHERIBSDTEST(vm_reservation_align,
 	    "mmap failed to align representable region with requested "
 	    "alignment %lx for %p", align_shift + 1, map);
 
-	/* Explicit cheri alignment */
-	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
-	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_ALIGNED_CHERI, -1, 0));
-	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
-	    "mmap failed to align representable region with requested "
-	    "cheri alignment for %p", map);
-
 	cheribsdtest_success();
 }
 

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -822,12 +822,6 @@ CHERIBSDTEST(vm_reservation_align,
 	    "mmap failed to align representable region with requested "
 	    "cheri alignment for %p", map);
 
-	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len,
-	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_ALIGNED_CHERI_SEAL, -1, 0));
-	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
-	    "mmap failed to align representable region with requested "
-	    "cheri seal alignment for %p", map);
-
 	cheribsdtest_success();
 }
 

--- a/lib/libsys/mmap.2
+++ b/lib/libsys/mmap.2
@@ -155,23 +155,6 @@ will fail.
 The
 .Fa n
 argument specifies the binary logarithm of the desired alignment.
-.It Dv MAP_ALIGNED_CHERI
-Align the region as required to allow a CHERI capability to be created.
-If a suitable region cannot be found or the address of
-.Fa addr
-or the length in
-.Fa len
-is not representable as a precise capability,
-.Fn mmap
-will fail.
-The
-.Dv MAP_ALIGNED_CHERI
-flag is assumed for CheriABI programs when address space is being
-reserved.
-On architectures without CHERI support or where all capabilities are
-precise,
-.Dv MAP_ALIGNED_CHERI
-has no effect.
 .It Dv MAP_ALIGNED_SUPER
 Align the region to maximize the potential use of large
 .Pq Dq super
@@ -549,14 +532,6 @@ were specified, but the requested region is already used by a mapping.
 was specified, but
 .Dv MAP_FIXED
 was not.
-.It Bq Er EINVAL
-.Dv MAP_ALIGNED_CHERI
-(implied on CheriABI)
-was specified and
-.Fa addr
-or
-.Fa size
-was not sufficently aligned for the current architecture.
 .It Bq Er EINVAL
 .Dv MAP_GUARD
 was specified, but the

--- a/lib/libsys/mmap.2
+++ b/lib/libsys/mmap.2
@@ -172,19 +172,6 @@ On architectures without CHERI support or where all capabilities are
 precise,
 .Dv MAP_ALIGNED_CHERI
 has no effect.
-.It Dv MAP_ALIGNED_CHERI_SEAL
-Align the region as required to allow a CHERI capability to be sealed.
-If a suitable region cannot be found or the address of
-.Fa addr
-or the length in
-.Fa len
-is not representable as a precise, sealable capability,
-.Fn mmap
-will fail.
-On architectures without CHERI support or where all capabilities are
-precise,
-.Dv MAP_ALIGNED_CHERI_SEAL
-has no effect.
 .It Dv MAP_ALIGNED_SUPER
 Align the region to maximize the potential use of large
 .Pq Dq super
@@ -565,8 +552,6 @@ was not.
 .It Bq Er EINVAL
 .Dv MAP_ALIGNED_CHERI
 (implied on CheriABI)
-or
-.Dv MAP_ALIGNED_CHERI_SEAL
 was specified and
 .Fa addr
 or

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -122,12 +122,8 @@
  *
  * MAP_ALIGNED_CHERI returns memory aligned appropriately for the requested
  * length or fails.  Passing an under-rounded length fails.
- *
- * MAP_ALIGNED_CHERI_SEAL returns memory aligned to allow sealing given the
- * requested length or fails.  Passing an under-rounded length fails.
  */
 #define	MAP_ALIGNED_CHERI	MAP_ALIGNED(2)	/* align for CHERI data */
-#define	MAP_ALIGNED_CHERI_SEAL	MAP_ALIGNED(3)	/* align for sealing on CHERI */
 
 /*
  * Flags provided to shm_rename

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -118,14 +118,6 @@
 #define	MAP_ALIGNED_SUPER	MAP_ALIGNED(1) /* align on a superpage */
 
 /*
- * CHERI specific flags and alignment constraints.
- *
- * MAP_ALIGNED_CHERI returns memory aligned appropriately for the requested
- * length or fails.  Passing an under-rounded length fails.
- */
-#define	MAP_ALIGNED_CHERI	MAP_ALIGNED(2)	/* align for CHERI data */
-
-/*
  * Flags provided to shm_rename
  */
 /* Don't overwrite dest, if it exists */

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -361,33 +361,6 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 		return (EPROT);
 	}
 
-	if ((flags & MAP_ALIGNMENT_MASK) == MAP_ALIGNED_SUPER) {
-#if VM_NRESERVLEVEL > 0
-		/*
-		 * pmap_align_superpage() is a no-op for allocations
-		 * less than a super page so request data alignment
-		 * in that case.
-		 *
-		 * In practice this is a no-op as super-pages are
-		 * precisely representable.
-		 */
-		if (uap->len < (1UL << (VM_LEVEL_0_ORDER + PAGE_SHIFT)) &&
-		    CHERI_REPRESENTABLE_ALIGNMENT(uap->len) > (1UL << PAGE_SHIFT)) {
-			flags &= ~MAP_ALIGNMENT_MASK;
-			flags |= MAP_ALIGNED_CHERI;
-		}
-#endif
-	}
-	else if ((flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED(0) &&
-	    (flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED(3) && /* MAP_ALIGNED_CHERI_SEAL */
-	    (flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED_CHERI) {
-		/* Reject nonsensical sub-page alignment requests */
-		if ((flags >> MAP_ALIGNMENT_SHIFT) < PAGE_SHIFT) {
-			SYSERRCAUSE("subpage alignment request");
-			return (EINVAL);
-		}
-	}
-
 	/*
 	 * NOTE: If this architecture requires an alignment constraint, it is
 	 * set at this point.  A simple assert is not easy to contruct...
@@ -573,37 +546,8 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 	if (len > size)
 		return (ENOMEM);
 
-	align = flags & MAP_ALIGNMENT_MASK;
-#if !__has_feature(capabilities)
-	/* In the non-CHERI case, remove the alignment request. */
-	if (align == MAP_ALIGNED_CHERI) {
-		flags &= ~MAP_ALIGNMENT_MASK;
-		align = 0;
-	}
-#else /* __has_feature(capabilities) */
-	/*
-	 * Convert MAP_ALIGNED_CHERI into explicit alignment
-	 * requests and pad lengths.  The combination of alignment (via
-	 * the updated, explicit alignment flags) and padding is required
-	 * for any request that would otherwise be unrepresentable due
-	 * to compressed capability bounds.
-	 */
-	if (align == MAP_ALIGNED_CHERI) {
-		flags &= ~MAP_ALIGNMENT_MASK;
-		if (CHERI_REPRESENTABLE_ALIGNMENT(size) > PAGE_SIZE) {
-			flags |= MAP_ALIGNED(CHERI_ALIGN_SHIFT(size));
-
-			if (size != CHERI_REPRESENTABLE_LENGTH(size))
-				size = CHERI_REPRESENTABLE_LENGTH(size);
-
-			if (CHERI_ALIGN_MASK(size) != 0)
-				addr_mask = CHERI_ALIGN_MASK(size);
-		}
-		align = flags & MAP_ALIGNMENT_MASK;
-	}
-#endif
-
 	/* Ensure alignment is at least a page and fits in a pointer. */
+	align = flags & MAP_ALIGNMENT_MASK;
 	if (align != 0 && align != MAP_ALIGNED_SUPER &&
 	    (align >> MAP_ALIGNMENT_SHIFT >= sizeof(void *) * NBBY ||
 	    align >> MAP_ALIGNMENT_SHIFT < PAGE_SHIFT)) {

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -379,8 +379,8 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 #endif
 	}
 	else if ((flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED(0) &&
-		 (flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED_CHERI &&
-		 (flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED_CHERI_SEAL) {
+	    (flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED(3) && /* MAP_ALIGNED_CHERI_SEAL */
+	    (flags & MAP_ALIGNMENT_MASK) != MAP_ALIGNED_CHERI) {
 		/* Reject nonsensical sub-page alignment requests */
 		if ((flags >> MAP_ALIGNMENT_SHIFT) < PAGE_SHIFT) {
 			SYSERRCAUSE("subpage alignment request");
@@ -576,22 +576,17 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 	align = flags & MAP_ALIGNMENT_MASK;
 #if !__has_feature(capabilities)
 	/* In the non-CHERI case, remove the alignment request. */
-	if (align == MAP_ALIGNED_CHERI || align == MAP_ALIGNED_CHERI_SEAL) {
+	if (align == MAP_ALIGNED_CHERI) {
 		flags &= ~MAP_ALIGNMENT_MASK;
 		align = 0;
 	}
 #else /* __has_feature(capabilities) */
 	/*
-	 * Convert MAP_ALIGNED_CHERI(_SEAL) into explicit alignment
+	 * Convert MAP_ALIGNED_CHERI into explicit alignment
 	 * requests and pad lengths.  The combination of alignment (via
 	 * the updated, explicit alignment flags) and padding is required
 	 * for any request that would otherwise be unrepresentable due
 	 * to compressed capability bounds.
-	 *
-	 * XXX: With CHERI Concentrate, there is no difference in
-	 * precision between sealed and unsealed capabilities.  We
-	 * retain the duplicate code paths in case other otype tradeoffs
-	 * are made at a later date.
 	 */
 	if (align == MAP_ALIGNED_CHERI) {
 		flags &= ~MAP_ALIGNMENT_MASK;
@@ -603,18 +598,6 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 
 			if (CHERI_ALIGN_MASK(size) != 0)
 				addr_mask = CHERI_ALIGN_MASK(size);
-		}
-		align = flags & MAP_ALIGNMENT_MASK;
-	} else if (align == MAP_ALIGNED_CHERI_SEAL) {
-		flags &= ~MAP_ALIGNMENT_MASK;
-		if (CHERI_SEALABLE_ALIGNMENT(size) > (1UL << PAGE_SHIFT)) {
-			flags |= MAP_ALIGNED(CHERI_SEAL_ALIGN_SHIFT(size));
-
-			if (size != CHERI_SEALABLE_LENGTH(size))
-				size = CHERI_SEALABLE_LENGTH(size);
-
-			if (CHERI_SEAL_ALIGN_MASK(size) != 0)
-				addr_mask = CHERI_SEAL_ALIGN_MASK(size);
 		}
 		align = flags & MAP_ALIGNMENT_MASK;
 	}


### PR DESCRIPTION
This PR proposes to remove MAP_ALIGNED_CHERI and MAP_ALIGNED_CHERI_SEAL. I'm not 100% certain this is what I want to do, but I did it in an old branch where I was aiming to add capability PROT_ values and I'd like to do it or discard it.

The argument for removal is that a hybrid program needs to be aware of size rounding or it will either create aliasing violations or leak address space on `munmap`, thus adding MAP_ALIGN() macros isn't a big deal. Reservations could solve this, but I you probably need to opt all the way in to forcing representability on all allocations at which point it's a new ABI whose rules you need to follow. One could decide that MAP_ALIGNED_CHERI* triggers reservation roundup in which case at least the main one is useful. (I think sentries likely eliminate the possibility of separate sealing alignment in practice.)