### PR TITLE
jemalloc: resolve sub-capabilities in je_malloc_underlying_allocation

### DIFF
--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -22,6 +22,60 @@
 #include "jemalloc/internal/witness.h"
 
 JEMALLOC_ALWAYS_INLINE void *
+get_underlying_allocation(tsdn_t *tsdn, void *ptr) {
+    void *ubptr;
+
+#ifndef __CHERI_PURE_CAPABILITY__
+    ubptr = ptr;
+#else
+    if (unlikely(!cheri_gettag(ptr))) {
+        malloc_write("<jemalloc>: can't unbound invalid cap\n");
+        abort();
+    }
+    if (unlikely(cheri_getoffset(ptr) > cheri_getlen(ptr))) {
+        malloc_write("<jemalloc>: refusing to unbound cap with address "
+            "not within bounds\n");
+        abort();
+    }
+    if (unlikely(cheri_getlen(ptr) == 0)) {
+        malloc_write("<jemalloc>: refusing to unbound cap with 0 length\n");
+        abort();
+    } // Needed for one off error when calculating underlying allocation starting address
+    if (unlikely(cheri_getsealed(ptr))) {
+        malloc_write("<jemalloc>: refusing to unbound sealed cap\n");
+        abort();
+    }
+
+    rtree_ctx_t *rtree_ctx;
+    rtree_ctx_t rtree_ctx_fallback;
+    extent_t *extent;
+    szind_t szind;
+    rtree_ctx = tsdn_rtree_ctx(tsdn, &rtree_ctx_fallback);
+
+    if (rtree_extent_szind_read(tsdn, &extents_rtree, rtree_ctx,
+        (uintptr_t)ptr, false, &extent, &szind)) {
+        abort();
+    }
+
+    assert(extent_state_get(extent) == extent_state_active);
+    /* Only slab members should be looked up via interior pointers. */
+    assert(extent_addr_get(extent) == ptr || extent_slab_get(extent));
+    assert(extent != NULL);
+    assert(szind != SC_NSIZES);
+
+    size_t underlying_size = sz_index2size(szind);
+    void *extent_base = extent->e_addr;
+
+    size_t offset = (uintptr_t)ptr - (uintptr_t)extent_base;
+    size_t region_index = offset / underlying_size;
+    void *region_base = (void *)((uintptr_t)extent_base + region_index * underlying_size);
+
+    ubptr = cheri_setbounds(cheri_setaddress(extent_base, (ptraddr_t)region_base), underlying_size);
+#endif
+    return (ubptr);
+}
+
+JEMALLOC_ALWAYS_INLINE void *
 unbound_ptr(tsdn_t *tsdn, void *ptr) {
 	void *ubptr;
 

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -40,7 +40,7 @@ get_underlying_allocation(tsdn_t *tsdn, void *ptr) {
     if (unlikely(cheri_getlen(ptr) == 0)) {
         malloc_write("<jemalloc>: refusing to unbound cap with 0 length\n");
         abort();
-    } // Needed for one off error when calculating underlying allocation starting address
+    } // Needed for off-by-one error when calculating underlying allocation starting address
     if (unlikely(cheri_getsealed(ptr))) {
         malloc_write("<jemalloc>: refusing to unbound sealed cap\n");
         abort();

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -3805,6 +3805,18 @@ je_malloc_underlying_allocation(void *ptr) {
 		}
 	}
 
+	/* 
+	 * Check that ptr corresponds to a ptr returned by malloc.
+	 * This effectively only checks the address and permissions 
+	 * without CHERI_PERM_SW_VMEM. 
+	 * https://github.com/CTSRD-CHERI/cheribsd/issues/2446
+	 */ 	
+	void *ret_check = cheri_andperm(cheri_setbounds(ret, cheri_getlen(ptr)), ~CHERI_PERM_SW_VMEM);
+	if (unlikely(!cheri_equal_exact(ptr, ret_check))) {
+		malloc_write("<jemalloc>: capability doesn't correspond to an allocation\n");
+        abort();
+	}
+
 	check_entry_exit_locking(tsdn);
 	return (ret);
 }

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -3799,22 +3799,9 @@ je_malloc_underlying_allocation(void *ptr) {
 	if (unlikely(ptr == NULL)) {
 		ret = NULL;
 	} else {
-		size_t underlying_size = ivsalloc(tsdn, ptr);
-		if (underlying_size == 0) {
-			ret = NULL;
-		} else {
-			/*
-			 * XXX unbound_ptr will actually work if this isn't
-			 * a pointer to an original allocation but is
-			 * contained within an extent - we can
-			 * probably fix this in rtree functions.
-			 */
-			ret = unbound_ptr(tsdn, ptr);
-			/* Bounds as with BOUND_PTR, but preserve SW_VMEM */
-			if (ret != NULL)
-				ret = cheri_andperm(
-				    cheri_setbounds(ret, underlying_size),
-				    CHERI_PERMS_USERSPACE_DATA | CHERI_PERM_SW_VMEM);
+		ret = get_underlying_allocation(tsdn, ptr);
+		if (ret != NULL) {
+			ret = cheri_andperm(ret, CHERI_PERMS_USERSPACE_DATA | CHERI_PERM_SW_VMEM);
 		}
 	}
 


### PR DESCRIPTION
Fixes #2446 

### Summary
`je_malloc_underlying_allocation()` previously relied only on the caller-supplied pointer properties. Sub-capabilities (with modified bounds) could be passed in and were implicitly accepted, weakening heap spatial safety and risking temporal safety violations in quarantine.

This change reconstructs the canonical allocation capability from allocator metadata and compares it against the caller-supplied pointer using `cheri_equal_exact`. Only if they match is the allocation considered valid. This enforces that the capability corresponds exactly to the one handed out by `malloc(3)`, modulo `SW_VMEM` stripping.

### Rationale
- Aligns with the C standard requirement that `free(3)` must be passed the exact pointer returned by allocation functions.
- Prevents sub-capabilities from being mistaken as canonical allocations, fixing both spatial and temporal safety.
- Retains practical compatibility: the allocator uses its own metadata (rtree, size class) to construct the authoritative capability, then validates.

### Design
- Use rtree + size-class arithmetic to reconstruct the allocation’s canonical capability.
- Normalize permissions by masking out `CHERI_PERM_SW_VMEM`, which is not retained by the allocator.
- Apply `cheri_equal_exact()` to check equivalence between reconstructed capability and the user-supplied pointer.
- If they differ, log an error and abort.

### Testing
- Ran CheriBSD Kyua suite: `kyua test -k /usr/tests/Kyuafile lib/libc/stdlib`.
- Results unchanged relative to current tree: all tests pass except the failures `posix_memalign_test:aligned_alloc_basic` and `posix_memalign_basic`.

