### PR TITLE
procstat: Fix bug with procstat compartments

### DIFF
--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -479,7 +479,6 @@ procstat_getcompartments(struct procstat *procstat, struct kinfo_proc *kp,
 out_free:
 	free(inbuf);
 out:
-	*ncompartsp = 0;
 	return (-1);
 }
 

--- a/usr.bin/procstat/procstat_compartments.c
+++ b/usr.bin/procstat/procstat_compartments.c
@@ -50,7 +50,7 @@ procstat_compartments(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit("{T:/%5s %-19s %4s %-40s}\n", "PID", "COMM", "CID",
 		    "CNAME");
 	if (procstat_getcompartments(procstat, kipp, &cccp, &ncomparts) != 0)
-		goto out;
+		return;
 	for (size_t i = 0; i < ncomparts; ++i) {
 		xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
 		xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
@@ -58,6 +58,5 @@ procstat_compartments(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit(" {:cname/%-40s/%s}", cccp[i].ccc_name);
 		xo_emit("\n");
 	}
-out:
 	free(cccp);
 }


### PR DESCRIPTION
libprocstat is responsible for allocating the array of compartment information that is returned to the procstat command-line tool, which is responsible for freeing it. But procstat should not attempt to free the array if libprocstat returns an error.

Also fixes a bug that might cause NULL to be dereferenced in libprocstat.