### PR TITLE
Userspace runtime loader support for sub-library c18n

### DIFF
--- a/contrib/elftoolchain/common/elfdefinitions.h
+++ b/contrib/elftoolchain/common/elfdefinitions.h
@@ -965,6 +965,8 @@ _ELF_DEFINE_PT(PT_PHDR,             6,				\
 _ELF_DEFINE_PT(PT_TLS,              7, "thread local storage")	\
 _ELF_DEFINE_PT(PT_LOOS,             0x60000000UL,		\
 	"start of OS-specific range")				\
+_ELF_DEFINE_PT(PT_CHERI_PCC,        0x64348450UL,		\
+	"CHERI PCC bounds")					\
 _ELF_DEFINE_PT(PT_SUNW_UNWIND,      0x6464E550UL,		\
 	"Solaris/amd64 stack unwind tables")			\
 _ELF_DEFINE_PT(PT_GNU_EH_FRAME,     0x6474E550UL,		\

--- a/contrib/elftoolchain/common/elfdefinitions.h
+++ b/contrib/elftoolchain/common/elfdefinitions.h
@@ -187,6 +187,10 @@ _ELF_DEFINE_DT(DT_SUNW_CAP,         0x60000010UL,			\
 	"address of hardware capabilities section")			\
 _ELF_DEFINE_DT(DT_SUNW_ASLR,        0x60000023UL,			\
 	"Address Space Layout Randomization flag")			\
+_ELF_DEFINE_DT(DT_C18N_STRTAB,      0x64331380UL,			\
+	"address of compartment string table")				\
+_ELF_DEFINE_DT(DT_C18N_STRTABSZ,    0x64331381UL,			\
+	"size of the compartment string table")				\
 _ELF_DEFINE_DT(DT_HIOS,             0x6FFFF000UL,			\
 	"end of OS-specific types")					\
 _ELF_DEFINE_DT(DT_VALRNGLO,         0x6FFFFD00UL,			\
@@ -965,6 +969,8 @@ _ELF_DEFINE_PT(PT_PHDR,             6,				\
 _ELF_DEFINE_PT(PT_TLS,              7, "thread local storage")	\
 _ELF_DEFINE_PT(PT_LOOS,             0x60000000UL,		\
 	"start of OS-specific range")				\
+_ELF_DEFINE_PT(PT_C18N_NAME,        0x64331380UL,		\
+	"Sub-object compartment")				\
 _ELF_DEFINE_PT(PT_CHERI_PCC,        0x64348450UL,		\
 	"CHERI PCC bounds")					\
 _ELF_DEFINE_PT(PT_SUNW_UNWIND,      0x6464E550UL,		\

--- a/contrib/elftoolchain/elfdump/elfdump.c
+++ b/contrib/elftoolchain/elfdump/elfdump.c
@@ -191,6 +191,8 @@ d_tags(uint64_t tag)
 	case DT_FLAGS:		return "DT_FLAGS";
 	case DT_PREINIT_ARRAY:	return "DT_PREINIT_ARRAY"; /* XXX DT_ENCODING */
 	case DT_PREINIT_ARRAYSZ:return "DT_PREINIT_ARRAYSZ";
+	case DT_C18N_STRTAB:	return "DT_C18N_STRTAB";
+	case DT_C18N_STRTABSZ:	return "DT_C18N_STRTABSZ";
 	/* 0x6000000D - 0x6ffff000 operating system-specific semantics */
 	case 0x6ffffdf5:	return "DT_GNU_PRELINKED";
 	case 0x6ffffdf6:	return "DT_GNU_CONFLICTSZ";
@@ -351,6 +353,7 @@ elf_phdr_type_str(unsigned int type)
 	case PT_SHLIB:			return "PT_SHLIB";
 	case PT_PHDR:			return "PT_PHDR";
 	case PT_TLS:			return "PT_TLS";
+	case PT_C18N_NAME:		return "PT_C18N_NAME";
 	case PT_CHERI_PCC:		return "PT_CHERI_PCC";
 	case PT_GNU_EH_FRAME:		return "PT_GNU_EH_FRAME";
 	case PT_GNU_STACK:		return "PT_GNU_STACK";
@@ -1667,6 +1670,7 @@ elf_print_dynamic(struct elfdump *ed)
 		case DT_VERNEED:
 		case DT_VERNEEDNUM:
 		case DT_VERSYM:
+		case DT_C18N_STRTABSZ:
 			if (ed->flags & SOLARIS_FMT)
 				PRT("%#jx\n", (uintmax_t)dyn.d_un.d_val);
 			else
@@ -1683,6 +1687,7 @@ elf_print_dynamic(struct elfdump *ed)
 		case DT_REL:
 		case DT_JMPREL:
 		case DT_DEBUG:
+		case DT_C18N_STRTAB:
 			if (ed->flags & SOLARIS_FMT)
 				PRT("%#jx\n", (uintmax_t)dyn.d_un.d_ptr);
 			else

--- a/contrib/elftoolchain/elfdump/elfdump.c
+++ b/contrib/elftoolchain/elfdump/elfdump.c
@@ -351,6 +351,7 @@ elf_phdr_type_str(unsigned int type)
 	case PT_SHLIB:			return "PT_SHLIB";
 	case PT_PHDR:			return "PT_PHDR";
 	case PT_TLS:			return "PT_TLS";
+	case PT_CHERI_PCC:		return "PT_CHERI_PCC";
 	case PT_GNU_EH_FRAME:		return "PT_GNU_EH_FRAME";
 	case PT_GNU_STACK:		return "PT_GNU_STACK";
 	case PT_GNU_RELRO:		return "PT_GNU_RELRO";

--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -711,6 +711,7 @@ phdr_type(unsigned int mach, unsigned int ptype)
 	case PT_SHLIB: return "SHLIB";
 	case PT_PHDR: return "PHDR";
 	case PT_TLS: return "TLS";
+	case PT_CHERI_PCC: return "CHERI_PCC";
 	case PT_GNU_EH_FRAME: return "GNU_EH_FRAME";
 	case PT_GNU_STACK: return "GNU_STACK";
 	case PT_GNU_RELRO: return "GNU_RELRO";

--- a/contrib/elftoolchain/readelf/readelf.c
+++ b/contrib/elftoolchain/readelf/readelf.c
@@ -711,6 +711,7 @@ phdr_type(unsigned int mach, unsigned int ptype)
 	case PT_SHLIB: return "SHLIB";
 	case PT_PHDR: return "PHDR";
 	case PT_TLS: return "TLS";
+	case PT_C18N_NAME: return "C18N_NAME";
 	case PT_CHERI_PCC: return "CHERI_PCC";
 	case PT_GNU_EH_FRAME: return "GNU_EH_FRAME";
 	case PT_GNU_STACK: return "GNU_STACK";
@@ -886,6 +887,8 @@ dt_type(unsigned int mach, unsigned int dtype)
 	case DT_SUNW_FILTER: return "SUNW_FILTER";
 	case DT_SUNW_CAP: return "SUNW_CAP";
 	case DT_SUNW_ASLR: return "SUNW_ASLR";
+	case DT_C18N_STRTAB: return "C18N_STRTAB";
+	case DT_C18N_STRTABSZ: return "C18N_STRTABSZ";
 	case DT_CHECKSUM: return "CHECKSUM";
 	case DT_PLTPADSZ: return "PLTPADSZ";
 	case DT_MOVEENT: return "MOVEENT";
@@ -3031,6 +3034,7 @@ dump_dyn_val(struct readelf *re, GElf_Dyn *dyn, uint32_t stab)
 	case DT_GNU_HASH:
 	case DT_GNU_LIBLIST:
 	case DT_GNU_CONFLICT:
+	case DT_C18N_STRTAB:
 		printf(" 0x%jx\n", (uintmax_t) dyn->d_un.d_val);
 		break;
 	case DT_PLTRELSZ:
@@ -3045,6 +3049,7 @@ dump_dyn_val(struct readelf *re, GElf_Dyn *dyn, uint32_t stab)
 	case DT_FINI_ARRAYSZ:
 	case DT_GNU_CONFLICTSZ:
 	case DT_GNU_LIBLISTSZ:
+	case DT_C18N_STRTABSZ:
 		printf(" %ju (bytes)\n", (uintmax_t) dyn->d_un.d_val);
 		break;
  	case DT_RELACOUNT:

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -794,12 +794,9 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 		return (0);
 #endif
 
-#ifdef __CHERI_PURE_CAPABILITY__
-	data_cap = obj->relocbase;
-	text_rodata_cap = obj->text_rodata_cap;
-#elif __has_feature(capabilities)
-	data_cap = cheri_getdefault();
-	text_rodata_cap = cheri_getpcc();
+#if __has_feature(capabilities)
+	data_cap = get_datasegment_cap(obj);
+	text_rodata_cap = get_codesegment_cap(obj);
 #endif
 
 	/*

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -492,7 +492,8 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 				target = (uintptr_t)make_function_pointer(def,
 				    defobj);
 #ifdef CHERI_LIB_C18N
-				target = (uintptr_t)tramp_intern(obj,
+				target = (uintptr_t)tramp_intern(plt,
+				    plt->compart_id,
 				    &(struct tramp_data) {
 					.target = (void *)target,
 					.defobj = defobj,
@@ -571,7 +572,8 @@ reloc_jmpslots(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 			}
 			target = (uintptr_t)make_function_pointer(def, defobj);
 #ifdef CHERI_LIB_C18N
-			target = (uintptr_t)tramp_intern(obj, &(struct tramp_data) {
+			target = (uintptr_t)tramp_intern(plt, plt->compart_id,
+			    &(struct tramp_data) {
 				.target = (void *)target,
 				.defobj = defobj,
 				.def = def,
@@ -632,7 +634,8 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 #endif
 	lock_release(rtld_bind_lock, lockstate);
 #ifdef CHERI_LIB_C18N
-	ptr = (uintptr_t)tramp_intern(NULL, &(struct tramp_data) {
+	ptr = (uintptr_t)tramp_intern(NULL, RTLD_COMPART_ID,
+	    &(struct tramp_data) {
 		.target = (void *)ptr,
 		.defobj = obj,
 		.sig = (struct func_sig) { .valid = true,
@@ -729,7 +732,8 @@ reloc_gnu_ifunc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 			lock_release(rtld_bind_lock, lockstate);
 			target = (uintptr_t)rtld_resolve_ifunc(defobj, def);
 #ifdef CHERI_LIB_C18N
-			target = (uintptr_t)tramp_intern(obj, &(struct tramp_data) {
+			target = (uintptr_t)tramp_intern(plt, plt->compart_id,
+			    &(struct tramp_data) {
 				.target = (void *)target,
 				.defobj = defobj,
 				.def = def,

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -252,9 +252,12 @@ _rtld_safebox_code(void *target, struct func_sig sig)
 	}
 
 	if (sig.valid) {
+		const char *pcc;
+
+		pcc = pcc_cap(obj, (const char *)target - obj->relocbase);
 		asm ("chkssu	%0, %0, %1"
 		    : "+C" (target)
-		    : "C" (obj->text_rodata_cap)
+		    : "C" (pcc)
 		    : "cc");
 		target = cheri_seal(target,
 		    sealer_tramp + func_sig_to_otype(sig));

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -234,7 +234,7 @@ _rtld_safebox_code(void *target, struct func_sig sig)
 
 	if (!func_sig_legal(sig)) {
 		_rtld_error(
-		    "_rtld_sandbox_code: Invalid signature "
+		    "_rtld_safebox_code: Invalid signature "
 		    C18N_SIG_FORMAT_STRING,
 		    C18N_SIG_FORMAT(sig));
 		return (NULL);
@@ -246,7 +246,7 @@ _rtld_safebox_code(void *target, struct func_sig sig)
 	obj = obj_from_addr(target);
 	if (obj == NULL) {
 		_rtld_error(
-		    "_rtld_sandbox_code: "
+		    "_rtld_safebox_code: "
 		    "%#p does not belong to any object", target);
 		return (NULL);
 	}

--- a/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
@@ -62,7 +62,7 @@ make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 {
 	const void * __capability ret;
 
-	ret = get_codesegment_cap(defobj) + def->st_value;
+	ret = pcc_cap(defobj, def->st_value);
 	/* Remove store and seal permissions */
 	ret = cheri_clearperm(ret, FUNC_PTR_REMOVE_PERMS);
 	if (tight_bounds) {

--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -49,6 +49,8 @@
 
 struct Struct_Obj_Entry;
 
+#define	MD_PLT_ENTRY
+
 #define	MD_OBJ_ENTRY	\
     bool variant_pcs : 1;	/* Object has a variant pcs function */
 

--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -86,7 +86,8 @@ uintptr_t reloc_jmpslot(uintptr_t *where, uintptr_t target,
 /* TODO: Per-function captable/PLT/FNDESC support */
 #ifdef CHERI_LIB_C18N
 #define call_init_array_pointer(_obj, _target)				\
-	(((InitArrFunc)tramp_intern(NULL, &(struct tramp_data) {	\
+	(((InitArrFunc)tramp_intern(NULL, RTLD_COMPART_ID,		\
+	    &(struct tramp_data) {					\
 		.target = (void *)(_target).value,			\
 		.defobj = _obj,						\
 		.sig = (struct func_sig) { .valid = true,		\
@@ -94,7 +95,8 @@ uintptr_t reloc_jmpslot(uintptr_t *where, uintptr_t target,
 	}))(main_argc, main_argv, environ))
 
 #define call_fini_array_pointer(_obj, _target)				\
-	(((InitFunc)tramp_intern(NULL, &(struct tramp_data) {		\
+	(((InitFunc)tramp_intern(NULL, RTLD_COMPART_ID,			\
+	    &(struct tramp_data) {					\
 		.target = (void *)(_target).value,			\
 		.defobj = _obj,						\
 		.sig = (struct func_sig) { .valid = true,		\

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -181,7 +181,7 @@ ENTRY(C18N_SYM(_rtld_bind_start))
 #endif
 	add	x1, x1, x3		/* reloff = x3 + offset = (3 or 1.5) * offset */
 
-	/* Load obj */
+	/* Load plt */
 	ldr	PTR(0), [PTR(16), #-PTR_WIDTH]
 
 	/* Call into rtld */

--- a/libexec/rtld-elf/amd64/rtld_machdep.h
+++ b/libexec/rtld-elf/amd64/rtld_machdep.h
@@ -35,6 +35,8 @@
 
 struct Struct_Obj_Entry;
 
+#define	MD_PLT_ENTRY
+
 #define	MD_OBJ_ENTRY
 
 /* Return the address of the .dynamic section in the dynamic linker. */

--- a/libexec/rtld-elf/amd64/rtld_start.S
+++ b/libexec/rtld-elf/amd64/rtld_start.S
@@ -55,7 +55,7 @@
 /*
  * Binder entry point.  Control is transferred to here by code in the PLT.
  * On entry, there are two arguments on the stack.  In ascending address
- * order, they are (1) "obj", a pointer to the calling object's Obj_Entry,
+ * order, they are (1) "plt", a pointer to the calling object's Plt_Entry,
  * and (2) "reloff", the byte offset of the appropriate relocation entry
  * in the PLT relocation table.
  *
@@ -65,7 +65,7 @@
  *
  * Stack map:
  * reloff       0x60
- * obj          0x58
+ * plt          0x58
  * spare	0x50
  * rflags       0x48
  * rax          0x40
@@ -116,7 +116,7 @@ _rtld_bind_start:
 	.cfi_adjust_cfa_offset 8
 	.cfi_offset	%r11,-96
 
-	movq	0x58(%rsp),%rdi		# Fetch obj argument
+	movq	0x58(%rsp),%rdi		# Fetch plt argument
 	movq	0x60(%rsp),%rsi		# Fetch reloff argument
 	leaq	(%rsi,%rsi,2),%rsi	# multiply by 3
 	leaq	(,%rsi,8),%rsi		# now 8, for 24 (sizeof Elf_Rela)
@@ -154,7 +154,7 @@ _rtld_bind_start:
 	.cfi_restore %rax
 	popfq				# Restore rflags
 	.cfi_adjust_cfa_offset -8
-	leaq	16(%rsp),%rsp		# Discard spare, obj, do not change rflags
+	leaq	16(%rsp),%rsp		# Discard spare, plt, do not change rflags
 	ret				# "Return" to target address
 	.cfi_endproc
 	.size	_rtld_bind_start, . - _rtld_bind_start

--- a/libexec/rtld-elf/arm/rtld_machdep.h
+++ b/libexec/rtld-elf/arm/rtld_machdep.h
@@ -36,6 +36,8 @@
 
 struct Struct_Obj_Entry;
 
+#define	MD_PLT_ENTRY
+
 #define	MD_OBJ_ENTRY
 
 /* Return the address of the .dynamic section in the dynamic linker. */

--- a/libexec/rtld-elf/arm/rtld_start.S
+++ b/libexec/rtld-elf/arm/rtld_start.S
@@ -81,7 +81,7 @@ _rtld_bind_start:
 	sub	r1, r1, #4		/* r1 = 4 * n */
 	add	r1, r1, r1		/* r1 = 8 * n */
 
-	ldr	r0, [lr, #-4]		/* get obj ptr from GOT[1] */
+	ldr	r0, [lr, #-4]		/* get plt ptr from GOT[1] */
 	mov	r4, ip			/* save GOT location */
 
 	mov	r5, sp			/* Save the stack pointer */

--- a/libexec/rtld-elf/cheri/cheri_reloc.c
+++ b/libexec/rtld-elf/cheri/cheri_reloc.c
@@ -55,10 +55,9 @@ process___cap_relocs(Obj_Entry* obj)
 	    (struct capreloc *)(obj->cap_relocs + obj->cap_relocs_size);
 
 	char * __capability data_base = get_datasegment_cap(obj);
-	const char * __capability code_base = get_codesegment_cap(obj);
 
-	dbg("Processing %lu __cap_relocs for %s (code base = %#lp, data base = %#lp)\n",
-	    (end_relocs - start_relocs), obj->path, code_base, data_base);
+	dbg("Processing %lu __cap_relocs for %s (data base = %#lp)\n",
+	    (end_relocs - start_relocs), obj->path, data_base);
 
 	bool tight_pcc_bounds;
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -87,7 +86,7 @@ process___cap_relocs(Obj_Entry* obj)
 		if ((reloc->permissions & function_reloc_flag) ==
 		    function_reloc_flag) {
 			/* code pointer */
-			cap = (uintcap_t)code_base + reloc->object;
+			cap = (uintcap_t)pcc_cap(obj, reloc->object);
 			cap = cheri_clearperm(cap, FUNC_PTR_REMOVE_PERMS);
 
 			/*
@@ -98,7 +97,7 @@ process___cap_relocs(Obj_Entry* obj)
 		} else if ((reloc->permissions & constant_reloc_flag) ==
 		    constant_reloc_flag) {
 			 /* read-only data pointer */
-			cap = (uintcap_t)code_base + reloc->object;
+			cap = (uintcap_t)pcc_cap(obj, reloc->object);
 			cap = cheri_clearperm(cap, FUNC_PTR_REMOVE_PERMS);
 			cap = cheri_clearperm(cap, DATA_PTR_REMOVE_PERMS);
 		} else {

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -44,17 +44,6 @@
 #if !defined(CHERI_INIT_GLOBALS_VERSION) || CHERI_INIT_GLOBALS_VERSION < 5
 #error "cheri_init_globals.h is outdated. Please update LLVM"
 #endif
-
-/* FIXME: replace this with cheri_init_globals_impl once everyone has updated clang */
-static __attribute__((always_inline))
-void _do___caprelocs(const struct capreloc *start_relocs,
-    const struct capreloc *stop_relocs, void * __capability gdc,
-    const void * __capability pcc, ptraddr_t base_addr, bool tight_pcc_bounds)
-{
-	cheri_init_globals_impl(start_relocs, stop_relocs, /*data_cap=*/gdc,
-	    /*code_cap=*/pcc, /*rodata_cap=*/pcc,
-	    /*tight_code_bounds=*/tight_pcc_bounds, base_addr);
-}
 #endif
 
 static inline int

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -40,8 +40,6 @@
 #endif
 
 #ifdef RTLD_HAS_CAPRELOCS
-/* The clang-provided header is not warning-clean: */
-__unused static void cheri_init_globals(void);
 #include <cheri_init_globals.h>
 #if !defined(CHERI_INIT_GLOBALS_VERSION) || CHERI_INIT_GLOBALS_VERSION < 5
 #error "cheri_init_globals.h is outdated. Please update LLVM"

--- a/libexec/rtld-elf/debug.c
+++ b/libexec/rtld-elf/debug.c
@@ -73,6 +73,8 @@ dump_relocations (Obj_Entry *obj0)
 void
 dump_obj_relocations (Obj_Entry *obj)
 {
+    Plt_Entry *plt;
+    unsigned long i;
 
     rtld_printf("Object \"%s\", relocbase %p\n", obj->path, obj->relocbase);
 
@@ -88,16 +90,19 @@ dump_obj_relocations (Obj_Entry *obj)
         dump_Elf_Rela(obj, obj->rela, obj->relasize);
     }
 
-    if (obj->pltrelsize) {
-        rtld_printf("PLT Relocations: %ld\n",
-            (obj->pltrelsize / sizeof(Elf_Rel)));
-        dump_Elf_Rel(obj, obj->pltrel, obj->pltrelsize);
-    }
+    for (i = 0; i < obj->nplts; i++) {
+	plt = &obj->plts[i];
+	if (plt->relsize) {
+	    rtld_printf("PLT[%lu] Relocations: %ld\n", i,
+                (plt->relsize / sizeof(Elf_Rel)));
+	    dump_Elf_Rel(obj, plt->rel, plt->relsize);
+	}
 
-    if (obj->pltrelasize) {
-        rtld_printf("PLT Relocations with Addend: %ld\n",
-            (obj->pltrelasize / sizeof(Elf_Rela)));
-        dump_Elf_Rela(obj, obj->pltrela, obj->pltrelasize);
+	if (plt->relasize) {
+	    rtld_printf("PLT[%lu] Relocations with Addend: %ld\n", i,
+		(plt->relasize / sizeof(Elf_Rela)));
+	    dump_Elf_Rela(obj, plt->rela, plt->relasize);
+	}
     }
 }
 

--- a/libexec/rtld-elf/i386/rtld_machdep.h
+++ b/libexec/rtld-elf/i386/rtld_machdep.h
@@ -35,6 +35,8 @@
 
 struct Struct_Obj_Entry;
 
+#define	MD_PLT_ENTRY
+
 #define	MD_OBJ_ENTRY
 
 /* Return the address of the .dynamic section in the dynamic linker. */

--- a/libexec/rtld-elf/i386/rtld_start.S
+++ b/libexec/rtld-elf/i386/rtld_start.S
@@ -64,7 +64,7 @@
 /*
  * Binder entry point.  Control is transferred to here by code in the PLT.
  * On entry, there are two arguments on the stack.  In ascending address
- * order, they are (1) "obj", a pointer to the calling object's Obj_Entry,
+ * order, they are (1) "plt", a pointer to the calling object's Plt_Entry,
  * and (2) "reloff", the byte offset of the appropriate relocation entry
  * in the PLT relocation table.
  *
@@ -81,13 +81,13 @@ _rtld_bind_start:
 	pushl	%edx			# Save %edx
 	pushl	%ecx			# Save %ecx
 	pushl	20(%esp)		# Copy reloff argument
-	pushl	20(%esp)		# Copy obj argument
+	pushl	20(%esp)		# Copy plt argument
 
 	call	_rtld_bind		# Transfer control to the binder
 	/* Now %eax contains the entry point of the function being called. */
 
 	addl	$8,%esp			# Discard binder arguments
-	movl	%eax,20(%esp)		# Store target over obj argument
+	movl	%eax,20(%esp)		# Store target over plt argument
 	popl	%ecx			# Restore %ecx
 	popl	%edx			# Restore %edx
 	popl	%eax			# Restore %eax

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -540,6 +540,8 @@ obj_free(Obj_Entry *obj)
 	free(obj->origin_path);
     if (obj->z_origin)
 	free(__DECONST(void*, obj->rpath));
+    if (obj->plts)
+	free(obj->plts);
     if (obj->priv)
 	free(obj->priv);
     if (obj->path)

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -118,10 +118,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
     char *note_map;
     size_t note_map_len;
     Elf_Addr text_end;
-#ifdef __CHERI_PURE_CAPABILITY__
-    Elf_Addr text_rodata_start_offset = 0;
-    Elf_Addr text_rodata_end_offset = 0;
-#endif
 
     hdr = get_elf_header(fd, path, sb, main_path, &phdr);
     if (hdr == NULL)
@@ -161,16 +157,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 		    path, nsegs);
 		goto error;
 	    }
-#ifdef __CHERI_PURE_CAPABILITY__
-	    if (!(segs[nsegs]->p_flags & PF_W)) {
-		Elf_Addr start_addr = segs[nsegs]->p_vaddr;
-		text_rodata_start_offset = rtld_min(start_addr, text_rodata_start_offset);
-		text_rodata_end_offset = rtld_max(start_addr + segs[nsegs]->p_memsz, text_rodata_end_offset);
-		dbg("%s: processing readonly PT_LOAD[%d], new text/rodata start "
-		    " = %zx text/rodata end = %zx", path, nsegs,
-		    (size_t)text_rodata_start_offset, (size_t)text_rodata_end_offset);
-	    }
-#endif
 	    if ((segs[nsegs]->p_flags & PF_X) == PF_X) {
 		text_end = MAX(text_end,
 		    rtld_round_page(segs[nsegs]->p_vaddr +
@@ -205,13 +191,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	case PT_GNU_RELRO:
 	    relro_page = phdr->p_vaddr;
 	    relro_size = phdr->p_memsz;
-#ifdef __CHERI_PURE_CAPABILITY__
-	    text_rodata_start_offset = rtld_min(phdr->p_vaddr, text_rodata_start_offset);
-	    text_rodata_end_offset = rtld_max(phdr->p_vaddr + phdr->p_memsz, text_rodata_end_offset);
-	    dbg("%s: Adding PT_GNU_RELRO, new text/rodata start "
-		" = %zx text/rodata end = %zx", path,
-		(size_t)text_rodata_start_offset, (size_t)text_rodata_end_offset);
-#endif
 	    break;
 
 	case PT_NOTE:
@@ -379,12 +358,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	rtld_fdprintf(STDERR_FILENO, "%s: nonzero vaddrbase %zd may be broken "
 	    "for CheriABI", path, obj->vaddrbase);
     }
-    obj->text_rodata_start_offset = text_rodata_start_offset;
-    obj->text_rodata_end_offset = text_rodata_end_offset;
-    /*
-     * Note: no csetbounds yet since we also need to include .cap_table (which
-     * is part of the r/w section). Bounds are set after .dynamic is read.
-     */
     obj->text_rodata_cap = obj->relocbase;
     fix_obj_mapping_cap_permissions(obj, path);
 #endif

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -552,6 +552,14 @@ obj_free(Obj_Entry *obj)
     if (obj->path)
 	free(obj->path);
 #ifdef __CHERI_PURE_CAPABILITY__
+#ifdef CHERI_LIB_C18N
+    if (obj->comparts) {
+	for (unsigned long i = 0; i < obj->ncomparts; i++) {
+	    free(obj->comparts[i].compart_name);
+	}
+	free(obj->comparts);
+    }
+#endif
     if (obj->pcc_caps)
 	free(obj->pcc_caps);
 #endif

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -111,8 +111,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 #ifndef __CHERI_PURE_CAPABILITY__
     Elf_Word stack_flags;
 #endif
-    Elf_Addr relro_page;
-    size_t relro_size;
     caddr_t note_start;
     caddr_t note_end;
     char *note_map;
@@ -132,8 +130,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
     nsegs = -1;
     phdyn = phinterp = phtls = NULL;
     phdr_vaddr = 0;
-    relro_page = 0;
-    relro_size = 0;
     note_start = 0;
     note_end = 0;
     note_map = NULL;
@@ -186,11 +182,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 #else
 	    stack_flags = phdr->p_flags;
 #endif
-	    break;
-
-	case PT_GNU_RELRO:
-	    relro_page = phdr->p_vaddr;
-	    relro_size = phdr->p_memsz;
 	    break;
 
 	case PT_NOTE:
@@ -397,9 +388,6 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 #ifndef __CHERI_PURE_CAPABILITY__
     obj->stack_flags = stack_flags;
 #endif
-    obj->relro_page = obj->relocbase + rtld_trunc_page(relro_page);
-    obj->relro_size = rtld_trunc_page(relro_page + relro_size) -
-      rtld_trunc_page(relro_page);
     if (note_start < note_end)
 	digest_notes(obj, (const Elf_Note *)note_start, (const Elf_Note *)note_end);
     if (note_map != NULL)

--- a/libexec/rtld-elf/powerpc/rtld_machdep.h
+++ b/libexec/rtld-elf/powerpc/rtld_machdep.h
@@ -35,8 +35,10 @@
 
 struct Struct_Obj_Entry;
 
-#define	MD_OBJ_ENTRY	\
+#define	MD_PLT_ENTRY	\
     Elf_Addr *gotptr;		/* GOT pointer (secure-plt only) */
+
+#define	MD_OBJ_ENTRY
 
 /* Return the address of the .dynamic section in the dynamic linker. */
 #define rtld_dynamic(obj)    (&_DYNAMIC)

--- a/libexec/rtld-elf/powerpc64/rtld_machdep.h
+++ b/libexec/rtld-elf/powerpc64/rtld_machdep.h
@@ -35,6 +35,8 @@
 
 struct Struct_Obj_Entry;
 
+#define	MD_PLT_ENTRY
+
 #define	MD_OBJ_ENTRY	\
     Elf_Addr glink;		/* GLINK PLT call stub section */
 

--- a/libexec/rtld-elf/powerpc64/rtld_start.S
+++ b/libexec/rtld-elf/powerpc64/rtld_start.S
@@ -146,7 +146,7 @@ _ENTRY(_rtld_bind_start)
 	mr	%r3,%r11
 	mulli	%r4,%r12,24		# Multiply index by sizeof(Elf_Rela)
 
-	bl      _rtld_bind		# target addr = _rtld_bind(obj, reloff)
+	bl      _rtld_bind		# target addr = _rtld_bind(plt, reloff)
 	nop
 
 #if !defined(_CALL_ELF) || _CALL_ELF == 1

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -129,8 +129,9 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 	caprelocslim = (const struct capreloc *)((const char *)caprelocs + caprelocssz);
 	pcc = __builtin_cheri_program_counter_get();
 	/* TODO: allow using tight bounds for RTLD */
-	_do___caprelocs(caprelocs, caprelocslim, relocbase, pcc,
-	    (Elf_Addr)relocbase, false);
+	cheri_init_globals_impl(caprelocs, caprelocslim,
+	    /*data_cap=*/relocbase, /*code_cap=*/pcc, /*rodata_cap=*/pcc,
+	    /*tight_code_bounds=*/false, (Elf_Addr)relocbase);
 }
 #endif /* __CHERI_PURE_CAPABILITY__ */
 

--- a/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
@@ -61,7 +61,7 @@ make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 {
 	const void * __capability ret;
 
-	ret = get_codesegment_cap(defobj) + def->st_value;
+	ret = pcc_cap(defobj, def->st_value);
 	/* Remove store and seal permissions */
 	ret = cheri_clearperm(ret, FUNC_PTR_REMOVE_PERMS);
 	if (tight_bounds) {

--- a/libexec/rtld-elf/riscv/rtld_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_machdep.h
@@ -44,6 +44,8 @@
 
 struct Struct_Obj_Entry;
 
+#define	MD_PLT_ENTRY
+
 #define	MD_OBJ_ENTRY
 
 #ifndef __CHERI_PURE_CAPABILITY__

--- a/libexec/rtld-elf/riscv/rtld_start.S
+++ b/libexec/rtld-elf/riscv/rtld_start.S
@@ -147,7 +147,7 @@ ENTRY(.rtld_start)
 END(.rtld_start)
 
 /*
- * t0 = obj pointer
+ * t0 = plt pointer
  * t1 = reloc offset
  */
 ENTRY(_rtld_bind_start)
@@ -190,7 +190,7 @@ ENTRY(_rtld_bind_start)
 	slli	a1, t1, 1	/* Mult items by 2 */
 	add	a1, a1, t1	/* Plus item */
 
-	/* Load obj */
+	/* Load plt */
 	MV_PTR	PTR(a0), PTR(t0)
 
 	/* Call into rtld */

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1478,6 +1478,22 @@ create_pcc_caps(Obj_Entry *obj)
 		case PT_CHERI_PCC:
 			pcc_cap = obj->text_rodata_cap + ph->p_vaddr;
 			pcc_cap = cheri_setbounds(pcc_cap, ph->p_memsz);
+
+			/*
+			 * TODO: Use cheri_setbounds_exact once we can
+			 * assume that never traps (ISAv9).
+			 */
+			if (cheri_getbase(pcc_cap) !=
+			    cheri_getaddress(pcc_cap)) {
+				_rtld_error("pcc_cap %#p start is not aligned for %s",
+				    pcc_cap, obj->path);
+				return (false);
+			}
+			if (cheri_getlen(pcc_cap) != ph->p_memsz) {
+				_rtld_error("pcc_cap %#p length is not %zu for %s",
+				    pcc_cap, (size_t)ph->p_memsz, obj->path);
+				return (false);
+			}
 			obj->pcc_caps[i] = pcc_cap;
 			i++;
 			break;

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1961,12 +1961,6 @@ digest_phdr(const Elf_Phdr *phdr, int phnum, dlfunc_t entry, const char *path)
 #endif
 	    break;
 
-	case PT_GNU_RELRO:
-	    obj->relro_page = obj->relocbase + rtld_trunc_page(ph->p_vaddr);
-	    obj->relro_size = rtld_trunc_page(ph->p_vaddr + ph->p_memsz) -
-	      rtld_trunc_page(ph->p_vaddr);
-	    break;
-
 	case PT_NOTE:
 	    note_start = obj->relocbase + ph->p_vaddr;
 	    note_end = note_start + ph->p_filesz;
@@ -2680,11 +2674,6 @@ parse_rtld_phdr(Obj_Entry *obj)
 #else
 			obj->stack_flags = ph->p_flags;
 #endif
-			break;
-		case PT_GNU_RELRO:
-			obj->relro_page = obj->relocbase +
-			    rtld_trunc_page(ph->p_vaddr);
-			obj->relro_size = rtld_round_page(ph->p_memsz);
 			break;
 		case PT_NOTE:
 			note_start = (Elf_Note *)((char *)obj->relocbase + ph->p_vaddr);
@@ -3737,7 +3726,7 @@ relocate_object(Obj_Entry *obj, bool bind_now, Obj_Entry *rtldobj,
 	    lockstate) == -1)
 		return (-1);
 
-	if (!obj->mainprog && obj_enforce_relro(obj) == -1)
+	if (obj != rtldobj && !obj->mainprog && obj_enforce_relro(obj) == -1)
 		return (-1);
 
 	/*
@@ -6392,16 +6381,28 @@ _rtld_is_dlopened(void *arg)
 static int
 obj_remap_relro(Obj_Entry *obj, int prot)
 {
-	if (obj->relro_size == 0)
-		return (0);
+	const Elf_Phdr *ph;
+	caddr_t relro_page;
+	size_t relro_size;
 
-	dbg("Enforcing RELRO for %s (%p -> %p)", obj->path, obj->relro_page,
-	    obj->relro_page + obj->relro_size);
-	if (obj->relro_size > 0 && mprotect(obj->relro_page, obj->relro_size,
-	    prot) == -1) {
-		_rtld_error("%s: Cannot set relro protection to %#x: %s",
-		    obj->path, prot, rtld_strerror(errno));
-		return (-1);
+	for (ph = obj->phdr;  (const char *)ph < (const char *)obj->phdr +
+	    obj->phsize; ph++) {
+		switch (ph->p_type) {
+		case PT_GNU_RELRO:
+			relro_page = obj->relocbase +
+			    rtld_trunc_page(ph->p_vaddr);
+			relro_size =
+			    rtld_round_page(ph->p_vaddr + ph->p_memsz) -
+			    rtld_trunc_page(ph->p_vaddr);
+			dbg("Enforcing RELRO for %s (%p -> %p)", obj->path,
+			    relro_page, relro_page + relro_size);
+			if (mprotect(relro_page, relro_size, prot) == -1) {
+				_rtld_error("%s: Cannot set relro protection to %#x: %s",
+				    obj->path, prot, rtld_strerror(errno));
+				return (-1);
+			}
+			break;
+		}
 	}
 	return (0);
 }

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -238,9 +238,6 @@ typedef struct Struct_Obj_Entry {
     size_t tlsalign;		/* Alignment of static TLS block */
     size_t tlspoffset;		/* p_offset of the static TLS block */
 
-    caddr_t relro_page;
-    size_t relro_size;
-
     /* Items from the dynamic section. */
     uintptr_t *pltgot;		/* PLT or GOT, depending on architecture */
     const Elf_Rel *rel;		/* Relocation entries */

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -191,6 +191,18 @@ typedef struct Struct_Plt_Entry {
     MD_PLT_ENTRY;
 } Plt_Entry;
 
+#ifdef CHERI_LIB_C18N
+typedef struct Struct_Compart_Entry {
+    struct Struct_Obj_Entry *obj;
+
+    const char *name;
+    Elf_Addr start;
+    Elf_Addr end;
+    char *compart_name;
+    uint16_t compart_id;
+} Compart_Entry;
+#endif
+
 #define VER_INFO_HIDDEN	0x01
 
 /*
@@ -264,6 +276,12 @@ typedef struct Struct_Obj_Entry {
     const Elf_Sym *symtab;	/* Symbol table */
     const char *strtab;		/* String table */
     unsigned long strsize;	/* Size in bytes of string table */
+#ifdef CHERI_LIB_C18N
+    Compart_Entry *comparts;
+    unsigned long ncomparts;
+    const char *c18nstrtab;	/* Compartment string table */
+    unsigned long c18nstrsize;	/* Size in bytes of compartment string table */
+#endif
 #ifdef RTLD_HAS_CAPRELOCS
     caddr_t cap_relocs;		/* start of the __cap_relocs section */
     size_t cap_relocs_size;	/* size of the __cap_relocs section */
@@ -301,6 +319,7 @@ typedef struct Struct_Obj_Entry {
     int vernum;			/* Number of entries in vertab */
 
 #ifdef CHERI_LIB_C18N
+    const char *soname;
     uint16_t compart_id;
     const struct func_sig *sigtab;
 #endif

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -214,11 +214,9 @@ typedef struct Struct_Obj_Entry {
     /*
      * For CHERI we need a capability for the executable + rodata segments so
      * that we can derive code capabilities from it.
-     * By having these additional members we can remove execute permissions from
+     * By having this additional member we can remove execute permissions from
      * relocbase and mapbase.
      */
-    Elf_Addr text_rodata_start_offset;
-    Elf_Addr text_rodata_end_offset;
     const char *text_rodata_cap;	/* Capability for the executable mapping */
 #endif
     caddr_t relocbase;		/* Relocation constant = mapbase - vaddrbase */

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -230,6 +230,8 @@ typedef struct Struct_Obj_Entry {
      * relocbase and mapbase.
      */
     const char *text_rodata_cap;	/* Capability for the executable mapping */
+    const char **pcc_caps;
+    unsigned long npcc_caps;
 #endif
     caddr_t relocbase;		/* Relocation constant = mapbase - vaddrbase */
     const Elf_Dyn *dynamic;	/* Dynamic section */
@@ -508,6 +510,10 @@ extern Elf_Sym sym_zero;	/* For resolving undefined weak refs. */
 extern bool ld_bind_not;
 extern bool ld_fast_sigblock;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+bool create_pcc_caps(Obj_Entry *);
+const char *pcc_cap(const Obj_Entry *, Elf_Off);
+#endif
 void dump_relocations(Obj_Entry *);
 void dump_obj_relocations(Obj_Entry *);
 void dump_Elf_Rel(Obj_Entry *, const Elf_Rel *, u_long);
@@ -530,6 +536,7 @@ void dump_Elf_Rela(Obj_Entry *, const Elf_Rela *, u_long);
 	    cheri_setaddress(cheri_getdefault(),		\
 	        (ptraddr_t)(uintptr_t)obj->mapbase),		\
 	    obj->mapsize)
+#define	pcc_cap(obj, offset)	(get_codesegment_cap((obj)) + (offset))
 #endif
 
 __END_DECLS

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -188,6 +188,9 @@ typedef struct Struct_Plt_Entry {
     const Elf_Rela *rela;	/* PLT relocation entries with addend */
     unsigned long relasize;	/* Size in bytes of PLT addend reloc info */
     bool jmpslots_done : 1;	/* Already have relocated the jump slots */
+#ifdef CHERI_LIB_C18N
+    uint16_t compart_id;
+#endif
     MD_PLT_ENTRY;
 } Plt_Entry;
 
@@ -320,7 +323,7 @@ typedef struct Struct_Obj_Entry {
 
 #ifdef CHERI_LIB_C18N
     const char *soname;
-    uint16_t compart_id;
+    uint16_t default_compart_id;
     const struct func_sig *sigtab;
 #endif
 

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -565,6 +565,10 @@ tramp_should_include(const Obj_Entry *reqobj, const struct tramp_data *data)
 {
 	const char *sym;
 
+	/* XXX: This will not be needed once function pointers are wrapped. */
+	if (data->target == NULL)
+		return (false);
+
 	if (data->def == NULL)
 		return (true);
 

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -61,6 +61,7 @@ typedef uint16_t compart_id_t;
 typedef struct { uint16_t val; } stk_table_index;
 
 compart_id_t compart_id_allocate(const char *);
+compart_id_t compart_id_for_address(const Obj_Entry *, Elf_Addr);
 
 /*
  * Stack switching
@@ -243,7 +244,7 @@ void tramp_hook(void);
 
 size_t tramp_compile(char **, const struct tramp_data *);
 
-void *tramp_intern(const Obj_Entry *reqobj, const struct tramp_data *);
+void *tramp_intern(const Plt_Entry *, compart_id_t, const struct tramp_data *);
 struct tramp_header *tramp_reflect(const void *);
 struct func_sig sigtab_get(const Obj_Entry *, unsigned long);
 

--- a/libexec/rtld-elf/rtld_lock.c
+++ b/libexec/rtld-elf/rtld_lock.c
@@ -428,7 +428,7 @@ _rtld_thread_init(struct RtldLockInfo *pli)
 #ifdef CHERI_LIB_C18N
 		tmplockinfo = *pli;
 #define WRAP(_target, _valid, _reg_args, _mem_args, _ret_args)	\
-	_target = tramp_intern(NULL, &(struct tramp_data) {			\
+	_target = tramp_intern(NULL, RTLD_COMPART_ID, &(struct tramp_data) {	\
 		.target = _target,						\
 		.defobj = obj,							\
 		.sig = (struct func_sig) {					\

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -533,6 +533,7 @@ typedef struct {
 #define	PT_PHDR		6	/* Location of program header itself. */
 #define	PT_TLS		7	/* Thread local storage segment */
 #define	PT_LOOS		0x60000000	/* First OS-specific. */
+#define	PT_CHERI_PCC	0x64348450	/* CHERI PCC bounds. */
 #define	PT_SUNW_UNWIND	0x6464e550	/* amd64 UNWIND program header */
 #define	PT_GNU_EH_FRAME	0x6474e550
 #define	PT_GNU_STACK	0x6474e551

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -533,6 +533,7 @@ typedef struct {
 #define	PT_PHDR		6	/* Location of program header itself. */
 #define	PT_TLS		7	/* Thread local storage segment */
 #define	PT_LOOS		0x60000000	/* First OS-specific. */
+#define	PT_C18N_NAME	0x64331380	/* Sub-object compartment. */
 #define	PT_CHERI_PCC	0x64348450	/* CHERI PCC bounds. */
 #define	PT_SUNW_UNWIND	0x6464e550	/* amd64 UNWIND program header */
 #define	PT_GNU_EH_FRAME	0x6474e550
@@ -631,6 +632,8 @@ typedef struct {
 #define	DT_SUNW_FILTER		0x6000000f	/* symbol filter name */
 #define	DT_SUNW_CAP		0x60000010	/* hardware/software */
 #define	DT_SUNW_ASLR		0x60000023	/* ASLR control */
+#define	DT_C18N_STRTAB		0x64331380	/* Compartment string table */
+#define	DT_C18N_STRTABSZ	0x64331381	/* Compartment string table size */
 #define	DT_HIOS		0x6ffff000	/* Last OS-specific */
 
 /*


### PR DESCRIPTION
- **rtld: Remove code to track start and end offsets of text and rodata**
- **rtld: Support multiple PT_GNU_RELRO program headers**
- **rtld: Support multiple PLTs**
- **elf: Add definition of PT_CHERI_BOUNDS program header type**
- **elftoolchain: Add support for PT_CHERI_BOUNDS**
- **rtld: Support narrower PCC bounds via PT_CHERI_BOUNDS**
- **rtld: Require PT_CHERI_BOUNDS to be exact**
- **elf: Add definitions for PT_COMPARTMENT and DT_C18NSTRTAB***
- **elftoolchain: Add support for PT_COMPARTMENT and DT_C18NSTRTAB***
- **rtld: Add compartments for sub-object compartments described by PT_COMPARTMENT**
- **rtld_c18n: Fix copy/paste typo in _rtld_safebox_code error messages**
- **rtld: Use compartment IDs from sub-object compartments for policy enforcement**
