### PR TITLE
First cut at a "procstat compartments” command: list c18n compartments.

### DIFF
--- a/lib/libprocstat/Symbol.map
+++ b/lib/libprocstat/Symbol.map
@@ -51,4 +51,5 @@ FBSD_1.7 {
 	 procstat_get_revoker_epoch;
 	 procstat_get_revoker_state;
 	 procstat_getc18n;
+	 procstat_getcompartments;
 };

--- a/lib/libprocstat/libprocstat.3
+++ b/lib/libprocstat/libprocstat.3
@@ -1,5 +1,11 @@
+.\" Copyright (c) 2024 Capabilities Limited
 .\" Copyright (c) 2011 Sergey Kandaurov <pluknet@FreeBSD.org>
 .\" All rights reserved.
+.\"
+.\" This software was developed by SRI International, the University of
+.\" Cambridge Computer Laboratory (Department of Computer Science and
+.\" Technology), and Capabilities Limited under Defense Advanced Research
+.\" Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -22,7 +28,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 3, 2022
+.Dd December 5, 2024
 .Dt LIBPROCSTAT 3
 .Os
 .Sh NAME
@@ -47,6 +53,8 @@
 .Nm procstat_getargv ,
 .Nm procstat_getauxv ,
 .Nm procstat_getenvv ,
+.Nm procstat_getc18n ,
+.Nm procstat_getcompartments ,
 .Nm procstat_getfiles ,
 .Nm procstat_getgroups ,
 .Nm procstat_getkstack ,
@@ -67,6 +75,7 @@
 .In sys/param.h
 .In sys/queue.h
 .In sys/socket.h
+.In cheri/c18n.h
 .In libprocstat.h
 .Ft void
 .Fn procstat_close "struct procstat *procstat"
@@ -169,6 +178,19 @@
 .Fa "struct procstat *procstat"
 .Fa "struct kinfo_proc *kp"
 .Fa "unsigned int *count"
+.Fc
+.Ft "int"
+.Fo procstat_getc18n
+.Fa "struct procstat *procstat"
+.Fa "struct kinfo_proc *kp"
+.Fa "struct rtld_c18n_stats *stats"
+.Fc
+.Ft "int"
+.Fo procstat_getcompartments
+.Fa "struct procstat *procstat"
+.Fa "struct kinfo_proc *kp"
+.Fa "struct cheri_c18n_compart *comparts"
+.Fa "u_int *ncompartsp"
 .Fc
 .Ft "char **"
 .Fo procstat_getenvv
@@ -570,6 +592,28 @@ argument indicates an actual error message in case of failure.
 .It Li PS_FST_TYPE_SHM
 .Nm procstat_get_shm_info
 .El
+.Pp
+The
+.Fn procstat_getc18n
+function retrieves
+compartmentalization (\c
+.Xr c18n )
+statistics for a target process, including its number of intra-process
+compartments, instantiated trampolines, and other values.
+The
+.Fn procstat_getcompartments
+function retrieves a compartment list for target process.
+The
+.Fa comparts
+argument is a pointer to a caller-allocated array of
+.Ft struct cheri_c18n_compart
+entries of size
+.Fa *ncompartsp
+passed by reference.
+On return, the compartment list is terminated with a compartment ID of
+.Dv CHERI_C18N_COMPART_LAST .
+If a terminating entry is not found in the returned array, then there was
+insufficient space, and the caller should allocate a larger array and retry.
 .Sh SEE ALSO
 .Xr fstat 1 ,
 .Xr fuser 1 ,
@@ -583,6 +627,7 @@ argument indicates an actual error message in case of failure.
 .Xr sysctl 3 ,
 .Xr pts 4 ,
 .Xr core 5 ,
+.Xr c18n 7 ,
 .Xr vnode 9
 .Sh HISTORY
 The
@@ -595,6 +640,9 @@ The
 .Nm libprocstat
 library was written by
 .An Stanislav Sedov Aq Mt stas@FreeBSD.org .
