### PR TITLE
Fix a couple of kernel bugs affecting the revoker

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -556,10 +556,10 @@ pagecopy(void *s, void *d)
 	memcpy(d, s, PAGE_SIZE);
 }
 
-#if __has_feature(capabilities)
 static __inline void
 pagecopy_cleartags(void *s, void *d)
 {
+#if __has_feature(capabilities)
 	void * __capability *dst;
 	void * __capability *src;
 	u_int i;
@@ -568,8 +568,10 @@ pagecopy_cleartags(void *s, void *d)
 	src = s;
 	for (i = 0; i < PAGE_SIZE / sizeof(*dst); i++)
 		*dst++ = cheri_cleartag(*src++);
-}
+#else
+	pagecopy(s, d);
 #endif
+}
 
 static __inline pd_entry_t *
 pmap_l0(pmap_t pmap, vm_offset_t va)
@@ -7276,10 +7278,10 @@ pmap_copy_page(vm_page_t msrc, vm_page_t mdst)
 	vm_pointer_t src = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(msrc));
 	vm_pointer_t dst = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(mdst));
 
-#if __has_feature(capabilities)
 	pagecopy_cleartags((void *)src, (void *)dst);
 }
 
+#if __has_feature(capabilities)
 void
 pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 {
@@ -7287,9 +7289,9 @@ pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 	vm_pointer_t dst = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(mdst));
 
 	VM_PAGE_ASSERT_PGA_CAPMETA_COPY(msrc, mdst);
-#endif
 	pagecopy((void *)src, (void *)dst);
 }
+#endif
 
 int unmapped_buf_allowed = 1;
 

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -366,10 +366,10 @@ pagecopy(void *s, void *d)
 	memcpy(d, s, PAGE_SIZE);
 }
 
-#if __has_feature(capabilities)
 static __inline void
 pagecopy_cleartags(void *s, void *d)
 {
+#if __has_feature(capabilities)
 	void * __capability *dst;
 	void * __capability *src;
 	u_int i;
@@ -378,8 +378,10 @@ pagecopy_cleartags(void *s, void *d)
 	src = s;
 	for (i = 0; i < PAGE_SIZE / sizeof(*dst); i++)
 		*dst++ = cheri_cleartag(*src++);
-}
+#else
+	pagecopy(s, d);
 #endif
+}
 
 static __inline void
 pagezero(void *p)
@@ -4630,10 +4632,10 @@ pmap_copy_page(vm_page_t msrc, vm_page_t mdst)
 	vm_pointer_t src = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(msrc));
 	vm_pointer_t dst = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(mdst));
 
-#if __has_feature(capabilities)
 	pagecopy_cleartags((void *)src, (void *)dst);
 }
 
+#if __has_feature(capabilities)
 void
 pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 {
@@ -4641,9 +4643,9 @@ pmap_copy_page_tags(vm_page_t msrc, vm_page_t mdst)
 	vm_pointer_t dst = PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(mdst));
 
 	VM_PAGE_ASSERT_PGA_CAPMETA_COPY(msrc, mdst);
-#endif
 	pagecopy((void *)src, (void *)dst);
 }
+#endif
 
 int unmapped_buf_allowed = 1;
 

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -1338,14 +1338,14 @@ vm_fault_cow(struct faultstate *fs)
 #endif
 			pmap_copy_page(fs->m, fs->first_m);
 
-		vm_page_valid(fs->first_m);
 		if (fs->wired && (fs->fault_flags & VM_FAULT_WIRE) == 0) {
 			vm_page_wire(fs->first_m);
 			vm_page_unwire(fs->m, PQ_INACTIVE);
 		}
 		/*
-		 * Save the cow page to be released after
-		 * pmap_enter is complete.
+		 * Save the COW page to be released after pmap_enter is
+		 * complete.  The new copy will be marked valid when we're ready
+		 * to map it.
 		 */
 		fs->m_cow = fs->m;
 		fs->m = NULL;
@@ -2069,6 +2069,19 @@ found:
 	 */
 	if (hardfault)
 		fs.entry->next_read = vaddr + ptoa(ahead) + PAGE_SIZE;
+
+	/*
+	 * If the page to be mapped was copied from a backing object, we defer
+	 * marking it valid until here, where the fault handler is guaranteed to
+	 * succeed.  Otherwise we can end up with a shadowed, mapped page in the
+	 * backing object, which violates an invariant of vm_object_collapse()
+	 * that shadowed pages are not mapped.
+	 */
+	if (fs.m_cow != NULL) {
+		KASSERT(vm_page_none_valid(fs.m),
+		    ("vm_fault: page %p is already valid", fs.m_cow));
+		vm_page_valid(fs.m);
+	}
 
 	/*
 	 * Page must be completely valid or it is not fit to

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -2227,20 +2227,6 @@ vm_fault_prefault(const struct faultstate *fs, vm_offset_t addra,
 	if (pmap != vmspace_pmap(curthread->td_proc->p_vmspace))
 		return;
 
-#ifdef CHERI_CAPREVOKE
-	/*
-	 * If we're trying to insert pages during a load-side revocation scan,
-	 * we should be having the revoker visit each before exposing them to
-	 * userland.  However, this raises a number of challenges, and this
-	 * method is just an optimization, so we nop it out right now.
-	 *
-	 * XXX CAPREVOKE This could be much better in just about every way
-	 */
-	if (cheri_revoke_st_is_revoking(fs->map->vm_cheri_revoke_st)) {
-		return;
-	}
-#endif
-
 	entry = fs->entry;
 
 	if (addra < backward * PAGE_SIZE) {

--- a/usr.bin/procstat/procstat_cheri.c
+++ b/usr.bin/procstat/procstat_cheri.c
@@ -147,7 +147,7 @@ get_revoker_epoch(struct procstat *procstat, struct kinfo_proc *kipp)
 			return ("na");
 		default:
 			snprintf(revoker_epoch_buf, sizeof(revoker_epoch_buf),
-			    "%#ju", (uintmax_t)epoch);
+			    "%ju", (uintmax_t)epoch);
 			return (revoker_epoch_buf);
 		}
 	} else {


### PR DESCRIPTION
This fixes a couple of panics that could manifest while building world on CheriBSD. For some reason they are quite hard to trigger unless library c18n is enabled (and even then it took quite a while for me). One is an upstream bug in the page fault handler, which the async revoker exposed since it faults in parallel with the application thread(s), and one is specific to CheriBSD.

While here, remove a check in vm_fault_prefault() that inhibited prefaulting when revocation is active, as I believe other existing checks are sufficient, and we were disabling prefaulting from VM objects where it ought to be safe, i.e., from shared mappings of vnodes.