### PR TITLE
Use PCC bounds from .caprelocs / .rela.dyn

### DIFF
--- a/lib/csu/aarch64/caprel.h
+++ b/lib/csu/aarch64/caprel.h
@@ -14,6 +14,7 @@
 
 #include <sys/types.h>
 #include <machine/elf.h>
+#include <stdbool.h>
 
 #include <cheri/cherireg.h>
 #include <cheriintrin.h>
@@ -35,7 +36,7 @@
 static __always_inline uintcap_t
 init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
     const void * __capability text_rodata_cap, Elf_Addr base_addr,
-    Elf_Size addend)
+    Elf_Size addend, bool use_code_bounds)
 {
 	uintcap_t cap;
 	Elf_Addr address, len;
@@ -48,6 +49,8 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)text_rodata_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, base_addr + address);
+	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
+		cap = cheri_bounds_set(cap, len);
 	cap = cheri_perms_clear(cap, CAP_RELOC_REMOVE_PERMS);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
@@ -55,16 +58,11 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	}
 	if (perms == MORELLO_FRAG_RWDATA || perms == MORELLO_FRAG_RODATA) {
 		cap = cheri_perms_clear(cap, DATA_PTR_REMOVE_PERMS);
-		cap = cheri_bounds_set(cap, len);
 	}
 
 	cap += addend;
 
 	if (perms == MORELLO_FRAG_EXECUTABLE) {
-		/*
-		 * TODO tight bounds: lower bound and len should be set
-		 * with LSB == 0 for C64 code.
-		 */
 		cap = cheri_sentry_create(cap);
 	}
 
@@ -73,7 +71,8 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 
 static __always_inline void
 elf_reloc(const Elf_Rela *rela, void * __capability data_cap,
-    const void * __capability code_cap, Elf_Addr relocbase)
+    const void * __capability code_cap, Elf_Addr relocbase,
+    bool use_code_bounds)
 {
 	Elf_Addr addr;
 	Elf_Addr *where;
@@ -89,7 +88,7 @@ elf_reloc(const Elf_Rela *rela, void * __capability data_cap,
 	where = (Elf_Addr *)addr;
 #endif
 	*(uintcap_t *)(void *)where = init_cap_from_fragment(where, data_cap,
-	    code_cap, relocbase, rela->r_addend);
+	    code_cap, relocbase, rela->r_addend, use_code_bounds);
 }
 
 #endif /* __CAPREL_H__ */

--- a/lib/csu/aarch64/crt1_c.c
+++ b/lib/csu/aarch64/crt1_c.c
@@ -43,7 +43,7 @@
 extern int _DYNAMIC;
 #pragma weak _DYNAMIC
 
-#define	RODATA_PTR(x)	(&x)
+#define	RODATA_PTR(x)	(&(*x))
 
 #include "caprel.h"
 

--- a/lib/csu/aarch64/crt1_c.c
+++ b/lib/csu/aarch64/crt1_c.c
@@ -43,8 +43,6 @@
 extern int _DYNAMIC;
 #pragma weak _DYNAMIC
 
-#define	RODATA_PTR(x)	(&(*x))
-
 #include "caprel.h"
 
 #include "crt_init_globals.c"

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -47,15 +47,6 @@
 #ifndef PIC
 #define	CHERI_INIT_RELA
 
-#define	RODATA_PTR(x) ({						\
-	__typeof__((0, x)) _p;						\
-									\
-	__asm__ (							\
-	    "adrp %0, %c1\n\t"						\
-	    "add %0, %0, :lo12:%c1\n\t"					\
-	    : "=C" (_p) : "i" (x));					\
-	_p; })
-
 #include "caprel.h"
 
 #include "crt_init_globals.c"

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -48,12 +48,12 @@
 #define	CHERI_INIT_RELA
 
 #define	RODATA_PTR(x) ({						\
-	__typeof__(x) *_p;						\
+	__typeof__((0, x)) _p;						\
 									\
 	__asm__ (							\
-	    "adrp %0, " __STRING(x) "\n\t"				\
-	    "add %0, %0, :lo12:" __STRING(x) "\n\t"			\
-	    : "=C" (_p));						\
+	    "adrp %0, %c1\n\t"						\
+	    "add %0, %0, :lo12:%c1\n\t"					\
+	    : "=C" (_p) : "i" (x));					\
 	_p; })
 
 #include "caprel.h"

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -41,8 +41,8 @@
 #endif
 
 #ifdef CHERI_INIT_RELA
-extern const Elf_Rela __weak_symbol __rela_dyn_start __hidden;
-extern const Elf_Rela __weak_symbol __rela_dyn_end __hidden;
+extern const Elf_Rela __weak_symbol __rela_dyn_start[] __hidden;
+extern const Elf_Rela __weak_symbol __rela_dyn_end[] __hidden;
 
 static __always_inline void
 crt_init_rela(const Elf_Phdr *phdr __unused)

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -61,8 +61,8 @@ crt_init_rela(const Elf_Phdr *phdr __unused)
 
 	code_cap = cheri_pcc_get();
 
-	rela = RODATA_PTR(__rela_dyn_start);
-	relalim = RODATA_PTR(__rela_dyn_end);
+	rela = CHERI_RODATA_PTR(__rela_dyn_start);
+	relalim = CHERI_RODATA_PTR(__rela_dyn_end);
 	for (; rela < relalim; rela++)
 		elf_reloc(rela, data_cap, code_cap, 0);
 }

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -45,14 +45,21 @@ extern const Elf_Rela __weak_symbol __rela_dyn_start[] __hidden;
 extern const Elf_Rela __weak_symbol __rela_dyn_end[] __hidden;
 
 static __always_inline void
