### PR TITLE
`s/__CHERI__/__has_feature(capabilities)/`

### DIFF
--- a/libexec/rtld-elf/tests/cheri/abi-mismatch/basic_hybrid_lib/basic.c
+++ b/libexec/rtld-elf/tests/cheri/abi-mismatch/basic_hybrid_lib/basic.c
@@ -29,12 +29,9 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#if !__has_feature(capabilities)
-#error "This should support capabilities"
-#endif
 
-#ifndef __CHERI__
-#error Must be a hybrid library
+#if !__has_feature(capabilities)
+#error The compiler must support capabilities
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
 #error Must be a hybrid library

--- a/libexec/rtld-elf/tests/cheri/abi-mismatch/basic_purecap_lib/basic.c
+++ b/libexec/rtld-elf/tests/cheri/abi-mismatch/basic_purecap_lib/basic.c
@@ -29,8 +29,9 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#ifndef __CHERI__
-#error Must be a purecap library
+
+#if !__has_feature(capabilities)
+#error The compiler must support capabilities
 #endif
 #ifndef __CHERI_PURE_CAPABILITY__
 #error Must be a purecap library

--- a/tools/tools/syscall_timing/syscall_timing.c
+++ b/tools/tools/syscall_timing/syscall_timing.c
@@ -37,7 +37,7 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 
-#ifdef __CHERI__
+#if __has_feature(capabilities)
 #include <cheri/cheri.h>
 #endif
 


### PR DESCRIPTION
This backwards compatible change facilitates https://github.com/CTSRD-CHERI/llvm-project/pull/763.

With this change all remaining instances of `__CHERI__` are in LLVM code so should be fixed by subrepo pull.