### PR TITLE
Rework shared memory in light of revocation and explicit mmap permissions

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -876,12 +876,10 @@ main(int argc, char *argv[])
 	 * failure status.
 	 */
 	assert(sizeof(*ccsp) <= (size_t)getpagesize());
-	ccsp = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE, MAP_ANON, -1,
-	    0);
+	ccsp = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE | PROT_CAP,
+	    MAP_ANON | MAP_SHARED, -1, 0);
 	if (ccsp == MAP_FAILED)
 		err(EX_OSERR, "mmap");
-	if (minherit(ccsp, getpagesize(), INHERIT_SHARE) < 0)
-		err(EX_OSERR, "minherit");
 
 	/*
 	 * Disable core dumps unless specifically enabled.

--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -389,11 +389,16 @@ CHERIBSDTEST(cheriabi_minherit_invalid_ptr,
 	CHERIBSDTEST_CHECK_CALL_ERROR(minherit(mappings.middle + mappings.maplen,
 	    mappings.maplen, INHERIT_NONE), EPROT);
 
+	/*
+	 * minherit() should not be able to mark a MAP_ANON mapping shared
+	 * upless it was initially marked as shared.
+	 */
+	CHERIBSDTEST_CHECK_CALL_ERROR(minherit(mappings.middle, mappings.maplen,
+	    INHERIT_SHARE), EACCES);
+
 	/* Sanity check: minherit() on a valid capability should succeed. */
 	CHERIBSDTEST_CHECK_SYSCALL(minherit(mappings.middle, mappings.maplen,
 	    INHERIT_NONE));
-	CHERIBSDTEST_CHECK_SYSCALL(minherit(mappings.middle, mappings.maplen,
-	    INHERIT_SHARE));
 
 	/* Unmapping the original capabilities should succeed. */
 	free_adjacent_mappings(&mappings);

--- a/bin/cheribsdtest/cheribsdtest_ptrace.c
+++ b/bin/cheribsdtest/cheribsdtest_ptrace.c
@@ -217,11 +217,12 @@ CHERIBSDTEST(ptrace_writecap, "Basic tests of PIOD_WRITE_CHERI_CAP")
 	uintcap_t *map, pp[2];
 	char capbuf[2][sizeof(uintcap_t) + 1];
 
-	fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
+	fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR | O_SHARECAP,
+	    0600));
 	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0));
 
 	pid = fork_child();
 

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -287,7 +287,6 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 			fprintf(stderr, "rx cap: %#lp\n", c);
 
 		tag = cheri_gettag(c);
-		CHERIBSDTEST_VERIFY2(tag == 0, "tag read");
 
 		CHERIBSDTEST_CHECK_SYSCALL(munmap(map, getpagesize()));
 		close(sv[0]);
@@ -347,8 +346,10 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 		waitpid(pid, &res, 0);
 		if (res == 0) {
 			cheribsdtest_success();
-		} else {
+		} else if (WIFEXITED(res) && WEXITSTATUS(res) == 1) {
 			cheribsdtest_failure_errx("tag transfer succeeded");
+		} else {
+			cheribsdtest_failure_errx("child setup error occured (this *unexpected*");
 		}
 	}
 }

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -191,12 +191,28 @@ CHERIBSDTEST(vm_mmap_diallowed_prot,
 }
 
 CHERIBSDTEST(vm_tag_shm_open_anon_shared,
-    "check tags are stored for SHM_ANON MAP_SHARED pages")
+    "check tags are stored for SHM_ANON MAP_SHARED pages when requested")
+{
+	int fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
+	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
+	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE | PROT_CAP,
+	    MAP_SHARED);
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(vm_tag_shm_open_anon_shared_implied_cap,
+    "check tags are not stored for SHM_ANON MAP_SHARED pages by default",
+    .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO,
+    .ct_signum = SIGSEGV,
+    .ct_si_code = SEGV_STORETAG,
+    .ct_si_trapno = TRAPNO_STORE_CAP_PF,
+    .ct_check_skip = skip_need_writable_tmp)
 {
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
 	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE, MAP_SHARED);
-	cheribsdtest_success();
+
+	cheribsdtest_failure_errx("store succeeded");
 }
 
 CHERIBSDTEST(vm_tag_shm_open_anon_private,
@@ -204,7 +220,8 @@ CHERIBSDTEST(vm_tag_shm_open_anon_private,
 {
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
 	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
-	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE, MAP_PRIVATE);
+	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE | PROT_CAP,
+	    MAP_PRIVATE);
 	cheribsdtest_success();
 }
 
@@ -220,14 +237,15 @@ CHERIBSDTEST(vm_tag_shm_open_anon_shared2x,
 	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 
 	map2 = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-		PROT_READ, MAP_SHARED, fd, 0));
+	    PROT_READ | PROT_CAP, MAP_SHARED, fd, 0));
 
 	/* Verify that no capability present */
 	c2 = *map2;
 	CHERIBSDTEST_VERIFY2(cheri_gettag(c2) == 0, "tag exists on first read");
 	CHERIBSDTEST_VERIFY2(c2 == NULL, "Initial read NULL");
 
-	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE, MAP_SHARED);
+	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE | PROT_CAP,
+	    MAP_SHARED);
 
 	/* And now verify that it is, thanks to the aliased maps */
 	c2 = *map2;
@@ -237,10 +255,7 @@ CHERIBSDTEST(vm_tag_shm_open_anon_shared2x,
 	cheribsdtest_success();
 }
 
-CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
-    "test SHM_ANON vs SCM_RIGHTS",
-    .ct_xfail_reason =
-	"Tags currently survive cross-AS aliasing of SHM_ANON objects")
+CHERIBSDTEST(vm_shm_open_anon_unix_cross_as, "test SHM_ANON vs SCM_RIGHTS")
 {
 	int sv[2];
 	int pid;
@@ -280,7 +295,7 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 		CHERIBSDTEST_VERIFY2(fd >= 0, "fd read OK");
 
 		map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-		    PROT_READ, MAP_PRIVATE, fd, 0));