-crt_init_rela(const Elf_Phdr *phdr __unused)
+crt_init_rela(const Elf_Phdr *phdr __unused, const Elf_Phdr *phlimit __unused)
 {
 	const Elf_Rela *rela, *relalim;
 	void * __capability data_cap;
 	const void * __capability code_cap;
+	bool use_code_bounds = false;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	data_cap = __DECONST(void *, phdr);
+	for (const Elf_Phdr *ph = phdr; ph < phlimit; ph++) {
+		if (ph->p_type == PT_CHERI_PCC) {
+			use_code_bounds = true;
+			break;
+		}
+	}
 #else
 	data_cap = cheri_ddc_get();
 #endif
@@ -64,7 +71,7 @@ crt_init_rela(const Elf_Phdr *phdr __unused)
 	rela = CHERI_RODATA_PTR(__rela_dyn_start);
 	relalim = CHERI_RODATA_PTR(__rela_dyn_end);
 	for (; rela < relalim; rela++)
-		elf_reloc(rela, data_cap, code_cap, 0);
+		elf_reloc(rela, data_cap, code_cap, 0, use_code_bounds);
 }
 #endif
 
@@ -85,12 +92,15 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
     const void * __capability *rodata_cap_out)
 {
 	const Elf_Phdr *phlimit = phdr + phnum;
+	const struct capreloc *start_relocs;
+	const struct capreloc *stop_relocs;
 	Elf_Addr text_start = (Elf_Addr)-1l;
 	Elf_Addr text_end = 0;
 	Elf_Addr readonly_start = (Elf_Addr)-1l;
 	Elf_Addr readonly_end = 0;
 	Elf_Addr writable_start = (Elf_Addr)-1l;
 	Elf_Addr writable_end = 0;
+	bool use_code_bounds = false;
 	bool have_rodata_segment = false;
 	bool have_text_segment = false;
 	bool have_data_segment = false;
@@ -99,7 +109,7 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 	const void * __capability rodata_cap;
 
 #ifdef CHERI_INIT_RELA
-	crt_init_rela(phdr);
+	crt_init_rela(phdr, phlimit);
 #endif
 
 	/* Attempt to bound the data capability to only the writable segment */
@@ -110,6 +120,8 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 				__builtin_trap();
 				break;
 			}
+			if (ph->p_type == PT_CHERI_PCC)
+				use_code_bounds = true;
 			continue;
 		}
 		/*
@@ -208,7 +220,12 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 		if (!cheri_tag_get(code_cap))
 			__builtin_trap();
 	}
-	cheri_init_globals_3(data_cap, code_cap, rodata_cap);
+
+	start_relocs = CHERI_RODATA_PTR(__start___cap_relocs);
+	stop_relocs = CHERI_RODATA_PTR(__stop___cap_relocs);
+
+	cheri_init_globals_impl(start_relocs, stop_relocs, data_cap, code_cap,
+	    rodata_cap, use_code_bounds, 0);
 	if (data_cap_out)
 		*data_cap_out = data_cap;
 	if (code_cap_out)

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -148,7 +148,7 @@ init_pltgot(Plt_Entry *plt)
 static uintcap_t
 init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
     const void * __capability pcc_cap, Elf_Addr base_addr,
-    Elf_Size addend)
+    Elf_Size addend, bool use_code_bounds)
 {
 	uintcap_t cap;
 	Elf_Addr address, len;
@@ -161,6 +161,8 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)pcc_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, base_addr + address);
+	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
+		cap = cheri_bounds_set(cap, len);
 	cap = cheri_perms_clear(cap, CAP_RELOC_REMOVE_PERMS);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
@@ -168,16 +170,11 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	}
 	if (perms == MORELLO_FRAG_RWDATA || perms == MORELLO_FRAG_RODATA) {
 		cap = cheri_perms_clear(cap, DATA_PTR_REMOVE_PERMS);
-		cap = cheri_bounds_set(cap, len);
 	}
 
 	cap += addend;
 
 	if (perms == MORELLO_FRAG_EXECUTABLE) {
-		/*
-		 * TODO tight bounds: lower bound and len should be set
-		 * with LSB == 0 for C64 code.
-		 */
 		cap = cheri_sentry_create(cap);
 	}
 
@@ -198,14 +195,36 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
+	const Elf_Phdr *phdr = NULL;
 	const Elf_Rela *rela = NULL, *relalim;
+	size_t phnum = 0;
 	unsigned long relasz;
 	Elf_Addr *where;
 	void *pcc;
+	bool use_code_bounds = false;
 
 	for (; aux->a_type != AT_NULL; aux++) {
-		if (aux->a_type == AT_BASE) {
+		switch (aux->a_type) {
+		case AT_BASE:
 			relocbase = aux->a_un.a_ptr;
+			break;
+		case AT_PHDR:
+			phdr = aux->a_un.a_ptr;
+			break;
+		case AT_PHNUM:
+			phnum = aux->a_un.a_val;
+			break;
+		case AT_PHENT:
+			/* NB: Can't use assert() here. */
+			if (aux->a_un.a_val != sizeof(*phdr))
+				__builtin_trap();
+			break;
+		}
+	}
+
+	for (; phnum > 0; phdr++, phnum--) {
+		if (phdr->p_type == PT_CHERI_PCC) {
+			use_code_bounds = true;
 			break;
 		}
 	}
@@ -237,7 +256,7 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 			where = (Elf_Addr *)(relocbase + rela->r_offset);
 			*(uintcap_t *)where = init_cap_from_fragment(where,
 			    relocbase, pcc, (Elf_Addr)(uintptr_t)relocbase,
-			    rela->r_addend);
+			    rela->r_addend, use_code_bounds);
 			break;
 		default:
 			__builtin_trap();
