### PR TITLE
include: ssp: ignore fortify for purecap

### DIFF
--- a/include/ssp/ssp.h
+++ b/include/ssp/ssp.h
@@ -36,7 +36,7 @@
 
 #include <sys/cdefs.h>
 
-#if !defined(__cplusplus)
+#if !defined(__cplusplus) && !defined(__CHERI_PURE_CAPABILITY__)
 # if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0 && \
      (__OPTIMIZE__ > 0 || defined(__clang__))
 #  if _FORTIFY_SOURCE > 1


### PR DESCRIPTION
lib/libc/secure and hence *_chk() libc function variants for SSP are not built when the world is compiled for the pure-capability ABI.

In such a case, don't define __SSP_FORTIFY_LEVEL, based on _FORTIFY_SOURCE, that is used to redefine libc functions to their *_chk() variants. This check matches the check in lib/libc/Makefile to exclude lib/libc/secure.

With this change, devel/m4 that uses _FORTIFY_SOURCE builds correctly.