### PR TITLE
Fix mismerge of upstream commit which was skipped:

### DIFF
--- a/usr.sbin/bhyve/virtio.c
+++ b/usr.sbin/bhyve/virtio.c
@@ -114,10 +114,8 @@ vi_reset_dev(struct virtio_softc *vs)
 	vs->vs_negotiated_caps = 0;
 	vs->vs_curq = 0;
 	/* vs->vs_status = 0; -- redundant */
-#ifdef __amd64__
 	if (vs->vs_isr)
 		pci_lintr_deassert(vs->vs_pi);
-#endif
 	vs->vs_isr = 0;
 	vs->vs_msix_cfg_idx = VIRTIO_MSI_NO_VECTOR;
 }
@@ -164,11 +162,8 @@ vi_intr_init(struct virtio_softc *vs, int barnum, int use_msix)
 	/* Only 1 MSI vector for bhyve */
 	pci_emul_add_msicap(vs->vs_pi, 1);
 
-	/* XXX-MJ missing an implementation for arm64 */
-#ifdef __amd64__
 	/* Legacy interrupts are mandatory for virtio devices */
 	pci_lintr_request(vs->vs_pi);
-#endif
 
 	return (0);
 }
@@ -656,10 +651,8 @@ bad:
 	case VIRTIO_PCI_ISR:
 		value = vs->vs_isr;
 		vs->vs_isr = 0;		/* a read clears this flag */
-#ifdef __amd64__
 		if (value)
 			pci_lintr_deassert(pi);
-#endif
 		break;
 	case VIRTIO_MSI_CONFIG_VECTOR:
 		value = vs->vs_msix_cfg_idx;


### PR DESCRIPTION
    bhyve: Support legacy PCI interrupts on arm64

    This allows us to remove various #ifdef hacks and enable building more
    PCI devices.

    Note that a hole is left in the interrupt mapping for the RTC rather
    than having the two core devices straddle the PCIe interrupts. QEMU's
    virt machine also takes this approach.

    Reviewed by:    jhb
    MFC after:      2 weeks
    Obtained from:  CheriBSD
