### PR TITLE
io compartments to compression libraries

### DIFF
--- a/lib/libbz2/Compartments.json
+++ b/lib/libbz2/Compartments.json
@@ -1,0 +1,23 @@
+{
+    "compartments": {
+	"io": {
+	    "symbols": [
+		"BZ2_bzWriteOpen",
+		"BZ2_bzWrite",
+		"BZ2_bzWriteClose",
+		"BZ2_bzWriteClose64",
+		"BZ2_bzReadOpen",
+		"BZ2_bzReadClose",
+		"BZ2_bzRead",
+		"BZ2_bzReadGetUnused",
+		"BZ2_bzopen",
+		"BZ2_bzdopen",
+		"BZ2_bzread",
+		"BZ2_bzwrite",
+		"BZ2_bzflush",
+		"BZ2_bzclose",
+		"BZ2_bzerror"
+            ]
+        }
+    }
+}

--- a/lib/libbz2/Makefile
+++ b/lib/libbz2/Makefile
@@ -4,6 +4,8 @@ BZ2DIR=	${SRCTOP}/contrib/bzip2
 
 LIB=		bz2
 SHLIB_MAJOR=	4
+COMPARTMENT_POLICY=	${.CURDIR}/Compartments.json
+
 SRCS=		bzlib.c blocksort.c compress.c crctable.c decompress.c \
 		huffman.c randtable.c
 INCS=		bzlib.h

--- a/lib/libz/Compartments.json
+++ b/lib/libz/Compartments.json
@@ -1,0 +1,9 @@
+{
+    "compartments": {
+	"io": {
+	    "files": [
+		"gz*.*o"
+            ]
+        }
+    }
+}

--- a/lib/libz/Makefile
+++ b/lib/libz/Makefile
@@ -51,6 +51,7 @@ CFLAGS+=	-DUNALIGNED_OK
 
 VERSION_DEF=	${.CURDIR}/Versions.def
 SYMBOL_MAPS=	${.CURDIR}/Symbol.map
+COMPARTMENT_POLICY=	${.CURDIR}/Compartments.json
 
 INCS=		zconf.h zlib.h
 

--- a/lib/libzstd/Compartments.json
+++ b/lib/libzstd/Compartments.json
@@ -1,0 +1,11 @@
+{
+    "compartments": {
+	"io": {
+	    "files": [
+		"cover.*o",
+		"fastcover.*o",
+		"zdict.*o"
+            ]
+        }
+    }
+}

--- a/lib/libzstd/Makefile
+++ b/lib/libzstd/Makefile
@@ -42,6 +42,8 @@ LIBADD=	pthread
 # explicitly disable assembly.
 CFLAGS+=	-DZSTD_DISABLE_ASM
 
+COMPARTMENT_POLICY=	${.CURDIR}/Compartments.json
+
 PRIVATELIB=	yes
 PACKAGE=	runtime
 


### PR DESCRIPTION
zlib has two major parts.  The core deflate compression works entierly in memory.  There is also the gzlib portion which provides an analog to POSIX IO interfaces and uses IO underneath.