### PR TITLE
c18n: Remove unnecessary check for purecap ABI

### DIFF
--- a/lib/libc/aarch64/gen/_setjmp.S
+++ b/lib/libc/aarch64/gen/_setjmp.S
@@ -55,11 +55,11 @@ ENTRY(_setjmp)
 #endif
 
 	/* Return value */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	mov	c1, c0
 #endif
 	mov	x0, #0
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Tail-call to save Executive mode state
 	 */
@@ -81,7 +81,7 @@ ENTRY(_longjmp)
 
 	/* Restore the stack pointer */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	mov	c2, c8
 #else
 	mov	REGN(sp), REG(8)
@@ -104,12 +104,12 @@ ENTRY(_longjmp)
 #endif
 
 	/* Load the return value */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	mov	c3, c0
 #endif
 	cmp	x1, #0
 	csinc	x0, x1, xzr, ne
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libc/aarch64/gen/setjmp.S
+++ b/lib/libc/aarch64/gen/setjmp.S
@@ -32,7 +32,7 @@
 #include <machine/setjmp.h>
 #include <sys/elf_common.h>
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 .weak _rtld_setjmp
 .weak _rtld_longjmp
 #endif
@@ -70,11 +70,11 @@ ENTRY(setjmp)
 	stp	d14, d15, [REG(0)], #16
 
 	/* Return value */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	mov	c1, c0
 #endif
 	mov	x0, #0
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Tail-call to save Executive mode state
 	 */
@@ -110,7 +110,7 @@ ENTRY(longjmp)
 
 	/* Restore the stack pointer */
 	ldr	REG(8), [REG(0)], #(REG_WIDTH)
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	mov	c2, c8
 #else
 	mov	REGN(sp), REG(8)
@@ -131,12 +131,12 @@ ENTRY(longjmp)
 	ldp	d14, d15, [REG(0)], #16
 
 	/* Load the return value */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	mov	c3, c0
 #endif
 	cmp	x1, #0
 	csinc	x0, x1, xzr, ne
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Tail-call to restore Executive mode state
 	 */

