### PR TITLE
netlink: Re-derive the base capability of the snl msg_buffer in realloc

### DIFF
--- a/sys/netlink/netlink_snl.h
+++ b/sys/netlink/netlink_snl.h
@@ -1095,6 +1095,16 @@ snl_realloc_msg_buffer(struct snl_writer *nw, size_t sz)
 		}
 		nw->base = (char *)new_base;
 	}
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (cheri_getlen(new_base) != cheri_getlen(nw->base)) {
+		nw->base = (char *)cheri_setboundsexact(new_base, nw->size);
+		if (nw->hdr != NULL) {
+			int hdr_off = (char *)(nw->hdr) - nw->base;
+			nw->hdr = (struct nlmsghdr *)
+						(void *)((char *)nw->base + hdr_off);
+		}
+	}
+#endif
 
 	return (true);
 }


### PR DESCRIPTION
If the new base pointer obtained in snl_realloc_msg_buffer does not have the same bounds as the original base pointer, we need to re-derive all the capabilities that are relative to the base. This was found while fuzzing. 

Tagging @YiChenChai.