### PR TITLE
riscv: Store kernel DDC on stack rather than in STDC while in userspace

### DIFF
--- a/sys/riscv/cheri/cheri_debug.c
+++ b/sys/riscv/cheri/cheri_debug.c
@@ -63,7 +63,6 @@ DB_SHOW_COMMAND(scr, ddb_dump_scr)
 	db_printf("ddc: %#.16lp\n",  scr_read(ddc));
 	db_printf("pcc: %#.16lp\n",  scr_read(pcc));
 	db_printf("stcc: %#.16lp\n",  scr_read(stcc));
-	db_printf("stdc: %#.16lp\n",  scr_read(stdc));
 	db_printf("sscratchc: %#.16lp\n",  scr_read(sscratchc));
 	db_printf("sepcc: %#.16lp\n",  scr_read(sepcc));
 

--- a/sys/riscv/include/frame.h
+++ b/sys/riscv/include/frame.h
@@ -95,6 +95,9 @@ struct sigframe64 {
  */
 struct kernframe {
 	uintcap_t	kf_tp;
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
+	uintcap_t	kf_ddc;
+#endif
 };
 #endif
 

--- a/sys/riscv/include/frame.h
+++ b/sys/riscv/include/frame.h
@@ -69,6 +69,10 @@ struct trapframe {
 	uint64_t tf_scause;
 };
 
+#ifdef _KERNEL
+#define	TF_SIZE	(roundup2(sizeof(struct trapframe), STACKALIGNBYTES + 1))
+#endif
+
 /*
  * Signal frame. Pushed onto user stack before calling sigcode.
  */
@@ -81,6 +85,16 @@ struct sigframe {
 struct sigframe64 {
 	struct __siginfo64 sf_si;	/* actual saved siginfo */
 	ucontext64_t	sf_uc;	/* actual saved ucontext */
+};
+#endif
+
+#ifdef _KERNEL
+/*
+ * Kernel frame. Reserved near the top of kernel stacks for saving kernel
+ * state while in userspace.
+ */
+struct kernframe {
+	uintcap_t	kf_tp;
 };
 #endif
 

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -49,7 +49,7 @@
 	 * in the kernel DDC.  We haven't saved any registers yet,
 	 * so store 'ct0' in 'scratchc' temporarily.
 	 *
-	 * XXX: Bounds?  Maybe could use TF_SIZE + 16 as length?
+	 * XXX: Bounds?  Maybe could use TF_SIZE + KF_SIZE as length?
 	 * A purecap kernel would have proper bounds on csp already.
 	 */
 	cspecialw sscratchc, ct0
@@ -75,9 +75,9 @@
 .if \mode == 0	/* We came from userspace. */
 	/* Load our pcpu */
 #if __has_feature(capabilities)
-	clc	ctp, (TF_SIZE)(csp)
+	clc	ctp, (TF_SIZE + KF_TP)(csp)
 #else
-	ld	tp, (TF_SIZE)(sp)
+	ld	tp, (TF_SIZE + KF_TP)(sp)
 #endif
 .endif
 
@@ -266,7 +266,7 @@
 	 * Build a capability for 'csp' using 'sp' as an address
 	 * in the kernel DDC.
 	 *
-	 * XXX: Bounds?  Maybe could use TF_SIZE + 16 as length?
+	 * XXX: Bounds?  Maybe could use TF_SIZE + KF_SIZE as length?
 	 * A purecap kernel would have proper bounds on csp already.
 	 */
 	cspecialr ct0, ddc
@@ -289,7 +289,7 @@
 	cspecialw sscratchc, ct0
 
 	/* Store our pcpu */
-	csc	ctp, (TF_SIZE)(csp)
+	csc	ctp, (TF_SIZE + KF_TP)(csp)
 	clc	ctp, (TF_TP)(csp)
 
 	/* And restore the user's global pointer */
@@ -339,7 +339,7 @@
 	csrw	sscratch, t0
 
 	/* Store our pcpu */
-	sd	tp, (TF_SIZE)(sp)
+	sd	tp, (TF_SIZE + KF_TP)(sp)
 	ld	tp, (TF_TP)(sp)
 
 	/* And restore the user's global pointer */

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -43,17 +43,23 @@
 .option push
 #ifndef __CHERI_PURE_CAPABILITY__
 .option capmode
+	/*
+	 * If coming from userspace, load_registers 0 leaves 'csp' as a
+	 * capability, which is then stored in 'sscratchc' whilst in
+	 * userspace, and similarly for fork_trampoline, so no derivation is
+	 * needed on re-entering the kernel.
+	 */
 .if \mode == 1
 	/*
 	 * Build a capability for 'csp' using 'sp' as an address
 	 * in the kernel DDC.  We haven't saved any registers yet,
-	 * so store 'ct0' in 'scratchc' temporarily.
+	 * so store 'ct0' in 'sscratchc' temporarily.
 	 *
 	 * XXX: Bounds?  Maybe could use TF_SIZE + KF_SIZE as length?
 	 * A purecap kernel would have proper bounds on csp already.
 	 */
 	cspecialw sscratchc, ct0
-	cspecialr ct0, stdc
+	cspecialr ct0, ddc
 	csetaddr ct0, ct0, sp
 	cmove	csp, ct0
 	cspecialr ct0, sscratchc
@@ -129,12 +135,15 @@
 	cspecialr ct0, ddc
 	csc	ct0, (TF_DDC)(csp)
 
+.if \mode == 0
+	/* Load our DDC */
 #ifdef __CHERI_PURE_CAPABILITY__
 	cmove	ct0, cnull
 #else
-	cspecialr ct0, stdc
+	clc	ct0, (TF_SIZE + KF_DDC)(csp)
 #endif
 	cspecialw ddc, ct0
+.endif
 
 #ifndef __CHERI_PURE_CAPABILITY__
 	/* Switch to non-capmode PCC. */
@@ -213,8 +222,8 @@
 
 .if \mode == 0
 #ifdef __CHERI_PURE_CAPABILITY__
-	cspecialr ct0, stdc
-	cmove	cgp, ct0
+	/* CHERI-RISC-V purecap doesn't currently use cgp. */
+	cmove	cgp, cnull
 #else
 .option push
 .option norelax
@@ -272,6 +281,14 @@
 	cspecialr ct0, ddc
 	csetaddr ct0, ct0, sp
 	cmove	csp, ct0
+#endif
+
+#ifndef __CHERI_PURE_CAPABILITY__
+.if \mode == 0
+	/* Store our DDC */
+	cspecialr ct0, ddc
+	csc	ct0, (TF_SIZE + KF_DDC)(csp)
+.endif
 #endif
 
 	/*

--- a/sys/riscv/riscv/genassym.c
+++ b/sys/riscv/riscv/genassym.c
@@ -106,6 +106,9 @@ ASSYM(TF_SCAUSE, offsetof(struct trapframe, tf_scause));
 ASSYM(TF_SSTATUS, offsetof(struct trapframe, tf_sstatus));
 
 ASSYM(KF_TP, offsetof(struct kernframe, kf_tp));
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
+ASSYM(KF_DDC, offsetof(struct kernframe, kf_ddc));
+#endif
 
 ASSYM(RISCV_BOOTPARAMS_SIZE, sizeof(struct riscv_bootparams));
 ASSYM(RISCV_BOOTPARAMS_KERN_PHYS, offsetof(struct riscv_bootparams, kern_phys));

--- a/sys/riscv/riscv/genassym.c
+++ b/sys/riscv/riscv/genassym.c
@@ -89,7 +89,7 @@ ASSYM(TD_MD, offsetof(struct thread, td_md));
 ASSYM(TD_LOCK, offsetof(struct thread, td_lock));
 ASSYM(TD_MDFLAGS, offsetof(struct thread, td_md.md_flags));
 
-ASSYM(TF_SIZE, roundup2(sizeof(struct trapframe), STACKALIGNBYTES + 1));
+ASSYM(TF_SIZE, TF_SIZE);
 ASSYM(TF_RA, offsetof(struct trapframe, tf_ra));
 ASSYM(TF_SP, offsetof(struct trapframe, tf_sp));
 ASSYM(TF_GP, offsetof(struct trapframe, tf_gp));
@@ -104,6 +104,8 @@ ASSYM(TF_DDC, offsetof(struct trapframe, tf_ddc));
 ASSYM(TF_STVAL, offsetof(struct trapframe, tf_stval));
 ASSYM(TF_SCAUSE, offsetof(struct trapframe, tf_scause));
 ASSYM(TF_SSTATUS, offsetof(struct trapframe, tf_sstatus));
+
+ASSYM(KF_TP, offsetof(struct kernframe, kf_tp));
 
 ASSYM(RISCV_BOOTPARAMS_SIZE, sizeof(struct riscv_bootparams));
 ASSYM(RISCV_BOOTPARAMS_KERN_PHYS, offsetof(struct riscv_bootparams, kern_phys));

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -322,8 +322,6 @@ va:
 #ifdef __CHERI_PURE_CAPABILITY__
 	cllc	ct0, cpu_exception_handler
 	cspecialw stcc, ct0
-	cmove	ct1, cnull
-	cspecialw stdc, ct1
 #else
 	la	t0, cpu_exception_handler
 #if __has_feature(capabilities)
@@ -332,8 +330,6 @@ va:
 	li	t0, 1
 	csetflags ct1, ct1, t0
 	cspecialw stcc, ct1
-	cspecialr ct1, ddc
-	cspecialw stdc, ct1
 #else
 	csrw	stvec, t0
 #endif
@@ -343,6 +339,8 @@ va:
 #if __has_feature(capabilities)
 	cmove	ct0, cnull
 	cspecialw sscratchc, ct0
+	/* Ensure stdc is null and thus not used */
+	cspecialw stdc, ct0
 #else
 	li	t0, 0
 	csrw	sscratch, t0
@@ -614,8 +612,6 @@ mpva:
 #ifdef __CHERI_PURE_CAPABILITY__
 	cllc	ct0, cpu_exception_handler
 	cspecialw stcc, ct0
-	cmove	ct1, cnull
-	cspecialw stdc, ct1
 #else
 	la	t0, cpu_exception_handler
 #if __has_feature(capabilities)
@@ -624,8 +620,6 @@ mpva:
 	li	t0, 1
 	csetflags ct1, ct1, t0
 	cspecialw stcc, ct1
-	cspecialr ct1, ddc
-	cspecialw stdc, ct1
 #else
 	csrw	stvec, t0
 #endif
@@ -635,6 +629,8 @@ mpva:
 #if __has_feature(capabilities)
 	cmove	ct0, cnull
 	cspecialw sscratchc, ct0
+	/* Ensure stdc is null and thus not used */
+	cspecialw stdc, ct0
 #else
 	li	t0, 0
 	csrw	sscratch, t0

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -675,6 +675,15 @@ ENTRY(fork_trampoline)
 	cmove	csp, ct0
 #endif
 
+#ifndef __CHERI_PURE_CAPABILITY__
+	/*
+	 * Store our DDC on stack, we will load it back
+	 * on kernel mode trap.
+	 */
+	cspecialr ct0, ddc
+	csc	ct0, (TF_SIZE + KF_DDC)(csp)
+#endif
+
 	/*
 	 * Switch to user DDC.  After this point, all stack accesses
 	 * must use 'csp' instead of 'sp'.

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -667,7 +667,7 @@ ENTRY(fork_trampoline)
 	 * Build a capability for 'csp' using 'sp' as an address
 	 * in the kernel DDC.
 	 *
-	 * XXX: Bounds?  Maybe could use TF_SIZE + 8 as length?
+	 * XXX: Bounds?  Maybe could use TF_SIZE + KF_SIZE as length?
 	 * A purecap kernel would have proper bounds on csp already.
 	 */
 	cspecialr ct0, ddc
@@ -725,7 +725,7 @@ ENTRY(fork_trampoline)
 	 * Store our pcpup on stack, we will load it back
 	 * on kernel mode trap.
 	 */
-	csc	ctp, (TF_SIZE)(csp)
+	csc	ctp, (TF_SIZE + KF_TP)(csp)
 	clc	ctp, (TF_TP)(csp)
 
 	/* Save kernel stack so we can use it doing a user trap */
@@ -781,7 +781,7 @@ ENTRY(fork_trampoline)
 	 * Store our pcpup on stack, we will load it back
 	 * on kernel mode trap.
 	 */
-	sd	tp, (TF_SIZE)(sp)
+	sd	tp, (TF_SIZE + KF_TP)(sp)
 	ld	tp, (TF_TP)(sp)
 
 	/* Save kernel stack so we can use it doing a user trap */


### PR DESCRIPTION
This mirrors how (C)TP is handled in all kernels, which has the exact
same problem. We no longer require STDC at all, though still initialise
it for good measure while it exists.

As part of this, add and improve existing comments, since the limited
number of scratch registers and lack of register banking makes this code
quite intricate.

This PR is also based on cherry-picking an upstream refactor to make this
change simpler.
