### PR TITLE
p9fs: Use UNLINKAT instead of REMOVE to implement removals

### DIFF
--- a/sys/fs/p9fs/p9_client.c
+++ b/sys/fs/p9fs/p9_client.c
@@ -669,6 +669,27 @@ p9_client_remove(struct p9_fid *fid)
 	return (error);
 }
 
+int
+p9_client_unlink(struct p9_fid *dfid, const char *name, int32_t flags)
+{
+	int error;
+	struct p9_client *clnt;
+	struct p9_req_t *req;
+
+	error = 0;
+	clnt = dfid->clnt;
+
+	req = p9_client_request(clnt, P9PROTO_TUNLINKAT, &error, "dsd",
+	    dfid->fid, name, flags);
+	if (error != 0) {
+		P9_DEBUG(PROTO, "RUNLINKAT fid %d\n", dfid->fid);
+		return (error);
+	}
+
+	p9_free_req(clnt, req);
+	return (error);
+}
+
 /* Inform the file server that the current file represented by fid is no longer
  * needed by the client. Any allocated fid on the server needs a clunk to be
  * destroyed.

--- a/sys/fs/p9fs/p9_client.h
+++ b/sys/fs/p9fs/p9_client.h
@@ -140,6 +140,7 @@ int p9_client_write(struct p9_fid *fid, uint64_t offset, uint32_t count, char *d
 int p9_client_file_create(struct p9_fid *fid, char *name, uint32_t perm, int mode,
     char *extension);
 int p9_client_remove(struct p9_fid *fid);
+int p9_client_unlink(struct p9_fid *dfid, const char *name, int32_t flags);
 int p9_dirent_read(struct p9_client *clnt, char *buf, int start, int len,
     struct p9_dirent *dirent);
 int p9_client_statfs(struct p9_fid *fid, struct p9_statfs *stat);

--- a/sys/fs/p9fs/p9_protocol.h
+++ b/sys/fs/p9fs/p9_protocol.h
@@ -267,6 +267,8 @@ struct p9_iattr_dotl {
 
 #define P9PROTO_TGETATTR_BLK		512
 
+#define	P9PROTO_UNLINKAT_REMOVEDIR	0x200
+
 /* PDU buffer used for SG lists. */
 struct p9_buffer {
 	uint32_t size;


### PR DESCRIPTION
Cherry pick @markjdb's last p9fs fix that hasn't been merged yet so it lands in the release.