### PR TITLE
arm64: fix calculating kernel size for preload metadata

### DIFF
--- a/sys/arm64/arm64/machdep_boot.c
+++ b/sys/arm64/arm64/machdep_boot.c
@@ -115,7 +115,8 @@ fake_preload_metadata(void *dtb_ptr, size_t dtb_size)
 
 	PRELOAD_PUSH_VALUE(uint32_t, MODINFO_SIZE);
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(size_t));
-	PRELOAD_PUSH_VALUE(uint64_t, (size_t)(&end - VM_MIN_KERNEL_ADDRESS));
+	PRELOAD_PUSH_VALUE(uint64_t,
+		(size_t)((vm_offset_t)&end - VM_MIN_KERNEL_ADDRESS));
 
 	if (dtb_ptr != NULL) {
 		/* Copy DTB to KVA space and insert it into module chain. */


### PR DESCRIPTION
Cast &end to vm_offset_t before subtracting VM_MIN_KERNEL_ADDRESS to ensure the resulting size is correct for PRELOAD_PUSH_VALUE. This fixes a boot run-time error in the purecap kernel where nonsense size results in an invalid mapbase capability.