### PR TITLE
libgcc_s: Re-enable c18n support

### DIFF
--- a/lib/libgcc_s/Makefile
+++ b/lib/libgcc_s/Makefile
@@ -53,7 +53,8 @@ SRCS+=		s_scalbnl.c
 .endif
 
 .if ${MACHINE_ABI:Mpurecap} && ${MACHINE_CPUARCH} == "aarch64"
-CFLAGS+=	-D_LIBUNWIND_HAS_CHERI_LIB_C18N
+SYMBOL_MAPS+=	${.CURDIR}/Symbol-c18n.map
+CFLAGS+=	-D_LIBUNWIND_CHERI_C18N_SUPPORT
 .endif
 
 .include <bsd.lib.mk>

--- a/lib/libgcc_s/Symbol-c18n.map
+++ b/lib/libgcc_s/Symbol-c18n.map
@@ -1,0 +1,5 @@
+FBSDprivate_1.0 {
+	_rtld_unw_getcontext;
+	_rtld_unw_setcontext;
+	_rtld_unw_getsealer;
+};


### PR DESCRIPTION
We've not yet imported an updated libunwind, so should keep the old
build system parts here until that's happened, otherwise we'll have
libgcc_s built without c18n support.

This partially reverts commit 6959da2853cea290b6f360311c53b8560391d861.
