### PR TITLE
arm64/vmm: Fix handling of MDCR_EL2.TDE

### DIFF
--- a/sys/arm64/vmm/vmm_arm64.c
+++ b/sys/arm64/vmm/vmm_arm64.c
@@ -1539,7 +1539,7 @@ vmmops_setcap(void *vcpui, int num, int val)
 			break;
 		if (val != 0)
 			hypctx->mdcr_el2 |= MDCR_EL2_TDE;
-		else
+		else if ((hypctx->setcaps & (1ul << VM_CAP_SS_EXIT)) == 0)
 			hypctx->mdcr_el2 &= ~MDCR_EL2_TDE;
 		break;
 	case VM_CAP_SS_EXIT:
@@ -1560,7 +1560,8 @@ vmmops_setcap(void *vcpui, int num, int val)
 			hypctx->mdscr_el1 &= ~MDSCR_SS;
 			hypctx->mdscr_el1 |= hypctx->debug_mdscr;
 			hypctx->debug_mdscr &= ~MDSCR_SS;
-			hypctx->mdcr_el2 &= ~MDCR_EL2_TDE;
+			if ((hypctx->setcaps & (1ul << VM_CAP_BRK_EXIT)) == 0)
+				hypctx->mdcr_el2 &= ~MDCR_EL2_TDE;
 		}
 		break;
 	case VM_CAP_MASK_HWINTR:


### PR DESCRIPTION
This fixes the main problem with the guest occasionally dropping into the kernel debugger while stepping from the host. There is another related bug fix upstream that is still in code review, but I think this one is useful enough on its own that we should just bring it in.