### PR TITLE
arm64/vmm: Preserve PSR_C64 when injecting an exception

### DIFF
--- a/sys/arm64/vmm/vmm_arm64.c
+++ b/sys/arm64/vmm/vmm_arm64.c
@@ -1528,19 +1528,18 @@ vmmops_setcap(void *vcpui, int num, int val)
 
 		if (val != 0) {
 			hypctx->debug_spsr |= (hypctx->tf.tf_spsr & PSR_SS);
-			hypctx->debug_mdscr |= hypctx->mdscr_el1 &
-			    (MDSCR_SS | MDSCR_KDE);
+			hypctx->debug_mdscr |= (hypctx->mdscr_el1 & MDSCR_SS);
 
 			hypctx->tf.tf_spsr |= PSR_SS;
-			hypctx->mdscr_el1 |= MDSCR_SS | MDSCR_KDE;
+			hypctx->mdscr_el1 |= MDSCR_SS;
 			hypctx->mdcr_el2 |= MDCR_EL2_TDE;
 		} else {
 			hypctx->tf.tf_spsr &= ~PSR_SS;
 			hypctx->tf.tf_spsr |= hypctx->debug_spsr;
 			hypctx->debug_spsr &= ~PSR_SS;
-			hypctx->mdscr_el1 &= ~(MDSCR_SS | MDSCR_KDE);
+			hypctx->mdscr_el1 &= ~MDSCR_SS;
 			hypctx->mdscr_el1 |= hypctx->debug_mdscr;
-			hypctx->debug_mdscr &= ~(MDSCR_SS | MDSCR_KDE);
+			hypctx->debug_mdscr &= ~MDSCR_SS;
 			hypctx->mdcr_el2 &= ~MDCR_EL2_TDE;
 		}
 		break;


### PR DESCRIPTION
I'm not sure if this might be simplistic, but it resolves a problem I see with breakpoint injection from bhyve's gdb stub. This arises when the debugger has installed a breakpoint, and the guest triggers a breakpoint exception some other way, e.g., a dtrace FBT probe.