### PR TITLE
rtld c18n: Use basename of pathnames for compartment names

### DIFF
--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -6417,9 +6417,11 @@ c18n_add_obj(Obj_Entry *obj, int flags)
 		name = obj->soname;
 	else if (!STAILQ_EMPTY(&obj->names))
 		name = STAILQ_FIRST(&obj->names)->name;
-	else if (obj->path != NULL)
-		name = obj->path;
-	else {
+	else if (obj->path != NULL) {
+		name = strrchr(obj->path, '/');
+		if (name == NULL || name[1] == '\0')
+			name = obj->path;
+	} else {
 		_rtld_error("Shared object at %#p cannot be named",
 		    obj->mapbase);
 		return (false);


### PR DESCRIPTION
For object files without DT_SONAME or other names which fallback to
obj->path, trim the path to the basename to set the compartment name.
