### PR TITLE
Jenkinsfile cleanups

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -323,14 +323,5 @@ selectedArchitectures.each { arch ->
     }
 }
 
-boolean runParallel = true
-echo("Running jobs in parallel: ${runParallel}")
-if (runParallel) {
-    jobs.failFast = false
-    parallel jobs
-} else {
-    jobs.each { key, value ->
-        echo("RUNNING ${key}")
-        value()
-    }
-}
+jobs.failFast = false
+parallel jobs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,7 +287,7 @@ selectedArchitectures.each { arch ->
             extraBuildOptions += ' -DWITHOUT_MALLOC_PRODUCTION'
         }
         def cheribuildArgs = [
-                "'--cheribsd/build-options=${extraBuildOptions}'",
+                "--cheribsd/build-options=${extraBuildOptions}",
                 '--cheribsd/default-kernel-abi=purecap',
                 '--keep-install-dir',
                 '--install-prefix=/rootfs',
@@ -305,7 +305,7 @@ selectedArchitectures.each { arch ->
             }
         }
         cheribuildProject(target: "cheribsd-${arch}", architecture: arch,
-                          extraArgs: cheribuildArgs.join(" "),
+                          extraArgs: cheribuildArgs,
                           skipArchiving: true, skipTarball: true,
                           sdkCompilerOnly: true,
                           // We only need clang not the CheriBSD sysroot since we are building that.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,7 +280,6 @@ ls -la "artifacts-${suffix}/"
 def selectedArchitectures = isManualBuild() ? params.architectures.split('\n') : allArchitectures
 echo("Selected architectures: ${selectedArchitectures}")
 selectedArchitectures.each { suffix ->
-    String name = "cheribsd-${suffix}"
     jobs[suffix] = { ->
         def extraBuildOptions = '-s'
         if (GlobalVars.isTestSuiteJob) {


### PR DESCRIPTION
- **Jenkinsfile: Drop purecapKernelArchitectures parameter**
- **Jenkinsfile: Remove unused name variable**
- **Jenkinsfile: Drop "suffix" terminology**
- **Jenkinsfile: Drop always-true runParallel**
- **Jenkinsfile: Pass cheribuildArgs as a List**
- **Jenkinsfile: Use cheribuildProject's parallelism rather than our own**