@@ -409,6 +428,7 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 	const Elf_Sym *def, *sym;
 #ifdef __CHERI_PURE_CAPABILITY__
 	const char *pcc;
+	bool use_code_bounds = obj->npcc_caps != 0;
 #endif
 	bool lazy;
 
@@ -469,7 +489,7 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 					*where = init_cap_from_fragment(
 					    fragment, obj->relocbase, pcc,
 					    (Elf_Addr)(uintptr_t)obj->relocbase,
-					    rela->r_addend);
+					    rela->r_addend, use_code_bounds);
 #else
 				*where += (Elf_Addr)obj->relocbase;
 #endif
@@ -591,6 +611,7 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 	uintptr_t *where, target, ptr;
 #ifdef __CHERI_PURE_CAPABILITY__
 	Elf_Addr *fragment;
+	bool use_code_bounds = obj->npcc_caps != 0;
 #endif
 
 	where = (uintptr_t *)(obj->relocbase + rela->r_offset);
@@ -622,7 +643,7 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 		ptr = init_cap_from_fragment(fragment, obj->relocbase,
 		    pcc_cap(obj, fragment[0]),
 		    (Elf_Addr)(uintptr_t)obj->relocbase,
-		    rela->r_addend);
+		    rela->r_addend, use_code_bounds);
 #else
 	ptr = (uintptr_t)(obj->relocbase + rela->r_addend);
 #endif
@@ -788,6 +809,7 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 	Elf_Addr *where, symval;
 #if __has_feature(capabilities)
 	void * __capability data_cap;
+	bool use_code_bounds = false;
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -797,6 +819,7 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 	 */
 	if (obj == obj_rtld)
 		return (0);
+	use_code_bounds = obj->npcc_caps != 0;
 #endif
 
 #if __has_feature(capabilities)
@@ -900,14 +923,14 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 			    init_cap_from_fragment(where, data_cap,
 				pcc_cap(obj, where[0]),
 				(Elf_Addr)(uintptr_t)obj->relocbase,
-				rela->r_addend);
+				rela->r_addend, use_code_bounds);
 			break;
 		case R_MORELLO_FUNC_RELATIVE:
 			*(uintcap_t *)(void *)where =
 			    init_cap_from_fragment(where, data_cap,
 				pcc_cap(obj, where[0]),
 				(Elf_Addr)(uintptr_t)obj->relocbase,
-				rela->r_addend);
+				rela->r_addend, use_code_bounds);
 #ifdef CHERI_LIB_C18N
 			*(void **)where = tramp_intern(NULL, RTLD_COMPART_ID,
 			    &(struct tramp_data) {

--- a/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
@@ -49,8 +49,7 @@
 	(CHERI_PERM_SW_VMEM)
 
 #ifdef __CHERI_PURE_CAPABILITY__
-/* TODO: ABIs with tight bounds */
-#define can_use_tight_pcc_bounds(obj) ((void)(obj), false)
+#define can_use_tight_pcc_bounds(obj) ((obj)->npcc_caps != 0)
 #endif
 
 /*

--- a/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
@@ -46,8 +46,7 @@
 	(CHERI_PERM_SW_VMEM)
 
 #ifdef __CHERI_PURE_CAPABILITY__
-/* TODO: ABIs with tight bounds */
-#define can_use_tight_pcc_bounds(obj) ((void)(obj), false)
+#define can_use_tight_pcc_bounds(obj) ((obj)->npcc_caps != 0)
 #endif
 
 /*

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -461,7 +461,13 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 	const Elf_Rel *rel;
 	const Elf_Rela *rela;
 	int error;
+#if __has_feature(capabilities)
+	bool use_code_bounds = false;
+#endif
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	use_code_bounds = (lf->flags & LINKER_FILE_PCC_BOUNDS) != 0;
+#endif
 	switch (type) {
 	case ELF_RELOC_REL:
 		rel = (const Elf_Rel *)data;
@@ -520,7 +526,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 			    (val == addr1 ? relocbase :
 			    linker_kernel_file->address);
 			*(uintcap_t *)(void *)where = build_reloc_cap(addr1,
-			    size, perms, addend, base, base, false);
+			    size, perms, addend, base, base, use_code_bounds);
 		}
 #endif
 		return (0);
@@ -622,7 +628,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		} else
 			addr = build_cap_from_fragment(where,
 			    (Elf_Addr)relocbase, rela->r_addend,
-			    relocbase, relocbase, false);
+			    relocbase, relocbase, use_code_bounds);
 		addr = ((uintptr_t (*)(void))addr)();
 		*(uintptr_t *)where = addr;
 		break;
@@ -761,10 +767,33 @@ arm64_exec_protect(struct image_params *imgp, int flags __unused)
 void __nosanitizecoverage
 elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 {
+	const Elf_Ehdr *hdr;
+	const Elf_Phdr *phdr, *phlimit;
 	const Elf_Rela *rela = NULL, *rela_end;
 	Elf_Addr *fragment;
 	uintptr_t cap;
 	size_t rela_size = 0;
+	bool use_code_bounds = false;
+
+	/* See if there is an ELF header is at KERNBASE. */
+	hdr = data_cap;
+	if (IS_ELF(*hdr) &&
+	    hdr->e_ident[EI_CLASS] == ELF_TARG_CLASS &&
+	    hdr->e_ident[EI_DATA] == ELF_TARG_DATA &&
+	    hdr->e_ident[EI_VERSION] == EV_CURRENT &&
+	    hdr->e_machine == ELF_TARG_MACH &&
+	    hdr->e_version == ELF_TARG_VER &&
+	    hdr->e_phentsize == sizeof(Elf_Phdr) &&
+	    ELF_IS_CHERI(hdr)) {
+		phdr = (const Elf_Phdr *)((const char *)hdr + hdr->e_phoff);
+		phlimit = phdr + hdr->e_phnum;
+		for (; phdr < phlimit; phdr++) {
+			if (phdr->p_type == PT_CHERI_PCC) {
+				use_code_bounds = true;
+				break;
+			}
+		}
+	}
 
 	for (; dynp->d_tag != DT_NULL; dynp++) {
 		switch (dynp->d_tag) {
@@ -789,7 +818,8 @@ elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 			fragment = (Elf_Addr *)cheri_address_set(data_cap,
 			    rela->r_offset);
 			cap = build_cap_from_fragment(fragment, 0,
-			    rela->r_addend, data_cap, code_cap, false);
+			    rela->r_addend, data_cap, code_cap,
+			    use_code_bounds);
 			*((uintptr_t *)fragment) = cap;
 			break;
 		}

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -396,13 +396,16 @@ decode_fragment(Elf_Addr *fragment, Elf_Addr relocbase, Elf_Addr *addrp,
 
 static uintcap_t __nosanitizecoverage
 build_reloc_cap(Elf_Addr addr, Elf_Addr size, uint8_t perms, Elf_Addr offset,
-    void * __capability data_cap, const void * __capability code_cap)
+    void * __capability data_cap, const void * __capability code_cap,
+    bool use_code_bounds)
 {
 	uintcap_t cap;
 
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)code_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, addr);
+	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
+		cap = cheri_bounds_set(cap, size);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE ||
 	    perms == MORELLO_FRAG_RODATA) {
@@ -414,7 +417,6 @@ build_reloc_cap(Elf_Addr addr, Elf_Addr size, uint8_t perms, Elf_Addr offset,
 	    perms == MORELLO_FRAG_RODATA) {
 		cap = cheri_perms_clear(cap, CHERI_PERM_SEAL |
 		    CHERI_PERM_EXECUTE);
-		cap = cheri_bounds_set(cap, size);
 	}
 	cap += offset;
 	if (perms == MORELLO_FRAG_EXECUTABLE) {
@@ -429,13 +431,15 @@ build_reloc_cap(Elf_Addr addr, Elf_Addr size, uint8_t perms, Elf_Addr offset,
 #ifdef __CHERI_PURE_CAPABILITY__
 static uintcap_t __nosanitizecoverage
 build_cap_from_fragment(Elf_Addr *fragment, Elf_Addr relocbase, Elf_Addr offset,
-    void * __capability data_cap, const void * __capability code_cap)
+    void * __capability data_cap, const void * __capability code_cap,
+    bool use_code_bounds)
 {
 	Elf_Addr addr, size;
 	uint8_t perms;
 
 	decode_fragment(fragment, relocbase, &addr, &size, &perms);
-	return (build_reloc_cap(addr, size, perms, offset, data_cap, code_cap));
+	return (build_reloc_cap(addr, size, perms, offset, data_cap, code_cap,
+	    use_code_bounds));
 }
 #endif
 #endif
@@ -516,7 +520,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 			    (val == addr1 ? relocbase :
 			    linker_kernel_file->address);
 			*(uintcap_t *)(void *)where = build_reloc_cap(addr1,
-			    size, perms, addend, base, base);
+			    size, perms, addend, base, base, false);
 		}
 #endif
 		return (0);