+		    PROT_READ | PROT_CAP, MAP_SHARED, fd, 0));
 		c = *map;
 
 		if (verbose)
@@ -308,12 +323,12 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 
 		close(sv[0]);
 
-		fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON, O_RDWR, 0600));
+		fd = CHERIBSDTEST_CHECK_SYSCALL(shm_open(SHM_ANON,
+		    O_RDWR | O_SHARECAP, 0600));
 		CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 
 		map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-						PROT_READ | PROT_WRITE,
-						MAP_SHARED, fd, 0));
+		    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0));
 
 		/* Just some pointer */
 		*map = &fd;
@@ -345,9 +360,9 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 
 		waitpid(pid, &res, 0);
 		if (res == 0) {
-			cheribsdtest_success();
+			cheribsdtest_failure_errx("tags failed to transfer");
 		} else if (WIFEXITED(res) && WEXITSTATUS(res) == 1) {
-			cheribsdtest_failure_errx("tag transfer succeeded");
+			cheribsdtest_success();
 		} else {
 			cheribsdtest_failure_errx("child setup error occured (this *unexpected*");
 		}
@@ -366,7 +381,7 @@ CHERIBSDTEST(shm_open_read_nocaps,
 	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0));
 
 	/* Just some pointer */
 	*map = &fd;
@@ -637,12 +652,11 @@ skip_need_writable_tmp(const char *name __unused)
  * and write a tagged capability to it.
  *
  * 2) Create a second copy-on-write mapping; read back the tagged value via
- * the second mapping, and confirm that it still has a tag.
- * (cheribsdtest_vm_cow_read)
+ * the second mapping, and confirm that it still has a tag.  (vm_cow_read)
  *
  * 3) Write an adjacent word in the second mapping, which should cause a
  * copy-on-write, then read back the capability and confirm that it still has
- * a tag.  (cheribsdtest_vm_cow_write)
+ * a tag.  (vm_cow_write)
  */
 CHERIBSDTEST(vm_cow_read,
     "read capabilities from a copy-on-write page")
@@ -662,9 +676,11 @@ CHERIBSDTEST(vm_cow_read,
 	 * Create 'real' and copy-on-write mappings.
 	 */
 	cp_real = CHERIBSDTEST_CHECK_SYSCALL2(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), "mmap cp_real");
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0),
+	    "mmap cp_real");
 	cp_copy = CHERIBSDTEST_CHECK_SYSCALL2(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0), "mmap cp_copy");
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_PRIVATE, fd, 0),
+	    "mmap cp_copy");
 
 	/*
 	 * Write out a tagged capability to 'real' mapping -- doesn't really
@@ -711,9 +727,11 @@ CHERIBSDTEST(vm_cow_write,
 	 * Create 'real' and copy-on-write mappings.
 	 */
 	cp_real = CHERIBSDTEST_CHECK_SYSCALL2(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), "mmap cp_real");
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0),
+	    "mmap cp_real");
 	cp_copy = CHERIBSDTEST_CHECK_SYSCALL2(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0), "mmap cp_copy");
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_PRIVATE, fd, 0),
+	    "mmap cp_copy");
 
 	/*
 	 * Write out a tagged capability to 'real' mapping -- doesn't really
@@ -1249,7 +1267,7 @@ CHERIBSDTEST(vm_shm_largepage_basic,
 		    "psind=%d errno=%d", psind, errno);
 		CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, ps[psind]));
 		addr = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, ps[psind],
-		    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+		    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0));
 
 		/* Verify mmap output */
 		CHERIBSDTEST_VERIFY2(cheri_gettag(addr) != 0,
@@ -2699,7 +2717,7 @@ CHERIBSDTEST(cheri_revoke_shm_anon_hoard_unmapped,
 	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-	    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+	    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0));
 
 	to_revoke = malloc(1);
 	*map = to_revoke;
@@ -2785,7 +2803,7 @@ CHERIBSDTEST(cheri_revoke_shm_anon_hoard_closed,
 		CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
 
 		map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-		    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+		    PROT_READ | PROT_WRITE | PROT_CAP, MAP_SHARED, fd, 0));
 
 		to_revoke = malloc(1);
 		*map = to_revoke;

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -2706,8 +2706,7 @@ CHERIBSDTEST(cheri_revoke_cow_mapping,
 }
 
 CHERIBSDTEST(cheri_revoke_shm_anon_hoard_unmapped,
-    "Capability is revoked within an unmapped shm object",
-    .ct_xfail_reason = "unmapped part of shm objects aren't revoked")
+    "Capability is revoked within an unmapped shm object")
 {
 	int fd;
 	void * volatile to_revoke;
@@ -2739,8 +2738,7 @@ CHERIBSDTEST(cheri_revoke_shm_anon_hoard_unmapped,
 }
 
 CHERIBSDTEST(cheri_revoke_shm_anon_hoard_closed,
-    "Capability is revoked within an unmapped and closed shm object",
-    .ct_xfail_reason = "unmapped part of shm objects aren't revoked")
+    "Capability is revoked within an unmapped and closed shm object")
 {
 	int sv[2];
 	int pid;

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -280,7 +280,7 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 		CHERIBSDTEST_VERIFY2(fd >= 0, "fd read OK");
 
 		map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, getpagesize(),
-		    PROT_READ, MAP_SHARED, fd, 0));
+		    PROT_READ, MAP_PRIVATE, fd, 0));
 		c = *map;
 
 		if (verbose)

--- a/lib/libsys/shm_open.2
+++ b/lib/libsys/shm_open.2
@@ -112,6 +112,22 @@ The size of the object can be adjusted via
 and queried via
 .Xr fstat 2 .
 .Pp
