### PR TITLE
pkgbase: Set a couple of package metadata variables for CheriBSD

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -665,9 +665,9 @@ SOURCE_DATE_EPOCH=	${TIMEEPOCHNOW:gmtime}
 SOURCE_DATE_EPOCH=	${PKG_TIMESTAMP}
 .endif
 
-PKG_NAME_PREFIX?=	FreeBSD
+PKG_NAME_PREFIX?=	CheriBSD
 PKG_MAINTAINER?=	re@FreeBSD.org
-PKG_WWW?=		https://www.FreeBSD.org
+PKG_WWW?=		https://www.CheriBSD.org
 .export PKG_NAME_PREFIX
 .export PKG_MAINTAINER
 .export PKG_WWW


### PR DESCRIPTION
This is a local diff I've been carrying around for my pkgbase setup. Since I'm probably the only one using pkgbase on CheriBSD, I think this won't break anything.

The value for PKG_MAINTAINER is wrong of course, but I'm not sure what alternative would be appropriate.