@@ -618,7 +622,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		} else
 			addr = build_cap_from_fragment(where,
 			    (Elf_Addr)relocbase, rela->r_addend,
-			    relocbase, relocbase);
+			    relocbase, relocbase, false);
 		addr = ((uintptr_t (*)(void))addr)();
 		*(uintptr_t *)where = addr;
 		break;
@@ -785,7 +789,7 @@ elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 			fragment = (Elf_Addr *)cheri_address_set(data_cap,
 			    rela->r_offset);
 			cap = build_cap_from_fragment(fragment, 0,
-			    rela->r_addend, data_cap, code_cap);
+			    rela->r_addend, data_cap, code_cap, false);
 			*((uintptr_t *)fragment) = cap;
 			break;
 		}

--- a/sys/arm64/include/cherireg.h
+++ b/sys/arm64/include/cherireg.h
@@ -222,4 +222,21 @@
 #define	CHERI_COMPARTMENT_ID_USERSPACE_LENGTH	0x8000000000000000UL
 #define	CHERI_COMPARTMENT_ID_USERSPACE_OFFSET	0x0
 
+/*
+ * Derive an unbounded pointer before initial relocation.  For
+ * purecap, derive the pointer from PCC.
+ */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	CHERI_RODATA_PTR(x) ({						\
+	__typeof__((0, x)) _p;						\
+									\
+	__asm__ (							\
+	    "adrp %0, %c1\n\t"						\
+	    "add %0, %0, :lo12:%c1\n\t"					\
+	    : "=C" (_p) : "i" (x));					\
+	_p; })
+#else
+#define	CHERI_RODATA_PTR(x)	(&(*x))
+#endif
+
 #endif /* _ARM64_INCLUDE_CHERIREG_H_ */

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -164,7 +164,7 @@ typedef void (cap_relocs_cb)(void *arg, bool function, bool constant,
 
 int	init_linker_file_cap_relocs(const void *start_relocs,
 	    const void *stop_relocs, void *data_cap, ptraddr_t base_addr,
-	    cap_relocs_cb *cb, void *cb_arg);
+	    bool can_set_code_bounds, cap_relocs_cb *cb, void *cb_arg);
 #endif
 #endif /* !_KERNEL */
 

