### PR TITLE
drm: Some refactoring and bug fixes to address VM panics

### DIFF
--- a/sys/dev/drm/core/drm_vm.c
+++ b/sys/dev/drm/core/drm_vm.c
@@ -370,6 +370,7 @@ static const struct vm_operations_struct drm_vm_ops = {
 	.fault = drm_vm_fault,
 	.open = drm_vm_open,
 	.close = drm_vm_close,
+	.objtype = OBJT_MGTDEVICE,
 };
 
 /** Shared virtual memory operations */
@@ -377,6 +378,7 @@ static const struct vm_operations_struct drm_vm_shm_ops = {
 	.fault = drm_vm_shm_fault,
 	.open = drm_vm_open,
 	.close = drm_vm_shm_close,
+	.objtype = OBJT_MGTDEVICE,
 };
 
 /** DMA virtual memory operations */
@@ -384,6 +386,7 @@ static const struct vm_operations_struct drm_vm_dma_ops = {
 	.fault = drm_vm_dma_fault,
 	.open = drm_vm_open,
 	.close = drm_vm_close,
+	.objtype = OBJT_MGTDEVICE,
 };
 
 /** Scatter-gather virtual memory operations */

--- a/sys/dev/drm/drmkpi/include/linux/mm.h
+++ b/sys/dev/drm/drmkpi/include/linux/mm.h
@@ -119,20 +119,18 @@ struct vm_area_struct {
 struct vm_fault {
 	unsigned int flags;
 	pgoff_t	pgoff;
-	union {
-		/* user-space address */
-		void *virtual_address;	/* < 4.11 */
-		unsigned long address;	/* >= 4.11 */
-	};
+	vm_object_t object;
+	vm_pindex_t pindex;	/* fault pindex */
+	int count;		/* pages faulted in */
 	struct page *page;
-	struct vm_area_struct *vma;
 };
 
 struct vm_operations_struct {
 	void    (*open) (struct vm_area_struct *);
 	void    (*close) (struct vm_area_struct *);
-	int     (*fault) (struct vm_area_struct *, struct vm_fault *);
+	int     (*fault) (struct vm_fault *);
 	int	(*access) (struct vm_area_struct *, unsigned long, void *, int, int);
+	int	objtype;
 };
 
 struct sysinfo {

--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -278,6 +278,7 @@ out_release:
 }
 
 static struct rwlock drm_vma_lock;
+RW_SYSINIT(drm_freebsd, &drm_vma_lock, "drmcompat-vma-lock");
 static TAILQ_HEAD(, vm_area_struct) drm_vma_head =
     TAILQ_HEAD_INITIALIZER(drm_vma_head);
 
@@ -795,18 +796,3 @@ int drm_irq_uninstall(struct drm_device *dev)
 {
 	panic("%s: Not implemented yet.", __func__);
 }
-
-static void
-drm_stub_init(void *arg)
-{
-	rw_init(&drm_vma_lock, "drmcompat-vma-lock");
-}
-
-static void
-drm_stub_uninit(void *arg)
-{
-	rw_destroy(&drm_vma_lock);
-}
-
-SYSINIT(drm_stub, SI_SUB_DRIVERS, SI_ORDER_SECOND, drm_stub_init, NULL);
-SYSUNINIT(drm_stub, SI_SUB_DRIVERS, SI_ORDER_SECOND, drm_stub_uninit, NULL);

--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -566,7 +566,7 @@ drm_fstub_do_mmap(struct file *file, const struct file_operations *fops,
 		sglist_append_phys(sg, (vm_paddr_t)vmap->vm_pfn << PAGE_SHIFT,
 		    vmap->vm_len);
 
-		*obj = vm_pager_allocate(OBJT_SG, sg, vmap->vm_len, prot, 0,
+		*obj = vm_pager_allocate(OBJT_SG, sg, size, prot, 0,
 		    td->td_ucred);
 
 		drm_vmap_free(vmap);

--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -381,7 +381,6 @@ drm_cdev_pager_populate(vm_object_t vm_obj, vm_pindex_t pidx, int fault_type,
 		vmf.vma = vmap;
 
 		vmap->vm_pfn_count = 0;
-		vmap->vm_pfn_pcount = &vmap->vm_pfn_count;
 		vmap->vm_obj = vm_obj;
 
 		err = vmap->vm_ops->fault(vmap, &vmf);
@@ -482,6 +481,7 @@ drm_fstub_do_mmap(struct file *file, const struct file_operations *fops,
 	vmap->vm_flags = vmap->vm_page_prot = (prot & VM_PROT_ALL);
 	vmap->vm_ops = NULL;
 	vmap->vm_file = file;
+	vmap->vm_pfn_pcount = &vmap->vm_pfn_count;
 
 	rv = fops->mmap(file, vmap);
 	if (rv != 0) {

--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -397,7 +397,7 @@ drm_cdev_pager_populate(vm_object_t vm_obj, vm_pindex_t pidx, int fault_type,
 		err = VM_PAGER_AGAIN;
 		break;
 	case VM_FAULT_SIGBUS:
-		err = VM_PAGER_BAD;
+		err = VM_PAGER_FAIL;
 		break;
 	case VM_FAULT_NOPAGE:
 		/*

--- a/sys/dev/drm/freebsd/drm_os_freebsd.c
+++ b/sys/dev/drm/freebsd/drm_os_freebsd.c
@@ -311,46 +311,9 @@ drm_vmap_find(void *handle)
 }
 
 static int
-drm_cdev_pager_fault(vm_object_t vm_obj, vm_ooffset_t offset, int prot,
-    vm_page_t *mres)
+drm_cdev_pager_fault(vm_object_t vm_obj __unused, vm_ooffset_t offset __unused,
+    int prot __unused, vm_page_t *mres __unused)
 {
-	struct vm_area_struct *vmap;
-
-	vmap = drm_vmap_find(vm_obj->handle);
-
-	MPASS(vmap != NULL);
-	MPASS(vmap->vm_private_data == vm_obj->handle);
-
-	if (likely(vmap->vm_ops != NULL && offset < vmap->vm_len)) {
-		vm_paddr_t paddr = IDX_TO_OFF(vmap->vm_pfn) + offset;
-		vm_page_t page;
-
-		if (((*mres)->flags & PG_FICTITIOUS) != 0) {
-			/*
-			 * If the passed in result page is a fake
-			 * page, update it with the new physical
-			 * address.
-			 */
-			page = *mres;
-			vm_page_updatefake(page, paddr, vm_obj->memattr);
-		} else {
-			/*
-			 * Replace the passed in "mres" page with our
-			 * own fake page and free up the all of the
-			 * original pages.
-			 */
-			VM_OBJECT_WUNLOCK(vm_obj);
-			page = vm_page_getfake(paddr, vm_obj->memattr);
-			VM_OBJECT_WLOCK(vm_obj);
-
-			vm_page_replace(page, vm_obj,
-			    (*mres)->pindex, *mres);
-
-			*mres = page;
-		}
-		page->valid = VM_PAGE_BITS_ALL;
-		return (VM_PAGER_OK);
-	}
 	return (VM_PAGER_FAIL);
 }
 

--- a/sys/dev/drm/panfrost/panfrost_gem.c
+++ b/sys/dev/drm/panfrost/panfrost_gem.c
@@ -694,9 +694,11 @@ panfrost_gem_get_pages(struct panfrost_gem_object *bo)
 		error = panfrost_alloc_pages_iommu(bo);
 	else
 		error = panfrost_alloc_pages_contig(bo);
-
-	if (error)
+	if (error) {
+		printf("%s:%d failed to allocate %d pages\n",
+		    __func__, __LINE__, npages);
 		return (error);
+	}
 
 	bo->sgt = drm_prime_pages_to_sg(m0, npages);
 

--- a/sys/dev/drm/panfrost/panfrost_mmu.c
+++ b/sys/dev/drm/panfrost/panfrost_mmu.c
@@ -336,9 +336,12 @@ panfrost_mmu_page_fault(struct panfrost_softc *sc, int as, uint64_t addr)
 
 	/* Map 2MiB. */
 	for (i = 0; i < 512; i++) {
+		int error __diagused;
+
 		page = bo->pages[page_offset + i];
 		pa = VM_PAGE_TO_PHYS(page);
-		pmap_gpu_enter(&mmu->p, va, pa, prot, 0);
+		error = pmap_gpu_enter(&mmu->p, va, pa, prot, 0);
+		KASSERT(error == 0, ("pmap_gpu_enter() failed: %d", error));
 		va += PAGE_SIZE;
 	}
 
@@ -575,6 +578,8 @@ panfrost_mmu_map(struct panfrost_softc *sc,
 		while (len > 0) {
 			pa = VM_PAGE_TO_PHYS(page);
 			error = pmap_gpu_enter(&mmu->p, va, pa, prot, 0);
+			KASSERT(error == 0,
+			    ("pmap_gpu_enter() failed: %d", error));
 			va += PAGE_SIZE;
 			page++;
 			len -= PAGE_SIZE;

--- a/sys/vm/phys_pager.c
+++ b/sys/vm/phys_pager.c
@@ -154,16 +154,16 @@ static void
 phys_pager_dealloc(vm_object_t object)
 {
 
+	VM_OBJECT_WUNLOCK(object);
 	if (object->handle != NULL) {
-		VM_OBJECT_WUNLOCK(object);
 		mtx_lock(&phys_pager_mtx);
 		TAILQ_REMOVE(&phys_pager_object_list, object, pager_object_list);
 		mtx_unlock(&phys_pager_mtx);
-		VM_OBJECT_WLOCK(object);
 	}
-	object->type = OBJT_DEAD;
 	if (object->un_pager.phys.ops->phys_pg_dtor != NULL)
 		object->un_pager.phys.ops->phys_pg_dtor(object);
+	VM_OBJECT_WLOCK(object);
+	object->type = OBJT_DEAD;
 	object->handle = NULL;
 }
 


### PR DESCRIPTION
The last commit is the main change. I had tried a couple of times to split it up but it was hard to do correctly, so I gave up in the interest of making the patches available a bit more quickly.

I took some small liberties in modifying drmkpi and DRM to better match the design of FreeBSD's fault handler. Since this code (drm device file mmap, fault handling) is highly non-portable anyway, I think this should be acceptable.

This should fix the panics reported in #2097 . I might be too optimistic, but so far it also seems to address some issues I was seeing with tearing and clipped text.