### PR TITLE
Fix malloc & free in early constructors

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -40,7 +40,7 @@ CHERIBSDTEST_DIR:=	${.PARSEDIR}
 .PATH: ${CHERIBSDTEST_DIR}
 CFLAGS+=	-I${CHERIBSDTEST_DIR}/${MACHINE}
 
-CFLAGS+=	'-DPROG="${PROG}"'
+CFLAGS+=	'-DPROG="${PROG}"' '-DPROG_SUFFIX="${PROG:S/^cheribsdtest//}"'
 
 .if ${MACHINE_ABI:Mpurecap}
 SRCS+=	cheribsdtest_cheriabi.c

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -665,7 +665,7 @@ mk_exec_args(const struct cheri_test *ctp)
 	char const **exec_args;
 	int argc = 0, error;
 
-	execpath = malloc(MAXPATHLEN);
+	execpath = malloc(PATH_MAX);
 	if (execpath == NULL)
 		err(EX_OSERR, "malloc");
 	exec_args = calloc(5, sizeof(*exec_args));
@@ -679,7 +679,7 @@ mk_exec_args(const struct cheri_test *ctp)
 	 * AT_EXECPATH or add some sort of execve_self(3) implemented
 	 * by rtld for dynamic binaries and libc for static.
 	 */