--- a/sys/cheri/cheri_cap_relocs.c
+++ b/sys/cheri/cheri_cap_relocs.c
@@ -32,15 +32,31 @@
 
 #include <sys/stddef.h>
 #include <sys/types.h>
+#include <machine/cherireg.h>
 #include <cheri_init_globals.h>
 
-/* Invoked from locore. */
-extern void init_cap_relocs(void *data_cap, void *code_cap);
+/* Referenced from locore. */
+void kernel_cap_relocs_cb(void *arg, bool function, bool constant,
+    ptraddr_t object, void **src);
 
 void
-init_cap_relocs(void *data_cap, void *code_cap)
+kernel_cap_relocs_cb(void *arg, bool function, bool constant,
+    ptraddr_t object, void **src)
 {
-	cheri_init_globals_3(data_cap, code_cap, data_cap);
+	void *cap;
+
+	cap = __builtin_cheri_address_set(arg, object);
+	if (function) {
+		cap = __builtin_cheri_perms_and(cap, CHERI_PERMS_KERNEL_CODE);
+#ifdef CHERI_FLAGS_CAP_MODE
+		cap = __builtin_cheri_flags_set(cap, CHERI_FLAGS_CAP_MODE);
+#endif
+	} else if (constant) {
+		cap = __builtin_cheri_perms_and(cap, CHERI_PERMS_KERNEL_RODATA);
+	} else {
+		cap = __builtin_cheri_perms_and(cap, CHERI_PERMS_KERNEL_DATA);
+	}
+	*src = cap;
 }
 
 /* Can't include <sys/cheri.h>. */

--- a/sys/cheri/cheri_cap_relocs.c
+++ b/sys/cheri/cheri_cap_relocs.c
@@ -65,26 +65,16 @@ typedef void (cap_relocs_cb)(void *arg, bool function, bool constant,
 
 int	init_linker_file_cap_relocs(const void *start_relocs,
 	    const void *stop_relocs, void *data_cap, ptraddr_t base_addr,
-	    cap_relocs_cb *cb, void *cb_arg);
+	    bool can_set_code_bounds, cap_relocs_cb *cb, void *cb_arg);
 
 /* Can't include <sys/systm.h>. */
 int	printf(const char *, ...) __printflike(1, 2);
 
 int
 init_linker_file_cap_relocs(const void *start_relocs, const void *stop_relocs,
-    void *data_cap, ptraddr_t base_addr, cap_relocs_cb *cb, void *cb_arg)
+    void *data_cap, ptraddr_t base_addr, bool can_set_code_bounds,
+    cap_relocs_cb *cb, void *cb_arg)
 {
-	/*
-	 * Set code bounds if the ABI allows it.
-	 * When building for hybrid or with the pc-relative captable ABI we do
-	 * not further constrain the given code_cap.
-	 */
-#if !defined(__CHERI_PURE_CAPABILITY__) || __CHERI_CAPABILITY_TABLE__ == 3
-	bool can_set_code_bounds = false;
-#else
-	bool can_set_code_bounds = true;
-#endif
-
 	/*
 	 * This cannot use cheri_init_globals_impl directly as symbols
 	 * for kernel modules in the vnet and dpcpu sets need to use

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -2188,7 +2188,7 @@ link_elf_reloc_local(linker_file_t lf)
 		data_cap = cheri_perms_and(ef->mapbase, CHERI_PERMS_KERNEL_DATA);
 		if (init_linker_file_cap_relocs(ef->caprelocs,
 		    (char *)ef->caprelocs + ef->caprelocssize, data_cap,
-		    (ptraddr_t)ef->address, resolve_cap_reloc, ef) != 0)
+		    (ptraddr_t)ef->address, false, resolve_cap_reloc, ef) != 0)
 			return (ENOEXEC);
 	}
 #endif

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -83,6 +83,8 @@ typedef struct elf_file {
 	caddr_t		address;	/* Relocation address */
 #ifdef __CHERI_PURE_CAPABILITY__
 	caddr_t		mapbase;	/* Capability for derived pointers */
+	caddr_t		*pcc_caps;	/* Capability for code pointers */
+	size_t		npcc_caps;
 #endif
 #ifdef SPARSE_MAPPING
 	vm_object_t	object;		/* VM object to hold file pages */
@@ -429,18 +431,145 @@ make_capability(const Elf_Sym *sym, caddr_t val)
 }
 #endif
 
+#ifdef __CHERI_PURE_CAPABILITY__
+static caddr_t
+ef_pcc_cap(elf_file_t ef, ptraddr_t offset)
+{
+	caddr_t pcc_cap;
+	Elf_Addr addr;
+
+	if (ef->npcc_caps == 0)
+		return (ef->mapbase);
+
+	addr = (Elf_Addr)ef->address + offset;
+	for (size_t i = 0; i < ef->npcc_caps; i++) {
+		pcc_cap = ef->pcc_caps[i];
+		if (addr >= (ptraddr_t)pcc_cap &&
+		    addr < cheri_top_get(pcc_cap)) {
+			return (pcc_cap);
+		}
+	}
+	return (NULL);
+}
+#endif
+
 static caddr_t
 ef_symbol_address(elf_file_t ef, const Elf_Sym *sym)
 {
 #ifdef __CHERI_PURE_CAPABILITY__
-	caddr_t val;
+	caddr_t base, val;
 
-	val = ef_address(ef, sym->st_value);
+	switch (ELF_ST_TYPE(sym->st_info)) {
+	case STT_FUNC:
+	case STT_GNU_IFUNC:
+		base = ef_pcc_cap(ef, sym->st_value);
+		break;
+	default:
+		base = ef->mapbase;
+		break;
+	}
+
+	val = cheri_address_set(base, (ptraddr_t)ef->address + sym->st_value);
 	return (make_capability(sym, val));
 #else
 	return (ef_address(ef, sym->st_value));
 #endif
 }
