### PR TITLE
kld: Check for sentries explicitly when ignoring relocation addends

### DIFF
--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -586,8 +586,18 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		 * sentries.  The addend should probably be passed to
 		 * the lookup function instead.
 		 */
-		if (addend != 0)
+		if (addend != 0) {
+			KASSERT(!cheri_getsealed(addr),
+			    ("%s: sentry %#p with non-zero addend %#lx",
+			    __func__, (void *)addr, addend));
+
+			/*
+			 * XXX: Prevent the add below from being
+			 * hoisted out of the condition.
+			 */
+			__asm__("" : "+r" (addend));
 			addr += addend;
+		}
 		*(uintptr_t *)where = addr;
 		break;
 	case R_MORELLO_JUMP_SLOT:

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -593,8 +593,18 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		 * sentries.  The addend should probably be passed to
 		 * the lookup function instead.
 		 */
-		if (addend != 0)
+		if (addend != 0) {
+			KASSERT(!cheri_getsealed(addr),
+			    ("%s: sentry %#p with non-zero addend %#lx",
+			    __func__, (void *)addr, addend));
+
+			/*
+			 * XXX: Prevent the add below from being
+			 * hoisted out of the condition.
+			 */
+			__asm__("" : "+r" (addend));
 			addr += addend;
+		}
 
 		beforecap = *(uintptr_t *)where;
 		*(uintptr_t *)where = addr;


### PR DESCRIPTION
The compiler might optimize out the check for 0 assuming that adding 0
is idempotent, but adding 0 is not idempotent for sealed capabilities.

Reported by:	Alex Richardson
Co-authored-by: Jessica Clarke <jrtc27@jrtc27.com>
