### PR TITLE
arm64: Bump the default number of kstack pages

### DIFF
--- a/sys/arm64/include/param.h
+++ b/sys/arm64/include/param.h
@@ -114,7 +114,7 @@
 
 #ifndef KSTACK_PAGES
 #ifdef __CHERI_PURE_CAPABILITY__
-#define	KSTACK_PAGES	5	/* pages of kernel stack (with pcb) */
+#define	KSTACK_PAGES	6	/* pages of kernel stack (with pcb) */
 #elif defined(KASAN) || defined(KMSAN)
 #define	KSTACK_PAGES	6
 #else

--- a/sys/riscv/include/param.h
+++ b/sys/riscv/include/param.h
@@ -97,7 +97,7 @@
 
 #ifndef KSTACK_PAGES
 #ifdef __CHERI_PURE_CAPABILITY__
-#define	KSTACK_PAGES	5	/* pages of kernel stack (with pcb) */
+#define	KSTACK_PAGES	6	/* pages of kernel stack (with pcb) */
 #else
 #define	KSTACK_PAGES	4	/* pages of kernel stack (with pcb) */
 #endif


### PR DESCRIPTION
We hit the existing limit in purecap kernels when booting a bhyve VM using an image stored over NFS.  NFS requires a deep stack, and interrupt handling on top of that is enough to trigger overflow in bhyve's block I/O threads.

Bump the number of pages to 8 to be safe.  This is double the number used on aarch64, but that is perhaps not too excessive given the 2x storage overhead of capabilities.

I verified that the current limit for aarch64 kernels is sufficient for my workload.