### PR TITLE
Various fixes for working rtwn

### DIFF
--- a/sys/dev/rtwn/if_rtwn.c
+++ b/sys/dev/rtwn/if_rtwn.c
@@ -332,6 +332,11 @@ rtwn_sysctlattach(struct rtwn_softc *sc)
 	    sc->sc_ht40, "Enable 40 MHz mode support");
 #endif
 
+	sc->sc_ena_tsf64 = 0;
+	SYSCTL_ADD_INT(ctx, SYSCTL_CHILDREN(tree), OID_AUTO,
+	    "ena_tsf64", CTLFLAG_RWTUN, &sc->sc_ena_tsf64,
+	    sc->sc_ena_tsf64, "Enable/disable per-packet TSF64 reporting");
+
 #ifdef RTWN_DEBUG
 	SYSCTL_ADD_U32(ctx, SYSCTL_CHILDREN(tree), OID_AUTO,
 	    "debug", CTLFLAG_RWTUN, &sc->sc_debug, sc->sc_debug,

--- a/sys/dev/rtwn/if_rtwn.c
+++ b/sys/dev/rtwn/if_rtwn.c
@@ -1129,6 +1129,9 @@ rtwn_newstate(struct ieee80211vap *vap, enum ieee80211_state nstate, int arg)
 			/* Stop Rx of data frames. */
 			rtwn_write_2(sc, R92C_RXFLTMAP2, 0);
 
+			/* Stop Rx of control frames. */
+			rtwn_write_2(sc, R92C_RXFLTMAP1, 0);
+
 			/* Reset EDCA parameters. */
 			rtwn_write_4(sc, R92C_EDCA_VO_PARAM, 0x002f3217);
 			rtwn_write_4(sc, R92C_EDCA_VI_PARAM, 0x005e4317);
@@ -1267,6 +1270,11 @@ rtwn_run(struct rtwn_softc *sc, struct ieee80211vap *vap)
 	rtwn_write_2(sc, R92C_BCN_INTERVAL(uvp->id), ni->ni_intval);
 
 	if (sc->vaps_running == sc->monvaps_running) {
+		/* Enable Rx of BAR control frames. */
+		rtwn_write_2(sc, R92C_RXFLTMAP1,
+		    1 << (IEEE80211_FC0_SUBTYPE_BAR >>
+		    IEEE80211_FC0_SUBTYPE_SHIFT));
+
 		/* Enable Rx of data frames. */
 		rtwn_write_2(sc, R92C_RXFLTMAP2, 0xffff);
 

--- a/sys/dev/rtwn/if_rtwn_rx.c
+++ b/sys/dev/rtwn/if_rtwn_rx.c
@@ -285,8 +285,18 @@ rtwn_rx_common(struct rtwn_softc *sc, struct mbuf *m, void *desc)
 		rxs.c_pktflags |= IEEE80211_RX_F_FAIL_FCSCRC;
 
 	rxs.r_flags |= IEEE80211_R_TSF_START;	/* XXX undocumented */
-	rxs.r_flags |= IEEE80211_R_TSF64;
-	rxs.c_rx_tsf = rtwn_extend_rx_tsf(sc, stat);
+
+	/*
+	 * Doing the TSF64 extension on USB is expensive, especially
+	 * if it's being done on every MPDU in an AMPDU burst.
+	 */
+	if (sc->sc_ena_tsf64) {
+		rxs.r_flags |= IEEE80211_R_TSF64;
+		rxs.c_rx_tsf = rtwn_extend_rx_tsf(sc, stat);
+	} else {
+		rxs.r_flags |= IEEE80211_R_TSF32;
+		rxs.c_rx_tsf = le32toh(stat->tsf_low);
+	}
 
 	/* Get RSSI from PHY status descriptor. */
 	is_cck = (rxs.c_pktflags & IEEE80211_RX_F_CCK) != 0;

--- a/sys/dev/rtwn/if_rtwn_rx.c
+++ b/sys/dev/rtwn/if_rtwn_rx.c
@@ -510,7 +510,7 @@ rtwn_set_promisc(struct rtwn_softc *sc)
 	RTWN_ASSERT_LOCKED(sc);
 
 	mask_all = R92C_RCR_ACF | R92C_RCR_ADF | R92C_RCR_AMF | R92C_RCR_AAP;
-	mask_min = R92C_RCR_APM | R92C_RCR_APPFCS;
+	mask_min = R92C_RCR_APM;
 
 	if (sc->bcn_vaps == 0)
 		mask_min |= R92C_RCR_CBSSID_BCN;
@@ -529,5 +529,12 @@ rtwn_set_promisc(struct rtwn_softc *sc)
 		sc->rcr &= ~mask_min;
 		sc->rcr |= mask_all;
 	}
+
+	/*
+	 * Add FCS, to work around occasional 4 byte truncation.
+	 * See the previous comment above R92C_RCR_APPFCS.
+	 */
+	sc->rcr |= R92C_RCR_APPFCS;
+
 	rtwn_rxfilter_set(sc);
 }

