### PR TITLE
Revert "Fix mbtowc_test:mbtowc."

### DIFF
--- a/lib/libc/locale/gb18030.c
+++ b/lib/libc/locale/gb18030.c
@@ -32,18 +32,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "lib",
- *   "changes": [
- *     "other"
- *   ],
- *   "change_comment": "fixes mbtowc_test:mbtowc buffer overrun"
- * }
- * CHERI CHANGES END
- */
 
 /*
  * PRC National Standard GB 18030-2000 encoding of Chinese text.
@@ -122,7 +110,7 @@ _GB18030_mbrtowc(wchar_t * __restrict pwc, const char * __restrict s,
 		pwc = NULL;
 	}
 
-	ncopy = MIN(MIN(MIN(n, MB_CUR_MAX), sizeof(gs->bytes) - gs->count), strlen(s));
+	ncopy = MIN(MIN(n, MB_CUR_MAX), sizeof(gs->bytes) - gs->count);
 	memcpy(gs->bytes + gs->count, s, ncopy);
 	ocount = gs->count;
 	gs->count += ncopy;


### PR DESCRIPTION
This change is incorrect when the `s` argument isn't a string and it is not required for any libc/locale tests to pass including mbtowc_test:mbtowc. It's not clear what this fixed at the time, but a lot has improved since 2018.

This reverts commit 92bb865938911e67dc4e98e73cd5239f62b31f76. This reverts commit 54665cbb6e7a0a2e449107f01e2ad25a15ff0433.

Fixes:		#2455