### PR TITLE
if_bridge: Fix SIOC[GS]DRVSPEC check for BC_F_COPYOUTCAP addition

### DIFF
--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -916,12 +916,12 @@ bridge_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 		bc = &bridge_control_table[ifd->ifd_cmd];
 
 		if (cmd == SIOCGDRVSPEC &&
-		    (bc->bc_flags & BC_F_COPYOUT) == 0) {
+		    (bc->bc_flags & (BC_F_COPYOUT | BC_F_COPYOUTCAP)) == 0) {
 			error = EINVAL;
 			break;
 		}
 		else if (cmd == SIOCSDRVSPEC &&
-		    (bc->bc_flags & BC_F_COPYOUT) != 0) {
+		    (bc->bc_flags & (BC_F_COPYOUT | BC_F_COPYOUTCAP)) != 0) {
 			error = EINVAL;
 			break;
 		}


### PR DESCRIPTION
Otherwise the three ioctls that use BC_F_COPYOUTCAP (BRDGGIFS, BRDGRTS
and BRDGGIFSSTP) will give EINVAL for SIOCGDRVSPEC (and will erroneously
be permitted for SIOCSDRVSPEC). This does stop them crashing ifconfig,
but by making them fail, rather than corrupting its state.

Fixes:	5f9bb1d97b05 ("if_bridge: Use copyincap/copyoutcap for ioctls containing capabilities")
