### PR TITLE
c18n: Replace manual compartment transitions with trampolines

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.h
@@ -75,15 +75,6 @@
 	ldr	\reg, [STACK_TABLE_C, #STACK_TABLE_RTLD]
 .endmacro
 
-.macro	update_stk_table	osp, sp, index
-	mrs	STACK_TABLE_C, TRUSTED_STACK
-	ldrh	\index, [STACK_TABLE_C, #TRUSTED_FRAME_CALLEE]
-
-	mrs	STACK_TABLE_C, STACK_TABLE
-	ldr	\osp, [STACK_TABLE_C, \index, uxtw #0]
-	str	\sp, [STACK_TABLE_C, \index, uxtw #0]
-.endmacro
-
 #else
 
 static inline void *

--- a/libexec/rtld-elf/aarch64/rtld_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_machdep.h
@@ -158,4 +158,9 @@ extern void *__tls_get_addr(tls_index *ti);
 
 #define md_abi_variant_hook(x)
 
+extern void (*rtld_bind_start_fptr)(void);
+extern void *(*rtld_tlsdesc_static_fptr)(void *);
+extern void *(*rtld_tlsdesc_undef_fptr)(void *);
+extern void *(*rtld_tlsdesc_dynamic_fptr)(void *);
+
 #endif

--- a/libexec/rtld-elf/aarch64/rtld_start.S
+++ b/libexec/rtld-elf/aarch64/rtld_start.S
@@ -51,8 +51,6 @@
  * _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
  */
 
-#ifndef C18N_VARIANT
-
 ENTRY(.rtld_start)
 #ifdef __CHERI_PURE_CAPABILITY__
 	.cfi_undefined	c30
@@ -105,42 +103,14 @@ ENTRY(.rtld_start)
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */
 END(.rtld_start)
 
-#define	C18N_VARIANT
-#undef	CHERI_LIB_C18N
-#endif /* C18N_VARIANT */
-
-#define	C18N_SYM(name)		__CONCAT(name, C18N_VARIANT)
-
 /*
  * sp + 0 = &GOT[x + 3]
  * sp + 8 = RA
  * x16 = &GOT[2]
  * x17 = &_rtld_bind_start
  */
-ENTRY(C18N_SYM(_rtld_bind_start))
-#ifdef CHERI_LIB_C18N
-	/*
-	 * Get the caller's current stack top.
-	 */
-	get_untrusted_stk	c10
-	/*
-	 * Update the stack lookup table with the caller's current stack top and
-	 * get the caller's old stack top.
-	 */
-	update_stk_table	c11, c10, w12
-	/*
-	 * Switch to RTLD's stack.
-	 */
-	get_rtld_stk		c12
-	set_untrusted_stk	c12
-	/*
-	 * Save caller's old stack top.
-	 */
-	str	c11, [csp, #-CAP_WIDTH]!
-	mov	c17, c10
-#else
+ENTRY(_rtld_bind_start)
 	mov	PTR(17), PTRN(sp)
-#endif
 
 	/* Save frame pointer and SP */
 	stp	PTR(29), PTR(30), [PTRN(sp), #-(PTR_WIDTH * 2)]!
@@ -185,7 +155,15 @@ ENTRY(C18N_SYM(_rtld_bind_start))
 	ldr	PTR(0), [PTR(16), #-PTR_WIDTH]
 
 	/* Call into rtld */
-	bl	_rtld_bind
+	adrp	PTR(10), :got:rtld_bind_fptr
+	ldr	PTR(10), [PTR(10), :got_lo12:rtld_bind_fptr]
+	ldr	PTR(10), [PTR(10)]
+	/* Under c18n, the trampoline always clear c10, a scratch register. */
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	blr	x10
+#else
+	blr	PTR(10)
+#endif
 
 	/* Backup the address to branch to */
 	mov	PTR(16), PTR(0)
@@ -204,53 +182,16 @@ ENTRY(C18N_SYM(_rtld_bind_start))
 	/* Restore frame pointer */
 	ldp	PTR(29), PTR(zr), [PTRN(sp)], #(PTR_WIDTH * 2)
 
-#ifdef CHERI_LIB_C18N
-	/*
-	 * Load caller's old stack top.
-	 */
-	ldr	c10, [csp], #CAP_WIDTH
-	/*
-	 * Update the stack lookup table with the caller's old stack top and get
-	 * the caller's current stack top.
-	 */
-	update_stk_table	c11, c10, w12
-	/*
-	 * Pop the return address saved by the PLT.
-	 */
-	ldp	czr, c30, [c11], #(PTR_WIDTH * 2)
-	/*
-	 * Switch to caller's stack.
-	 */
-	set_untrusted_stk	c11
-
-	/*
-	 * Clear temporary registers that might contain RTLD-privileged
-	 * capabilities. Typically, the resolver returns a trampoline which will
-	 * clear them, but if the resolved function is trusted, then no such
-	 * clearing would be performed.
-	 */
-	mov	x13, xzr
-	mov	x14, xzr
-	mov	x15, xzr
-	/*
-	 * c16: Callee's code
-	 */
-	mov	x17, xzr
-	mov	x18, xzr
-#else
 	/* Restore link register saved by the plt code */
 	ldp	PTR(zr), PTR(30), [PTRN(sp)], #(PTR_WIDTH * 2)
-#endif
 
 	/* Call into the correct function */
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
 	br	x16
-#elif defined(CHERI_LIB_C18N)
-	brr	PTR(16)
 #else
 	br	PTR(16)
 #endif
-END(C18N_SYM(_rtld_bind_start))
+END(_rtld_bind_start)
 
 /*
  * struct rel_tlsdesc {
@@ -262,35 +203,27 @@ END(C18N_SYM(_rtld_bind_start))
  *
  * Resolver function for TLS symbols resolved at load time
  */
-ENTRY(C18N_SYM(_rtld_tlsdesc_static))
+ENTRY(_rtld_tlsdesc_static)
 #ifdef __CHERI_PURE_CAPABILITY__
 	ldp	x0, x1, [c0, #16]
 	add	c0, c2, x0
 	scbnds	c0, c0, x1
-#if defined(CHERI_LIB_C18N) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	retr	c30
-#else
 	RETURN
-#endif
 #else /* defined(__CHERI_PURE_CAPABILITY__) */
 	ldr	x0, [x0, #8]
 	ret
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */
-END(C18N_SYM(_rtld_tlsdesc_static))
+END(_rtld_tlsdesc_static)
 
 /*
  * uint64_t _rtld_tlsdesc_undef(void);
  *
  * Resolver function for weak and undefined TLS symbols
  */
-ENTRY(C18N_SYM(_rtld_tlsdesc_undef))
+ENTRY(_rtld_tlsdesc_undef)
 #ifdef __CHERI_PURE_CAPABILITY__
 	ldr	x0, [c0, #16]
-#if defined(CHERI_LIB_C18N) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	retr	c30
-#else
 	RETURN
-#endif
 #else /* defined(__CHERI_PURE_CAPABILITY__) */
 	str	x1, [sp, #-16]!
 	.cfi_adjust_cfa_offset	16
@@ -303,14 +236,14 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_undef))
 	.cfi_adjust_cfa_offset 	-16
 	ret
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */
-END(C18N_SYM(_rtld_tlsdesc_undef))
+END(_rtld_tlsdesc_undef)
 
 /*
  * uint64_t _rtld_tlsdesc_dynamic(struct rel_tlsdesc *);
  *
  * Resolver function for TLS symbols from dlopen()
  */
-ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
+ENTRY(_rtld_tlsdesc_dynamic)
 #ifdef __CHERI_PURE_CAPABILITY__
 	stp	c3, c4, [csp, #-32]!
 	.cfi_adjust_cfa_offset	2 * 16
@@ -339,11 +272,7 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	/* Restore registers and return */
 	ldp	 c3,  c4, [csp], #32
 	.cfi_adjust_cfa_offset 	-2 * 16
-#if defined(CHERI_LIB_C18N) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	retr	c30
-#else
 	RETURN
-#endif
 
 	/*
 	 * Slow path
@@ -368,27 +297,6 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	stp	c15, c16, [csp, #(7 * 32)]
 	stp	c17, c18, [csp, #(8 * 32)]
 	str	c19,	  [csp, #(9 * 32)]
-#ifdef CHERI_LIB_C18N
-	/*
-	 * Get the caller's current stack top. This step is only needed for
-	 * _rtld_tlsdesc_dynamic because it might call external functions.
-	 */
-	get_untrusted_stk	c10
-	/*
-	 * Update the stack lookup table with the caller's current stack top and
-	 * get the caller's old stack top.
-	 */
-	update_stk_table	c11, c10, w12
-	/*
-	 * Switch to RTLD's stack.
-	 */
-	get_rtld_stk		c10
-	set_untrusted_stk	c10
-	/*
-	 * Save caller's old stack top.
-	 */
-	str	c11, [csp, #-CAP_WIDTH]!
-#endif
 	.cfi_rel_offset		 c1, 32
 	.cfi_rel_offset		 c2, 48
 	.cfi_rel_offset		 c5, 64
@@ -413,25 +321,17 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	ldr	w1, [c3, #16]		/* tlsdesc->tls_index */
 	ldr	x2, [c3, #24]		/* tlsdesc->tls_offs */
 	ldr	x19, [c3, #32]		/* tlsdesc->tls_size */
-	bl	tls_get_addr_common
+	adrp	PTR(10), :got:tls_get_addr_common_fptr
+	ldr	PTR(10), [PTR(10), :got_lo12:tls_get_addr_common_fptr]
+	ldr	PTR(10), [PTR(10)]
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	blr	x10
+#else
+	blr	PTR(10)
+#endif
 	scbnds	c0, c0, x19
 
 	/* Restore slow path registers */
-#ifdef CHERI_LIB_C18N
-	/*
-	 * Load caller's old stack top.
-	 */
-	ldr	c10, [csp], #CAP_WIDTH
-	/*
-	 * Update the stack lookup table with the caller's old stack top and get
-	 * the caller's current stack top.
-	 */
-	update_stk_table	c11, c10, w12
-	/*
-	 * Switch to caller's stack.
-	 */
-	set_untrusted_stk	c11
-#endif
 	ldr	c19,	  [csp, #(9 * 32)]
 	ldp	c17, c18, [csp, #(8 * 32)]
 	ldp	c15, c16, [csp, #(7 * 32)]
@@ -449,11 +349,7 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	/* Restore fast path registers and return */
 	ldp	 c3,  c4, [csp], #32
 	.cfi_adjust_cfa_offset 	-2 * 16
-#if defined(CHERI_LIB_C18N) && !defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-	retr	c30
-#else
 	RETURN
-#endif
 #else /* defined(__CHERI_PURE_CAPABILITY__) */
 	/* Save registers used in fast path */
 	stp	x1,  x2, [sp, #(-2 * 16)]!
@@ -552,6 +448,6 @@ ENTRY(C18N_SYM(_rtld_tlsdesc_dynamic))
 	.cfi_adjust_cfa_offset	-2 * 16
 	ret
 #endif /* defined(__CHERI_PURE_CAPABILITY__) */
-END(C18N_SYM(_rtld_tlsdesc_dynamic))
+END(_rtld_tlsdesc_dynamic)
 
 GNU_PROPERTY_AARCH64_FEATURE_1_NOTE(GNU_PROPERTY_AARCH64_FEATURE_1_VAL)

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -104,6 +104,9 @@ __BEGIN_DECLS
 #define NEW(type)	((type *) xmalloc(sizeof(type)))
 #define CNEW(type)	((type *) xcalloc(1, sizeof(type)))
 
+extern void *rtld_bind_fptr;
+extern void *tls_get_addr_common_fptr;
+
 extern size_t tls_last_offset;
 extern size_t tls_last_size;
 extern size_t tls_static_space;

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -768,6 +768,29 @@ create_stk(size_t size)
 
 #define	C18N_TRUSTED_STACK_SIZE		(128 * 1024)
 
+/*
+ * When entering the RTLD without a trampoline (e.g., during stack resolution),
+ * a dummy trusted frame indicating that the current compartment is RTLD must be
+ * pushed.
+ */
+static struct trusted_frame *
+push_dummy_rtld_trusted_frame(struct trusted_frame *tf)
+{
+	*--tf = (struct trusted_frame) {
+		.callee = cid_to_index(RTLD_COMPART_ID)
+	};
+	set_trusted_stk(tf);
+	return (tf);
+}
+
+static struct trusted_frame *
+pop_dummy_rtld_trusted_frame(struct trusted_frame *tf)
+{
+	assert(get_trusted_stk() == tf);
+	set_trusted_stk(++tf);
+	return (tf);
+}
+
 static void
 init_stk_table(struct stk_table *table, struct tcb_wrapper *wrap)
 {
@@ -1691,6 +1714,14 @@ _rtld_tramp_reflect(const void *addr)
  */
 #define	C18N_FUNC_SIG_COUNT	72
 
+static void *
+make_restricted(void *fptr)
+{
+	fptr = cheri_clearperm(fptr, CHERI_PERM_EXECUTIVE);
+	fptr = cheri_buildcap(cheri_getpcc(), (uintptr_t)fptr);
+	return (cheri_sealentry(fptr));
+}
+
 void
 c18n_init(Obj_Entry *obj_rtld, Elf_Auxinfo *aux_info[])
 {
@@ -1825,6 +1856,39 @@ c18n_init2(Obj_Entry *obj_rtld)
 	assert(tramp_pg_size > 0);
 	atomic_store_explicit(&tramp_pgs.head, tramp_pg_new(NULL),
 	    memory_order_relaxed);
+
+	/*
+	 * Turn function pointers to be inserted into objects' GOTs into
+	 * Restricted mode capabilities.
+	 */
+	rtld_bind_start_fptr = make_restricted(rtld_bind_start_fptr);
+	rtld_tlsdesc_static_fptr = make_restricted(rtld_tlsdesc_static_fptr);
+	rtld_tlsdesc_undef_fptr = make_restricted(rtld_tlsdesc_undef_fptr);
+	rtld_tlsdesc_dynamic_fptr = make_restricted(rtld_tlsdesc_dynamic_fptr);
+
+	/*
+	 * Wrap RTLD function pointers that are called by user code in
+	 * trampolines.
+	 */
+	rtld_bind_fptr = tramp_intern(NULL, RTLD_COMPART_ID,
+	    &(struct tramp_data) {
+		.target = rtld_bind_fptr,
+		.defobj = obj_rtld,
+		.sig = (struct func_sig) {
+			.valid = true,
+			.reg_args = 2, .mem_args = false, .ret_args = ONE
+		}
+	});
+
+	tls_get_addr_common_fptr = tramp_intern(NULL, RTLD_COMPART_ID,
+	    &(struct tramp_data) {
+		.target = tls_get_addr_common_fptr,
+		.defobj = obj_rtld,
+		.sig = (struct func_sig) {
+			.valid = true,
+			.reg_args = 3, .mem_args = false, .ret_args = ONE
+		}
+	});
 
 	/*
 	 * XXX: Manually wrap _rtld_unw_setcontext_impl in a trampoline for now

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -167,29 +167,6 @@ struct tcb *c18n_allocate_tcb(struct tcb *);
 void c18n_free_tcb(void);
 
 /*
- * When entering the RTLD without a trampoline (e.g., during lazy binding, TLS
- * lookup, or stack resolution), a dummy trusted frame indicating that the
- * current compartment is RTLD must be pushed.
- */
-static inline struct trusted_frame *
-push_dummy_rtld_trusted_frame(struct trusted_frame *tf)
-{
-	*--tf = (struct trusted_frame) {
-		.callee = cid_to_index(RTLD_COMPART_ID)
-	};
-	set_trusted_stk(tf);
-	return (tf);
-}
-
-static inline struct trusted_frame *
-pop_dummy_rtld_trusted_frame(struct trusted_frame *tf)
-{
-	assert(get_trusted_stk() == tf);
-	set_trusted_stk(++tf);
-	return (tf);
-}
-
-/*
  * Stack unwinding
  */
 int c18n_is_tramp(uintptr_t, const struct trusted_frame *);
@@ -269,11 +246,6 @@ func_sig_legal(struct func_sig sig)
  */
 void *_rtld_sandbox_code(void *, struct func_sig);
 void *_rtld_safebox_code(void *, struct func_sig);
-
-void _rtld_bind_start_c18n(void);
-void *_rtld_tlsdesc_static_c18n(void *);
-void *_rtld_tlsdesc_undef_c18n(void *);
-void *_rtld_tlsdesc_dynamic_c18n(void *);
 
 void c18n_init(Obj_Entry *, Elf_Auxinfo *[]);
 void c18n_init2(Obj_Entry *);

--- a/libexec/rtld-elf/rtld_c18n_mi.S
+++ b/libexec/rtld-elf/rtld_c18n_mi.S
@@ -25,10 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#define	C18N_VARIANT	_c18n
-#include "rtld_start.S"
-#undef C18N_VARIANT
-
 .section	.rodata
 .globl	c18n_default_policy
 .type	c18n_default_policy,%object


### PR DESCRIPTION
Previously, in _rtld_bind_c18n and _rtld_tlsdesc_dynamic, we emulate the effect of a compartment transition trampoline with hand-written assembly instructions. It turns out that it is fine to just use trampolines, greatly simplifying the code.