### PR TITLE
mprotect doc and test update

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -301,6 +301,24 @@ CHERIBSDTEST(cheriabi_mprotect_upgrade_prot_cap,
 	cheribsdtest_success();
 }
 
+CHERIBSDTEST(cheriabi_mprotect_restore_prot_cap,
+    "Check that downgrading and then upgrading restores capability permissions")
+{
+	void * volatile *p;
+
+	p = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, PAGE_SIZE,
+	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0));
+	CHERIBSDTEST_CHECK_SYSCALL(mprotect(__DEVOLATILE(void *, p), PAGE_SIZE,
+	    PROT_NONE));
+	CHERIBSDTEST_CHECK_SYSCALL(mprotect(__DEVOLATILE(void *, p), PAGE_SIZE,
+	    PROT_READ | PROT_WRITE));
+
+	/* Attempt to store a capability */
+	*p = __DEVOLATILE(void *, p);
+
+	cheribsdtest_success();
+}
+
 CHERIBSDTEST(cheriabi_mprotect_downgrade_prot_cap,
     "Check that downgrading to PROT_MAX(PROT_READ) includes capability read",
     .ct_flags = CT_FLAG_SIGNAL | CT_FLAG_SI_CODE | CT_FLAG_SI_TRAPNO | CT_FLAG_SI_ADDR,

--- a/lib/libsys/mprotect.2
+++ b/lib/libsys/mprotect.2
@@ -60,6 +60,14 @@ The pages can be read.
 The pages can be written.
 .It Dv PROT_EXEC
 The pages can be executed.
+.It Dv PROT_CAP
+CHERI capabilities may be read or written as dictated by
+.Dv PROT_READ
+and
+.Dv PROT_WRITE .
+.It Dv PROT_NO_CAP
+Respect the absence of
+.Dv PROT_CAP .
 .El
 .Pp
 In addition to these standard protection flags,
@@ -80,6 +88,13 @@ values wrapped in the
 macro into the
 .Fa prot
 argument.
+.Pp
+For more information on the
+.Dv PROT_CAP
+and
+.Dv PROT_NO_CAP
+flags, see the discussion in
+.Xr mmap 2 .
 .Sh RETURN VALUES
 .Rv -std mprotect
 .Sh ERRORS
@@ -108,10 +123,17 @@ The
 .Fa prot
 argument contains permissions which are not a subset of the specified
 maximum permissions.
+.It Bq Er ENOTSUP
+.Dv PROT_CAP
+without
+.Dv PROT_READ
+or
+.Dv PROT_WRITE .
 .El
 .Sh SEE ALSO
 .Xr madvise 2 ,
 .Xr mincore 2 ,
+.Xr mmap 2 ,
 .Xr msync 2 ,
 .Xr munmap 2
 .Sh HISTORY


### PR DESCRIPTION
Documented PROT_CAP and add a test for restoring PROT_WRITE with implied PROT_CAP.