### PR TITLE
proccontrol: make -s require a target

### DIFF
--- a/usr.bin/proccontrol/proccontrol.1
+++ b/usr.bin/proccontrol/proccontrol.1
@@ -26,7 +26,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 5, 2023
+.Dd August 23, 2024
 .Dt PROCCONTROL 1
 .Os
 .Sh NAME
@@ -35,9 +35,12 @@
 .Sh SYNOPSIS
 .Nm
 .Fl m Ar mode
-.Op Fl s Ar control
-.Op Fl q
+.Fl s Ar control
 .Fl p Ar pid | command
+.Nm
+.Fl m Ar mode
+.Fl q
+.Op Fl p Ar pid | command
 .Sh DESCRIPTION
 The
 .Nm

--- a/usr.bin/proccontrol/proccontrol.c
+++ b/usr.bin/proccontrol/proccontrol.c
@@ -98,11 +98,15 @@ str2pid(const char *str)
 static void __dead2
 usage(void)
 {
-
-	fprintf(stderr, "Usage: proccontrol -m (aslr|protmax|trace|trapcap|"
-	    "stackgap|nonewprivs|wxmap"KPTI_USAGE LA_USAGE CHERI_REVOKE_USAGE
-	    CHERI_C18N_USAGE
-	    ") [-q] [-s (enable|disable)] [-p pid | command]\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "    proccontrol -m mode -s (enable|disable) "
+	    "(-p pid | command)\n");
+	fprintf(stderr, "    proccontrol -m mode -q [-p pid]\n");
+	fprintf(stderr, "Modes: "
+	    "aslr|protmax|trace|trapcap|stackgap|nonewprivs|wxmap"
+	    KPTI_USAGE LA_USAGE
+	    CHERI_REVOKE_USAGE CHERI_C18N_USAGE
+	    "\n");
 	exit(1);
 }
 
@@ -183,6 +187,8 @@ main(int argc, char *argv[])
 			usage();
 		pid = getpid();
 	} else if (pid == -1) {
+		if (!query)
+			usage();
 		pid = getpid();
 	}
 


### PR DESCRIPTION
This conflicts locally so merging now to hopefully save @bsdjhb some effort.

Require a command to exec or a pid to target and update usage and the manpage to make this more clear.

It makes no sense to invoke a procctl(2) command on the current process only to exit.  Users are sometimes confused about how proccontrol works and think it effects their shell environment when invoked without a target.  Disallowing this nonsensical behavior and clarifiying usage will hopefully reduce confusion.

Reviewed by:	kib
Differential Revision:	https://reviews.freebsd.org/D46422

(cherry picked from commit 70174ef7d2c80abdfca0e3ad9d0bb1af61318542) (cherry picked from commit 5cbb98c8259c48ba22c8359f4c14f5438329ce58)