### PR TITLE
Backport R_RISCV_FUNC_RELATIVE support to 25.03

### DIFF
--- a/lib/libkldelf/ef_riscv.c
+++ b/lib/libkldelf/ef_riscv.c
@@ -73,6 +73,7 @@ ef_riscv_reloc(struct elf_file *ef, const void *reldata, Elf_Type reltype,
 		le64enc(where, addr);
 		break;
 	case R_RISCV_RELATIVE:	/* B + A */
+	case R_RISCV_FUNC_RELATIVE:
 		addr = relbase + addend;
 		le64enc(where, addr);
 		break;

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -545,6 +545,7 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 			    defobj->tlsoffset - TLS_TP_OFFSET - TLS_TCB_SIZE);
 			break;
 		case R_RISCV_RELATIVE:
+		case R_RISCV_FUNC_RELATIVE:
 			*where = (Elf_Addr)(obj->relocbase + rela->r_addend);
 			break;
 		case R_RISCV_IRELATIVE:

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -319,6 +319,7 @@ static const struct type2str_ent t2s[] = {
 	{ R_RISCV_64,		"R_RISCV_64"		},
 	{ R_RISCV_JUMP_SLOT,	"R_RISCV_JUMP_SLOT"	},
 	{ R_RISCV_RELATIVE,	"R_RISCV_RELATIVE"	},
+	{ R_RISCV_FUNC_RELATIVE,"R_RISCV_FUNC_RELATIVE"	},
 	{ R_RISCV_JAL,		"R_RISCV_JAL"		},
 	{ R_RISCV_CALL,		"R_RISCV_CALL"		},
 	{ R_RISCV_PCREL_HI20,	"R_RISCV_PCREL_HI20"	},
@@ -432,6 +433,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		break;
 
 	case R_RISCV_RELATIVE:
+	case R_RISCV_FUNC_RELATIVE:
 		before64 = *where;
 		*where = elf_relocaddr(lf, (Elf_Addr)relocbase + addend);
 		if (debug_kld)

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -1424,15 +1424,9 @@ typedef struct {
 #define	R_RISCV_32_PCREL	57
 #define	R_RISCV_IRELATIVE	58
 
-/* Relocation types added by CHERI used by the dynamic linker */
-#define	R_RISCV_CHERI_CAPABILITY		193
-#define	R_RISCV_CHERI_CAPABILITY_CALL		194
-
-/* Relocation types added by CHERI not used by the dynamic linker */
-#define	R_RISCV_CHERI_SIZE			195
-#define	R_RISCV_CHERI_TPREL_CINCOFFSET		196
-#define	R_RISCV_CHERI_TLS_IE_CAPTAB_PCREL_HI20	197
-#define	R_RISCV_CHERI_TLS_GD_CAPTAB_PCREL_HI20	198
+/* Relocation types added by CHERI */
+#define	R_RISCV_CHERI_CAPABILITY	193
+#define	R_RISCV_FUNC_RELATIVE		194
 
 #define	R_SPARC_NONE		0
 #define	R_SPARC_8		1


### PR DESCRIPTION
This will allow CHERI LLVM to still build 25.03 without needing a way to opt
out of generating these relocations.

Note that 25.03 has the lax caprelocs parsing, and so will ignore all the other
permission bits for function caprelocs, thereby handling both (normal) function
and code caprelocs with no changes needed.

- **sys/elf_common.h: Sync CHERI-RISC-V relocations**
- **link_elf: Handle new R_RISCV_FUNC_RELATIVE**
- **riscv: Handle new R_RISCV_FUNC_RELATIVE**
- **libkldelf: Handle new R_RISCV_FUNC_RELATIVE**
