### PR TITLE
zfs: allow building for Morello without _L64 defined

### DIFF
--- a/sys/contrib/subrepo-openzfs/include/os/freebsd/spl/sys/isa_defs.h
+++ b/sys/contrib/subrepo-openzfs/include/os/freebsd/spl/sys/isa_defs.h
@@ -145,7 +145,7 @@ extern "C" {
  * Define the appropriate "implementation choices"
  */
 #if !defined(_LP64)
-#error "_LP64 not defined"
+#define	_LP64
 #endif
 #define	_SUNOS_VTOC_16
 


### PR DESCRIPTION
Until LLVM 17, the Morello compiler unconditionally defined `_LP64` and `__LP64__`, but after the merge it no longer defines them. Follow the same approach as RISC-V in this file and just unconditionally define it for `__aarch64__`.