### PR TITLE
arm64: Use .code directive over deprecated .arch_extension

### DIFF
--- a/lib/libcheri_caprevoke/aarch64/libcaprevoke_md.h
+++ b/lib/libcheri_caprevoke/aarch64/libcaprevoke_md.h
@@ -48,7 +48,7 @@ caprev_shadow_set_fw(uint64_t * __capability fw, void * __capability user_obj,
 	__asm__ __volatile__ (
 #ifndef __CHERI_PURE_CAPABILITY__
 		"bx #4\n\t"
-		".arch_extension c64\n\t"
+		".code c64\n\t"
 #endif
 		"1:\n\t"
 		/* Load reserve first word */
@@ -95,8 +95,7 @@ caprev_shadow_set_fw(uint64_t * __capability fw, void * __capability user_obj,
 		"2:\n\t"
 #ifndef __CHERI_PURE_CAPABILITY__
 		"bx #4\n\t"
-		".arch_extension noc64\n\t"
-		".arch_extension a64c\n\t"
+		".code a64\n\t"
 #endif
 	: /* outputs */
 		[stxr_status] "+&r" (stxr_status),

--- a/sys/arm64/arm64/cheri_revoke_machdep.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep.c
@@ -139,7 +139,7 @@ vm_do_cheri_revoke(int *res, const struct vm_cheri_revoke_cookie *crc,
 		__asm__ __volatile__ (
 #ifndef __CHERI_PURE_CAPABILITY__
 			"bx #4\n\t"
-			".arch_extension c64\n\t"
+			".code c64\n\t"
 #endif
 			"0: ldxr %[cscratch], [%[cutp]]\n\t"
 			"cmp %[cscratch], %[cut]\n\t"
@@ -149,8 +149,7 @@ vm_do_cheri_revoke(int *res, const struct vm_cheri_revoke_cookie *crc,
 			"1:\n\t"
 #ifndef __CHERI_PURE_CAPABILITY__
 			"bx #4\n\t"
-			".arch_extension noc64\n\t"
-			".arch_extension a64c\n\t"
+			".code a64\n\t"
 #endif
 		  : [stxr_status] "+&r" (stxr_status),
 		    [cscratch] "=&C" (cscratch), [cutr] "+C" (cutr)

--- a/sys/arm64/arm64/copyinout.S
+++ b/sys/arm64/arm64/copyinout.S
@@ -53,7 +53,7 @@
  * Fault handler for the copy{in,out} functions below.
  */
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
-	.arch_extension	c64
+	.code	c64
 #endif
 ENTRY(copyio_c64_fault)
 	EXIT_C64

--- a/sys/arm64/arm64/efirt_support.S
+++ b/sys/arm64/arm64/efirt_support.S
@@ -105,15 +105,14 @@ ENTRY(efi_rt_arch_call_nofault)
 	 * RET X30 won't honour or clear the LSB.
 	 */
 	bx	#4
-	.arch_extension	noc64
-	.arch_extension	a64c
+	.code	a64
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	blr	x6
 #else
 	blr	c6
 #endif
 	bx	#4
-	.arch_extension	c64
+	.code	c64
 
 	/* EFI calls run in the same EL so trash SP metadata */
 	ldr	c8, [sp, #(16 * PTR_WIDTH)]

--- a/sys/arm64/arm64/freebsd64cb_sigtramp.S
+++ b/sys/arm64/arm64/freebsd64cb_sigtramp.S
@@ -44,7 +44,7 @@
 
 SIGCODE(freebsd64cb_sigcode)
 #ifndef __CHERI_PURE_CAPABILITY__
-	.arch_extension c64
+	.code	c64
 #endif
 	blr	x8
 	add	c0, csp, #SF_UC
@@ -59,8 +59,7 @@ SIGCODE(freebsd64cb_sigcode)
 
 	b	1b
 #ifndef __CHERI_PURE_CAPABILITY__
-	.arch_extension noc64
-	.arch_extension a64c
+	.code	a64
 #endif
 	/* This may be copied to the stack, keep it 16-byte aligned */
 	.align	3

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -188,14 +188,13 @@
 
 	/* We assume that we enter here in a64 mode. */
 	bx	#4
-	.arch_extension c64
+	.code	c64
 #endif
 #endif
 .endmacro
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	.arch_extension noc64
-	.arch_extension a64c
+	.code	a64
 #endif
 ENTRY(_start)
 	/* Enter the kernel exception level */
@@ -360,8 +359,7 @@ END(_start)
 
 #ifdef SMP
 #ifdef __CHERI_PURE_CAPABILITY__
-	.arch_extension noc64
-	.arch_extension a64c
+	.code	a64
 #endif
 /*
  * void
@@ -387,7 +385,7 @@ ENTRY(mpentry_spintable)
 	b	mpentry_common
 END(mpentry_spintable)
 #ifdef __CHERI_PURE_CAPABILITY__
-	.arch_extension c64
+	.code	c64
 #endif
 
 /* Wait for the current CPU to be released */
@@ -411,8 +409,7 @@ LENTRY(spintable_wait)
 LEND(mpentry_spintable)
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	.arch_extension noc64
-	.arch_extension a64c
+	.code	a64
 #endif
 LENTRY(mpentry_common)
 	/* Disable interrupts */
@@ -502,8 +499,7 @@ LEND(mpentry_common)
  *  - Configure EL2 to support running the kernel at EL1 and exit to that
  */
 #ifdef __CHERI_PURE_CAPABILITY__
-	.arch_extension noc64
-	.arch_extension a64c
+	.code	a64
 #endif
 LENTRY(enter_kernel_el)
 #define	INIT_SCTLR_EL1	(SCTLR_LSMAOE | SCTLR_nTLSMD | SCTLR_EIS | \
@@ -669,7 +665,7 @@ LENTRY(enter_kernel_el)
 #undef INIT_SCTLR_EL1
 LEND(enter_kernel_el)
 #ifdef __CHERI_PURE_CAPABILITY__
-	.arch_extension c64
+	.code	c64
 #endif
 
 /*

--- a/sys/arm64/arm64/sigtramp.S
+++ b/sys/arm64/arm64/sigtramp.S
@@ -46,7 +46,7 @@
 SIGCODE(sigcode)
 #if __has_feature(capabilities)
 #ifndef __CHERI_PURE_CAPABILITY__
-	.arch_extension c64
+	.code	c64
 #endif
 	blrr	c8
 	add	c0, csp, #SF_UC
@@ -67,8 +67,7 @@ SIGCODE(sigcode)
 	b	1b
 #if __has_feature(capabilities)
 #ifndef __CHERI_PURE_CAPABILITY__
-	.arch_extension noc64
-	.arch_extension a64c
+	.code	a64
 #endif
 #endif
 	/* This may be copied to the stack, keep it 16-byte aligned */

--- a/sys/arm64/include/asm.h
+++ b/sys/arm64/include/asm.h
@@ -108,11 +108,10 @@
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 #define	ENTER_C64		\
 	bx #4;			\
-	.arch_extension	c64
+	.code	c64
 #define	EXIT_C64		\
 	bx #4;			\
-	.arch_extension	noc64;	\
-	.arch_extension	a64c
+	.code	a64
 #else
 #define	ENTER_C64
 #define	EXIT_C64


### PR DESCRIPTION
As part of deprecating including the encoding mode in -march, putting it
in .arch_extension was also deprected. However, whilst inferring the
mode from -mabi had already been added prior to that, no alternative to
.arch_extension had been, and so the corresponding warning was turned
off by default, which remains the case to this day.

Switch over to the cleaner .code directive to both simplify the code and
ensure that we're ready in case that warning ever gets enabled by
default (or even becomes an error).
