### PR TITLE
 procstat: Print whether a compartment contains dlopened libraries 

### DIFF
--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -407,12 +407,12 @@ out:
 
 int
 procstat_getcompartments(struct procstat *procstat, struct kinfo_proc *kp,
-    struct cheri_c18n_compart **comparts, size_t *ncompartsp)
+    struct kinfo_cheri_c18n_compart **comparts, size_t *ncompartsp)
 {
 	int name[4];
 	char *inbuf;
 	size_t n, i, cur, size;
-	struct cheri_c18n_compart *outbuf, *cp;
+	struct kinfo_cheri_c18n_compart *outbuf, *cp;
 
 	if (comparts == NULL || ncompartsp == NULL)
 		goto out;
@@ -456,8 +456,8 @@ procstat_getcompartments(struct procstat *procstat, struct kinfo_proc *kp,
 		goto out_free;
 	}
 	for (n = 0, cur = 0; cur < size; ++n) {
-		cp = (struct cheri_c18n_compart *)(void *)&inbuf[cur];
-		cur += cp->ccc_structsize;
+		cp = (struct kinfo_cheri_c18n_compart *)(void *)(inbuf + cur);
+		cur += cp->kccc_structsize;
 	}
 
 	/* Unpack elements of the input buffer into the output buffer. */
@@ -465,9 +465,9 @@ procstat_getcompartments(struct procstat *procstat, struct kinfo_proc *kp,
 	if (outbuf == NULL)
 		goto out_free;
 	for (i = 0, cur = 0; i < n; ++i) {
-		cp = (struct cheri_c18n_compart *)(void *)&inbuf[cur];
-		cur += cp->ccc_structsize;
-		memcpy(&outbuf[i], cp, cp->ccc_structsize);
+		cp = (struct kinfo_cheri_c18n_compart *)(void *)(inbuf + cur);
+		cur += cp->kccc_structsize;
+		memcpy(&outbuf[i], cp, cp->kccc_structsize);
 	}
 
 	*comparts = outbuf;

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -219,7 +219,7 @@ struct advlock_list	*procstat_getadvlock(struct procstat *procstat);
 int	procstat_getc18n(struct procstat *procstat, struct kinfo_proc *kp,
     struct rtld_c18n_stats *stats);
 int	procstat_getcompartments(struct procstat *procstat,
-    struct kinfo_proc *kp, struct cheri_c18n_compart **comparts,
+    struct kinfo_proc *kp, struct kinfo_cheri_c18n_compart **comparts,
     size_t *ncomparts);
 struct filestat_list	*procstat_getfiles(struct procstat *procstat,
     struct kinfo_proc *kp, int mmapped);

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -244,8 +244,11 @@ string_base_search(const struct string_base *sb, const char *str)
 
 struct compart {
 	/*
-	 * Name of the compartment. Must be the first field to enable kernel
-	 * access to compartment information.
+	 * Compartment information exposed to the kernel.
+	 */
+	struct rtld_c18n_compart info;
+	/*
+	 * Name of the compartment.
 	 */
 	const char *name;
 	/*
@@ -313,6 +316,7 @@ expand_comparts_data(compart_id_t capacity)
 static struct compart *
 add_comparts_data(const char *name)
 {
+	compart_id_t i;
 	struct compart *com;
 
 	rtld_require(comparts.size <= COMPART_ID_MAX,
@@ -325,8 +329,13 @@ add_comparts_data(const char *name)
 	    memory_order_acq_rel);
 	GDB_COMPARTS_STATE(RCT_ADD, NULL);
 
-	com = &comparts.data[INC_NUM_COMPART];
+	i = INC_NUM_COMPART;
+	com = &comparts.data[i];
 	*com = (struct compart) {
+		.info = (struct rtld_c18n_compart) {
+			.rcc_name = name,
+			.rcc_id = i
+		},
 		.name = name
 	};
 	c18n_info->comparts_size = r_debug.r_comparts_size = comparts.size;

--- a/sys/cheri/c18n.h
+++ b/sys/cheri/c18n.h
@@ -60,6 +60,15 @@ struct rtld_c18n_stats {
 };
 
 /*
+ * Compartment information exposed by RTLD.
+ */
+struct rtld_c18n_compart {
+	const char * __kerncap	rcc_name;
+	size_t			rcc_id;
+	uint8_t			rcc_has_dlopened : 1;
+};
+
+/*
  * The interface provided by the kernel for RTLD to supply compartmentalisation
  * information. The version field doubles as a synchronisation flag where a
  * non-zero value indicates that the other fields have been initialised.
@@ -91,15 +100,15 @@ struct cheri_c18n_info {
  */
 #define	CHERI_C18N_COMPART_MAXNAME	(PATH_MAX + NAME_MAX + 2)
 
-struct cheri_c18n_compart {
+struct kinfo_cheri_c18n_compart {
 	/*
 	 * The last field of this struct may be truncated. This field contains
 	 * the actual aligned size of the current object.
 	 */
-	size_t		ccc_structsize;
-	ssize_t		ccc_id;
-	uint8_t		ccc_is_dlopened : 1;
-	char		ccc_name[CHERI_C18N_COMPART_MAXNAME];
+	size_t		kccc_structsize;
+	size_t		kccc_id;
+	uint8_t		kccc_has_dlopened : 1;
+	char		kccc_name[CHERI_C18N_COMPART_MAXNAME];
 };
 
 #ifndef IN_RTLD

--- a/usr.bin/procstat/procstat_compartments.c
+++ b/usr.bin/procstat/procstat_compartments.c
@@ -43,20 +43,20 @@
 void
 procstat_compartments(struct procstat *procstat, struct kinfo_proc *kipp)
 {
-	struct cheri_c18n_compart *cccp;
+	struct kinfo_cheri_c18n_compart *kcccp;
 	size_t ncomparts;
 
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0)
 		xo_emit("{T:/%5s %-19s %4s %-40s}\n", "PID", "COMM", "CID",
 		    "CNAME");
-	if (procstat_getcompartments(procstat, kipp, &cccp, &ncomparts) != 0)
+	if (procstat_getcompartments(procstat, kipp, &kcccp, &ncomparts) != 0)
 		return;
 	for (size_t i = 0; i < ncomparts; ++i) {
 		xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
 		xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
-		xo_emit(" {:cid/%4d/%zu}", cccp[i].ccc_id);
-		xo_emit(" {:cname/%-40s/%s}", cccp[i].ccc_name);
+		xo_emit(" {:cid/%4d/%zu}", kcccp[i].kccc_id);
+		xo_emit(" {:cname/%-40s/%s}", kcccp[i].kccc_name);
 		xo_emit("\n");
 	}
-	free(cccp);
+	free(kcccp);
 }

--- a/usr.bin/procstat/procstat_compartments.c
+++ b/usr.bin/procstat/procstat_compartments.c
@@ -47,14 +47,16 @@ procstat_compartments(struct procstat *procstat, struct kinfo_proc *kipp)
 	size_t ncomparts;
 
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0)
-		xo_emit("{T:/%5s %-19s %4s %-40s}\n", "PID", "COMM", "CID",
-		    "CNAME");
+		xo_emit("{T:/%5s %-19s %4s %6s %-40s}\n", "PID", "COMM", "CID",
+		    "DLOPEN", "CNAME");
 	if (procstat_getcompartments(procstat, kipp, &kcccp, &ncomparts) != 0)
 		return;
 	for (size_t i = 0; i < ncomparts; ++i) {
 		xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
 		xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
 		xo_emit(" {:cid/%4d/%zu}", kcccp[i].kccc_id);
+		xo_emit(" {n:has_dlopened/%6s/%s}",
+		    kcccp[i].kccc_has_dlopened ?  "true" : "false");
 		xo_emit(" {:cname/%-40s/%s}", kcccp[i].kccc_name);
 		xo_emit("\n");
 	}


### PR DESCRIPTION
Add another column to the output of `procstat -a compartments` that indicates whether a compartment contains at least one library that is dlopened.

Meanwhile, clean up a number of inconsistent uses of error codes in c18n-related procstat functions.