### PR TITLE
Bump __CheriBSD_version to 20250612

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20250301
+#define __CheriBSD_version 20250612
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,


### PR DESCRIPTION
**NOTE: the packages for this branch are not deployed yet.**

Bump __CheriBSD_version to the current date to rebuild packages for dev without affecting the CheriBSD 25.03 release.