### PR TITLE
netgraph: Fix CHERI tag violations due to tight subobject bounds in sockaddr_* structs

### DIFF
--- a/sys/netgraph/bluetooth/include/ng_btsocket.h
+++ b/sys/netgraph/bluetooth/include/ng_btsocket.h
@@ -51,7 +51,7 @@
 struct sockaddr_hci {
 	u_char		hci_len;	/* total length */
 	u_char		hci_family;	/* address family */
-	char		hci_node[32];	/* address (size == NG_NODESIZ ) */
+	char		hci_node[32] __subobject_variable_length_maxsize(32);	/* address (size == NG_NODESIZ ) */
 };
 
 /* Raw HCI socket options */

--- a/sys/netgraph/ng_socket.h
+++ b/sys/netgraph/ng_socket.h
@@ -60,7 +60,7 @@ enum {
 struct sockaddr_ng {
 	unsigned char	sg_len;		/* total length */
 	sa_family_t	sg_family;	/* address family */
-	char		sg_data[32];	/* see NG_NODESIZ in ng_message.h */
+	char		sg_data[32] __subobject_variable_length_maxsize(32);	/* see NG_NODESIZ in ng_message.h */
 };
 
 #endif /* _NETGRAPH_NG_SOCKET_H_ */


### PR DESCRIPTION
In a purecap kernel built with subobject bounds, casting sockaddr to sockaddr_* structures will lead to capability bounds fault crashes when accessing data fields that fall out of struct sockaddr. 

This fixed #2279.