### PR TITLE
cheribsdtest: Don't link against libpthread for non-mt variants

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -62,13 +62,9 @@ CFLAGS+=	-DCHERIBSDTEST_CHERI_REVOKE_TESTS
 # Enable sub-object bounds only in tests specifically designed for them.
 CFLAGS.cheribsdtest_bounds_subobject.c+=-cheri-bounds=subobject-safe
 
-.ifdef CHERIBSD_THREAD_TESTS
-CFLAGS+=	-DCHERIBSD_THREAD_TESTS
-.endif
-
 MAN=
 
-LIBADD+=	procstat pthread util xo z
+LIBADD+=	procstat util xo z
 
 .ifdef CHERIBSD_DYNAMIC_TESTS
 CFLAGS+=	-DCHERIBSD_DYNAMIC_TESTS
@@ -85,7 +81,11 @@ NO_SHARED?=	YES
 SRCS+=		cheribsdtest_ifunc.c
 .endif
 
+# Both variants exist so we can test with and without libthr's interposition on
+# things like signals.
 .ifdef CHERIBSD_THREAD_TESTS
+CFLAGS+=	-DCHERIBSD_THREAD_TESTS
+LIBADD+=	pthread
 SRCS+=		cheribsdtest_tls_threads.c
 .endif
 

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -66,7 +66,6 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <libprocstat.h>
-#include <pthread.h>
 #include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -75,6 +74,10 @@
 #include <string.h>
 #include <sysexits.h>
 #include <unistd.h>
+
+#ifdef CHERIBSD_THREAD_TESTS
+#include <pthread.h>
+#endif
 
 #include "cheribsdtest.h"
 
@@ -1731,6 +1734,7 @@ CHERIBSDTEST(cheri_revoke_async,
 	cheribsdtest_success();
 }
 
+#ifdef CHERIBSD_THREAD_TESTS
 static void *
 forker(void *arg)
 {
@@ -1820,6 +1824,7 @@ CHERIBSDTEST(cheri_revoke_async_fork,
 
 	cheribsdtest_success();
 }
+#endif /* CHERIBSD_THREAD_TESTS */
 
 /*
  * Repeatedly invoke libcheri_caprevoke logic.


### PR DESCRIPTION
Restricting libpthread to just the -mt variants is a very deliberate
choice in order to ensure that we test the implementations of things
like signals without libthr's interposition.

Document this clearly in the Makefile so this doesn't happen again.

Fixes:	abb906e73878 ("cheribsdtest: Add a couple of regression tests for async revocation")
