### PR TITLE
Revert "Jenkinsfile: Build and ship -NOCAPREVOKE(-NODEBUG) kernels"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -297,7 +297,6 @@ selectedArchitectures.each { suffix ->
                 '--cheribsd/build-lib32',
                 '--cheribsd/build-tests',
                 '--cheribsd/build-bench-kernels',
-                '--cheribsd/build-nocaprevoke-kernels',
                 '--cheribsd/with-manpages',
                 '--cheribsd/debug-info',
                 '--cheribsd/debug-files',


### PR DESCRIPTION
These served two purposes, benchmarking and as a fallback in case the
revocation support code was unstable. For benchmarking, revocation can
be turned off in userspace and we have not observed any significant
effects when doing so compared with previous kernels that lacked
revocation support. For instability, we've been shipping kernels with
revocation support by default for quite a while now, and whilst there
are still occasional bugs in that code to iron out, these kernel configs
are not widely used, nor are they widely tested.

This reverts commit 37026bbaa156d4eb0de848739801b14d552f7929.