+On system supporting CHERI capabilities, capabilities may only be shared
+within a single address space unless the shared memory object is created
+with the
+.Dv O_SHARECAP
+flag in the initial call to
+.Fn shm_open .
+Additionally, capabilities are only allowed via mappings created using
+.Xr mmap 2
+where the
+.Dv PROT_CAP
+permission is specified.
+On fork, pages with capability permissions remain shared, but are
+downgraded to remove capability permissions unless
+.Dv O_SHARECAP
+was used during object creation.
+.Pp
 The new descriptor is set to close during
 .Xr execve 2
 system calls;

--- a/lib/libsysdecode/flags.c
+++ b/lib/libsysdecode/flags.c
@@ -276,8 +276,9 @@ sysdecode_fadvice(int advice)
 	return (lookup_value(fadvisebehav, advice));
 }
 
-bool
-sysdecode_open_flags(FILE *fp, int flags, int *rem)
+static bool
+_sysdecode_open_flags(FILE *fp, int flags, int *rem,
+    struct name_table open_flag_table[])
 {
 	bool printed;
 	int mode;
@@ -309,10 +310,22 @@ sysdecode_open_flags(FILE *fp, int flags, int *rem)
 		printed = false;
 	}
 	val = (unsigned)flags;
-	print_mask_part(fp, openflags, &val, &printed);
+	print_mask_part(fp, open_flag_table, &val, &printed);
 	if (rem != NULL)
 		*rem = val | mode;
 	return (printed);
+}
+
+bool
+sysdecode_open_flags(FILE *fp, int flags, int *rem)
+{
+	return (_sysdecode_open_flags(fp, flags, rem, openflags));
+}
+
+bool
+sysdecode_shm_open_flags(FILE *fp, int flags, int *rem)
+{
+	return (_sysdecode_open_flags(fp, flags, rem, shm_open_flags));
 }
 
 bool

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -127,6 +127,7 @@ gen_table "rlimit"          "RLIMIT_[A-Z]+[[:space:]]+[0-9]+"              "sys/
 gen_table "rusage"          "RUSAGE_[A-Z]+[[:space:]]+[-0-9]+"             "sys/resource.h"
 gen_table "schedpolicy"     "SCHED_[A-Z]+[[:space:]]+[0-9]+"               "sys/sched.h"
 gen_table "sendfileflags"   "SF_[A-Z]+[[:space:]]+[0-9]+"                  "sys/socket.h"
+gen_table "shm_open_flags"  "O_ACCMODE|O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC"   "sys/fcntl.h"
 gen_table "shmatflags"      "SHM_[A-Z]+[[:space:]]+[0-9]{6}"               "sys/shm.h"
 gen_table "shutdownhow"     "SHUT_[A-Z]+[[:space:]]+[0-9]+"                "sys/socket.h"
 gen_table "sigbuscode"      "BUS_[A-Z]+[[:space:]]+[0-9]+"                 "sys/signal.h"

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -127,7 +127,7 @@ gen_table "rlimit"          "RLIMIT_[A-Z]+[[:space:]]+[0-9]+"              "sys/
 gen_table "rusage"          "RUSAGE_[A-Z]+[[:space:]]+[-0-9]+"             "sys/resource.h"
 gen_table "schedpolicy"     "SCHED_[A-Z]+[[:space:]]+[0-9]+"               "sys/sched.h"
 gen_table "sendfileflags"   "SF_[A-Z]+[[:space:]]+[0-9]+"                  "sys/socket.h"
-gen_table "shm_open_flags"  "O_ACCMODE|O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC"   "sys/fcntl.h"
+gen_table "shm_open_flags"  "O_ACCMODE|O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC|O_SHARECAP"   "sys/fcntl.h"
 gen_table "shmatflags"      "SHM_[A-Z]+[[:space:]]+[0-9]{6}"               "sys/shm.h"
 gen_table "shutdownhow"     "SHUT_[A-Z]+[[:space:]]+[0-9]+"                "sys/socket.h"
 gen_table "sigbuscode"      "BUS_[A-Z]+[[:space:]]+[0-9]+"                 "sys/signal.h"

--- a/lib/libsysdecode/sysdecode.h
+++ b/lib/libsysdecode/sysdecode.h
@@ -109,6 +109,7 @@ bool	sysdecode_sctp_snd_flags(FILE *_fp, int _flags, int *_rem);
 const char *sysdecode_semctl_cmd(int _cmd);
 bool	sysdecode_semget_flags(FILE *_fp, int _flag, int *_rem);
 bool	sysdecode_sendfile_flags(FILE *_fp, int _flags, int *_rem);
+bool	sysdecode_shm_open_flags(FILE *_fp, int _flags, int *_rem);
 bool	sysdecode_shmat_flags(FILE *_fp, int _flags, int *_rem);
 const char *sysdecode_shmctl_cmd(int _cmd);
 const char *sysdecode_shutdown_how(int _how);

--- a/lib/libsysdecode/sysdecode_mask.3
+++ b/lib/libsysdecode/sysdecode_mask.3
@@ -50,6 +50,7 @@
 .Nm sysdecode_rfork_flags ,
 .Nm sysdecode_semget_flags ,
 .Nm sysdecode_sendfile_flags ,
+.Nm sysdecode_shm_open_flags ,
 .Nm sysdecode_shmat_flags ,
 .Nm sysdecode_sctp_nxt_flags ,
 .Nm sysdecode_sctp_rcv_flags ,
@@ -119,6 +120,8 @@
 .Ft bool
 .Fn sysdecode_sendfile_flags "FILE *fp" "int flags" "int *rem"
 .Ft bool
+.Fn sysdecode_shm_open_flags "FILE *fp" "int flags" "int *rem"
+.Ft bool
 .Fn sysdecode_shmat_flags "FILE *fp" "int flags" "int *rem"
 .Ft bool
 .Fn sysdecode_socket_type "FILE *fp" "int type" "int *rem"
@@ -186,6 +189,7 @@ Most of these functions decode an argument passed to a system call:
 .It Fn sysdecode_rfork_flags Ta Xr rfork 2 Ta Fa flags
 .It Fn sysdecode_semget_flags Ta Xr semget 2 Ta Fa flags
 .It Fn sysdecode_sendfile_flags Ta Xr sendfile 2 Ta Fa flags
