### PR TITLE
cheribsdtest: avoid minherit in infrastructure

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -915,12 +915,10 @@ main(int argc, char *argv[])
 	 * failure status.
 	 */
 	assert(sizeof(*ccsp) <= (size_t)getpagesize());
-	ccsp = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE, MAP_ANON, -1,
-	    0);
+	ccsp = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE,
+	    MAP_ANON | MAP_SHARED, -1, 0);
 	if (ccsp == MAP_FAILED)
 		err(EX_OSERR, "mmap");
-	if (minherit(ccsp, getpagesize(), INHERIT_SHARE) < 0)
-		err(EX_OSERR, "minherit");
 
 	/*
 	 * Disable core dumps unless specifically enabled.


### PR DESCRIPTION
Make the ccsp shared on creation with MAP_SHARED rather than using a non-portable call to minherit.  Tests for minherit continue to exist, but we can use POSIX functionality.

Noticed when discussing making cheribsdtest portable.