### PR TITLE
ext2fs: Fix capability bound issue in ext2fs

### DIFF
--- a/sys/fs/ext2fs/ext2_htree.c
+++ b/sys/fs/ext2fs/ext2_htree.c
@@ -300,7 +300,9 @@ ext2_htree_find_leaf(struct inode *ip, const char *name, int namelen,
 	if ((levels = rootp->h_info.h_ind_levels) > 1)
 		goto error;
 
-	entp = (struct ext2fs_htree_entry *)(((char *)&rootp->h_info) +
+	/* Preserve capability bound here. */
+	entp = (struct ext2fs_htree_entry *)(((char *)rootp) +
+	    offsetof(struct ext2fs_htree_root, h_info) +
 	    rootp->h_info.h_info_len);
 
 	if (ext2_htree_get_limit(entp) !=


### PR DESCRIPTION
Capability bound error can occur when using ext2fs. This is caused by
```
entp = (struct ext2fs_htree_entry *)(((char *)&rootp->h_info) + rootp->h_info.h_info_len);
```
which limits the bound to the `h_info` subobject, but the `entp` pointer is actually used to access other subobjects in the structure. 
This PR fixes the issue by preserving the bound.
