### PR TITLE
Various kernel linker fixes

### DIFF
--- a/sys/amd64/amd64/elf_machdep.c
+++ b/sys/amd64/amd64/elf_machdep.c
@@ -276,7 +276,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 {
 	Elf64_Addr *where, val;
 	Elf32_Addr *where32, val32;
-	Elf_Addr addr;
+	uintptr_t addr;
 	Elf_Addr addend;
 	Elf_Size rtype, symidx;
 	const Elf_Rel *rel;

--- a/sys/arm/arm/elf_machdep.c
+++ b/sys/arm/arm/elf_machdep.c
@@ -183,7 +183,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
     int type, int local, elf_lookup_fn lookup)
 {
 	Elf_Addr *where;
-	Elf_Addr addr;
+	uintptr_t addr;
 	Elf_Addr addend;
 	Elf_Word rtype, symidx;
 	const Elf_Rel *rel;

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -583,17 +583,21 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		error = LINKER_SYMIDX_CAPABILITY(lf, symidx, 1, &cap);
 		if (error != 0)
 			return (-1);
-		cap += addend;
+
+		/*
+		 * XXX: This is conditional to avoid invalidating
+		 * sentries.  The addend should probably be passed to
+		 * the lookup function instead.
+		 */
+		if (addend != 0)
+			cap += addend;
 		*(uintcap_t *)where = cap;
 		break;
 	case R_MORELLO_JUMP_SLOT:
 		error = LINKER_SYMIDX_CAPABILITY(lf, symidx, 1, &cap);
 		if (error != 0)
 			return (-1);
-		cap = cheri_clearperm(cap, CHERI_PERM_SEAL |
-		    CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
-		    CHERI_PERM_STORE_LOCAL_CAP);
-		*(uintcap_t *)where = cheri_sealentry(cap);
+		*(uintcap_t *)where = cap;
 		break;
 	case R_MORELLO_IRELATIVE:
 		/* XXX: See libexec/rtld-elf/aarch64/reloc.c. */

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -450,12 +450,12 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 {
 #define	ARM64_ELF_RELOC_LOCAL		(1 << 0)
 #define	ARM64_ELF_RELOC_LATE_IFUNC	(1 << 1)
-	Elf_Addr *where, addr, addend;
+	Elf_Addr *where, addend;
+	uintptr_t addr;
 #ifdef __CHERI_PURE_CAPABILITY__
 	uintcap_t cap;
-#else
-	Elf_Addr val;
 #endif
+	Elf_Addr val;
 	Elf_Word rtype, symidx;
 	const Elf_Rel *rel;
 	const Elf_Rela *rela;
@@ -504,7 +504,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 			Elf_Addr addr1, size;
 			uint8_t perms;
 
-			decode_fragment(where, (Elf_Addr)relocbase, &addr,
+			decode_fragment(where, (Elf_Addr)relocbase, &val,
 			    &size, &perms);
 
 			/*
@@ -514,9 +514,9 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 			 * In this case we must use the kernel's base
 			 * capability.
 			 */
-			addr1 = elf_relocaddr(lf, addr + addend) - addend;
+			addr1 = elf_relocaddr(lf, val + addend) - addend;
 			base = (__cheri_tocap void * __capability)
-			    (addr == addr1 ? relocbase :
+			    (val == addr1 ? relocbase :
 			    linker_kernel_file->address);
 			*(uintcap_t *)(void *)where = build_reloc_cap(addr1,
 			    size, perms, addend, base, base);

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -755,7 +755,7 @@ elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 	for (; dynp->d_tag != DT_NULL; dynp++) {
 		switch (dynp->d_tag) {
 		case DT_RELA:
-			rela = (const Elf_Rela *)((const char *)data_cap +
+			rela = (const Elf_Rela *)cheri_setaddress(data_cap,
 			    dynp->d_un.d_ptr);
 			break;
 		case DT_RELASZ:
@@ -772,7 +772,7 @@ elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 		switch (ELF_R_TYPE(rela->r_info)) {
 		case R_MORELLO_RELATIVE:
 		case R_MORELLO_FUNC_RELATIVE:
-			fragment = (Elf_Addr *)((char *)data_cap +
+			fragment = (Elf_Addr *)cheri_setaddress(data_cap,
 			    rela->r_offset);
 			cap = build_cap_from_fragment(fragment, 0,
 			    rela->r_addend, data_cap, code_cap);

--- a/sys/arm64/arm64/exception.S
+++ b/sys/arm64/arm64/exception.S
@@ -287,7 +287,7 @@ END(handle_el1h_irq)
 ENTRY(handle_el1h_fiq)
 	save_registers 1
 	KMSAN_ENTER
-	mov	x0, sp
+	mov	PTR(0), PTRN(sp)
 	mov	x1, #INTR_ROOT_FIQ
 	bl	intr_irq_handler
 	KMSAN_LEAVE
@@ -298,7 +298,7 @@ END(handle_el1h_fiq)
 ENTRY(handle_el1h_serror)
 	save_registers 1
 	KMSAN_ENTER
-	mov	x0, sp
+	mov	PTR(0), PTRN(sp)
 1:	bl	do_serror
 	b	1b
 	KMSAN_LEAVE
@@ -334,7 +334,7 @@ END(handle_el0_irq)
 ENTRY(handle_el0_fiq)
 	save_registers 0
 	KMSAN_ENTER
-	mov	x0, sp
+	mov	PTR(0), PTRN(sp)
 	mov	x1, #INTR_ROOT_FIQ
 	bl	intr_irq_handler
 	do_ast

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -292,6 +292,12 @@ virtdone:
 	scbnds	c2, c2, x0
 #endif
 
+	/* Narrow bounds on data_cap to match code_cap. */
+	gcbase	x0, c2
+	scvalue c1, c1, x0
+	gclen	x0, c2
+	scbnds	c1, c1, x0
+
 	/* Assume can we reach _DYNAMIC from PCC */
 	adrp	c0, _DYNAMIC
 	add	c0, c0, :lo12:_DYNAMIC

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -101,11 +101,13 @@
 	ldr	x\regn, =\dstsym
 #ifdef __CHERI_PURE_CAPABILITY__
 	orr	x\regn, x\regn, #1	/* c64 mode */
-	ldr	x\scratch2n, =etext	/* XXX-AM: TODO use correct end symbol */
+	ldr	x\scratch2n, =_end
 	ldr	x\scratch1n, =KERNBASE
 	sub	x\scratch2n, x\scratch2n, x\scratch1n
 	cvtp	c\scratch1n, x\scratch1n
-	//scbnds	c\scratch1n, c\scratch1n, x\scratch2n /* XXX-AM: needs reordering of ELF sections */
+#ifndef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	scbnds	c\scratch1n, c\scratch1n, x\scratch2n
+#endif
 	scvalue	c\regn, c\scratch1n, x\regn
 	clrperm	c\regn, c\regn, w
 #endif
@@ -277,6 +279,19 @@ virtdone:
 	ldr	x0, =~CHERI_PERMS_KERNEL_CODE
 	adr	c2, #0
 	clrperm	c2, c2, x0
+
+#ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
+	/*
+	 * Narrow bounds on the code_cap passed to elf_reloc_self since
+	 * PCC has infinite bounds in the benchmark ABI.
+	 */
+	ldr	x0, =_end
+	ldr	x3, =KERNBASE
+	sub	x0, x0, x3
+	scvalue	c2, c2, x3
+	scbnds	c2, c2, x0
+#endif
+
 	/* Assume can we reach _DYNAMIC from PCC */
 	adrp	c0, _DYNAMIC
 	add	c0, c0, :lo12:_DYNAMIC

--- a/sys/i386/i386/elf_machdep.c
+++ b/sys/i386/i386/elf_machdep.c
@@ -173,7 +173,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
     int type, elf_lookup_fn lookup, int flags)
 {
 	Elf_Addr *where;
-	Elf_Addr addr;
+	uintptr_t addr;
 	Elf_Addr addend;
 	Elf_Word rtype, symidx;
 	const Elf_Rel *rel;

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -1017,6 +1017,8 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	if (ctors_addrp != NULL && ctors_sizep != NULL) {
 		lf->ctors_addr = ef->address + *ctors_addrp;
 		lf->ctors_size = *ctors_sizep;
+		lf->ctors_addr = cheri_kern_setbounds(lf->ctors_addr,
+		    lf->ctors_size);
 	}
 
 #ifdef __arm__
@@ -1401,6 +1403,8 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 			/* Record relocated address and size of .ctors. */
 			lf->ctors_addr = mapbase + shdr[i].sh_addr - base_vaddr;
 			lf->ctors_size = shdr[i].sh_size;
+			lf->ctors_addr = cheri_kern_setbounds(lf->ctors_addr,
+			    lf->ctors_size);
 		}
 	}
 	if (symtabindex < 0 || symstrindex < 0)

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -1790,11 +1790,11 @@ link_elf_symbol_values1(linker_file_t lf, c_linker_sym_t sym,
 			return (ENOENT);
 		symval->name = ef->strtab + es->st_name;
 		val = (caddr_t)ef->address + es->st_value;
-		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC)
-			val = ((caddr_t (*)(void))val)();
 #ifdef __CHERI_PURE_CAPABILITY__
 		val = make_capability(es, val);
 #endif
+		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC)
+			val = ((caddr_t (*)(void))val)();
 		symval->value = val;
 		symval->size = es->st_size;
 		return (0);
@@ -1827,11 +1827,11 @@ link_elf_debug_symbol_values(linker_file_t lf, c_linker_sym_t sym,
 	if (es >= ef->ddbsymtab && es < (ef->ddbsymtab + ef->ddbsymcnt)) {
 		symval->name = ef->ddbstrtab + es->st_name;
 		val = (caddr_t)ef->address + es->st_value;
-		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC)
-			val = ((caddr_t (*)(void))val)();
 #ifdef __CHERI_PURE_CAPABILITY__
 		val = make_capability(es, val);
 #endif
+		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC)
+			val = ((caddr_t (*)(void))val)();
 		symval->value = val;
 		symval->size = es->st_size;
 		return (0);
@@ -2249,6 +2249,9 @@ elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
 	symp = ef->symtab + symidx;
 	if (ELF_ST_TYPE(symp->st_info) == STT_GNU_IFUNC) {
 		val = (caddr_t)ef->address + symp->st_value;
+#ifdef __CHERI_PURE_CAPABILITY__
+		val = make_capability(symp, val);
+#endif
 		*res = ((Elf_Addr (*)(void))val)();
 		return (0);
 	}

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -181,7 +181,7 @@ static int	link_elf_symidx_address(linker_file_t, unsigned long, int,
 static int	link_elf_symidx_capability(linker_file_t, unsigned long, int,
 		    uintcap_t *);
 #endif
-static int	elf_lookup(linker_file_t, Elf_Size, int, Elf_Addr *);
+static int	elf_lookup(linker_file_t, Elf_Size, int, uintptr_t *);
 
 static kobj_method_t link_elf_methods[] = {
 	KOBJMETHOD(linker_lookup_symbol,	link_elf_lookup_symbol),
@@ -2108,7 +2108,7 @@ link_elf_symidx_address(linker_file_t lf, unsigned long symidx, int deps,
 #endif
 
 static int
-elf_lookup(linker_file_t lf, Elf_Size symidx, int deps, Elf_Addr *res)
+elf_lookup(linker_file_t lf, Elf_Size symidx, int deps, uintptr_t *res)
 {
 	ptraddr_t addr;
 	int error;
@@ -2240,7 +2240,7 @@ link_elf_propagate_vnets(linker_file_t lf)
  */
 static int
 elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
-    Elf_Addr *res)
+    uintptr_t *res)
 {
 	elf_file_t ef;
 	const Elf_Sym *symp;
@@ -2253,7 +2253,7 @@ elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
 #ifdef __CHERI_PURE_CAPABILITY__
 		val = make_capability(symp, val);
 #endif
-		*res = ((Elf_Addr (*)(void))val)();
+		*res = ((uintptr_t (*)(void))val)();
 		return (0);
 	}
 	return (ENOENT);

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -1737,6 +1737,7 @@ make_capability(const Elf_Sym *sym, caddr_t val)
 #ifdef CHERI_FLAGS_CAP_MODE
 		val = cheri_setflags(val, CHERI_FLAGS_CAP_MODE);
 #endif
+		val = cheri_sealentry(val);
 		break;
 	default:
 		val = cheri_setbounds(val, sym->st_size);

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -1572,6 +1572,7 @@ make_capability(const Elf_Sym *sym, caddr_t val)
 #ifdef CHERI_FLAGS_CAP_MODE
 		val = cheri_setflags(val, CHERI_FLAGS_CAP_MODE);
 #endif
+		val = cheri_sealentry(val);
 		break;
 	default:
 		val = cheri_setbounds(val, sym->st_size);

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -156,7 +156,7 @@ static void	link_elf_propagate_vnets(linker_file_t);
 #endif
 
 static int	elf_obj_lookup(linker_file_t lf, Elf_Size symidx, int deps,
-		    Elf_Addr *);
+		    uintptr_t *);
 
 static kobj_method_t link_elf_methods[] = {
 	KOBJMETHOD(linker_lookup_symbol,	link_elf_lookup_symbol),
@@ -1765,12 +1765,12 @@ elf_obj_cleanup_globals_cache(elf_file_t ef)
  * the case that the symbol can be found through the hash table.
  */
 static int
-elf_obj_lookup(linker_file_t lf, Elf_Size symidx, int deps, Elf_Addr *res)
+elf_obj_lookup(linker_file_t lf, Elf_Size symidx, int deps, uintptr_t *res)
 {
 	elf_file_t ef = (elf_file_t)lf;
 	Elf_Sym *sym;
 	const char *symbol;
-	Elf_Addr res1;
+	uintptr_t res1;
 	void *ifunc;
 
 	/* Don't even try to lookup the symbol if the index is bogus. */
@@ -1790,7 +1790,7 @@ elf_obj_lookup(linker_file_t lf, Elf_Size symidx, int deps, Elf_Addr *res)
 		ifunc = (void *)res1;
 #endif
 		if (ELF_ST_TYPE(sym->st_info) == STT_GNU_IFUNC)
-			res1 = ((Elf_Addr (*)(void))ifunc)();
+			res1 = ((uintptr_t (*)(void))ifunc)();
 		*res = res1;
 		return (0);
 	}
@@ -1812,7 +1812,7 @@ elf_obj_lookup(linker_file_t lf, Elf_Size symidx, int deps, Elf_Addr *res)
 			*res = 0;
 			return (EINVAL);
 		}
-		res1 = (Elf_Addr)linker_file_lookup_symbol(lf, symbol, deps);
+		res1 = (uintptr_t)linker_file_lookup_symbol(lf, symbol, deps);
 
 		/*
 		 * Cache global lookups during module relocation. The failure

--- a/sys/kern/link_elf_obj.c
+++ b/sys/kern/link_elf_obj.c
@@ -1601,11 +1601,11 @@ link_elf_symbol_values1(linker_file_t lf, c_linker_sym_t sym,
 		if (!see_local && ELF_ST_BIND(es->st_info) == STB_LOCAL)
 			return (ENOENT);
 		symval->name = ef->ddbstrtab + es->st_name;
-		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC)
-			val = ((caddr_t (*)(void))val)();
 #ifdef __CHERI_PURE_CAPABILITY__
 		val = make_capability(es, val);
 #endif
+		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC)
+			val = ((caddr_t (*)(void))val)();
 		symval->value = val;
 		symval->size = es->st_size;
 		return (0);

--- a/sys/kern/linker_if.m
+++ b/sys/kern/linker_if.m
@@ -65,40 +65,6 @@ METHOD int search_symbol {
 };
 
 #
-# Lookup a symbol by index rather than name.  If the symbol is not
-# found then return ENOENT, otherwise zero.
-#
-# Useful for processing relocations.
-#
-METHOD int symidx_address {
-	linker_file_t	file;
-	unsigned long	index;
-	int		deps;
-	ptraddr_t	*address;
-};
-
-CODE {
-	#ifdef __CHERI_PURE_CAPABILITY__
-};
-HEADER {
-	#ifdef __CHERI_PURE_CAPABILITY__
-};
-
-METHOD int symidx_capability {
-	linker_file_t	file;
-	unsigned long	index;
-	int		deps;
-	uintcap_t	*cap;
-};
-
-CODE {
-	#endif
-};
-HEADER {
-	#endif
-};
-
-#
 # Call the callback with each specified function defined in the file.
 # Stop and return the error if the callback returns an error.
 #

--- a/sys/powerpc/powerpc/elf32_machdep.c
+++ b/sys/powerpc/powerpc/elf32_machdep.c
@@ -236,7 +236,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 {
 	Elf_Addr *where;
 	Elf_Half *hwhere;
-	Elf_Addr addr;
+	uintptr_t addr;
 	Elf_Addr addend, val;
 	Elf_Word rtype, symidx;
 	const Elf_Rela *rela;

--- a/sys/powerpc/powerpc/elf64_machdep.c
+++ b/sys/powerpc/powerpc/elf64_machdep.c
@@ -325,7 +325,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
     int type, int local, elf_lookup_fn lookup)
 {
 	Elf_Addr *where;
-	Elf_Addr addr;
+	uintptr_t addr;
 	Elf_Addr addend, val;
 	Elf_Word rtype, symidx;
 	const Elf_Rela *rela;

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -364,7 +364,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 	uintptr_t addr;
 	Elf_Addr val;
 #ifdef __CHERI_PURE_CAPABILITY__
-	uintcap_t beforecap, cap;
+	uintcap_t beforecap;
 #endif
 	Elf64_Addr *where;
 	Elf_Addr addend;
@@ -577,7 +577,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	case R_RISCV_CHERI_CAPABILITY:
-		error = LINKER_SYMIDX_CAPABILITY(lf, symidx, 1, &cap);
+		error = lookup(lf, symidx, 1, &addr);
 		if (error != 0)
 			return (-1);
 
@@ -587,15 +587,14 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		 * the lookup function instead.
 		 */
 		if (addend != 0)
-			cap += addend;
+			addr += addend;
 
-		beforecap = *(uintcap_t *)where;
-		*(uintcap_t *)where = cap;
+		beforecap = *(uintptr_t *)where;
+		*(uintptr_t *)where = addr;
 		if (debug_kld)
-			printf("%p %c %-24s %#lp -> %#lp\n", where,
+			printf("%p %c %-24s %#lp -> %#p\n", where,
 			    (local ? 'l' : 'g'), reloctype_to_str(rtype),
-			    (void * __capability)beforecap,
-			    (void * __capability)cap);
+			    (void *)beforecap, (void *)addr);
 		break;
 #endif
 	default:

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -580,7 +580,14 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		if (error != 0)
 			return (-1);
 
-		cap += addend;
+		/*
+		 * XXX: This is conditional to avoid invalidating
+		 * sentries.  The addend should probably be passed to
+		 * the lookup function instead.
+		 */
+		if (addend != 0)
+			cap += addend;
+
 		beforecap = *(uintcap_t *)where;
 		*(uintcap_t *)where = cap;
 		if (debug_kld)

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -361,7 +361,8 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 {
 	Elf_Size rtype, symidx;
 	const Elf_Rela *rela;
-	Elf_Addr val, addr;
+	uintptr_t addr;
+	Elf_Addr val;
 #ifdef __CHERI_PURE_CAPABILITY__
 	uintcap_t beforecap, cap;
 #endif

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -381,10 +381,10 @@ va:
 	/* Initialize cap relocs. */
 	li	t0, CHERI_PERMS_KERNEL_DATA
 	candperm ca0, cs0, t0
-	cllc	ca1, _C_LABEL(init_cap_relocs)
+	cllc	cra, _C_LABEL(init_cap_relocs)
 	li	t0, CHERI_PERMS_KERNEL_CODE
-	candperm ca2, cs0, t0
-	cjalr	ca1
+	candperm ca1, cra, t0
+	cjalr	cra
 
 	/* Initialize capabilities. */
 	cmove	ca0, cs0

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -301,7 +301,7 @@ extern int kld_debug;
 
 #endif
 
-typedef int elf_lookup_fn(linker_file_t, Elf_Size, int, Elf_Addr *);
+typedef int elf_lookup_fn(linker_file_t, Elf_Size, int, uintptr_t *);
 
 /* Support functions */
 bool	elf_is_ifunc_reloc(Elf_Size r_info);


### PR DESCRIPTION
- **link_elf_obj.c: Bring over make_capability from link_elf.c**
- **link_elf: Finalize capability prior to invoking IFUNC resolver**
- **link_elf: Seal function pointer capabilities as sentries**
- **kld: Return a uintptr_t from elf_lookup functions instead of a Elf_Addr**
- **link_elf_obj: Fix some IFUNC handling on purecap**
- **elf_reloc: Use capabilities from the elf_lookup function directly**
- **link_elf: Set bounds on lf->ctors_addr**
- **link_elf: Use tighter bounds on code capabilities for the kernel**
- **arm64: Update more exception vectors for purecap**
- **arm64: Use narrower bounds for PCC in locore**
- **arm64: Narrow bounds on data capability used for early ELF relocations**
- **riscv: Actually strip permissioms from code_cap passed to init_cap_relocs**
