### PR TITLE
Backport TLS cleanups committed upstream

### DIFF
--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -98,8 +98,8 @@ __libc_tls_get_addr(void *vti)
 
 	dtv = _tcb_get()->tcb_dtv;
 	ti = vti;
-	return ((char *)(dtv[ti->ti_module + 1] + ti->ti_offset) +
-	    TLS_DTV_OFFSET);
+	return ((char *)dtv[ti->ti_module + 1] + (ti->ti_offset +
+	    TLS_DTV_OFFSET));
 }
 
 #ifdef __i386__

--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -182,10 +182,10 @@ get_tls_block_ptr(void *tcb, size_t tcbsize)
 void
 __libc_free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
 {
-	intptr_t *dtv;
-	intptr_t **tls;
+	uintptr_t *dtv;
+	uintptr_t **tls;
 
-	tls = (intptr_t **)tcb;
+	tls = (uintptr_t **)tcb;
 	dtv = tls[0];
 	tls_free(dtv);
 	tls_free_aligned(get_tls_block_ptr(tcb, tcbsize));
@@ -214,7 +214,7 @@ __libc_free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
 void *
 __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 {
-	intptr_t *dtv, **tcb;
+	uintptr_t *dtv, **tcb;
 	char *tls_block, *tls;
 	size_t extra_size, maxalign, post_size, pre_size, tls_block_size;
 
@@ -243,7 +243,7 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 		abort();
 	}
 	memset(tls_block, 0, tls_block_size);
-	tcb = (intptr_t **)(tls_block + pre_size + extra_size);
+	tcb = (uintptr_t **)(tls_block + pre_size + extra_size);
 	tls = (char *)tcb + TLS_TCB_SIZE + post_size;
 
 	if (oldtcb != NULL) {
@@ -253,9 +253,9 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 
 		/* Adjust the DTV. */
 		dtv = tcb[0];
-		dtv[2] = (intptr_t)tls;
+		dtv[2] = (uintptr_t)tls;
 	} else {
-		dtv = tls_malloc(3 * sizeof(void *));
+		dtv = tls_malloc(3 * sizeof(uintptr_t));
 		if (dtv == NULL) {
 			tls_msg("__libc_allocate_tls: Out of memory.\n");
 			abort();
@@ -264,7 +264,7 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 		tcb[0] = dtv;
 		dtv[0] = 1;		/* Generation. */
 		dtv[1] = 1;		/* Segments count. */
-		dtv[2] = (intptr_t)tls;
+		dtv[2] = (uintptr_t)tls;
 
 		if (libc_tls_init_size > 0)
 			memcpy(tls, libc_tls_init, libc_tls_init_size);
@@ -284,8 +284,8 @@ void
 __libc_free_tls(void *tcb, size_t tcbsize __unused, size_t tcbalign)
 {
 	size_t size;
-	Elf_Addr* dtv;
-	Elf_Addr tlsstart, tlsend;
+	uintptr_t *dtv;
+	uintptr_t tlsstart, tlsend;
 
 	/*
 	 * Figure out the size of the initial TLS block so that we can
@@ -294,8 +294,8 @@ __libc_free_tls(void *tcb, size_t tcbsize __unused, size_t tcbalign)
 	tcbalign = MAX(tcbalign, libc_tls_init_align);
 	size = roundup2(libc_tls_static_space, tcbalign);
 
-	dtv = ((Elf_Addr**)tcb)[1];
-	tlsend = (Elf_Addr) tcb;
+	dtv = ((uintptr_t **)tcb)[1];
+	tlsend = (uintptr_t)tcb;
 	tlsstart = tlsend - size;
 	tls_free_aligned((void*)tlsstart);
 	tls_free(dtv);
@@ -309,28 +309,28 @@ __libc_allocate_tls(void *oldtls, size_t tcbsize, size_t tcbalign)
 {
 	size_t size;
 	char *tls;
-	Elf_Addr *dtv;
-	Elf_Addr segbase, oldsegbase;
+	uintptr_t *dtv;
+	uintptr_t segbase, oldsegbase;
 
 	tcbalign = MAX(tcbalign, libc_tls_init_align);
 	size = roundup2(libc_tls_static_space, tcbalign);
 
-	if (tcbsize < 2 * sizeof(Elf_Addr))
-		tcbsize = 2 * sizeof(Elf_Addr);
+	if (tcbsize < 2 * sizeof(uintptr_t))
+		tcbsize = 2 * sizeof(uintptr_t);
 	tls = tls_calloc(1, size + tcbsize);
 	if (tls == NULL) {
 		tls_msg("__libc_allocate_tls: Out of memory.\n");
 		abort();
 	}
-	dtv = tls_malloc(3 * sizeof(Elf_Addr));
+	dtv = tls_malloc(3 * sizeof(uintptr_t));
 	if (dtv == NULL) {
 		tls_msg("__libc_allocate_tls: Out of memory.\n");
 		abort();
 	}
 
-	segbase = (Elf_Addr)(tls + size);
-	((Elf_Addr*)segbase)[0] = segbase;
-	((Elf_Addr*)segbase)[1] = (Elf_Addr) dtv;
+	segbase = (uintptr_t)(tls + size);
+	((uintptr_t *)segbase)[0] = segbase;
+	((uintptr_t *)segbase)[1] = (uintptr_t)dtv;
 
 	dtv[0] = 1;
 	dtv[1] = 1;
@@ -340,7 +340,7 @@ __libc_allocate_tls(void *oldtls, size_t tcbsize, size_t tcbalign)
 		/*
 		 * Copy the static TLS block over whole.
 		 */
-		oldsegbase = (Elf_Addr) oldtls;
+		oldsegbase = (uintptr_t)oldtls;
 		memcpy((void *)(segbase - libc_tls_static_space),
 		    (const void *)(oldsegbase - libc_tls_static_space),
 		    libc_tls_static_space);
@@ -349,7 +349,8 @@ __libc_allocate_tls(void *oldtls, size_t tcbsize, size_t tcbalign)
 		 * We assume that this block was the one we created with
 		 * allocate_initial_tls().
 		 */
-		_rtld_free_tls(oldtls, 2*sizeof(Elf_Addr), sizeof(Elf_Addr));
+		_rtld_free_tls(oldtls, 2 * sizeof(uintptr_t),
+		    sizeof(uintptr_t));
 	} else {
 		memcpy((void *)(segbase - libc_tls_static_space),
 		    libc_tls_init, libc_tls_init_size);

--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -183,10 +183,8 @@ void
 __libc_free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
 {
 	uintptr_t *dtv;
-	uintptr_t **tls;
 
-	tls = (uintptr_t **)tcb;
-	dtv = tls[0];
+	dtv = ((struct tcb *)tcb)->tcb_dtv;
 	tls_free(dtv);
 	tls_free_aligned(get_tls_block_ptr(tcb, tcbsize));
 }
@@ -214,7 +212,8 @@ __libc_free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
 void *
 __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 {
-	uintptr_t *dtv, **tcb;
+	uintptr_t *dtv;
+	struct tcb *tcb;
 	char *tls_block, *tls;
 	size_t extra_size, maxalign, post_size, pre_size, tls_block_size;
 
@@ -243,7 +242,7 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 		abort();
 	}
 	memset(tls_block, 0, tls_block_size);
-	tcb = (uintptr_t **)(tls_block + pre_size + extra_size);
+	tcb = (struct tcb *)(tls_block + pre_size + extra_size);
 	tls = (char *)tcb + TLS_TCB_SIZE + post_size;
 
 	if (oldtcb != NULL) {
@@ -252,7 +251,7 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 		tls_free_aligned(oldtcb);
 
 		/* Adjust the DTV. */
-		dtv = tcb[0];
+		dtv = tcb->tcb_dtv;
 		dtv[2] = (uintptr_t)tls;
 	} else {
 		dtv = tls_malloc(3 * sizeof(uintptr_t));
@@ -261,7 +260,7 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 			abort();
 		}
 		/* Build the DTV. */
-		tcb[0] = dtv;
+		tcb->tcb_dtv = dtv;
 		dtv[0] = 1;		/* Generation. */
 		dtv[1] = 1;		/* Segments count. */
 		dtv[2] = (uintptr_t)tls;
@@ -294,7 +293,7 @@ __libc_free_tls(void *tcb, size_t tcbsize __unused, size_t tcbalign)
 	tcbalign = MAX(tcbalign, libc_tls_init_align);
 	size = roundup2(libc_tls_static_space, tcbalign);
 
-	dtv = ((uintptr_t **)tcb)[1];
+	dtv = ((struct tcb *)tcb)->tcb_dtv;
 	tlsend = (uintptr_t)tcb;
 	tlsstart = tlsend - size;
 	tls_free_aligned((void*)tlsstart);
@@ -309,7 +308,8 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 {
 	size_t size;
 	char *tls_block, *tls;
-	uintptr_t *dtv, **tcb;
+	uintptr_t *dtv;
+	struct tcb *tcb;
 
 	tcbalign = MAX(tcbalign, libc_tls_init_align);
 	size = roundup2(libc_tls_static_space, tcbalign);
@@ -327,10 +327,10 @@ __libc_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 		abort();
 	}
 
-	tcb = (uintptr_t **)(tls_block + size);
+	tcb = (struct tcb *)(tls_block + size);
 	tls = (char *)tcb - libc_tls_static_space;
-	tcb[0] = (uintptr_t *)tcb;
-	tcb[1] = dtv;
+	tcb->tcb_self = tcb;
+	tcb->tcb_dtv = dtv;
 
 	dtv[0] = 1;
 	dtv[1] = 1;

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -1073,7 +1073,7 @@ allocate_initial_tls(Obj_Entry *objs)
 void *
 __tls_get_addr(tls_index* ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset));

--- a/libexec/rtld-elf/amd64/reloc.c
+++ b/libexec/rtld-elf/amd64/reloc.c
@@ -568,7 +568,7 @@ allocate_initial_tls(Obj_Entry *objs)
 void *
 __tls_get_addr(tls_index *ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset));

--- a/libexec/rtld-elf/arm/reloc.c
+++ b/libexec/rtld-elf/arm/reloc.c
@@ -467,7 +467,7 @@ allocate_initial_tls(Obj_Entry *objs)
 void *
 __tls_get_addr(tls_index* ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset));

--- a/libexec/rtld-elf/i386/reloc.c
+++ b/libexec/rtld-elf/i386/reloc.c
@@ -542,7 +542,7 @@ __attribute__((__regparm__(1)))
 void *
 ___tls_get_addr(tls_index *ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset));
