### PR TITLE
Backport tmpfs threshold fix

### DIFF
--- a/sys/fs/tmpfs/tmpfs.h
+++ b/sys/fs/tmpfs/tmpfs.h
@@ -548,7 +548,7 @@ tmpfs_update(struct vnode *vp)
  * without a size limit.
  */
 #if !defined(TMPFS_MEM_PERCENT)
-#define TMPFS_MEM_PERCENT		95
+#define TMPFS_MEM_PERCENT		100
 #endif
 
 /*

--- a/sys/fs/tmpfs/tmpfs_subr.c
+++ b/sys/fs/tmpfs/tmpfs_subr.c
@@ -424,7 +424,7 @@ sysctl_mem_percent(SYSCTL_HANDLER_ARGS)
 	if ((unsigned) percent > 100)
 		return (EINVAL);
 
-	*(long *)arg1 = percent;
+	*(int *)arg1 = percent;
 	tmpfs_set_reserve_from_percent();
 	return (0);
 }


### PR DESCRIPTION
Without this, installing in a 4G VM fails (at least with ZFS root selected); the installation appears to succeed, but there are errors in /tmp/bsdinstall_log due to running out of space in /tmp, meaning rc.conf, sysctl.conf and loader.conf are missing in the installed system, causing zfs.ko to not be loaded and thus the kernel not be able to mount root.

It was also reported upstream that poudriere falls over for larger packages even with 64G, and I encountered issues upstream with buildworld -j4 on a 16G system when /tmp is configured to be a tmpfs (non-default, but what cheribuild likes to do).
