### PR TITLE
c18n: Distinguish explicitly dlopened compartments from dependencies

### DIFF
--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -423,6 +423,7 @@ TAILQ_HEAD(obj_entry_q, Struct_Obj_Entry);
 				   initialization during the image start. */
 #define	RTLD_LO_IGNSTLS 0x40	/* Do not allocate static TLS */
 #define	RTLD_LO_DEEPBIND 0x80	/* Force symbolic for this object */
+#define	RTLD_LO_DLOPEN_TOP 0x100 /* Explicitly named by dlopen. */
 
 /*
  * Symbol cache entry used during relocation to avoid multiple lookups

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -59,7 +59,7 @@ typedef uint16_t compart_id_t;
  */
 typedef struct { uint16_t val; } stk_table_index;
 
-compart_id_t compart_id_allocate(const char *);
+compart_id_t compart_id_allocate(const char *, int);
 compart_id_t compart_id_for_address(const Obj_Entry *, Elf_Addr);
 
 /*

--- a/sys/cheri/c18n.h
+++ b/sys/cheri/c18n.h
@@ -65,7 +65,8 @@ struct rtld_c18n_stats {
 struct rtld_c18n_compart {
 	const char * __kerncap	rcc_name;
 	size_t			rcc_id;
-	uint8_t			rcc_has_dlopened : 1;
+	uint8_t			rcc_dlopened_explicitly : 1;
+	uint8_t			rcc_dlopened : 1;
 };
 
 /*
@@ -107,7 +108,8 @@ struct kinfo_cheri_c18n_compart {
 	 */
 	size_t		kccc_structsize;
 	size_t		kccc_id;
-	uint8_t		kccc_has_dlopened : 1;
+	uint8_t		kccc_dlopened_explicitly : 1;
+	uint8_t		kccc_dlopened : 1;
 	char		kccc_name[CHERI_C18N_COMPART_MAXNAME];
 };
 

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2704,7 +2704,8 @@ sysctl_kern_proc_c18n_compartments(SYSCTL_HANDLER_ARGS)
 		len = roundup2(len, _Alignof(struct kinfo_cheri_c18n_compart));
 		kccc.kccc_structsize = len;
 		kccc.kccc_id = rcc.rcc_id;;
-		kccc.kccc_has_dlopened = rcc.rcc_has_dlopened;
+		kccc.kccc_dlopened_explicitly = rcc.rcc_dlopened_explicitly;
+		kccc.kccc_dlopened = rcc.rcc_dlopened;
 
 		/* Copy out userspace structure. */
 		error = SYSCTL_OUT(req, &kccc, len);

--- a/usr.bin/procstat/procstat_compartments.c
+++ b/usr.bin/procstat/procstat_compartments.c
@@ -55,8 +55,8 @@ procstat_compartments(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
 		xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
 		xo_emit(" {:cid/%4d/%zu}", kcccp[i].kccc_id);
-		xo_emit(" {:flag/%-5s/%s}", kcccp[i].kccc_has_dlopened ? "D"
-		    : "-");
+		xo_emit(" {:flag/%-5s/%s%s}", kcccp[i].kccc_dlopened ?
+		    (kcccp[i].kccc_dlopened_explicitly ? "D" : "d") : "-");
 		xo_emit(" {:cname/%-40s/%s}", kcccp[i].kccc_name);
 		xo_emit("\n");
 	}


### PR DESCRIPTION
Add a new RTLD_LO_DLOPEN_TOP flag that is passed to load_object by dlopen but is not passed down to dependencies.

Pass down the flags from load_object down to compart_id_allocate. Rename the has_dlopened flag to just dlopened and set it if RTLD_LO_DLOPEN is set.  Add a new dlopened_explicitly flag that is set for RTLD_LO_DLOPEN_TOP.

Change procstat to use D for explicitly dlopened compartments, and d for implicitly loaded compartments.