### PR TITLE
rtld: Add a dependency for rtld_c18n_policy.txt

### DIFF
--- a/libexec/rtld-elf/Makefile
+++ b/libexec/rtld-elf/Makefile
@@ -151,6 +151,7 @@ SRCS+= \
 	rtld_c18n_mi.S \
 	rtld_c18n_machdep.c \
 	rtld_c18n_asm.S
+rtld_c18n_mi.o: rtld_c18n_policy.txt
 .endif
 
 .if ${MACHINE_ABI:Mpurecap}


### PR DESCRIPTION
Previously rtld_c18n_policy.txt updates didn't cause rtld_c18n_mi.S to be recompiled.