--- a/sys/dev/rtwn/if_rtwn_tx.c
+++ b/sys/dev/rtwn/if_rtwn_tx.c
@@ -263,6 +263,11 @@ rtwn_start(struct rtwn_softc *sc)
 	struct mbuf *m;
 
 	RTWN_ASSERT_LOCKED(sc);
+
+	/* Ensure no work is scheduled during reset/teardown */
+	if ((sc->sc_flags & RTWN_RUNNING) == 0)
+		return;
+
 	while ((m = mbufq_dequeue(&sc->sc_snd)) != NULL) {
 		if (sc->qfullmsk != 0) {
 			mbufq_prepend(&sc->sc_snd, m);

--- a/sys/dev/rtwn/if_rtwnvar.h
+++ b/sys/dev/rtwn/if_rtwnvar.h
@@ -32,7 +32,7 @@
 #define RTWN_MACID_VALID 	0x8000
 #define RTWN_MACID_LIMIT	128
 
-#define RTWN_TX_TIMEOUT		5000	/* ms */
+#define RTWN_TX_TIMEOUT		1000	/* ms */
 #define RTWN_MAX_EPOUT		4
 #define RTWN_PORT_COUNT		2
 

--- a/sys/dev/rtwn/if_rtwnvar.h
+++ b/sys/dev/rtwn/if_rtwnvar.h
@@ -96,7 +96,7 @@ struct rtwn_cmdq {
 #define RTWN_CMDQ_SIZE		16
 
 struct rtwn_node {
-	struct ieee80211_node	ni;	/* must be the first */
+	struct ieee80211_node	ni __subobject_member_used_for_c_inheritance;	/* must be the first */
 	int			id;
 
 	struct rtwn_tx_phystat	last_physt;
@@ -105,7 +105,7 @@ struct rtwn_node {
 #define RTWN_NODE(ni)		((struct rtwn_node *)(ni))
 
 struct rtwn_vap {
-	struct ieee80211vap	vap;
+	struct ieee80211vap	vap __subobject_member_used_for_c_inheritance;
 	int			id;
 #define RTWN_VAP_ID_INVALID	-1
 	int			curr_mode;

--- a/sys/dev/rtwn/if_rtwnvar.h
+++ b/sys/dev/rtwn/if_rtwnvar.h
@@ -174,6 +174,7 @@ struct rtwn_softc {
 #if 1
 	int			sc_ht40;
 #endif
+	int			sc_ena_tsf64;
 	uint32_t		sc_debug;
 	int			sc_hwcrypto;
 	int			sc_ratectl_sysctl;

--- a/sys/dev/rtwn/rtl8812a/r12a_rx.c
+++ b/sys/dev/rtwn/rtl8812a/r12a_rx.c
@@ -178,6 +178,15 @@ r12a_handle_c2h_report(struct rtwn_softc *sc, uint8_t *buf, int len)
 int
 r12a_check_frame_checksum(struct rtwn_softc *sc, struct mbuf *m)
 {
+	/*
+	 * XXX: RTL8821AU seems to incorrectly handle at least UDP checksum
+	 * fields of 0, treating them as an error. Ignore the offloaded
+	 * checksumming result until this has been better characterised
+	 * (including whether all-ones is correctly handled).
+	 *
+	 * https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285837
+	 */
+#if 0
 	struct r12a_softc *rs = sc->sc_priv;
 	struct r92c_rx_stat *stat;
 	uint32_t rxdw1;
@@ -202,6 +211,7 @@ r12a_check_frame_checksum(struct rtwn_softc *sc, struct mbuf *m)
 			m->m_pkthdr.csum_data = 0xffff;
 		}
 	}
+#endif
 
 	return (0);
 }

--- a/sys/dev/rtwn/usb/rtwn_usb_ep.c
+++ b/sys/dev/rtwn/usb/rtwn_usb_ep.c
@@ -55,7 +55,7 @@
 
 #include <dev/rtwn/rtl8192c/usb/r92cu_reg.h>
 
-static const struct usb_config rtwn_config_common[RTWN_N_TRANSFER] = {
+static const struct usb_config rtwn_config_common[RTWN_BULK_EP_COUNT] = {
 	[RTWN_BULK_RX] = {
 		.type = UE_BULK,
 		.endpoint = UE_ADDR_ANY,
@@ -76,7 +76,7 @@ static const struct usb_config rtwn_config_common[RTWN_N_TRANSFER] = {
 			.pipe_bof = 1,
 			.force_short_xfer = 1,
 		},
-		.callback = rtwn_bulk_tx_callback,
+		.callback = rtwn_bulk_tx_callback_be,
 		.timeout = RTWN_TX_TIMEOUT,	/* ms */
 	},
 	[RTWN_BULK_TX_BK] = {
@@ -89,7 +89,7 @@ static const struct usb_config rtwn_config_common[RTWN_N_TRANSFER] = {
 			.pipe_bof = 1,
 			.force_short_xfer = 1,
 		},
-		.callback = rtwn_bulk_tx_callback,
+		.callback = rtwn_bulk_tx_callback_bk,
 		.timeout = RTWN_TX_TIMEOUT,	/* ms */
 	},
 	[RTWN_BULK_TX_VI] = {
@@ -102,7 +102,7 @@ static const struct usb_config rtwn_config_common[RTWN_N_TRANSFER] = {
 			.pipe_bof = 1,
 			.force_short_xfer = 1
 		},
-		.callback = rtwn_bulk_tx_callback,
+		.callback = rtwn_bulk_tx_callback_vi,
 		.timeout = RTWN_TX_TIMEOUT,	/* ms */
 	},
 	[RTWN_BULK_TX_VO] = {
@@ -115,7 +115,7 @@ static const struct usb_config rtwn_config_common[RTWN_N_TRANSFER] = {
 			.pipe_bof = 1,
 			.force_short_xfer = 1
 		},
-		.callback = rtwn_bulk_tx_callback,
+		.callback = rtwn_bulk_tx_callback_vo,
 		.timeout = RTWN_TX_TIMEOUT,	/* ms */
 	},
 };
@@ -200,22 +200,33 @@ rtwn_usb_setup_endpoints(struct rtwn_usb_softc *uc)
 
 	/* NB: keep in sync with rtwn_dma_init(). */
 	rtwn_config[RTWN_BULK_TX_VO].endpoint = addr[0];
+	uc->wme2qid[WME_AC_VO] = RTWN_BULK_TX_VO;
 	switch (uc->ntx) {
 	case 4:
 	case 3:
 		rtwn_config[RTWN_BULK_TX_BE].endpoint = addr[2];
 		rtwn_config[RTWN_BULK_TX_BK].endpoint = addr[2];
 		rtwn_config[RTWN_BULK_TX_VI].endpoint = addr[1];
+		uc->wme2qid[WME_AC_BE] = RTWN_BULK_TX_BE;
+		uc->wme2qid[WME_AC_BK] = RTWN_BULK_TX_BE;
+		uc->wme2qid[WME_AC_VI] = RTWN_BULK_TX_VI;
 		break;
 	case 2:
 		rtwn_config[RTWN_BULK_TX_BE].endpoint = addr[1];
 		rtwn_config[RTWN_BULK_TX_BK].endpoint = addr[1];
 		rtwn_config[RTWN_BULK_TX_VI].endpoint = addr[0];
+		uc->wme2qid[WME_AC_BE] = RTWN_BULK_TX_VI;
+		uc->wme2qid[WME_AC_BK] = RTWN_BULK_TX_VI;
+		uc->wme2qid[WME_AC_VI] = RTWN_BULK_TX_VO;
 		break;
 	case 1:
 		rtwn_config[RTWN_BULK_TX_BE].endpoint = addr[0];
 		rtwn_config[RTWN_BULK_TX_BK].endpoint = addr[0];
 		rtwn_config[RTWN_BULK_TX_VI].endpoint = addr[0];
+
+		uc->wme2qid[WME_AC_BE] = RTWN_BULK_TX_VO;
+		uc->wme2qid[WME_AC_BK] = RTWN_BULK_TX_VO;
+		uc->wme2qid[WME_AC_VI] = RTWN_BULK_TX_VO;
 		break;
 	default:
 		KASSERT(0, ("unhandled number of endpoints %d\n", uc->ntx));
@@ -225,7 +236,7 @@ rtwn_usb_setup_endpoints(struct rtwn_usb_softc *uc)
 	rtwn_config[RTWN_BULK_RX].bufsize =
 	    uc->uc_rx_buf_size * RTWN_USB_RXBUFSZ_UNIT;
 	error = usbd_transfer_setup(uc->uc_udev, &iface_index,
-	    uc->uc_xfer, rtwn_config, RTWN_N_TRANSFER, uc, &sc->sc_mtx);
+	    uc->uc_xfer, rtwn_config, RTWN_BULK_EP_COUNT, uc, &sc->sc_mtx);
 	free(rtwn_config, M_TEMP);
 
 	if (error) {

--- a/sys/dev/rtwn/usb/rtwn_usb_tx.h
+++ b/sys/dev/rtwn/usb/rtwn_usb_tx.h
@@ -17,7 +17,10 @@
 #ifndef RTWN_USB_TX_H
 #define RTWN_USB_TX_H
 
-void	rtwn_bulk_tx_callback(struct usb_xfer *, usb_error_t);
+void	rtwn_bulk_tx_callback_bk(struct usb_xfer *, usb_error_t);
+void	rtwn_bulk_tx_callback_be(struct usb_xfer *, usb_error_t);
+void	rtwn_bulk_tx_callback_vi(struct usb_xfer *, usb_error_t);
+void	rtwn_bulk_tx_callback_vo(struct usb_xfer *, usb_error_t);
 int	rtwn_usb_tx_start(struct rtwn_softc *, struct ieee80211_node *,
 	    struct mbuf *, uint8_t *, uint8_t, int);
 

--- a/sys/dev/rtwn/usb/rtwn_usb_var.h
+++ b/sys/dev/rtwn/usb/rtwn_usb_var.h
@@ -37,6 +37,7 @@ struct rtwn_data {
 	uint8_t				*buf;
 	/* 'id' is meaningful for beacons only */
 	int				id;
+	int				qid;
 	uint16_t			buflen;
 	struct mbuf			*m;
 	struct ieee80211_node		*ni;
@@ -50,15 +51,16 @@ enum {
 	RTWN_BULK_TX_BK,	/* = WME_AC_BK */
 	RTWN_BULK_TX_VI,	/* = WME_AC_VI */
 	RTWN_BULK_TX_VO,	/* = WME_AC_VO */
-	RTWN_N_TRANSFER = 5,
+	RTWN_BULK_EP_COUNT = 5,
 };
 
 #define RTWN_EP_QUEUES		RTWN_BULK_RX
+#define	RTWN_BULK_TX_FIRST	RTWN_BULK_TX_BE
 
 struct rtwn_usb_softc {
 	struct rtwn_softc	uc_sc __subobject_member_used_for_c_inheritance;		/* must be the first */
 	struct usb_device	*uc_udev;
-	struct usb_xfer		*uc_xfer[RTWN_N_TRANSFER];
+	struct usb_xfer		*uc_xfer[RTWN_BULK_EP_COUNT];
 
 	struct rtwn_data	uc_rx[RTWN_USB_RX_LIST_COUNT];
 	rtwn_datahead		uc_rx_active;
@@ -70,14 +72,16 @@ struct rtwn_usb_softc {
 	int			uc_rx_off;
 
 	struct rtwn_data	uc_tx[RTWN_USB_TX_LIST_COUNT];
-	rtwn_datahead		uc_tx_active;
+	rtwn_datahead		uc_tx_active[RTWN_BULK_EP_COUNT];
 	rtwn_datahead		uc_tx_inactive;
-	rtwn_datahead		uc_tx_pending;
+	rtwn_datahead		uc_tx_pending[RTWN_BULK_EP_COUNT];
 
 	int			(*uc_align_rx)(int, int);
 
 	int			ntx;
 	int			tx_agg_desc_num;
+
+	uint8_t			wme2qid[4];
 };
 #define RTWN_USB_SOFTC(sc)	((struct rtwn_usb_softc *)(sc))
 

--- a/sys/net80211/ieee80211.c
+++ b/sys/net80211/ieee80211.c
@@ -2710,3 +2710,57 @@ ieee80211_is_key_unicast(const struct ieee80211vap *vap,
 	 */
 	return (!ieee80211_is_key_global(vap, key));
 }
+
+/**
+ * Determine whether the given control frame is from a known node
+ * and destined to us.
+ *
+ * In some instances a control frame won't have a TA (eg ACKs), so
+ * we should only verify the RA for those.
+ *
+ * @param ni	ieee80211_node representing the sender, or BSS node
+ * @param m0	mbuf representing the 802.11 frame.
+ * @returns	false if the frame is not a CTL frame (with a warning logged);
+ *		true if the frame is from a known sender / valid recipient,
+ *		false otherwise.
+ */
+bool
+ieee80211_is_ctl_frame_for_vap(struct ieee80211_node *ni, const struct mbuf *m0)
+{
+	const struct ieee80211vap *vap = ni->ni_vap;
+	const struct ieee80211_frame *wh;
+	uint8_t subtype;
+
+	wh = mtod(m0, const struct ieee80211_frame *);
+	subtype = wh->i_fc[0] & IEEE80211_FC0_SUBTYPE_MASK;
+
+	/* Verify it's a ctl frame. */
+	KASSERT(IEEE80211_IS_CTL(wh), ("%s: not a CTL frame (fc[0]=0x%04x)",
+	    __func__, wh->i_fc[0]));
+	if (!IEEE80211_IS_CTL(wh)) {
+		if_printf(vap->iv_ifp,
+		    "%s: not a control frame (fc[0]=0x%04x)\n",
+		    __func__, wh->i_fc[0]);
+		return (false);
+	}
+
+	/* Verify the TA if present. */
+	switch (subtype) {
+	case IEEE80211_FC0_SUBTYPE_CTS:
+	case IEEE80211_FC0_SUBTYPE_ACK:
+		/* No TA. */
+		break;
+	default:
+		/*
+		 * Verify TA matches ni->ni_macaddr; for unknown
+		 * sources it will be the BSS node and ni->ni_macaddr
+		 * will the BSS MAC.
+		 */
+		if (!IEEE80211_ADDR_EQ(wh->i_addr2, ni->ni_macaddr))
+			return (false);
+		break;
+	}
+
+	/* Verify the RA */
+	return (IEEE80211_ADDR_EQ(wh->i_addr1, vap->iv_myaddr));
+}

--- a/sys/net80211/ieee80211_adhoc.c
+++ b/sys/net80211/ieee80211_adhoc.c
@@ -663,7 +663,8 @@ adhoc_input(struct ieee80211_node *ni, struct mbuf *m,
 	case IEEE80211_FC0_TYPE_CTL:
 		vap->iv_stats.is_rx_ctl++;
 		IEEE80211_NODE_STAT(ni, rx_ctrl);
-		vap->iv_recv_ctl(ni, m, subtype);
+		if (ieee80211_is_ctl_frame_for_vap(ni, m))
+			vap->iv_recv_ctl(ni, m, subtype);
 		goto out;
 
 	default:

--- a/sys/net80211/ieee80211_crypto_ccmp.c
+++ b/sys/net80211/ieee80211_crypto_ccmp.c
@@ -593,6 +593,7 @@ done:
 static int
 ccmp_decrypt(struct ieee80211_key *key, u_int64_t pn, struct mbuf *m, int hdrlen)
 {
+	const struct ieee80211_rx_stats *rxs;
 	struct ccmp_ctx *ctx = key->wk_private;
 	struct ieee80211vap *vap = ctx->cc_vap;
 	struct ieee80211_frame *wh;
@@ -603,6 +604,10 @@ ccmp_decrypt(struct ieee80211_key *key, u_int64_t pn, struct mbuf *m, int hdrlen
 	int i;
 	uint8_t *pos;
 	u_int space;
+
+	rxs = ieee80211_get_rx_params_ptr(m);
+	if ((rxs != NULL) && (rxs->c_pktflags & IEEE80211_RX_F_DECRYPTED) != 0)
+		return (1);
 
 	ctx->cc_vap->iv_stats.is_crypto_ccmp++;
 
@@ -666,6 +671,14 @@ ccmp_decrypt(struct ieee80211_key *key, u_int64_t pn, struct mbuf *m, int hdrlen
 			space = m->m_len;
 		}
 	}
+
+	/*
+	 * If the MIC (we use MMIC despite not being Micheal) was stripped
+	 * by HW/driver we are done.
+	 */
+	if ((rxs != NULL) && (rxs->c_pktflags & IEEE80211_RX_F_MMIC_STRIP) != 0)
+		return (1);
+
 	if (memcmp(mic, a, ccmp.ic_trailer) != 0) {
 		IEEE80211_NOTE_MAC(vap, IEEE80211_MSG_CRYPTO, wh->i_addr2,
 		    "%s", "AES-CCM decrypt failed; MIC mismatch");

--- a/sys/net80211/ieee80211_hostap.c
+++ b/sys/net80211/ieee80211_hostap.c
@@ -893,7 +893,8 @@ hostap_input(struct ieee80211_node *ni, struct mbuf *m,
 	case IEEE80211_FC0_TYPE_CTL:
 		vap->iv_stats.is_rx_ctl++;
 		IEEE80211_NODE_STAT(ni, rx_ctrl);
-		vap->iv_recv_ctl(ni, m, subtype);
+		if (ieee80211_is_ctl_frame_for_vap(ni, m))
+			vap->iv_recv_ctl(ni, m, subtype);
 		goto out;
 	default:
 		IEEE80211_DISCARD(vap, IEEE80211_MSG_ANY,

--- a/sys/net80211/ieee80211_ioctl.c
+++ b/sys/net80211/ieee80211_ioctl.c
@@ -147,7 +147,8 @@ ieee80211_ioctl_getchaninfo(struct ieee80211vap *vap, struct ieee80211req *ireq)
 	if (space > ireq->i_len)
 		space = ireq->i_len;
 	/* XXX assumes compatible layout */
-	return copyout(&ic->ic_nchans, ireq->i_data, space);
+	return copyout((char *)ic + __offsetof(struct ieee80211com, ic_nchans),
+	    ireq->i_data, space);
 }
 
 static int

--- a/sys/net80211/ieee80211_radiotap.h
+++ b/sys/net80211/ieee80211_radiotap.h
@@ -55,7 +55,7 @@
 
 #define	IEEE80211_RADIOTAP_HDRLEN	64	/* XXX deprecated */
 
-struct ieee80211_radiotap_vendor_header {
+struct __no_subobject_bounds ieee80211_radiotap_vendor_header {
 	uint8_t		vh_oui[3];	/* 3 byte vendor OUI */
 	uint8_t		vh_sub_ns;	/* Sub namespace of this section */
 	uint16_t	vh_skip_len;	/* Length of this vendor section */
@@ -66,7 +66,7 @@ struct ieee80211_radiotap_vendor_header {
  *
  * Note well: all radiotap fields are little-endian.
  */
-struct ieee80211_radiotap_header {
+struct __no_subobject_bounds ieee80211_radiotap_header {
 	uint8_t		it_version;	/* Version 0. Only increases
 					 * for drastic changes,
 					 * introduction of compatible

--- a/sys/net80211/ieee80211_sta.c
+++ b/sys/net80211/ieee80211_sta.c
@@ -976,7 +976,8 @@ sta_input(struct ieee80211_node *ni, struct mbuf *m,
 	case IEEE80211_FC0_TYPE_CTL:
 		vap->iv_stats.is_rx_ctl++;
 		IEEE80211_NODE_STAT(ni, rx_ctrl);
-		vap->iv_recv_ctl(ni, m, subtype);
+		if (ieee80211_is_ctl_frame_for_vap(ni, m))
+			vap->iv_recv_ctl(ni, m, subtype);
 		goto out;
 
 	default:
@@ -2058,6 +2059,7 @@ sta_recv_mgmt(struct ieee80211_node *ni, struct mbuf *m0, int subtype,
 static void
 sta_recv_ctl(struct ieee80211_node *ni, struct mbuf *m, int subtype)
 {
+
 	switch (subtype) {
 	case IEEE80211_FC0_SUBTYPE_BAR:
 		ieee80211_recv_bar(ni, m);

--- a/sys/net80211/ieee80211_var.h
+++ b/sys/net80211/ieee80211_var.h
@@ -829,6 +829,9 @@ bool	ieee80211_is_key_global(const struct ieee80211vap *vap,
 bool	ieee80211_is_key_unicast(const struct ieee80211vap *vap,
 	    const struct ieee80211_key *key);
 
+bool	ieee80211_is_ctl_frame_for_vap(struct ieee80211_node *,
+	    const struct mbuf *);
+
 void	ieee80211_radiotap_attach(struct ieee80211com *,
 	    struct ieee80211_radiotap_header *th, int tlen,
 		uint32_t tx_radiotap,


### PR DESCRIPTION
- rtwn: ensure TX work isn't scheduled during reset / abort
- rtwn: change the USB TX transfers to only do one pending transfer per endpoint
- rtwn: enable FCS in the recive config to work around truncated frames
- rtwn: don't do 64 bit TSF extension by default
- rtwn: make sure RCR_APPFCS stays set in monitor mode / mode changes.
- net80211: crypto: ccmp: fix more hardware offload bits
- net80211: validate control frame TA/RA before further processing
- rtwn: enable reception of BAR frames
- rtwn: Disable IP/TCP/UDP checksum offloading
- rtwn: Add missing subobject bounds annotations
- net80211: Don't bound structs that extend radiotap headers
- net80211: Fix subobject bounds issue in IEEE80211_IOC_CHANINFO
