### PR TITLE
cheribsdtest: Use an aligned PC value in null_pointer_exec_sigsegv

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_signal.c
+++ b/bin/cheribsdtest/cheribsdtest_signal.c
@@ -340,7 +340,7 @@ CHERIBSDTEST(null_pointer_exec_sigsegv,
     .ct_si_code = SEGV_MAPERR,
     .ct_si_trapno = TRAPNO_EXEC_PF)
 {
-	void (*p)(void) = (void *)(uintptr_t)1;
+	void (*p)(void) = (void *)(uintptr_t)4;
 
 	p();
 	cheribsdtest_failure_errx("Unexpected branch to NULL pointer");


### PR DESCRIPTION
Real Morello hardware gives precedence to the unaligned PC fault and
reports SIGBUS instead of SIGSEGV.