-	error = elf_aux_info(AT_EXECPATH, execpath, MAXPATHLEN);
+	error = elf_aux_info(AT_EXECPATH, execpath, PATH_MAX);
 	if (error != 0)
 		errx(EX_OSERR, "elf_aux_info: %s", strerror(error));
 	exec_args[argc++] = execpath;

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -261,7 +261,7 @@ cheribsdtest_run_test(const struct cheri_test *ctp)
 		return;
 
 	if (ctp->ct_check_skip != NULL) {
-		skip_reason = ctp->ct_check_skip(ctp->ct_name);
+		skip_reason = ctp->ct_check_skip(ctp);
 		if (skip_reason != NULL) {
 			if (xo_get_style(NULL) == XO_STYLE_XML) {
 				xo_attr("message", "%s", skip_reason);

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -342,4 +342,7 @@ extern pid_t cheribsdtest_spawn_child(enum spawn_child_mode mode);
 
 const char *skip_need_cheri_revoke(const struct cheri_test *ctp);
 
+const char *cheribsdtest_get_helper_path(void);
+const char *cheribsdtest_skip_no_helper(const struct cheri_test *ctp);
+
 #endif /* !_CHERIBSDTEST_H_ */

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -156,7 +156,7 @@ struct cheri_test {
 	const char	*ct_desc;
 	void		(*ct_func)(void);
 	void		(*ct_child_func)(void);
-	const char *	(*ct_check_skip)(const char *);
+	const char *	(*ct_check_skip)(const struct cheri_test *);
 	const char *	(*ct_check_xfail)(const char *);
 	u_int		 ct_flags;
 	int		 ct_signum;
@@ -340,6 +340,6 @@ extern ptraddr_t find_address_space_gap(size_t len, size_t align);
  */
 extern pid_t cheribsdtest_spawn_child(enum spawn_child_mode mode);
 
-const char *skip_need_cheri_revoke(const char *name);
+const char *skip_need_cheri_revoke(const struct cheri_test *ctp);
 
 #endif /* !_CHERIBSDTEST_H_ */

--- a/bin/cheribsdtest/cheribsdtest_fs.c
+++ b/bin/cheribsdtest/cheribsdtest_fs.c
@@ -42,7 +42,7 @@
 #include "cheribsdtest.h"
 
 static const char *
-skip_non_tmpfs_tmp(const char *name __unused)
+skip_non_tmpfs_tmp(const struct cheri_test *ctp __unused)
 {
 	struct statfs sb;
 

--- a/bin/cheribsdtest/cheribsdtest_malloc.c
+++ b/bin/cheribsdtest/cheribsdtest_malloc.c
@@ -310,6 +310,33 @@ CHERIBSDTEST(malloc_revocation_ctl_suid_elfnote_enable_protctl_disable,
 	    "malloc_is_revoking_suid_elfnote_enable", true, &arg);
 }
 
+CHERIBSDTEST(malloc_early_constructor,
+    "invoke malloc in an early constructor",
+    .ct_check_skip = cheribsdtest_skip_no_helper)
+{
+	pid_t pid;
+	int res;
+	char *helper_path = strdup(cheribsdtest_get_helper_path());
+
+	pid = fork();
+	CHERIBSDTEST_VERIFY(pid >= 0);
+	if (pid == 0) {
+		char *argv[2];
+
+		argv[0] = helper_path;
+		argv[1] = NULL;
+		execve(argv[0], argv, NULL);
+		abort();
+	} else {
+		waitpid(pid, &res, 0);
+		if (WIFEXITED(res) && WEXITSTATUS(res) == 0)
+			cheribsdtest_success();
+		else
+			cheribsdtest_failure_errx("child %s exited improperly",
+			    helper_path);
+	}
+}
+
 static void
 check_mallocx(size_t size)
 {

--- a/bin/cheribsdtest/cheribsdtest_malloc.c
+++ b/bin/cheribsdtest/cheribsdtest_malloc.c
@@ -61,7 +61,7 @@ CHERIBSDTEST(malloc_double_free, "malloc aborts on double free",
 }
 
 static const char *
-skip_malloc_not_revoking(const char *name __unused)
+skip_malloc_not_revoking(const struct cheri_test *ctp __unused)
 {
 	if (malloc_is_revoking())
 		return (NULL);

--- a/bin/cheribsdtest/cheribsdtest_util.c
+++ b/bin/cheribsdtest/cheribsdtest_util.c
@@ -129,7 +129,7 @@ cheribsdtest_set_expected_si_addr(void *addr)
 }
 
 const char *
-skip_need_cheri_revoke(const char *name __unused)
+skip_need_cheri_revoke(const struct cheri_test *ctp __unused)
 {
 	if (!feature_present("cheri_revoke"))
 		return ("Kernel does not support revocation");

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -81,7 +81,8 @@
 
 #include "cheribsdtest.h"
 
-static const char *skip_need_writable_tmp(const char *name __unused);
+static const char *skip_need_writable_tmp(
+    const struct cheri_test *ctp __unused);
 
 /*
  * Tests to check that tags are ... or aren't ... preserved for various page
@@ -611,7 +612,7 @@ CHERIBSDTEST(vm_tag_tmpfile_private_prefault,
 }
 
 static const char *
-skip_need_writable_tmp(const char *name __unused)
+skip_need_writable_tmp(const struct cheri_test *ctp __unused)
 {
 	static const char *reason = NULL;
 	static int checked = 0;
@@ -1362,7 +1363,8 @@ CHERIBSDTEST(vm_capdirty, "verify capdirty marking and mincore")
  */
 
 static const char *
-skip_need_quarantine_unmapped_reservations(const char *name __unused)
+skip_need_quarantine_unmapped_reservations(
+    const struct cheri_test *ctp __unused)
 {
 	if (!feature_present("cheri_revoke"))
 		return ("Kernel does not support revocation");

--- a/libexec/Makefile
+++ b/libexec/Makefile
@@ -124,6 +124,7 @@ _tests=		tests
 .endif
 
 .if ${MACHINE_CPU:Mcheri}
+SUBDIR+=	malloc_early_constructor
 SUBDIR+=	malloc_is_revoking
 .endif
 

--- a/libexec/malloc_early_constructor/Makefile
+++ b/libexec/malloc_early_constructor/Makefile
@@ -1,0 +1,21 @@
+.include <src.opts.mk>
+
+SUBDIR=		purecap \
+		purecap-dynamic \
+		purecap-dynamic-mt \
+		purecap-mt
+
+.if ${MACHINE_ABI:Mpurecap} || ${MK_LIB64C} == "yes"
+.if ${MACHINE_CPUARCH} == "aarch64"
+SUBDIR+=	mt-c18n
+.endif
+.endif
+
+.if (${MACHINE_ABI:Mpurecap} && ${MACHINE_ABI:Mbenchmark}) || ${MK_LIB64CB} == "yes"
+SUBDIR+=	purecap-benchmark \
+		purecap-benchmark-dynamic \
+		purecap-benchmark-dynamic-mt \
+		purecap-benchmark-mt
+.endif
+
+.include <bsd.subdir.mk>

--- a/libexec/malloc_early_constructor/Makefile.inc
+++ b/libexec/malloc_early_constructor/Makefile.inc
@@ -1,0 +1,28 @@
+.include <src.opts.mk>
+
+BINDIR=	/usr/libexec
+
+.if ${.CURDIR:M*benchmark*}
+.if !${MACHINE_ABI:Mbenchmark}
+NEED_COMPAT=	64CB
+.include <bsd.compat.mk>
+.endif
+.else
+.if !${MACHINE_ABI:Mpurecap}
+NEED_COMPAT=    64C
+.include <bsd.compat.mk>
+.endif
+.endif
+
+PROG:=	${.PARSEDIR:tA:T}-${.CURDIR:T}
+.PATH: ${.PARSEDIR}
+SRCS:=	${.PARSEDIR:tA:T}.c
+MAN=
+
+.if ${.CURDIR:M*-mt*}
+LIBADD+=	pthread
+.endif
+
+.if ${.CURDIR:M*static*}
+NO_SHARED=t
+.endif

--- a/libexec/malloc_early_constructor/malloc_early_constructor.c
+++ b/libexec/malloc_early_constructor/malloc_early_constructor.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+
+/*
+ * Perform a malloc in the earliest allowed non-system constructor.
+ * If malloc is not initialized before this point it could fail.
+ */
+__attribute__((__constructor__(101)))
+static void
+foo(void)
+{
+	void * volatile ptr;
+
+	ptr = malloc(1);
+	free(ptr);
+}
+
+int
+main(void)
+{
+	return (0);
+}

--- a/libexec/malloc_early_constructor/mt-c18n/Makefile
+++ b/libexec/malloc_early_constructor/mt-c18n/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-benchmark-dynamic-mt/Makefile
+++ b/libexec/malloc_early_constructor/purecap-benchmark-dynamic-mt/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-benchmark-dynamic/Makefile
+++ b/libexec/malloc_early_constructor/purecap-benchmark-dynamic/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-benchmark-mt/Makefile
+++ b/libexec/malloc_early_constructor/purecap-benchmark-mt/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-benchmark/Makefile
+++ b/libexec/malloc_early_constructor/purecap-benchmark/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-dynamic-mt/Makefile
+++ b/libexec/malloc_early_constructor/purecap-dynamic-mt/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-dynamic/Makefile
+++ b/libexec/malloc_early_constructor/purecap-dynamic/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap-mt/Makefile
+++ b/libexec/malloc_early_constructor/purecap-mt/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>

--- a/libexec/malloc_early_constructor/purecap/Makefile
+++ b/libexec/malloc_early_constructor/purecap/Makefile
@@ -1,0 +1,3 @@
+# See ../Makefile.inc
+
+.include <bsd.prog.mk>


### PR DESCRIPTION
Set a priority for the mrs constructer in the "system" range.

It's not clear to me what the right priority is. 100 works for this test, but it's seems easy to argue for something higher like 50.