### PR TITLE
MAP_STACK fixes

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -308,14 +308,15 @@ _cheribsdtest_check_errno(const char *context, int actual, int expected)
 }
 
 /** Check that @p call fails and errno is set to @p expected_errno */
-#define CHERIBSDTEST_CHECK_CALL_ERROR(call, expected_errno)			\
-	do {									\
-		errno = 0;							\
-		int __ret = call;						\
-		int call_errno = errno;						\
-		CHERIBSDTEST_VERIFY2(__ret == -1,				\
-		    #call " unexpectedly returned %d", __ret);			\
-		_cheribsdtest_check_errno(#call, call_errno, expected_errno);	\
+#define CHERIBSDTEST_CHECK_CALL_ERROR(call, expected_errno)		\
+	do {								\
+		errno = 0;						\
+		int __ret = call;					\
+		int call_errno = errno;					\
+		CHERIBSDTEST_VERIFY2(__ret == -1,			\
+		    #call " unexpectedly returned %d", __ret);		\
+		_cheribsdtest_check_errno(#call, call_errno,		\
+		    expected_errno);					\
 	} while (0)
 
 /* For libc_memcpy and libc_memset tests and the unaligned copy tests: */

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -2851,7 +2851,8 @@ CHERIBSDTEST(cheri_revoke_shm_anon_hoard_closed,
  * caused a panic.
  * https://github.com/CTSRD-CHERI/cheribsd/issues/2252
  */
-CHERIBSDTEST(mmap_insert_stack, "insert a stack mapping in a reservation")
+CHERIBSDTEST(mmap_insert_stack,
+    "try to insert a stack mapping in a reservation")
 {
 	void *p;
 
@@ -2860,13 +2861,13 @@ CHERIBSDTEST(mmap_insert_stack, "insert a stack mapping in a reservation")
 	    MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
 
 	/*
-	 * This would fail, but leave the map in a broken state due to
-	 * trying to insert a reservation inside an existing one.
-	 *
-	 * We don't check it because it is needed to set up the panic.
+	 * Historically would fail, but leave the map in a broken state
+	 * due to trying to insert a reservation inside an existing one.
+	 * This is now rejected outright.
 	 */
-	mmap(cheri_setaddress(p, 0x20ffc000), 0x2000,
-	    PROT_WRITE | PROT_READ, MAP_STACK | MAP_FIXED, -1, 0);
+	CHERIBSDTEST_CHECK_CALL_ERROR(mmap(cheri_setaddress(p, 0x20ffc000),
+	    0x2000, PROT_WRITE | PROT_READ, MAP_STACK | MAP_FIXED, -1, 0),
+	    ENOMEM);
 
 	/*
 	 * This would trigger a panic by trying to remove an unmapped

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -168,7 +168,7 @@ CHERIBSDTEST(vm_notag_mprotect_no_cap,
 static void
 mmap_check_bad_protections(int prot, int expected_errno)
 {
-	CHERIBSDTEST_CHECK_CALL_ERROR((int)(intptr_t)mmap(NULL, getpagesize(),
+	CHERIBSDTEST_CHECK_CALL_ERROR(mmap(NULL, getpagesize(),
 	    prot, MAP_ANON, -1, 0), expected_errno);
 }
 

--- a/lib/libsys/mmap.2
+++ b/lib/libsys/mmap.2
@@ -409,6 +409,14 @@ and
 .Dv PROT_WRITE .
 The size of the guard, in pages, is specified by sysctl
 .Dv security.bsd.stack_guard_page .
+.Pp
+Under CheriABI,
+.Dv MAP_STACK
+may not be combined with
+.Dv MAP_FIXED
+and an
+.Fa addr
+argument that is a valid pointer.
 .El
 .Pp
 The

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -335,6 +335,8 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 	if (cheri_gettag(uap->addr)) {
 		if ((flags & MAP_FIXED) == 0)
 			return (EPROT);
+		else if ((flags & MAP_STACK) != 0)
+			return (ENOMEM);
 		else if ((cheri_getperm(uap->addr) & CHERI_PERM_SW_VMEM))
 			source_cap = uap->addr;
 		else {


### PR DESCRIPTION
Fix the underlying issue in #2252 (failed vm_map_stack_lock due to write reservations) and then forbid the MAP_STACK within an existing reservation since it's not done anywhere and doesn't make much sense.