### PR TITLE
Move CHERI_CODEPTR_RELOCS to bsd.{lib,prog}.mk

### DIFF
--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -25,6 +25,7 @@
 #              mitigation.
 # - init-all:  supports stack variable initialization.
 # - aarch64-sha512: supports the AArch64 sha512 intrinsic functions.
+# - morello-codeptr-relocs: support code pointer relocations on Morello
 #
 # When bootstrapping on macOS, 'apple-clang' will be set in COMPILER_FEATURES
 # to differentiate Apple's version of Clang. Apple Clang uses a different
@@ -298,6 +299,15 @@ ${X_}COMPILER_FEATURES+=	fileprefixmap
 # AArch64 sha512 intrinsics are supported (and have been tested) in
 # clang 13 and gcc 9.
 ${X_}COMPILER_FEATURES+=	aarch64-sha512
+.endif
+
+.if ${${X_}COMPILER_TYPE} == "clang" && ${${X_}COMPILER_VERSION} >= 150000
+# XXX: This (like aarch64-sha512) depends on the feature only being used
+# on the correct target.  It also isn't completely accurate as revisions
+# of the compiler exist which are based on LLVM 15 and don't support
+# -cheri-codeptr-relocs.  Such systems will fail to build with an error
+# so this should be ok.
+${X_}COMPILER_FEATURES+=	morello-codeptr-relocs
 .endif
 
 .else

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -337,10 +337,6 @@ MACHINE_CPU += riscv
 CFLAGS+=	-march=morello
 CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs
 LDFLAGS+=	-march=morello
-.  if ${MK_CHERI_CODEPTR_RELOCS} != "no"
-CFLAGS+=	-cheri-codeptr-relocs
-LDFLAGS+=	-cheri-codeptr-relocs
-.  endif
 . endif
 
 . if ${MACHINE_ARCH:Maarch64*cb*}

--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -116,6 +116,11 @@ LDFLAGS+= -Wl,-zbti-report=error
 # TODO: Remove after the next release
 .if ${MACHINE_CPUARCH} == "aarch64" && ${MACHINE_CPU:Mcheri} && !defined(BOOTSTRAPPING)
 LDFLAGS+= -Wl,--local-caprelocs=elf
+
+.if ${MK_CHERI_CODEPTR_RELOCS} != "no" && ${COMPILER_FEATURES:Mmorello-codeptr-relocs}
+CFLAGS+=	-cheri-codeptr-relocs
+LDFLAGS+=	-cheri-codeptr-relocs
+.endif
 .endif
 
 # Initialize stack variables on function entry

--- a/share/mk/bsd.prog.mk
+++ b/share/mk/bsd.prog.mk
@@ -88,6 +88,11 @@ LDFLAGS+= -Wl,-zbti-report=error
 # TODO: Remove after the next release
 .if ${MACHINE_CPUARCH} == "aarch64" && ${MACHINE_CPU:Mcheri} && !defined(BOOTSTRAPPING)
 LDFLAGS+= -Wl,--local-caprelocs=elf
+
+.if ${MK_CHERI_CODEPTR_RELOCS} != "no" && ${COMPILER_FEATURES:Mmorello-codeptr-relocs}
+CFLAGS+=	-cheri-codeptr-relocs
+LDFLAGS+=	-cheri-codeptr-relocs
+.endif
 .endif
 
 # Initialize stack variables on function entry

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -153,9 +153,6 @@ INLINE_LIMIT?=	8000
 .if ${MACHINE_CPU:Mcheri}
 CFLAGS+=	-march=morello
 CFLAGS+=	-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs
-. if ${MK_CHERI_CODEPTR_RELOCS} != "no"
-CFLAGS+=	-cheri-codeptr-relocs
-. endif
 .endif
 
 .if ${MACHINE_ARCH:Maarch*c*}

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -197,6 +197,13 @@ LDFLAGS+=	-z notext -z ifunc-noplt
 .endif
 .endif  # ${MACHINE_CPUARCH} == "amd64"
 
+.if ${MACHINE_CPUARCH} == "aarch64" && ${MACHINE_ABI:Mcheri}
+.if ${MK_CHERI_CODEPTR_RELOCS} != "no" && ${COMPILER_FEATURES:Mmorello-codeptr-relocs}
+CFLAGS+=	-cheri-codeptr-relocs
+LDFLAGS+=	-cheri-codeptr-relocs
+.endif
+.endif
+
 .if ${MACHINE_CPUARCH} == "riscv"
 # Hack: Work around undefined weak symbols being out of range when linking with
 # LLD (address is a PC-relative calculation, and BFD works around this by


### PR DESCRIPTION
bsd.cpu.mk is included by sys.mk when in a FreeBSD port Makefile which means it's included without MK_* variables defined.  Due to the way this works (checking for ${.CURDIR}/../../Mk/bsd.port.mk) it's also from places like share/doc/IPV6/Makefile on MacOS where the mk directory matches Mk.