### PR TITLE
vmbus: check for __SIZEOF_LONG__ instead of __LP64__

### DIFF
--- a/sys/dev/hyperv/vmbus/vmbus_reg.h
+++ b/sys/dev/hyperv/vmbus/vmbus_reg.h
@@ -60,7 +60,7 @@ CTASSERT(sizeof(struct vmbus_message) == VMBUS_MSG_SIZE);
  * Hyper-V SynIC event flags
  */
 
-#ifdef __LP64__
+#if __SIZEOF_LONG__ == 8
 #define VMBUS_EVTFLAGS_MAX	32
 #define VMBUS_EVTFLAG_SHIFT	6
 #else


### PR DESCRIPTION
This value is used for an array of u_long, so we just need to to check sizeof(long). Another option would be to use uint64_t instead but this is the minimal change needed to build for Morello now that the compiler no longer defined __LP64__.