### PR TITLE
Introduce vfcntl()

### DIFF
--- a/lib/libsys/Symbol.sys.map
+++ b/lib/libsys/Symbol.sys.map
@@ -383,7 +383,8 @@ FBSD_1.7 {
 };
 
 FBSD_1.8 {
-	 kcmp;
+	kcmp;
+	vfcntl;
 };
 
 FBSDprivate_1.0 {

--- a/lib/libsys/fcntl.2
+++ b/lib/libsys/fcntl.2
@@ -37,6 +37,9 @@
 .In fcntl.h
 .Ft int
 .Fn fcntl "int fd" "int cmd" "..."
+.In stdarg.h
+.Ft int
+.Fn vfcntl "int fd" "int cmd" "va_list ap"
 .Sh DESCRIPTION
 The
 .Fn fcntl

--- a/lib/libsys/fcntl.c
+++ b/lib/libsys/fcntl.c
@@ -49,20 +49,19 @@
 #include <sys/syscall.h>
 #include "libc_private.h"
 
-#pragma weak fcntl
-int
-fcntl(int fd, int cmd, ...)
+typedef int (*fcntl_func)(int, int, intptr_t);
+
+static int
+call_fcntl(fcntl_func fn, int fd, int cmd, va_list ap)
 {
-	va_list args;
 	intptr_t arg;
 
-	va_start(args, cmd);
 	switch (cmd) {
 	case F_GETLK:
 	case F_SETLK:
 	case F_SETLKW:
 	case F_KINFO:
-		arg = va_arg(args, intptr_t);
+		arg = va_arg(ap, intptr_t);
 		break;
 
 	case F_GETFD:
@@ -74,13 +73,26 @@ fcntl(int fd, int cmd, ...)
 		break;
 
 	default:
-		arg = va_arg(args, int);
+		arg = va_arg(ap, int);
 		break;
 	}
+
+	return (fn(fd, cmd, arg));
+}
+
+#pragma weak fcntl
+int
+fcntl(int fd, int cmd, ...)
+{
+	va_list args;
+	int result;
+	fcntl_func fn = (fcntl_func)*__libsys_interposing_slot(INTERPOS_fcntl);
+
+	va_start(args, cmd);
+	result = call_fcntl(fn, fd, cmd, args);
 	va_end(args);
 
-	return (((int (*)(int, int, intptr_t))
-	    *(__libc_interposing_slot(INTERPOS_fcntl)))(fd, cmd, arg));
+	return (result);
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -90,31 +102,12 @@ int
 _fcntl(int fd, int cmd, ...)
 {
 	va_list args;
-	intptr_t arg;
+	int result;
 
 	va_start(args, cmd);
-	switch (cmd) {
-	case F_GETLK:
-	case F_SETLK:
-	case F_SETLKW:
-	case F_KINFO:
-		arg = va_arg(args, intptr_t);
-		break;
-
-	case F_GETFD:
-	case F_GETFL:
-	case F_GETOWN:
-	case F_GET_SEALS:
-	case F_ISUNIONSTACK:
-		arg = 0;
-		break;
-
-	default:
-		arg = va_arg(args, int);
-		break;
-	}
+	result = call_fcntl(__sys_fcntl, fd, cmd, args);
 	va_end(args);
 
-	return (__sys_fcntl(fd, cmd, arg));
+	return (result);
 }
 #endif

--- a/sys/sys/fcntl.h
+++ b/sys/sys/fcntl.h
@@ -376,6 +376,7 @@ int	open(const char *, int, ...);
 int	creat(const char *, mode_t);
 int	fcntl(int, int, ...);
 #if __BSD_VISIBLE
+int	vfcntl(int, int, __va_list);
 int	flock(int, int);
 int	fspacectl(int, int, const struct spacectl_range *, int,
 	    struct spacectl_range *);


### PR DESCRIPTION
This is a variant of fcntl that takes a va_list instead of variadic
arguments and can be used to safely interpose fcntl by libraries such
as epoll-shim that would otherwise have to reimplement the logic inside
fcntl.c to avoid reading incorrect arguments for CheriBSD.

See https://github.com/jiixyj/epoll-shim/pull/36