### PR TITLE
zfs: Detect purecap kernels via MACHINE_ABI not a list of MACHINE_ARCH

### DIFF
--- a/sys/modules/zfs/Makefile
+++ b/sys/modules/zfs/Makefile
@@ -528,6 +528,6 @@ zfs-sha512-x86_64.o: sha512-x86_64.S
 	${CTFCONVERT_CMD}
 .endif
 
-.if ${MACHINE_ARCH} == "aarch64c" || ${MACHINE_ARCH} == "riscv64c"
+.if ${MACHINE_ABI:Mpurecap}
 CFLAGS+=-Xclang -cheri-bounds=conservative
 .endif


### PR DESCRIPTION
The current list is missing aarch64cb, so zfs for purecap benchmark
kernels is built with subobject bounds and thus panics with a bounds
fault early in boot if used. Instead of updating the list to include
aarch64cb, just check MACHINE_ABI, which is available here.
