### PR TITLE
Bump __CheriBSD_version for function pointer changes

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20250127
+#define __CheriBSD_version 20250301
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,


### PR DESCRIPTION
With updated port versions this will also trigger the compiler wrapper to link with -cheri-codeptr-relocs.

This should be re-merged once package builds are complete.