### PR TITLE
Add missing file to libc++ build

### DIFF
--- a/lib/cheri-libc++/Makefile
+++ b/lib/cheri-libc++/Makefile
@@ -16,6 +16,7 @@ SHLIB_LDSCRIPT=	libc++.ldscript
 
 SRCS+=		algorithm.cpp
 SRCS+=		any.cpp
+SRCS+=		assert.cpp
 SRCS+=		atomic.cpp
 SRCS+=		barrier.cpp
 SRCS+=		bind.cpp


### PR DESCRIPTION
This is only needed when enabling the libc++-internal assertions.