+
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Check for a valid ELF executable header at ef->mapbase.
+ *
+ * NB: RISC-V kernels do not map phdrs into memory.
+ */
+static bool
+have_phdrs(elf_file_t ef)
+{
+	const Elf_Ehdr *hdr;
+	hdr = (const Elf_Ehdr *)ef->mapbase;
+	return (IS_ELF(*hdr) &&
+	    hdr->e_ident[EI_CLASS] == ELF_TARG_CLASS &&
+	    hdr->e_ident[EI_DATA] == ELF_TARG_DATA &&
+	    hdr->e_ident[EI_VERSION] == EV_CURRENT &&
+	    hdr->e_machine == ELF_TARG_MACH &&
+	    hdr->e_version == ELF_TARG_VER &&
+	    hdr->e_phentsize == sizeof(Elf_Phdr) &&
+	    ELF_IS_CHERI(hdr));
+}
+
+static bool
+ef_create_pcc_caps(elf_file_t ef, const Elf_Phdr *phstart,
+    const Elf_Phdr *phlimit)
+{
+	const Elf_Phdr *phdr;
+	caddr_t pcc_cap;
+	size_t i, j;
+	bool valid;
+
+	for (phdr = phstart; phdr < phlimit; phdr++) {
+		switch (phdr->p_type) {
+		case PT_CHERI_PCC:
+			ef->npcc_caps++;
+			break;
+		}
+	}
+
+	if (ef->npcc_caps == 0)
+		return (true);
+
+	valid = true;
+	ef->lf.flags |= LINKER_FILE_PCC_BOUNDS;
+	i = 0;
+	ef->pcc_caps = mallocarray(ef->npcc_caps, sizeof(*ef->pcc_caps),
+	    M_LINKER, M_WAITOK | M_ZERO);
+	for (phdr = phstart; phdr < phlimit; phdr++) {
+		switch (phdr->p_type) {
+		case PT_CHERI_PCC:
+			pcc_cap = ef_address(ef, phdr->p_vaddr);
+			pcc_cap = cheri_bounds_set_exact(pcc_cap,
+			    phdr->p_memsz);
+
+			if (!cheri_tag_get(pcc_cap)) {
+				printf("%s: pcc_cap[%lu] %#p is not exact\n",
+				    ef->lf.filename, i, pcc_cap);
+				valid = false;
+			}
+			ef->pcc_caps[i] = pcc_cap;
+			i++;
+			break;
+		}
+	}
+
+	for (i = 1; i < ef->npcc_caps; i++) {
+		pcc_cap = ef->pcc_caps[i];
+		for (j = 0; j < i; j++) {
+			if (cheri_is_address_inbounds(pcc_cap,
+				cheri_base_get(ef->pcc_caps[j])) ||
+			    cheri_is_address_inbounds(ef->pcc_caps[j],
+				cheri_base_get(pcc_cap))) {
+				printf("%s: Overlapping PCC capabilities\n",
+				    ef->lf.filename);
+				return (false);
+			}
+		}
+	}
+	return (valid);
+}
+
+static bool
+preload_init_pcc_caps(elf_file_t ef)
+{
+	const Elf_Ehdr *hdr;
+	const Elf_Phdr *phdr;
+
+	if (!have_phdrs(ef))
+		return (true);
+
+	hdr = (const Elf_Ehdr *)ef->mapbase;
+	phdr = (const Elf_Phdr *)((const char *)hdr + hdr->e_phoff);
+	return (ef_create_pcc_caps(ef, phdr, phdr + hdr->e_phnum));
+}
+#endif
 
 /*
  * Actions performed after linking/loading both the preloaded kernel and any
@@ -541,6 +670,8 @@ link_elf_init(void* arg)
 	ef->address = cheri_address_set(kernel_root_cap, 0);
 	ef->mapbase = cheri_bounds_set(ef->address + KERNBASE,
 	    (ptraddr_t)_end - KERNBASE);
+	if (!preload_init_pcc_caps(ef))
+		panic("%s: Can't create PCC caps for kernel", __func__);
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #endif
 #ifdef SPARSE_MAPPING
@@ -1051,6 +1182,10 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	ef->address = cheri_perms_and(ef->address, CHERI_PERMS_KERNEL_CODE |
 	    CHERI_PERMS_KERNEL_DATA);
 	ef->mapbase = ef->address;
+	if (!preload_init_pcc_caps(ef)) {
+		error = ENOEXEC;
+		goto out;
+	}
 #else
 	ef->address = *(caddr_t *)baseptr;
 #endif
@@ -1091,6 +1226,9 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 		return (error);
 	}
 	error = link_elf_reloc_local(lf);
+#ifdef __CHERI_PURE_CAPABILITY__
+out:
+#endif
 	if (error != 0) {
 		linker_file_unload(lf, LINKER_UNLOAD_FORCE);
 		return (error);
@@ -1329,6 +1467,11 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 	ef->address = mapbase;
 #ifdef __CHERI_PURE_CAPABILITY__
 	ef->mapbase = mapbase;
+	if (!ef_create_pcc_caps(ef, phlimit - hdr->e_phnum, phlimit)) {
+		link_elf_error(filename, "Can't create PCC capabilities");
+		error = ENOEXEC;
+		goto out;
+	}
 #endif
 
 	/*
@@ -1560,6 +1703,9 @@ link_elf_unload_file(linker_file_t file)
 		link_elf_delete_gdb(&ef->gdb);
 		GDB_STATE(RT_CONSISTENT);
 	}
+#endif
+#ifdef __CHERI_PURE_CAPABILITY__
+	free(ef->pcc_caps, M_LINKER);
 #endif
 
 	/* Notify MD code that a module is being unloaded. */
