### PR TITLE
pf: Fix for purecap kernel with subobject bounds

### DIFF
--- a/sys/net/pfvar.h
+++ b/sys/net/pfvar.h
@@ -1598,7 +1598,7 @@ struct pf_pdesc {
 #ifdef INET6
 		struct icmp6_hdr	icmp6;
 #endif /* INET6 */
-		char any[0];
+		char any[0] __no_subobject_bounds;
 	} hdr;
 
 	struct pf_krule	*nat_rule;	/* nat/rdr rule applied to packet */

--- a/sys/net/pfvar.h
+++ b/sys/net/pfvar.h
@@ -1918,6 +1918,7 @@ struct pfioc_qstats_v1 {
 	 * written entirely in terms of the v0 or v1 type.
 	 */
 	u_int32_t	 version;  /* Requested version of stats struct */
+	void	*pad;
 };
 
 /* Latest version of struct pfioc_qstats_vX */

--- a/sys/netpfil/pf/pf.h
+++ b/sys/netpfil/pf/pf.h
@@ -296,7 +296,7 @@ struct pf_addr {
 		u_int8_t		addr8[16];
 		u_int16_t		addr16[8];
 		u_int32_t		addr32[4];
-	};		    /* 128-bit address */
+	} __no_subobject_bounds;		    /* 128-bit address */
 };
 
 #define PFI_AFLAG_NETWORK	0x01

--- a/sys/netpfil/pf/pf_norm.c
+++ b/sys/netpfil/pf/pf_norm.c
@@ -1478,10 +1478,10 @@ pf_normalize_tcp(struct pfi_kkif *kif, struct mbuf *m, int ipoff,
 	    (tcp_get_flags(th) & (TH_RES1|TH_RES2|TH_RES2)) != 0) {
 		u_int16_t	ov, nv;
 
-		ov = *(u_int16_t *)(&th->th_ack + 1);
+		ov = *(u_int16_t *)(__unbounded_addressof(th->th_ack) + 1);
 		flags &= ~(TH_RES1 | TH_RES2 | TH_RES3);
 		tcp_set_flags(th, flags);
-		nv = *(u_int16_t *)(&th->th_ack + 1);
+		nv = *(u_int16_t *)(__unbounded_addressof(th->th_ack) + 1);
 
 		th->th_sum = pf_proto_cksum_fixup(m, th->th_sum, ov, nv, 0);
 		rewrite = 1;


### PR DESCRIPTION
The issues that this PR fixes were found by fuzzing. 

Tagging @YiChenChai. 