### PR TITLE
Fix install of CheriBSD/amd64 on FreeBSD/amd64 hosts

### DIFF
--- a/lib/libc/tests/ssp/Makefile
+++ b/lib/libc/tests/ssp/Makefile
@@ -30,7 +30,7 @@ PROGS+=		h_memset
 # now on amd64 when it trips the stack bounds specified in t_ssp.sh . This
 # probably needs to be fixed as it's currently hardcoded.
 .if ${COMPILER_TYPE} == "clang" && !defined(_SKIP_BUILD) && \
-    (!defined(_RECURSING_PROGS) || ${PROG} == "h_raw")
+    (!defined(_RECURSING_PROGS) || ${PROG} == "h_raw") && ${MK_TOOLCHAIN} == "yes"
 .include "${SRCTOP}/lib/libclang_rt/compiler-rt-vars.mk"
 _libclang_rt_ubsan=	${SYSROOT}${SANITIZER_LIBDIR}/libclang_rt.ubsan_standalone-${CRTARCH}.a
 .if exists(${_libclang_rt_ubsan})

--- a/lib/libc/tests/ssp/Makefile
+++ b/lib/libc/tests/ssp/Makefile
@@ -30,7 +30,8 @@ PROGS+=		h_memset
 # now on amd64 when it trips the stack bounds specified in t_ssp.sh . This
 # probably needs to be fixed as it's currently hardcoded.
 .if ${COMPILER_TYPE} == "clang" && !defined(_SKIP_BUILD) && \
-    (!defined(_RECURSING_PROGS) || ${PROG} == "h_raw") && ${MK_TOOLCHAIN} == "yes"
+    (!defined(_RECURSING_PROGS) || ${PROG} == "h_raw") && \
+    defined(MK_CLANG) && ${MK_CLANG} == "yes"
 .include "${SRCTOP}/lib/libclang_rt/compiler-rt-vars.mk"
 _libclang_rt_ubsan=	${SYSROOT}${SANITIZER_LIBDIR}/libclang_rt.ubsan_standalone-${CRTARCH}.a
 .if exists(${_libclang_rt_ubsan})


### PR DESCRIPTION
- **libc/tests: Fix installation without MK_TOOLCHAIN**
- **libc/tests: Further refine the condition for installing h_raw**
