### PR TITLE
cheribsdtest: Enable global_data_ifunc_fptr for Morello

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_ifunc.c
+++ b/bin/cheribsdtest/cheribsdtest_ifunc.c
@@ -55,18 +55,6 @@ CHERIBSDTEST(call_ifunc, "Check IFUNCs can be called")
 	cheribsdtest_success();
 }
 
-/*
- * Morello LLD forgets to set the size for the canonical PLT symbol, and we use
- * --fatal-warnings, so fails with the following error:
- *
- *   ld: error: could not determine size of cap reloc against function (in PLT) canon_plt_ifunc
- *
- * Morello LLD also fails to set the C64 LSB in the canonical PLT's VA so it
- * wouldn't work anyway.
- *
- * Enable once both are fixed.
- */
-#if !defined(__aarch64__) || !defined(__CHERI_PURE_CAPABILITY__)
 DEFINE_UIFUNC(static, int, canon_plt_ifunc, (void))
 {
 	return (simple_ifunc_impl);
@@ -84,7 +72,6 @@ CHERIBSDTEST(global_data_ifunc_fptr,
 
 	cheribsdtest_success();
 }
-#endif
 
 #ifdef CHERIBSD_DYNAMIC_TESTS
 CHERIBSDTEST(dynamic_ifunc,


### PR DESCRIPTION
Morello LLVM has now been fixed so this test can be re-enabled.
