### PR TITLE
cheribsdtest: Fix nofault_cfromptr with LLVM assuming ISAv9 semantics

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -225,22 +225,18 @@ CHERIBSDTEST(nofault_cfromptr, "Exercise CFromPtr success")
 	char * __capability cd; /* stored into here */
 
 	cb = cheri_ptr(buf, 256);
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__riscv_xcheri_no_relocation)
 	/*
 	 * morello-llvm emits cvtz for this intrinsic, which has an
 	 * address interpretation by default (unlike CFromPtr, which
 	 * has an offset interpretation).
 	 * https://git.morello-project.org/morello/llvm-project/-/issues/16
+	 *
+	 * Similarly, CHERI-RISC-V with ISAv9 always uses address
+	 * interpretation instead of offsetting from the base.
 	 */
 	cd = __builtin_cheri_cap_from_pointer(cb, (ptraddr_t)buf + 10);
 #else
-	/*
-	 * This pragma is require to allow compiling this file both with and
-	 * without overloaded CHERI builtins.
-	 *
-	 * FIXME: remove once everyone has updated to overloaded builtins.
-	 */
-#pragma clang diagnostic ignored "-Wint-conversion"
 	cd = __builtin_cheri_cap_from_pointer(cb, 10);
 #endif
 	*cd = '\0';


### PR DESCRIPTION
In https://github.com/CTSRD-CHERI/llvm-project/pull/708, we decided to be consistent and always use address semantics for CFromPtr expansion, so now RISC-V LLVM matches the Morello behaviour