### PR TITLE
Don't leak compartment name pointers after dlclose()

### DIFF
--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -550,12 +550,8 @@ obj_free(Obj_Entry *obj)
 	free(obj->path);
 #ifdef __CHERI_PURE_CAPABILITY__
 #ifdef CHERI_LIB_C18N
-    if (obj->comparts) {
-	for (unsigned long i = 0; i < obj->ncomparts; i++) {
-	    free(obj->comparts[i].compart_name);
-	}
+    if (obj->comparts)
 	free(obj->comparts);
-    }
 #endif
     if (obj->pcc_caps)
 	free(obj->pcc_caps);

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -6324,6 +6324,7 @@ c18n_setup_compartments(Obj_Entry *obj, const char *name, int flags)
 {
 	Compart_Entry *compart;
 	const Elf_Phdr *ph;
+	char *compart_name;
 	size_t len;
 
 	assert(obj->default_compart_id == 0);
@@ -6354,11 +6355,12 @@ c18n_setup_compartments(Obj_Entry *obj, const char *name, int flags)
 			compart->end = compart->start + ph->p_memsz;
 
 			len = strlen(name) + 1 + strlen(compart->name) + 1;
-			compart->compart_name = malloc(len);
-			rtld_snprintf(compart->compart_name, len, "%s:%s",
-			    name, compart->name);
+			compart_name = malloc(len);
+			rtld_snprintf(compart_name, len, "%s:%s", name,
+			    compart->name);
 			compart->compart_id =
-			    compart_id_allocate(compart->compart_name, flags);
+			    compart_id_allocate(compart_name, flags);
+			free(compart_name);
 			compart++;
 			break;
 		}

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -205,7 +205,6 @@ typedef struct Struct_Compart_Entry {
     const char *name;
     Elf_Addr start;
     Elf_Addr end;
-    char *compart_name;
     uint16_t compart_id;
 } Compart_Entry;
 #endif


### PR DESCRIPTION
- **proc: Update c18n compartments sysctl handler for struct rtld_c18n_compart**
- **proc: Validate bounds of entire c18n comparts array once**
- **proc: Better handle short reads in proc_read_string_properly**