@@ -2191,7 +2337,9 @@ link_elf_reloc_local(linker_file_t lf)
 		data_cap = cheri_perms_and(ef->mapbase, CHERI_PERMS_KERNEL_DATA);
 		if (init_linker_file_cap_relocs(ef->caprelocs,
 		    (char *)ef->caprelocs + ef->caprelocssize, data_cap,
-		    (ptraddr_t)ef->address, false, resolve_cap_reloc, ef) != 0)
+		    (ptraddr_t)ef->address,
+		    (lf->flags & LINKER_FILE_PCC_BOUNDS) != 0,
+		    resolve_cap_reloc, ef) != 0)
 			return (ENOEXEC);
 	}
 #endif
@@ -2284,6 +2432,31 @@ elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
 	return (ENOENT);
 }
 
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Set LINKER_FILE_PCC_BOUNDS but don't allocate pcc_caps[].
+ */
+static void
+preload_check_for_pcc_caps(elf_file_t ef)
+{
+	const Elf_Ehdr *hdr;
+	const Elf_Phdr *phdr, *phlimit;
+
+	if (!have_phdrs(ef))
+		return;
+
+	hdr = (const Elf_Ehdr *)ef->mapbase;
+	phdr = (const Elf_Phdr *)((const char *)hdr + hdr->e_phoff);
+	phlimit = phdr + hdr->e_phnum;
+	for (; phdr < phlimit; phdr++) {
+		if (phdr->p_type == PT_CHERI_PCC) {
+			ef->lf.flags |= LINKER_FILE_PCC_BOUNDS;
+			return;
+		}
+	}
+}
+#endif
+
 void
 link_elf_ireloc(void)
 {
@@ -2311,6 +2484,7 @@ link_elf_ireloc(void)
 	ef->address = cheri_address_set(kernel_root_cap, 0);
 	ef->mapbase = cheri_bounds_set(ef->address + KERNBASE,
 	    (ptraddr_t)_end - KERNBASE);
+	preload_check_for_pcc_caps(ef);
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #endif
 	parse_dynamic(ef);

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -403,6 +403,45 @@ ef_address(elf_file_t ef, ptraddr_t offset)
 #endif
 }
 
+#ifdef __CHERI_PURE_CAPABILITY__
+/*
+ * Given a pointer into a linker file derived from ef->{map|pcc}base, narrow
+ * its permissions and bounds.
+ */
+static caddr_t
+make_capability(const Elf_Sym *sym, caddr_t val)
+{
+	switch (ELF_ST_TYPE(sym->st_info)) {
+	case STT_FUNC:
+	case STT_GNU_IFUNC:
+		val = cheri_perms_and(val, CHERI_PERMS_KERNEL_CODE);
+#ifdef CHERI_FLAGS_CAP_MODE
+		val = cheri_flags_set(val, CHERI_FLAGS_CAP_MODE);
+#endif
+		val = cheri_sentry_create(val);
+		break;
+	default:
+		val = cheri_bounds_set(val, sym->st_size);
+		val = cheri_perms_and(val, CHERI_PERMS_KERNEL_DATA);
+		break;
+	}
+	return (val);
+}
+#endif
+
+static caddr_t
+ef_symbol_address(elf_file_t ef, const Elf_Sym *sym)
+{
+#ifdef __CHERI_PURE_CAPABILITY__
+	caddr_t val;
+
+	val = ef_address(ef, sym->st_value);
+	return (make_capability(sym, val));
+#else
+	return (ef_address(ef, sym->st_value));
+#endif
+}
+
 /*
  * Actions performed after linking/loading both the preloaded kernel and any
  * modules; whether preloaded or dynamicly loaded.
@@ -1737,33 +1776,6 @@ link_elf_lookup_debug_symbol(linker_file_t lf, const char *name,
 	return (ENOENT);
 }
 
-#ifdef __CHERI_PURE_CAPABILITY__
-/*
- * Given a pointer into a linker file derived from ef->mapbase, narrow
- * its permissions and bounds.
- */
-static caddr_t
-make_capability(const Elf_Sym *sym, caddr_t val)
-{
-
-	switch (ELF_ST_TYPE(sym->st_info)) {
-	case STT_FUNC:
-	case STT_GNU_IFUNC:
-		val = cheri_perms_and(val, CHERI_PERMS_KERNEL_CODE);
-#ifdef CHERI_FLAGS_CAP_MODE
-		val = cheri_flags_set(val, CHERI_FLAGS_CAP_MODE);
-#endif
-		val = cheri_sentry_create(val);
-		break;
-	default:
-		val = cheri_bounds_set(val, sym->st_size);
-		val = cheri_perms_and(val, CHERI_PERMS_KERNEL_DATA);
-		break;
-	}
-	return (val);
-}
-#endif
-
 static int
 link_elf_lookup_debug_symbol_ctf(linker_file_t lf, const char *name,
     c_linker_sym_t *sym, linker_ctf_t *lc)
