### PR TITLE
em(4): fix clearing checksum offload context.

### DIFF
--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -3651,7 +3651,7 @@ em_initialize_transmit_unit(if_ctx_t ctx)
 		bus_addr = txr->tx_paddr;
 
 		/* Clear checksum offload context. */
-		offp = (caddr_t)&txr->csum_flags;
+		offp = (caddr_t)txr + offsetof(struct tx_ring, csum_flags);
 		endp = (caddr_t)(txr + 1);
 		bzero(offp, endp - offp);
 


### PR DESCRIPTION
ensure offp capability covers all checksum fields of the struct we want to clear