### PR TITLE
Fix possible out of bound read in armv8_crc32c

### DIFF
--- a/sys/libkern/arm64/crc32c_armv8.S
+++ b/sys/libkern/arm64/crc32c_armv8.S
@@ -39,14 +39,14 @@ ENTRY(armv8_crc32c)
 	cbz	w2, end
 	tbz	x1, #0x0, half_word_aligned
 	sub	w2, w2, 0x1
-	ldr	w10, [PTR(1)], #0x1
+	ldrb	w10, [PTR(1)], #0x1
 	crc32cb	w0, w0, w10
 half_word_aligned:
 	cmp	w2, #0x2
 	b.lo	last_byte
 	tbz	x1, #0x1, word_aligned
 	sub	w2, w2, 0x2
-	ldr	w10, [PTR(1)], #0x2
+	ldrh	w10, [PTR(1)], #0x2
 	crc32ch	w0, w0, w10
 word_aligned:
 	cmp	w2, #0x4
@@ -69,11 +69,11 @@ last_word:
 	crc32cw	w0, w0, w10
 last_half_word:
 	tbz	w2, #0x1, last_byte
-	ldr	w10, [PTR(1)], #0x2
+	ldrh	w10, [PTR(1)], #0x2
 	crc32ch	w0, w0, w10
 last_byte:
 	tbz	w2, #0x0, end 
-	ldr	w10, [PTR(1)], #0x1
+	ldrb	w10, [PTR(1)], #0x1
 	crc32cb	w0, w0, w10
 end:
 	ret


### PR DESCRIPTION
The armv8_crc32c function uses `ldr` to load 4 bytes of data even if the remaining data could be less than 4 bytes. This causes capability bound error.
This error can be triggered, for example, when accessing files in an ext2fs partition, which requires the calculation of crc32.

This piece of code also demonstrates the problem:
```
#include <stdio.h>
#include <sys/gsb_crc32.h>

int main() {
    unsigned char buf[7];
    printf("%d", armv8_crc32c(0, buf, 7));
}
```

which prints `In-address space security exception (core dumped)`.

PS: I also wonder if this should be fixed upstream as well.