### PR TITLE
Add support for R_AARCH64_RELATIVE PLT entries for ld-elf64.so.

### DIFF
--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -524,6 +524,9 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 #endif
 			obj->irelative = true;
 			break;
+		case R_AARCH64_RELATIVE:
+			*where = (Elf_Addr)(obj->relocbase + rela->r_addend);
+			break;
 		case R_AARCH64_NONE:
 			break;
 #ifdef __CHERI_PURE_CAPABILITY__


### PR DESCRIPTION
This requirement seems to have arisen with sub-library compartmentalization
support with clang/ld, but doesn't seem harmful to have.