### PR TITLE
Fix crashes extracting paths from device pager  VM objects

### DIFF
--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -3202,8 +3202,9 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 
 			kve->kve_ref_count = obj->ref_count;
 			kve->kve_shadow_count = obj->shadow_count;
-			if (obj->type == OBJT_DEVICE ||
-			    obj->type == OBJT_MGTDEVICE) {
+			if ((obj->type == OBJT_DEVICE ||
+			    obj->type == OBJT_MGTDEVICE) &&
+			    (obj->flags & OBJ_CDEVH) != 0) {
 				cdev = obj->un_pager.devp.handle;
 				if (cdev != NULL) {
 					csw = dev_refthread(cdev, &ref);

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -3204,7 +3204,7 @@ kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen, int flags)
 			kve->kve_shadow_count = obj->shadow_count;
 			if (obj->type == OBJT_DEVICE ||
 			    obj->type == OBJT_MGTDEVICE) {
-				cdev = obj->un_pager.devp.dev;
+				cdev = obj->un_pager.devp.handle;
 				if (cdev != NULL) {
 					csw = dev_refthread(cdev, &ref);
 					if (csw != NULL) {

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -977,6 +977,11 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			p = va_arg(ap, char *);
 			if (p == NULL)
 				p = "(null)";
+#ifdef __CHERI_PURE_CAPABILITY__
+			else if (!cheri_can_access(p, CHERI_PERM_LOAD,
+			    (ptraddr_t)p, 1))
+				p = "(invalid)";
+#endif
 			if (!dot)
 				n = strlen (p);
 			else

--- a/sys/vm/device_pager.c
+++ b/sys/vm/device_pager.c
@@ -118,8 +118,8 @@ cdev_pager_lookup(void *handle)
 again:
 	mtx_lock(&dev_pager_mtx);
 	object = vm_pager_object_lookup(&dev_pager_object_list, handle);
-	if (object != NULL && object->un_pager.devp.dev == NULL) {
-		msleep(&object->un_pager.devp.dev, &dev_pager_mtx,
+	if (object != NULL && object->un_pager.devp.handle == NULL) {
+		msleep(&object->un_pager.devp.handle, &dev_pager_mtx,
 		    PVM | PDROP, "cdplkp", 0);
 		vm_object_deallocate(object);
 		goto again;
@@ -183,8 +183,8 @@ again:
 			object1->type = OBJT_DEAD;
 			vm_object_deallocate(object1);
 			object1 = NULL;
-			if (object->un_pager.devp.dev == NULL) {
-				msleep(&object->un_pager.devp.dev,
+			if (object->un_pager.devp.handle == NULL) {
+				msleep(&object->un_pager.devp.handle,
 				    &dev_pager_mtx, PVM | PDROP, "cdplkp", 0);
 				vm_object_deallocate(object);
 				goto again;
@@ -218,7 +218,7 @@ again:
 				mtx_lock(&dev_pager_mtx);
 				TAILQ_REMOVE(&dev_pager_object_list, object,
 				    pager_object_list);
-				wakeup(&object->un_pager.devp.dev);
+				wakeup(&object->un_pager.devp.handle);
 				mtx_unlock(&dev_pager_mtx);
 				object->type = OBJT_DEAD;
 				vm_object_deallocate(object);
@@ -228,14 +228,14 @@ again:
 				mtx_lock(&dev_pager_mtx);
 				object->flags |= OBJ_COLORED;
 				object->pg_color = color;
-				object->un_pager.devp.dev = handle;
-				wakeup(&object->un_pager.devp.dev);
+				object->un_pager.devp.handle = handle;
+				wakeup(&object->un_pager.devp.handle);
 			}
 		}
 		MPASS(object1 == NULL);
 	} else {
-		if (object->un_pager.devp.dev == NULL) {
-			msleep(&object->un_pager.devp.dev,
+		if (object->un_pager.devp.handle == NULL) {
+			msleep(&object->un_pager.devp.handle,
 			    &dev_pager_mtx, PVM | PDROP, "cdplkp", 0);
 			vm_object_deallocate(object);
 			goto again;
@@ -301,7 +301,7 @@ dev_pager_dealloc(vm_object_t object)
 	vm_page_t m;
 
 	VM_OBJECT_WUNLOCK(object);
-	object->un_pager.devp.ops->cdev_pg_dtor(object->un_pager.devp.dev);
+	object->un_pager.devp.ops->cdev_pg_dtor(object->un_pager.devp.handle);
 
 	mtx_lock(&dev_pager_mtx);
 	TAILQ_REMOVE(&dev_pager_object_list, object, pager_object_list);

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -1906,6 +1906,9 @@ vm_mmap_cdev(struct thread *td, vm_size_t objsize, vm_prot_t *protp,
 	    td->td_ucred);
 	if (obj == NULL)
 		return (EINVAL);
+	VM_OBJECT_WLOCK(obj);
+	vm_object_set_flag(obj, OBJ_CDEVH);
+	VM_OBJECT_WUNLOCK(obj);
 	*objp = obj;
 	*flagsp = flags;
 	return (0);

--- a/sys/vm/vm_object.c
+++ b/sys/vm/vm_object.c
@@ -2524,7 +2524,7 @@ vm_object_list_handler(struct sysctl_req *req, bool swap_only)
 			kvo->kvo_swapped = sp > UINT32_MAX ? UINT32_MAX : sp;
 		}
 		if (obj->type == OBJT_DEVICE || obj->type == OBJT_MGTDEVICE) {
-			cdev = obj->un_pager.devp.dev;
+			cdev = obj->un_pager.devp.handle;
 			if (cdev != NULL) {
 				csw = dev_refthread(cdev, &ref);
 				if (csw != NULL) {

--- a/sys/vm/vm_object.c
+++ b/sys/vm/vm_object.c
@@ -2523,7 +2523,8 @@ vm_object_list_handler(struct sysctl_req *req, bool swap_only)
 			sp = swap_pager_swapped_pages(obj);
 			kvo->kvo_swapped = sp > UINT32_MAX ? UINT32_MAX : sp;
 		}
-		if (obj->type == OBJT_DEVICE || obj->type == OBJT_MGTDEVICE) {
+		if ((obj->type == OBJT_DEVICE || obj->type == OBJT_MGTDEVICE) &&
+		    (obj->flags & OBJ_CDEVH) != 0) {
 			cdev = obj->un_pager.devp.handle;
 			if (cdev != NULL) {
 				csw = dev_refthread(cdev, &ref);

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -137,7 +137,7 @@ struct vm_object {
 		struct {
 			TAILQ_HEAD(, vm_page) devp_pglist;
 			const struct cdev_pager_ops *ops;
-			struct cdev *dev;
+			void *handle;
 		} devp;
 
 		/*

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -204,6 +204,7 @@ struct vm_object {
 #define	OBJ_PAGERPRIV2	0x00008000	/* Pager private */
 #define	OBJ_SYSVSHM	0x00010000	/* SysV SHM */
 #define	OBJ_POSIXSHM	0x00020000	/* Posix SHM */
+#define	OBJ_CDEVH	0x00040000	/* OBJT_DEVICE handle is cdev */
 #define	OBJ_HASCAP	0x01000000	/* object can store capabilities */
 #define	OBJ_NOCAP	0x02000000	/* object and all shadow objects can
 					   not store capabilities */


### PR DESCRIPTION
- **sys: Don't crash on invalid strings passed to %s for printf**
- **device_pager: rename the un_pager.devp.dev field to handle**
- **vm_object: do not assume that un_pager.devp.dev is cdev**