+.Xr c18n 3 -related
+monitoring APIs were added by
+.An Robert N. M. Watson Aq Mt rwatson@FreeBSD.org .
 .Pp
 This manual page was written by
 .An Sergey Kandaurov Aq Mt pluknet@FreeBSD.org .

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -217,6 +217,9 @@ void	procstat_freevmmap(struct procstat *procstat,
 struct advlock_list	*procstat_getadvlock(struct procstat *procstat);
 int	procstat_getc18n(struct procstat *procstat, struct kinfo_proc *kp,
     struct rtld_c18n_stats *stats);
+int	procstat_getcompartments(struct procstat *procstat,
+    struct kinfo_proc *kp, struct cheri_c18n_compart *comparts,
+    u_int *ncomparts);
 struct filestat_list	*procstat_getfiles(struct procstat *procstat,
     struct kinfo_proc *kp, int mmapped);
 struct kinfo_proc	*procstat_getprocs(struct procstat *procstat,

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -43,6 +43,7 @@ extern const char *ld_compartment_unwind;
 extern const char *ld_compartment_stats;
 extern const char *ld_compartment_switch_count;
 extern struct rtld_c18n_stats *c18n_stats;
+extern struct cheri_c18n_info *c18n_info;
 
 /*
  * Policies

--- a/sys/cheri/c18n.h
+++ b/sys/cheri/c18n.h
@@ -2,6 +2,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2024 Dapeng Gao
+ * Copyright (c) 2024 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +41,7 @@
 #define	_Atomic(t)			t
 #endif
 
-#define RTLD_C18N_STATS_VERSION		1
+#define RTLD_C18N_STATS_VERSION		2
 #define RTLD_C18N_STATS_MAX_SIZE	256
 
 /*
@@ -58,12 +64,33 @@ struct rtld_c18n_stats {
  * information. The version field doubles as a synchronisation flag where a
  * non-zero value indicates that the other fields have been initialised.
  */
-#define CHERI_C18N_INFO_VERSION		1
+#define CHERI_C18N_INFO_VERSION		2
 
 struct cheri_c18n_info {
 	_Atomic(uint8_t) version;
 	size_t stats_size;
 	struct rtld_c18n_stats * __kerncap	stats;
+
+	/*
+	 * Access to the compartment-list array.  Currently, racy to the point
+	 * of sadness.  Ideally we might use a generation field so that races
+	 * could be masked by the kernel.  We don't do this yet.
+	 */
+	size_t compart_size;	/* Size of compartment array entries. */
+	size_t capacity;	/* Number of compartment array entries. */
+	void * __kerncap comparts;
+};
+
+/*
+ * The interface provided by the kernel via sysctl for compartmentalization
+ * monitoring tools such as procstat.
+ */
+#define	CHERI_C18N_COMPART_MAXNAME	64
+#define	CHERI_C18N_COMPART_LAST		-1
+struct cheri_c18n_compart {
+	int	ccc_id;
+	char	ccc_name[CHERI_C18N_COMPART_MAXNAME];
+	u_char	_ccc_pad[60];	/* Shrink as new fields added above. */
 };
 
 #ifndef IN_RTLD

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1065,6 +1065,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_PROC_REVOKER_STATE	47	/* revoker state */
 #define	KERN_PROC_REVOKER_EPOCH	48	/* revoker epoch */
 #define	KERN_PROC_C18N		49	/* compartmentalisation statistics */
+#define	KERN_PROC_C18N_COMPARTS	50	/* compartment list */
 
 /*
  * KERN_IPC identifiers

--- a/usr.bin/procstat/Makefile
+++ b/usr.bin/procstat/Makefile
@@ -11,6 +11,7 @@ SRCS=	procstat.c		\
 	procstat_bin.c		\
 	procstat_c18n.c		\
 	procstat_cheri.c	\
+	procstat_compartments.c	\
 	procstat_cred.c		\
 	procstat_cs.c		\
 	procstat_files.c	\

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -176,6 +176,10 @@ Display CHERI-specific information about the process.
 If the
 .Fl v
 flag is passed then extra information is shown.
+.It Ar compartments
+Display information on
+.Xr c18n 7
+compartments within the process.
 .It Ar environment | Fl e
 Display environment variables for the process.
 .Pp
@@ -379,6 +383,21 @@ revoker being initialized
 revoker initialized, epoch open
 .It closing
 revoker finishing an epoch
+.El
+.Ss Compartment List
+Display the list of
+.Xr c18n 7
+compartments within a process:
+.Pp
+.Bl -tag -width CNAME -compact
+.It PID
+process ID
+.It COMM
+command
+.It CID
+compartment ID
+.It CNAME
+compartment name
 .El
 .Ss Environment Variables
 Display the process ID, command, and environment variables:

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -97,6 +97,8 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_NORMAL },
 	{ "cheri", "cheri", "[-v]", &procstat_cheri, &cmdopt_verbose,
 	    PS_CMP_NORMAL },
+	{ "compartments", "compartments", NULL, &procstat_compartments,
+	    cmdopt_none, PS_CMP_NORMAL },
 	{ "cpuset", "cs", NULL, &procstat_cs, &cmdopt_cpuset, PS_CMP_NORMAL },
 	{ "cs", "cs", NULL, &procstat_cs, &cmdopt_cpuset, PS_CMP_NORMAL },
 	{ "credential", "credentials", NULL, &procstat_cred, &cmdopt_none,

--- a/usr.bin/procstat/procstat.h
+++ b/usr.bin/procstat/procstat.h
@@ -62,6 +62,8 @@ void	procstat_basic(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_bin(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_c18n(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cheri(struct procstat *prstat, struct kinfo_proc *kipp);
+void	procstat_compartments(struct procstat *procstat,
+	    struct kinfo_proc *kipp);
 void	procstat_cred(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_cs(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_env(struct procstat *prstat, struct kinfo_proc *kipp);

--- a/usr.bin/procstat/procstat_compartments.c
+++ b/usr.bin/procstat/procstat_compartments.c
@@ -1,0 +1,77 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/user.h>
+
+#include <cheri/c18n.h>
+
+#include <err.h>
+#include <libprocstat.h>
+
+#include "procstat.h"
+
+#define	C18N_MAX_COMPARTS	1024	/* Horrible but functional, for now. */
+void
+procstat_compartments(struct procstat *procstat __unused,
+    struct kinfo_proc *kipp)
+{
+	struct cheri_c18n_compart *cccp, *ccc_incp;
+	u_int i, ncomparts;
+
+	ncomparts = C18N_MAX_COMPARTS;
+	cccp = malloc(ncomparts * sizeof(*cccp));
+	if (cccp == NULL) {
+		warn("malloc");
+		return;
+	}
+	if ((procstat_opts & PS_OPT_NOHEADER) == 0)
+		xo_emit("{T:/%5s %-19s %4s %-32s}\n", "PID", "COMM", "CID",
+		    "CNAME");
+	if (procstat_getcompartments(procstat, kipp, cccp, &ncomparts) != 0) {
+		if (errno != EPERM)
+			warn("procstat_getcomparts");
+		goto out;
+	}
+	ccc_incp = cccp;
+	for (i = 0; i < ncomparts; i++, ccc_incp++) {
+		if (ccc_incp->ccc_id == CHERI_C18N_COMPART_LAST)
+			break;
+		xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
+		xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
+		xo_emit(" {:cid/%4d/%d}", ccc_incp->ccc_id);
+		xo_emit(" {:cname/%-32s/%s}", ccc_incp->ccc_name);
+		xo_emit("\n");
+	}
+out:
+	free(cccp);
+}


### PR DESCRIPTION
Adds a new `sysctl` that allows querying the compartment list maintained by `rtld` in the target process, and a new `libprocstat` API to query it. Implements `procstat compartments` using that sysctl.