### PR TITLE
libdwarf: allow pointers in DwarfLoc lr_number2

### DIFF
--- a/contrib/elftoolchain/libdwarf/libdwarf.h
+++ b/contrib/elftoolchain/libdwarf/libdwarf.h
@@ -40,6 +40,11 @@ typedef uint8_t		Dwarf_Small;
 typedef int64_t		Dwarf_Signed;
 typedef uint64_t	Dwarf_Addr;
 typedef void		*Dwarf_Ptr;
+#ifdef __CHERI_PURE_CAPABILITY__
+typedef uintptr_t	Dwarf_Uintptr;
+#else
+typedef uint64_t	Dwarf_Uintptr;
+#endif
 
 typedef struct _Dwarf_Abbrev	*Dwarf_Abbrev;
 typedef struct _Dwarf_Arange	*Dwarf_Arange;
@@ -109,9 +114,9 @@ typedef int (*Dwarf_Callback_Func_b)(char *_name, int _size,
 typedef Dwarf_Unsigned Dwarf_Tag;
 
 typedef struct {
-        Dwarf_Small	lr_atom;
-        Dwarf_Unsigned	lr_number;
-	Dwarf_Unsigned	lr_number2;
+	Dwarf_Small	lr_atom;
+	Dwarf_Unsigned	lr_number;
+	Dwarf_Uintptr	lr_number2;
 	Dwarf_Unsigned	lr_offset;
 } Dwarf_Loc;
 

--- a/contrib/elftoolchain/libdwarf/libdwarf_loc.c
+++ b/contrib/elftoolchain/libdwarf/libdwarf_loc.c
@@ -43,7 +43,7 @@ _dwarf_loc_fill_loc(Dwarf_Debug dbg, Dwarf_Locdesc *lbuf, uint8_t pointer_size,
 {
 	int count;
 	uint64_t operand1;
-	uint64_t operand2;
+	Dwarf_Uintptr operand2;
 	uint8_t *ps, *pe, s;
 
 	count = 0;
@@ -293,7 +293,7 @@ _dwarf_loc_fill_loc(Dwarf_Debug dbg, Dwarf_Locdesc *lbuf, uint8_t pointer_size,
 		case DW_OP_implicit_value:
 		case DW_OP_GNU_entry_value:
 			operand1 = _dwarf_decode_uleb128(&p);
-			operand2 = (Dwarf_Unsigned) (uintptr_t) p;
+			operand2 = (uintptr_t) p;
 			p += operand1;
 			break;
 
@@ -343,7 +343,7 @@ _dwarf_loc_fill_loc(Dwarf_Debug dbg, Dwarf_Locdesc *lbuf, uint8_t pointer_size,
 		 */
 		case DW_OP_GNU_const_type:
 			operand1 = _dwarf_decode_uleb128(&p);
-			operand2 = (Dwarf_Unsigned) (uintptr_t) p;
+			operand2 = (uintptr_t) p;
 			s = *p++;
 			p += s;
 			break;


### PR DESCRIPTION
For a few DWARF types, a pointer is smuggled through the DwarfLoc lr_number2 member.  Add a new Dwarf_Uintptr type and use it to allow this to work on CHERI.  It differs from the standard uintptr_t in that it is always capable of holding a 64-bit integer.

This allows `readelf -wi /usr/lib/debug/lib/libc.so.7.debug` to succeed.