### PR TITLE
c18n: Teach __elf_phdr_match_addr to unwrap trampolines

### DIFF
--- a/lib/libc/gen/elf_utils.c
+++ b/lib/libc/gen/elf_utils.c
@@ -42,11 +42,22 @@ void __pthread_map_stacks_exec(void);
 #endif
 void __pthread_distribute_static_tls(size_t, void *, size_t, size_t);
 
+#ifdef CHERI_LIB_C18N
+ptraddr_t _rtld_tramp_reflect(const void *);
+#endif
+
 int
 __elf_phdr_match_addr(struct dl_phdr_info *phdr_info, void *addr)
 {
 	const Elf_Phdr *ph;
 	int i;
+#ifdef CHERI_LIB_C18N
+	ptraddr_t target;
+
+	target = _rtld_tramp_reflect(addr);
+	if (target != 0)
+		addr = (void *)(uintptr_t)target;
+#endif
 
 	for (i = 0; i < phdr_info->dlpi_phnum; i++) {
 		ph = &phdr_info->dlpi_phdr[i];

--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -1,6 +1,7 @@
 FBSDprivate_1.0 {
     r_debug_comparts_state;
     _compart_size;
+    _rtld_tramp_reflect;
     _rtld_thread_start_init;
     _rtld_thread_start;
     _rtld_thr_exit;

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1660,6 +1660,20 @@ tramp_reflect(const void *data)
 	return (NULL);
 }
 
+ptraddr_t _rtld_tramp_reflect(const void *);
+
+ptraddr_t
+_rtld_tramp_reflect(const void *addr)
+{
+	struct tramp_header *header;
+
+	header = tramp_reflect(addr);
+	if (header == NULL)
+		return (0);
+
+	return ((ptraddr_t)header->target);
+}
+
 /*
  * APIs
  */

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -49,6 +49,7 @@ trust
 
 callee [RTLD]
 export to [TCB]
+	_rtld_tramp_reflect
 	_rtld_thread_start_init
 	_rtld_thread_start
 	_rtld_thr_exit


### PR DESCRIPTION
Expose RTLD's tramp_reflect to libc so that __elf_phdr_match_addr can use it to unwrap any function pointers passed into it.