+.It Fn sysdecode_shm_open_flags Ta Xr shm_open 2 Ta Fa flags
 .It Fn sysdecode_shmat_flags Ta Xr shmat 2 Ta Fa flags
 .It Fn sysdecode_socket_type Ta Xr socket 2 Ta Fa type
 .It Fn sysdecode_thr_create_flags Ta Xr thr_create 2 Ta Fa flags

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -4560,7 +4560,7 @@ umtx_shm_create_reg(struct thread *td, const struct umtx_key *key,
 		return (ENOMEM);
 	reg = uma_zalloc(umtx_shm_reg_zone, M_WAITOK | M_ZERO);
 	bcopy(key, &reg->ushm_key, sizeof(*key));
-	reg->ushm_obj = shm_alloc(td->td_ucred, O_RDWR, false);
+	reg->ushm_obj = shm_alloc(td->td_ucred, O_RDWR, false, false);
 	reg->ushm_cred = crhold(cred);
 	error = shm_dotruncate(reg->ushm_obj, PAGE_SIZE);
 	if (error != 0) {

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -900,6 +900,7 @@ shmget_allocate_segment(struct thread *td, key_t key, size_t size, int mode)
 	}
 
 	vm_object_set_flag(shm_object, OBJ_HASCAP);
+	vm_object_set_flag(shm_object, OBJ_SHARECAP);
 	shmseg->object = shm_object;
 	shmseg->u.shm_perm.cuid = shmseg->u.shm_perm.uid = cred->cr_uid;
 	shmseg->u.shm_perm.cgid = shmseg->u.shm_perm.gid = cred->cr_gid;

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -937,7 +937,7 @@ shm_dotruncate(struct shmfd *shmfd, off_t length)
  * routines.
  */
 struct shmfd *
-shm_alloc(struct ucred *ucred, mode_t mode, bool largepage)
+shm_alloc(struct ucred *ucred, mode_t mode, bool largepage, bool sharecap)
 {
 	struct shmfd *shmfd;
 	vm_object_t obj;
@@ -962,6 +962,16 @@ shm_alloc(struct ucred *ucred, mode_t mode, bool largepage)
 	}
 	KASSERT(shmfd->shm_object != NULL, ("shm_create: vm_pager_allocate"));
 	vm_object_set_flag(shmfd->shm_object, OBJ_HASCAP);
+	if (sharecap) {
+		shmfd->shm_vmspace = NULL;
+		vm_object_set_flag(shmfd->shm_object, OBJ_SHARECAP);
+	} else {
+		shmfd->shm_vmspace = curproc->p_vmspace;
+		vm_map_lock(&curproc->p_vmspace->vm_map);
+		LIST_INSERT_HEAD(&curproc->p_vmspace->vm_shm_objects,
+		    shmfd, shm_vmspace_entry);
+		vm_map_unlock(&curproc->p_vmspace->vm_map);
+	}
 	vfs_timestamp(&shmfd->shm_birthtime);
 	shmfd->shm_atime = shmfd->shm_mtime = shmfd->shm_ctime =
 	    shmfd->shm_birthtime;
@@ -994,6 +1004,11 @@ shm_drop(struct shmfd *shmfd)
 #ifdef MAC
 		mac_posixshm_destroy(shmfd);
 #endif
+		if (shmfd->shm_vmspace != NULL) {
+			vm_map_lock(&shmfd->shm_vmspace->vm_map);
+			LIST_REMOVE(shmfd, shm_vmspace_entry);
+			vm_map_unlock(&shmfd->shm_vmspace->vm_map);
+		}
 		rangelock_destroy(&shmfd->shm_rl);
 		mtx_destroy(&shmfd->shm_mtx);
 		obj = shmfd->shm_object;
@@ -1005,6 +1020,30 @@ shm_drop(struct shmfd *shmfd)
 		vm_object_deallocate(obj);
 		free(shmfd, M_SHMFD);
 	}
+}
+
+void
+shm_vmspace_free(struct vmspace *vm)
+{
+	struct shmfd *shmfd;
+
+	/*
+	 * XXX-BD: do we actually need a lock given all references have
+	 * been dropped? The comment before vm_map_clear() in
+	 * vmspace_dofree() suggests we do...
+	 */
+	vm_map_lock(&vm->vm_map);
+	while (!LIST_EMPTY(&vm->vm_shm_objects)) {
+		shmfd = LIST_FIRST(&vm->vm_shm_objects);
+
+		KASSERT(shmfd->shm_vmspace == vm, ("wrong vmspace! %p != %p",
+		    shmfd->shm_vmspace, vm));
+
+		LIST_REMOVE(shmfd, shm_vmspace_entry);
+		shmfd->shm_vmspace = NULL;	 /* XXX: atomic_rel? */
+		/* XXX: free refs to shmfds? */
+	}
+	vm_map_unlock(&vm->vm_map);
 }
 
 /*
@@ -1168,7 +1207,7 @@ kern_shm_open2(struct thread *td, const char * __capability userpath,
 	Fnv32_t fnv;
 	mode_t cmode;
 	int error, fd, initial_seals;
-	bool largepage;
+	bool largepage, sharecap;
 
 	if ((shmflags & ~(SHM_ALLOW_SEALING | SHM_GROW_ON_WRITE |
 	    SHM_LARGEPAGE)) != 0)
@@ -1184,8 +1223,15 @@ kern_shm_open2(struct thread *td, const char * __capability userpath,
 	if ((flags & O_ACCMODE) != O_RDONLY && (flags & O_ACCMODE) != O_RDWR)
 		return (EINVAL);
 
-	if ((flags & ~(O_ACCMODE | O_CREAT | O_EXCL | O_TRUNC | O_CLOEXEC)) != 0)
+	if ((flags & ~(O_ACCMODE | O_CREAT | O_EXCL | O_TRUNC | O_CLOEXEC |
+	    O_SHARECAP)) != 0)
 		return (EINVAL);
+
+	/* XXX: add a proc flag to allow/disallow */
+	if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
+		sharecap = (flags & O_SHARECAP) != 0;
+	else
+		sharecap = false;
 
 	largepage = (shmflags & SHM_LARGEPAGE) != 0;
 	if (largepage && !PMAP_HAS_LARGEPAGES)