@@ -1837,10 +1849,7 @@ link_elf_symbol_values1(linker_file_t lf, c_linker_sym_t sym,
 		if (!see_local && ELF_ST_BIND(es->st_info) == STB_LOCAL)
 			return (ENOENT);
 		symval->name = ef->strtab + es->st_name;
-		val = ef_address(ef, es->st_value);
-#ifdef __CHERI_PURE_CAPABILITY__
-		val = make_capability(es, val);
-#endif
+		val = ef_symbol_address(ef, es);
 		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC) {
 			link_elf_ifunc_symbol_value(lf, &val, &size);
 		} else {
@@ -1878,10 +1887,7 @@ link_elf_debug_symbol_values(linker_file_t lf, c_linker_sym_t sym,
 
 	if (es >= ef->ddbsymtab && es < (ef->ddbsymtab + ef->ddbsymcnt)) {
 		symval->name = ef->ddbstrtab + es->st_name;
-		val = ef_address(ef, es->st_value);
-#ifdef __CHERI_PURE_CAPABILITY__
-		val = make_capability(es, val);
-#endif
+		val = ef_symbol_address(ef, es);
 		if (ELF_ST_TYPE(es->st_info) == STT_GNU_IFUNC) {
 			link_elf_ifunc_symbol_value(lf, &val, &size);
 		} else {
@@ -2087,10 +2093,7 @@ elf_lookup(linker_file_t lf, Elf_Size symidx, int deps, uintptr_t *res)
 			*res = 0;
 			return (EINVAL);
 		}
-		addr = ef_address(ef, sym->st_value);
-#ifdef __CHERI_PURE_CAPABILITY__
-		addr = make_capability(sym, addr);
-#endif
+		addr = ef_symbol_address(ef, sym);
 		*res = (uintptr_t)addr;
 		return (0);
 	}
@@ -2274,10 +2277,7 @@ elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
 	ef = (elf_file_t)lf;
 	symp = ef->symtab + symidx;
 	if (ELF_ST_TYPE(symp->st_info) == STT_GNU_IFUNC) {
-		val = ef_address(ef, symp->st_value);
-#ifdef __CHERI_PURE_CAPABILITY__
-		val = make_capability(symp, val);
-#endif
+		val = ef_symbol_address(ef, symp);
 		*res = ((uintptr_t (*)(void))val)();
 		return (0);
 	}

--- a/sys/riscv/include/cherireg.h
+++ b/sys/riscv/include/cherireg.h
@@ -234,4 +234,20 @@
 #define	_CHERI_EXCCODE_RESERVED1e	0x1e
 #define	_CHERI_EXCCODE_RESERVED1f	0x1f
 
+/*
+ * Derive an unbounded pointer before initial relocation.  For
+ * purecap, derive the pointer from PCC.
+ */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	CHERI_RODATA_PTR(x) ({						\
+	__typeof__((0, x)) _p;						\
+									\
+	__asm__ (							\
+	    "cllc %0, %c1\n\t"						\
+	    : "=C" (_p) : "i" (x));					\
+	_p; })
+#else
+#define	CHERI_RODATA_PTR(x)	(&(*x))
+#endif
+
 #endif /* !_MACHINE_CHERIREG_H_ */

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -396,10 +396,17 @@ va:
 
 	/* Initialize cap relocs. */
 	li	t0, CHERI_PERMS_KERNEL_DATA
-	candperm ca0, cs0, t0
-	cllc	cra, _C_LABEL(init_cap_relocs)
-	li	t0, CHERI_PERMS_KERNEL_CODE
-	candperm ca1, cra, t0
+	cllc	ca0, _C_LABEL(__start___cap_relocs)
+	candperm ca0, ca0, t0
+	cllc	ca1, _C_LABEL(__stop___cap_relocs)
+	sub	t1, a1, a0
+	csetbounds ca0, ca0, t1
+	cincoffset ca1, ca0, t1
+	candperm ca2, cs0, t0
+	mv	a3, zero
+	cllc	ca4, _C_LABEL(kernel_cap_relocs_cb)
+	csetflags ca5, ca4, zero
+	cllc	cra, _C_LABEL(init_linker_file_cap_relocs)
 	cjalr	cra
 
 	/* Initialize capabilities. */

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -404,8 +404,9 @@ va:
 	cincoffset ca1, ca0, t1
 	candperm ca2, cs0, t0
 	mv	a3, zero
-	cllc	ca4, _C_LABEL(kernel_cap_relocs_cb)
-	csetflags ca5, ca4, zero
+	mv	a4, zero		/* TODO: true for PT_CHERI_PCC */
+	cllc	ca5, _C_LABEL(kernel_cap_relocs_cb)
+	csetflags ca6, ca5, zero
 	cllc	cra, _C_LABEL(init_linker_file_cap_relocs)
 	cjalr	cra
 

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -77,6 +77,9 @@ struct linker_file {
     int			flags;
 #define LINKER_FILE_LINKED	0x1	/* file has been fully linked */
 #define LINKER_FILE_MODULES	0x2	/* file has >0 modules at preload */
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	LINKER_FILE_PCC_BOUNDS	0x4	/* use PCC bounds from relative relocations */
+#endif
     TAILQ_ENTRY(linker_file) link;	/* list of all loaded files */
     char*		filename;	/* file which was loaded */
     char*		pathname;	/* file name with full path */


### PR DESCRIPTION
Note that for CHERI-RISC-V, this depends on changes in the c18n toolchain that are not yet in the packaged version.  My assumption is that for our next release we will be requiring a newer c18n toolchain anyway, so we can assume that if `PT_CHERI_PCC` is present, we are using an updated toolchain that writes caprelocs with the per-compartment PCC bounds.

We probably need to get an updated c18n package built (after my rebasing work finishes) before landing the last change.