### PR TITLE
rtld caprelocs: Derive read-only capabilities from the data capability

### DIFF
--- a/libexec/rtld-elf/cheri/cheri_reloc.c
+++ b/libexec/rtld-elf/cheri/cheri_reloc.c
@@ -104,7 +104,7 @@ process___cap_relocs(Obj_Entry *obj)
 			can_set_bounds = tight_pcc_bounds;
 		} else if (reloc->permissions == constant_reloc_flag) {
 			 /* read-only data pointer */
-			cap = (uintcap_t)pcc_cap(obj, reloc->object);
+			cap = (uintcap_t)data_base + reloc->object;
 			cap = cheri_clearperm(cap, FUNC_PTR_REMOVE_PERMS);
 			cap = cheri_clearperm(cap, DATA_PTR_REMOVE_PERMS);
 		} else if (reloc->permissions == 0) {


### PR DESCRIPTION
Eventually lld will restrict PT_CHERI_PCC to only cover sections
accessed directly via PCC in which case symbols in some read-only
sections may lie outside the bounds of PCC.  To prepare for this,
derive read-only capabilities from a capability that spans the entire
object.
