### PR TITLE
bsdinstall: Switched back to amended single-button finalconfig

### DIFF
--- a/usr.sbin/bsdinstall/scripts/finalconfig
+++ b/usr.sbin/bsdinstall/scripts/finalconfig
@@ -60,8 +60,9 @@ while true; do
 	REVISIT=$(echo $CHERI_DESKTOP_REVISIT $CHERI_VM_SUPPORT_REVISIT | \
 	    xargs -o bsddialog --backtitle "$OSNAME Installer" \
 	    --title "Final Configuration" --ok-label "Select" \
-	    --cancel-label "Finish" --default-no --menu \
+	    --no-cancel --menu \
 	    "Setup of your $OSNAME system is nearly complete. You can now modify your configuration choices. After this screen, you will have an opportunity to make more complex changes using a shell." 0 0 0 \
+		"Finish" "Apply configuration and exit installer" \
 		"Add User" "Add a user to the system" \
 		"Root Password" "Change root password" \
 		"Hostname" "Set system hostname" \
@@ -78,6 +79,9 @@ while true; do
 	fi
 
 	case "$REVISIT" in
+	"Finish")
+		break
+		;;
 	"Add User")
 		bsdinstall adduser
 		;;


### PR DESCRIPTION
Commit ac78e3e9c581 ("bsdinstall: Add "Finish" button to finalconfig")
removed the Exit entry from the menu, renamed OK to Select and added a
Finish in place of the old Exit entry. On the surface this seemed like a
good idea, as at a glance OK wasn't clear that it was selecting an entry
rather than just closing the box, Exit isn't the most obvious term
to use for proceeding through the installer without doing anything, and
it separated out the different cases of "do something extra" and
"continue". However, because bsddialog (and dialog) keep a menu entry
highlighted even when the Cancel (in this case, Finish) button is
selected, this now looks even more confusing, with users easily
believing that they are about to select the Add User option (being
either surprised when it doesn't actually do that, or being confused
about how to not select it).

Instead, go back to the old scheme that fits more with bsddialog's
supported functionality but tweak it to try and improve on the confusing
UI/UX from the past. Specifically, the UI changes compared with the
original version are as follows:

1. The OK button is renamed to Select, as in the current UI
2. The Exit entry is renamed to Finish, mirroring the label of the
   button in the current UI that it replaces

This partially reverts commit ac78e3e9c581ac3b695adeec1ae312d619a1402b.

Reviewed by:	khorben_defora.org
Differential Revision:	https://reviews.freebsd.org/D47229

(cherry picked from commit 97350075fe3a7951b7ef86a63c0a3f033dc03118)