@@ -1248,7 +1294,7 @@ kern_shm_open2(struct thread *td, const char * __capability userpath,
 			fdrop(fp, td);
 			return (EINVAL);
 		}
-		shmfd = shm_alloc(td->td_ucred, cmode, largepage);
+		shmfd = shm_alloc(td->td_ucred, cmode, largepage, sharecap);
 		shmfd->shm_seals = initial_seals;
 		shmfd->shm_flags = shmflags;
 	} else {
@@ -1264,7 +1310,7 @@ kern_shm_open2(struct thread *td, const char * __capability userpath,
 				if (error == 0) {
 #endif
 					shmfd = shm_alloc(td->td_ucred, cmode,
-					    largepage);
+					    largepage, sharecap);
 					shmfd->shm_seals = initial_seals;
 					shmfd->shm_flags = shmflags;
 					shm_insert(path, fnv, shmfd);
@@ -1309,6 +1355,9 @@ kern_shm_open2(struct thread *td, const char * __capability userpath,
 			else if ((flags & (O_CREAT | O_EXCL)) ==
 			    (O_CREAT | O_EXCL))
 				error = EEXIST;
+			else if (sharecap &&
+			    (shmfd->shm_object->flags & O_SHARECAP) == 0)
+				error = EPERM;
 			else if (shmflags != 0 && shmflags != shmfd->shm_flags)
 				error = EINVAL;
 			else {
@@ -1762,10 +1811,27 @@ shm_mmap(struct file *fp, vm_map_t map, vm_pointer_t *addr,
 			goto out;
 		}
 	}
-	maxprot &= cap_maxprot;
+	if ((cap_maxprot & (VM_PROT_CAP | VM_PROT_NO_IMPLY_CAP)) != 0) {
+		/*
+		 * If we want capabilty permissions, we must either be in
+		 * the original address space or the object must have the
+		 * OBJ_SHARECAP flag set.
+		 */
+		if ((cap_maxprot & VM_PROT_CAP) != 0 &&
+		    (shmfd->shm_object->flags & OBJ_SHARECAP) == 0 &&
+		    shmfd->shm_vmspace != td->td_proc->p_vmspace) {
+			error = EACCES;
+			goto out;
+		}
 
-	prot = VM_PROT_ADD_CAP(prot);
-	maxprot = VM_PROT_ADD_CAP(prot);
+		/*
+		 * If we've asked for (or explicitly rejected) capability
+		 * permissions, imply them for maxprot so we don't end up
+		 * with prot as a superset of maxport.
+		 */
+		maxprot = VM_PROT_ADD_CAP(maxprot);
+	}
+	maxprot &= cap_maxprot;
 
 	/* See comment in vn_mmap(). */
 	if (

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -78,6 +78,7 @@
 #include <sys/stat.h>
 #include <sys/syscallsubr.h>
 #include <sys/sysctl.h>
+#include <sys/sysent.h>
 #include <sys/sysproto.h>
 #include <sys/systm.h>
 #include <sys/sx.h>
@@ -1044,6 +1045,104 @@ shm_vmspace_free(struct vmspace *vm)
 		/* XXX: free refs to shmfds? */
 	}
 	vm_map_unlock(&vm->vm_map);
+}
+
+void
+shm_map_local_objs(struct proc *p, struct vm_cheri_revoke_cookie *crc)
+{
+	struct vmspace *vm = p->p_vmspace;
+	vm_map_t map = &vm->vm_map;
+	struct shmfd *shmfd;
+	void *rl_cookie;
+	vm_prot_t prot, max_prot;
+	int rv;
+
+	vm_map_lock(map);
+	LIST_FOREACH(shmfd, &vm->vm_shm_objects, shm_vmspace_entry) {
+		vm_offset_t align = PAGE_SIZE;
+		vm_offset_t vaddr = 0;
+		vm_pointer_t reservation;
+		/* XXX: can we avoid mapping some objects? */
+
+		prot = max_prot = VM_PROT_ALL;
+
+		shm_hold(shmfd);
+		rl_cookie = shm_rangelock_wlock(shmfd, 0, OFF_MAX);
+
+		vm_object_reference(shmfd->shm_object);
+
+		KASSERT(shmfd->shm_hoard_addr == 0,
+		    ("shm obj already mapped?"));
+		if (shm_largepage(shmfd))
+			align = pagesizes[shmfd->shm_lp_psind];
+		align = MAX(align,
+		    CHERI_REPRESENTABLE_ALIGNMENT(shmfd->shm_size));
+
+		/*
+		 * We don't need to do the retry dance to try and avoid sbrk
+		 * space because this only applies to pure-capability
+		 * processes and those don't do sbrk.
+		 */
+		rv = vm_map_find_aligned(map, &vaddr,
+		    shmfd->shm_size, vm_map_max(map), align);
+		if (rv != KERN_SUCCESS)
+			goto fail;
+		reservation = vaddr;
+		rv = vm_map_reservation_create_locked(map,
+		    &reservation, shmfd->shm_size, max_prot);
+		if (rv != KERN_SUCCESS)
+			goto fail;
+		rv = vm_map_insert(map, shmfd->shm_object, 0,
+		    reservation, reservation + shmfd->shm_size,
+		    prot, max_prot, MAP_DISABLE_COREDUMP | MAP_INHERIT_NONE,
+		    reservation);
+
+		if (rv != KERN_SUCCESS)
+			vm_map_reservation_delete_locked(map,
+			    reservation);
+		shmfd->shm_hoard_addr = reservation;
+		shmfd->shm_hoard_size = shmfd->shm_size;
+fail:
+		shm_rangelock_unlock(shmfd, rl_cookie);
+		if (rv != KERN_SUCCESS) {
+			vm_object_deallocate(shmfd->shm_object);
+			shm_drop(shmfd);
+		}
+
+		if (rv != KERN_SUCCESS) {
+			/*
+			 * XXX Out of suitable address space?
+			 * What to do?  Probably kill all procs in the
+			 * vmspace as we can't revoke?
+			 */
+			panic("Can't map shm object");
+		}
+	}
+	vm_map_unlock(map);
+}
+
+void
+shm_unmap_local_objs(struct proc *p, struct vm_cheri_revoke_cookie *crc)
+{
+	struct vmspace *vm = p->p_vmspace;
+	vm_map_t map = &vm->vm_map;
+	struct shmfd *shmfd;
+	void *rl_cookie;
+	int rv;
+
+	vm_map_lock(map);
+	LIST_FOREACH(shmfd, &vm->vm_shm_objects, shm_vmspace_entry) {
+		rl_cookie = shm_rangelock_wlock(shmfd, 0, OFF_MAX);
+		rv = vm_map_delete(map, shmfd->shm_hoard_addr,
+		    shmfd->shm_hoard_addr + shmfd->shm_hoard_size, false);
+		if (rv != KERN_SUCCESS)
+			panic("failed to delete shm hoard map entry\n");
+		shmfd->shm_hoard_addr = 0;
+		shmfd->shm_hoard_size = 0;
+		shm_rangelock_unlock(shmfd, rl_cookie);
+		shm_drop(shmfd);
+	}
+	vm_map_unlock(map);
 }
 
 /*

--- a/sys/sys/fcntl.h
+++ b/sys/sys/fcntl.h
@@ -142,6 +142,12 @@ typedef	__pid_t		pid_t;
 #define	O_EMPTY_PATH	0x02000000
 #endif
 
+#if __BSD_VISIBLE
+#define	O_SHARECAP	O_DIRECTORY	/* Allow cross address space capability
+					   sharing.  POSIX shm and memfd
+					   specific. */
+#endif
+
 /*
  * XXX missing O_RSYNC.
  */

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -278,6 +278,8 @@ struct shmfd {
 	vm_pindex_t	shm_pages;	/* allocated pages */
 	struct vmspace	*shm_vmspace;
 	LIST_ENTRY(shmfd) shm_vmspace_entry;
+	vm_pointer_t	shm_hoard_addr;
+	vm_ooffset_t	shm_hoard_size;
 	int		shm_refs;
 	uid_t		shm_uid;
 	gid_t		shm_gid;
@@ -311,6 +313,8 @@ struct shmfd {
 
 #ifdef _KERNEL
 struct prison;
+struct proc;
+struct vm_cheri_revoke_cookie;
 
 int	shm_map(struct file *fp, size_t size, off_t offset, void **memp);
 int	shm_unmap(struct file *fp, void *mem, size_t size);
@@ -324,6 +328,9 @@ void	shm_vmspace_free(struct vmspace *vm);
 int	shm_dotruncate(struct shmfd *shmfd, off_t length);
 bool	shm_largepage(struct shmfd *shmfd);
 void	shm_remove_prison(struct prison *pr);
+void	shm_map_local_objs(struct proc *p, struct vm_cheri_revoke_cookie *crc);
+void	shm_unmap_local_objs(struct proc *p,
+	    struct vm_cheri_revoke_cookie *crc);
 
 extern struct fileops shm_ops;
 

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -276,6 +276,8 @@ struct shmfd {
 	vm_ooffset_t	shm_size;
 	vm_object_t	shm_object;
 	vm_pindex_t	shm_pages;	/* allocated pages */
+	struct vmspace	*shm_vmspace;
+	LIST_ENTRY(shmfd) shm_vmspace_entry;
 	int		shm_refs;
 	uid_t		shm_uid;
 	gid_t		shm_gid;
@@ -314,9 +316,11 @@ int	shm_map(struct file *fp, size_t size, off_t offset, void **memp);
 int	shm_unmap(struct file *fp, void *mem, size_t size);
 
 int	shm_access(struct shmfd *shmfd, struct ucred *ucred, int flags);
-struct shmfd *shm_alloc(struct ucred *ucred, mode_t mode, bool largepage);
+struct shmfd *shm_alloc(struct ucred *ucred, mode_t mode, bool largepage,
+	    bool sharecap);
 struct shmfd *shm_hold(struct shmfd *shmfd);
 void	shm_drop(struct shmfd *shmfd);
+void	shm_vmspace_free(struct vmspace *vm);
 int	shm_dotruncate(struct shmfd *shmfd, off_t length);
 bool	shm_largepage(struct shmfd *shmfd);
 void	shm_remove_prison(struct prison *pr);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -3779,14 +3779,35 @@ vm_map_inherit(vm_map_t map, vm_offset_t start, vm_offset_t end,
 		}
 	}
 #endif
-	if (new_inheritance == VM_INHERIT_COPY) {
+	if (new_inheritance == VM_INHERIT_COPY ||
+	    new_inheritance == VM_INHERIT_SHARE) {
 		for (entry = start_entry; entry->start < end;
 		    prev_entry = entry, entry = vm_map_entry_succ(entry)) {
-			if ((entry->eflags & MAP_ENTRY_SPLIT_BOUNDARY_MASK)
+			if (new_inheritance == VM_INHERIT_COPY &&
+			    (entry->eflags & MAP_ENTRY_SPLIT_BOUNDARY_MASK)
 			    != 0) {
 				rv = KERN_INVALID_ARGUMENT;
 				goto unlock;
 			}
+			/*
+			 * CheriABI: mostly disallow post-fork sharing via
+			 * minherit().  Developers should use mmap and
+			 * MAP_SHARED instead.  Do allow no-op reqests
+			 * and sharing of mappings that either have no
+			 * capabilities or where objects have the
+			 * OBJ_SHARECAP flag.
+			 */
+			if (new_inheritance == VM_INHERIT_SHARE &&
+			    entry->inheritance != VM_INHERIT_SHARE &&
+			    /* XXX: check reservations instead? */
+			    SV_CURPROC_FLAG(SV_CHERI) &&
+			    (entry->object.vm_object == NULL ||
+			     (entry->object.vm_object->flags &
+			      (OBJ_NOCAP | OBJ_SHARECAP)) == 0)) {
+				rv = KERN_PROTECTION_FAILURE;
+				goto unlock;
+			}
+
 		}
 	}
 	for (entry = start_entry; entry->start < end; prev_entry = entry,

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -421,6 +421,7 @@ vmspace_alloc(vm_pointer_t min, vm_pointer_t max, pmap_pinit_t pinit)
 	 */
 	vm->vm_prev_cid = 0;
 #endif
+	LIST_INIT(&vm->vm_shm_objects);
 	return (vm);
 }
 
@@ -450,6 +451,11 @@ vmspace_dofree(struct vmspace *vm)
 	 * exit1().
 	 */
 	shmexit(vm);
+
+	/*
+	 * Clean up local posix shm objects.
+	 */
+	shm_vmspace_free(vm);
 
 	/*
 	 * Lock the map, to wait out all other references to it.
@@ -5107,6 +5113,7 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 	vm_object_t object;
 	int error, locked __diagused;
 	vm_inherit_t inh;
+	bool strip_cap_perms = false;
 
 	old_map = &vm1->vm_map;
 	/* Copy immutable fields of vm1 to vm2. */
@@ -5150,6 +5157,10 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 
 #if __has_feature(capabilities)
 	vm2->vm_prev_cid = vm1->vm_prev_cid;
+	/*
+	 * NB: we don't copy vm_shm_objects as by definition, no copied
+	 * objects will be local to the new vmspace.
+	 */
 #endif
 
 	new_map->anon_loc = old_map->anon_loc;
@@ -5180,6 +5191,11 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 				vm_map_entry_back(old_entry);
 				object = old_entry->object.vm_object;
 			}
+
+			/* XXX: add a proc flag to allow/disallow */
+			if ((old_entry->max_protection & VM_PROT_CAP) != 0 &&
+			    (object->flags & OBJ_SHARECAP) == 0)
+				strip_cap_perms = true;
 
 			/*
 			 * Add the reference before calling vm_object_shadow
@@ -5242,6 +5258,11 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 			*new_entry = *old_entry;
 			new_entry->eflags &= ~(MAP_ENTRY_USER_WIRED |
 			    MAP_ENTRY_IN_TRANSITION);
+			if (strip_cap_perms) {
+				new_entry->protection &= ~VM_PROT_CAP;
+				new_entry->max_protection &= ~VM_PROT_CAP;
+				new_entry->inheritance = VM_INHERIT_SHARE;
+			}
 			new_entry->wiring_thread = NULL;
 			new_entry->wired_count = 0;
 			if (new_entry->eflags & MAP_ENTRY_WRITECNT) {
@@ -5259,11 +5280,19 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 
 			/*
 			 * Update the physical map
+			 *
+			 * If this is a shared object that might contain
+			 * capabilities, we've removed the capability
+			 * permissions and need to let a fault set
+			 * hardware permissions up properly rather than
+			 * blindly copying them.
 			 */
-			pmap_copy(new_map->pmap, old_map->pmap,
-			    new_entry->start,
-			    (old_entry->end - old_entry->start),
-			    old_entry->start);
+			if (strip_cap_perms) {
+				pmap_copy(new_map->pmap, old_map->pmap,
+				    new_entry->start,
+				    (old_entry->end - old_entry->start),
+				    old_entry->start);
+			}
 			break;
 
 		case VM_INHERIT_COPY:

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -1936,6 +1936,10 @@ vm_map_insert1(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
 	    max != VM_PROT_NONE))
 		return (KERN_INVALID_ARGUMENT);
 
+	if ((cow & (MAP_INHERIT_SHARE | MAP_INHERIT_NONE)) ==
+	    (MAP_INHERIT_SHARE | MAP_INHERIT_NONE))
+		return (KERN_INVALID_ARGUMENT);
+
 	protoeflags = 0;
 	if (cow & MAP_COPY_ON_WRITE)
 		protoeflags |= MAP_ENTRY_COW | MAP_ENTRY_NEEDS_COPY;
@@ -1961,6 +1965,8 @@ vm_map_insert1(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
 		protoeflags |= MAP_ENTRY_STACK_GAP_UP;
 	if (cow & MAP_INHERIT_SHARE)
 		inheritance = VM_INHERIT_SHARE;
+	else if (cow & MAP_INHERIT_NONE)
+		inheritance = VM_INHERIT_NONE;
 	else
 		inheritance = VM_INHERIT_DEFAULT;
 	if ((cow & MAP_CREATE_SHADOW) != 0)

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -138,6 +138,7 @@ static uma_zone_t vmspace_zone;
 static int vmspace_zinit(void *mem, int size, int flags);
 static void _vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min,
     vm_pointer_t max);
+static inline void vm_map_entry_back(vm_map_entry_t entry);
 static void vm_map_entry_deallocate(vm_map_entry_t entry, boolean_t system_map);
 static void vm_map_entry_delete(vm_map_t map, vm_map_entry_t entry);
 static void vm_map_entry_dispose(vm_map_t map, vm_map_entry_t entry);
@@ -2120,6 +2121,18 @@ charged:
 	KASSERT(cred == NULL || !ENTRY_CHARGED(new_entry),
 	    ("overcommit: vm_map_insert leaks vm_map %p", new_entry));
 	new_entry->cred = cred;
+
+	if ((cow & MAP_SHARECAP) != 0) {
+		KASSERT(new_entry->object.vm_object == NULL,
+		    ("MAP_SHARECAP with non-NULL object"));
+		KASSERT(new_entry->inheritance == VM_INHERIT_SHARE,
+		    ("MAP_SHARECAP on unshared mapping"));
+		vm_map_entry_back(new_entry);
+		VM_OBJECT_WLOCK(new_entry->object.vm_object);
+		vm_object_set_flag(new_entry->object.vm_object, OBJ_HASCAP);
+		vm_object_set_flag(new_entry->object.vm_object, OBJ_SHARECAP);
+		VM_OBJECT_WUNLOCK(new_entry->object.vm_object);
+	}
 
 	/*
 	 * Insert the new entry into the list

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -379,6 +379,7 @@ struct vmspace {
 #if __has_feature(capabilities)
 	uint64_t vm_prev_cid;	/* (d) last compartment ID allocated */
 #endif
+	LIST_HEAD(, shmfd) vm_shm_objects;	/* (d) local shm objects */
 	/*
 	 * Keep the PMAP last, so that CPU-specific variations of that
 	 * structure on a single architecture don't result in offset

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -470,6 +470,7 @@ long vmspace_resident_count(struct vmspace *vmspace);
 #define	MAP_SPLIT_BOUNDARY_MASK	0x00180000
 #define	MAP_NO_HINT		0x00200000
 #define	MAP_CREATE_SHADOW	0x00400000
+#define	MAP_INHERIT_NONE	0x00800000
 
 #define	MAP_SPLIT_BOUNDARY_SHIFT 19
 

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -471,6 +471,7 @@ long vmspace_resident_count(struct vmspace *vmspace);
 #define	MAP_NO_HINT		0x00200000
 #define	MAP_CREATE_SHADOW	0x00400000
 #define	MAP_INHERIT_NONE	0x00800000
+#define	MAP_SHARECAP		0x01000000
 
 #define	MAP_SPLIT_BOUNDARY_SHIFT 19
 

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -318,7 +318,7 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 	 * derived from the passed capability.  In all other cases, the
 	 * new capability is derived from the per-thread mmap capability.
 	 *
-	 * If MAP_FIXED specified and addr does not meet the above
+	 * If MAP_FIXED is specified and addr does not meet the above
 	 * requirements, then MAP_EXCL is implied to prevent changing
 	 * page contents without permission.
 	 *

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -203,6 +203,8 @@ struct vm_object {
 #define	OBJ_NOCAP	0x20000		/* object and all shadow objects can
 					   not store capabilities */
 #define	OBJ_CHERISHADOW	0x40000		/* object is the shadow bitmap */
+#define	OBJ_SHARECAP	0x80000		/* capabilities in object can be
+					   shared across vmspaces */
 
 /*
  * Helpers to perform conversion between vm_object page indexes and offsets.

--- a/usr.bin/kdump/kdump.c
+++ b/usr.bin/kdump/kdump.c
@@ -1339,7 +1339,7 @@ ktrsyscall_freebsd(struct ktr_syscall *ktr, register_t **resip,
 					print_number(ip, narg, c);
 				}
 				putchar(',');
-				print_mask_arg(sysdecode_open_flags, ip[0]);
+				print_mask_arg(sysdecode_shm_open_flags, ip[0]);
 				putchar(',');
 				decode_filemode(ip[1]);
 				ip += 2;
@@ -1354,7 +1354,7 @@ ktrsyscall_freebsd(struct ktr_syscall *ktr, register_t **resip,
 					print_number(ip, narg, c);
 				}
 				putchar(',');
-				print_mask_arg(sysdecode_open_flags, ip[0]);
+				print_mask_arg(sysdecode_shm_open_flags, ip[0]);
 				putchar(',');
 				decode_filemode(ip[1]);
 				putchar(',');

--- a/usr.bin/truss/syscall.h
+++ b/usr.bin/truss/syscall.h
@@ -121,6 +121,7 @@ enum Argtype {
 	Ptraceop,
 	Sendfileflags,
 	Sendfilehdtr,
+	ShmOpen,
 	Quotactlcmd,
 	Reboothowto,
 	Resource,

--- a/usr.bin/truss/syscalls.c
+++ b/usr.bin/truss/syscalls.c
@@ -529,9 +529,9 @@ static const struct syscall_decode decoded_syscalls[] = {
 	  .args = { { Int, 0 }, { Sockoptlevel, 1 }, { Sockoptname, 2 },
 		    { Ptr | IN, 3 }, { Socklent, 4 } } },
 	{ .name = "shm_open", .ret_type = 1, .nargs = 3,
-	  .args = { { ShmName | IN, 0 }, { Open, 1 }, { Octal, 2 } } },
+	  .args = { { ShmName | IN, 0 }, { ShmOpen, 1 }, { Octal, 2 } } },
 	{ .name = "shm_open2", .ret_type = 1, .nargs = 5,
-	  .args = { { ShmName | IN, 0 }, { Open, 1 }, { Octal, 2 },
+	  .args = { { ShmName | IN, 0 }, { ShmOpen, 1 }, { Octal, 2 },
 		    { ShmFlags, 3 }, { Name | IN, 4 } } },
 	{ .name = "shm_rename", .ret_type = 1, .nargs = 3,
 	  .args = { { Name | IN, 0 }, { Name | IN, 1 }, { Hex, 2 } } },
@@ -2028,6 +2028,9 @@ print_arg(struct syscall_arg *sc, syscallarg_t *args, syscallarg_t *retval,
 		break;
 	case Whence:
 		print_integer_arg(sysdecode_whence, fp, args[sc->offset]);
+		break;
+	case ShmOpen:
+		print_mask_arg(sysdecode_shm_open_flags, fp, args[sc->offset]);
 		break;
 	case ShmFlags:
 		print_mask_arg(sysdecode_shmflags, fp, args[sc->offset]);


### PR DESCRIPTION
Sharing memory that can contain capabilities across address spaces is fraught with peril, but also somewhat common. Increase the degree to which the programmer must alter their code to express the intent share capabilities across address spaces with the aim of making such uses auditable.

TODO:
- [ ]  Add elfctl knob(s) to enable/disable cross address space sharing
- [ ]  minherit(INHERIT_NONE) when not covering a full reservation is probably a panic implementation post fork and thus should be disallowed.