### PR TITLE
Backport CHERI-RISC-V R_RISCV_JUMP_SLOT support

### DIFF
--- a/libexec/rtld-elf/riscv/rtld_start.S
+++ b/libexec/rtld-elf/riscv/rtld_start.S
@@ -147,14 +147,10 @@ ENTRY(.rtld_start)
 END(.rtld_start)
 
 /*
- * t0 = plt pointer
+ * (c)t0 = plt pointer
  * t1 = reloc offset
  */
 ENTRY(_rtld_bind_start)
-#ifdef __CHERI_PURE_CAPABILITY__
-	/* Currently unused and unimplemented for pure-capability code */
-	unimp
-#else /* defined(__CHERI_PURE_CAPABILITY__) */
 	/* Save the arguments and (c)ra */
 	/*
 	 * We require 8 GP(C)Rs, 1 pointer and 8 FPRs, but the stack must be
@@ -186,15 +182,23 @@ ENTRY(_rtld_bind_start)
 	STORE_FLT	fa7, (FLT_OFFSET + FLT_SIZE * 7)(PTR(sp))
 #endif
 
-	/* Reloc offset is 3x of the .got.plt offset */
+	/* Reloc offset is 3x or 1.5x of the .got.plt offset */
+#ifdef __CHERI_PURE_CAPABILITY__
+	srli	a1, t1, 1	/* Divide items by 2 */
+#else
 	slli	a1, t1, 1	/* Mult items by 2 */
+#endif
 	add	a1, a1, t1	/* Plus item */
 
 	/* Load plt */
 	MV_PTR	PTR(a0), PTR(t0)
 
 	/* Call into rtld */
+#ifdef __CHERI_PURE_CAPABILITY__
+	cjal	_rtld_bind
+#else
 	jal	_rtld_bind
+#endif
 
 	/* Backup the address to branch to */
 	MV_PTR	PTR(t0), PTR(a0)
@@ -225,5 +229,4 @@ ENTRY(_rtld_bind_start)
 
 	/* Call into the correct function */
 	JR_PTR	PTR(t0)
-#endif /* defined(__CHERI_PURE_CAPABILITY__) */
 END(_rtld_bind_start)

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -2158,6 +2158,24 @@ link_elf_reloc_local(linker_file_t lf)
 	const Elf_Rela *rela;
 	elf_file_t ef = (elf_file_t)lf;
 
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(DT_CHERI___CAPRELOCS)
+	/*
+	 * Perform __cap_relocs relocations if there are any:
+	 *
+	 * NB: Must come first as each CHERI-RISC-V's R_RISCV_JUMP_SLOT has a
+	 * corresponding relocation here for .plt[0] and we don't want that to
+	 * overwrite the eagerly-bound target.
+	 */
+	if (ef->caprelocs != NULL) {
+		void *data_cap;
+
+		data_cap = cheri_andperm(ef->address, CHERI_PERMS_KERNEL_DATA);
+		init_linker_file_cap_relocs(ef->caprelocs,
+		    (char *)ef->caprelocs + ef->caprelocssize, data_cap,
+		    (ptraddr_t)ef->address, resolve_cap_reloc, ef);
+	}
+#endif
+
 	/* Perform relocations without addend if there are any: */
 	if ((rel = ef->rel) != NULL) {
 		rellim = (const Elf_Rel *)((const char *)ef->rel + ef->relsize);
@@ -2178,17 +2196,6 @@ link_elf_reloc_local(linker_file_t lf)
 			rela++;
 		}
 	}
-
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(DT_CHERI___CAPRELOCS)
-	if (ef->caprelocs != NULL) {
-		void *data_cap;
-
-		data_cap = cheri_andperm(ef->address, CHERI_PERMS_KERNEL_DATA);
-		init_linker_file_cap_relocs(ef->caprelocs,
-		    (char *)ef->caprelocs + ef->caprelocssize, data_cap,
-		    (ptraddr_t)ef->address, resolve_cap_reloc, ef);
-	}
-#endif
 }
 
 static long

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -63,6 +63,12 @@
 
 #include "linker_if.h"
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#define	PTR_ALT	"#"
+#else
+#define	PTR_ALT
+#endif
+
 u_long elf_hwcap;
 
 static struct sysentvec elf_freebsd_sysvec = {
@@ -367,11 +373,13 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 #endif
 	Elf64_Addr *where;
 	Elf_Addr addend;
+	uintptr_t beforeptr;
 	uint32_t before32_1;
 	uint32_t before32;
 	uint64_t before64;
 	uint32_t *insn32p;
 	uint32_t imm20;
+	uintptr_t ptr;
 	int error;
 
 	switch (type) {
@@ -407,16 +415,20 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		break;
 
 	case R_RISCV_JUMP_SLOT:
-		error = lookup(lf, symidx, 1, &addr);
+#ifdef __CHERI_PURE_CAPABILITY__
+		error = LINKER_SYMIDX_CAPABILITY(lf, symidx, 1, &ptr);
+#else
+		error = lookup(lf, symidx, 1, &ptr);
+#endif
 		if (error != 0)
 			return (-1);
 
-		before64 = *where;
-		*where = addr;
+		beforeptr = *(uintptr_t *)where;
+		*(uintptr_t *)where = ptr;
 		if (debug_kld)
-			printf("%p %c %-24s %016lx -> %016lx\n", where,
-			    (local ? 'l' : 'g'), reloctype_to_str(rtype),
-			    before64, *where);
+			printf("%p %c %-24s %" PTR_ALT "p -> %" PTR_ALT "p\n",
+			    where, (local ? 'l' : 'g'), reloctype_to_str(rtype),
+			    (void *)beforeptr, (void *)ptr);
 		break;
 
 	case R_RISCV_RELATIVE:


### PR DESCRIPTION
This will keep 25.03 building even with a toolchain that enables this by default (or doesn't even support the old approach).
