### PR TITLE
caprevoke: Avoid crashing if the revoker encounters a kernel capability

### DIFF
--- a/sys/arm64/arm64/cheri_revoke_machdep_tests.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep_tests.c
@@ -53,6 +53,11 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 	const uint8_t * __capability bmloc;
 
 	ptraddr_t va = cheri_getbase(cut);
+	if (__predict_false(va >= VM_MAX_USER_ADDRESS)) {
+		printf("%s: kernel capability leaked to userspace: %#lp\n",
+		    __func__, (void * __capability)cut);
+		return (0);
+	}
 
 	bmloc = crshadow - VM_CHERI_REVOKE_BSZ_OTYPE -
 	    (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
@@ -90,6 +95,11 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 	const uint8_t * __capability bmloc;
 
 	ptraddr_t va = cheri_getbase(cut);
+	if (__predict_false(va >= VM_MAX_USER_ADDRESS)) {
+		printf("%s: kernel capability leaked to userspace: %#lp\n",
+		    __func__, (void * __capability)cut);
+		return (0);
+	}
 
 	bmloc = crshadow + (va / VM_CHERI_REVOKE_GSZ_MEM_NOMAP / 8);
 

--- a/sys/riscv/riscv/cheri_revoke_machdep_tests.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep_tests.c
@@ -53,6 +53,11 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 	const uint8_t * __capability bmloc;
 
 	ptraddr_t va = cheri_getbase(cut);
+	if (__predict_false(va >= VM_MAX_USER_ADDRESS)) {
+		printf("%s: kernel capability leaked to userspace: %#lp\n",
+		    __func__, (void * __capability)cut);
+		return (0);
+	}
 
 	bmloc = crshadow - VM_CHERI_REVOKE_BSZ_OTYPE -
 	    (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
@@ -91,6 +96,11 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 	const uint8_t * __capability bmloc;
 
 	ptraddr_t va = cheri_getbase(cut);
+	if (__predict_false(va >= VM_MAX_USER_ADDRESS)) {
+		printf("%s: kernel capability leaked to userspace: %#lp\n",
+		    __func__, (void * __capability)cut);
+		return (0);
+	}
 
 	bmloc = crshadow + (va / VM_CHERI_REVOKE_GSZ_MEM_NOMAP / 8);
 


### PR DESCRIPTION
This mitigates a bug in the `DTRACEIOC_EPROBE` ioctl handler (which I have since fixed locally) that caused kernel panics when running certain dtrace scripts.