### PR TITLE
Address a few problems with L3C mappings on Morello

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -6257,6 +6257,11 @@ pmap_caploadgen_update(pmap_t pmap, vm_offset_t va, vm_page_t *mp, int flags)
 		res = PMAP_CAPLOADGEN_UNABLE;
 		goto out;
 	case 3:
+		if ((tpte & ATTR_CONTIGUOUS) != 0) {
+			m = NULL;
+			res = PMAP_CAPLOADGEN_UNABLE;
+			goto out;
+		}
 		break;
 	}
 

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -5643,6 +5643,9 @@ pmap_enter_l3c_rx(pmap_t pmap, vm_offset_t va, vm_page_t m, vm_page_t *ml3p,
 		l3e |= ATTR_S1_UXN;
 	if (pmap != kernel_pmap)
 		l3e |= ATTR_S1_nG;
+#if __has_feature(capabilities)
+	l3e |= pmap_pte_cr(pmap, va, prot);
+#endif
 	return (pmap_enter_l3c(pmap, va, l3e, PMAP_ENTER_NOSLEEP |
 	    PMAP_ENTER_NOREPLACE | PMAP_ENTER_NORECLAIM, m, ml3p, lockp));
 }

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -5667,6 +5667,18 @@ pmap_enter_l3c(pmap_t pmap, vm_offset_t va, pt_entry_t l3e, u_int flags,
 	KASSERT(!VA_IS_CLEANMAP(va) || (l3e & ATTR_SW_MANAGED) == 0,
 	    ("pmap_enter_l3c: managed mapping within the clean submap"));
 
+#ifdef CHERI_CAPREVOKE
+	if (!ADDR_IS_KERNEL(va)) {
+		/*
+		 * pmap_caploadgen_update() currently does not handle L3C
+		 * mappings.  Avoid creating them at all on the basis that the
+		 * pessimization of going through vm_fault() for capload faults
+		 * is probably worse than not having L3C mappings at all. 
+		 */
+		return (KERN_FAILURE);
+	}
+#endif
+
 	/*
 	 * If the L3 PTP is not resident, we attempt to create it here.
 	 */


### PR DESCRIPTION
This is a stopgap to fix some instability after recent dev merges. The main change is to simply disable creation of L3C mappings in userspace for now. I also fixed up some of the L3C routines, as they represent yet another place which synthesizes PTEs and thus needs to be taught about Morello-specific bits.