### PR TITLE
arm64 pmap_change_{attr,prot}: Switch first arg to vm_pointer_t

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -470,7 +470,7 @@ static pv_entry_t pmap_pvh_remove(struct md_page *pvh, pmap_t pmap,
 static void pmap_abort_ptp(pmap_t pmap, vm_offset_t va, vm_page_t mpte);
 static bool pmap_activate_int(pmap_t pmap);
 static void pmap_alloc_asid(pmap_t pmap);
-static int pmap_change_props_locked(vm_offset_t va, vm_size_t size,
+static int pmap_change_props_locked(vm_pointer_t va, vm_size_t size,
     vm_prot_t prot, int mode, bool skip_unmapped);
 static pt_entry_t *pmap_demote_l1(pmap_t pmap, pt_entry_t *l1, vm_offset_t va);
 static pt_entry_t *pmap_demote_l2_locked(pmap_t pmap, pt_entry_t *l2,
@@ -7490,7 +7490,7 @@ pmap_page_set_memattr(vm_page_t m, vm_memattr_t ma)
  * virtual address range or the direct map.
  */
 int
-pmap_change_attr(vm_offset_t va, vm_size_t size, int mode)
+pmap_change_attr(vm_pointer_t va, vm_size_t size, int mode)
 {
 	int error;
 
@@ -7508,7 +7508,7 @@ pmap_change_attr(vm_offset_t va, vm_size_t size, int mode)
  * map are never executable.
  */
 int
-pmap_change_prot(vm_offset_t va, vm_size_t size, vm_prot_t prot)
+pmap_change_prot(vm_pointer_t va, vm_size_t size, vm_prot_t prot)
 {
 	int error;
 
@@ -7523,10 +7523,11 @@ pmap_change_prot(vm_offset_t va, vm_size_t size, vm_prot_t prot)
 }
 
 static int
-pmap_change_props_locked(vm_offset_t va, vm_size_t size, vm_prot_t prot,
+pmap_change_props_locked(vm_pointer_t va, vm_size_t size, vm_prot_t prot,
     int mode, bool skip_unmapped)
 {
-	vm_offset_t base, offset, tmpva;
+	vm_pointer_t base, tmpva;
+	vm_offset_t offset;
 	vm_size_t pte_size;
 	vm_paddr_t pa;
 	pt_entry_t pte, *ptep, *newpte;
@@ -7664,7 +7665,7 @@ pmap_change_props_locked(vm_offset_t va, vm_size_t size, vm_prot_t prot,
 			 * the cache.
 			 */
 			if (mode == VM_MEMATTR_UNCACHEABLE)
-				cpu_dcache_wbinv_range((void *)(uintptr_t)tmpva, pte_size);
+				cpu_dcache_wbinv_range((void *)tmpva, pte_size);
 			tmpva += pte_size;
 		}
 	}

--- a/sys/arm64/include/pmap.h
+++ b/sys/arm64/include/pmap.h
@@ -160,8 +160,8 @@ extern vm_pointer_t virtual_end;
 
 void	pmap_activate_vm(pmap_t);
 void	pmap_bootstrap(vm_size_t);
-int	pmap_change_attr(vm_offset_t va, vm_size_t size, int mode);
-int	pmap_change_prot(vm_offset_t va, vm_size_t size, vm_prot_t prot);
+int	pmap_change_attr(vm_pointer_t va, vm_size_t size, int mode);
+int	pmap_change_prot(vm_pointer_t va, vm_size_t size, vm_prot_t prot);
 void	pmap_kenter(vm_offset_t sva, vm_size_t size, vm_paddr_t pa, int mode);
 void	pmap_kenter_device(vm_offset_t, vm_size_t, vm_paddr_t);
 bool	pmap_klookup(vm_offset_t va, vm_paddr_t *pa);

--- a/sys/compat/linuxkpi/common/include/asm/set_memory.h
+++ b/sys/compat/linuxkpi/common/include/asm/set_memory.h
@@ -34,7 +34,7 @@
 static inline int
 set_memory_uc(unsigned long addr, int numpages)
 {
-	vm_offset_t va;
+	vm_pointer_t va;
 	vm_size_t len;
 
 	va = PHYS_TO_DMAP(addr);
@@ -47,7 +47,7 @@ static inline int
 set_memory_wc(unsigned long addr, int numpages)
 {
 #ifdef VM_MEMATTR_WRITE_COMBINING
-	vm_offset_t va;
+	vm_pointer_t va;
 	vm_size_t len;
 
 	va = PHYS_TO_DMAP(addr);
@@ -62,7 +62,7 @@ set_memory_wc(unsigned long addr, int numpages)
 static inline int
 set_memory_wb(unsigned long addr, int numpages)
 {
-	vm_offset_t va;
+	vm_pointer_t va;
 	vm_size_t len;
 
 	va = PHYS_TO_DMAP(addr);

--- a/sys/compat/linuxkpi/common/include/linux/io.h
+++ b/sys/compat/linuxkpi/common/include/linux/io.h
@@ -545,7 +545,7 @@ void lkpi_arch_phys_wc_del(int);
 static inline int
 arch_io_reserve_memtype_wc(resource_size_t start, resource_size_t size)
 {
-	vm_offset_t va;
+	vm_pointer_t va;
 
 	va = PHYS_TO_DMAP(start);
 
@@ -559,7 +559,7 @@ arch_io_reserve_memtype_wc(resource_size_t start, resource_size_t size)
 static inline void
 arch_io_free_memtype_wc(resource_size_t start, resource_size_t size)
 {
-	vm_offset_t va;
+	vm_pointer_t va;
 
 	va = PHYS_TO_DMAP(start);
 

--- a/sys/dev/agp/agp_i810.c
+++ b/sys/dev/agp/agp_i810.c
@@ -1234,7 +1234,7 @@ agp_gen4_install_gatt(device_t dev, const vm_size_t gtt_offset)
 	struct agp_i810_softc *sc;
 
 	sc = device_get_softc(dev);
-	pmap_change_attr((vm_offset_t)rman_get_virtual(sc->sc_res[0]) +
+	pmap_change_attr((vm_pointer_t)rman_get_virtual(sc->sc_res[0]) +
 	    gtt_offset, rman_get_size(sc->sc_res[0]) - gtt_offset,
 	    VM_MEMATTR_WRITE_COMBINING);
 	agp_i830_install_gatt_init(sc);

--- a/sys/dev/ena/ena.c
+++ b/sys/dev/ena/ena.c
@@ -2599,11 +2599,11 @@ static int
 ena_enable_wc(device_t pdev, struct resource *res)
 {
 #if defined(__i386) || defined(__amd64) || defined(__aarch64__)
-	vm_offset_t va;
+	vm_pointer_t va;
 	vm_size_t len;
 	int rc;
 
-	va = (vm_offset_t)rman_get_virtual(res);
+	va = (vm_pointer_t)rman_get_virtual(res);
 	len = rman_get_size(res);
 	/* Enable write combining */
 	rc = pmap_change_attr(va, len, VM_MEMATTR_WRITE_COMBINING);

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -901,7 +901,7 @@ preload_protect(elf_file_t ef, vm_prot_t prot)
 			nprot |= VM_PROT_WRITE;
 		if ((phdr->p_flags & PF_X) != 0)
 			nprot |= VM_PROT_EXECUTE;
-		error = pmap_change_prot((vm_offset_t)ef->address +
+		error = pmap_change_prot((vm_pointer_t)ef->address +
 		    phdr->p_vaddr, round_page(phdr->p_memsz), nprot);
 		if (error != 0)
 			break;


### PR DESCRIPTION
This passes down a valid pointer all the way to cpu_dcache_*.
Previously the pointer was silently truncated to an address.
