### PR TITLE
net80211: Preserve CHERI bounds of ieee80211_htrateset after casting

### DIFF
--- a/sys/net80211/_ieee80211.h
+++ b/sys/net80211/_ieee80211.h
@@ -382,7 +382,7 @@ struct ieee80211_channel {
 
 struct ieee80211_rateset {
 	uint8_t		rs_nrates;
-	uint8_t		rs_rates[IEEE80211_RATE_MAXSIZE];
+	uint8_t		rs_rates[IEEE80211_RATE_MAXSIZE] __subobject_variable_length;
 };
 
 /*


### PR DESCRIPTION
When joining a 802.11n network, `ieee80211_setup_htrates` casts an object of type `struct ieee80211_htrateset` to the smaller `struct ieee80211_rateset` and passes it to `ieee80211_fix_rate`. `ieee80211_fix_rate` uses the `rs_nrates` field to index into the rates array `rs_rates` and we'll get a bounds exception, even though the access is actually correct. This PR adds an annotation to preserve the bounds of the original object before casting.