### PR TITLE
Bump __CheriBSD_version to 20241108

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20240617
+#define __CheriBSD_version 20241108
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,


### PR DESCRIPTION
Bump __CheriBSD_version to the current date to rebuild packages for dev without affecting the CheriBSD 24.05 release.

Packages for this ABI version are deployed now.