### PR TITLE
Fixes to pcb_onfault handling

### DIFF
--- a/sys/arm64/arm64/trap.c
+++ b/sys/arm64/arm64/trap.c
@@ -293,15 +293,14 @@ external_abort(struct thread *td, struct trapframe *frame, uint64_t esr,
 	 * bus_space_peek() and/or bus_space_poke() functions.
 	 */
 	if (test_bs_fault((uintcap_t)frame->tf_elr)) {
-#if __has_feature(capabilities)
-#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-		trapframe_set_elr(frame,
-		    (uintcap_t)cheri_setaddress(cheri_getpcc(),
-		    (uint64_t)generic_bs_fault));
-#else
-		frame->tf_elr = (uintcap_t)cheri_setaddress(cheri_getpcc(),
-		    (uint64_t)generic_bs_fault);
-#endif
+#if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+		frame->tf_elr = cheri_setaddress(frame->tf_elr,
+		    (ptraddr_t)generic_bs_fault);
+#elif defined(__CHERI_PURE_CAPABILITY__)
+		trapframe_set_elr(frame, (uintptr_t)generic_bs_fault);
+#elif __has_feature(capabilities)
+		trapframe_set_elr(frame, cheri_setaddress(frame->tf_elr,
+		    (ptraddr_t)generic_bs_fault));
 #else
 		frame->tf_elr = (uint64_t)generic_bs_fault;
 #endif
@@ -325,13 +324,14 @@ cap_abort(struct thread *td, struct trapframe *frame, uint64_t esr,
 		if (td->td_intr_nesting_level == 0 &&
 		    pcb->pcb_onfault != 0) {
 			frame->tf_x[0] = EPROT;
-#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-			trapframe_set_elr(frame,
-			    (uintcap_t)cheri_setaddress(cheri_getpcc(),
-			    pcb->pcb_onfault));
+#if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+			frame->tf_elr = cheri_setaddress(frame->tf_elr,
+			    pcb->pcb_onfault);
+#elif defined(__CHERI_PURE_CAPABILITY__)
+			trapframe_set_elr(frame, pcb->pcb_onfault);
 #else
-			frame->tf_elr = (uintcap_t)cheri_setaddress(
-			    cheri_getpcc(), pcb->pcb_onfault);
+			trapframe_set_elr(frame, cheri_setaddress(frame->tf_elr,
+			    pcb->pcb_onfault));
 #endif
 			return;
 		}
@@ -517,15 +517,14 @@ bad_far:
 		} else {
 			if (td->td_intr_nesting_level == 0 &&
 			    pcb->pcb_onfault != 0) {
-#if __has_feature(capabilities)
-#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
-				trapframe_set_elr(frame,
-				    (uintcap_t)cheri_setaddress(cheri_getpcc(),
-				    pcb->pcb_onfault));
-#else
-				frame->tf_elr = (uintcap_t)cheri_setaddress(
-				    cheri_getpcc(), pcb->pcb_onfault);
-#endif
+#if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
+				frame->tf_elr = cheri_setaddress(frame->tf_elr,
+				    pcb->pcb_onfault);
+#elif defined(__CHERI_PURE_CAPABILITY__)
+				trapframe_set_elr(frame, pcb->pcb_onfault);
+#elif __has_feature(capabilities)
+				trapframe_set_elr(frame, cheri_setaddress(
+				    frame->tf_elr, pcb->pcb_onfault));
 #else
 				frame->tf_elr = pcb->pcb_onfault;
 #endif

--- a/sys/riscv/include/pcb.h
+++ b/sys/riscv/include/pcb.h
@@ -58,7 +58,7 @@ struct pcb {
 	uint64_t	pcb_fpflags;	/* Floating point flags */
 #define	PCB_FP_STARTED	0x1
 #define	PCB_FP_USERMASK	0x1
-	vm_offset_t	pcb_onfault;	/* Copyinout fault handler */
+	vm_pointer_t	pcb_onfault;	/* Copyinout fault handler */
 };
 
 #ifdef _KERNEL

--- a/sys/riscv/riscv/cheri_revoke_machdep.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep.c
@@ -281,7 +281,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 #endif
 
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
-	curthread->td_pcb->pcb_onfault = (vm_offset_t)vm_cheri_revoke_tlb_fault;
+	curthread->td_pcb->pcb_onfault = (vm_pointer_t)vm_cheri_revoke_tlb_fault;
 	enable_user_memory_access();
 #endif
 
@@ -366,7 +366,7 @@ vm_cheri_revoke_test(const struct vm_cheri_revoke_cookie *crc, uintcap_t cut)
 
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
 		curthread->td_pcb->pcb_onfault =
-		    (vm_offset_t)vm_cheri_revoke_tlb_fault;
+		    (vm_pointer_t)vm_cheri_revoke_tlb_fault;
 		enable_user_memory_access();
 #endif
 		res = crc->map->vm_cheri_revoke_test(crc->crshadow, cut,

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -433,7 +433,7 @@ skip_pmap:
 		} else {
 			if (pcb->pcb_onfault != 0) {
 				frame->tf_a[0] = error;
-#if __has_feature(capabilities)
+#if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 				frame->tf_sepc = (uintcap_t)cheri_setaddress(
 				    cheri_getpcc(), pcb->pcb_onfault);
 #else
@@ -538,8 +538,12 @@ do_trap_supervisor(struct trapframe *frame)
 	case SCAUSE_CHERI:
 		if (curthread->td_pcb->pcb_onfault != 0) {
 			frame->tf_a[0] = EPROT;
+#ifndef __CHERI_PURE_CAPABILITY__
 			frame->tf_sepc = (uintcap_t)cheri_setaddress(
 			    cheri_getpcc(), curthread->td_pcb->pcb_onfault);
+#else
+			frame->tf_sepc = curthread->td_pcb->pcb_onfault;
+#endif
 			break;
 		}
 		dump_regs(frame);

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -434,8 +434,8 @@ skip_pmap:
 			if (pcb->pcb_onfault != 0) {
 				frame->tf_a[0] = error;
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
-				frame->tf_sepc = (uintcap_t)cheri_setaddress(
-				    cheri_getpcc(), pcb->pcb_onfault);
+				frame->tf_sepc = cheri_setaddress(
+				    frame->tf_sepc, pcb->pcb_onfault);
 #else
 				frame->tf_sepc = pcb->pcb_onfault;
 #endif
@@ -539,8 +539,8 @@ do_trap_supervisor(struct trapframe *frame)
 		if (curthread->td_pcb->pcb_onfault != 0) {
 			frame->tf_a[0] = EPROT;
 #ifndef __CHERI_PURE_CAPABILITY__
-			frame->tf_sepc = (uintcap_t)cheri_setaddress(
-			    cheri_getpcc(), curthread->td_pcb->pcb_onfault);
+			frame->tf_sepc = cheri_setaddress(frame->tf_sepc,
+			    curthread->td_pcb->pcb_onfault);
 #else
 			frame->tf_sepc = curthread->td_pcb->pcb_onfault;
 #endif


### PR DESCRIPTION
- **riscv: Use vm_pointer_t for pcb_onfault**
- **ricsv: Use pcb_onfault to set all of tf_sepc for purecap kernels**
- **riscv: Derive new exception PC for onfault from saved exception PC**
- **morello: Cleanup setting a new PCC from pcb_onfault**
