### PR TITLE
libc: Add compartments for malloc backends

### DIFF
--- a/lib/libc/stdlib/malloc/jemalloc/Compartments.json
+++ b/lib/libc/stdlib/malloc/jemalloc/Compartments.json
@@ -1,0 +1,9 @@
+{
+    "compartments": {
+	"jemalloc": {
+	    "files": [
+		"jemalloc_*.*o"
+	    ]
+	}
+    }
+}

--- a/lib/libc/stdlib/malloc/jemalloc/Makefile.inc
+++ b/lib/libc/stdlib/malloc/jemalloc/Makefile.inc
@@ -26,6 +26,8 @@ CFLAGS.jemalloc_${src}+=	-DMALLOC_REVOCATION_SHIM
 .endif
 .endfor
 
+COMPARTMENT_POLICY+=${LIBC_SRCTOP}/stdlib/malloc/jemalloc/Compartments.json
+
 MAN+=jemalloc.3
 CLEANFILES+=jemalloc.3
 jemalloc.3: ${SRCTOP}/contrib/jemalloc/doc/jemalloc.3 .NOMETA

--- a/lib/libc/stdlib/malloc/mrs/Compartments.json
+++ b/lib/libc/stdlib/malloc/mrs/Compartments.json
@@ -1,0 +1,9 @@
+{
+    "compartments": {
+	"mrs": {
+	    "files": [
+		"mrs.*o"
+	    ]
+	}
+    }
+}

--- a/lib/libc/stdlib/malloc/mrs/Makefile.inc
+++ b/lib/libc/stdlib/malloc/mrs/Makefile.inc
@@ -2,6 +2,8 @@
 
 MISRCS+=	mrs.c
 
+COMPARTMENT_POLICY+=${LIBC_SRCTOP}/stdlib/malloc/mrs/Compartments.json
+
 MAN+=	mrs.3
 MLINKS+= \
 	mrs.3 malloc.3 \

--- a/lib/libc/stdlib/malloc/snmalloc/Compartments.json
+++ b/lib/libc/stdlib/malloc/snmalloc/Compartments.json
@@ -1,0 +1,9 @@
+{
+    "compartments": {
+	"snmalloc": {
+	    "files": [
+		"malloc.*o"
+	    ]
+	}
+    }
+}

--- a/lib/libc/stdlib/malloc/snmalloc/Makefile.inc
+++ b/lib/libc/stdlib/malloc/snmalloc/Makefile.inc
@@ -1,6 +1,8 @@
 .PATH: ${LIBC_SRCTOP}/stdlib/malloc/snmalloc
 
-MISRCS+=	malloc.cc
+MISRCS+=	malloc.c
+
+COMPARTMENT_POLICY+=${LIBC_SRCTOP}/stdlib/malloc/snmalloc/Compartments.json
 
 # Specify the locations in contrib for headers.
 CXXFLAGS.malloc.cc+=	-I${SRCTOP}/contrib/subrepo-snmalloc/src/snmalloc


### PR DESCRIPTION
Separate compartments are used for jemalloc, mrs, and snmalloc.  The
stub malloc_revoke routines are left in the default compartment.
