### PR TITLE
cheri: Use container bounds when accessing sockaddr_dl from sdlbuf

### DIFF
--- a/sys/netinet/ip_input.c
+++ b/sys/netinet/ip_input.c
@@ -1228,7 +1228,7 @@ ip_savecontrol(struct inpcb *inp, struct mbuf **mp, struct ip *ip,
 	if (inp->inp_flags & INP_RECVIF) {
 		struct ifnet *ifp;
 		struct sdlbuf {
-			struct sockaddr_dl sdl;
+			struct sockaddr_dl sdl __subobject_use_container_bounds;
 			u_char	pad[32];
 		} sdlbuf;
 		struct sockaddr_dl *sdp;


### PR DESCRIPTION
Fixes #2256.