### PR TITLE
cheribsdtest: Add tests in anticipation of c18n where function pointers are wrapped by default

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_fptr_canon.c
+++ b/bin/cheribsdtest/cheribsdtest_fptr_canon.c
@@ -30,6 +30,8 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/types.h>
+
 #include <dlfcn.h>
 
 #include <cheribsdtest_dynamic.h>
@@ -79,6 +81,24 @@ CHERIBSDTEST(fptr_canon_dlfunc,
 
 	CHERIBSDTEST_VERIFY2(cheri_ptr_equal_exact(fptr_inside, fptr_dlfunc),
 	    "inside %#p differs from dlfunc %#p", fptr_inside, fptr_dlfunc);
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(fptr_canon_int,
+    "Check that function pointers are canonical when relocated as integer "
+    "addresses")
+{
+	volatile ptraddr_t fptr_int;
+	void (* volatile fptr_dlsym)(void);
+
+	fptr_int = cheribsdtest_dynamic_get_dummy_fptr_addr();
+	fptr_dlsym = (void (*)(void))dlsym(RTLD_DEFAULT,
+	    "cheribsdtest_dynamic_dummy_func");
+
+	CHERIBSDTEST_VERIFY2(fptr_int == (ptraddr_t)fptr_dlsym,
+	    "Integer address %p differs from dlsym %#p",
+	    (void *)(uintptr_t)fptr_int, fptr_dlsym);
 
 	cheribsdtest_success();
 }

--- a/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic.h
+++ b/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic.h
@@ -28,6 +28,7 @@
 
 void cheribsdtest_dynamic_dummy_func(void);
 void (*cheribsdtest_dynamic_get_dummy_fptr(void))(void);
+ptraddr_t cheribsdtest_dynamic_get_dummy_fptr_addr(void);
 
 void * __capability cheribsdtest_dynamic_identity_cap(void * __capability cap);
 

--- a/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_fptr.c
+++ b/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic_fptr.c
@@ -44,3 +44,11 @@ void
 {
 	return (&cheribsdtest_dynamic_dummy_func);
 }
+
+ptraddr_t
+cheribsdtest_dynamic_get_dummy_fptr_addr(void)
+{
+	static volatile ptraddr_t addr =
+	    (ptraddr_t)&cheribsdtest_dynamic_dummy_func;
+	return (addr);
+}


### PR DESCRIPTION
Add test for global integer variables containing function addresses.
Also increases the length of signal_returncap because c18n with default-wrapped trampolines requires that.