### PR TITLE
libmalloc_simple: Set bounds for __crt_aligned_alloc_offset with offset 0

### DIFF
--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -605,7 +605,8 @@ __crt_aligned_alloc_offset(size_t align, size_t size, size_t offset)
 		if (cheri_align > align)
 			align = cheri_align;
 #endif
-		return (__simple_malloc_aligned(size, align));
+		p = __simple_malloc_aligned(size, align);
+		return (bound_ptr(p, size));
 	}
 
 	/*


### PR DESCRIPTION
Confusingly, __simple_malloc_aligned does not set bounds (similarly for
__simple_malloc_unaligned), unlike __simple_malloc etc, so as the caller
we must do so. The non-zero offset case already had to do this due to
allocationg additional allocator-internal space, but this requirement
even for the case where no additional space is included was missed.

Fixes:	1bd421a421c2 ("libmalloc_simple: Add an implementation of __crt_aligned_alloc_offset")