@@ -552,7 +552,7 @@ ___tls_get_addr(tls_index *ti)
 void *
 __tls_get_addr(tls_index *ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset));

--- a/libexec/rtld-elf/powerpc/reloc.c
+++ b/libexec/rtld-elf/powerpc/reloc.c
@@ -844,7 +844,7 @@ allocate_initial_tls(Obj_Entry *list)
 void*
 __tls_get_addr(tls_index* ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset +

--- a/libexec/rtld-elf/powerpc64/reloc.c
+++ b/libexec/rtld-elf/powerpc64/reloc.c
@@ -764,7 +764,7 @@ allocate_initial_tls(Obj_Entry *list)
 void*
 __tls_get_addr(tls_index* ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset +

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -589,7 +589,7 @@ allocate_initial_tls(Obj_Entry *objs)
 void *
 __tls_get_addr(tls_index* ti)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 	dtvp = &_tcb_get()->tcb_dtv;
 	return (tls_get_addr_common(dtvp, ti->ti_module, ti->ti_offset +

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -186,7 +186,7 @@ static int symlook_list(SymLook *, const Objlist *, DoneList *);
 static int symlook_needed(SymLook *, const Needed_Entry *, DoneList *);
 static int symlook_obj1_sysv(SymLook *, const Obj_Entry *);
 static int symlook_obj1_gnu(SymLook *, const Obj_Entry *);
-static void *tls_get_addr_slow(uintptr_t **, int, size_t, bool) __noinline;
+static void *tls_get_addr_slow(struct dtv **, int, size_t, bool) __noinline;
 static void trace_loaded_objects(Obj_Entry *, bool);
 static void unlink_object(Obj_Entry *);
 static void unload_object(Obj_Entry *, RtldLockState *lockstate);
@@ -4809,7 +4809,7 @@ dlinfo(void *handle, int request, void *p)
 static void
 rtld_fill_dl_phdr_info(const Obj_Entry *obj, struct dl_phdr_info *phdr_info)
 {
-	uintptr_t **dtvp;
+	struct dtv **dtvp;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	phdr_info->dlpi_addr = (uintptr_t)cheri_andperm(obj->relocbase,
@@ -5853,24 +5853,26 @@ unref_dag(Obj_Entry *root)
  * Common code for MD __tls_get_addr().
  */
 static void *
-tls_get_addr_slow(uintptr_t **dtvp, int index, size_t offset, bool locked)
+tls_get_addr_slow(struct dtv **dtvp, int index, size_t offset, bool locked)
 {
-	uintptr_t *newdtv, *dtv;
+	struct dtv *newdtv, *dtv;
 	RtldLockState lockstate;
 	int to_copy;
 
 	dtv = *dtvp;
 	/* Check dtv generation in case new modules have arrived */
-	if (dtv[0] != tls_dtv_generation) {
+	if (dtv->dtv_gen != tls_dtv_generation) {
 		if (!locked)
 			wlock_acquire(rtld_bind_lock, &lockstate);
-		newdtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
-		to_copy = dtv[1];
+		newdtv = xcalloc(1, sizeof(struct dtv) + tls_max_index *
+		    sizeof(struct dtv_slot));
+		to_copy = dtv->dtv_size;
 		if (to_copy > tls_max_index)
 			to_copy = tls_max_index;
-		memcpy(&newdtv[2], &dtv[2], to_copy * sizeof(uintptr_t));
-		newdtv[0] = tls_dtv_generation;
-		newdtv[1] = tls_max_index;
+		memcpy(newdtv->dtv_slots, dtv->dtv_slots, to_copy *
+		    sizeof(struct dtv_slot));
+		newdtv->dtv_gen = tls_dtv_generation;
+		newdtv->dtv_size = tls_max_index;
 		free(dtv);
 		if (!locked)
 			lock_release(rtld_bind_lock, &lockstate);
@@ -5878,29 +5880,30 @@ tls_get_addr_slow(uintptr_t **dtvp, int index, size_t offset, bool locked)
 	}
 
 	/* Dynamically allocate module TLS if necessary */
-	if (dtv[index + 1] == 0) {
+	if (dtv->dtv_slots[index - 1].dtvs_tls == 0) {
 		/* Signal safe, wlock will block out signals. */
 		if (!locked)
 			wlock_acquire(rtld_bind_lock, &lockstate);
-		if (!dtv[index + 1])
-			dtv[index + 1] = (uintptr_t)allocate_module_tls(index);
+		if (!dtv->dtv_slots[index - 1].dtvs_tls)
+			dtv->dtv_slots[index - 1].dtvs_tls =
+			    allocate_module_tls(index);
 		if (!locked)
 			lock_release(rtld_bind_lock, &lockstate);
 	}
-	return ((void *)(dtv[index + 1] + offset));
+	return (dtv->dtv_slots[index - 1].dtvs_tls + offset);
 }
 
 void *
-tls_get_addr_common(uintptr_t **dtvp, int index, size_t offset)
+tls_get_addr_common(struct dtv **dtvp, int index, size_t offset)
 {
-	uintptr_t *dtv;
+	struct dtv *dtv;
 	void *ret;
 
 	dtv = *dtvp;
 	/* Check dtv generation in case new modules have arrived */
-	if (__predict_true(dtv[0] == tls_dtv_generation &&
-	    dtv[index + 1] != 0))
-		return ((void *)(dtv[index + 1] + offset));
+	if (__predict_true(dtv->dtv_gen == tls_dtv_generation &&
+	    dtv->dtv_slots[index - 1].dtvs_tls != 0))
+		return (dtv->dtv_slots[index - 1].dtvs_tls + offset);
 
 #ifdef CHERI_LIB_C18N
 	struct trusted_frame *tf;
@@ -5953,7 +5956,7 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 {
     Obj_Entry *obj;
     char *tls_block;
-    uintptr_t *dtv;
+    struct dtv *dtv;
     struct tcb *tcb;
     char *addr;
     uintptr_t i;
@@ -5985,18 +5988,22 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 
 	/* Adjust the DTV. */
 	dtv = tcb->tcb_dtv;
-	for (i = 0; i < dtv[1]; i++) {
-	    if (dtv[i + 2] >= (uintptr_t)oldtcb &&
-		dtv[i + 2] < (uintptr_t)oldtcb + tls_static_space) {
-		dtv[i + 2] = (uintptr_t)((char *)tcb +
-		    ((char *)dtv[i + 2] - (char *)oldtcb));
+	for (i = 0; i < dtv->dtv_size; i++) {
+	    if ((uintptr_t)dtv->dtv_slots[i].dtvs_tls >=
+		(uintptr_t)oldtcb &&
+		(uintptr_t)dtv->dtv_slots[i].dtvs_tls <
+		(uintptr_t)oldtcb + tls_static_space) {
+		dtv->dtv_slots[i].dtvs_tls = (char *)tcb +
+		    (dtv->dtv_slots[i].dtvs_tls -
+		    (char *)oldtcb);
 	    }
 	}
     } else {
-	dtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
+	dtv = xcalloc(1, sizeof(struct dtv) + tls_max_index *
+	    sizeof(struct dtv_slot));
 	tcb->tcb_dtv = dtv;
-	dtv[0] = tls_dtv_generation;
-	dtv[1] = tls_max_index;
+	dtv->dtv_gen = tls_dtv_generation;
+	dtv->dtv_size = tls_max_index;
 
 	for (obj = globallist_curr(objs); obj != NULL;
 	  obj = globallist_next(obj)) {
@@ -6014,7 +6021,7 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 		memset(addr + tls_init_offset + obj->tlsinitsize,
 		    0, obj->tlssize - obj->tlsinitsize - tls_init_offset);
 	    }
-	    dtv[obj->tlsindex + 1] = (uintptr_t)addr;
+	    dtv->dtv_slots[obj->tlsindex - 1].dtvs_tls = addr;
 	}
     }
 
@@ -6024,10 +6031,10 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 void
 free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
 {
-    uintptr_t *dtv;
+    struct dtv *dtv;
     uintptr_t tlsstart, tlsend;
     size_t post_size;
-    size_t dtvsize, i, tls_init_align __unused;
+    size_t i, tls_init_align __unused;
 
     assert(tcbsize >= TLS_TCB_SIZE);
     tls_init_align = rtld_max(obj_main->tlsalign, 1);
@@ -6039,11 +6046,11 @@ free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
     tlsend = (uintptr_t)tcb + tls_static_space;
 
     dtv = ((struct tcb *)tcb)->tcb_dtv;
-    dtvsize = dtv[1];
-    for (i = 0; i < dtvsize; i++) {
-	if (dtv[i + 2] != 0 && (dtv[i + 2] < tlsstart ||
-	    dtv[i + 2] >= tlsend)) {
-	    free((void *)dtv[i + 2]);
+    for (i = 0; i < dtv->dtv_size; i++) {
+	if (dtv->dtv_slots[i].dtvs_tls != NULL &&
+	    ((uintptr_t)dtv->dtv_slots[i].dtvs_tls < tlsstart ||
+	    (uintptr_t)dtv->dtv_slots[i].dtvs_tls >= tlsend)) {
+	    free(dtv->dtv_slots[i].dtvs_tls);
 	}
     }
     free(dtv);
@@ -6063,7 +6070,7 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
     Obj_Entry *obj;
     size_t size, ralign;
     char *tls_block;
-    uintptr_t *dtv, *olddtv;
+    struct dtv *dtv, *olddtv;
     struct tcb *tcb;
     char *addr;
     size_t i;
@@ -6075,14 +6082,15 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 
     assert(tcbsize >= 2 * sizeof(uintptr_t));
     tls_block = xmalloc_aligned(size, ralign, 0 /* XXX */);
-    dtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
+    dtv = xcalloc(1, sizeof(struct dtv) + tls_max_index *
+	sizeof(struct dtv_slot));
 
     tcb = (struct tcb *)(tls_block + roundup(tls_static_space, ralign));
     tcb->tcb_self = tcb;
     tcb->tcb_dtv = dtv;
 
-    dtv[0] = tls_dtv_generation;
-    dtv[1] = tls_max_index;
+    dtv->dtv_gen = tls_dtv_generation;
+    dtv->dtv_size = tls_max_index;
 
     if (oldtcb != NULL) {
 	/*
@@ -6097,11 +6105,14 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 	 * move them over.
 	 */
 	olddtv = ((struct tcb *)oldtcb)->tcb_dtv;
-	for (i = 0; i < olddtv[1]; i++) {
-	    if (olddtv[i + 2] < (uintptr_t)oldtcb - size ||
-		olddtv[i + 2] > (uintptr_t)oldtcb) {
-		    dtv[i + 2] = olddtv[i + 2];
-		    olddtv[i + 2] = 0;
+	for (i = 0; i < olddtv->dtv_size; i++) {
+	    if ((uintptr_t)olddtv->dtv_slots[i].dtvs_tls <
+		(uintptr_t)oldtcb - size ||
+		(uintptr_t)olddtv->dtv_slots[i].dtvs_tls >
+		(uintptr_t)oldtcb) {
+		    dtv->dtv_slots[i].dtvs_tls =
+			olddtv->dtv_slots[i].dtvs_tls;
+		    olddtv->dtv_slots[i].dtvs_tls = NULL;
 	    }
 	}
 
@@ -6121,7 +6132,7 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 			memcpy(addr, obj->tlsinit, obj->tlsinitsize);
 			obj->static_tls_copied = true;
 		}
-		dtv[obj->tlsindex + 1] = (uintptr_t)addr;
+		dtv->dtv_slots[obj->tlsindex - 1].dtvs_tls = addr;
 	}
     }
 
@@ -6131,9 +6142,9 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 void
 free_tls(void *tcb, size_t tcbsize  __unused, size_t tcbalign)
 {
-    uintptr_t *dtv;
+    struct dtv *dtv;
     size_t size, ralign;
-    int dtvsize, i;
+    size_t i;
     uintptr_t tlsstart, tlsend;
 
     /*
@@ -6146,18 +6157,18 @@ free_tls(void *tcb, size_t tcbsize  __unused, size_t tcbalign)
     size = roundup(tls_static_space, ralign);
 
     dtv = ((struct tcb *)tcb)->tcb_dtv;
-    dtvsize = dtv[1];
     tlsend = (uintptr_t)tcb;
     tlsstart = tlsend - size;
-    for (i = 0; i < dtvsize; i++) {
-	    if (dtv[i + 2] != 0 && (dtv[i + 2] < tlsstart ||
-	        dtv[i + 2] > tlsend)) {
-		    free((void *)dtv[i + 2]);
+    for (i = 0; i < dtv->dtv_size; i++) {
+	    if (dtv->dtv_slots[i].dtvs_tls != NULL &&
+	        ((uintptr_t)dtv->dtv_slots[i].dtvs_tls < tlsstart ||
+	        (uintptr_t)dtv->dtv_slots[i].dtvs_tls > tlsend)) {
+		    free(dtv->dtv_slots[i].dtvs_tls);
 	}
     }
 
     free((void *)tlsstart);
-    free((void *)dtv);
+    free(dtv);
 }
 
 #endif	/* TLS_VARIANT_II */

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -6056,13 +6056,13 @@ free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
  * Allocate Static TLS using the Variant II method.
  */
 void *
-allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
+allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 {
     Obj_Entry *obj;
     size_t size, ralign;
-    char *tls;
+    char *tls_block;
     uintptr_t *dtv, *olddtv;
-    uintptr_t segbase, oldsegbase;
+    uintptr_t **tcb;
     char *addr;
     size_t i;
 
@@ -6072,33 +6072,32 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
     size = roundup(tls_static_space, ralign) + roundup(tcbsize, ralign);
 
     assert(tcbsize >= 2 * sizeof(uintptr_t));
-    tls = xmalloc_aligned(size, ralign, 0 /* XXX */);
+    tls_block = xmalloc_aligned(size, ralign, 0 /* XXX */);
     dtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
 
-    segbase = (uintptr_t)(tls + roundup(tls_static_space, ralign));
-    ((uintptr_t *)segbase)[0] = segbase;
-    ((uintptr_t *)segbase)[1] = (uintptr_t)dtv;
+    tcb = (uintptr_t **)(tls_block + roundup(tls_static_space, ralign));
+    tcb[0] = (uintptr_t *)tcb;
+    tcb[1] = dtv;
 
     dtv[0] = tls_dtv_generation;
     dtv[1] = tls_max_index;
 
-    if (oldtls != NULL) {
+    if (oldtcb != NULL) {
 	/*
 	 * Copy the static TLS block over whole.
 	 */
-	oldsegbase = (uintptr_t)oldtls;
-	memcpy((void *)(segbase - tls_static_space),
-	    (const void *)(oldsegbase - tls_static_space),
+	memcpy((char *)tcb - tls_static_space,
+	    (const char *)oldtcb - tls_static_space,
 	    tls_static_space);
 
 	/*
 	 * If any dynamic TLS blocks have been created tls_get_addr(),
 	 * move them over.
 	 */
-	olddtv = ((uintptr_t **)oldsegbase)[1];
+	olddtv = ((uintptr_t **)oldtcb)[1];
 	for (i = 0; i < olddtv[1]; i++) {
-	    if (olddtv[i + 2] < oldsegbase - size ||
-		olddtv[i + 2] > oldsegbase) {
+	    if (olddtv[i + 2] < (uintptr_t)oldtcb - size ||
+		olddtv[i + 2] > (uintptr_t)oldtcb) {
 		    dtv[i + 2] = olddtv[i + 2];
 		    olddtv[i + 2] = 0;
 	    }
@@ -6108,12 +6107,12 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
 	 * We assume that this block was the one we created with
 	 * allocate_initial_tls().
 	 */
-	free_tls(oldtls, 2 * sizeof(uintptr_t), sizeof(uintptr_t));
+	free_tls(oldtcb, 2 * sizeof(uintptr_t), sizeof(uintptr_t));
     } else {
 	for (obj = objs; obj != NULL; obj = TAILQ_NEXT(obj, next)) {
 		if (obj->marker || obj->tlsoffset == 0)
 			continue;
-		addr = (char *)segbase - obj->tlsoffset;
+		addr = (char *)tcb - obj->tlsoffset;
 		memset(addr + obj->tlsinitsize, 0, obj->tlssize -
 		    obj->tlsinitsize);
 		if (obj->tlsinit) {
@@ -6124,11 +6123,11 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
 	}
     }
 
-    return ((void *)segbase);
+    return (tcb);
 }
 
 void
-free_tls(void *tls, size_t tcbsize  __unused, size_t tcbalign)
+free_tls(void *tcb, size_t tcbsize  __unused, size_t tcbalign)
 {
     uintptr_t *dtv;
     size_t size, ralign;
@@ -6144,9 +6143,9 @@ free_tls(void *tls, size_t tcbsize  __unused, size_t tcbalign)
 	    ralign = tls_static_max_align;
     size = roundup(tls_static_space, ralign);
 
-    dtv = ((uintptr_t **)tls)[1];
+    dtv = ((uintptr_t **)tcb)[1];
     dtvsize = dtv[1];
-    tlsend = (uintptr_t)tls;
+    tlsend = (uintptr_t)tcb;
     tlsstart = tlsend - size;
     for (i = 0; i < dtvsize; i++) {
 	    if (dtv[i + 2] != 0 && (dtv[i + 2] < tlsstart ||
@@ -6267,13 +6266,13 @@ free_tls_offset(Obj_Entry *obj)
 }
 
 void *
-_rtld_allocate_tls(void *oldtls, size_t tcbsize, size_t tcbalign)
+_rtld_allocate_tls(void *oldtcb, size_t tcbsize, size_t tcbalign)
 {
     void *ret;
     RtldLockState lockstate;
 
     wlock_acquire(rtld_bind_lock, &lockstate);
-    ret = allocate_tls(globallist_curr(TAILQ_FIRST(&obj_list)), oldtls,
+    ret = allocate_tls(globallist_curr(TAILQ_FIRST(&obj_list)), oldtcb,
       tcbsize, tcbalign);
 #ifdef CHERI_LIB_C18N
     /*

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -5959,7 +5959,7 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
     struct dtv *dtv;
     struct tcb *tcb;
     char *addr;
-    uintptr_t i;
+    size_t i;
     size_t extra_size, maxalign, post_size, pre_size, tls_block_size;
     size_t tls_init_align, tls_init_offset;
 

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -5864,11 +5864,11 @@ tls_get_addr_slow(uintptr_t **dtvp, int index, size_t offset, bool locked)
 	if (dtv[0] != tls_dtv_generation) {
 		if (!locked)
 			wlock_acquire(rtld_bind_lock, &lockstate);
-		newdtv = xcalloc(tls_max_index + 2, sizeof(newdtv[0]));
+		newdtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
 		to_copy = dtv[1];
 		if (to_copy > tls_max_index)
 			to_copy = tls_max_index;
-		memcpy(&newdtv[2], &dtv[2], to_copy * sizeof(newdtv[0]));
+		memcpy(&newdtv[2], &dtv[2], to_copy * sizeof(uintptr_t));
 		newdtv[0] = tls_dtv_generation;
 		newdtv[1] = tls_max_index;
 		free(dtv);
@@ -5955,7 +5955,7 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
     char *tls_block;
     uintptr_t *dtv, **tcb;
     char *addr;
-    Elf_Addr i;
+    uintptr_t i;
     size_t extra_size, maxalign, post_size, pre_size, tls_block_size;
     size_t tls_init_align, tls_init_offset;
 
@@ -5985,16 +5985,16 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 	/* Adjust the DTV. */
 	dtv = tcb[0];
 	for (i = 0; i < dtv[1]; i++) {
-	    if (dtv[i+2] >= (Elf_Addr)oldtcb &&
-		dtv[i+2] < (Elf_Addr)oldtcb + tls_static_space) {
-		dtv[i+2] = (uintptr_t)tcb + ((Elf_Addr)dtv[i+2] - (Elf_Addr)oldtcb);
+	    if (dtv[i + 2] >= (uintptr_t)oldtcb &&
+		dtv[i + 2] < (uintptr_t)oldtcb + tls_static_space) {
+		dtv[i + 2] = (uintptr_t)tcb + ((Elf_Addr)dtv[i + 2] - (Elf_Addr)oldtcb);
 	    }
 	}
     } else {
-	dtv = xcalloc(tls_max_index + 2, sizeof(void *));
+	dtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
 	tcb[0] = dtv;
-	dtv[0] = (uintptr_t)tls_dtv_generation;
-	dtv[1] = (uintptr_t)tls_max_index;
+	dtv[0] = tls_dtv_generation;
+	dtv[1] = tls_max_index;
 
 	for (obj = globallist_curr(objs); obj != NULL;
 	  obj = globallist_next(obj)) {
@@ -6003,13 +6003,13 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 	    tls_init_offset = obj->tlspoffset & (obj->tlsalign - 1);
 	    addr = (char *)tcb + obj->tlsoffset;
 	    if (tls_init_offset > 0)
-		memset((void *)addr, 0, tls_init_offset);
+		memset(addr, 0, tls_init_offset);
 	    if (obj->tlsinitsize > 0) {
-		memcpy((void *)(addr + tls_init_offset), obj->tlsinit,
+		memcpy(addr + tls_init_offset, obj->tlsinit,
 		    obj->tlsinitsize);
 	    }
 	    if (obj->tlssize > obj->tlsinitsize) {
-		memset((void *)(addr + tls_init_offset + obj->tlsinitsize),
+		memset(addr + tls_init_offset + obj->tlsinitsize,
 		    0, obj->tlssize - obj->tlsinitsize - tls_init_offset);
 	    }
 	    dtv[obj->tlsindex + 1] = (uintptr_t)addr;
@@ -6022,8 +6022,8 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 void
 free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
 {
-    char **dtv;
-    char *tlsstart, *tlsend;
+    uintptr_t *dtv;
+    uintptr_t tlsstart, tlsend;
     size_t post_size;
     size_t dtvsize, i, tls_init_align __unused;
 
@@ -6033,14 +6033,15 @@ free_tls(void *tcb, size_t tcbsize, size_t tcbalign __unused)
     /* Compute fragments sizes. */
     post_size = calculate_tls_post_size(tls_init_align);
 
-    tlsstart = (char *)tcb + TLS_TCB_SIZE + post_size;
-    tlsend = (char *)tcb + tls_static_space;
+    tlsstart = (uintptr_t)tcb + TLS_TCB_SIZE + post_size;
+    tlsend = (uintptr_t)tcb + tls_static_space;
 
-    dtv = *(void **)tcb;
-    dtvsize = (size_t)dtv[1];
+    dtv = *(uintptr_t **)tcb;
+    dtvsize = dtv[1];
     for (i = 0; i < dtvsize; i++) {
-	if (dtv[i+2] && (dtv[i+2] < tlsstart || dtv[i+2] >= tlsend)) {
-	    free((void*)dtv[i+2]);
+	if (dtv[i + 2] != 0 && (dtv[i + 2] < tlsstart ||
+	    dtv[i + 2] >= tlsend)) {
+	    free((void *)dtv[i + 2]);
 	}
     }
     free(dtv);
@@ -6060,8 +6061,9 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
     Obj_Entry *obj;
     size_t size, ralign;
     char *tls;
-    Elf_Addr *dtv, *olddtv;
-    Elf_Addr segbase, oldsegbase, addr;
+    uintptr_t *dtv, *olddtv;
+    uintptr_t segbase, oldsegbase;
+    char *addr;
     size_t i;
 
     ralign = tcbalign;
@@ -6069,31 +6071,31 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
 	    ralign = tls_static_max_align;
     size = roundup(tls_static_space, ralign) + roundup(tcbsize, ralign);
 
-    assert(tcbsize >= 2*sizeof(Elf_Addr));
+    assert(tcbsize >= 2 * sizeof(uintptr_t));
     tls = xmalloc_aligned(size, ralign, 0 /* XXX */);
-    dtv = xcalloc(tls_max_index + 2, sizeof(Elf_Addr));
+    dtv = xcalloc(tls_max_index + 2, sizeof(uintptr_t));
 
-    segbase = (Elf_Addr)(tls + roundup(tls_static_space, ralign));
-    ((Elf_Addr *)segbase)[0] = segbase;
-    ((Elf_Addr *)segbase)[1] = (Elf_Addr) dtv;
+    segbase = (uintptr_t)(tls + roundup(tls_static_space, ralign));
+    ((uintptr_t *)segbase)[0] = segbase;
+    ((uintptr_t *)segbase)[1] = (uintptr_t)dtv;
 
     dtv[0] = tls_dtv_generation;
     dtv[1] = tls_max_index;
 
-    if (oldtls) {
+    if (oldtls != NULL) {
 	/*
 	 * Copy the static TLS block over whole.
 	 */
-	oldsegbase = (Elf_Addr) oldtls;
+	oldsegbase = (uintptr_t)oldtls;
 	memcpy((void *)(segbase - tls_static_space),
-	   (const void *)(oldsegbase - tls_static_space),
-	   tls_static_space);
+	    (const void *)(oldsegbase - tls_static_space),
+	    tls_static_space);
 
 	/*
 	 * If any dynamic TLS blocks have been created tls_get_addr(),
 	 * move them over.
 	 */
-	olddtv = ((Elf_Addr **)oldsegbase)[1];
+	olddtv = ((uintptr_t **)oldsegbase)[1];
 	for (i = 0; i < olddtv[1]; i++) {
 	    if (olddtv[i + 2] < oldsegbase - size ||
 		olddtv[i + 2] > oldsegbase) {
@@ -6106,19 +6108,19 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
 	 * We assume that this block was the one we created with
 	 * allocate_initial_tls().
 	 */
-	free_tls(oldtls, 2 * sizeof(Elf_Addr), sizeof(Elf_Addr));
+	free_tls(oldtls, 2 * sizeof(uintptr_t), sizeof(uintptr_t));
     } else {
 	for (obj = objs; obj != NULL; obj = TAILQ_NEXT(obj, next)) {
 		if (obj->marker || obj->tlsoffset == 0)
 			continue;
-		addr = segbase - obj->tlsoffset;
-		memset((void *)(addr + obj->tlsinitsize),
-		    0, obj->tlssize - obj->tlsinitsize);
+		addr = (char *)segbase - obj->tlsoffset;
+		memset(addr + obj->tlsinitsize, 0, obj->tlssize -
+		    obj->tlsinitsize);
 		if (obj->tlsinit) {
-			memcpy((void *)addr, obj->tlsinit, obj->tlsinitsize);
+			memcpy(addr, obj->tlsinit, obj->tlsinitsize);
 			obj->static_tls_copied = true;
 		}
-		dtv[obj->tlsindex + 1] = addr;
+		dtv[obj->tlsindex + 1] = (uintptr_t)addr;
 	}
     }
 
@@ -6128,10 +6130,10 @@ allocate_tls(Obj_Entry *objs, void *oldtls, size_t tcbsize, size_t tcbalign)
 void
 free_tls(void *tls, size_t tcbsize  __unused, size_t tcbalign)
 {
-    Elf_Addr* dtv;
+    uintptr_t *dtv;
     size_t size, ralign;
     int dtvsize, i;
-    Elf_Addr tlsstart, tlsend;
+    uintptr_t tlsstart, tlsend;
 
     /*
      * Figure out the size of the initial TLS block so that we can
@@ -6142,9 +6144,9 @@ free_tls(void *tls, size_t tcbsize  __unused, size_t tcbalign)
 	    ralign = tls_static_max_align;
     size = roundup(tls_static_space, ralign);
 
-    dtv = ((Elf_Addr **)tls)[1];
+    dtv = ((uintptr_t **)tls)[1];
     dtvsize = dtv[1];
-    tlsend = (Elf_Addr)tls;
+    tlsend = (uintptr_t)tls;
     tlsstart = tlsend - size;
     for (i = 0; i < dtvsize; i++) {
 	    if (dtv[i + 2] != 0 && (dtv[i + 2] < tlsstart ||

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -5988,7 +5988,8 @@ allocate_tls(Obj_Entry *objs, void *oldtcb, size_t tcbsize, size_t tcbalign)
 	for (i = 0; i < dtv[1]; i++) {
 	    if (dtv[i + 2] >= (uintptr_t)oldtcb &&
 		dtv[i + 2] < (uintptr_t)oldtcb + tls_static_space) {
-		dtv[i + 2] = (uintptr_t)tcb + ((Elf_Addr)dtv[i + 2] - (Elf_Addr)oldtcb);
+		dtv[i + 2] = (uintptr_t)((char *)tcb +
+		    ((char *)dtv[i + 2] - (char *)oldtcb));
 	    }
 	}
     } else {

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -627,7 +627,7 @@ void _rtld_bind_start(void);
 void *rtld_resolve_ifunc(const Obj_Entry *obj, const Elf_Sym *def);
 void symlook_init(SymLook *, const char *);
 int symlook_obj(SymLook *, const Obj_Entry *);
-void *tls_get_addr_common(uintptr_t **dtvp, int index, size_t offset);
+void *tls_get_addr_common(struct dtv **dtvp, int index, size_t offset);
 void *allocate_tls(Obj_Entry *, void *, size_t, size_t);
 void free_tls(void *, size_t, size_t);
 void *allocate_module_tls(int index);

--- a/sys/sys/_tls_variant_i.h
+++ b/sys/sys/_tls_variant_i.h
@@ -37,8 +37,18 @@
 
 struct pthread;
 
+struct dtv_slot {
+	char			*dtvs_tls;
+};
+
+struct dtv {
+	uintptr_t		dtv_gen;
+	uintptr_t		dtv_size;
+	struct dtv_slot		dtv_slots[];
+};
+
 struct tcb {
-	uintptr_t		* __kerncap tcb_dtv;	/* required by rtld */
+	struct dtv		* __kerncap tcb_dtv;	/* required by rtld */
 	struct pthread		* __kerncap tcb_thread;
 };
 

--- a/sys/x86/include/tls.h
+++ b/sys/x86/include/tls.h
@@ -36,13 +36,23 @@
 
 struct pthread;
 
+struct dtv_slot {
+	char			*dtvs_tls;
+};
+
+struct dtv {
+	uintptr_t		dtv_gen;
+	uintptr_t		dtv_size;
+	struct dtv_slot		dtv_slots[];
+};
+
 /*
  * Variant II tcb, first two members are required by rtld,
  * %fs (amd64) / %gs (i386) points to the structure.
  */
 struct tcb {
 	struct tcb		*tcb_self;	/* required by rtld */
-	uintptr_t		*tcb_dtv;	/* required by rtld */
+	struct dtv		*tcb_dtv;	/* required by rtld */
 	struct pthread		*tcb_thread;
 };
 


### PR DESCRIPTION
- **libc: Reassociate pointer arithmetic in __libc_tls_get_addr**
- **libc: Consistently use uintptr_t for TLS implementation**
- **rtld-elf: Consistently use uintptr_t for TLS implementation**
- **libc: Use variables more consistent with Variant I for Variant II TLS**
- **rtld-elf: Use variables more consistent with Variant I for Variant II TLS**
- **libc: Use struct tcb * rather than uintptr_t ** for the tcb**
- **rtld-elf: Use struct tcb * rather than uintptr_t ** for the tcb**
- **rtld-elf: Use clear pointer provenance when updating DTV pointer**
- **tls: Introduce struct dtv and struct dtv_slot**
- **rtld-elf: Use size_t rather than uintptr_t for an index**
