### PR TITLE
Narrow bounds on kernel malloc allocations.

### DIFF
--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -616,13 +616,25 @@ malloc_large(size_t size, struct malloc_type *mtp, struct domainset *policy,
 {
 	void *va;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (size != CHERI_REPRESENTABLE_LENGTH(size)) {
+		flags |= M_ZERO;
+	}
+#endif
+
 	size = roundup(size, PAGE_SIZE);
 	va = kmem_malloc_domainset(policy, size, flags);
 	if (va != NULL) {
-		/* Use low bits unused for slab pointers. */
-		vsetzoneslab((uintptr_t)va, NULL, MALLOC_LARGE_SLAB(size));
+		/*
+		 * Use low bits unused for slab pointers.
+		 * XXX-AM: Abuse the zone pointer to stash the original pointer.
+		 * On CHERI systems, this is necessary to recover the bounds of
+		 * the original allocation.
+		 */
+		vsetzoneslab((uintptr_t)va, va, MALLOC_LARGE_SLAB(size));
 		uma_total_inc(size);
 #ifdef __CHERI_PURE_CAPABILITY__
+		va = cheri_bounds_set(va, osize);
 		KASSERT(cheri_length_get(va) <= CHERI_REPRESENTABLE_LENGTH(size),
 		    ("Invalid bounds: expected %#zx found %#zx",
 		        (size_t)CHERI_REPRESENTABLE_LENGTH(size),
@@ -645,10 +657,32 @@ malloc_large(size_t size, struct malloc_type *mtp, struct domainset *policy,
 static void
 free_large(void *addr, size_t size)
 {
-
 	kmem_free(addr, size);
 	uma_total_dec(size);
 }
+
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Recover original bounds for a malloc_large allocation.
+ *
+ * Error conditions:
+ * - Clear the capability tag if the given capability is not a subset of
+ * the saved object capability.
+ */
+static void *
+malloc_large_grow_bounds(void *saved_ptr, void *addr)
+{
+	KASSERT(cheri_is_subset(saved_ptr, addr),
+	    ("Unexpected malloc_large grow bounds: pointer %#p is "
+		"not derived from %#p", addr, saved_ptr));
+
+	addr = cheri_setaddress(saved_ptr, (vm_offset_t)addr);
+	addr = cheri_setboundsexact(addr, cheri_getlen(saved_ptr));
+	KASSERT(cheri_gettag(addr),
+	    ("Failed to recover malloc_large bounds for %#p", addr));
+	return (addr);
+}
+#endif
 #undef	IS_MALLOC_LARGE
 #undef	MALLOC_LARGE_SLAB
 
@@ -1031,6 +1065,7 @@ _free(void *addr, struct malloc_type *mtp, bool dozero)
 	case SLAB_COOKIE_MALLOC_LARGE:
 		size = malloc_large_size(slab);
 #ifdef __CHERI_PURE_CAPABILITY__
+		addr = malloc_large_grow_bounds(zone, addr);
 		if (__predict_false(cheri_length_get(addr) !=
 		    CHERI_REPRESENTABLE_LENGTH(size)))
 			panic("Invalid bounds: expected %#zx found %#zx",

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -616,12 +616,6 @@ malloc_large(size_t size, struct malloc_type *mtp, struct domainset *policy,
 {
 	void *va;
 
-#ifdef __CHERI_PURE_CAPABILITY__
-	if (size != CHERI_REPRESENTABLE_LENGTH(size)) {
-		flags |= M_ZERO;
-	}
-#endif
-
 	size = roundup(size, PAGE_SIZE);
 	va = kmem_malloc_domainset(policy, size, flags);
 	if (va != NULL) {
@@ -639,6 +633,10 @@ malloc_large(size_t size, struct malloc_type *mtp, struct domainset *policy,
 		    ("Invalid bounds: expected %#zx found %#zx",
 		        (size_t)CHERI_REPRESENTABLE_LENGTH(size),
 		        (size_t)cheri_length_get(va)));
+		if ((flags & M_ZERO) == 0 && osize < cheri_length_get(va)) {
+			bzero((void *)((uintptr_t)va + osize),
+			    cheri_length_get(va) - osize);
+		}
 #endif
 	}
 	malloc_type_allocated(mtp, va, va == NULL ? 0 : size);

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -110,7 +110,7 @@ dtrace_malloc_probe_func_t __read_mostly	dtrace_malloc_probe;
 #define	MALLOC_DEBUG	1
 #endif
 
-#if defined(KASAN) || defined(DEBUG_REDZONE)
+#if defined(KASAN) || defined(DEBUG_REDZONE) || defined(__CHERI_PURE_CAPABILITY__)
 #define	DEBUG_REDZONE_ARG_DEF	, unsigned long osize
 #define	DEBUG_REDZONE_ARG	, osize
 #else
@@ -666,7 +666,7 @@ void *
 	int indx;
 	caddr_t va;
 	uma_zone_t zone;
-#if defined(DEBUG_REDZONE) || defined(KASAN)
+#if defined(DEBUG_REDZONE) || defined(KASAN) || defined(__CHERI_PURE_CAPABILITY__)
 	unsigned long osize = size;
 #endif
 
@@ -681,6 +681,14 @@ void *
 	if (__predict_false(size > kmem_zmax))
 		return (malloc_large(size, mtp, DOMAINSET_RR(), flags
 		    DEBUG_REDZONE_ARG));
+
+	/*
+	 * XXX-AM: Imply M_ZERO to ensure that non-representable padding
+	 * space is zero-initialized.
+	 */
+	if (size != CHERI_REPRESENTABLE_LENGTH(size)) {
+		flags |= M_ZERO;
+	}
 
 	if (size & KMEM_ZMASK)
 		size = (size & ~KMEM_ZMASK) + KMEM_ZBASE;
@@ -712,6 +720,14 @@ void *
 	    ("Invalid bounds: expected %#zx found %#zx",
 	        (size_t)CHERI_REPRESENTABLE_LENGTH(size),
 	        (size_t)cheri_length_get(va)));
+
+	/* Intentionally inexect bounds allow for non-representable sizes */
+	va = cheri_setbounds(va, osize);
+	KASSERT(cheri_gettag(va),
+	    ("Invalid malloc: %#p requested size %zx", va, osize));
+	KASSERT(cheri_getlen(va) == CHERI_REPRESENTABLE_LENGTH(osize),
+	    ("Invalid malloc: %#p expected length %zx", va,
+		(size_t)CHERI_REPRESENTABLE_LENGTH(osize)));
 #endif
 	return ((void *) va);
 }
@@ -751,7 +767,7 @@ malloc_domainset(size_t size, struct malloc_type *mtp, struct domainset *ds,
 	caddr_t va;
 	int domain;
 	int indx;
-#if defined(KASAN) || defined(DEBUG_REDZONE)
+#if defined(KASAN) || defined(DEBUG_REDZONE) || defined(__CHERI_PURE_CAPABILITY__)
 	unsigned long osize = size;
 #endif
 
@@ -766,6 +782,11 @@ malloc_domainset(size_t size, struct malloc_type *mtp, struct domainset *ds,
 	if (__predict_false(size > kmem_zmax))
 		return (malloc_large(size, mtp, DOMAINSET_RR(), flags
 		    DEBUG_REDZONE_ARG));
+
+	/* XXX-AM: see malloc() */
+	if (size != CHERI_REPRESENTABLE_LENGTH(size)) {
+		flags |= M_ZERO;
+	}
 
 	vm_domainset_iter_policy_init(&di, ds, &domain, &flags);
 	do {
@@ -790,6 +811,15 @@ malloc_domainset(size_t size, struct malloc_type *mtp, struct domainset *ds,
 		kmsan_orig(va, size, KMSAN_TYPE_MALLOC, KMSAN_RET_ADDR);
 	}
 #endif
+#ifdef __CHERI_PURE_CAPABILITY__
+	/* Intentionally inexect bounds allow for non-representable sizes */
+	va = cheri_setbounds(va, osize);
+	KASSERT(cheri_gettag(va),
+	    ("Invalid malloc: %#p requested size %zx", va, osize));
+	KASSERT(cheri_getlen(va) == CHERI_REPRESENTABLE_LENGTH(osize),
+	    ("Invalid malloc: %#p expected length %zx", va,
+		(size_t)CHERI_REPRESENTABLE_LENGTH(osize)));
+#endif
 	return (va);
 }
 
@@ -807,7 +837,7 @@ void *
 malloc_domainset_exec(size_t size, struct malloc_type *mtp, struct domainset *ds,
     int flags)
 {
-#if defined(DEBUG_REDZONE) || defined(KASAN)
+#if defined(DEBUG_REDZONE) || defined(KASAN) || defined(__CHERI_PURE_CAPABILITY__)
 	unsigned long osize = size;
 #endif
 #ifdef MALLOC_DEBUG
@@ -982,6 +1012,7 @@ _free(void *addr, struct malloc_type *mtp, bool dozero)
 	case __predict_true(SLAB_COOKIE_SLAB_PTR):
 		size = zone->uz_size;
 #ifdef __CHERI_PURE_CAPABILITY__
+		addr = uma_zgrow_bounds(zone, addr);
 		if (__predict_false(cheri_length_get(addr) !=
 		    CHERI_REPRESENTABLE_LENGTH(size)))
 			panic("Invalid bounds: expected %#zx found %#zx",
@@ -1060,6 +1091,10 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 #endif
 	unsigned long alloc;
 	void *newaddr;
+#ifdef __CHERI_PURE_CAPABILITY__
+	uma_keg_t keg;
+	int i;
+#endif
 
 	KASSERT(mtp->ks_version == M_VERSION,
 	    ("realloc: bad malloc type version"));
@@ -1098,7 +1133,15 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 	/* Get the size of the original block */
 	switch (GET_SLAB_COOKIE(slab)) {
 	case __predict_true(SLAB_COOKIE_SLAB_PTR):
+#ifdef __CHERI_PURE_CAPABILITY__
 		alloc = zone->uz_size;
+		keg = zone->uz_keg;
+		i = slab_item_index(slab, keg, addr);
+		addr = slab_item(slab, keg, i);
+		addr = cheri_setboundsexact(addr, alloc);
+#else
+		alloc = zone->uz_size;
+#endif
 		break;
 	case SLAB_COOKIE_MALLOC_LARGE:
 		alloc = malloc_large_size(slab);

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -714,14 +714,6 @@ void *
 		return (malloc_large(size, mtp, DOMAINSET_RR(), flags
 		    DEBUG_REDZONE_ARG));
 
-	/*
-	 * XXX-AM: Imply M_ZERO to ensure that non-representable padding
-	 * space is zero-initialized.
-	 */
-	if (size != CHERI_REPRESENTABLE_LENGTH(size)) {
-		flags |= M_ZERO;
-	}
-
 	if (size & KMEM_ZMASK)
 		size = (size & ~KMEM_ZMASK) + KMEM_ZBASE;
 	indx = kmemsize[size >> KMEM_ZSHIFT];
@@ -757,9 +749,13 @@ void *
 	va = cheri_setbounds(va, osize);
 	KASSERT(cheri_gettag(va),
 	    ("Invalid malloc: %#p requested size %zx", va, osize));
-	KASSERT(cheri_getlen(va) == CHERI_REPRESENTABLE_LENGTH(osize),
+	KASSERT(cheri_getlen(va) <= CHERI_REPRESENTABLE_LENGTH(osize),
 	    ("Invalid malloc: %#p expected length %zx", va,
 		(size_t)CHERI_REPRESENTABLE_LENGTH(osize)));
+	if (va != NULL && (flags & M_ZERO) == 0 && osize < cheri_getlen(va)) {
+		bzero((void *)((uintptr_t)va + osize),
+		    cheri_getlen(va) - osize);
+	}
 #endif
 	return ((void *) va);
 }

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -1121,8 +1121,7 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 	unsigned long alloc;
 	void *newaddr;
 #ifdef __CHERI_PURE_CAPABILITY__
-	uma_keg_t keg;
-	int i;
+	size_t olength;
 #endif
 
 	KASSERT(mtp->ks_version == M_VERSION,
@@ -1138,6 +1137,7 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 		panic("Expect valid capability");
 	if (__predict_false(cheri_is_sealed(addr)))
 		panic("Expect unsealed capability");
+	olength = cheri_getlen(addr);
 #endif
 
 	/*
@@ -1162,18 +1162,26 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 	/* Get the size of the original block */
 	switch (GET_SLAB_COOKIE(slab)) {
 	case __predict_true(SLAB_COOKIE_SLAB_PTR):
+		alloc = zone->uz_size;
 #ifdef __CHERI_PURE_CAPABILITY__
-		alloc = zone->uz_size;
-		keg = zone->uz_keg;
-		i = slab_item_index(slab, keg, addr);
-		addr = slab_item(slab, keg, i);
-		addr = cheri_setboundsexact(addr, alloc);
-#else
-		alloc = zone->uz_size;
+		if (size > olength) {
+			addr = uma_zgrow_bounds(zone, addr);
+			KASSERT(cheri_getlen(addr) == alloc,
+			    ("realloc mismatch uma_zgrow_bounds: %zx != %zx",
+			        cheri_getlen(addr), alloc));
+		}
 #endif
 		break;
 	case SLAB_COOKIE_MALLOC_LARGE:
 		alloc = malloc_large_size(slab);
+#ifdef __CHERI_PURE_CAPABILITY__
+		if (size > olength) {
+			addr = malloc_large_grow_bounds(zone, addr);
+			KASSERT(cheri_getlen(addr) == size,
+			    ("realloc large object bounds mismatch: %zx != %zx",
+			        cheri_getlen(addr), size));
+		}
+#endif
 		break;
 	default:
 #ifdef INVARIANTS
@@ -1187,7 +1195,19 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 	if (size <= alloc &&
 	    (size > (alloc >> REALLOC_FRACTION) || alloc == MINALLOCSIZE)) {
 		kasan_mark((void *)addr, size, alloc, KASAN_MALLOC_REDZONE);
+#ifdef __CHERI_PURE_CAPABILITY__
+		addr = cheri_setbounds(addr, size);
+		/*
+		 * Zero only the non-representable portion of allocation
+		 * that was not reachable from the original capability.
+		 */
+		if (size > olength) {
+			bzero((void *)((uintptr_t)addr + olength),
+			    cheri_getlen(addr) - olength);
+		}
+#else
 		return (addr);
+#endif
 	}
 #endif /* !DEBUG_REDZONE */
 
@@ -1200,7 +1220,16 @@ realloc(void *addr, size_t size, struct malloc_type *mtp, int flags)
 	 * valid before performing the copy.
 	 */
 	kasan_mark(addr, alloc, alloc, 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+	/*
+	 * We have unbounded addr here, need to avoid copying
+	 * past the original length.
+	 * XXX-AM: is it worth it re-setting bounds on addr?
+	 */
+	bcopy(addr, newaddr, min(size, olength));
+#else
 	bcopy(addr, newaddr, min(size, alloc));
+#endif
 	free(addr, mtp);
 	return (newaddr);
 }

--- a/sys/vm/uma.h
+++ b/sys/vm/uma.h
@@ -428,6 +428,12 @@ uma_zfree_pcpu(uma_zone_t zone, void *item)
  * item capabilities?
  * Given that this is a privileged operation, I would like to maintain the
  * intentionality of the operation here.
+ *
+ * Error conditions:
+ * - Clear the item capability tag if the item does not belong
+ * to the given zone.
+ * - Clear the item capability tag if the item does not belong
+ * to the slab from vtoslab.
  */
 void *uma_zgrow_bounds(uma_zone_t zone, void *item);
 #else

--- a/sys/vm/uma.h
+++ b/sys/vm/uma.h
@@ -415,6 +415,25 @@ uma_zfree_pcpu(uma_zone_t zone, void *item)
 	uma_zfree_pcpu_arg(zone, item, NULL);
 }
 
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Reset bounds on an item to the full item size.
+ *
+ * This is intended for nested allocators to recover items capabilities before
+ * free-ing them.
+ * Note that UMA maintains the invariant that a full item capability must be
+ * passed to uma_zfree functions.
+ * XXX-AM: Should we instead relax that invariant (optionally via a zone flag),
+ * or add a different set of uma_zfree_narrow functions that allow for partial
+ * item capabilities?
+ * Given that this is a privileged operation, I would like to maintain the
+ * intentionality of the operation here.
+ */
+void *uma_zgrow_bounds(uma_zone_t zone, void *item);
+#else
+#define	uma_zgrow_bounds(zone, item) (item)
+#endif
+
 /*
  * Wait until the specified zone can allocate an item.
  */

--- a/sys/vm/uma_core.c
+++ b/sys/vm/uma_core.c
@@ -5032,6 +5032,41 @@ zone_free_item(uma_zone_t zone, void *item, void *udata, enum zfreeskip skip)
 		zone_free_limit(zone, 1);
 }
 
+#ifdef __CHERI_PURE_CAPABILITY__
+/* See uma.h */
+void *
+uma_zgrow_bounds(uma_zone_t zone, void *item)
+{
+	uma_keg_t keg = zone->uz_keg;
+	uma_slab_t slab;
+	int index;
+
+	KASSERT((zone->uz_flags & UMA_ZFLAG_VTOSLAB) != 0,
+	    ("Purecap kernel UMA zone missing UMA_ZFLAG_VTOSLAB"));
+	// XXX handle PCPU and SMR?
+
+	/*
+	 * XXX-AM: It should be safe to only check the index range
+	 * with INVARIANTS. If an item does not belong to the slab the computed
+	 * index will be garbage but it will fail setbounds with the slab_data()
+	 * capability.
+	 * Not sure whether it can be possible to construct a pointer in the
+	 * middle of two items.
+	 */
+	slab = vtoslab((vm_offset_t)item);
+	index = slab_item_index(slab, keg, item);
+	KASSERT(index >= 0 && index < keg->uk_ipers,
+	    ("Invalid item index %d for slab %#p from item %#p for zone %s",
+		index, slab, item, zone->uz_name));
+	item = cheri_setboundsexact(slab_item(slab, keg, index),
+	    keg->uk_size);
+	KASSERT(cheri_gettag(item),
+	    ("Failed to recover item %#p bounds for zone %s",
+		item, zone->uz_name));
+	return (item);
+}
+#endif
+
 /* See uma.h */
 int
 uma_zone_set_max(uma_zone_t zone, int nitems)

--- a/sys/vm/uma_core.c
+++ b/sys/vm/uma_core.c
@@ -5043,15 +5043,14 @@ uma_zgrow_bounds(uma_zone_t zone, void *item)
 
 	KASSERT((zone->uz_flags & UMA_ZFLAG_VTOSLAB) != 0,
 	    ("Purecap kernel UMA zone missing UMA_ZFLAG_VTOSLAB"));
-	// XXX handle PCPU and SMR?
+	KASSERT((zone->uz_flags & (UMA_ZONE_PCPU | UMA_ZONE_SMR)) == 0,
+	    ("Can not grow bounds on PCPU and SMR zones"));
 
 	/*
 	 * XXX-AM: It should be safe to only check the index range
 	 * with INVARIANTS. If an item does not belong to the slab the computed
 	 * index will be garbage but it will fail setbounds with the slab_data()
 	 * capability.
-	 * Not sure whether it can be possible to construct a pointer in the
-	 * middle of two items.
 	 */
 	slab = vtoslab((vm_offset_t)item);
 	index = slab_item_index(slab, keg, item);

--- a/sys/vm/uma_int.h
+++ b/sys/vm/uma_int.h
@@ -404,6 +404,7 @@ struct uma_hash_slab {
 
 typedef struct uma_hash_slab * uma_hash_slab_t;
 
+#ifdef _KERNEL
 static inline uma_hash_slab_t
 slab_tohashslab(uma_slab_t slab)
 {
@@ -438,6 +439,7 @@ slab_item_index(uma_slab_t slab, uma_keg_t keg, void *item)
 	data = (uintptr_t)slab_data(slab, keg);
 	return (((ptraddr_t)item - (ptraddr_t)data) / keg->uk_rsize);
 }
+#endif /* _KERNEL */
 
 STAILQ_HEAD(uma_bucketlist, uma_bucket);
 

--- a/sys/vm/uma_int.h
+++ b/sys/vm/uma_int.h
@@ -414,11 +414,24 @@ slab_tohashslab(uma_slab_t slab)
 static inline void *
 slab_data(uma_slab_t slab, uma_keg_t keg)
 {
+	void *data;
 
-	if ((keg->uk_flags & UMA_ZFLAG_OFFPAGE) == 0)
-		return ((void *)((uintptr_t)slab - keg->uk_pgoff));
-	else
-		return (slab_tohashslab(slab)->uhs_data);
+	if ((keg->uk_flags & UMA_ZFLAG_OFFPAGE) == 0) {
+		data = (void *)cheri_kern_setboundsexact(
+		    (uintptr_t)slab - keg->uk_pgoff, keg->uk_pgoff);
+#ifdef __CHERI_PURE_CAPABILITY__
+		KASSERT(cheri_gettag(data),
+		    ("Unrepresentable slab uk_pgoff %x", keg->uk_pgoff));
+#endif
+	} else {
+		data = slab_tohashslab(slab)->uhs_data;
+#ifdef __CHERI_PURE_CAPABILITY__
+		KASSERT(cheri_getlen(data) == keg->uk_ppera * PAGE_SIZE,
+		    ("Unexpected offpage slab capability: %#p, "
+			"expected %d pages", data, keg->uk_ppera));
+#endif
+	}
+	return (data);
 }
 
 static inline void *

--- a/sys/vm/uma_int.h
+++ b/sys/vm/uma_int.h
@@ -414,24 +414,11 @@ slab_tohashslab(uma_slab_t slab)
 static inline void *
 slab_data(uma_slab_t slab, uma_keg_t keg)
 {
-	void *data;
 
-	if ((keg->uk_flags & UMA_ZFLAG_OFFPAGE) == 0) {
-		data = (void *)cheri_kern_setboundsexact(
-		    (uintptr_t)slab - keg->uk_pgoff, keg->uk_pgoff);
-#ifdef __CHERI_PURE_CAPABILITY__
-		KASSERT(cheri_gettag(data),
-		    ("Unrepresentable slab uk_pgoff %x", keg->uk_pgoff));
-#endif
-	} else {
-		data = slab_tohashslab(slab)->uhs_data;
-#ifdef __CHERI_PURE_CAPABILITY__
-		KASSERT(cheri_getlen(data) == keg->uk_ppera * PAGE_SIZE,
-		    ("Unexpected offpage slab capability: %#p, "
-			"expected %d pages", data, keg->uk_ppera));
-#endif
-	}
-	return (data);
+	if ((keg->uk_flags & UMA_ZFLAG_OFFPAGE) == 0)
+		return ((void *)((uintptr_t)slab - keg->uk_pgoff));
+	else
+		return (slab_tohashslab(slab)->uhs_data);
 }
 
 static inline void *


### PR DESCRIPTION
This is required to prevent memory leaks through the extra space in the allocations.
In general, kernel malloc uses a number of fixed-size UMA zones to back small allocations (<= 64K) and a dedicated malloc_large for large allocations that grabs memory directly from kmem.
In both cases, the requested allocation size may be smaller than the actual committed size if the requested size is not representable. Representablity is platform-dependent and we can not make assumptions about the minimum representable size (although I think it will always be >= PAGE_SIZE).

With CHERI this is problematic because the caller will receive a capability that might be larger than the requested size and some of the additional committed space is reachable but uninitialized (unless M_ZERO).
This patch does the following:
1. Add an interface function to UMA to recover the original item bounds (provisionally named uma_zgrow_bounds, I'm open to better names).
2. Narrow bounds to the closest representable size in kernel malloc and realloc variants.
3. Recover original bounds for both small and large allocations on free, so that we maintain the invariant that the lower-level allocator always receives on free() the same capability returned on alloc. In order to do this, we (continue to) abuse the vtoslab infrastructure for malloc_large to stash the original pointer in place of the zone pointer in the vm_page_t descriptor. I really think we should have a cleaner interface for this, but it is beyond the point of this patch.
4. Explicitly zero the committed allocation space that lies between the requested allocation size and the actual capability top. In other words, we zero the representability padding of the allocation.