--- a/lib/libc/gen/posix_spawn.c
+++ b/lib/libc/gen/posix_spawn.c
@@ -341,7 +341,7 @@ do_posix_spawn(pid_t *pid, const char *path,
 	p = rfork_thread(RFSPAWN, stack + stacksz, _posix_spawn_thr, &psa);
 	free(stack);
 #else
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	p = __sys_rfork(RFSPAWN);
 #else
 	p = rfork(RFSPAWN);

--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -394,7 +394,7 @@ struct __nl_cat_d *__catopen_l(const char *name, int type,
 int __strerror_rl(int errnum, char *strerrbuf, size_t buflen,
 	    struct _xlocale *locale);
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 __pid_t		__sys_rfork(int);
 int	sigaction_c18n(int, const struct sigaction *, struct sigaction *);
 #endif

--- a/lib/libc/sys/sigaction.c
+++ b/lib/libc/sys/sigaction.c
@@ -35,7 +35,7 @@
 
 __weak_reference(__sys_sigaction, __sigaction);
 __weak_reference(sigaction, __libc_sigaction);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 /*
  * This weak symbol will always be resolved at runtime.
  */

--- a/lib/libsys/interposing_table.c
+++ b/lib/libsys/interposing_table.c
@@ -56,7 +56,7 @@ static interpos_func_t __libsys_interposing[INTERPOS_MAX] = {
 	SLOT(sendmsg, __sys_sendmsg),
 	SLOT(sendto, __sys_sendto),
 	SLOT(setcontext, __sys_setcontext),
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	SLOT(sigaction, sigaction_c18n),
 #else
 	SLOT(sigaction, __sys_sigaction),

--- a/lib/libthr/thread/thr_create.c
+++ b/lib/libthr/thread/thr_create.c
@@ -56,7 +56,7 @@
 
 static int  create_stack(struct pthread_attr *pattr);
 static void thread_start(struct pthread *curthread) __used;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #pragma weak _thread_start = thread_start
 
 /*
@@ -151,7 +151,7 @@ _pthread_create(pthread_t * __restrict thread,
 		new_thread->flags = THR_FLAGS_NEED_SUSPEND;
 		create_suspended = 1;
 	} else {
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 		/*
 		 * c18n: Always block all signals when creating a new thread to
 		 * allow RTLD to set up the environment to handle signals.
@@ -187,7 +187,7 @@ _pthread_create(pthread_t * __restrict thread,
 		locked = 1;
 	} else
 		locked = 0;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	param.start_func = (void (*)(void *)) _rtld_thread_start;
 #else
 	param.start_func = (void (*)(void *)) thread_start;
@@ -298,7 +298,7 @@ thread_start(struct pthread *curthread)
 	sigset_t set;
 	bool restore_sigmask;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * At this point, curthread->tcb contains a fake wrapper TCB created by
 	 * RTLD when the thread was created. The real TCB has now been installed

--- a/lib/libthr/thread/thr_rtld.c
+++ b/lib/libthr/thread/thr_rtld.c
@@ -50,7 +50,7 @@ static void	_thr_rtld_rlock_acquire(void *);
 static int	_thr_rtld_set_flag(int);
 static void	_thr_rtld_wlock_acquire(void *);
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 void _thread_start(struct pthread *);
 void _thr_sighandler(int, siginfo_t *, void *);
 
@@ -291,7 +291,7 @@ _thr_rtld_init(void)
 	/* mask signals, also force to resolve __sys_sigprocmask PLT */
 	_thr_signal_block(curthread);
 	_rtld_thread_init(&li);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	_rtld_thread_start_init(_thread_start);
 	_rtld_sighandler_init(_thr_sighandler);
 #endif

--- a/lib/libthr/thread/thr_sig.c
+++ b/lib/libthr/thread/thr_sig.c
@@ -69,7 +69,7 @@ static void handle_signal(struct sigaction *, int, siginfo_t *, ucontext_t *);
 static void check_deferred_signal(struct pthread *);
 static void check_suspend(struct pthread *);
 static void check_cancel(struct pthread *curthread, ucontext_t *ucp);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #pragma weak _thr_sighandler = thr_sighandler
 
 /*
@@ -296,7 +296,7 @@ handle_signal(struct sigaction *actp, int sig, siginfo_t *info, ucontext_t *ucp)
 	if (!cancel_async)
 		curthread->cancel_enable = 0;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	(void)sigfunc;
 #else
 	/* restore correct mask before calling user handler */
@@ -313,7 +313,7 @@ handle_signal(struct sigaction *actp, int sig, siginfo_t *info, ucontext_t *ucp)
 	 * so after setjmps() returns once more, the user code may need to
 	 * re-set cancel_enable flag by calling pthread_setcancelstate().
 	 */
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	_rtld_siginvoke(sig, info, ucp, actp);
 #else
 	if ((actp->sa_flags & SA_SIGINFO) != 0) {
@@ -336,7 +336,7 @@ handle_signal(struct sigaction *actp, int sig, siginfo_t *info, ucontext_t *ucp)
 	/* reschedule cancellation */
 	check_cancel(curthread, &uc2);
 	errno = err;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Calling sigreturn outside of sigcode does not work with
 	 * compartmentalisation. Hence we set the user context and let the
@@ -432,7 +432,7 @@ check_deferred_signal(struct pthread *curthread)
 	/* remove signal */
 	curthread->deferred_siginfo.si_signo = 0;
 	handle_signal(&act, info.si_signo, &info, uc);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	setcontext(uc);
 #endif
 }
@@ -500,7 +500,7 @@ _thr_signal_init(int dlopened)
 		for (sig = 1; sig <= _SIG_MAXSIG; sig++) {
 			if (sig == SIGCANCEL)
 				continue;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 			error = _rtld_sigaction(sig, NULL, &oact);
 #else
 			error = __sys_sigaction(sig, NULL, &oact);
@@ -514,7 +514,7 @@ _thr_signal_init(int dlopened)
 			remove_thr_signals(&usa->sigact.sa_mask);
 			nact.sa_flags &= ~SA_NODEFER;
 			nact.sa_flags |= SA_SIGINFO;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 			/* XXX: Ignore sigaltstack for now */
 			nact.sa_flags &= ~SA_ONSTACK;
 			nact.sa_sigaction = _rtld_sighandler;
@@ -650,7 +650,7 @@ __thr_sigaction(int sig, const struct sigaction *act, struct sigaction *oact)
 			remove_thr_signals(&usa->sigact.sa_mask);
 			newact.sa_flags &= ~SA_NODEFER;
 			newact.sa_flags |= SA_SIGINFO;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 			/* XXX: Ignore sigaltstack for now */
 			newact.sa_flags &= ~SA_ONSTACK;
 			newact.sa_sigaction = _rtld_sighandler;

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -38,7 +38,7 @@
 
 #include "debug.h"
 #include "rtld.h"
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif
 #include "rtld_printf.h"
@@ -112,14 +112,14 @@ init_pltgot(Obj_Entry *obj)
 {
 
 	if (obj->pltgot != NULL) {
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 		if (C18N_ENABLED)
 			obj->pltgot[1] = (uintptr_t)cheri_seal(obj,
 			    sealer_pltgot);
 		else
 #endif
 			obj->pltgot[1] = (uintptr_t)obj;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 		if (C18N_ENABLED)
 			obj->pltgot[2] = (uintptr_t)&_rtld_bind_start_c18n;
 		else
@@ -510,7 +510,7 @@ reloc_jmpslots(Obj_Entry *obj, int flags, RtldLockState *lockstate)
 				continue;
 			}
 			target = (uintptr_t)make_function_pointer(def, defobj);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 			target = (uintptr_t)tramp_intern(obj, &(struct tramp_data) {
 				.target = (void *)target,
 				.defobj = defobj,
@@ -572,7 +572,7 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 	ptr = (uintptr_t)(obj->relocbase + rela->r_addend);
 #endif
 	lock_release(rtld_bind_lock, lockstate);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	ptr = (uintptr_t)tramp_intern(NULL, &(struct tramp_data) {
 		.target = (void *)ptr,
 		.defobj = obj,
@@ -663,7 +663,7 @@ reloc_gnu_ifunc(Obj_Entry *obj, int flags,
 				continue;
 			lock_release(rtld_bind_lock, lockstate);
 			target = (uintptr_t)rtld_resolve_ifunc(defobj, def);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 			target = (uintptr_t)tramp_intern(obj, &(struct tramp_data) {
 				.target = (void *)target,
 				.defobj = defobj,

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -119,7 +119,7 @@ END(.rtld_start)
  * x17 = &_rtld_bind_start
  */
 ENTRY(C18N_SYM(_rtld_bind_start))
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Get the caller's current stack top.
 	 */
@@ -205,7 +205,7 @@ ENTRY(C18N_SYM(_rtld_bind_start))
 	/* Restore frame pointer */
 	ldp	PTR(29), PTR(zr), [PTRN(sp)], #(PTR_WIDTH * 2)
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	/*
 	 * Load caller's old stack top.
 	 */
@@ -246,7 +246,7 @@ ENTRY(C18N_SYM(_rtld_bind_start))
 	/* Call into the correct function */
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	br	x16
-#elif defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#elif defined(CHERI_LIB_C18N)
 	brr	PTR(16)
 #else
 	br	PTR(16)

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -35,7 +35,7 @@
 
 #include "debug.h"
 #include "rtld.h"
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif
 

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -51,7 +51,7 @@
 
 #include "debug.h"
 #include "rtld.h"
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif
 
@@ -278,7 +278,7 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	    base_addr, mapsize, PROT_NONE | PROT_MAX(_PROT_ALL), base_flags);
     mapbase = mmap(base_addr, mapsize, PROT_NONE | PROT_MAX(_PROT_ALL),
 	base_flags, -1, 0);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     mapbase = cheri_clearperm(mapbase, c18n_code_perm_clear);
 #endif
     if (mapbase == MAP_FAILED) {

--- a/libexec/rtld-elf/rtld-libc/rtld_libc.h
+++ b/libexec/rtld-elf/rtld-libc/rtld_libc.h
@@ -51,7 +51,7 @@ int	__sys___getcwd(char *, size_t);
 int	__sys_sigprocmask(int, const sigset_t *, sigset_t *);
 int	__sys_thr_kill(long, int);
 int	__sys_thr_self(long *);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 void    __sys_thr_exit(long *);
 struct sigaction;
 int     __sys_sigaction(int, const struct sigaction *, struct sigaction *);

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -68,7 +68,7 @@
 #include "rtld_utrace.h"
 #include "notes.h"
 #include "rtld_libc.h"
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif
 
@@ -396,7 +396,7 @@ enum {
 	LD_SHOW_AUXV,
 	LD_STATIC_TLS_EXTRA,
 	LD_SKIP_INIT_FUNCS,
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	LD_UTRACE_COMPARTMENT,
 	LD_COMPARTMENT_ENABLE,
 	LD_COMPARTMENT_DISABLE,
@@ -446,7 +446,7 @@ static struct ld_env_var_desc ld_env_vars[] = {
 	LD_ENV_DESC(SHOW_AUXV, false),
 	LD_ENV_DESC(STATIC_TLS_EXTRA, false),
 	LD_ENV_DESC(SKIP_INIT_FUNCS, true),
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	LD_ENV_DESC(UTRACE_COMPARTMENT, false),
 	LD_ENV_DESC(COMPARTMENT_ENABLE, false),
 	LD_ENV_DESC(COMPARTMENT_DISABLE, false),
@@ -682,7 +682,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     if (aux_info[AT_BSDFLAGS] != NULL) {
 	if ((aux_info[AT_BSDFLAGS]->a_un.a_val & ELF_BSDF_SIGFASTBLK) != 0)
 	    ld_fast_sigblock = true;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	if ((aux_info[AT_BSDFLAGS]->a_un.a_val & ELF_BSDF_CHERI_C18N) != 0)
 	    ld_compartment_enable = true;
 #endif
@@ -854,7 +854,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     if (!ld_tracing)
 	ld_tracing = ld_get_env_var(LD_TRACE_LOADED_OBJECTS);
     ld_utrace = ld_get_env_var(LD_UTRACE);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     ld_compartment_utrace = ld_get_env_var(LD_UTRACE_COMPARTMENT);
     ld_compartment_policy = ld_get_env_var(LD_COMPARTMENT_POLICY);
     ld_compartment_overhead = ld_get_env_var(LD_COMPARTMENT_OVERHEAD);
@@ -921,7 +921,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 	assert(aux_info[AT_PHENT]->a_un.a_val == sizeof(Elf_Phdr));
 	assert(aux_info[AT_ENTRY] != NULL);
 	imgentry = (dlfunc_t) aux_info[AT_ENTRY]->a_un.a_ptr;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	imgentry = (dlfunc_t) cheri_clearperm(imgentry, c18n_code_perm_clear);
 #endif
 	dbg("Values from kernel:\n\tAT_PHDR=" PTR_FMT "\n"
@@ -988,7 +988,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     linkmap_add(obj_main);
     linkmap_add(&obj_rtld);
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     if (C18N_ENABLED) {
 	c18n_init(&obj_rtld, aux_info);
 
@@ -1064,7 +1064,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
        exit (0);
     }
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     if (C18N_ENABLED)
 	c18n_init2(&obj_rtld);
 #endif
@@ -1183,7 +1183,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     /* Return the exit procedure and the program entry point. */
     if (rtld_exit_ptr == NULL) {
 	rtld_exit_ptr = make_rtld_function_pointer(rtld_exit);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	rtld_exit_ptr = tramp_intern(NULL, &(struct tramp_data) {
 		.target = rtld_exit_ptr,
 		.defobj = &obj_rtld,
@@ -1197,7 +1197,7 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
     *exit_proc = rtld_exit_ptr;
     *objp = obj_main;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     return ((func_ptr_type)tramp_intern(NULL, &(struct tramp_data) {
 	    .target = cheri_sealentry(obj_main->entry),
 	    .defobj = obj_main,
@@ -1218,7 +1218,7 @@ rtld_resolve_ifunc(const Obj_Entry *obj, const Elf_Sym *def)
 	uintptr_t target;
 
 	ptr = (void *)make_function_pointer(def, obj);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	ptr = tramp_intern(NULL, &(struct tramp_data) {
 		.target = ptr,
 		.defobj = obj,
@@ -1240,7 +1240,7 @@ _rtld_bind(Obj_Entry *obj, Elf_Size reloff)
     uintptr_t *where;
     uintptr_t target;
     RtldLockState lockstate;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     struct trusted_frame *tf;
 
     if (C18N_ENABLED) {
@@ -1295,7 +1295,7 @@ _rtld_bind(Obj_Entry *obj, Elf_Size reloff)
      */
     target = reloc_jmpslot(where, target, defobj, obj, rel);
     lock_release(rtld_bind_lock, &lockstate);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     if (C18N_ENABLED)
 	tf = pop_dummy_rtld_trusted_frame(tf);
 #endif
@@ -1572,7 +1572,7 @@ digest_dynamic1(Obj_Entry *obj, int early, const Elf_Dyn **dyn_rpath,
 	    assert(dynp->d_un.d_val == sizeof(Elf_Sym));
 	    break;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	case DT_CHERI_C18N_SIG:
 	    if (ld_compartment_sig != NULL)
 		obj->sigtab = (const struct func_sig *)
@@ -3386,7 +3386,7 @@ Obj_Entry *
 obj_from_addr(const void *addr)
 {
     Obj_Entry *obj;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     struct tramp_header *header;
 
     if (C18N_ENABLED) {
@@ -3555,7 +3555,7 @@ objlist_call_init(Objlist *list, RtldLockState *lockstate)
 	lock_release(rtld_bind_lock, lockstate);
 	if (reg != NULL) {
 		func_ptr_type exit_ptr = make_rtld_function_pointer(rtld_exit);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 		exit_ptr = tramp_intern(NULL, &(struct tramp_data) {
 			.target = exit_ptr,
 			.defobj = &obj_rtld,
@@ -3568,7 +3568,7 @@ objlist_call_init(Objlist *list, RtldLockState *lockstate)
 		dbg("Calling __libc_atexit(rtld_exit (" PTR_FMT "))", (void*)exit_ptr);
 		reg(exit_ptr);
 		rtld_exit_ptr = make_rtld_function_pointer(rtld_nop_exit);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 		rtld_exit_ptr = tramp_intern(NULL, &(struct tramp_data) {
 			.target = rtld_exit_ptr,
 			.defobj = &obj_rtld,
@@ -4534,7 +4534,7 @@ dlsym(void *handle, const char *name)
 {
 	void *retaddr;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	retaddr = c18n_return_address();
 #else
 	retaddr = __builtin_return_address(0);
@@ -4552,7 +4552,7 @@ dlfunc(void *handle, const char *name)
 	} rv;
 	void *retaddr;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	retaddr = c18n_return_address();
 #else
 	retaddr = __builtin_return_address(0);
@@ -4573,7 +4573,7 @@ dlvsym(void *handle, const char *name, const char *version)
 	ventry.hash = elf_hash(version);
 	ventry.flags= 0;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	retaddr = c18n_return_address();
 #else
 	retaddr = __builtin_return_address(0);
@@ -4685,7 +4685,7 @@ dlinfo(void *handle, int request, void *p)
     if (handle == NULL || handle == RTLD_SELF) {
 	void *retaddr;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	retaddr = c18n_return_address();
 #else
 	retaddr = __builtin_return_address(0);	/* __GNUC__ only */
@@ -4759,7 +4759,7 @@ dl_iterate_phdr(__dl_iterate_hdr_callback callback, void *param)
 	init_marker(&marker);
 	error = 0;
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	callback = tramp_intern(NULL, &(struct tramp_data) {
 		.target = callback,
 		.defobj = obj_from_addr(callback),
@@ -5070,7 +5070,7 @@ get_program_var_addr(const char *name, RtldLockState *lockstate)
 	return (NULL);
     if (ELF_ST_TYPE(req.sym_out->st_info) == STT_FUNC) {
 	void *target = make_function_pointer(req.sym_out, req.defobj_out);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	target = tramp_intern(NULL, &(struct tramp_data) {
 		.target = target,
 		.defobj = req.defobj_out,
@@ -5080,7 +5080,7 @@ get_program_var_addr(const char *name, RtldLockState *lockstate)
 	return ((const void **)target);
     } else if (ELF_ST_TYPE(req.sym_out->st_info) == STT_GNU_IFUNC) {
 	void *target = rtld_resolve_ifunc(req.defobj_out, req.sym_out);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	target = tramp_intern(NULL, &(struct tramp_data) {
 		.target = target,
 		.defobj = req.defobj_out,
@@ -5817,14 +5817,14 @@ tls_get_addr_common(uintptr_t **dtvp, int index, size_t offset)
 	    dtv[index + 1] != 0))
 		return ((void *)(dtv[index + 1] + offset));
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	struct trusted_frame *tf;
 
 	if (C18N_ENABLED)
 		tf = push_dummy_rtld_trusted_frame(get_trusted_stk());
 #endif
 	ret = tls_get_addr_slow(dtvp, index, offset, false);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	if (C18N_ENABLED)
 		tf = pop_dummy_rtld_trusted_frame(tf);
 #endif
@@ -6188,7 +6188,7 @@ _rtld_allocate_tls(void *oldtls, size_t tcbsize, size_t tcbalign)
     wlock_acquire(rtld_bind_lock, &lockstate);
     ret = allocate_tls(globallist_curr(TAILQ_FIRST(&obj_list)), oldtls,
       tcbsize, tcbalign);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     /*
      * Create a fake wrapper TCB containing pointers to the real TCB and stack
      * lookup table. This is passed to the new thread as its initial TCB. Once
@@ -6208,7 +6208,7 @@ _rtld_free_tls(void *tcb, size_t tcbsize, size_t tcbalign)
     RtldLockState lockstate;
 
     wlock_acquire(rtld_bind_lock, &lockstate);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     if (C18N_ENABLED)
 	c18n_free_tcb();
 #endif
@@ -6228,7 +6228,7 @@ object_add_name(Obj_Entry *obj, const char *name)
     if (entry != NULL) {
 	strcpy(entry->name, name);
 	STAILQ_INSERT_TAIL(&obj->names, entry, link);
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	if (C18N_ENABLED && obj->compart_id == 0)
 	    obj->compart_id = compart_id_allocate(entry->name);
 #endif

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -277,7 +277,7 @@ typedef struct Struct_Obj_Entry {
     Ver_Entry *vertab;		/* Versions required /defined by this object */
     int vernum;			/* Number of entries in vertab */
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
     uint16_t compart_id;
     const struct func_sig *sigtab;
 #endif

--- a/libexec/rtld-elf/rtld_lock.c
+++ b/libexec/rtld-elf/rtld_lock.c
@@ -66,7 +66,7 @@
 #include "rtld.h"
 #include "rtld_machdep.h"
 #include "rtld_libc.h"
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif
 
@@ -248,7 +248,7 @@ thread_mask_clear(int mask)
 	lockinfo.thread_clr_flag(mask);
 }
 
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 #define	RTLD_LOCK_CNT	4
 #else
 #define	RTLD_LOCK_CNT	3
@@ -261,7 +261,7 @@ static struct rtld_lock {
 rtld_lock_t	rtld_bind_lock = &rtld_locks[0];
 rtld_lock_t	rtld_libc_lock = &rtld_locks[1];
 rtld_lock_t	rtld_phdr_lock = &rtld_locks[2];
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 rtld_lock_t	rtld_tramp_lock = &rtld_locks[3];
 #endif
 
@@ -410,7 +410,7 @@ _rtld_thread_init(struct RtldLockInfo *pli)
 	SymLook req;
 	void *locks[RTLD_LOCK_CNT];
 	int flags, i, res;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 	struct RtldLockInfo tmplockinfo;
 #endif
 
@@ -425,7 +425,7 @@ _rtld_thread_init(struct RtldLockInfo *pli)
 			if (res == 0)
 				lockinfo.rtli_version = pli->rtli_version;
 		}
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 		tmplockinfo = *pli;
 #define WRAP(_target, _valid, _reg_args, _mem_args, _ret_args)	\
 	_target = tramp_intern(NULL, &(struct tramp_data) {			\

--- a/libexec/rtld-elf/rtld_lock.h
+++ b/libexec/rtld-elf/rtld_lock.h
@@ -82,7 +82,7 @@ typedef struct rtld_lock *rtld_lock_t;
 extern rtld_lock_t	rtld_bind_lock;
 extern rtld_lock_t	rtld_libc_lock;
 extern rtld_lock_t	rtld_phdr_lock;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#ifdef CHERI_LIB_C18N
 extern rtld_lock_t	rtld_tramp_lock;
 #endif
 

--- a/sys/sys/link_elf.h
+++ b/sys/sys/link_elf.h
@@ -74,7 +74,7 @@ struct r_debug {
 		RT_DELETE			/* removing a shared library */
 	}		r_state;
 	void		*r_ldbase;		/* Base address of rtld */
-#if defined(IN_RTLD) && defined(__CHERI_PURE_CAPABILITY__) && defined(CHERI_LIB_C18N)
+#if defined(IN_RTLD) && defined(CHERI_LIB_C18N)
 	enum {
 		RCT_CONSISTENT,			/* vector is stable */
 		RCT_ADD,			/* adding a compartment */


### PR DESCRIPTION
CHERI_LIB_C18N is only ever defined under the purecap ABI, so there is no need to separately check for the purecap ABI.