### PR TITLE
several caprevoke optimizations

### DIFF
--- a/sys/vm/swap_pager.h
+++ b/sys/vm/swap_pager.h
@@ -85,5 +85,11 @@ u_long swap_pager_swapped_pages(vm_object_t object);
 void swapoff_all(void);
 bool swap_pager_init_object(vm_object_t object, void *handle,
     struct ucred *cred, vm_ooffset_t size, vm_ooffset_t offset);
+
+#ifdef CHERI_CAPREVOKE
+vm_pindex_t swap_pager_cheri_revoke_next(vm_object_t object,
+    vm_pindex_t pindex);
+#endif
+
 #endif				/* _KERNEL */
 #endif				/* _VM_SWAP_PAGER_H_ */


### PR DESCRIPTION
The procstat-related patches should perhaps be upstreamed as well, though `procstat vm` doesn't have a verbose mode in vanilla FreeBSD.