### PR TITLE
Fix panics from kyua sys/* tests in purecap kernels

### DIFF
--- a/sys/dev/wg/if_wg.c
+++ b/sys/dev/wg/if_wg.c
@@ -139,7 +139,7 @@ struct aip_addr {
 };
 
 struct wg_aip {
-	struct radix_node	 a_nodes[2];
+	struct radix_node	 a_nodes[2] __subobject_use_container_bounds;
 	LIST_ENTRY(wg_aip)	 a_entry;
 	struct aip_addr		 a_addr;
 	struct aip_addr		 a_mask;

--- a/sys/dev/wg/wg_noise.c
+++ b/sys/dev/wg/wg_noise.c
@@ -61,7 +61,7 @@ struct noise_index {
 };
 
 struct noise_keypair {
-	struct noise_index		 kp_index;
+	struct noise_index		 kp_index __subobject_use_container_bounds;
 	u_int				 kp_refcnt;
 	bool				 kp_can_send;
 	bool				 kp_is_initiator;
@@ -93,7 +93,7 @@ enum noise_handshake_state {
 };
 
 struct noise_remote {
-	struct noise_index		 r_index;
+	struct noise_index		 r_index __subobject_use_container_bounds;
 
 	CK_LIST_ENTRY(noise_remote) 	 r_entry;
 	bool				 r_entry_inserted;

--- a/sys/kern/kern_malloc.c
+++ b/sys/kern/kern_malloc.c
@@ -638,7 +638,7 @@ malloc_large(size_t size, struct malloc_type *mtp, struct domainset *policy,
 		uma_total_inc(size);
 #ifdef __CHERI_PURE_CAPABILITY__
 		KASSERT(cheri_getlen(va) <= CHERI_REPRESENTABLE_LENGTH(size),
-		    ("Invalid bounds: expected %zx found %zx",
+		    ("Invalid bounds: expected %#zx found %#zx",
 		        (size_t)CHERI_REPRESENTABLE_LENGTH(size),
 		        (size_t)cheri_getlen(va)));
 #endif
@@ -723,7 +723,7 @@ void *
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
 	KASSERT(cheri_getlen(va) <= CHERI_REPRESENTABLE_LENGTH(size),
-	    ("Invalid bounds: expected %zx found %zx",
+	    ("Invalid bounds: expected %#zx found %#zx",
 	        (size_t)CHERI_REPRESENTABLE_LENGTH(size),
 	        (size_t)cheri_getlen(va)));
 #endif
@@ -998,7 +998,7 @@ _free(void *addr, struct malloc_type *mtp, bool dozero)
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (__predict_false(cheri_getlen(addr) !=
 		    CHERI_REPRESENTABLE_LENGTH(size)))
-			panic("Invalid bounds: expected %zx found %zx",
+			panic("Invalid bounds: expected %#zx found %#zx",
 			    (size_t)CHERI_REPRESENTABLE_LENGTH(size),
 			    cheri_getlen(addr));
 #endif
@@ -1016,7 +1016,7 @@ _free(void *addr, struct malloc_type *mtp, bool dozero)
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (__predict_false(cheri_getlen(addr) !=
 		    CHERI_REPRESENTABLE_LENGTH(size)))
-			panic("Invalid bounds: expected %zx found %zx",
+			panic("Invalid bounds: expected %#zx found %#zx",
 			    (size_t)CHERI_REPRESENTABLE_LENGTH(size),
 			    cheri_getlen(addr));
 #endif

--- a/sys/netpfil/ipfw/ip_fw_table_algo.c
+++ b/sys/netpfil/ipfw/ip_fw_table_algo.c
@@ -4017,7 +4017,7 @@ struct table_algo addr_kfib = {
 };
 
 struct mac_radix_entry {
-	struct radix_node	rn[2];
+	struct radix_node	rn[2] __subobject_use_container_bounds;
 	uint32_t		value;
 	uint8_t			masklen;
 	struct sa_mac		sa;

--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -122,7 +122,7 @@ struct mb_args {
 /*
  * Packet tag structure (see below for details).
  */
-struct m_tag {
+struct __no_subobject_bounds m_tag {
 	SLIST_ENTRY(m_tag)	m_tag_link;	/* List of packet tags */
 	u_int16_t		m_tag_id;	/* Tag ID */
 	u_int16_t		m_tag_len;	/* Length of data */


### PR DESCRIPTION
- **malloc: Include leading 0x prefixes when printing capability bounds**
- **mbuf: Disable subobject bounds for struct m_tag**
- **wg: Disable subobject bounds for yet another embedded struct radix_node**
- **ipfw: Disable suboject bounds for yet another embedded struct radix_node**
- **wg: Disable subobject bounds for embedded struct noise_index objects**
