### PR TITLE
c18n: only enable policy files on purecap

### DIFF
--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -292,7 +292,7 @@ LDFLAGS+=	-Wl,--undefined-version
 .endif
 .endif
 
-.if ${MK_COMPARTMENT_POLICY} != "no"
+.if ${MK_COMPARTMENT_POLICY} != "no" && ${MACHINE_ABI:Mpurecap}
 .if !empty(COMPARTMENT_POLICY)
 ${SHLIB_NAME_FULL}:	${COMPARTMENT_POLICY}
 LDFLAGS+=	${COMPARTMENT_POLICY:S/^/-Wl,--compartment-policy=/}

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -170,7 +170,7 @@ DEBUGMKDIR=
 PROG_FULL=	${PROG}
 .endif
 
-.if ${MK_COMPARTMENT_POLICY} != "no"
+.if ${MK_COMPARTMENT_POLICY} != "no" && ${MACHINE_ABI:Mpurecap}
 .if !empty(COMPARTMENT_POLICY)
 ${PROG_FULL}:	${COMPARTMENT_POLICY}
 LDFLAGS+=	${COMPARTMENT_POLICY:S/^/-Wl,--compartment-policy=/}


### PR DESCRIPTION
There are usecases for other ABIs, but for now go ahead and confine it to purecap.  We might eventually want another knob to enable sub-library compartmentalization on hybrid for benchmarking.