### PR TITLE
c18n: Block all signals upon entering _rtld_thr_exit

### DIFF
--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1885,8 +1885,15 @@ void
 _rtld_thr_exit(long *state)
 {
 	size_t i;
+	sigset_t nset;
 	struct stk_table_stk_info *data;
 	struct stk_table *table = get_stk_table();
+
+	/*
+	 * Block all signals before destroying thread-specific data structures.
+	 */
+	SIGFILLSET(nset);
+	sigprocmask(SIG_SETMASK, &nset, NULL);
 
 	/*
 	 * Uninstall the trusted stack and the stack lookup table.


### PR DESCRIPTION
_rtld_thr_exit destructs all thread-specific data structures and receiving a signal during this period would be very problematic.