### PR TITLE
freebsd64_getfhat: path is a userspace argument

### DIFF
--- a/sys/compat/freebsd64/freebsd64_vfs.c
+++ b/sys/compat/freebsd64/freebsd64_vfs.c
@@ -1193,7 +1193,7 @@ int
 freebsd64_getfhat(struct thread *td, struct freebsd64_getfhat_args *uap)
 {
 	return (kern_getfhat(td, uap->flags, uap->fd,
-	    __USER_CAP_STR(uap->path), UIO_SYSSPACE,
+	    __USER_CAP_STR(uap->path), UIO_USERSPACE,
 	    __USER_CAP_OBJ(uap->fhp), UIO_USERSPACE));
 }
 


### PR DESCRIPTION
It appears I accidently marked the path argument to kern_getfhat as a kernel pointer in the initial implementation (bbeb37ff330ab).

Fixes: #2278