### PR TITLE
Fixes to get sub-lib c18n working on Morello

### DIFF
--- a/contrib/elftoolchain/elfcopy/segments.c
+++ b/contrib/elftoolchain/elfcopy/segments.c
@@ -528,6 +528,10 @@ copy_phdr(struct elfcopy *ecp)
 			continue;
 		}
 
+		/* Don't rewrite PT_CHERI_PCC and PT_C18N_NAME headers. */
+		if (seg->type == PT_CHERI_PCC || seg->type == PT_C18N_NAME)
+			continue;
+
 		if (seg->nsec > 0) {
 			s = seg->v_sec[0];
 			seg->vaddr = s->vma;

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -378,7 +378,7 @@ map_object(int fd, const char *path, const struct stat *sb, const char* main_pat
 	obj->tlsinit = mapbase + phtls->p_vaddr;
     }
 #ifdef __CHERI_PURE_CAPABILITY__
-    if (!create_pcc_caps(obj)) {
+    if (!create_pcc_caps(obj, path)) {
 	obj_free(obj);
 	goto error1;
     }

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1459,7 +1459,7 @@ rtld_die(void)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 bool
-create_pcc_caps(Obj_Entry *obj)
+create_pcc_caps(Obj_Entry *obj, const char *name)
 {
 	const Elf_Phdr *ph;
 	const char *pcc_cap;
@@ -1493,12 +1493,12 @@ create_pcc_caps(Obj_Entry *obj)
 			if (cheri_getbase(pcc_cap) !=
 			    cheri_getaddress(pcc_cap)) {
 				_rtld_error("pcc_cap %#p start is not aligned for %s",
-				    pcc_cap, obj->path);
+				    pcc_cap, name);
 				return (false);
 			}
 			if (cheri_getlen(pcc_cap) != ph->p_memsz) {
 				_rtld_error("pcc_cap %#p length is not %zu for %s",
-				    pcc_cap, (size_t)ph->p_memsz, obj->path);
+				    pcc_cap, (size_t)ph->p_memsz, name);
 				return (false);
 			}
 			obj->pcc_caps[i] = pcc_cap;
@@ -2178,7 +2178,7 @@ digest_phdr(const Elf_Phdr *phdr, int phnum, dlfunc_t entry, const char *path)
      */
     obj->text_rodata_cap = (const char *)cheri_copyaddress(entry, obj->relocbase);
     fix_obj_mapping_cap_permissions(obj, path);
-    if (!create_pcc_caps(obj))
+    if (!create_pcc_caps(obj, path))
 	return (NULL);
 #endif
 
@@ -2931,7 +2931,7 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 #ifdef __CHERI_PURE_CAPABILITY__
     objtmp.text_rodata_cap = objtmp.relocbase;
     fix_obj_mapping_cap_permissions(&objtmp, "RTLD");
-    if (!create_pcc_caps(&objtmp))
+    if (!create_pcc_caps(&objtmp, "RTLD"))
 	rtld_die();
 #endif
 

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -533,7 +533,7 @@ extern bool ld_bind_not;
 extern bool ld_fast_sigblock;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-bool create_pcc_caps(Obj_Entry *);
+bool create_pcc_caps(Obj_Entry *, const char *);
 const char *pcc_cap(const Obj_Entry *, Elf_Off);
 #endif
 void dump_relocations(Obj_Entry *);


### PR DESCRIPTION
- **rtld: Fix error reporting when create_pcc_caps fails**
- **elftoolchain objcopy: Don't rewrite PT_CHERI_PCC and PT_C18N_NAME headers**
