### PR TITLE
Rename __USER_CAP* and *copy{in,out}cap*

### DIFF
--- a/sbin/ipf/ipftest/ip_fil.c
+++ b/sbin/ipf/ipftest/ip_fil.c
@@ -619,7 +619,7 @@ ipf_checkv6sum(fin)
  * See above for description, except that all addressing is in user space.
  */
 int
-copyoutptr(softc, src, dst, size)
+copyout_indirect(softc, src, dst, size)
 	void *src, *dst;
 	size_t size;
 {
@@ -635,7 +635,7 @@ copyoutptr(softc, src, dst, size)
  * See above for description, except that all addressing is in user space.
  */
 int
-copyinptr(src, dst, size)
+copyin_indirect(src, dst, size)
 	void *src, *dst;
 	size_t size;
 {

--- a/sbin/ipf/libipf/interror.c
+++ b/sbin/ipf/libipf/interror.c
@@ -28,8 +28,8 @@ static ipf_error_entry_t *find_error(int);
 static ipf_error_entry_t ipf_errors[IPF_NUM_ERRORS] = {
 	{	1,	"auth table locked/full" },
 	{	2,	"" },
-	{	3,	"copyinptr received bad address" },
-	{	4,	"copyoutptr received bad address" },
+	{	3,	"copyin_indirect received bad address" },
+	{	4,	"copyout_indirect received bad address" },
 	{	5,	"" },
 	{	6,	"cannot load a rule with FR_T_BUILTIN flag set" },
 	{	7,	"internal rule without FR_T_BUILDINT flag set" },

--- a/share/man/man9/Makefile
+++ b/share/man/man9/Makefile
@@ -918,9 +918,13 @@ MLINKS+=casuword.9 casueword.9 \
 	casuword.9 casuword32.9
 MLINKS+=copy.9 copyin.9 \
 	copy.9 copyin_nofault.9 \
+	copy.9 copyinptr.9 \
+	copy.9 copyinptr_nofault.9 \
 	copy.9 copyinstr.9 \
 	copy.9 copyout.9 \
 	copy.9 copyout_nofault.9 \
+	copy.9 copyoutptr.9 \
+	copy.9 copyoutptr_nofault.9 \
 	copy.9 copystr.9
 MLINKS+=counter.9 counter_u64_alloc.9 \
 	counter.9 counter_u64_free.9 \

--- a/share/man/man9/Makefile
+++ b/share/man/man9/Makefile
@@ -2153,7 +2153,9 @@ MLINKS+=socket.9 soabort.9 \
 	socket.9 solisten_proto_check.9 \
 	socket.9 sonewconn.9 \
 	socket.9 sooptcopyin.9 \
+	socket.9 sooptcopyinptr.9 \
 	socket.9 sooptcopyout.9 \
+	socket.9 sooptcopyoutptr.9 \
 	socket.9 sopoll.9 \
 	socket.9 sopoll_generic.9 \
 	socket.9 soreceive.9 \

--- a/share/man/man9/copy.9
+++ b/share/man/man9/copy.9
@@ -32,15 +32,19 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 11, 2020
+.Dd December 9, 2025
 .Dt COPY 9
 .Os
 .Sh NAME
 .Nm copy ,
 .Nm copyin ,
 .Nm copyin_nofault ,
+.Nm copyinptr ,
+.Nm copyinptr_nofault ,
 .Nm copyout ,
 .Nm copyout_nofault ,
+.Nm copyoutptr ,
+.Nm copyoutptr_nofault ,
 .Nm copystr ,
 .Nm copyinstr
 .Nd heterogenous address space copy functions
@@ -52,9 +56,17 @@
 .Ft int
 .Fn copyin_nofault "const void *uaddr" "void *kaddr" "size_t len"
 .Ft int
+.Fn copyinptr "const void *uaddr" "void *kaddr" "size_t len"
+.Ft int
+.Fn copyinptr_nofault "const void *uaddr" "void *kaddr" "size_t len"
+.Ft int
 .Fn copyout "const void *kaddr" "void *uaddr" "size_t len"
 .Ft int
 .Fn copyout_nofault "const void *kaddr" "void *uaddr" "size_t len"
+.Ft int
+.Fn copyoutptr "const void *kaddr" "void *uaddr" "size_t len"
+.Ft int
+.Fn copyoutptr_nofault "const void *kaddr" "void *uaddr" "size_t len"
 .Ft int __deprecated
 .Fn copystr "const void *kfaddr" "void *kdaddr" "size_t len" "size_t *done"
 .Ft int
@@ -80,7 +92,14 @@ functions copy
 bytes of data from the user-space address
 .Fa uaddr
 to the kernel-space address
-.Fa kaddr .
+.Fa kaddr
+without preserving pointer provenance.
+The
+.Fn copyinptr
+and
+.Fn copyinptr_nofault
+functions do the same,
+but preserve the provenance of copied pointers.
 .Pp
 The
 .Fn copyout
@@ -91,7 +110,14 @@ functions copy
 bytes of data from the kernel-space address
 .Fa kaddr
 to the user-space address
-.Fa uaddr .
+.Fa uaddr
+without perservice pointer provenance.
+The
+.Fn copyoutptr
+and
+.Fn copyoutptr_nofault
+functions do the same,
+but preserve the provenance of copied pointers.
 .Pp
 The
 .Fn copyin_nofault
@@ -102,6 +128,16 @@ accessible without incurring a page fault.
 The source and destination addresses must be physically mapped for
 read and write access, respectively, and neither the source nor
 destination addresses may be pageable.
+.Pp
+The
+.Fn copyinptr ,
+.Fn copyinptr_nofault ,
+.Fn copyoutptr ,
+and
+.Fn copyoutptr_nofault
+functions must be used when copying data which may contain pointers,
+but they should only be used when necessary to limit the number of
+code paths that could leak pointers.
 .Pp
 The
 .Fn copystr

--- a/share/man/man9/socket.9
+++ b/share/man/man9/socket.9
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd September 6, 2022
+.Dd December 9, 2025
 .Dt SOCKET 9
 .Os
 .Sh NAME
@@ -146,7 +146,10 @@
 .Ft int
 .Fn sooptcopyin "struct sockopt *sopt" "void *buf" "size_t len" "size_t minlen"
 .Ft int
+.Fn sooptcopyinptr "struct sockopt *sopt" "void *buf" "size_t len" "size_t minlen"
+.Ft int
 .Fn sooptcopyout "struct sockopt *sopt" "const void *buf" "size_t len"
+.Fn sooptcopyoutptr "struct sockopt *sopt" "const void *buf" "size_t len"
 .Sh DESCRIPTION
 The kernel
 .Nm
@@ -577,6 +580,12 @@ and
 are useful for transferring
 .Vt struct sockopt
 data between user and kernel code.
+They do not preserve pointer provenance.
+If the copied data contains pointers, the
+.Fn sooptcopyinptr
+and
+.Fn sooptcopyoutptr
+functions must be used instead.
 .Sh SEE ALSO
 .Xr bind 2 ,
 .Xr close 2 ,

--- a/sys/amd64/linux32/linux32_machdep.c
+++ b/sys/amd64/linux32/linux32_machdep.c
@@ -99,7 +99,7 @@ linux_copyout_rusage(struct rusage *ru, void *uaddr)
 int
 linux_readv(struct thread *td, struct linux_readv_args *uap)
 {
-	return (user_readv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_readv(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, freebsd32_copyinuio));
 }
 

--- a/sys/arm64/arm64/copyinout.S
+++ b/sys/arm64/arm64/copyinout.S
@@ -269,9 +269,9 @@ ending:
  * Copy specified amount of data from the user to kernel space, preserving
  * capability tags
  *
- * int copyincap(const void * __capability uaddr, void *kdaddr, size_t len)
+ * int copyinptr(const void * __capability uaddr, void *kdaddr, size_t len)
  */
-ENTRY(copyincap)
+ENTRY(copyinptr)
 	cbz	x2, 1f
 	check_user_access 0, 2, copyio_fault_nopcb
 
@@ -295,15 +295,15 @@ ENTRY(copyincap)
 
 1:	mov	x0, xzr		/* return 0 */
 	RETURN
-END(copyincap)
+END(copyinptr)
 
 /*
  * Copy specified amount of data from kernel to the user space, preserving
  * capability tags
  *
- * int copyoutcap(const void *kaddr, void * __capability udaddr, size_t len)
+ * int copyoutptr(const void *kaddr, void * __capability udaddr, size_t len)
  */
-ENTRY(copyoutcap)
+ENTRY(copyoutptr)
 	cbz	x2, 1f
 	check_user_access 1, 2, copyio_fault_nopcb
 
@@ -327,7 +327,7 @@ ENTRY(copyoutcap)
 
 1:	mov	x0, xzr		/* return 0 */
 	RETURN
-END(copyoutcap)
+END(copyoutptr)
 
 /*
  * Local helpers to copy through capabilities

--- a/sys/arm64/arm64/exec_machdep.c
+++ b/sys/arm64/arm64/exec_machdep.c
@@ -992,7 +992,7 @@ sys_sigreturn(struct thread *td, struct sigreturn_args *uap)
 	ucontext_t uc;
 	int error;
 
-	if (copyincap(uap->sigcntxp, &uc, sizeof(uc)))
+	if (copyinptr(uap->sigcntxp, &uc, sizeof(uc)))
 		return (EFAULT);
 
 	/* Stop an interrupt from causing the sve state to be dropped */
@@ -1146,7 +1146,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	fp = (struct sigframe * __capability)STACKALIGN(fp);
 
 	/* Copy the sigframe out to the user's stack. */
-	if (copyoutcap(&frame, fp, sizeof(*fp)) != 0) {
+	if (copyoutptr(&frame, fp, sizeof(*fp)) != 0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td,
 		    (__cheri_fromcap void *)fp);

--- a/sys/arm64/arm64/freebsd64_machdep.c
+++ b/sys/arm64/arm64/freebsd64_machdep.c
@@ -214,7 +214,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 
 	memset(&mc, 0, sizeof(mc));
 	if (mcp->mc_flags & _MC_CAP_VALID) {
-		error = copyincap(USER_PTR(mcp->mc_capregs,
+		error = copyinptr(USER_PTR(mcp->mc_capregs,
 		    sizeof(mc.mc_capregs)), &mc.mc_capregs,
 		    sizeof(mc.mc_capregs));
 		if (error)
@@ -308,7 +308,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	PROC_UNLOCK(td->td_proc);
 
 	/* Copy the capability registers out to the user's stack. */
-	if (copyoutcap(&mc.mc_capregs, USER_PTR(capregs,
+	if (copyoutptr(&mc.mc_capregs, USER_PTR(capregs,
 	    sizeof(mc.mc_capregs)), sizeof(mc.mc_capregs)) != 0) {
 		PROC_LOCK(p);
 		printf("pid %d, tid %d: could not copy out cap registers\n",
@@ -318,7 +318,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	}
 
 	/* Copy the sigframe out to the user's stack. */
-	if (copyoutcap(&frame, USER_PTR(fp, sizeof(struct sigframe64)),
+	if (copyoutptr(&frame, USER_PTR(fp, sizeof(struct sigframe64)),
 	    sizeof(struct sigframe64)) != 0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%lx", td, fp);
@@ -347,7 +347,7 @@ freebsd64_sigreturn(struct thread *td, struct freebsd64_sigreturn_args *uap)
 	ucontext64_t uc;
 	int error;
 
-	error = copyincap(USER_PTR_OBJ(uap->sigcntxp), &uc, sizeof(uc));
+	error = copyinptr(USER_PTR_OBJ(uap->sigcntxp), &uc, sizeof(uc));
 	if (error != 0)
 		return (error);
 

--- a/sys/arm64/arm64/freebsd64_machdep.c
+++ b/sys/arm64/arm64/freebsd64_machdep.c
@@ -214,7 +214,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 
 	memset(&mc, 0, sizeof(mc));
 	if (mcp->mc_flags & _MC_CAP_VALID) {
-		error = copyincap(__USER_CAP(mcp->mc_capregs,
+		error = copyincap(USER_PTR(mcp->mc_capregs,
 		    sizeof(mc.mc_capregs)), &mc.mc_capregs,
 		    sizeof(mc.mc_capregs));
 		if (error)
@@ -308,7 +308,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	PROC_UNLOCK(td->td_proc);
 
 	/* Copy the capability registers out to the user's stack. */
-	if (copyoutcap(&mc.mc_capregs, __USER_CAP(capregs,
+	if (copyoutcap(&mc.mc_capregs, USER_PTR(capregs,
 	    sizeof(mc.mc_capregs)), sizeof(mc.mc_capregs)) != 0) {
 		PROC_LOCK(p);
 		printf("pid %d, tid %d: could not copy out cap registers\n",
@@ -318,7 +318,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	}
 
 	/* Copy the sigframe out to the user's stack. */
-	if (copyoutcap(&frame, __USER_CAP(fp, sizeof(struct sigframe64)),
+	if (copyoutcap(&frame, USER_PTR(fp, sizeof(struct sigframe64)),
 	    sizeof(struct sigframe64)) != 0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%lx", td, fp);
@@ -347,7 +347,7 @@ freebsd64_sigreturn(struct thread *td, struct freebsd64_sigreturn_args *uap)
 	ucontext64_t uc;
 	int error;
 
-	error = copyincap(__USER_CAP_OBJ(uap->sigcntxp), &uc, sizeof(uc));
+	error = copyincap(USER_PTR_OBJ(uap->sigcntxp), &uc, sizeof(uc));
 	if (error != 0)
 		return (error);
 

--- a/sys/arm64/arm64/freebsd64_machdep.c
+++ b/sys/arm64/arm64/freebsd64_machdep.c
@@ -68,6 +68,7 @@
 
 #include <cheri/cheric.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 #include <compat/freebsd64/freebsd64_syscall.h>
 #include <compat/freebsd64/freebsd64_util.h>

--- a/sys/arm64/arm64/trap.c
+++ b/sys/arm64/arm64/trap.c
@@ -205,7 +205,7 @@ cpu_fetch_syscall_args(struct thread *td)
 
 #if __has_feature(capabilities)
 	if (__predict_false(stack_args != NULL)) {
-		error = copyincap(stack_args, dst_ap, sa->callp->sy_narg *
+		error = copyinptr(stack_args, dst_ap, sa->callp->sy_narg *
 		    sizeof(*dst_ap));
 		if (error)
 			return (error);

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -100,10 +100,10 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			switch (uio->uio_rw) {
 #if __has_feature(capabilities)
 			case UIO_READ_CAP:
-				error = copyoutcap(cp, iov->iov_base, cnt);
+				error = copyoutptr(cp, iov->iov_base, cnt);
 				break;
 			case UIO_WRITE_CAP:
-				error = copyincap(iov->iov_base, cp, cnt);
+				error = copyinptr(iov->iov_base, cp, cnt);
 				break;
 #endif
 			case UIO_READ:

--- a/sys/arm64/conf/GENERIC-MORELLO
+++ b/sys/arm64/conf/GENERIC-MORELLO
@@ -31,7 +31,7 @@ options		CHERI_CAPREVOKE_STATS
 options		CHERI_CAPREVOKE_FAST_COPYIN
 options		CHERI_CAPREVOKE_CLEARTAGS
 
-# Needs porting to use __USER_CAP
+# Needs porting to use USER_PTR
 nooptions 	COMPAT_FREEBSD32
 
 # Doesn't build with Morello LLVM

--- a/sys/cam/ctl/ctl_frontend_iscsi.c
+++ b/sys/cam/ctl/ctl_frontend_iscsi.c
@@ -1927,7 +1927,7 @@ cfiscsi_ioctl_listen(struct ctl_iscsi *ci)
 		return;
 	}
 
-	error = getsockaddr(&sa, __USER_CAP(cilp->addr, cilp->addrlen),
+	error = getsockaddr(&sa, USER_PTR(cilp->addr, cilp->addrlen),
 	    cilp->addrlen);
 	if (error != 0) {
 		CFISCSI_DEBUG("getsockaddr, error %d", error);

--- a/sys/cam/scsi/scsi_cd.c
+++ b/sys/cam/scsi/scsi_cd.c
@@ -1750,12 +1750,12 @@ te_data_get_ptr(void *irtep, u_long cmd)
 		return (irteup->irte.data);
 #ifdef COMPAT_FREEBSD32
 	case sizeof(irteup->irte32):
-		return (__USER_CAP(irteup->irte32.data,
+		return (USER_PTR(irteup->irte32.data,
 		    irteup->irte32.data_len));
 #endif
 #ifdef COMPAT_FREEBSD64
 	case sizeof(irteup->irte64):
-		return (__USER_CAP(irteup->irte64.data,
+		return (USER_PTR(irteup->irte64.data,
 		    irteup->irte64.data_len));
 #endif
 	default:

--- a/sys/cam/scsi/scsi_cd.c
+++ b/sys/cam/scsi/scsi_cd.c
@@ -52,6 +52,7 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/kernel.h>
+#include <sys/abi_compat.h>
 #include <sys/bio.h>
 #include <sys/conf.h>
 #include <sys/disk.h>

--- a/sys/cam/scsi/scsi_enc.c
+++ b/sys/cam/scsi/scsi_enc.c
@@ -471,7 +471,7 @@ enc_ioctl(struct cdev *dev, u_long cmd, caddr_t arg_addr, int flag,
 			error = EINVAL;
 			break;
 		}
-		error = copyincap(addr, &sstr, sizeof(sstr));
+		error = copyinptr(addr, &sstr, sizeof(sstr));
 		if (error)
 			break;
 		cam_periph_lock(periph);
@@ -504,7 +504,7 @@ enc_ioctl(struct cdev *dev, u_long cmd, caddr_t arg_addr, int flag,
 	case ENCIOC_GETELMDESC: {
 		encioc_elm_desc_t elmd;
 
-		error = copyincap(addr, &elmd, sizeof(elmd));
+		error = copyinptr(addr, &elmd, sizeof(elmd));
 		if (error)
 			break;
 		if (elmd.elm_idx >= cache->nelms) {
@@ -517,7 +517,7 @@ enc_ioctl(struct cdev *dev, u_long cmd, caddr_t arg_addr, int flag,
 				break;
 		} else
 			elmd.elm_desc_len = 0;
-		error = copyoutcap(&elmd, addr, sizeof(elmd));
+		error = copyoutptr(&elmd, addr, sizeof(elmd));
 		break;
 	}
 	case ENCIOC_GETELMDEVNAMES: {
@@ -527,7 +527,7 @@ enc_ioctl(struct cdev *dev, u_long cmd, caddr_t arg_addr, int flag,
 			error = EINVAL;
 			break;
 		}
-		error = copyincap(addr, &elmdn, sizeof(elmdn));
+		error = copyinptr(addr, &elmdn, sizeof(elmdn));
 		if (error)
 			break;
 		if (elmdn.elm_idx >= cache->nelms) {
@@ -539,7 +539,7 @@ enc_ioctl(struct cdev *dev, u_long cmd, caddr_t arg_addr, int flag,
 		cam_periph_unlock(periph);
 		if (error)
 			break;
-		error = copyoutcap(&elmdn, addr, sizeof(elmdn));
+		error = copyoutptr(&elmdn, addr, sizeof(elmdn));
 		break;
 	}
 	case ENCIOC_SETELMSTAT: {

--- a/sys/cam/scsi/scsi_pass.c
+++ b/sys/cam/scsi/scsi_pass.c
@@ -1878,7 +1878,7 @@ passdoioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag, struct thread 
 		xpt_print(periph->path, "Copying user CCB %p to "
 			  "kernel address %p\n", *user_ccb, ccb);
 #endif
-		error = copyincap(*user_ccb, ccb, sizeof(*ccb));
+		error = copyinptr(*user_ccb, ccb, sizeof(*ccb));
 		if (error != 0) {
 			xpt_print(periph->path, "Copy of user CCB %p to "
 				  "kernel address %p failed with error %d\n",
@@ -2069,7 +2069,7 @@ camioqueue_error:
 			  "kernel address %p\n", *user_ccb, &io_req->ccb);
 #endif
 
-		error = copyoutcap(&io_req->ccb, *user_ccb, sizeof(union ccb));
+		error = copyoutptr(&io_req->ccb, *user_ccb, sizeof(union ccb));
 		if (error != 0) {
 			xpt_print(periph->path, "Copy to user CCB %p from "
 				  "kernel address %p failed with error %d\n",

--- a/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c
@@ -13420,7 +13420,7 @@ dtrace_dof_copyin(uintcap_t uarg, int *errp)
 
 	dof = kmem_alloc(hdr.dofh_loadsz, KM_SLEEP);
 
-	if (copyincap((void *__capability)uarg, dof, hdr.dofh_loadsz) != 0 ||
+	if (copyinptr((void *__capability)uarg, dof, hdr.dofh_loadsz) != 0 ||
 	    dof->dofh_loadsz != hdr.dofh_loadsz) {
 		kmem_free(dof, hdr.dofh_loadsz);
 		*errp = EFAULT;

--- a/sys/cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/dtrace/fasttrap.c
@@ -2254,7 +2254,7 @@ fasttrap_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int fflag,
 
 #if __has_feature(capabilities)
 		if (!SV_PROC_FLAG(td->td_proc, SV_CHERI))
-			uprobe = __USER_CAP(*(uint64_t *)arg,
+			uprobe = USER_PTR(*(uint64_t *)arg,
 			    sizeof(fasttrap_probe_spec_t));
 		else
 #endif

--- a/sys/cddl/dev/dtrace/dtrace_ioctl.c
+++ b/sys/cddl/dev/dtrace/dtrace_ioctl.c
@@ -121,7 +121,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 		DTRACE_IOCTL_PRINTF("%s(%d): DTRACEIOC_AGGDESC\n",__func__,__LINE__);
 
-		if (copyincap(paggdesc, &aggdesc, sizeof (aggdesc)) != 0)
+		if (copyinptr(paggdesc, &aggdesc, sizeof (aggdesc)) != 0)
 			return (EFAULT);
 
 		mutex_enter(&dtrace_lock);
@@ -203,7 +203,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 		mutex_exit(&dtrace_lock);
 
-		if (copyoutcap(buf, paggdesc, dest - (uintptr_t)buf) != 0) {
+		if (copyoutptr(buf, paggdesc, dest - (uintptr_t)buf) != 0) {
 			kmem_free(buf, size);
 			return (EFAULT);
 		}
@@ -220,7 +220,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 		dtrace_debug_output();
 
-		if (copyincap(pdesc, &desc, sizeof (desc)) != 0)
+		if (copyinptr(pdesc, &desc, sizeof (desc)) != 0)
 			return (EFAULT);
 
 		DTRACE_IOCTL_PRINTF("%s(%d): %s curcpu %d cpu %d\n",
@@ -262,7 +262,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 				desc.dtbd_oldest = 0;
 				sz = sizeof (desc);
 
-				if (copyoutcap(&desc, pdesc, sz) != 0)
+				if (copyoutptr(&desc, pdesc, sz) != 0)
 					return (EFAULT);
 
 				return (0);
@@ -290,7 +290,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 			mutex_exit(&dtrace_lock);
 
-			if (copyoutcap(&desc, pdesc, sizeof (desc)) != 0)
+			if (copyoutptr(&desc, pdesc, sizeof (desc)) != 0)
 				return (EFAULT);
 
 			buf->dtb_flags |= DTRACEBUF_CONSUMED;
@@ -350,7 +350,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 		/*
 		 * Finally, copy out the buffer description.
 		 */
-		if (copyoutcap(&desc, pdesc, sizeof (desc)) != 0)
+		if (copyoutptr(&desc, pdesc, sizeof (desc)) != 0)
 			return (EFAULT);
 
 		return (0);
@@ -378,7 +378,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 		DTRACE_IOCTL_PRINTF("%s(%d): DTRACEIOC_DOFGET\n",__func__,__LINE__);
 
-		if (copyincap(pdof, &hdr, sizeof (hdr)) != 0)
+		if (copyinptr(pdof, &hdr, sizeof (hdr)) != 0)
 			return (EFAULT);
 
 		mutex_enter(&dtrace_lock);
@@ -386,7 +386,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 		mutex_exit(&dtrace_lock);
 
 		len = MIN(hdr.dofh_loadsz, dof->dofh_loadsz);
-		rval = copyoutcap(dof, pdof, len);
+		rval = copyoutptr(dof, pdof, len);
 		dtrace_dof_destroy(dof);
 
 		return (rval == 0 ? 0 : EFAULT);
@@ -465,7 +465,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 		DTRACE_IOCTL_PRINTF("%s(%d): DTRACEIOC_EPROBE\n",__func__,__LINE__);
 
-		if (copyincap(pepdesc, &epdesc, sizeof (dtrace_eprobedesc_t)) != 0)
+		if (copyinptr(pepdesc, &epdesc, sizeof (dtrace_eprobedesc_t)) != 0)
 			return (EFAULT);
 
 		mutex_enter(&dtrace_lock);
@@ -528,7 +528,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 
 		mutex_exit(&dtrace_lock);
 
-		if (copyoutcap(buf, pepdesc, dest - (uintptr_t)buf) != 0) {
+		if (copyoutptr(buf, pepdesc, dest - (uintptr_t)buf) != 0) {
 			kmem_free(buf, size);
 			return (EFAULT);
 		}

--- a/sys/cheri/cheri_cidcap.c
+++ b/sys/cheri/cheri_cidcap.c
@@ -64,7 +64,7 @@ kern_cheri_cidcap_alloc(struct thread *td, uintcap_t * __capability cidp)
 
 	KASSERT(cheri_gettag(cidcap), ("untagged cidcap allocated"));
 
-	return (copyoutcap(&cidcap, cidp, sizeof(cidcap)));
+	return (copyoutptr(&cidcap, cidp, sizeof(cidcap)));
 }
 
 int

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -379,7 +379,7 @@ freebsd32_sigaltstack(struct thread *td,
 		error = copyin(uap->ss, &s32, sizeof(s32));
 		if (error)
 			return (error);
-		ss.ss_sp = __USER_CAP_UNBOUND(PTRIN(s32.ss_sp));
+		ss.ss_sp = USER_PTR_UNBOUND(PTRIN(s32.ss_sp));
 		CP(s32, ss, ss_size);
 		CP(s32, ss, ss_flags);
 		ssp = &ss;
@@ -405,9 +405,9 @@ freebsd32_execve(struct thread *td, struct freebsd32_execve_args *uap)
 	error = pre_execve(td, &oldvmspace);
 	if (error != 0)
 		return (error);
-	error = exec_copyin_args(&eargs, __USER_CAP_STR(uap->fname),
-	    UIO_USERSPACE, __USER_CAP_UNBOUND(uap->argv),
-	    __USER_CAP_UNBOUND(uap->envv));
+	error = exec_copyin_args(&eargs, USER_PTR_STR(uap->fname),
+	    UIO_USERSPACE, USER_PTR_UNBOUND(uap->argv),
+	    USER_PTR_UNBOUND(uap->envv));
 	if (error == 0)
 		error = kern_execve(td, &eargs, NULL, oldvmspace);
 	post_execve(td, error, oldvmspace);
@@ -426,7 +426,7 @@ freebsd32_fexecve(struct thread *td, struct freebsd32_fexecve_args *uap)
 	if (error != 0)
 		return (error);
 	error = exec_copyin_args(&eargs, NULL, UIO_SYSSPACE,
-	    __USER_CAP_UNBOUND(uap->argv), __USER_CAP_UNBOUND(uap->envv));
+	    USER_PTR_UNBOUND(uap->argv), USER_PTR_UNBOUND(uap->envv));
 	if (error == 0) {
 		eargs.fd = uap->fd;
 		error = kern_execve(td, &eargs, NULL, oldvmspace);
@@ -570,8 +570,8 @@ freebsd32_select(struct thread *td, struct freebsd32_select_args *uap)
 	/*
 	 * XXX Do pointers need PTRIN()?
 	 */
-	return (kern_select(td, uap->nd, __USER_CAP_UNBOUND(uap->in),
-	    __USER_CAP_UNBOUND(uap->ou), __USER_CAP_UNBOUND(uap->ex), tvp,
+	return (kern_select(td, uap->nd, USER_PTR_UNBOUND(uap->in),
+	    USER_PTR_UNBOUND(uap->ou), USER_PTR_UNBOUND(uap->ex), tvp,
 	    sizeof(int32_t) * 8));
 }
 
@@ -604,8 +604,8 @@ freebsd32_pselect(struct thread *td, struct freebsd32_pselect_args *uap)
 	/*
 	 * XXX Do pointers need PTRIN()?
 	 */
-	error = kern_pselect(td, uap->nd, __USER_CAP_UNBOUND(uap->in),
-	    __USER_CAP_UNBOUND(uap->ou), __USER_CAP_UNBOUND(uap->ex), tvp,
+	error = kern_pselect(td, uap->nd, USER_PTR_UNBOUND(uap->in),
+	    USER_PTR_UNBOUND(uap->ou), USER_PTR_UNBOUND(uap->ex), tvp,
 	    uset, sizeof(int32_t) * 8);
 	return (error);
 }
@@ -1171,7 +1171,7 @@ int
 freebsd32_readv(struct thread *td, struct freebsd32_readv_args *uap)
 {
 
-	return (user_readv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_readv(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, freebsd32_copyinuio));
 }
 
@@ -1179,7 +1179,7 @@ int
 freebsd32_writev(struct thread *td, struct freebsd32_writev_args *uap)
 {
 
-	return (user_writev(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_writev(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, freebsd32_copyinuio));
 }
 
@@ -1187,7 +1187,7 @@ int
 freebsd32_preadv(struct thread *td, struct freebsd32_preadv_args *uap)
 {
 
-	return (user_preadv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_preadv(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, PAIR32TO64(off_t, uap->offset),
 	    freebsd32_copyinuio));
 }
@@ -1197,7 +1197,7 @@ freebsd32_pwritev(struct thread *td, struct freebsd32_pwritev_args *uap)
 {
 
 	return (user_pwritev(td, uap->fd,
-	    (struct iovec *__capability)__USER_CAP_ARRAY(uap->iovp,
+	    (struct iovec *__capability)USER_PTR_ARRAY(uap->iovp,
 		uap->iovcnt), uap->iovcnt, PAIR32TO64(off_t, uap->offset),
 	    freebsd32_copyinuio));
 }
@@ -1434,7 +1434,7 @@ freebsd32_recvmsg(struct thread *td, struct freebsd32_recvmsg_args *uap)
 	error = freebsd32_copyinmsghdr(uap->msg, &msg);
 	if (error)
 		return (error);
-	error = freebsd32_copyiniov(__USER_CAP(msg.msg_iov,
+	error = freebsd32_copyiniov(USER_PTR(msg.msg_iov,
 	    msg.msg_iovlen * sizeof(struct iovec32)), msg.msg_iovlen, &iov,
 	    EMSGSIZE);
 	if (error)
@@ -1589,7 +1589,7 @@ freebsd32_sendmsg(struct thread *td, struct freebsd32_sendmsg_args *uap)
 	error = freebsd32_copyinmsghdr(uap->msg, &msg);
 	if (error)
 		return (error);
-	error = freebsd32_copyiniov(__USER_CAP(msg.msg_iov,
+	error = freebsd32_copyiniov(USER_PTR(msg.msg_iov,
 	    msg.msg_iovlen * sizeof(struct iovec32)), msg.msg_iovlen, &iov,
 	    EMSGSIZE);
 	if (error)
@@ -1597,7 +1597,7 @@ freebsd32_sendmsg(struct thread *td, struct freebsd32_sendmsg_args *uap)
 	msg.msg_iov = iov;
 	if (msg.msg_name != NULL) {
 		error = getsockaddr(&to,
-		    __USER_CAP(msg.msg_name, msg.msg_namelen), msg.msg_namelen);
+		    USER_PTR(msg.msg_name, msg.msg_namelen), msg.msg_namelen);
 		if (error) {
 			to = NULL;
 			goto out;
@@ -1830,7 +1830,7 @@ freebsd4_freebsd32_statfs(struct thread *td, struct freebsd4_freebsd32_statfs_ar
 	int error;
 
 	sp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, __USER_CAP_STR(uap->path), UIO_USERSPACE, sp);
+	error = kern_statfs(td, USER_PTR_STR(uap->path), UIO_USERSPACE, sp);
 	if (error == 0) {
 		copy_statfs(sp, &s32);
 		error = copyout(&s32, uap->buf, sizeof(s32));
@@ -1983,7 +1983,7 @@ freebsd11_freebsd32_getdirentries(struct thread *td,
 	int error;
 
 	error = freebsd11_kern_getdirentries(td, uap->fd,
-	    __USER_CAP(uap->buf, uap->count), uap->count, &base, NULL);
+	    USER_PTR(uap->buf, uap->count), uap->count, &base, NULL);
 	if (error)
 		return (error);
 	if (uap->basep != NULL) {
@@ -2000,7 +2000,7 @@ int
 freebsd6_freebsd32_pread(struct thread *td, struct freebsd6_freebsd32_pread_args *uap)
 {
 
-	return (kern_pread(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_pread(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte, PAIR32TO64(off_t, uap->offset)));
 }
 
@@ -2008,7 +2008,7 @@ int
 freebsd6_freebsd32_pwrite(struct thread *td, struct freebsd6_freebsd32_pwrite_args *uap)
 {
 
-	return (kern_pwrite(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_pwrite(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte, PAIR32TO64(off_t, uap->offset)));
 }
 
@@ -2060,9 +2060,9 @@ freebsd32_copyin_hdtr(const struct sf_hdtr32 * __capability uhdtr,
 	error = copyin(uhdtr, &hdtr32, sizeof(hdtr32));
 	if (error != 0)
 		return (error);
-	hdtr->headers = __USER_CAP_ARRAY(PTRIN(hdtr32.headers), hdtr32.hdr_cnt);
+	hdtr->headers = USER_PTR_ARRAY(PTRIN(hdtr32.headers), hdtr32.hdr_cnt);
 	hdtr->hdr_cnt = hdtr32.hdr_cnt;
-	hdtr->trailers = __USER_CAP_ARRAY(PTRIN(hdtr32.trailers),
+	hdtr->trailers = USER_PTR_ARRAY(PTRIN(hdtr32.trailers),
 	    hdtr32.trl_cnt);
 	hdtr->hdr_cnt = hdtr32.trl_cnt;
 
@@ -2077,7 +2077,7 @@ freebsd4_freebsd32_sendfile(struct thread *td,
 
 	return (kern_sendfile(td, uap->fd, uap->s,
 	    PAIR32TO64(off_t, uap->offset), uap->nbytes,
-	    __USER_CAP_OBJ(uap->hdtr), __USER_CAP_OBJ(uap->sbytes),
+	    USER_PTR_OBJ(uap->hdtr), USER_PTR_OBJ(uap->sbytes),
 	    uap->flags, 1, (copyin_hdtr_t *)freebsd32_copyin_hdtr,
 	    freebsd32_copyinuio));
 }
@@ -2089,7 +2089,7 @@ freebsd32_sendfile(struct thread *td, struct freebsd32_sendfile_args *uap)
 
 	return (kern_sendfile(td, uap->fd, uap->s,
 	    PAIR32TO64(off_t, uap->offset), uap->nbytes,
-	    __USER_CAP_OBJ(uap->hdtr), __USER_CAP_OBJ(uap->sbytes),
+	    USER_PTR_OBJ(uap->hdtr), USER_PTR_OBJ(uap->sbytes),
 	    uap->flags, 0, (copyin_hdtr_t *)freebsd32_copyin_hdtr,
 	    freebsd32_copyinuio));
 }
@@ -2168,7 +2168,7 @@ ofreebsd32_stat(struct thread *td, struct ofreebsd32_stat_args *uap)
 	struct ostat32 sb32;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error)
 		return (error);
@@ -2217,7 +2217,7 @@ freebsd32_fstatat(struct thread *td, struct freebsd32_fstatat_args *uap)
 	struct stat32 ub32;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &ub);
 	if (error)
 		return (error);
@@ -2235,7 +2235,7 @@ ofreebsd32_lstat(struct thread *td, struct ofreebsd32_lstat_args *uap)
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
 	if (error)
 		return (error);
 	copy_ostat(&sb, &sb32);
@@ -2353,7 +2353,7 @@ freebsd11_freebsd32_stat(struct thread *td,
 	struct freebsd11_stat32 sb32;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -2388,7 +2388,7 @@ freebsd11_freebsd32_fstatat(struct thread *td,
 	struct freebsd11_stat32 sb32;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -2407,7 +2407,7 @@ freebsd11_freebsd32_lstat(struct thread *td,
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	error = freebsd11_cvtstat32(&sb, &sb32);
@@ -2600,8 +2600,8 @@ freebsd32_jail(struct thread *td, struct freebsd32_jail_args *uap)
 			return (error);
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j32_v0.ip_number);
-		return (kern_jail(td, __USER_CAP_STR(PTRIN(j32_v0.path)),
-		    __USER_CAP_STR(PTRIN(j32_v0.hostname)), NULL, &ip4, 1,
+		return (kern_jail(td, USER_PTR_STR(PTRIN(j32_v0.path)),
+		    USER_PTR_STR(PTRIN(j32_v0.hostname)), NULL, &ip4, 1,
 		    NULL, 0, UIO_SYSSPACE));
 	}
 
@@ -2620,11 +2620,11 @@ freebsd32_jail(struct thread *td, struct freebsd32_jail_args *uap)
 		error = copyin(uap->jailp, &j32, sizeof(struct jail32));
 		if (error)
 			return (error);
-		return (kern_jail(td, __USER_CAP_STR(PTRIN(j32.path)),
-		    __USER_CAP_STR(PTRIN(j32.hostname)),
-		    __USER_CAP_STR(PTRIN(j32.jailname)),
-		    __USER_CAP_ARRAY(PTRIN(j32.ip4), j32.ip4s), j32.ip4s,
-		    __USER_CAP_ARRAY(PTRIN(j32.ip6), j32.ip6s), j32.ip6s,
+		return (kern_jail(td, USER_PTR_STR(PTRIN(j32.path)),
+		    USER_PTR_STR(PTRIN(j32.hostname)),
+		    USER_PTR_STR(PTRIN(j32.jailname)),
+		    USER_PTR_ARRAY(PTRIN(j32.ip4), j32.ip4s), j32.ip4s,
+		    USER_PTR_ARRAY(PTRIN(j32.ip6), j32.ip6s), j32.ip6s,
 		    UIO_USERSPACE));
 	}
 
@@ -2638,7 +2638,7 @@ int
 freebsd32_jail_set(struct thread *td, struct freebsd32_jail_set_args *uap)
 {
 
-	return (user_jail_set(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (user_jail_set(td, USER_PTR_ARRAY(uap->iovp, uap->iovcnt),
 	    uap->iovcnt, uap->flags, freebsd32_copyinuio));
 }
 
@@ -2665,7 +2665,7 @@ int
 freebsd32_jail_get(struct thread *td, struct freebsd32_jail_get_args *uap)
 {
 
-	return (user_jail_get(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (user_jail_get(td, USER_PTR_ARRAY(uap->iovp, uap->iovcnt),
 	    uap->iovcnt, uap->flags, freebsd32_copyinuio, freebsd32_updateiov));
 }
 
@@ -3228,8 +3228,8 @@ freebsd32_sigtimedwait(struct thread *td, struct freebsd32_sigtimedwait_args *ua
 int
 freebsd32_sigwaitinfo(struct thread *td, struct freebsd32_sigwaitinfo_args *uap)
 {
-	return (user_sigwaitinfo(td, __USER_CAP_OBJ(uap->set),
-	    __USER_CAP_OBJ(uap->info),
+	return (user_sigwaitinfo(td, USER_PTR_OBJ(uap->set),
+	    USER_PTR_OBJ(uap->info),
 	    (copyout_siginfo_t *)freebsd32_copyout_siginfo));
 }
 
@@ -3353,7 +3353,7 @@ int
 freebsd32_nmount(struct thread *td, struct freebsd32_nmount_args *uap)
 {
 
-	return (kern_nmount(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (kern_nmount(td, USER_PTR_ARRAY(uap->iovp, uap->iovcnt),
 	    uap->iovcnt, uap->flags, freebsd32_copyinuio));
 }
 
@@ -3620,7 +3620,7 @@ freebsd32___specialfd(struct thread *td,
 
 	switch(args->type) {
 	case SPECIALFD_EVENTFD:
-		req = __USER_CAP(args->req, sizeof(struct specialfd_eventfd));
+		req = USER_PTR(args->req, sizeof(struct specialfd_eventfd));
 		break;
 	default:
 		return (EINVAL);
@@ -3833,7 +3833,7 @@ freebsd32_ppoll(struct thread *td, struct freebsd32_ppoll_args *uap)
 	} else
 		ssp = NULL;
 
-	return (kern_poll(td, __USER_CAP_ARRAY(uap->fds, uap->nfds), uap->nfds,
+	return (kern_poll(td, USER_PTR_ARRAY(uap->fds, uap->nfds), uap->nfds,
 	    tsp, ssp));
 }
 
@@ -3905,13 +3905,13 @@ freebsd32_ntp_adjtime(struct thread *td, struct freebsd32_ntp_adjtime_args *uap)
 	struct timex32 tx32;
 	int error, retval;
 
-	error = copyin(__USER_CAP_OBJ(uap->tp), &tx32, sizeof(tx32));
+	error = copyin(USER_PTR_OBJ(uap->tp), &tx32, sizeof(tx32));
 	if (error == 0) {
 		timex_from_32(&tx, &tx32);
 		error = kern_ntp_adjtime(td, &tx, &retval);
 		if (error == 0) {
 			timex_to_32(&tx32, &tx);
-			error = copyout(&tx32, __USER_CAP_OBJ(uap->tp), sizeof(tx32));
+			error = copyout(&tx32, USER_PTR_OBJ(uap->tp), sizeof(tx32));
 			if (error == 0)
 				td->td_retval[0] = retval;
 		}

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -405,7 +405,7 @@ freebsd32_execve(struct thread *td, struct freebsd32_execve_args *uap)
 	error = pre_execve(td, &oldvmspace);
 	if (error != 0)
 		return (error);
-	error = exec_copyin_args(&eargs, USER_PTR_STR(uap->fname),
+	error = exec_copyin_args(&eargs, USER_PTR_PATH(uap->fname),
 	    UIO_USERSPACE, USER_PTR_UNBOUND(uap->argv),
 	    USER_PTR_UNBOUND(uap->envv));
 	if (error == 0)
@@ -1830,7 +1830,7 @@ freebsd4_freebsd32_statfs(struct thread *td, struct freebsd4_freebsd32_statfs_ar
 	int error;
 
 	sp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, USER_PTR_STR(uap->path), UIO_USERSPACE, sp);
+	error = kern_statfs(td, USER_PTR_PATH(uap->path), UIO_USERSPACE, sp);
 	if (error == 0) {
 		copy_statfs(sp, &s32);
 		error = copyout(&s32, uap->buf, sizeof(s32));
@@ -2168,7 +2168,7 @@ ofreebsd32_stat(struct thread *td, struct ofreebsd32_stat_args *uap)
 	struct ostat32 sb32;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error)
 		return (error);
@@ -2217,7 +2217,7 @@ freebsd32_fstatat(struct thread *td, struct freebsd32_fstatat_args *uap)
 	struct stat32 ub32;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_STR(uap->path),
+	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &ub);
 	if (error)
 		return (error);
@@ -2235,7 +2235,7 @@ ofreebsd32_lstat(struct thread *td, struct ofreebsd32_lstat_args *uap)
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_PATH(uap->path), UIO_USERSPACE, &sb);
 	if (error)
 		return (error);
 	copy_ostat(&sb, &sb32);
@@ -2353,7 +2353,7 @@ freebsd11_freebsd32_stat(struct thread *td,
 	struct freebsd11_stat32 sb32;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -2388,7 +2388,7 @@ freebsd11_freebsd32_fstatat(struct thread *td,
 	struct freebsd11_stat32 sb32;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_STR(uap->path),
+	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -2407,7 +2407,7 @@ freebsd11_freebsd32_lstat(struct thread *td,
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_PATH(uap->path), UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	error = freebsd11_cvtstat32(&sb, &sb32);
@@ -2600,7 +2600,7 @@ freebsd32_jail(struct thread *td, struct freebsd32_jail_args *uap)
 			return (error);
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j32_v0.ip_number);
-		return (kern_jail(td, USER_PTR_STR(PTRIN(j32_v0.path)),
+		return (kern_jail(td, USER_PTR_PATH(PTRIN(j32_v0.path)),
 		    USER_PTR_STR(PTRIN(j32_v0.hostname)), NULL, &ip4, 1,
 		    NULL, 0, UIO_SYSSPACE));
 	}
@@ -2620,7 +2620,7 @@ freebsd32_jail(struct thread *td, struct freebsd32_jail_args *uap)
 		error = copyin(uap->jailp, &j32, sizeof(struct jail32));
 		if (error)
 			return (error);
-		return (kern_jail(td, USER_PTR_STR(PTRIN(j32.path)),
+		return (kern_jail(td, USER_PTR_PATH(PTRIN(j32.path)),
 		    USER_PTR_STR(PTRIN(j32.hostname)),
 		    USER_PTR_STR(PTRIN(j32.jailname)),
 		    USER_PTR_ARRAY(PTRIN(j32.ip4), j32.ip4s), j32.ip4s,

--- a/sys/compat/freebsd64/freebsd64_abort2.c
+++ b/sys/compat/freebsd64/freebsd64_abort2.c
@@ -32,6 +32,7 @@
 #include <sys/syscallsubr.h>
 #include <sys/syslog.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 
 int

--- a/sys/compat/freebsd64/freebsd64_abort2.c
+++ b/sys/compat/freebsd64/freebsd64_abort2.c
@@ -49,13 +49,13 @@ freebsd64_abort2(struct thread *td, struct freebsd64_abort2_args *uap)
 	uargsp = NULL;
 	if (nargs > 0) {
 		if (uap->args != NULL) {
-			uargscap = __USER_CAP_ARRAY(uap->args, nargs);
+			uargscap = USER_PTR_ARRAY(uap->args, nargs);
 			for (i = 0; i < nargs; i++) {
 				if (fueword64(uargscap + i, &ptr) != 0) {
 					nargs = -1;
 					break;
 				} else
-					uargs[i] = __USER_CAP_UNBOUND(
+					uargs[i] = USER_PTR_UNBOUND(
 					    (void *)(uintptr_t)ptr);
 			}
 			if (nargs > 0)
@@ -63,7 +63,7 @@ freebsd64_abort2(struct thread *td, struct freebsd64_abort2_args *uap)
 		} else
 			nargs = -1;
 	}
-	return (kern_abort2(td, __USER_CAP_STR(uap->why), nargs, uargsp));
+	return (kern_abort2(td, USER_PTR_STR(uap->why), nargs, uargsp));
 }
 /*
  * CHERI CHANGES START

--- a/sys/compat/freebsd64/freebsd64_cheri.c
+++ b/sys/compat/freebsd64/freebsd64_cheri.c
@@ -37,6 +37,7 @@
 #include <cheri/cheric.h>
 #include <cheri/cherireg.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 
 int

--- a/sys/compat/freebsd64/freebsd64_cheri.c
+++ b/sys/compat/freebsd64/freebsd64_cheri.c
@@ -44,7 +44,7 @@ freebsd64_cheri_cidcap_alloc(struct thread *td, struct
     freebsd64_cheri_cidcap_alloc_args *uap)
 {
 #ifdef CHERI_PERM_COMPARTMENT_ID
-	return (kern_cheri_cidcap_alloc(td, __USER_CAP_OBJ(uap->cidp)));
+	return (kern_cheri_cidcap_alloc(td, USER_PTR_OBJ(uap->cidp)));
 #else
 	return (ENOTSUP);
 #endif

--- a/sys/compat/freebsd64/freebsd64_generic.c
+++ b/sys/compat/freebsd64/freebsd64_generic.c
@@ -53,14 +53,14 @@
 int
 freebsd64_read(struct thread *td, struct freebsd64_read_args *uap)
 {
-	return (user_read(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (user_read(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte));
 }
 
 int
 freebsd64_pread(struct thread *td, struct freebsd64_pread_args *uap)
 {
-	return (kern_pread(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_pread(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte, uap->offset));
 }
 
@@ -69,7 +69,7 @@ int
 freebsd6_freebsd64_pread(struct thread *td,
     struct freebsd6_freebsd64_pread_args *uap)
 {
-	return (kern_pread(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_pread(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte, uap->offset));
 }
 #endif
@@ -77,28 +77,28 @@ freebsd6_freebsd64_pread(struct thread *td,
 int
 freebsd64_readv(struct thread *td, struct freebsd64_readv_args *uap)
 {
-	return (user_readv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_readv(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, freebsd64_copyinuio));
 }
 
 int
 freebsd64_preadv(struct thread *td, struct freebsd64_preadv_args *uap)
 {
-	return (user_preadv(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_preadv(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, uap->offset, freebsd64_copyinuio));
 }
 
 int
 freebsd64_write(struct thread *td, struct freebsd64_write_args *uap)
 {
-	return (kern_write(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_write(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte));
 }
 
 int
 freebsd64_pwrite(struct thread *td, struct freebsd64_pwrite_args *uap)
 {
-	return (kern_pwrite(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_pwrite(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte, uap->offset));
 }
 
@@ -107,7 +107,7 @@ int
 freebsd6_freebsd64_pwrite(struct thread *td,
     struct freebsd6_freebsd64_pwrite_args *uap)
 {
-	return (kern_pwrite(td, uap->fd, __USER_CAP(uap->buf, uap->nbyte),
+	return (kern_pwrite(td, uap->fd, USER_PTR(uap->buf, uap->nbyte),
 	    uap->nbyte, uap->offset));
 }
 #endif
@@ -115,7 +115,7 @@ freebsd6_freebsd64_pwrite(struct thread *td,
 int
 freebsd64_writev(struct thread *td, struct freebsd64_writev_args *uap)
 {
-	return (user_writev(td, uap->fd, __USER_CAP_ARRAY(uap->iovp,
+	return (user_writev(td, uap->fd, USER_PTR_ARRAY(uap->iovp,
 	    uap->iovcnt), uap->iovcnt, freebsd64_copyinuio));
 }
 
@@ -123,7 +123,7 @@ int
 freebsd64_pwritev(struct thread *td, struct freebsd64_pwritev_args *uap)
 {
 	return (user_pwritev(td, uap->fd,
-	    (struct iovec *__capability)__USER_CAP_ARRAY(uap->iovp,
+	    (struct iovec *__capability)USER_PTR_ARRAY(uap->iovp,
 		uap->iovcnt), uap->iovcnt, uap->offset, freebsd64_copyinuio));
 }
 
@@ -137,7 +137,7 @@ freebsd64_ioctl(struct thread *td, struct freebsd64_ioctl_args *uap)
 	if (com & IOC_VOID)
 		udata = (void * __capability)(intcap_t)uap->data;
 	else
-		udata = __USER_CAP(uap->data, IOCPARM_LEN(com));
+		udata = USER_PTR(uap->data, IOCPARM_LEN(com));
 
 	return (user_ioctl(td, uap->fd, com, udata, &uap->data, 0));
 }
@@ -146,8 +146,8 @@ int
 freebsd64_fspacectl(struct thread *td, struct freebsd64_fspacectl_args *uap)
 {
 	return (user_fspacectl(td, uap->fd, uap->cmd,
-	    (const void * __capability)__USER_CAP_OBJ(uap->rqsr), uap->flags,
-	    __USER_CAP_OBJ(uap->rmsr)));
+	    (const void * __capability)USER_PTR_OBJ(uap->rqsr), uap->flags,
+	    USER_PTR_OBJ(uap->rmsr)));
 }
 
 int
@@ -158,7 +158,7 @@ freebsd64___specialfd(struct thread *td,
 
 	switch(args->type) {
 	case SPECIALFD_EVENTFD:
-		req = __USER_CAP(args->req, sizeof(struct specialfd_eventfd));
+		req = USER_PTR(args->req, sizeof(struct specialfd_eventfd));
 		break;
 	default:
 		return (EINVAL);
@@ -170,31 +170,31 @@ freebsd64___specialfd(struct thread *td,
 int
 freebsd64_pselect(struct thread *td, struct freebsd64_pselect_args *uap)
 {
-	return (user_pselect(td, uap->nd, __USER_CAP_UNBOUND(uap->in),
-	    __USER_CAP_UNBOUND(uap->ou), __USER_CAP_UNBOUND(uap->ex),
-	    __USER_CAP_OBJ(uap->ts), __USER_CAP_OBJ(uap->sm)));
+	return (user_pselect(td, uap->nd, USER_PTR_UNBOUND(uap->in),
+	    USER_PTR_UNBOUND(uap->ou), USER_PTR_UNBOUND(uap->ex),
+	    USER_PTR_OBJ(uap->ts), USER_PTR_OBJ(uap->sm)));
 }
 
 int
 freebsd64_select(struct thread *td, struct freebsd64_select_args *uap)
 {
-	return (user_select(td, uap->nd, __USER_CAP_UNBOUND(uap->in),
-	    __USER_CAP_UNBOUND(uap->ou), __USER_CAP_UNBOUND(uap->ex),
-	    __USER_CAP_OBJ(uap->tv)));
+	return (user_select(td, uap->nd, USER_PTR_UNBOUND(uap->in),
+	    USER_PTR_UNBOUND(uap->ou), USER_PTR_UNBOUND(uap->ex),
+	    USER_PTR_OBJ(uap->tv)));
 }
 
 int
 freebsd64_poll(struct thread *td, struct freebsd64_poll_args *uap)
 {
-	return (user_poll(td, __USER_CAP_ARRAY(uap->fds, uap->nfds),
+	return (user_poll(td, USER_PTR_ARRAY(uap->fds, uap->nfds),
 	    uap->nfds, uap->timeout));
 }
 
 int
 freebsd64_ppoll(struct thread *td, struct freebsd64_ppoll_args *uap)
 {
-	return (user_ppoll(td, __USER_CAP_ARRAY(uap->fds, uap->nfds),
-	    uap->nfds, __USER_CAP_OBJ(uap->ts), __USER_CAP_OBJ(uap->set)));
+	return (user_ppoll(td, USER_PTR_ARRAY(uap->fds, uap->nfds),
+	    uap->nfds, USER_PTR_OBJ(uap->ts), USER_PTR_OBJ(uap->set)));
 }
 
 int

--- a/sys/compat/freebsd64/freebsd64_jail.c
+++ b/sys/compat/freebsd64/freebsd64_jail.c
@@ -66,7 +66,7 @@ freebsd64_jail(struct thread *td, struct freebsd64_jail_args *uap)
 	int error;
 	void *jail = uap->jailp;
 
-	error = copyin(__USER_CAP(jail, sizeof(version)), &version,
+	error = copyin(USER_PTR(jail, sizeof(version)), &version,
 	    sizeof(version));
 	if (error)
 		return (error);
@@ -77,13 +77,13 @@ freebsd64_jail(struct thread *td, struct freebsd64_jail_args *uap)
 		struct in_addr ip4;
 
 		/* FreeBSD single IPv4 jails. */
-		error = copyin(__USER_CAP(jail, sizeof(j0)), &j0, sizeof(j0));
+		error = copyin(USER_PTR(jail, sizeof(j0)), &j0, sizeof(j0));
 		if (error)
 			return (error);
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j0.ip_number);
-		return (kern_jail(td, __USER_CAP_STR(j0.path),
-		    __USER_CAP_STR(j0.hostname), NULL, &ip4, 1,
+		return (kern_jail(td, USER_PTR_STR(j0.path),
+		    USER_PTR_STR(j0.hostname), NULL, &ip4, 1,
 		    NULL, 0, UIO_SYSSPACE)); }
 
 	case 1:
@@ -96,12 +96,12 @@ freebsd64_jail(struct thread *td, struct freebsd64_jail_args *uap)
 	case 2:	{ /* JAIL_API_VERSION */
 		struct jail64 j;
 		/* FreeBSD multi-IPv4/IPv6,noIP jails. */
-		error = copyin(__USER_CAP(jail, sizeof(j)), &j, sizeof(j));
+		error = copyin(USER_PTR(jail, sizeof(j)), &j, sizeof(j));
 		if (error)
 			return (error);
-		return (kern_jail(td, __USER_CAP_STR(j.path),
-		    __USER_CAP_STR(j.hostname), __USER_CAP_STR(j.jailname),
-		    __USER_CAP_STR(j.ip4), j.ip4s, __USER_CAP_STR(j.ip6),
+		return (kern_jail(td, USER_PTR_STR(j.path),
+		    USER_PTR_STR(j.hostname), USER_PTR_STR(j.jailname),
+		    USER_PTR_STR(j.ip4), j.ip4s, USER_PTR_STR(j.ip6),
 		    j.ip6s, UIO_USERSPACE));
 	}
 

--- a/sys/compat/freebsd64/freebsd64_jail.c
+++ b/sys/compat/freebsd64/freebsd64_jail.c
@@ -39,6 +39,7 @@
 
 #include <netinet/in.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 
 struct jail64_v0 {
@@ -46,17 +47,6 @@ struct jail64_v0 {
 	uint64_t	path;
 	uint64_t	hostname;
 	uint32_t	ip_number;
-};
-
-struct jail64 {
-	uint32_t	version;
-	uint64_t	path;
-	uint64_t	hostname;
-	uint64_t	jailname;
-	uint32_t	ip4s;
-	uint32_t	ip6s;
-	uint64_t	ip4;
-	uint64_t	ip6;
 };
 
 int

--- a/sys/compat/freebsd64/freebsd64_jail.c
+++ b/sys/compat/freebsd64/freebsd64_jail.c
@@ -82,7 +82,7 @@ freebsd64_jail(struct thread *td, struct freebsd64_jail_args *uap)
 			return (error);
 		/* jail_v0 is host order */
 		ip4.s_addr = htonl(j0.ip_number);
-		return (kern_jail(td, USER_PTR_STR(j0.path),
+		return (kern_jail(td, USER_PTR_PATH(j0.path),
 		    USER_PTR_STR(j0.hostname), NULL, &ip4, 1,
 		    NULL, 0, UIO_SYSSPACE)); }
 
@@ -99,7 +99,7 @@ freebsd64_jail(struct thread *td, struct freebsd64_jail_args *uap)
 		error = copyin(USER_PTR(jail, sizeof(j)), &j, sizeof(j));
 		if (error)
 			return (error);
-		return (kern_jail(td, USER_PTR_STR(j.path),
+		return (kern_jail(td, USER_PTR_PATH(j.path),
 		    USER_PTR_STR(j.hostname), USER_PTR_STR(j.jailname),
 		    USER_PTR_STR(j.ip4), j.ip4s, USER_PTR_STR(j.ip6),
 		    j.ip6s, UIO_USERSPACE));

--- a/sys/compat/freebsd64/freebsd64_mac.c
+++ b/sys/compat/freebsd64/freebsd64_mac.c
@@ -79,7 +79,7 @@ int
 freebsd64___mac_get_file(struct thread *td,
     struct freebsd64___mac_get_file_args *uap)
 {
-	return (kern_mac_get_path(td, USER_PTR_STR(uap->path_p),
+	return (kern_mac_get_path(td, USER_PTR_PATH(uap->path_p),
 	    USER_PTR_OBJ(uap->mac_p), FOLLOW));
 }
 
@@ -87,7 +87,7 @@ int
 freebsd64___mac_get_link(struct thread *td,
     struct freebsd64___mac_get_link_args *uap)
 {
-	return (kern_mac_get_path(td, USER_PTR_STR(uap->path_p),
+	return (kern_mac_get_path(td, USER_PTR_PATH(uap->path_p),
 	    USER_PTR_OBJ(uap->mac_p), NOFOLLOW));
 }
 
@@ -102,7 +102,7 @@ int
 freebsd64___mac_set_file(struct thread *td,
     struct freebsd64___mac_set_file_args *uap)
 {
-	return (kern_mac_set_path(td, USER_PTR_STR(uap->path_p),
+	return (kern_mac_set_path(td, USER_PTR_PATH(uap->path_p),
 	    USER_PTR_OBJ(uap->mac_p), FOLLOW));
 }
 
@@ -110,7 +110,7 @@ int
 freebsd64___mac_set_link(struct thread *td,
     struct freebsd64___mac_set_link_args *uap)
 {
-	return (kern_mac_set_path(td, USER_PTR_STR(uap->path_p),
+	return (kern_mac_set_path(td, USER_PTR_PATH(uap->path_p),
 	    USER_PTR_OBJ(uap->mac_p), NOFOLLOW));
 }
 

--- a/sys/compat/freebsd64/freebsd64_mac.c
+++ b/sys/compat/freebsd64/freebsd64_mac.c
@@ -51,75 +51,75 @@ int
 freebsd64___mac_get_pid(struct thread *td,
     struct freebsd64___mac_get_pid_args *uap)
 {
-	return (kern_mac_get_pid(td, uap->pid, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_get_pid(td, uap->pid, USER_PTR_OBJ(uap->mac_p)));
 }
 
 int
 freebsd64___mac_get_proc(struct thread *td,
     struct freebsd64___mac_get_proc_args *uap)
 {
-	return (kern_mac_get_proc(td, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_get_proc(td, USER_PTR_OBJ(uap->mac_p)));
 }
 
 int
 freebsd64___mac_set_proc(struct thread *td,
     struct freebsd64___mac_set_proc_args *uap)
 {
-	return (kern_mac_set_proc(td, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_set_proc(td, USER_PTR_OBJ(uap->mac_p)));
 }
 
 int
 freebsd64___mac_get_fd(struct thread *td,
     struct freebsd64___mac_get_fd_args *uap)
 {
-	return (kern_mac_get_fd(td, uap->fd, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_get_fd(td, uap->fd, USER_PTR_OBJ(uap->mac_p)));
 }
 
 int
 freebsd64___mac_get_file(struct thread *td,
     struct freebsd64___mac_get_file_args *uap)
 {
-	return (kern_mac_get_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), FOLLOW));
+	return (kern_mac_get_path(td, USER_PTR_STR(uap->path_p),
+	    USER_PTR_OBJ(uap->mac_p), FOLLOW));
 }
 
 int
 freebsd64___mac_get_link(struct thread *td,
     struct freebsd64___mac_get_link_args *uap)
 {
-	return (kern_mac_get_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), NOFOLLOW));
+	return (kern_mac_get_path(td, USER_PTR_STR(uap->path_p),
+	    USER_PTR_OBJ(uap->mac_p), NOFOLLOW));
 }
 
 int
 freebsd64___mac_set_fd(struct thread *td,
     struct freebsd64___mac_set_fd_args *uap)
 {
-	return (kern_mac_set_fd(td, uap->fd, __USER_CAP_OBJ(uap->mac_p)));
+	return (kern_mac_set_fd(td, uap->fd, USER_PTR_OBJ(uap->mac_p)));
 }
 
 int
 freebsd64___mac_set_file(struct thread *td,
     struct freebsd64___mac_set_file_args *uap)
 {
-	return (kern_mac_set_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), FOLLOW));
+	return (kern_mac_set_path(td, USER_PTR_STR(uap->path_p),
+	    USER_PTR_OBJ(uap->mac_p), FOLLOW));
 }
 
 int
 freebsd64___mac_set_link(struct thread *td,
     struct freebsd64___mac_set_link_args *uap)
 {
-	return (kern_mac_set_path(td, __USER_CAP_STR(uap->path_p),
-	    __USER_CAP_OBJ(uap->mac_p), NOFOLLOW));
+	return (kern_mac_set_path(td, USER_PTR_STR(uap->path_p),
+	    USER_PTR_OBJ(uap->mac_p), NOFOLLOW));
 }
 
 int
 freebsd64_mac_syscall(struct thread *td,
     struct freebsd64_mac_syscall_args *uap)
 {
-	return (kern_mac_syscall(td, __USER_CAP_OBJ(uap->policy), uap->call,
-	    __USER_CAP_UNBOUND(uap->arg)));
+	return (kern_mac_syscall(td, USER_PTR_OBJ(uap->policy), uap->call,
+	    USER_PTR_UNBOUND(uap->arg)));
 }
 
 int
@@ -134,9 +134,9 @@ freebsd64___mac_execve(struct thread *td,
 	if (error != 0)
 		return (error);
 	error = exec_copyin_args(&eargs, NULL, UIO_SYSSPACE,
-	    __USER_CAP_UNBOUND(uap->argv), __USER_CAP_UNBOUND(uap->envv));
+	    USER_PTR_UNBOUND(uap->argv), USER_PTR_UNBOUND(uap->envv));
 	if (error == 0)
-		error = kern_execve(td, &eargs, __USER_CAP_OBJ(uap->mac_p),
+		error = kern_execve(td, &eargs, USER_PTR_OBJ(uap->mac_p),
 		    oldvmspace);
 
 	post_execve(td, error, oldvmspace);

--- a/sys/compat/freebsd64/freebsd64_mac.c
+++ b/sys/compat/freebsd64/freebsd64_mac.c
@@ -41,6 +41,7 @@
 #include <sys/proc.h>
 #include <sys/syscallsubr.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 #include <compat/freebsd64/freebsd64_util.h>
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -143,8 +143,8 @@ static int freebsd64_kevent_copyin(void *arg, struct kevent *kevp, int count);
 int
 freebsd64_wait4(struct thread *td, struct freebsd64_wait4_args *uap)
 {
-	return (kern_wait4(td, uap->pid, __USER_CAP_OBJ(uap->status),
-	    uap->options, __USER_CAP_OBJ(uap->rusage)));
+	return (kern_wait4(td, uap->pid, USER_PTR_OBJ(uap->status),
+	    uap->options, USER_PTR_OBJ(uap->rusage)));
 }
 
 int
@@ -160,11 +160,11 @@ freebsd64_wait6(struct thread *td, struct freebsd64_wait6_args *uap)
 	} else
 		sip = NULL;
 	error = user_wait6(td, uap->idtype, uap->id,
-	    __USER_CAP_OBJ(uap->status), uap->options,
-	    __USER_CAP_OBJ(uap->wrusage), sip);
+	    USER_PTR_OBJ(uap->status), uap->options,
+	    USER_PTR_OBJ(uap->wrusage), sip);
 	if (uap->info != NULL && error == 0) {
 		siginfo_to_siginfo64(&si, &si64);
-		error = copyout(&si64, __USER_CAP_OBJ(uap->info), sizeof(si64));
+		error = copyout(&si64, USER_PTR_OBJ(uap->info), sizeof(si64));
 	}
 	return (error);
 }
@@ -179,9 +179,9 @@ freebsd64_execve(struct thread *td, struct freebsd64_execve_args *uap)
 	error = pre_execve(td, &oldvmspace);
 	if (error != 0)
 		return (error);
-	error = exec_copyin_args(&eargs, __USER_CAP_STR(uap->fname),
-	    UIO_USERSPACE, __USER_CAP_UNBOUND(uap->argv),
-	    __USER_CAP_UNBOUND(uap->envv));
+	error = exec_copyin_args(&eargs, USER_PTR_STR(uap->fname),
+	    UIO_USERSPACE, USER_PTR_UNBOUND(uap->argv),
+	    USER_PTR_UNBOUND(uap->envv));
 	if (error == 0)
 		error = kern_execve(td, &eargs, NULL, oldvmspace);
 	post_execve(td, error, oldvmspace);
@@ -199,7 +199,7 @@ freebsd64_fexecve(struct thread *td, struct freebsd64_fexecve_args *uap)
 	if (error != 0)
 		return (error);
 	error = exec_copyin_args(&eargs, NULL, UIO_SYSSPACE,
-	    __USER_CAP_UNBOUND(uap->argv), __USER_CAP_UNBOUND(uap->envv));
+	    USER_PTR_UNBOUND(uap->argv), USER_PTR_UNBOUND(uap->envv));
 	if (error == 0) {
 		eargs.fd = uap->fd;
 		error = kern_execve(td, &eargs, NULL, oldvmspace);
@@ -230,7 +230,7 @@ freebsd64_kevent_copyout(void *arg, struct kevent *kevp, int count)
 		ks64[i].udata = (__cheri_addr uint64_t)kevp[i].udata;
 		memcpy(&ks64[i].ext[0], &kevp->ext[0], sizeof(kevp->ext));
 	}
-	error = copyout(ks64, __USER_CAP_ARRAY(uap->eventlist, count),
+	error = copyout(ks64, USER_PTR_ARRAY(uap->eventlist, count),
 	    count * sizeof(*ks64));
 	if (error == 0)
 		uap->eventlist += count;
@@ -250,7 +250,7 @@ freebsd64_kevent_copyin(void *arg, struct kevent *kevp, int count)
 	KASSERT(count <= KQ_NEVENTS, ("count (%d) > KQ_NEVENTS", count));
 	uap = (struct freebsd64_kevent_args *)arg;
 
-	error = copyin(__USER_CAP_ARRAY(uap->changelist, count), ks64,
+	error = copyin(USER_PTR_ARRAY(uap->changelist, count), ks64,
 	    count * sizeof(*ks64));
 	if (error != 0)
 		return (error);
@@ -278,7 +278,7 @@ freebsd64_kevent(struct thread *td, struct freebsd64_kevent_args *uap)
 	int error;
 
 	if (uap->timeout) {
-		error = copyin(__USER_CAP_OBJ(uap->timeout), &ts, sizeof(ts));
+		error = copyin(USER_PTR_OBJ(uap->timeout), &ts, sizeof(ts));
 		if (error)
 			return (error);
 		tsp = &ts;
@@ -316,7 +316,7 @@ kevent11_freebsd64_copyout(void *arg, struct kevent *kevp, int count)
 		kev11.fflags = kevp->fflags;
 		kev11.data = kevp->data;
 		kev11.udata = (__cheri_addr uint64_t)kevp->udata;
-		error = copyout(&kev11, __USER_CAP_OBJ(uap->eventlist),
+		error = copyout(&kev11, USER_PTR_OBJ(uap->eventlist),
 		    sizeof(kev11));
 		if (error != 0)
 			break;
@@ -340,7 +340,7 @@ kevent11_freebsd64_copyin(void *arg, struct kevent *kevp, int count)
 	uap = (struct freebsd11_freebsd64_kevent_args *)arg;
 
 	for (i = 0; i < count; i++) {
-		error = copyin(__USER_CAP_OBJ(uap->changelist), &kev11,
+		error = copyin(USER_PTR_OBJ(uap->changelist), &kev11,
 		    sizeof(kev11));
 		if (error != 0)
 			break;
@@ -369,11 +369,11 @@ freebsd11_freebsd64_kevent(struct thread *td,
 	};
 	struct g_kevent_args gk_args = {
 		.fd = uap->fd,
-		.changelist = __USER_CAP_ARRAY(uap->changelist, uap->nchanges),
+		.changelist = USER_PTR_ARRAY(uap->changelist, uap->nchanges),
 		.nchanges = uap->nchanges,
-		.eventlist = __USER_CAP_ARRAY(uap->eventlist, uap->nevents),
+		.eventlist = USER_PTR_ARRAY(uap->eventlist, uap->nevents),
 		.nevents = uap->nevents,
-		.timeout = __USER_CAP_OBJ(uap->timeout),
+		.timeout = USER_PTR_OBJ(uap->timeout),
 	};
 
 	return (kern_kevent_generic(td, &gk_args, &k_ops,
@@ -407,7 +407,7 @@ freebsd64_copyinuio(const struct iovec * __capability cb_arg, u_int iovcnt,
 			freeuio(uio);
 			return (error);
 		}
-		IOVEC_INIT_C(&iov[i], __USER_CAP(iov64.iov_base, iov64.iov_len),
+		IOVEC_INIT_C(&iov[i], USER_PTR(iov64.iov_base, iov64.iov_len),
 		    iov64.iov_len);
 	}
 	uio->uio_iovcnt = iovcnt;
@@ -452,7 +452,7 @@ freebsd64_copyiniov(const struct iovec * __capability cb_arg, u_int iovcnt,
 			return (error);
 		}
 		IOVEC_INIT_C(iovs + i,
-		    __USER_CAP(useriov.iov_base, useriov.iov_len),
+		    USER_PTR(useriov.iov_base, useriov.iov_len),
 		    useriov.iov_len);
 	}
 	*iovp = iovs;
@@ -469,10 +469,10 @@ freebsd64_copyin_hdtr(const struct sf_hdtr64 * __capability uhdtr,
 	error = copyin(uhdtr, &hdtr64, sizeof(hdtr64));
 	if (error != 0)
 		return (error);
-	hdtr->headers = (void * __capability)__USER_CAP_ARRAY(hdtr64.headers,
+	hdtr->headers = (void * __capability)USER_PTR_ARRAY(hdtr64.headers,
 	    hdtr64.hdr_cnt);
 	hdtr->hdr_cnt = hdtr64.hdr_cnt;
-	hdtr->trailers = (void * __capability)__USER_CAP_ARRAY(hdtr64.trailers,
+	hdtr->trailers = (void * __capability)USER_PTR_ARRAY(hdtr64.trailers,
 	    hdtr64.trl_cnt);
 	hdtr->hdr_cnt = hdtr64.trl_cnt;
 
@@ -483,7 +483,7 @@ int
 freebsd64_sendfile(struct thread *td, struct freebsd64_sendfile_args *uap)
 {
 	return (kern_sendfile(td, uap->fd, uap->s, uap->offset, uap->nbytes,
-	    __USER_CAP_OBJ(uap->hdtr), __USER_CAP_OBJ(uap->sbytes),
+	    USER_PTR_OBJ(uap->hdtr), USER_PTR_OBJ(uap->sbytes),
 	    uap->flags, 0, (copyin_hdtr_t *)freebsd64_copyin_hdtr,
 	    freebsd64_copyinuio));
 }
@@ -491,7 +491,7 @@ freebsd64_sendfile(struct thread *td, struct freebsd64_sendfile_args *uap)
 int
 freebsd64_jail_set(struct thread *td, struct freebsd64_jail_set_args *uap)
 {
-	return (user_jail_set(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (user_jail_set(td, USER_PTR_ARRAY(uap->iovp, uap->iovcnt),
 	    uap->iovcnt, uap->flags, freebsd64_copyinuio));
 }
 
@@ -518,7 +518,7 @@ freebsd64_updateiov(const struct uio *uiop, struct iovec * __capability cb_arg)
 int
 freebsd64_jail_get(struct thread *td, struct freebsd64_jail_get_args *uap)
 {
-	return (user_jail_get(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (user_jail_get(td, USER_PTR_ARRAY(uap->iovp, uap->iovcnt),
 	    uap->iovcnt, uap->flags, freebsd64_copyinuio, freebsd64_updateiov));
 }
 
@@ -537,7 +537,7 @@ freebsd64_getcontext(struct thread *td, struct freebsd64_getcontext_args *uap)
 	PROC_LOCK(td->td_proc);
 	uc.uc_sigmask = td->td_sigmask;
 	PROC_UNLOCK(td->td_proc);
-	return (copyout(&uc, __USER_CAP_OBJ(uap->ucp), UC_COPY_SIZE));
+	return (copyout(&uc, USER_PTR_OBJ(uap->ucp), UC_COPY_SIZE));
 }
 
 int
@@ -548,7 +548,7 @@ freebsd64_setcontext(struct thread *td, struct freebsd64_setcontext_args *uap)
 
 	if (uap->ucp == NULL)
 		return (EINVAL);
-	if ((ret = copyin(__USER_CAP_OBJ(uap->ucp), &uc, UC_COPY_SIZE)) != 0)
+	if ((ret = copyin(USER_PTR_OBJ(uap->ucp), &uc, UC_COPY_SIZE)) != 0)
 		return (ret);
 	if ((ret = freebsd64_set_mcontext(td, &uc.uc_mcontext)) != 0)
 		return (ret);
@@ -571,10 +571,10 @@ freebsd64_swapcontext(struct thread *td, struct freebsd64_swapcontext_args *uap)
 	PROC_LOCK(td->td_proc);
 	uc.uc_sigmask = td->td_sigmask;
 	PROC_UNLOCK(td->td_proc);
-	if ((ret = copyout(&uc, __USER_CAP_OBJ(uap->oucp), UC_COPY_SIZE)) !=
+	if ((ret = copyout(&uc, USER_PTR_OBJ(uap->oucp), UC_COPY_SIZE)) !=
 	    0)
 		return (ret);
-	if ((ret = copyin(__USER_CAP_OBJ(uap->ucp), &uc, UC_COPY_SIZE)) != 0)
+	if ((ret = copyin(USER_PTR_OBJ(uap->ucp), &uc, UC_COPY_SIZE)) != 0)
 		return (ret);
 	if ((ret = freebsd64_set_mcontext(td, &uc.uc_mcontext)) != 0)
 		return (ret);
@@ -599,7 +599,7 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 
 	if (uap->com >= PROC_PROCCTL_MD_MIN)
 		return (cpu_procctl(td, uap->idtype, uap->id, uap->com,
-		    __USER_CAP_UNBOUND(uap->data)));
+		    USER_PTR_UNBOUND(uap->data)));
 
 	switch (uap->com) {
 	case PROC_ASLR_CTL:
@@ -611,7 +611,7 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 	case PROC_NO_NEW_PRIVS_CTL:
 	case PROC_WXMAP_CTL:
 	case PROC_LOGSIGEXIT_CTL:
-		error = copyin(__USER_CAP(uap->data, sizeof(flags)), &flags,
+		error = copyin(USER_PTR(uap->data, sizeof(flags)), &flags,
 		    sizeof(flags));
 		if (error != 0)
 			return (error);
@@ -627,17 +627,17 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 		data = &x.rs;
 		break;
 	case PROC_REAP_GETPIDS:
-		error = copyin(__USER_CAP(uap->data, sizeof(x64.rp)), &x64.rp,
+		error = copyin(USER_PTR(uap->data, sizeof(x64.rp)), &x64.rp,
 		    sizeof(x64.rp));
 		if (error != 0)
 			return (error);
 		CP(x64.rp, x.rp, rp_count);
-		x.rp.rp_pids = __USER_CAP(x64.rp.rp_pids,
+		x.rp.rp_pids = USER_PTR(x64.rp.rp_pids,
 		    x64.rp.rp_count * sizeof(*x.rp.rp_pids));
 		data = &x.rp;
 		break;
 	case PROC_REAP_KILL:
-		error = copyin(__USER_CAP(uap->data, sizeof(x.rk)), &x.rk,
+		error = copyin(USER_PTR(uap->data, sizeof(x.rk)), &x.rk,
 		    sizeof(x.rk));
 		if (error != 0)
 			return (error);
@@ -654,7 +654,7 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 		data = &flags;
 		break;
 	case PROC_PDEATHSIG_CTL:
-		error = copyin(__USER_CAP(uap->data, sizeof(signum)), &signum,
+		error = copyin(USER_PTR(uap->data, sizeof(signum)), &signum,
 		    sizeof(signum));
 		if (error != 0)
 			return (error);
@@ -670,11 +670,11 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 	switch (uap->com) {
 	case PROC_REAP_STATUS:
 		if (error == 0)
-			error = copyout(&x.rs, __USER_CAP(uap->data,
+			error = copyout(&x.rs, USER_PTR(uap->data,
 			    sizeof(x.rs)), sizeof(x.rs));
 		break;
 	case PROC_REAP_KILL:
-		error1 = copyout(&x.rk, __USER_CAP(uap->data, sizeof(x.rk)),
+		error1 = copyout(&x.rk, USER_PTR(uap->data, sizeof(x.rk)),
 		    sizeof(x.rk));
 		if (error == 0)
 			error = error1;
@@ -688,12 +688,12 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 	case PROC_WXMAP_STATUS:
 	case PROC_LOGSIGEXIT_STATUS:
 		if (error == 0)
-			error = copyout(&flags, __USER_CAP(uap->data,
+			error = copyout(&flags, USER_PTR(uap->data,
 			    sizeof(flags)), sizeof(flags));
 		break;
 	case PROC_PDEATHSIG_STATUS:
 		if (error == 0)
-			error = copyout(&signum, __USER_CAP(uap->data,
+			error = copyout(&signum, USER_PTR(uap->data,
 			    sizeof(signum)), sizeof(signum));
 		break;
 	}
@@ -703,7 +703,7 @@ freebsd64_procctl(struct thread *td, struct freebsd64_procctl_args *uap)
 int
 freebsd64_nmount(struct thread *td, struct freebsd64_nmount_args *uap)
 {
-	return (kern_nmount(td, __USER_CAP_ARRAY(uap->iovp, uap->iovcnt),
+	return (kern_nmount(td, USER_PTR_ARRAY(uap->iovp, uap->iovcnt),
 	    uap->iovcnt, uap->flags, freebsd64_copyinuio));
 }
 
@@ -891,16 +891,16 @@ freebsd64_mount(struct thread *td, struct freebsd64_mount_args *uap)
 int
 freebsd64_kenv(struct thread *td, struct freebsd64_kenv_args *uap)
 {
-	return (kern_kenv(td, uap->what, __USER_CAP_STR(uap->name),
-	    __USER_CAP_STR(uap->value), uap->len));
+	return (kern_kenv(td, uap->what, USER_PTR_STR(uap->name),
+	    USER_PTR_STR(uap->value), uap->len));
 }
 
 int
 freebsd64_kbounce(struct thread *td, struct freebsd64_kbounce_args *uap)
 {
 	void * bounce;
-	void * __capability dst = __USER_CAP(uap->dst, uap->len);
-	const void * __capability src = __USER_CAP(uap->src, uap->len);
+	void * __capability dst = USER_PTR(uap->dst, uap->len);
+	const void * __capability src = USER_PTR(uap->src, uap->len);
 	size_t len = uap->len;
 	int flags = uap->flags;
 	int error;
@@ -929,7 +929,7 @@ int
 freebsd64_audit(struct thread *td, struct freebsd64_audit_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_audit(td, __USER_CAP(uap->record, uap->length),
+	return (kern_audit(td, USER_PTR(uap->record, uap->length),
 	    uap->length));
 #else
 	return (ENOSYS);
@@ -940,7 +940,7 @@ int
 freebsd64_auditon(struct thread *td, struct freebsd64_auditon_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_auditon(td, uap->cmd, __USER_CAP(uap->data, uap->length),
+	return (kern_auditon(td, uap->cmd, USER_PTR(uap->data, uap->length),
 	    uap->length));
 #else
 	return (ENOSYS);
@@ -951,7 +951,7 @@ int
 freebsd64_getauid(struct thread *td, struct freebsd64_getauid_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_getauid(td, __USER_CAP_OBJ(uap->auid)));
+	return (kern_getauid(td, USER_PTR_OBJ(uap->auid)));
 #else
 	return (ENOSYS);
 #endif
@@ -961,7 +961,7 @@ int
 freebsd64_setauid(struct thread *td, struct freebsd64_setauid_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_setauid(td, __USER_CAP_OBJ(uap->auid)));
+	return (kern_setauid(td, USER_PTR_OBJ(uap->auid)));
 #else
 	return (ENOSYS);
 #endif
@@ -971,7 +971,7 @@ int
 freebsd64_getaudit(struct thread *td, struct freebsd64_getaudit_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_getaudit(td, __USER_CAP_OBJ(uap->auditinfo)));
+	return (kern_getaudit(td, USER_PTR_OBJ(uap->auditinfo)));
 #else
 	return (ENOSYS);
 #endif
@@ -981,7 +981,7 @@ int
 freebsd64_setaudit(struct thread *td, struct freebsd64_setaudit_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_setaudit(td, __USER_CAP_OBJ(uap->auditinfo)));
+	return (kern_setaudit(td, USER_PTR_OBJ(uap->auditinfo)));
 #else
 	return (ENOSYS);
 #endif
@@ -993,7 +993,7 @@ freebsd64_getaudit_addr(struct thread *td,
 {
 #ifdef	AUDIT
 	return (kern_getaudit_addr(td,
-	    __USER_CAP(uap->auditinfo_addr, uap->length), uap->length));
+	    USER_PTR(uap->auditinfo_addr, uap->length), uap->length));
 #else
 	return (ENOSYS);
 #endif
@@ -1005,7 +1005,7 @@ freebsd64_setaudit_addr(struct thread *td,
 {
 #ifdef	AUDIT
 	return (kern_setaudit_addr(td, 
-	    __USER_CAP(uap->auditinfo_addr, uap->length), uap->length));
+	    USER_PTR(uap->auditinfo_addr, uap->length), uap->length));
 #else
 	return (ENOSYS);
 #endif
@@ -1015,7 +1015,7 @@ int
 freebsd64_auditctl(struct thread *td, struct freebsd64_auditctl_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_auditctl(td, __USER_CAP_STR(uap->path)));
+	return (kern_auditctl(td, USER_PTR_STR(uap->path)));
 #else
 	return (ENOSYS);
 #endif
@@ -1029,7 +1029,7 @@ freebsd64_auditctl(struct thread *td, struct freebsd64_auditctl_args *uap)
 int
 freebsd64_acct(struct thread *td, struct freebsd64_acct_args *uap)
 {
-	return (kern_acct(td, __USER_CAP_STR(uap->path)));
+	return (kern_acct(td, USER_PTR_STR(uap->path)));
 }
 
 /*
@@ -1039,7 +1039,7 @@ int
 freebsd64_flag_captured(struct thread *td,
     struct freebsd64_flag_captured_args *uap)
 {
-	return (kern_flag_captured(td, __USER_CAP_STR(uap->message), uap->key,
+	return (kern_flag_captured(td, USER_PTR_STR(uap->message), uap->key,
 	    __func__));
 }
 
@@ -1049,7 +1049,7 @@ freebsd64_flag_captured(struct thread *td,
 int
 freebsd64_pdfork(struct thread *td, struct freebsd64_pdfork_args *uap)
 {
-	return (kern_pdfork(td, __USER_CAP_OBJ(uap->fdp), uap->flags));
+	return (kern_pdfork(td, USER_PTR_OBJ(uap->fdp), uap->flags));
 }
 
 /*
@@ -1058,7 +1058,7 @@ freebsd64_pdfork(struct thread *td, struct freebsd64_pdfork_args *uap)
 int
 freebsd64_cpuset(struct thread *td, struct freebsd64_cpuset_args *uap)
 {
-	return (kern_cpuset(td, __USER_CAP_OBJ(uap->setid)));
+	return (kern_cpuset(td, USER_PTR_OBJ(uap->setid)));
 }
 
 int
@@ -1066,7 +1066,7 @@ freebsd64_cpuset_getid(struct thread *td,
     struct freebsd64_cpuset_getid_args *uap)
 {
 	return (kern_cpuset_getid(td, uap->level, uap->which, uap->id,
-	    __USER_CAP_OBJ(uap->setid)));
+	    USER_PTR_OBJ(uap->setid)));
 }
 
 static int
@@ -1132,7 +1132,7 @@ freebsd64_cpuset_getaffinity(struct thread *td,
     struct freebsd64_cpuset_getaffinity_args *uap)
 {
 	return (user_cpuset_getaffinity(td, uap->level, uap->which,
-	    uap->id, uap->cpusetsize, __USER_CAP(uap->mask, uap->cpusetsize),
+	    uap->id, uap->cpusetsize, USER_PTR(uap->mask, uap->cpusetsize),
 	    &cpuset_copy64_cb));
 }
 
@@ -1141,7 +1141,7 @@ freebsd64_cpuset_setaffinity(struct thread *td,
     struct freebsd64_cpuset_setaffinity_args *uap)
 {
 	return (user_cpuset_setaffinity(td, uap->level, uap->which, uap->id,
-	    uap->cpusetsize, __USER_CAP(uap->mask, uap->cpusetsize),
+	    uap->cpusetsize, USER_PTR(uap->mask, uap->cpusetsize),
 	    &cpuset_copy64_cb));
 }
 
@@ -1151,8 +1151,8 @@ freebsd64_cpuset_getdomain(struct thread *td,
 {
 	return (kern_cpuset_getdomain(td, uap->level, uap->which,
 	    uap->id, uap->domainsetsize,
-	    __USER_CAP(uap->mask, uap->domainsetsize),
-	    __USER_CAP_OBJ(uap->policy),
+	    USER_PTR(uap->mask, uap->domainsetsize),
+	    USER_PTR_OBJ(uap->policy),
 	    &cpuset_copy64_cb));
 }
 
@@ -1162,7 +1162,7 @@ freebsd64_cpuset_setdomain(struct thread *td,
 {
 	return (kern_cpuset_setdomain(td, uap->level, uap->which,
 	    uap->id, uap->domainsetsize,
-	    __USER_CAP(uap->mask, uap->domainsetsize), uap->policy,
+	    USER_PTR(uap->mask, uap->domainsetsize), uap->policy,
 	    &cpuset_copy64_cb));
 }
 
@@ -1182,7 +1182,7 @@ freebsd64_fcntl(struct thread *td, struct freebsd64_fcntl_args *uap)
 	case F_SETLK:
 	case F_SETLKW:
 	case F_SETLK_REMOTE:
-		arg = (intcap_t)__USER_CAP_UNBOUND(uap->arg);
+		arg = (intcap_t)USER_PTR_UNBOUND(uap->arg);
 		break;
 	default:
 		arg = (intcap_t)uap->arg;
@@ -1194,7 +1194,7 @@ freebsd64_fcntl(struct thread *td, struct freebsd64_fcntl_args *uap)
 int
 freebsd64_fstat(struct thread *td, struct freebsd64_fstat_args *uap)
 {
-	return (user_fstat(td, uap->fd, __USER_CAP_OBJ(uap->sb)));
+	return (user_fstat(td, uap->fd, USER_PTR_OBJ(uap->sb)));
 }
 
 /*
@@ -1204,14 +1204,14 @@ freebsd64_fstat(struct thread *td, struct freebsd64_fstat_args *uap)
 int
 freebsd64_ktrace(struct thread *td, struct freebsd64_ktrace_args *uap)
 {
-	return (kern_ktrace(td, __USER_CAP_STR(uap->fname), uap->ops,
+	return (kern_ktrace(td, USER_PTR_STR(uap->fname), uap->ops,
 	    uap->facs, uap->pid));
 }
 
 int
 freebsd64_utrace(struct thread *td, struct freebsd64_utrace_args *uap)
 {
-	return (kern_utrace(td, __USER_CAP(uap->addr, uap->len),
+	return (kern_utrace(td, USER_PTR(uap->addr, uap->len),
 	    uap->len));
 }
 
@@ -1222,13 +1222,13 @@ freebsd64_utrace(struct thread *td, struct freebsd64_utrace_args *uap)
 int
 freebsd64_kldload(struct thread *td, struct freebsd64_kldload_args *uap)
 {
-	return (user_kldload(td, __USER_CAP_STR(uap->file)));
+	return (user_kldload(td, USER_PTR_STR(uap->file)));
 }
 
 int
 freebsd64_kldfind(struct thread *td, struct freebsd64_kldfind_args *uap)
 {
-	return (kern_kldfind(td, __USER_CAP_STR(uap->file)));
+	return (kern_kldfind(td, USER_PTR_STR(uap->file)));
 }
 
 int
@@ -1238,7 +1238,7 @@ freebsd64_kldstat(struct thread *td, struct freebsd64_kldstat_args *uap)
 	struct kld_file_stat64 stat64, * __capability stat64p;
 	int error, version;
 
-	stat64p = __USER_CAP_OBJ(uap->stat);
+	stat64p = USER_PTR_OBJ(uap->stat);
 	error = copyin(&stat64p->version, &version, sizeof(version));
 	if (error != 0)
 		return (error);
@@ -1255,7 +1255,7 @@ freebsd64_kldstat(struct thread *td, struct freebsd64_kldstat_args *uap)
 	stat64.address = (__cheri_addr uint64_t)stat.address;
 	CP(stat, stat64, size);
 	bcopy(&stat.pathname[0], &stat64.pathname[0], sizeof(stat.pathname));
-	return (copyout(&stat64, __USER_CAP(uap->stat, version), version));
+	return (copyout(&stat64, USER_PTR(uap->stat, version), version));
 }
 
 int
@@ -1263,7 +1263,7 @@ freebsd64_kldsym(struct thread *td, struct freebsd64_kldsym_args *uap)
 {
 	struct kld_sym_lookup64 lookup;
 	int error;
-	void * __capability data = __USER_CAP(uap->data, sizeof(lookup));
+	void * __capability data = USER_PTR(uap->data, sizeof(lookup));
 
 	error = copyin(data, &lookup, sizeof(lookup));
 	if (error != 0)
@@ -1272,7 +1272,7 @@ freebsd64_kldsym(struct thread *td, struct freebsd64_kldsym_args *uap)
 	    uap->cmd != KLDSYM_LOOKUP)
 		return (EINVAL);
 	error = kern_kldsym(td, uap->fileid, uap->cmd,
-	    __USER_CAP_STR(lookup.symname), &lookup.symvalue, &lookup.symsize);
+	    USER_PTR_STR(lookup.symname), &lookup.symvalue, &lookup.symsize);
 	if (error != 0)
 		return (error);
 	error = copyout(&lookup, data, sizeof(lookup));
@@ -1287,7 +1287,7 @@ int
 freebsd64_getloginclass(struct thread *td,
     struct freebsd64_getloginclass_args *uap)
 {
-	return (kern_getloginclass(td, __USER_CAP(uap->namebuf, uap->namelen),
+	return (kern_getloginclass(td, USER_PTR(uap->namebuf, uap->namelen),
 	    uap->namelen));
 }
 
@@ -1295,13 +1295,13 @@ int
 freebsd64_setloginclass(struct thread *td,
     struct freebsd64_setloginclass_args *uap)
 {
-	return (kern_setloginclass(td, __USER_CAP_STR(uap->namebuf)));
+	return (kern_setloginclass(td, USER_PTR_STR(uap->namebuf)));
 }
 
 int
 freebsd64_uuidgen(struct thread *td, struct freebsd64_uuidgen_args *uap)
 {
-	return (user_uuidgen(td, __USER_CAP_ARRAY(uap->store, uap->count),
+	return (user_uuidgen(td, USER_PTR_ARRAY(uap->store, uap->count),
 	    uap->count));
 }
 
@@ -1311,13 +1311,13 @@ freebsd64_uuidgen(struct thread *td, struct freebsd64_uuidgen_args *uap)
 int
 freebsd64_modfind(struct thread *td, struct freebsd64_modfind_args *uap)
 {
-	return (kern_modfind(td, __USER_CAP_STR(uap->name)));
+	return (kern_modfind(td, USER_PTR_STR(uap->name)));
 }
 
 int
 freebsd64_modstat(struct thread *td, struct freebsd64_modstat_args *uap)
 {
-	return (kern_modstat(td, uap->modid, __USER_CAP_OBJ(uap->stat)));
+	return (kern_modstat(td, uap->modid, USER_PTR_OBJ(uap->stat)));
 }
 
 /*
@@ -1327,41 +1327,41 @@ int
 freebsd64_getgroups(struct thread *td, struct freebsd64_getgroups_args *uap)
 {
 	return (kern_getgroups(td, uap->gidsetsize,
-	    __USER_CAP_ARRAY(uap->gidset, uap->gidsetsize)));
+	    USER_PTR_ARRAY(uap->gidset, uap->gidsetsize)));
 }
 
 int
 freebsd64_setgroups(struct thread *td, struct freebsd64_setgroups_args *uap)
 {
 	return (user_setgroups(td, uap->gidsetsize,
-	    __USER_CAP_ARRAY(uap->gidset, uap->gidsetsize)));
+	    USER_PTR_ARRAY(uap->gidset, uap->gidsetsize)));
 }
 
 int
 freebsd64_getresuid(struct thread *td, struct freebsd64_getresuid_args *uap)
 {
-	return (kern_getresuid(td, __USER_CAP_OBJ(uap->ruid),
-	    __USER_CAP_OBJ(uap->euid), __USER_CAP_OBJ(uap->suid)));
+	return (kern_getresuid(td, USER_PTR_OBJ(uap->ruid),
+	    USER_PTR_OBJ(uap->euid), USER_PTR_OBJ(uap->suid)));
 }
 
 int
 freebsd64_getresgid(struct thread *td, struct freebsd64_getresgid_args *uap)
 {
-	return (kern_getresgid(td, __USER_CAP_OBJ(uap->rgid),
-	    __USER_CAP_OBJ(uap->egid), __USER_CAP_OBJ(uap->sgid)));
+	return (kern_getresgid(td, USER_PTR_OBJ(uap->rgid),
+	    USER_PTR_OBJ(uap->egid), USER_PTR_OBJ(uap->sgid)));
 }
 
 int
 freebsd64_getlogin(struct thread *td, struct freebsd64_getlogin_args *uap)
 {
-	return (kern_getlogin(td, __USER_CAP(uap->namebuf, uap->namelen),
+	return (kern_getlogin(td, USER_PTR(uap->namebuf, uap->namelen),
 	    uap->namelen));
 }
 
 int
 freebsd64_setlogin(struct thread *td, struct freebsd64_setlogin_args *uap)
 {
-	return (kern_setlogin(td, __USER_CAP_STR(uap->namebuf)));
+	return (kern_setlogin(td, USER_PTR_STR(uap->namebuf)));
 }
 
 int
@@ -1373,7 +1373,7 @@ freebsd64_setcred(struct thread *td, struct freebsd64_setcred_args *uap)
 
 	if (uap->size != sizeof(wcred64))
 		return (EINVAL);
-	error = copyin(__USER_CAP_OBJ(uap->wcred), &wcred64, sizeof(wcred64));
+	error = copyin(USER_PTR_OBJ(uap->wcred), &wcred64, sizeof(wcred64));
 	if (error != 0)
 		return (error);
 	CP(wcred64, wcred, sc_uid);
@@ -1383,9 +1383,9 @@ freebsd64_setcred(struct thread *td, struct freebsd64_setcred_args *uap)
 	CP(wcred64, wcred, sc_rgid);
 	CP(wcred64, wcred, sc_svgid);
 	CP(wcred64, wcred, sc_supp_groups_nb);
-	wcred.sc_supp_groups = __USER_CAP(wcred64.sc_supp_groups,
+	wcred.sc_supp_groups = USER_PTR(wcred64.sc_supp_groups,
 	    wcred64.sc_supp_groups_nb * sizeof(gid_t));
-	wcred.sc_label = __USER_CAP(wcred64.sc_label, sizeof(struct mac64));
+	wcred.sc_label = USER_PTR(wcred64.sc_label, sizeof(struct mac64));
 	return (user_setcred(td, uap->flags, &wcred));
 }
 
@@ -1399,8 +1399,8 @@ freebsd64_rctl_get_racct(struct thread *td,
 {
 
 #ifdef RCTL
-	return (kern_rctl_get_racct(td, __USER_CAP(uap->inbufp, uap->inbuflen),
-	    uap->inbuflen, __USER_CAP(uap->outbufp, uap->outbuflen),
+	return (kern_rctl_get_racct(td, USER_PTR(uap->inbufp, uap->inbuflen),
+	    uap->inbuflen, USER_PTR(uap->outbufp, uap->outbuflen),
 	    uap->outbuflen));
 #else
 	return (ENOSYS);
@@ -1412,8 +1412,8 @@ freebsd64_rctl_get_rules(struct thread *td,
     struct freebsd64_rctl_get_rules_args *uap)
 {
 #ifdef RCTL
-	return (kern_rctl_get_rules(td, __USER_CAP(uap->inbufp, uap->inbuflen),
-	    uap->inbuflen, __USER_CAP(uap->outbufp, uap->outbuflen),
+	return (kern_rctl_get_rules(td, USER_PTR(uap->inbufp, uap->inbuflen),
+	    uap->inbuflen, USER_PTR(uap->outbufp, uap->outbuflen),
 	    uap->outbuflen));
 #else
 	return (ENOSYS);
@@ -1425,8 +1425,8 @@ freebsd64_rctl_get_limits(struct thread *td,
     struct freebsd64_rctl_get_limits_args *uap)
 {
 #ifdef RCTL
-	return (kern_rctl_get_limits(td, __USER_CAP(uap->inbufp, uap->inbuflen),
-	    uap->inbuflen, __USER_CAP(uap->outbufp, uap->outbuflen),
+	return (kern_rctl_get_limits(td, USER_PTR(uap->inbufp, uap->inbuflen),
+	    uap->inbuflen, USER_PTR(uap->outbufp, uap->outbuflen),
 	    uap->outbuflen));
 #else
 	return (ENOSYS);
@@ -1438,8 +1438,8 @@ freebsd64_rctl_add_rule(struct thread *td,
     struct freebsd64_rctl_add_rule_args *uap)
 {
 #ifdef RCTL
-	return (kern_rctl_add_rule(td, __USER_CAP(uap->inbufp, uap->inbuflen),
-	    uap->inbuflen, __USER_CAP(uap->outbufp, uap->outbuflen),
+	return (kern_rctl_add_rule(td, USER_PTR(uap->inbufp, uap->inbuflen),
+	    uap->inbuflen, USER_PTR(uap->outbufp, uap->outbuflen),
 	    uap->outbuflen));
 #else
 	return (ENOSYS);
@@ -1452,8 +1452,8 @@ freebsd64_rctl_remove_rule(struct thread *td,
 {
 #ifdef RCTL
 	return (kern_rctl_remove_rule(td,
-	    __USER_CAP(uap->inbufp, uap->inbuflen), uap->inbuflen,
-	    __USER_CAP(uap->outbufp, uap->outbuflen), uap->outbuflen));
+	    USER_PTR(uap->inbufp, uap->inbuflen), uap->inbuflen,
+	    USER_PTR(uap->outbufp, uap->outbuflen), uap->outbuflen));
 #else
 	return (ENOSYS);
 #endif
@@ -1467,14 +1467,14 @@ freebsd64_rtprio_thread(struct thread *td,
     struct freebsd64_rtprio_thread_args *uap)
 {
 	return (kern_rtprio_thread(td, uap->function, uap->lwpid,
-	    __USER_CAP_OBJ(uap->rtp)));
+	    USER_PTR_OBJ(uap->rtp)));
 }
 
 int
 freebsd64_rtprio(struct thread *td, struct freebsd64_rtprio_args *uap)
 {
 	return (kern_rtprio(td, uap->function, uap->pid,
-	    __USER_CAP_OBJ(uap->rtp)));
+	    USER_PTR_OBJ(uap->rtp)));
 }
 
 int
@@ -1483,7 +1483,7 @@ freebsd64_setrlimit(struct thread *td, struct freebsd64_setrlimit_args *uap)
 	struct rlimit alim;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->rlp), &alim, sizeof(struct rlimit));
+	error = copyin(USER_PTR_OBJ(uap->rlp), &alim, sizeof(struct rlimit));
 	if (error != 0)
 		return (error);
 	return (kern_setrlimit(td, uap->which, &alim));
@@ -1498,7 +1498,7 @@ freebsd64_getrlimit(struct thread *td, struct freebsd64_getrlimit_args *uap)
 	if (uap->which >= RLIM_NLIMITS)
 		return (EINVAL);
 	lim_rlimit(td, uap->which, &rlim);
-	error = copyout(&rlim, __USER_CAP_OBJ(uap->rlp), sizeof(struct rlimit));
+	error = copyout(&rlim, USER_PTR_OBJ(uap->rlp), sizeof(struct rlimit));
 	return (error);
 }
 
@@ -1507,7 +1507,7 @@ freebsd64_getrlimitusage(struct thread *td,
     struct freebsd64_getrlimitusage_args *uap)
 {
 	return (user_getrlimitusage(td, uap->which, uap->flags,
-	    __USER_CAP_OBJ(uap->res)));
+	    USER_PTR_OBJ(uap->res)));
 }
 
 int
@@ -1518,7 +1518,7 @@ freebsd64_getrusage(struct thread *td, struct freebsd64_getrusage_args *uap)
 
 	error = kern_getrusage(td, uap->who, &ru);
 	if (error == 0)
-		error = copyout(&ru, __USER_CAP_OBJ(uap->rusage),
+		error = copyout(&ru, USER_PTR_OBJ(uap->rusage),
 		    sizeof(struct rusage));
 	return (error);
 }
@@ -1541,12 +1541,12 @@ freebsd64___sysctl(struct thread *td, struct freebsd64___sysctl_args *uap)
 	if (uap->oldlenp == NULL)
 		oldlen = 0;
 	else
-		if (fueword(__USER_CAP_OBJ(uap->oldlenp), &oldlen) == -1)
+		if (fueword(USER_PTR_OBJ(uap->oldlenp), &oldlen) == -1)
 			return (EFAULT);
 
-	return (kern_sysctl(td, __USER_CAP_ARRAY(uap->name, uap->namelen),
-	    uap->namelen, __USER_CAP(uap->old, oldlen),
-	    __USER_CAP_OBJ(uap->oldlenp), __USER_CAP(uap->new, uap->newlen),
+	return (kern_sysctl(td, USER_PTR_ARRAY(uap->name, uap->namelen),
+	    uap->namelen, USER_PTR(uap->old, oldlen),
+	    USER_PTR_OBJ(uap->oldlenp), USER_PTR(uap->new, uap->newlen),
 	    uap->newlen, SCTL_MASK64));
 }
 
@@ -1565,17 +1565,17 @@ freebsd64___sysctlbyname(struct thread *td, struct
 	if (uap->oldlenp == NULL)
 		oldlen = 0;
 	else
-		if (fueword(__USER_CAP_OBJ(uap->oldlenp), &oldlen) == -1)
+		if (fueword(USER_PTR_OBJ(uap->oldlenp), &oldlen) == -1)
 			return (EFAULT);
 
-	error = kern___sysctlbyname(td, __USER_CAP(uap->name, uap->namelen),
-	    uap->namelen, __USER_CAP(uap->old, oldlen),
-	    &oldlen, __USER_CAP(uap->new, uap->newlen),
+	error = kern___sysctlbyname(td, USER_PTR(uap->name, uap->namelen),
+	    uap->namelen, USER_PTR(uap->old, oldlen),
+	    &oldlen, USER_PTR(uap->new, uap->newlen),
 	    uap->newlen, &rv, SCTL_MASK64, 1);
 	if (error != 0)
 		return (error);
 	if (uap->oldlenp != NULL)
-		error = copyout(&rv, __USER_CAP(uap->oldlenp, sizeof(rv)),
+		error = copyout(&rv, USER_PTR(uap->oldlenp, sizeof(rv)),
 		    sizeof(rv));
 
 	return (error);
@@ -1597,7 +1597,7 @@ freebsd64_thr_create_initthr(struct thread *td, void *thunk)
 
 	args = thunk;
 	if (args->tid != NULL &&
-	    suword(__USER_CAP_OBJ(args->tid), td->td_tid) != 0)
+	    suword(USER_PTR_OBJ(args->tid), td->td_tid) != 0)
 		return (EFAULT);
 
 	return (freebsd64_set_mcontext(td, &args->ctx.uc_mcontext));
@@ -1609,7 +1609,7 @@ freebsd64_thr_create(struct thread *td, struct freebsd64_thr_create_args *uap)
 	struct thr_create_initthr_args64 args;
 	int error;
 
-	if ((error = copyin(__USER_CAP_OBJ(uap->ctx), &args.ctx, sizeof(args.ctx))))
+	if ((error = copyin(USER_PTR_OBJ(uap->ctx), &args.ctx, sizeof(args.ctx))))
 		return (error);
 	args.tid = uap->id;
 	return (thread_create(td, NULL, freebsd64_thr_create_initthr, &args));
@@ -1620,7 +1620,7 @@ freebsd64_thr_self(struct thread *td, struct freebsd64_thr_self_args *uap)
 {
 	int error;
 
-	error = suword(__USER_CAP_OBJ(uap->id), td->td_tid);
+	error = suword(USER_PTR_OBJ(uap->id), td->td_tid);
 	if (error == -1)
 		return (EFAULT);
 	return (0);
@@ -1633,8 +1633,8 @@ freebsd64_thr_exit(struct thread *td, struct freebsd64_thr_exit_args *uap)
 
 	/* Signal userland that it can free the stack. */
 	if (uap->state != NULL) {
-		(void)suword(__USER_CAP_OBJ(uap->state), 1);
-		(void)kern_umtx_wake(td, __USER_CAP_OBJ(uap->state), INT_MAX,
+		(void)suword(USER_PTR_OBJ(uap->state), 1);
+		(void)kern_umtx_wake(td, USER_PTR_OBJ(uap->state), INT_MAX,
 		    0);
 	}
 
@@ -1649,7 +1649,7 @@ freebsd64_thr_suspend(struct thread *td, struct freebsd64_thr_suspend_args *uap)
 
 	tsp = NULL;
 	if (uap->timeout != NULL) {
-		error = umtx_copyin_timeout(__USER_CAP_OBJ(uap->timeout), &ts);
+		error = umtx_copyin_timeout(USER_PTR_OBJ(uap->timeout), &ts);
 		if (error != 0)
 			return (error);
 		tsp = &ts;
@@ -1662,7 +1662,7 @@ int
 freebsd64_thr_set_name(struct thread *td,
     struct freebsd64_thr_set_name_args *uap)
 {
-	return (kern_thr_set_name(td, uap->id, __USER_CAP_STR(uap->name)));
+	return (kern_thr_set_name(td, uap->id, USER_PTR_STR(uap->name)));
 }
 
 static int
@@ -1670,15 +1670,15 @@ freebsd64_thr_new_initthr(struct thread *td, void *thunk)
 {
 	stack_t stack;
 	struct thr_param64 *param = thunk;
-	long * __capability child_tid = __USER_CAP(param->child_tid,
+	long * __capability child_tid = USER_PTR(param->child_tid,
 	    sizeof(long));
-	long * __capability parent_tid = __USER_CAP(param->parent_tid,
+	long * __capability parent_tid = USER_PTR(param->parent_tid,
 	    sizeof(long));
 
 	if ((child_tid != NULL && suword(child_tid, td->td_tid)) ||
 	    (parent_tid != NULL && suword(parent_tid, td->td_tid)))
 		return (EFAULT);
-	stack.ss_sp = __USER_CAP_UNBOUND(param->stack_base);
+	stack.ss_sp = USER_PTR_UNBOUND(param->stack_base);
 	stack.ss_size = param->stack_size;
 	cpu_set_upcall(td,
 	    (void (* __capability)(void *))(uintcap_t)param->start_func,
@@ -1697,12 +1697,12 @@ freebsd64_thr_new(struct thread *td, struct freebsd64_thr_new_args *uap)
 	if (uap->param_size != sizeof(struct thr_param64))
 		return (EINVAL);
 
-	error = copyin(__USER_CAP_OBJ(uap->param), &param64, uap->param_size);
+	error = copyin(USER_PTR_OBJ(uap->param), &param64, uap->param_size);
 	if (error != 0)
 		return (error);
 
 	if (param64.rtp != 0) {
-		error = copyin(__USER_CAP(param64.rtp, sizeof(struct rtprio)),
+		error = copyin(USER_PTR(param64.rtp, sizeof(struct rtprio)),
 		    &rtp, sizeof(struct rtprio));
 		if (error)
 			return (error);
@@ -1721,7 +1721,7 @@ freebsd64_sched_setparam(struct thread *td,
     struct freebsd64_sched_setparam_args * uap)
 {
 	return (user_sched_setparam(td, uap->pid,
-	    __USER_CAP_OBJ(uap->param)));
+	    USER_PTR_OBJ(uap->param)));
 }
 
 int
@@ -1729,7 +1729,7 @@ freebsd64_sched_getparam(struct thread *td,
     struct freebsd64_sched_getparam_args *uap)
 {
 	return (user_sched_getparam(td, uap->pid,
-	    __USER_CAP_OBJ(uap->param)));
+	    USER_PTR_OBJ(uap->param)));
 }
 
 int
@@ -1737,7 +1737,7 @@ freebsd64_sched_setscheduler(struct thread *td,
     struct freebsd64_sched_setscheduler_args *uap)
 {
 	return (user_sched_setscheduler(td, uap->pid, uap->policy,
-	    __USER_CAP_OBJ(uap->param)));
+	    USER_PTR_OBJ(uap->param)));
 }
 
 int
@@ -1745,7 +1745,7 @@ freebsd64_sched_rr_get_interval(struct thread *td,
     struct freebsd64_sched_rr_get_interval_args *uap)
 {
 	return (user_sched_rr_get_interval(td, uap->pid,
-	    __USER_CAP_OBJ(uap->interval)));
+	    USER_PTR_OBJ(uap->interval)));
 }
 
 #else /* !_KPOSIX_PRIORITY_SCHEDULING */
@@ -1762,7 +1762,7 @@ FREEBSD64_SYSCALL_NOT_PRESENT_GEN(sched_rr_get_interval)
 int
 freebsd64_profil(struct thread *td, struct freebsd64_profil_args *uap)
 {
-	return (kern_profil(td, __USER_CAP(uap->samples, uap->size), uap->size,
+	return (kern_profil(td, USER_PTR(uap->samples, uap->size), uap->size,
 	    uap->offset, uap->scale));
 }
 
@@ -1773,13 +1773,13 @@ freebsd64_profil(struct thread *td, struct freebsd64_profil_args *uap)
 int
 freebsd64_swapon(struct thread *td, struct freebsd64_swapon_args *uap)
 {
-	return (kern_swapon(td, __USER_CAP_STR(uap->name)));
+	return (kern_swapon(td, USER_PTR_STR(uap->name)));
 }
 
 int
 freebsd64_swapoff(struct thread *td, struct freebsd64_swapoff_args *uap)
 {
-	return (kern_swapoff(td, __USER_CAP_STR(uap->name), UIO_USERSPACE,
+	return (kern_swapoff(td, USER_PTR_STR(uap->name), UIO_USERSPACE,
 	    uap->flags));
 }
 
@@ -1788,7 +1788,7 @@ int
 freebsd13_freebsd64_swapoff(struct thread *td,
     struct freebsd13_freebsd64_swapoff_args *uap)
 {
-	return (kern_swapoff(td, __USER_CAP_STR(uap->name), UIO_USERSPACE, 0));
+	return (kern_swapoff(td, USER_PTR_STR(uap->name), UIO_USERSPACE, 0));
 }
 #endif
 
@@ -1799,7 +1799,7 @@ freebsd13_freebsd64_swapoff(struct thread *td,
 int
 freebsd64_cap_getmode(struct thread *td, struct freebsd64_cap_getmode_args *uap)
 {
-	return (kern_cap_getmode(td, __USER_CAP_OBJ(uap->modep)));
+	return (kern_cap_getmode(td, USER_PTR_OBJ(uap->modep)));
 }
 
 int
@@ -1807,7 +1807,7 @@ freebsd64_cap_rights_limit(struct thread *td,
    struct freebsd64_cap_rights_limit_args *uap)
 {
 	return (user_cap_rights_limit(td, uap->fd,
-	    __USER_CAP_OBJ(uap->rightsp)));
+	    USER_PTR_OBJ(uap->rightsp)));
 }
 
 int
@@ -1815,7 +1815,7 @@ freebsd64___cap_rights_get(struct thread *td,
     struct freebsd64___cap_rights_get_args *uap)
 {
 	return (kern_cap_rights_get(td, uap->version, uap->fd,
-	    __USER_CAP_OBJ(uap->rightsp)));
+	    USER_PTR_OBJ(uap->rightsp)));
 }
 
 int
@@ -1823,7 +1823,7 @@ freebsd64_cap_ioctls_limit(struct thread *td,
     struct freebsd64_cap_ioctls_limit_args *uap)
 {
 	return (user_cap_ioctls_limit(td, uap->fd,
-	    __USER_CAP_ARRAY(uap->cmds, uap->ncmds), uap->ncmds));
+	    USER_PTR_ARRAY(uap->cmds, uap->ncmds), uap->ncmds));
 }
 
 int
@@ -1831,7 +1831,7 @@ freebsd64_cap_ioctls_get(struct thread *td,
     struct freebsd64_cap_ioctls_get_args *uap)
 {
 	return (kern_cap_ioctls_get(td, uap->fd,
-	    __USER_CAP_ARRAY(uap->cmds, uap->maxcmds), uap->maxcmds));
+	    USER_PTR_ARRAY(uap->cmds, uap->maxcmds), uap->maxcmds));
 }
 
 int
@@ -1839,7 +1839,7 @@ freebsd64_cap_fcntls_get(struct thread *td,
    struct freebsd64_cap_fcntls_get_args *uap)
 {
 	return (kern_cap_fcntls_get(td, uap->fd,
-	    __USER_CAP_OBJ(uap->fcntlrightsp)));
+	    USER_PTR_OBJ(uap->fcntlrightsp)));
 }
 #else /* !CAPABILITIES */
 int
@@ -1890,14 +1890,14 @@ freebsd64_cap_fcntls_get(struct thread *td,
 int
 freebsd64_getrandom(struct thread *td, struct freebsd64_getrandom_args *uap)
 {
-	return (kern_getrandom(td, __USER_CAP(uap->buf, uap->buflen),
+	return (kern_getrandom(td, USER_PTR(uap->buf, uap->buflen),
 	    uap->buflen, uap->flags));
 }
 
 int
 freebsd64_pipe2(struct thread *td, struct freebsd64_pipe2_args *uap)
 {
-	return (kern_pipe2(td, __USER_CAP_ARRAY(uap->fildes, 2), uap->flags));
+	return (kern_pipe2(td, USER_PTR_ARRAY(uap->fildes, 2), uap->flags));
 }
 
 /*
@@ -1907,7 +1907,7 @@ freebsd64_pipe2(struct thread *td, struct freebsd64_pipe2_args *uap)
 int
 freebsd64_pdgetpid(struct thread *td, struct freebsd64_pdgetpid_args *uap)
 {
-	return (user_pdgetpid(td, uap->fd, __USER_CAP_OBJ(uap->pidp)));
+	return (user_pdgetpid(td, uap->fd, USER_PTR_OBJ(uap->pidp)));
 }
 
 /*

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -179,7 +179,7 @@ freebsd64_execve(struct thread *td, struct freebsd64_execve_args *uap)
 	error = pre_execve(td, &oldvmspace);
 	if (error != 0)
 		return (error);
-	error = exec_copyin_args(&eargs, USER_PTR_STR(uap->fname),
+	error = exec_copyin_args(&eargs, USER_PTR_PATH(uap->fname),
 	    UIO_USERSPACE, USER_PTR_UNBOUND(uap->argv),
 	    USER_PTR_UNBOUND(uap->envv));
 	if (error == 0)
@@ -1015,7 +1015,7 @@ int
 freebsd64_auditctl(struct thread *td, struct freebsd64_auditctl_args *uap)
 {
 #ifdef	AUDIT
-	return (kern_auditctl(td, USER_PTR_STR(uap->path)));
+	return (kern_auditctl(td, USER_PTR_PATH(uap->path)));
 #else
 	return (ENOSYS);
 #endif
@@ -1029,7 +1029,7 @@ freebsd64_auditctl(struct thread *td, struct freebsd64_auditctl_args *uap)
 int
 freebsd64_acct(struct thread *td, struct freebsd64_acct_args *uap)
 {
-	return (kern_acct(td, USER_PTR_STR(uap->path)));
+	return (kern_acct(td, USER_PTR_PATH(uap->path)));
 }
 
 /*
@@ -1204,7 +1204,7 @@ freebsd64_fstat(struct thread *td, struct freebsd64_fstat_args *uap)
 int
 freebsd64_ktrace(struct thread *td, struct freebsd64_ktrace_args *uap)
 {
-	return (kern_ktrace(td, USER_PTR_STR(uap->fname), uap->ops,
+	return (kern_ktrace(td, USER_PTR_PATH(uap->fname), uap->ops,
 	    uap->facs, uap->pid));
 }
 
@@ -1222,13 +1222,13 @@ freebsd64_utrace(struct thread *td, struct freebsd64_utrace_args *uap)
 int
 freebsd64_kldload(struct thread *td, struct freebsd64_kldload_args *uap)
 {
-	return (user_kldload(td, USER_PTR_STR(uap->file)));
+	return (user_kldload(td, USER_PTR_PATH(uap->file)));
 }
 
 int
 freebsd64_kldfind(struct thread *td, struct freebsd64_kldfind_args *uap)
 {
-	return (kern_kldfind(td, USER_PTR_STR(uap->file)));
+	return (kern_kldfind(td, USER_PTR_PATH(uap->file)));
 }
 
 int
@@ -1773,13 +1773,13 @@ freebsd64_profil(struct thread *td, struct freebsd64_profil_args *uap)
 int
 freebsd64_swapon(struct thread *td, struct freebsd64_swapon_args *uap)
 {
-	return (kern_swapon(td, USER_PTR_STR(uap->name)));
+	return (kern_swapon(td, USER_PTR_PATH(uap->name)));
 }
 
 int
 freebsd64_swapoff(struct thread *td, struct freebsd64_swapoff_args *uap)
 {
-	return (kern_swapoff(td, USER_PTR_STR(uap->name), UIO_USERSPACE,
+	return (kern_swapoff(td, USER_PTR_PATH(uap->name), UIO_USERSPACE,
 	    uap->flags));
 }
 
@@ -1788,7 +1788,7 @@ int
 freebsd13_freebsd64_swapoff(struct thread *td,
     struct freebsd13_freebsd64_swapoff_args *uap)
 {
-	return (kern_swapoff(td, USER_PTR_STR(uap->name), UIO_USERSPACE, 0));
+	return (kern_swapoff(td, USER_PTR_PATH(uap->name), UIO_USERSPACE, 0));
 }
 #endif
 

--- a/sys/compat/freebsd64/freebsd64_mmap.c
+++ b/sys/compat/freebsd64/freebsd64_mmap.c
@@ -48,6 +48,7 @@
 #include <vm/vm_object.h>
 #include <vm/vm_extern.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 
 #if 0

--- a/sys/compat/freebsd64/freebsd64_mmap.c
+++ b/sys/compat/freebsd64/freebsd64_mmap.c
@@ -157,7 +157,7 @@ int
 freebsd64_mincore(struct thread *td, struct freebsd64_mincore_args *uap)
 {
 	return (kern_mincore(td, (uintptr_t)uap->addr, uap->len,
-	    __USER_CAP(uap->vec, uap->len)));
+	    USER_PTR(uap->vec, uap->len)));
 }
 
 int

--- a/sys/compat/freebsd64/freebsd64_process.c
+++ b/sys/compat/freebsd64/freebsd64_process.c
@@ -206,7 +206,7 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 			error = EINVAL;
 			break;
 		}
-		addr = __USER_CAP(uap->addr, uap->data * sizeof(lwpid_t));
+		addr = USER_PTR(uap->addr, uap->data * sizeof(lwpid_t));
 		break;
 	case PT_GETREGS:
 		bzero(&r.reg, sizeof r.reg);
@@ -223,53 +223,53 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 		bzero(&r.dbreg, sizeof r.dbreg);
 		break;
 	case PT_SETREGS:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r.reg)), &r.reg,
+		error = copyin(USER_PTR(uap->addr, sizeof(r.reg)), &r.reg,
 		    sizeof r.reg);
 		break;
 	case PT_SETFPREGS:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r.fpreg)), &r.fpreg,
+		error = copyin(USER_PTR(uap->addr, sizeof(r.fpreg)), &r.fpreg,
 		    sizeof r.fpreg);
 		break;
 	case PT_SETDBREGS:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r.dbreg)), &r.dbreg,
+		error = copyin(USER_PTR(uap->addr, sizeof(r.dbreg)), &r.dbreg,
 		    sizeof r.dbreg);
 		break;
 #if __has_feature(capabilities)
 	case PT_SETCAPREGS:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r.capreg)),
+		error = copyin(USER_PTR(uap->addr, sizeof(r.capreg)),
 		    &r.capreg, sizeof r.capreg);
 		break;
 #endif
 	case PT_GETREGSET:
 	case PT_SETREGSET:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r64.vec)), &r64.vec,
+		error = copyin(USER_PTR(uap->addr, sizeof(r64.vec)), &r64.vec,
 		    sizeof(r64.vec));
 		if (error != 0)
 			break;
-		IOVEC_INIT_C(&r.vec, __USER_CAP(r64.vec.iov_base,
+		IOVEC_INIT_C(&r.vec, USER_PTR(r64.vec.iov_base,
 		    r64.vec.iov_len), r64.vec.iov_len);
 		break;
 	case PT_SET_EVENT_MASK:
 		if (uap->data != sizeof(r.ptevents))
 			error = EINVAL;
 		else
-			error = copyin(__USER_CAP(uap->addr, uap->data),
+			error = copyin(USER_PTR(uap->addr, uap->data),
 			    &r.ptevents, uap->data);
 		break;
 	case PT_IO:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r64.piod)),
+		error = copyin(USER_PTR(uap->addr, sizeof(r64.piod)),
 		    &r64.piod, sizeof(r64.piod));
 		if (error)
 			break;
 		CP(r64.piod, r.piod, piod_op);
 		r.piod.piod_offs =
 		    (void * __capability)(uintcap_t)r64.piod.piod_offs;
-		r.piod.piod_addr = __USER_CAP(r64.piod.piod_addr,
+		r.piod.piod_addr = USER_PTR(r64.piod.piod_addr,
 		    r64.piod.piod_len);
 		CP(r64.piod, r.piod, piod_len);
 		break;
 	case PT_VM_ENTRY:
-		error = copyin(__USER_CAP(uap->addr, sizeof(r64.pve)),
+		error = copyin(USER_PTR(uap->addr, sizeof(r64.pve)),
 		    &r64.pve, sizeof(r64.pve));
 		if (error)
 			break;
@@ -283,14 +283,14 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 		CP(r64.pve, r.pve, pve_pathlen);
 		CP(r64.pve, r.pve, pve_fileid);
 		CP(r64.pve, r.pve, pve_fsid);
-		r.pve.pve_path = __USER_CAP(r64.pve.pve_path,
+		r.pve.pve_path = USER_PTR(r64.pve.pve_path,
 		    r64.pve.pve_pathlen);
 		break;
 	case PT_COREDUMP:
 		if (uap->data != sizeof(r.pc))
 			error = EINVAL;
 		else
-			error = copyin(__USER_CAP(uap->addr, uap->data), &r.pc,
+			error = copyin(USER_PTR(uap->addr, uap->data), &r.pc,
 			    uap->data);
 		break;
 	case PT_SC_REMOTE:
@@ -298,7 +298,7 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 			error = EINVAL;
 			break;
 		}
-		error = copyin(__USER_CAP(uap->addr, uap->data), &r64.sr,
+		error = copyin(USER_PTR(uap->addr, uap->data), &r64.sr,
 		    uap->data);
 		if (error != 0)
 			break;
@@ -308,7 +308,7 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 			error = EINVAL;
 			break;
 		}
-		error = copyin(__USER_CAP(r64.sr.pscr_args,
+		error = copyin(USER_PTR(r64.sr.pscr_args,
 		    sizeof(uint64_t) * r64.sr.pscr_nargs), pscr_args64,
 		    sizeof(uint64_t) * r64.sr.pscr_nargs);
 		if (error != 0)
@@ -318,7 +318,7 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 		r.sr.pscr_args = pscr_args;
 		break;
 	default:
-		addr = __USER_CAP_UNBOUND(uap->addr);
+		addr = USER_PTR_UNBOUND(uap->addr);
 		break;
 	}
 	if (error)
@@ -339,62 +339,62 @@ freebsd64_ptrace(struct thread *td, struct freebsd64_ptrace_args *uap)
 		CP(r.pve, r64.pve, pve_pathlen);
 		CP(r.pve, r64.pve, pve_fileid);
 		CP(r.pve, r64.pve, pve_fsid);
-		error = copyout(&r64.pve, __USER_CAP(uap->addr, sizeof(r64.pve)),
+		error = copyout(&r64.pve, USER_PTR(uap->addr, sizeof(r64.pve)),
 		    sizeof(r64.pve));
 		break;
 	case PT_IO:
 		CP(r.piod, r64.piod, piod_len);
 		error = copyout(&r64.piod,
-		    __USER_CAP(uap->addr, sizeof(r64.piod)), sizeof(r64.piod));
+		    USER_PTR(uap->addr, sizeof(r64.piod)), sizeof(r64.piod));
 		break;
 	case PT_GETREGS:
-		error = copyout(&r.reg, __USER_CAP(uap->addr, sizeof(r.reg)),
+		error = copyout(&r.reg, USER_PTR(uap->addr, sizeof(r.reg)),
 		    sizeof r.reg);
 		break;
 	case PT_GETFPREGS:
-		error = copyout(&r.fpreg, __USER_CAP(uap->addr, sizeof(r.fpreg)),
+		error = copyout(&r.fpreg, USER_PTR(uap->addr, sizeof(r.fpreg)),
 		    sizeof r.fpreg);
 		break;
 	case PT_GETDBREGS:
-		error = copyout(&r.dbreg, __USER_CAP(uap->addr, sizeof(r.dbreg)),
+		error = copyout(&r.dbreg, USER_PTR(uap->addr, sizeof(r.dbreg)),
 		    sizeof r.dbreg);
 		break;
 #if __has_feature(capabilities)
 	case PT_GETCAPREGS:
-		error = copyout(&r.capreg, __USER_CAP(uap->addr,
+		error = copyout(&r.capreg, USER_PTR(uap->addr,
 		    sizeof(r.capreg)), sizeof r.capreg);
 		break;
 #endif
 	case PT_GETREGSET:
 		r64.vec.iov_len = r.vec.iov_len;
-		error = copyout(&r64.vec, __USER_CAP(uap->addr,
+		error = copyout(&r64.vec, USER_PTR(uap->addr,
 		    sizeof(r64.vec)), sizeof(r64.vec));
 		break;
 	case PT_GET_EVENT_MASK:
 		/* NB: The size in uap->data is validated in kern_ptrace(). */
-		error = copyout(&r.ptevents, __USER_CAP(uap->addr, uap->data),
+		error = copyout(&r.ptevents, USER_PTR(uap->addr, uap->data),
 		    uap->data);
 		break;
 	case PT_LWPINFO:
 		ptrace_lwpinfo_to64(&r.pl, &r64.pl);
-		error = copyout(&r64.pl, __USER_CAP(uap->addr, uap->data),
+		error = copyout(&r64.pl, USER_PTR(uap->addr, uap->data),
 		    uap->data);
 		break;
 	case PT_GET_SC_ARGS:
 		for (i = 0; i < nitems(r.args); i++)
 			r64.args[i] = (__cheri_addr uint64_t)r.args[i];
-		error = copyout(r64.args, __USER_CAP(uap->addr, uap->data),
+		error = copyout(r64.args, USER_PTR(uap->addr, uap->data),
 		    MIN(uap->data, sizeof(r64.args)));
 		break;
 	case PT_GET_SC_RET:
 		ptrace_sc_ret_to64(&r.psr, &r64.psr);
-		error = copyout(&r64.psr, __USER_CAP(uap->addr, uap->data),
+		error = copyout(&r64.psr, USER_PTR(uap->addr, uap->data),
 		    MIN(uap->data, sizeof(r64.psr)));
 		break;
 	case PT_SC_REMOTE:
 		ptrace_sc_ret_to64(&r.sr.pscr_ret, &r64.sr.pscr_ret);
 		error = copyout(&r64.sr.pscr_ret,
-		    (char * __capability)__USER_CAP(uap->addr, uap->data) +
+		    (char * __capability)USER_PTR(uap->addr, uap->data) +
 		    offsetof(struct ptrace_sc_remote64, pscr_ret),
 		    sizeof(r64.psr));
 		break;

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -92,7 +92,7 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 	actp = (uap->act != NULL) ? &act : NULL;
 	oactp = (uap->oact != NULL) ? &oact : NULL;
 	if (actp) {
-		error = copyin(__USER_CAP_OBJ(uap->act), &act64, sizeof(act64));
+		error = copyin(USER_PTR_OBJ(uap->act), &act64, sizeof(act64));
 		if (error)
 			return (error);
 		if (is_magic_sighandler_constant(act64.sa_u))
@@ -108,7 +108,7 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 		oact64.sa_u = (__cheri_addr ptraddr_t)oactp->sa_handler;
 		oact64.sa_flags = oactp->sa_flags;
 		oact64.sa_mask = oactp->sa_mask;
-		error = copyout(&oact64, __USER_CAP_OBJ(uap->oact),
+		error = copyout(&oact64, USER_PTR_OBJ(uap->oact),
 		    sizeof(oact64));
 	}
 	return (error);
@@ -117,15 +117,15 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 int
 freebsd64_sigprocmask(struct thread *td, struct freebsd64_sigprocmask_args *uap)
 {
-	return (user_sigprocmask(td, uap->how, __USER_CAP_OBJ(uap->set),
-	    __USER_CAP_OBJ(uap->oset)));
+	return (user_sigprocmask(td, uap->how, USER_PTR_OBJ(uap->set),
+	    USER_PTR_OBJ(uap->oset)));
 }
 
 int
 freebsd64_sigwait(struct thread *td, struct freebsd64_sigwait_args *uap)
 {
-	return (user_sigwait(td, __USER_CAP_OBJ(uap->set),
-	    __USER_CAP_OBJ(uap->sig)));
+	return (user_sigwait(td, USER_PTR_OBJ(uap->set),
+	    USER_PTR_OBJ(uap->sig)));
 }
 
 void
@@ -158,29 +158,29 @@ int
 freebsd64_sigtimedwait(struct thread *td,
     struct freebsd64_sigtimedwait_args *uap)
 {
-	return (user_sigtimedwait(td, __USER_CAP_OBJ(uap->set),
-	    __USER_CAP_OBJ(uap->info), __USER_CAP_OBJ(uap->timeout),
+	return (user_sigtimedwait(td, USER_PTR_OBJ(uap->set),
+	    USER_PTR_OBJ(uap->info), USER_PTR_OBJ(uap->timeout),
 	    (copyout_siginfo_t *)freebsd64_copyout_siginfo));
 }
 
 int
 freebsd64_sigwaitinfo(struct thread *td, struct freebsd64_sigwaitinfo_args *uap)
 {
-	return (user_sigwaitinfo(td, __USER_CAP_OBJ(uap->set),
-	    __USER_CAP_OBJ(uap->info),
+	return (user_sigwaitinfo(td, USER_PTR_OBJ(uap->set),
+	    USER_PTR_OBJ(uap->info),
 	    (copyout_siginfo_t *)freebsd64_copyout_siginfo));
 }
 
 int
 freebsd64_sigpending(struct thread *td, struct freebsd64_sigpending_args *uap)
 {
-	return (kern_sigpending(td, __USER_CAP_OBJ(uap->set)));
+	return (kern_sigpending(td, USER_PTR_OBJ(uap->set)));
 }
 
 int
 freebsd64_sigsuspend(struct thread *td, struct freebsd64_sigsuspend_args *uap)
 {
-	return (user_sigsuspend(td, __USER_CAP_OBJ(uap->sigmask)));
+	return (user_sigsuspend(td, USER_PTR_OBJ(uap->sigmask)));
 }
 
 int
@@ -192,10 +192,10 @@ freebsd64_sigaltstack(struct thread *td,
 	int error;
 
 	if (uap->ss != NULL) {
-		error = copyin(__USER_CAP_OBJ(uap->ss), &ss64, sizeof(ss64));
+		error = copyin(USER_PTR_OBJ(uap->ss), &ss64, sizeof(ss64));
 		if (error != 0)
 			return (error);
-		ss.ss_sp = __USER_CAP_UNBOUND(ss64.ss_sp);
+		ss.ss_sp = USER_PTR_UNBOUND(ss64.ss_sp);
 		ss.ss_size = ss64.ss_size;
 		ss.ss_flags = ss64.ss_flags;
 	}
@@ -208,7 +208,7 @@ freebsd64_sigaltstack(struct thread *td,
 		ss64.ss_sp = (__cheri_addr uint64_t)oss.ss_sp;
 		ss64.ss_size = oss.ss_size;
 		ss64.ss_flags = oss.ss_flags;
-		error = copyout(&ss64, __USER_CAP_OBJ(uap->oss), sizeof(ss64));
+		error = copyout(&ss64, USER_PTR_OBJ(uap->oss), sizeof(ss64));
 	}
 	return (error);
 }
@@ -232,7 +232,7 @@ int freebsd64_sigfastblock(struct thread *td,
     struct freebsd64_sigfastblock_args *uap)
 {
 	return (kern_sigfastblock(td, uap->cmd,
-	    __USER_CAP(uap->ptr, sizeof(uint32_t))));
+	    USER_PTR(uap->ptr, sizeof(uint32_t))));
 }
 /*
  * CHERI CHANGES START

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -98,7 +98,7 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 		if (is_magic_sighandler_constant(act64.sa_u))
 			actp->sa_handler = cheri_fromint(act64.sa_u);
 		else
-			actp->sa_handler = __USER_CODE_CAP(act64.sa_u);
+			actp->sa_handler = USER_CODE_PTR(act64.sa_u);
 		actp->sa_flags = act64.sa_flags;
 		actp->sa_mask = act64.sa_mask;
 	}

--- a/sys/compat/freebsd64/freebsd64_time.c
+++ b/sys/compat/freebsd64/freebsd64_time.c
@@ -57,7 +57,7 @@ freebsd64_ffclock_getcounter(struct thread *td,
 	ffclock_read_counter(&ffcount);
 	if (ffcount == 0)
 		return (EAGAIN);
-	return (copyout(&ffcount, __USER_CAP_OBJ(uap->ffcount),
+	return (copyout(&ffcount, USER_PTR_OBJ(uap->ffcount),
 	    sizeof(ffcounter)));
 #else
 	return (ENOSYS);
@@ -69,7 +69,7 @@ freebsd64_ffclock_setestimate(struct thread *td,
     struct freebsd64_ffclock_setestimate_args *uap)
 {
 #ifdef	FFCLOCK
-	return (kern_ffclock_setestimate(td, __USER_CAP_OBJ(uap->cest)));
+	return (kern_ffclock_setestimate(td, USER_PTR_OBJ(uap->cest)));
 #else
 	return (ENOSYS);
 #endif
@@ -80,7 +80,7 @@ freebsd64_ffclock_getestimate(struct thread *td,
     struct freebsd64_ffclock_getestimate_args *uap)
 {
 #ifdef	FFCLOCK
-	return (kern_ffclock_getestimate(td, __USER_CAP_OBJ(uap->cest)));
+	return (kern_ffclock_getestimate(td, USER_PTR_OBJ(uap->cest)));
 #else
 	return (ENOSYS);
 #endif
@@ -92,7 +92,7 @@ freebsd64_ffclock_getestimate(struct thread *td,
 int
 freebsd64_ntp_gettime(struct thread *td, struct freebsd64_ntp_gettime_args *uap)
 {
-	return (kern_ntp_gettime(td, __USER_CAP_OBJ(uap->ntvp)));
+	return (kern_ntp_gettime(td, USER_PTR_OBJ(uap->ntvp)));
 }
 
 int
@@ -101,13 +101,13 @@ freebsd64_ntp_adjtime(struct thread *td, struct freebsd64_ntp_adjtime_args *uap)
 	struct timex ntv;
 	int error, retval;
 
-	error = copyin(__USER_CAP_OBJ(uap->tp), &ntv, sizeof(ntv));
+	error = copyin(USER_PTR_OBJ(uap->tp), &ntv, sizeof(ntv));
 	if (error != 0)
 		return (error);
 	error = kern_ntp_adjtime(td, &ntv, &retval);
 	if (error != 0)
 		return (error);
-	error = copyout(&ntv, __USER_CAP_OBJ(uap->tp), sizeof(ntv));
+	error = copyout(&ntv, USER_PTR_OBJ(uap->tp), sizeof(ntv));
 	if (error == 0)
 		td->td_retval[0] = retval;
 	return (error);
@@ -120,7 +120,7 @@ freebsd64_adjtime(struct thread *td, struct freebsd64_adjtime_args *uap)
 	int error;
 
 	if (uap->delta) {
-		error = copyin(__USER_CAP_OBJ(uap->delta), &delta,
+		error = copyin(USER_PTR_OBJ(uap->delta), &delta,
 		    sizeof(delta));
 		if (error != 0)
 			return (error);
@@ -129,7 +129,7 @@ freebsd64_adjtime(struct thread *td, struct freebsd64_adjtime_args *uap)
 		deltap = NULL;
 	error = kern_adjtime(td, deltap, &olddelta);
 	if (uap->olddelta && error == 0)
-		error = copyout(&olddelta, __USER_CAP_OBJ(uap->olddelta),
+		error = copyout(&olddelta, USER_PTR_OBJ(uap->olddelta),
 		    sizeof(olddelta));
 	return (error);
 }
@@ -147,7 +147,7 @@ freebsd64_clock_getcpuclockid2(struct thread *td,
 
 	error = kern_clock_getcpuclockid2(td, uap->id, uap->which, &clk_id);
 	if (error == 0)
-		error = copyout(&clk_id, __USER_CAP_OBJ(uap->clock_id),
+		error = copyout(&clk_id, USER_PTR_OBJ(uap->clock_id),
 		    sizeof(clockid_t));
 
 	return (error);
@@ -162,7 +162,7 @@ freebsd64_clock_gettime(struct thread *td,
 
 	error = kern_clock_gettime(td, uap->clock_id, &ats);
 	if (error == 0)
-		error = copyout(&ats, __USER_CAP_OBJ(uap->tp), sizeof(ats));
+		error = copyout(&ats, USER_PTR_OBJ(uap->tp), sizeof(ats));
 
 	return (error);
 }
@@ -174,7 +174,7 @@ freebsd64_clock_settime(struct thread *td,
 	struct timespec ats;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->tp), &ats, sizeof(ats));
+	error = copyin(USER_PTR_OBJ(uap->tp), &ats, sizeof(ats));
 	if (error != 0)
 		return (error);
 
@@ -193,7 +193,7 @@ freebsd64_clock_getres(struct thread *td,
 
 	error = kern_clock_getres(td, uap->clock_id, &ats);
 	if (error == 0)
-		error = copyout(&ats, __USER_CAP_OBJ(uap->tp), sizeof(ats));
+		error = copyout(&ats, USER_PTR_OBJ(uap->tp), sizeof(ats));
 	
 	return (error);
 }
@@ -202,7 +202,7 @@ int
 freebsd64_nanosleep(struct thread *td, struct freebsd64_nanosleep_args *uap)
 {
 	return (user_clock_nanosleep(td, CLOCK_REALTIME, TIMER_RELTIME,
-	    __USER_CAP_OBJ(uap->rqtp), __USER_CAP_OBJ(uap->rmtp)));
+	    USER_PTR_OBJ(uap->rqtp), USER_PTR_OBJ(uap->rmtp)));
 }
 
 int
@@ -212,7 +212,7 @@ freebsd64_clock_nanosleep(struct thread *td,
 	int error;
 
 	error = user_clock_nanosleep(td, uap->clock_id, uap->flags,
-	    __USER_CAP_OBJ(uap->rqtp), __USER_CAP_OBJ(uap->rmtp));
+	    USER_PTR_OBJ(uap->rqtp), USER_PTR_OBJ(uap->rmtp));
 	return (kern_posix_error(td, error));
 }
 
@@ -220,16 +220,16 @@ int
 freebsd64_gettimeofday(struct thread *td,
     struct freebsd64_gettimeofday_args *uap)
 {
-	return (kern_gettimeofday(td, __USER_CAP_OBJ(uap->tp),
-	     __USER_CAP_OBJ(uap->tzp)));
+	return (kern_gettimeofday(td, USER_PTR_OBJ(uap->tp),
+	     USER_PTR_OBJ(uap->tzp)));
 }
 
 int
 freebsd64_settimeofday(struct thread *td,
     struct freebsd64_settimeofday_args *uap)
 {
-	return (user_settimeofday(td, __USER_CAP_OBJ(uap->tv),
-	    __USER_CAP_OBJ(uap->tzp)));
+	return (user_settimeofday(td, USER_PTR_OBJ(uap->tv),
+	    USER_PTR_OBJ(uap->tzp)));
 }
 
 int
@@ -241,7 +241,7 @@ freebsd64_getitimer(struct thread *td, struct freebsd64_getitimer_args *uap)
 	error = kern_getitimer(td, uap->which, &aitv);
 	if (error != 0)
 		return (error);
-	return (copyout(&aitv, __USER_CAP_OBJ(uap->itv),
+	return (copyout(&aitv, USER_PTR_OBJ(uap->itv),
 	    sizeof(struct itimerval)));
 }
 
@@ -255,18 +255,18 @@ freebsd64_setitimer(struct thread *td, struct freebsd64_setitimer_args *uap)
 		error = kern_getitimer(td, uap->which, &aitv);
 		if (error != 0)
 			return (error);
-		return (copyout(&aitv, __USER_CAP_OBJ(uap->oitv),
+		return (copyout(&aitv, USER_PTR_OBJ(uap->oitv),
 		    sizeof(struct itimerval)));
 	}
 
-	error = copyin(__USER_CAP_OBJ(uap->itv), &aitv,
+	error = copyin(USER_PTR_OBJ(uap->itv), &aitv,
 	    sizeof(struct itimerval));
 	if (error != 0)
 		return (error);
 	error = kern_setitimer(td, uap->which, &aitv, &oitv);
 	if (error != 0 || uap->oitv == NULL)
 		return (error);
-	return (copyout(&oitv, __USER_CAP_OBJ(uap->oitv),
+	return (copyout(&oitv, USER_PTR_OBJ(uap->oitv),
 	    sizeof(struct itimerval)));
 }
 
@@ -281,7 +281,7 @@ freebsd64_ktimer_create(struct thread *td,
 	if (uap->evp == NULL) {
 		evp = NULL;
 	} else {
-		error = copyin(__USER_CAP_OBJ(uap->evp), &ev64, sizeof(ev64));
+		error = copyin(USER_PTR_OBJ(uap->evp), &ev64, sizeof(ev64));
 		if (error != 0)
 			return (error);
 		error = convert_sigevent64(&ev64, &ev);
@@ -292,7 +292,7 @@ freebsd64_ktimer_create(struct thread *td,
 	error = kern_ktimer_create(td, uap->clock_id, evp, &id, -1);
 	if (error != 0)
 		return (error);
-	error = copyout(&id, __USER_CAP_OBJ(uap->timerid), sizeof(int));
+	error = copyout(&id, USER_PTR_OBJ(uap->timerid), sizeof(int));
 	if (error != 0)
 		kern_ktimer_delete(td, id);
 	return (error);
@@ -305,13 +305,13 @@ freebsd64_ktimer_settime(struct thread *td,
 	struct itimerspec val, oval, *ovalp;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->value), &val, sizeof(val));
+	error = copyin(USER_PTR_OBJ(uap->value), &val, sizeof(val));
 	if (error != 0)
 		return (error);
 	ovalp = uap->ovalue != NULL ? &oval : NULL;
 	error = kern_ktimer_settime(td, uap->timerid, uap->flags, &val, ovalp);
 	if (error == 0 && uap->ovalue != NULL)
-		error = copyout(ovalp, __USER_CAP_OBJ(uap->ovalue),
+		error = copyout(ovalp, USER_PTR_OBJ(uap->ovalue),
 		    sizeof(*ovalp));
 	return (error);
 }
@@ -325,7 +325,7 @@ freebsd64_ktimer_gettime(struct thread *td,
 
 	error = kern_ktimer_gettime(td, uap->timerid, &val);
 	if (error == 0)
-		error = copyout(&val, __USER_CAP_OBJ(uap->value), sizeof(val));
+		error = copyout(&val, USER_PTR_OBJ(uap->value), sizeof(val));
 	return (error);
 }
 
@@ -338,7 +338,7 @@ freebsd64_timerfd_gettime(struct thread *td,
 
 	error = kern_timerfd_gettime(td, uap->fd, &curr_value);
 	if (error == 0)
-		error = copyout(&curr_value, __USER_CAP_OBJ(uap->curr_value),
+		error = copyout(&curr_value, USER_PTR_OBJ(uap->curr_value),
 		    sizeof(curr_value));
 
 	return (error);
@@ -351,7 +351,7 @@ freebsd64_timerfd_settime(struct thread *td,
 	struct itimerspec new_value, old_value;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->new_value), &new_value,
+	error = copyin(USER_PTR_OBJ(uap->new_value), &new_value,
 	    sizeof(new_value));
 	if (error != 0)
 		return (error);
@@ -363,7 +363,7 @@ freebsd64_timerfd_settime(struct thread *td,
 		    &new_value, &old_value);
 		if (error == 0)
 			error = copyout(&old_value,
-			    __USER_CAP_OBJ(uap->old_value), sizeof(old_value));
+			    USER_PTR_OBJ(uap->old_value), sizeof(old_value));
 	}
 	return (error);
 }

--- a/sys/compat/freebsd64/freebsd64_time.c
+++ b/sys/compat/freebsd64/freebsd64_time.c
@@ -41,6 +41,7 @@
 #include <sys/timeffc.h>
 #include <sys/timex.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 
 /*

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -50,7 +50,7 @@
 int
 freebsd64_bind(struct thread *td, struct freebsd64_bind_args *uap)
 {
-	return (user_bind(td, uap->s, __USER_CAP(uap->name, uap->namelen),
+	return (user_bind(td, uap->s, USER_PTR(uap->name, uap->namelen),
 	    uap->namelen));
 }
 
@@ -58,49 +58,49 @@ int
 freebsd64_bindat(struct thread *td, struct freebsd64_bindat_args *uap)
 {
 	return (user_bindat(td, uap->fd, uap->s,
-	    __USER_CAP(uap->name, uap->namelen), uap->namelen));
+	    USER_PTR(uap->name, uap->namelen), uap->namelen));
 }
 
 int
 freebsd64_accept(struct thread *td, struct freebsd64_accept_args *uap)
 {
-	return (user_accept(td, uap->s, __USER_CAP_UNBOUND(uap->name),
-	    __USER_CAP_OBJ(uap->anamelen), ACCEPT4_INHERIT));
+	return (user_accept(td, uap->s, USER_PTR_UNBOUND(uap->name),
+	    USER_PTR_OBJ(uap->anamelen), ACCEPT4_INHERIT));
 }
 
 int
 freebsd64_accept4(struct thread *td, struct freebsd64_accept4_args *uap)
 {
-	return (user_accept(td, uap->s, __USER_CAP_UNBOUND(uap->name),
-	    __USER_CAP_OBJ(uap->anamelen), uap->flags));
+	return (user_accept(td, uap->s, USER_PTR_UNBOUND(uap->name),
+	    USER_PTR_OBJ(uap->anamelen), uap->flags));
 }
 
 int
 freebsd64_connect(struct thread *td, struct freebsd64_connect_args *uap)
 {
 	return (user_connectat(td, AT_FDCWD, uap->s,
-	    __USER_CAP(uap->name, uap->namelen), uap->namelen));
+	    USER_PTR(uap->name, uap->namelen), uap->namelen));
 }
 
 int
 freebsd64_connectat(struct thread *td, struct freebsd64_connectat_args *uap)
 {
 	return (user_connectat(td, uap->fd, uap->s,
-	    __USER_CAP(uap->name, uap->namelen), uap->namelen));
+	    USER_PTR(uap->name, uap->namelen), uap->namelen));
 }
 
 int
 freebsd64_socketpair(struct thread *td, struct freebsd64_socketpair_args *uap)
 {
 	return (user_socketpair(td, uap->domain, uap->type, uap->protocol,
-	    __USER_CAP_ARRAY(uap->rsv, 2)));
+	    USER_PTR_ARRAY(uap->rsv, 2)));
 }
 
 int
 freebsd64_sendto(struct thread *td, struct freebsd64_sendto_args *uap)
 {
-	return (user_sendto(td, uap->s, __USER_CAP(uap->buf, uap->len),
-	    uap->len, uap->flags, __USER_CAP(uap->to, uap->tolen),
+	return (user_sendto(td, uap->s, USER_PTR(uap->buf, uap->len),
+	    uap->len, uap->flags, USER_PTR(uap->to, uap->tolen),
 	    uap->tolen));
 }
 
@@ -114,12 +114,12 @@ freebsd64_copyinmsghdr(struct msghdr64 * __capability umsg, struct msghdr *msg,
 	error = copyin(umsg, m64, sizeof(*m64));
 	if (error)
 		return (error);
-	msg->msg_name = __USER_CAP(m64->msg_name, m64->msg_namelen);
+	msg->msg_name = USER_PTR(m64->msg_name, m64->msg_namelen);
 	msg->msg_namelen = m64->msg_namelen;
 
 	msg->msg_iov = NULL;
 	error = freebsd64_copyiniov(
-	    (struct iovec *__capability)__USER_CAP_ARRAY(
+	    (struct iovec *__capability)USER_PTR_ARRAY(
 		(struct iovec64 *)(uintptr_t)m64->msg_iov, m64->msg_iovlen),
 	    m64->msg_iovlen, &iov, EMSGSIZE);
 	if (error)
@@ -127,7 +127,7 @@ freebsd64_copyinmsghdr(struct msghdr64 * __capability umsg, struct msghdr *msg,
 	msg->msg_iov = PTR2CAP(iov);
 	msg->msg_iovlen = m64->msg_iovlen;
 
-	msg->msg_control = __USER_CAP(m64->msg_control, m64->msg_controllen);
+	msg->msg_control = USER_PTR(m64->msg_control, m64->msg_controllen);
 	msg->msg_controllen = m64->msg_controllen;
 	msg->msg_flags = m64->msg_flags;
 	return (0);
@@ -343,7 +343,7 @@ freebsd64_sendmsg(struct thread *td, struct freebsd64_sendmsg_args *uap)
 	struct sockaddr *to = NULL;
 	int error;
 
-	error = freebsd64_copyinmsghdr(__USER_CAP_OBJ(uap->msg), &msg, &umsg64);
+	error = freebsd64_copyinmsghdr(USER_PTR_OBJ(uap->msg), &msg, &umsg64);
 	if (error)
 		return (error);
 
@@ -386,9 +386,9 @@ out:
 int
 freebsd64_recvfrom(struct thread *td, struct freebsd64_recvfrom_args *uap)
 {
-	return (kern_recvfrom(td, uap->s, __USER_CAP(uap->buf, uap->len),
-	    uap->len, uap->flags, __USER_CAP_UNBOUND(uap->from),
-	    __USER_CAP_OBJ(uap->fromlenaddr)));
+	return (kern_recvfrom(td, uap->s, USER_PTR(uap->buf, uap->len),
+	    uap->len, uap->flags, USER_PTR_UNBOUND(uap->from),
+	    USER_PTR_OBJ(uap->fromlenaddr)));
 }
 
 int
@@ -399,7 +399,7 @@ freebsd64_recvmsg(struct thread *td, struct freebsd64_recvmsg_args *uap)
 	struct mbuf *control = NULL;
 	struct mbuf **controlp;
 	int error;
-	struct msghdr64 * __capability umsg = __USER_CAP_OBJ(uap->msg);
+	struct msghdr64 * __capability umsg = USER_PTR_OBJ(uap->msg);
 
 	error = freebsd64_copyinmsghdr(umsg, &msg, &umsg64);
 	if (error != 0)
@@ -432,28 +432,28 @@ int
 freebsd64_setsockopt(struct thread *td, struct freebsd64_setsockopt_args *uap)
 {
 	return (kern_setsockopt(td, uap->s, uap->level, uap->name,
-	    __USER_CAP(uap->val, uap->valsize), UIO_USERSPACE, uap->valsize));
+	    USER_PTR(uap->val, uap->valsize), UIO_USERSPACE, uap->valsize));
 }
 
 int
 freebsd64_getsockopt(struct thread *td, struct freebsd64_getsockopt_args *uap)
 {
 	return (user_getsockopt(td, uap->s, uap->level, uap->name,
-	    __USER_CAP_UNBOUND(uap->val), __USER_CAP_OBJ(uap->avalsize)));
+	    USER_PTR_UNBOUND(uap->val), USER_PTR_OBJ(uap->avalsize)));
 }
 
 int
 freebsd64_getsockname(struct thread *td, struct freebsd64_getsockname_args *uap)
 {
-	return (user_getsockname(td, uap->fdes, __USER_CAP_UNBOUND(uap->asa),
-	    __USER_CAP_OBJ(uap->alen), false));
+	return (user_getsockname(td, uap->fdes, USER_PTR_UNBOUND(uap->asa),
+	    USER_PTR_OBJ(uap->alen), false));
 }
 
 int
 freebsd64_getpeername(struct thread *td, struct freebsd64_getpeername_args *uap)
 {
-	return (user_getpeername(td, uap->fdes, __USER_CAP_UNBOUND(uap->asa),
-	    __USER_CAP_OBJ(uap->alen), false));
+	return (user_getpeername(td, uap->fdes, USER_PTR_UNBOUND(uap->asa),
+	    USER_PTR_OBJ(uap->alen), false));
 }
 
 /*
@@ -465,7 +465,7 @@ int
 freebsd12_freebsd64_shm_open(struct thread *td,
     struct freebsd12_freebsd64_shm_open_args *uap)
 {
-	return (kern_shm_open(td, __USER_CAP_STR(uap->path),
+	return (kern_shm_open(td, USER_PTR_STR(uap->path),
 	    uap->flags | O_CLOEXEC, uap->mode, NULL));
 }
 #endif
@@ -473,21 +473,21 @@ freebsd12_freebsd64_shm_open(struct thread *td,
 int
 freebsd64_shm_open2(struct thread *td, struct freebsd64_shm_open2_args *uap)
 {
-	return (kern_shm_open2(td, __USER_CAP_STR(uap->path), uap->flags,
-	    uap->mode, uap->shmflags, NULL, __USER_CAP_STR(uap->name)));
+	return (kern_shm_open2(td, USER_PTR_STR(uap->path), uap->flags,
+	    uap->mode, uap->shmflags, NULL, USER_PTR_STR(uap->name)));
 }
 
 int
 freebsd64_shm_unlink(struct thread *td, struct freebsd64_shm_unlink_args *uap)
 {
-	return (kern_shm_unlink(td, __USER_CAP_STR(uap->path)));
+	return (kern_shm_unlink(td, USER_PTR_STR(uap->path)));
 }
 
 int
 freebsd64_shm_rename(struct thread *td, struct freebsd64_shm_rename_args *uap)
 {
-	return (kern_shm_rename(td, __USER_CAP_STR(uap->path_from),
-	    __USER_CAP_STR(uap->path_to), uap->flags));
+	return (kern_shm_rename(td, USER_PTR_STR(uap->path_from),
+	    USER_PTR_STR(uap->path_to), uap->flags));
 }
 /*
  * CHERI CHANGES START

--- a/sys/compat/freebsd64/freebsd64_uipc.c
+++ b/sys/compat/freebsd64/freebsd64_uipc.c
@@ -465,7 +465,7 @@ int
 freebsd12_freebsd64_shm_open(struct thread *td,
     struct freebsd12_freebsd64_shm_open_args *uap)
 {
-	return (kern_shm_open(td, USER_PTR_STR(uap->path),
+	return (kern_shm_open(td, USER_PTR_PATH(uap->path),
 	    uap->flags | O_CLOEXEC, uap->mode, NULL));
 }
 #endif
@@ -473,21 +473,21 @@ freebsd12_freebsd64_shm_open(struct thread *td,
 int
 freebsd64_shm_open2(struct thread *td, struct freebsd64_shm_open2_args *uap)
 {
-	return (kern_shm_open2(td, USER_PTR_STR(uap->path), uap->flags,
+	return (kern_shm_open2(td, USER_PTR_PATH(uap->path), uap->flags,
 	    uap->mode, uap->shmflags, NULL, USER_PTR_STR(uap->name)));
 }
 
 int
 freebsd64_shm_unlink(struct thread *td, struct freebsd64_shm_unlink_args *uap)
 {
-	return (kern_shm_unlink(td, USER_PTR_STR(uap->path)));
+	return (kern_shm_unlink(td, USER_PTR_PATH(uap->path)));
 }
 
 int
 freebsd64_shm_rename(struct thread *td, struct freebsd64_shm_rename_args *uap)
 {
-	return (kern_shm_rename(td, USER_PTR_STR(uap->path_from),
-	    USER_PTR_STR(uap->path_to), uap->flags));
+	return (kern_shm_rename(td, USER_PTR_PATH(uap->path_from),
+	    USER_PTR_PATH(uap->path_to), uap->flags));
 }
 /*
  * CHERI CHANGES START

--- a/sys/compat/freebsd64/freebsd64_vfs.c
+++ b/sys/compat/freebsd64/freebsd64_vfs.c
@@ -40,6 +40,7 @@
 #include <sys/stat.h>
 #include <sys/syscallsubr.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 
 #if defined(COMPAT_FREEBSD11)

--- a/sys/compat/freebsd64/freebsd64_vfs.c
+++ b/sys/compat/freebsd64/freebsd64_vfs.c
@@ -211,13 +211,13 @@ freebsd11_freebsd64_stat(struct thread *td,
 	struct freebsd11_stat64 osb;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	error = freebsd11_freebsd64_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->ub), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->ub), sizeof(osb));
 	return (error);
 }
 
@@ -235,7 +235,7 @@ freebsd11_freebsd64_nfstat(struct thread *td,
 	error = kern_fstat(td, uap->fd, &ub);
 	if (error == 0) {
 		freebsd11_freebsd64_cvtnstat(&ub, &nub);
-		error = copyout(&nub, __USER_CAP_OBJ(uap->sb), sizeof(nub));
+		error = copyout(&nub, USER_PTR_OBJ(uap->sb), sizeof(nub));
 	}
 	return (error);
 }
@@ -248,32 +248,32 @@ int
 freebsd64___acl_get_file(struct thread *td,
     struct freebsd64___acl_get_file_args *uap)
 {
-	return (kern___acl_get_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), FOLLOW));
+	return (kern___acl_get_path(td, USER_PTR_STR(uap->path), uap->type,
+	    USER_PTR_OBJ(uap->aclp), FOLLOW));
 }
 
 int
 freebsd64___acl_get_link(struct thread *td,
     struct freebsd64___acl_get_link_args *uap)
 {
-	return (kern___acl_get_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), NOFOLLOW));
+	return (kern___acl_get_path(td, USER_PTR_STR(uap->path), uap->type,
+	    USER_PTR_OBJ(uap->aclp), NOFOLLOW));
 }
 
 int
 freebsd64___acl_set_file(struct thread *td,
     struct freebsd64___acl_set_file_args *uap)
 {
-	return(kern___acl_set_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), FOLLOW));
+	return(kern___acl_set_path(td, USER_PTR_STR(uap->path), uap->type,
+	    USER_PTR_OBJ(uap->aclp), FOLLOW));
 }
 
 int
 freebsd64___acl_set_link(struct thread *td,
     struct freebsd64___acl_set_link_args *uap)
 {
-	return(kern___acl_set_path(td, __USER_CAP_STR(uap->path), uap->type,
-	    __USER_CAP_OBJ(uap->aclp), NOFOLLOW));
+	return(kern___acl_set_path(td, USER_PTR_STR(uap->path), uap->type,
+	    USER_PTR_OBJ(uap->aclp), NOFOLLOW));
 }
 
 int
@@ -281,7 +281,7 @@ freebsd64___acl_get_fd(struct thread *td,
     struct freebsd64___acl_get_fd_args *uap)
 {
 	return (kern___acl_get_fd(td, uap->filedes, uap->type,
-	    __USER_CAP_OBJ(uap->aclp)));
+	    USER_PTR_OBJ(uap->aclp)));
 }
 
 int
@@ -289,14 +289,14 @@ freebsd64___acl_set_fd(struct thread *td,
     struct freebsd64___acl_set_fd_args *uap)
 {
 	return (kern___acl_set_fd(td, uap->filedes, uap->type,
-	    __USER_CAP_OBJ(uap->aclp)));
+	    USER_PTR_OBJ(uap->aclp)));
 }
 
 int
 freebsd64___acl_delete_file(struct thread *td,
     struct freebsd64___acl_delete_file_args *uap)
 {
-	return (kern___acl_delete_path(td, __USER_CAP_STR(uap->path),
+	return (kern___acl_delete_path(td, USER_PTR_STR(uap->path),
 	    uap->type, FOLLOW));
 }
 
@@ -304,7 +304,7 @@ int
 freebsd64___acl_delete_link(struct thread *td,
     struct freebsd64___acl_delete_link_args *uap)
 {
-	return (kern___acl_delete_path(td, __USER_CAP_STR(uap->path),
+	return (kern___acl_delete_path(td, USER_PTR_STR(uap->path),
 	    uap->type, NOFOLLOW));
 }
 
@@ -312,16 +312,16 @@ int
 freebsd64___acl_aclcheck_file(struct thread *td,
     struct freebsd64___acl_aclcheck_file_args *uap)
 {
-	return (kern___acl_aclcheck_path(td, __USER_CAP_STR(uap->path),
-	    uap->type, __USER_CAP_OBJ(uap->aclp), FOLLOW));
+	return (kern___acl_aclcheck_path(td, USER_PTR_STR(uap->path),
+	    uap->type, USER_PTR_OBJ(uap->aclp), FOLLOW));
 }
 
 int
 freebsd64___acl_aclcheck_link(struct thread *td,
     struct freebsd64___acl_aclcheck_link_args *uap)
 {
-	return (kern___acl_aclcheck_path(td, __USER_CAP_STR(uap->path),
-	    uap->type, __USER_CAP_OBJ(uap->aclp), NOFOLLOW));
+	return (kern___acl_aclcheck_path(td, USER_PTR_STR(uap->path),
+	    uap->type, USER_PTR_OBJ(uap->aclp), NOFOLLOW));
 }
 
 int
@@ -329,7 +329,7 @@ freebsd64___acl_aclcheck_fd(struct thread *td,
     struct freebsd64___acl_aclcheck_fd_args *uap)
 {
 	return (kern___acl_aclcheck_fd(td, uap->filedes, uap->type,
-	    __USER_CAP_OBJ(uap->aclp)));
+	    USER_PTR_OBJ(uap->aclp)));
 }
 
 /*
@@ -338,7 +338,7 @@ freebsd64___acl_aclcheck_fd(struct thread *td,
 int
 freebsd64___getcwd(struct thread *td, struct freebsd64___getcwd_args *uap)
 {
-	return (kern___getcwd(td, __USER_CAP(uap->buf, uap->buflen),
+	return (kern___getcwd(td, USER_PTR(uap->buf, uap->buflen),
 	    uap->buflen));
 }
 
@@ -346,8 +346,8 @@ int
 freebsd64___realpathat(struct thread *td,
     struct freebsd64___realpathat_args *uap)
 {
-	return (kern___realpathat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    __USER_CAP(uap->buf, uap->size), uap->size, uap->flags,
+	return (kern___realpathat(td, uap->fd, USER_PTR_STR(uap->path),
+	    USER_PTR(uap->buf, uap->size), uap->size, uap->flags,
 	    UIO_USERSPACE));
 }
 
@@ -357,9 +357,9 @@ freebsd64___realpathat(struct thread *td,
 int
 freebsd64_extattrctl(struct thread *td, struct freebsd64_extattrctl_args *uap)
 {
-	return (kern_extattrctl(td, __USER_CAP_STR(uap->path), uap->cmd,
-	    __USER_CAP_STR(uap->filename), uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname)));
+	return (kern_extattrctl(td, USER_PTR_STR(uap->path), uap->cmd,
+	    USER_PTR_STR(uap->filename), uap->attrnamespace,
+	    USER_PTR_STR(uap->attrname)));
 }
 
 int
@@ -367,7 +367,7 @@ freebsd64_extattr_set_fd(struct thread *td,
     struct freebsd64_extattr_set_fd_args *uap)
 {
 	return (user_extattr_set_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname), __USER_CAP(uap->data, uap->nbytes),
+	    USER_PTR_STR(uap->attrname), USER_PTR(uap->data, uap->nbytes),
 	    uap->nbytes));
 }
 
@@ -375,18 +375,18 @@ int
 freebsd64_extattr_set_file(struct thread *td,
     struct freebsd64_extattr_set_file_args *uap)
 {
-	return (user_extattr_set_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
+	return (user_extattr_set_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
+	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
 }
 
 int
 freebsd64_extattr_set_link(struct thread *td,
     struct freebsd64_extattr_set_link_args *uap)
 {
-	return (user_extattr_set_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
+	return (user_extattr_set_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
+	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
 }
 
 int
@@ -394,26 +394,26 @@ freebsd64_extattr_get_fd(struct thread *td,
     struct freebsd64_extattr_get_fd_args *uap)
 {
 	return (user_extattr_get_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes));
+	    USER_PTR_STR(uap->attrname),
+	    USER_PTR(uap->data, uap->nbytes), uap->nbytes));
 }
 
 int
 freebsd64_extattr_get_file(struct thread *td,
     struct freebsd64_extattr_get_file_args *uap)
 {
-	return (user_extattr_get_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
+	return (user_extattr_get_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
+	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
 }
 
 int
 freebsd64_extattr_get_link(struct thread *td,
     struct freebsd64_extattr_get_link_args *uap)
 {
-	return (user_extattr_get_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname),
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
+	return (user_extattr_get_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
+	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
 }
 
 int
@@ -421,23 +421,23 @@ freebsd64_extattr_delete_fd(struct thread *td,
     struct freebsd64_extattr_delete_fd_args *uap)
 {
 	return (user_extattr_delete_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP_STR(uap->attrname)));
+	    USER_PTR_STR(uap->attrname)));
 }
 
 int
 freebsd64_extattr_delete_file(struct thread *td,
     struct freebsd64_extattr_delete_file_args *uap)
 {
-	return (user_extattr_delete_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname), FOLLOW));
+	return (user_extattr_delete_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR_STR(uap->attrname), FOLLOW));
 }
 
 int
 freebsd64_extattr_delete_link(struct thread *td,
     struct freebsd64_extattr_delete_link_args *uap)
 {
-	return (user_extattr_delete_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP_STR(uap->attrname), NOFOLLOW));
+	return (user_extattr_delete_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR_STR(uap->attrname), NOFOLLOW));
 }
 
 int
@@ -445,15 +445,15 @@ freebsd64_extattr_list_fd(struct thread *td,
     struct freebsd64_extattr_list_fd_args *uap)
 {
 	return (user_extattr_list_fd(td, uap->fd, uap->attrnamespace,
-	    __USER_CAP(uap->data, uap->nbytes), uap->nbytes));
+	    USER_PTR(uap->data, uap->nbytes), uap->nbytes));
 }
 
 int
 freebsd64_extattr_list_file(struct thread *td,
     struct freebsd64_extattr_list_file_args *uap)
 {
-	return (user_extattr_list_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP(uap->data, uap->nbytes),
+	return (user_extattr_list_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR(uap->data, uap->nbytes),
 	    uap->nbytes, FOLLOW));
 }
 
@@ -461,8 +461,8 @@ int
 freebsd64_extattr_list_link(struct thread *td,
     struct freebsd64_extattr_list_link_args *uap)
 {
-	return (user_extattr_list_path(td, __USER_CAP_STR(uap->path),
-	    uap->attrnamespace, __USER_CAP(uap->data, uap->nbytes),
+	return (user_extattr_list_path(td, USER_PTR_STR(uap->path),
+	    uap->attrnamespace, USER_PTR(uap->data, uap->nbytes),
 	    uap->nbytes, NOFOLLOW));
 }
 
@@ -480,12 +480,12 @@ freebsd11_freebsd64_lstat(struct thread *td,
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	error = freebsd11_freebsd64_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->ub), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->ub), sizeof(osb));
 	return (error);
 }
 
@@ -498,7 +498,7 @@ freebsd11_freebsd64_fhstat(struct thread *td,
 	struct freebsd11_stat64 osb;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
+	error = copyin(USER_PTR_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
 	if (error != 0)
 		return (error);
 	error = kern_fhstat(td, fh, &sb);
@@ -506,7 +506,7 @@ freebsd11_freebsd64_fhstat(struct thread *td,
 		return (error);
 	error = freebsd11_freebsd64_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->sb), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->sb), sizeof(osb));
 	return (error);
 }
 
@@ -518,13 +518,13 @@ freebsd11_freebsd64_fstatat(struct thread *td,
 	struct freebsd11_stat64 osb;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	error = freebsd11_freebsd64_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->buf), sizeof(osb));
 	return (error);
 }
 
@@ -541,7 +541,7 @@ freebsd11_freebsd64_fstat(struct thread *td,
 		return (error);
 	error = freebsd11_freebsd64_cvtstat(&sb, &osb);
 	if (error == 0)
-		error = copyout(&osb, __USER_CAP_OBJ(uap->sb), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->sb), sizeof(osb));
 	return (error);
 }
 
@@ -578,12 +578,12 @@ freebsd11_freebsd64_nstat(struct thread *td,
 	struct nstat64 nsb;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, __USER_CAP_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	freebsd11_freebsd64_cvtnstat(&sb, &nsb);
-	return (copyout(&nsb, __USER_CAP_OBJ(uap->ub), sizeof (nsb)));
+	return (copyout(&nsb, USER_PTR_OBJ(uap->ub), sizeof (nsb)));
 }
 
 /*
@@ -598,11 +598,11 @@ freebsd11_freebsd64_nlstat(struct thread *td,
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	freebsd11_freebsd64_cvtnstat(&sb, &nsb);
-	return (copyout(&nsb, __USER_CAP_OBJ(uap->ub), sizeof (nsb)));
+	return (copyout(&nsb, USER_PTR_OBJ(uap->ub), sizeof (nsb)));
 }
 
 int
@@ -613,10 +613,10 @@ freebsd11_freebsd64_getdirentries(struct thread *td,
 	int error;
 
 	error = freebsd11_kern_getdirentries(td, uap->fd,
-	    __USER_CAP(uap->buf, uap->count), uap->count, &base, NULL);
+	    USER_PTR(uap->buf, uap->count), uap->count, &base, NULL);
 
 	if (error == 0 && uap->basep != NULL)
-		error = copyout(&base, __USER_CAP(uap->basep, sizeof(long)),
+		error = copyout(&base, USER_PTR(uap->basep, sizeof(long)),
 		    sizeof(long));
 	return (error);
 }
@@ -638,27 +638,27 @@ freebsd11_freebsd64_getdents(struct thread *td,
 int
 freebsd64_quotactl(struct thread *td, struct freebsd64_quotactl_args *uap)
 {
-	return (kern_quotactl(td, __USER_CAP_STR(uap->path),
-	    uap->cmd, uap->uid, __USER_CAP_UNBOUND(uap->arg)));
+	return (kern_quotactl(td, USER_PTR_STR(uap->path),
+	    uap->cmd, uap->uid, USER_PTR_UNBOUND(uap->arg)));
 }
 
 int
 freebsd64_statfs(struct thread *td, struct freebsd64_statfs_args *uap)
 {
-	return (user_statfs(td, __USER_CAP_STR(uap->path),
-	    __USER_CAP_OBJ(uap->buf)));
+	return (user_statfs(td, USER_PTR_STR(uap->path),
+	    USER_PTR_OBJ(uap->buf)));
 }
 
 int
 freebsd64_fstatfs(struct thread *td, struct freebsd64_fstatfs_args *uap)
 {
-	return (user_fstatfs(td, uap->fd, __USER_CAP_OBJ(uap->buf)));
+	return (user_fstatfs(td, uap->fd, USER_PTR_OBJ(uap->buf)));
 }
 
 int
 freebsd64_getfsstat(struct thread *td, struct freebsd64_getfsstat_args *uap)
 {
-	return (user_getfsstat(td, __USER_CAP(uap->buf, uap->bufsize),
+	return (user_getfsstat(td, USER_PTR(uap->buf, uap->bufsize),
 	    uap->bufsize, uap->mode));
 }
 
@@ -678,10 +678,10 @@ freebsd11_freebsd64_statfs(struct thread *td,
 	int error;
 
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, __USER_CAP_STR(uap->path), UIO_USERSPACE, sfp);
+	error = kern_statfs(td, USER_PTR_STR(uap->path), UIO_USERSPACE, sfp);
 	if (error == 0) {
 		freebsd11_freebsd64_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->buf), sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -702,7 +702,7 @@ freebsd11_freebsd64_fstatfs(struct thread *td,
 	error = kern_fstatfs(td, uap->fd, sfp);
 	if (error == 0) {
 		freebsd11_freebsd64_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->buf), sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -731,7 +731,7 @@ freebsd11_freebsd64_getfsstat(struct thread *td,
 		sp = (__cheri_fromcap struct statfs *)buf;
 		while (count > 0 && error == 0) {
 			freebsd11_freebsd64_cvtstatfs(sp, &osb);
-			error = copyout(&osb, __USER_CAP_OBJ(uap->buf),
+			error = copyout(&osb, USER_PTR_OBJ(uap->buf),
 			    sizeof(osb));
 			sp++;
 			uap->buf++;
@@ -754,14 +754,14 @@ freebsd11_freebsd64_fhstatfs(struct thread *td,
 	fhandle_t fh;
 	int error;
 
-	error = copyin(__USER_CAP_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
+	error = copyin(USER_PTR_OBJ(uap->u_fhp), &fh, sizeof(fhandle_t));
 	if (error)
 		return (error);
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
 	error = kern_fhstatfs(td, fh, sfp);
 	if (error == 0) {
 		freebsd11_freebsd64_cvtstatfs(sfp, &osb);
-		error = copyout(&osb, __USER_CAP_OBJ(uap->buf), sizeof(osb));
+		error = copyout(&osb, USER_PTR_OBJ(uap->buf), sizeof(osb));
 	}
 	free(sfp, M_STATFS);
 	return (error);
@@ -805,26 +805,26 @@ freebsd11_freebsd64_cvtstatfs(struct statfs *nsp,
 int
 freebsd64_chdir(struct thread *td, struct freebsd64_chdir_args *uap)
 {
-	return (kern_chdir(td, __USER_CAP_STR(uap->path), UIO_USERSPACE));
+	return (kern_chdir(td, USER_PTR_STR(uap->path), UIO_USERSPACE));
 }
 
 int
 freebsd64_chroot(struct thread *td, struct freebsd64_chroot_args *uap)
 {
-	return (user_chroot(td, __USER_CAP_STR(uap->path)));
+	return (user_chroot(td, USER_PTR_STR(uap->path)));
 }
 
 int
 freebsd64_open(struct thread *td, struct freebsd64_open_args *uap)
 {
-	return (kern_openat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_openat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->flags, uap->mode));
 }
 
 int
 freebsd64_openat(struct thread *td, struct freebsd64_openat_args *uap)
 {
-	return (kern_openat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_openat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->flag, uap->mode));
 }
 
@@ -832,7 +832,7 @@ freebsd64_openat(struct thread *td, struct freebsd64_openat_args *uap)
 int
 freebsd64_mknodat(struct thread *td, struct freebsd64_mknodat_args *uap)
 {
-	return (kern_mknodat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_mknodat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->dev));
 }
 
@@ -841,7 +841,7 @@ int
 freebsd11_freebsd64_mknod(struct thread *td,
     struct freebsd11_freebsd64_mknod_args *uap)
 {
-	return (kern_mknodat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_mknodat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->dev));
 }
 
@@ -849,7 +849,7 @@ int
 freebsd11_freebsd64_mknodat(struct thread *td,
     struct freebsd11_freebsd64_mknodat_args *uap)
 {
-	return (kern_mknodat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_mknodat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->dev));
 }
 #endif /* COMPAT_FREEBSD11 */
@@ -857,98 +857,98 @@ freebsd11_freebsd64_mknodat(struct thread *td,
 int
 freebsd64_mkfifo(struct thread *td, struct freebsd64_mkfifo_args *uap)
 {
-	return (kern_mkfifoat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_mkfifoat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_mkfifoat(struct thread *td, struct freebsd64_mkfifoat_args *uap)
 {
-	return (kern_mkfifoat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_mkfifoat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_link(struct thread *td, struct freebsd64_link_args *uap)
 {
-	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    __USER_CAP_STR(uap->to), UIO_USERSPACE, AT_SYMLINK_FOLLOW));
+	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, USER_PTR_STR(uap->path),
+	    USER_PTR_STR(uap->to), UIO_USERSPACE, AT_SYMLINK_FOLLOW));
 }
 
 int
 freebsd64_linkat(struct thread *td, struct freebsd64_linkat_args *uap)
 {
-	return (kern_linkat(td, uap->fd1, uap->fd2, __USER_CAP_STR(uap->path1),
-	    __USER_CAP_STR(uap->path2), UIO_USERSPACE, uap->flag));
+	return (kern_linkat(td, uap->fd1, uap->fd2, USER_PTR_STR(uap->path1),
+	    USER_PTR_STR(uap->path2), UIO_USERSPACE, uap->flag));
 }
 
 int
 freebsd64_symlink(struct thread *td, struct freebsd64_symlink_args *uap)
 {
-	return (kern_symlinkat(td, __USER_CAP_STR(uap->path), AT_FDCWD,
-	    __USER_CAP_STR(uap->link), UIO_USERSPACE));
+	return (kern_symlinkat(td, USER_PTR_STR(uap->path), AT_FDCWD,
+	    USER_PTR_STR(uap->link), UIO_USERSPACE));
 }
 
 int
 freebsd64_symlinkat(struct thread *td, struct freebsd64_symlinkat_args *uap)
 {
-	return (kern_symlinkat(td, __USER_CAP_STR(uap->path1), uap->fd,
-	    __USER_CAP_STR(uap->path2), UIO_USERSPACE));
+	return (kern_symlinkat(td, USER_PTR_STR(uap->path1), uap->fd,
+	    USER_PTR_STR(uap->path2), UIO_USERSPACE));
 }
 
 int
 freebsd64_undelete(struct thread *td, struct freebsd64_undelete_args *uap)
 {
-	return (kern_undelete(td, __USER_CAP_STR(uap->path), UIO_USERSPACE));
+	return (kern_undelete(td, USER_PTR_STR(uap->path), UIO_USERSPACE));
 }
 
 int
 freebsd64_unlink(struct thread *td, struct freebsd64_unlink_args *uap)
 {
-	return (kern_funlinkat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_funlinkat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    FD_NONE, UIO_USERSPACE, 0, 0));
 }
 
 int
 freebsd64_unlinkat(struct thread *td, struct freebsd64_unlinkat_args *uap)
 {
-	return (kern_funlinkat_ex(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_funlinkat_ex(td, uap->fd, USER_PTR_STR(uap->path),
 	    FD_NONE, uap->flag, UIO_USERSPACE, 0));
 }
 
 int
 freebsd64_funlinkat(struct thread *td, struct freebsd64_funlinkat_args *uap)
 {
-	return (kern_funlinkat_ex(td, uap->dfd, __USER_CAP_STR(uap->path),
+	return (kern_funlinkat_ex(td, uap->dfd, USER_PTR_STR(uap->path),
 	    uap->fd, uap->flag, UIO_USERSPACE, 0));
 }
 
 int
 freebsd64_access(struct thread *td, struct freebsd64_access_args *uap)
 {
-	return (kern_accessat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_accessat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, 0, uap->amode));
 }
 
 int
 freebsd64_faccessat(struct thread *td, struct freebsd64_faccessat_args *uap)
 {
-	return (kern_accessat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_accessat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->flag, uap->amode));
 }
 
 int
 freebsd64_eaccess(struct thread *td, struct freebsd64_eaccess_args *uap)
 {
-	return (kern_accessat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_accessat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, AT_EACCESS, uap->amode));
 }
 
 int
 freebsd64_fstatat(struct thread *td, struct freebsd64_fstatat_args *uap)
 {
-	return (user_fstatat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    __USER_CAP_OBJ(uap->buf), uap->flag));
+	return (user_fstatat(td, uap->fd, USER_PTR_STR(uap->path),
+	    USER_PTR_OBJ(uap->buf), uap->flag));
 }
 
 int
@@ -957,7 +957,7 @@ freebsd64_pathconf(struct thread *td, struct freebsd64_pathconf_args *uap)
 	long value;
 	int error;
 
-	error = kern_pathconf(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
+	error = kern_pathconf(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
 	    uap->name, FOLLOW, &value);
 	if (error == 0)
 		td->td_retval[0] = value;
@@ -970,7 +970,7 @@ freebsd64_lpathconf(struct thread *td, struct freebsd64_lpathconf_args *uap)
 	long value;
 	int error;
 
-	error = kern_pathconf(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
+	error = kern_pathconf(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
 	    uap->name, NOFOLLOW, &value);
 	if (error == 0)
 		td->td_retval[0] = value;
@@ -980,100 +980,100 @@ freebsd64_lpathconf(struct thread *td, struct freebsd64_lpathconf_args *uap)
 int
 freebsd64_readlink(struct thread *td, struct freebsd64_readlink_args *uap)
 {
-	return (kern_readlinkat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP(uap->buf, uap->count), UIO_USERSPACE,
+	return (kern_readlinkat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	    UIO_USERSPACE, USER_PTR(uap->buf, uap->count), UIO_USERSPACE,
 	    uap->count));
 }
 
 int
 freebsd64_readlinkat(struct thread *td, struct freebsd64_readlinkat_args *uap)
 {
-	return (kern_readlinkat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP(uap->buf, uap->bufsize), UIO_USERSPACE,
+	return (kern_readlinkat(td, uap->fd, USER_PTR_STR(uap->path),
+	    UIO_USERSPACE, USER_PTR(uap->buf, uap->bufsize), UIO_USERSPACE,
 	    uap->bufsize));
 }
 
 int
 freebsd64_chflags(struct thread *td, struct freebsd64_chflags_args *uap)
 {
-	return (kern_chflagsat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_chflagsat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->flags, 0));
 }
 
 int
 freebsd64_chflagsat(struct thread *td, struct freebsd64_chflagsat_args *uap)
 {
-	return (kern_chflagsat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_chflagsat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->flags, uap->atflag));
 }
 
 int
 freebsd64_lchflags(struct thread *td, struct freebsd64_lchflags_args *uap)
 {
-	return (kern_chflagsat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_chflagsat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->flags, AT_SYMLINK_NOFOLLOW));
 }
 
 int
 freebsd64_chmod(struct thread *td, struct freebsd64_chmod_args *uap)
 {
-	return (kern_fchmodat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_fchmodat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, 0));
 }
 
 int
 freebsd64_fchmodat(struct thread *td, struct freebsd64_fchmodat_args *uap)
 {
-	return (kern_fchmodat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_fchmodat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->flag));
 }
 
 int
 freebsd64_lchmod(struct thread *td, struct freebsd64_lchmod_args *uap)
 {
-	return (kern_fchmodat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_fchmodat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode, AT_SYMLINK_NOFOLLOW));
 }
 
 int
 freebsd64_chown(struct thread *td, struct freebsd64_chown_args *uap)
 {
-	return (kern_fchownat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_fchownat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->uid, uap->gid, 0));
 }
 
 int
 freebsd64_fchownat(struct thread *td, struct freebsd64_fchownat_args *uap)
 {
-	return (kern_fchownat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_fchownat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->uid, uap->gid, uap->flag));
 }
 
 int
 freebsd64_lchown(struct thread *td, struct freebsd64_lchown_args *uap)
 {
-	return (kern_fchownat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_fchownat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->uid, uap->gid, AT_SYMLINK_NOFOLLOW));
 }
 
 int
 freebsd64_utimes(struct thread *td, struct freebsd64_utimes_args *uap)
 {
-	return (kern_utimesat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->tptr), UIO_USERSPACE));
+	return (kern_utimesat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	    UIO_USERSPACE, USER_PTR_OBJ(uap->tptr), UIO_USERSPACE));
 }
 
 int
 freebsd64_futimesat(struct thread *td, struct freebsd64_futimesat_args *uap)
 {
-	return (kern_utimesat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->times), UIO_USERSPACE));
+	return (kern_utimesat(td, uap->fd, USER_PTR_STR(uap->path),
+	    UIO_USERSPACE, USER_PTR_OBJ(uap->times), UIO_USERSPACE));
 }
 
 int
 freebsd64_futimes(struct thread *td, struct freebsd64_futimes_args *uap)
 {
-	return (kern_futimes(td, uap->fd, __USER_CAP_OBJ(uap->tptr),
+	return (kern_futimes(td, uap->fd, USER_PTR_OBJ(uap->tptr),
 	    UIO_USERSPACE));
 }
 
@@ -1081,29 +1081,29 @@ freebsd64_futimes(struct thread *td, struct freebsd64_futimes_args *uap)
 int
 freebsd64_lutimes(struct thread *td, struct freebsd64_lutimes_args *uap)
 {
-	return (kern_lutimes(td, __USER_CAP_OBJ(uap->path), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->tptr), UIO_USERSPACE));
+	return (kern_lutimes(td, USER_PTR_OBJ(uap->path), UIO_USERSPACE,
+	    USER_PTR_OBJ(uap->tptr), UIO_USERSPACE));
 }
 
 int
 freebsd64_futimens(struct thread *td, struct freebsd64_futimens_args *uap)
 {
-	return (kern_futimens(td, uap->fd, __USER_CAP_OBJ(uap->times),
+	return (kern_futimens(td, uap->fd, USER_PTR_OBJ(uap->times),
 	    UIO_USERSPACE));
 }
 
 int
 freebsd64_utimensat(struct thread *td, struct freebsd64_utimensat_args *uap)
 {
-	return (kern_utimensat(td, uap->fd, __USER_CAP_STR(uap->path),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->times), UIO_USERSPACE,
+	return (kern_utimensat(td, uap->fd, USER_PTR_STR(uap->path),
+	    UIO_USERSPACE, USER_PTR_OBJ(uap->times), UIO_USERSPACE,
 	    uap->flag));
 }
 
 int
 freebsd64_truncate(struct thread *td, struct freebsd64_truncate_args *uap)
 {
-	return (kern_truncate(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
+	return (kern_truncate(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
 	    uap->length));
 }
 
@@ -1112,7 +1112,7 @@ freebsd64_truncate(struct thread *td, struct freebsd64_truncate_args *uap)
 int
 freebsd6_truncate(struct thread *td, struct freebsd6_truncate_args *uap)
 {
-	return (kern_truncate(td, __USER_CAP_STR(uap->path), UIO_USERSPACE,
+	return (kern_truncate(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
 	    uap->length));
 }
 #endif
@@ -1120,35 +1120,35 @@ freebsd6_truncate(struct thread *td, struct freebsd6_truncate_args *uap)
 int
 freebsd64_rename(struct thread *td, struct freebsd64_rename_args *uap)
 {
-	return (kern_renameat(td, AT_FDCWD, __USER_CAP_STR(uap->from),
-	    AT_FDCWD, __USER_CAP_STR(uap->to), UIO_USERSPACE));
+	return (kern_renameat(td, AT_FDCWD, USER_PTR_STR(uap->from),
+	    AT_FDCWD, USER_PTR_STR(uap->to), UIO_USERSPACE));
 }
 
 int
 freebsd64_renameat(struct thread *td, struct freebsd64_renameat_args *uap)
 {
-	return (kern_renameat(td, uap->oldfd, __USER_CAP_STR(uap->old),
-	    uap->newfd, __USER_CAP_STR(uap->new), UIO_USERSPACE));
+	return (kern_renameat(td, uap->oldfd, USER_PTR_STR(uap->old),
+	    uap->newfd, USER_PTR_STR(uap->new), UIO_USERSPACE));
 }
 
 int
 freebsd64_mkdir(struct thread *td, struct freebsd64_mkdir_args *uap)
 {
-	return (kern_mkdirat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_mkdirat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_mkdirat(struct thread *td, struct freebsd64_mkdirat_args *uap)
 {
-	return (kern_mkdirat(td, uap->fd, __USER_CAP_STR(uap->path),
+	return (kern_mkdirat(td, uap->fd, USER_PTR_STR(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_rmdir(struct thread *td, struct freebsd64_rmdir_args *uap)
 {
-	return (kern_frmdirat(td, AT_FDCWD, __USER_CAP_STR(uap->path),
+	return (kern_frmdirat(td, AT_FDCWD, USER_PTR_STR(uap->path),
 	    FD_NONE, UIO_USERSPACE, 0));
 }
 
@@ -1157,85 +1157,85 @@ freebsd64_getdirentries(struct thread *td,
     struct freebsd64_getdirentries_args *uap)
 {
 	return (user_getdirentries(td, uap->fd,
-	    __USER_CAP(uap->buf, uap->count), uap->count,
-	    __USER_CAP_OBJ(uap->basep)));
+	    USER_PTR(uap->buf, uap->count), uap->count,
+	    USER_PTR_OBJ(uap->basep)));
 }
 
 int
 freebsd64_unmount(struct thread *td, struct freebsd64_unmount_args *uap)
 {
-	return (kern_unmount(td, __USER_CAP_STR(uap->path), uap->flags));
+	return (kern_unmount(td, USER_PTR_STR(uap->path), uap->flags));
 }
 
 int
 freebsd64_revoke(struct thread *td, struct freebsd64_revoke_args *uap)
 {
-	return (kern_revoke(td, __USER_CAP_STR(uap->path), UIO_USERSPACE));
+	return (kern_revoke(td, USER_PTR_STR(uap->path), UIO_USERSPACE));
 }
 
 int
 freebsd64_lgetfh(struct thread *td, struct freebsd64_lgetfh_args *uap)
 {
 	return (kern_getfhat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->fname), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->fhp), UIO_USERSPACE));
+	    USER_PTR_STR(uap->fname), UIO_USERSPACE,
+	    USER_PTR_OBJ(uap->fhp), UIO_USERSPACE));
 }
 
 int
 freebsd64_getfh(struct thread *td, struct freebsd64_getfh_args *uap)
 {
 	return (kern_getfhat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    __USER_CAP_STR(uap->fname), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->fhp), UIO_USERSPACE));
+	    USER_PTR_STR(uap->fname), UIO_USERSPACE,
+	    USER_PTR_OBJ(uap->fhp), UIO_USERSPACE));
 }
 
 int
 freebsd64_getfhat(struct thread *td, struct freebsd64_getfhat_args *uap)
 {
 	return (kern_getfhat(td, uap->flags, uap->fd,
-	    __USER_CAP_STR(uap->path), UIO_USERSPACE,
-	    __USER_CAP_OBJ(uap->fhp), UIO_USERSPACE));
+	    USER_PTR_STR(uap->path), UIO_USERSPACE,
+	    USER_PTR_OBJ(uap->fhp), UIO_USERSPACE));
 }
 
 int
 freebsd64_fhlink(struct thread *td, struct freebsd64_fhlink_args *uap)
 {
-	return (kern_fhlinkat(td, AT_FDCWD, __USER_CAP_STR(uap->to),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->fhp)));
+	return (kern_fhlinkat(td, AT_FDCWD, USER_PTR_STR(uap->to),
+	    UIO_USERSPACE, USER_PTR_OBJ(uap->fhp)));
 }
 
 int
 freebsd64_fhlinkat(struct thread *td, struct freebsd64_fhlinkat_args *uap)
 {
-	return (kern_fhlinkat(td, uap->tofd, __USER_CAP_STR(uap->to),
-	    UIO_USERSPACE, __USER_CAP_OBJ(uap->fhp)));
+	return (kern_fhlinkat(td, uap->tofd, USER_PTR_STR(uap->to),
+	    UIO_USERSPACE, USER_PTR_OBJ(uap->fhp)));
 }
 
 int
 freebsd64_fhreadlink(struct thread *td, struct freebsd64_fhreadlink_args *uap)
 {
-	return (kern_fhreadlink(td, __USER_CAP_OBJ(uap->fhp),
-	    __USER_CAP(uap->buf, uap->bufsize), uap->bufsize));
+	return (kern_fhreadlink(td, USER_PTR_OBJ(uap->fhp),
+	    USER_PTR(uap->buf, uap->bufsize), uap->bufsize));
 }
 
 int
 freebsd64_fhopen(struct thread *td, struct freebsd64_fhopen_args *uap)
 {
-	return (kern_fhopen(td, __USER_CAP_OBJ(uap->u_fhp), uap->flags));
+	return (kern_fhopen(td, USER_PTR_OBJ(uap->u_fhp), uap->flags));
 }
 
 int
 freebsd64_fhstat(struct thread *td, struct freebsd64_fhstat_args *uap)
 {
-	return (user_fhstat(td, __USER_CAP_OBJ(uap->u_fhp),
-	    __USER_CAP_OBJ(uap->sb)));
+	return (user_fhstat(td, USER_PTR_OBJ(uap->u_fhp),
+	    USER_PTR_OBJ(uap->sb)));
 }
 
 int
 freebsd64_fhstatfs(struct thread *td, struct freebsd64_fhstatfs_args *uap)
 {
-	return (user_fhstatfs(td, __USER_CAP_OBJ(uap->u_fhp),
-	    __USER_CAP_OBJ(uap->buf)));
+	return (user_fhstatfs(td, USER_PTR_OBJ(uap->u_fhp),
+	    USER_PTR_OBJ(uap->buf)));
 }
 
 int
@@ -1243,8 +1243,8 @@ freebsd64_copy_file_range(struct thread *td,
     struct freebsd64_copy_file_range_args *uap)
 {
 	return (user_copy_file_range(td, uap->infd,
-	    __USER_CAP_OBJ(uap->inoffp), uap->outfd,
-	    __USER_CAP_OBJ(uap->outoffp), uap->len, uap->flags));
+	    USER_PTR_OBJ(uap->inoffp), uap->outfd,
+	    USER_PTR_OBJ(uap->outoffp), uap->len, uap->flags));
 }
 /*
  * CHERI CHANGES START

--- a/sys/compat/freebsd64/freebsd64_vfs.c
+++ b/sys/compat/freebsd64/freebsd64_vfs.c
@@ -211,7 +211,7 @@ freebsd11_freebsd64_stat(struct thread *td,
 	struct freebsd11_stat64 osb;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -248,7 +248,7 @@ int
 freebsd64___acl_get_file(struct thread *td,
     struct freebsd64___acl_get_file_args *uap)
 {
-	return (kern___acl_get_path(td, USER_PTR_STR(uap->path), uap->type,
+	return (kern___acl_get_path(td, USER_PTR_PATH(uap->path), uap->type,
 	    USER_PTR_OBJ(uap->aclp), FOLLOW));
 }
 
@@ -256,7 +256,7 @@ int
 freebsd64___acl_get_link(struct thread *td,
     struct freebsd64___acl_get_link_args *uap)
 {
-	return (kern___acl_get_path(td, USER_PTR_STR(uap->path), uap->type,
+	return (kern___acl_get_path(td, USER_PTR_PATH(uap->path), uap->type,
 	    USER_PTR_OBJ(uap->aclp), NOFOLLOW));
 }
 
@@ -264,7 +264,7 @@ int
 freebsd64___acl_set_file(struct thread *td,
     struct freebsd64___acl_set_file_args *uap)
 {
-	return(kern___acl_set_path(td, USER_PTR_STR(uap->path), uap->type,
+	return(kern___acl_set_path(td, USER_PTR_PATH(uap->path), uap->type,
 	    USER_PTR_OBJ(uap->aclp), FOLLOW));
 }
 
@@ -272,7 +272,7 @@ int
 freebsd64___acl_set_link(struct thread *td,
     struct freebsd64___acl_set_link_args *uap)
 {
-	return(kern___acl_set_path(td, USER_PTR_STR(uap->path), uap->type,
+	return(kern___acl_set_path(td, USER_PTR_PATH(uap->path), uap->type,
 	    USER_PTR_OBJ(uap->aclp), NOFOLLOW));
 }
 
@@ -296,7 +296,7 @@ int
 freebsd64___acl_delete_file(struct thread *td,
     struct freebsd64___acl_delete_file_args *uap)
 {
-	return (kern___acl_delete_path(td, USER_PTR_STR(uap->path),
+	return (kern___acl_delete_path(td, USER_PTR_PATH(uap->path),
 	    uap->type, FOLLOW));
 }
 
@@ -304,7 +304,7 @@ int
 freebsd64___acl_delete_link(struct thread *td,
     struct freebsd64___acl_delete_link_args *uap)
 {
-	return (kern___acl_delete_path(td, USER_PTR_STR(uap->path),
+	return (kern___acl_delete_path(td, USER_PTR_PATH(uap->path),
 	    uap->type, NOFOLLOW));
 }
 
@@ -312,7 +312,7 @@ int
 freebsd64___acl_aclcheck_file(struct thread *td,
     struct freebsd64___acl_aclcheck_file_args *uap)
 {
-	return (kern___acl_aclcheck_path(td, USER_PTR_STR(uap->path),
+	return (kern___acl_aclcheck_path(td, USER_PTR_PATH(uap->path),
 	    uap->type, USER_PTR_OBJ(uap->aclp), FOLLOW));
 }
 
@@ -320,7 +320,7 @@ int
 freebsd64___acl_aclcheck_link(struct thread *td,
     struct freebsd64___acl_aclcheck_link_args *uap)
 {
-	return (kern___acl_aclcheck_path(td, USER_PTR_STR(uap->path),
+	return (kern___acl_aclcheck_path(td, USER_PTR_PATH(uap->path),
 	    uap->type, USER_PTR_OBJ(uap->aclp), NOFOLLOW));
 }
 
@@ -346,7 +346,7 @@ int
 freebsd64___realpathat(struct thread *td,
     struct freebsd64___realpathat_args *uap)
 {
-	return (kern___realpathat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern___realpathat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    USER_PTR(uap->buf, uap->size), uap->size, uap->flags,
 	    UIO_USERSPACE));
 }
@@ -357,8 +357,8 @@ freebsd64___realpathat(struct thread *td,
 int
 freebsd64_extattrctl(struct thread *td, struct freebsd64_extattrctl_args *uap)
 {
-	return (kern_extattrctl(td, USER_PTR_STR(uap->path), uap->cmd,
-	    USER_PTR_STR(uap->filename), uap->attrnamespace,
+	return (kern_extattrctl(td, USER_PTR_PATH(uap->path), uap->cmd,
+	    USER_PTR_PATH(uap->filename), uap->attrnamespace,
 	    USER_PTR_STR(uap->attrname)));
 }
 
@@ -375,7 +375,7 @@ int
 freebsd64_extattr_set_file(struct thread *td,
     struct freebsd64_extattr_set_file_args *uap)
 {
-	return (user_extattr_set_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_set_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
 	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
 }
@@ -384,7 +384,7 @@ int
 freebsd64_extattr_set_link(struct thread *td,
     struct freebsd64_extattr_set_link_args *uap)
 {
-	return (user_extattr_set_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_set_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
 	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
 }
@@ -402,7 +402,7 @@ int
 freebsd64_extattr_get_file(struct thread *td,
     struct freebsd64_extattr_get_file_args *uap)
 {
-	return (user_extattr_get_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_get_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
 	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, FOLLOW));
 }
@@ -411,7 +411,7 @@ int
 freebsd64_extattr_get_link(struct thread *td,
     struct freebsd64_extattr_get_link_args *uap)
 {
-	return (user_extattr_get_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_get_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR_STR(uap->attrname),
 	    USER_PTR(uap->data, uap->nbytes), uap->nbytes, NOFOLLOW));
 }
@@ -428,7 +428,7 @@ int
 freebsd64_extattr_delete_file(struct thread *td,
     struct freebsd64_extattr_delete_file_args *uap)
 {
-	return (user_extattr_delete_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_delete_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR_STR(uap->attrname), FOLLOW));
 }
 
@@ -436,7 +436,7 @@ int
 freebsd64_extattr_delete_link(struct thread *td,
     struct freebsd64_extattr_delete_link_args *uap)
 {
-	return (user_extattr_delete_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_delete_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR_STR(uap->attrname), NOFOLLOW));
 }
 
@@ -452,7 +452,7 @@ int
 freebsd64_extattr_list_file(struct thread *td,
     struct freebsd64_extattr_list_file_args *uap)
 {
-	return (user_extattr_list_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_list_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR(uap->data, uap->nbytes),
 	    uap->nbytes, FOLLOW));
 }
@@ -461,7 +461,7 @@ int
 freebsd64_extattr_list_link(struct thread *td,
     struct freebsd64_extattr_list_link_args *uap)
 {
-	return (user_extattr_list_path(td, USER_PTR_STR(uap->path),
+	return (user_extattr_list_path(td, USER_PTR_PATH(uap->path),
 	    uap->attrnamespace, USER_PTR(uap->data, uap->nbytes),
 	    uap->nbytes, NOFOLLOW));
 }
@@ -480,7 +480,7 @@ freebsd11_freebsd64_lstat(struct thread *td,
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_PATH(uap->path), UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	error = freebsd11_freebsd64_cvtstat(&sb, &osb);
@@ -518,7 +518,7 @@ freebsd11_freebsd64_fstatat(struct thread *td,
 	struct freebsd11_stat64 osb;
 	int error;
 
-	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_STR(uap->path),
+	error = kern_statat(td, uap->flag, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -578,7 +578,7 @@ freebsd11_freebsd64_nstat(struct thread *td,
 	struct nstat64 nsb;
 	int error;
 
-	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_STR(uap->path),
+	error = kern_statat(td, 0, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
@@ -598,7 +598,7 @@ freebsd11_freebsd64_nlstat(struct thread *td,
 	int error;
 
 	error = kern_statat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    USER_PTR_STR(uap->path), UIO_USERSPACE, &sb);
+	    USER_PTR_PATH(uap->path), UIO_USERSPACE, &sb);
 	if (error != 0)
 		return (error);
 	freebsd11_freebsd64_cvtnstat(&sb, &nsb);
@@ -638,14 +638,14 @@ freebsd11_freebsd64_getdents(struct thread *td,
 int
 freebsd64_quotactl(struct thread *td, struct freebsd64_quotactl_args *uap)
 {
-	return (kern_quotactl(td, USER_PTR_STR(uap->path),
+	return (kern_quotactl(td, USER_PTR_PATH(uap->path),
 	    uap->cmd, uap->uid, USER_PTR_UNBOUND(uap->arg)));
 }
 
 int
 freebsd64_statfs(struct thread *td, struct freebsd64_statfs_args *uap)
 {
-	return (user_statfs(td, USER_PTR_STR(uap->path),
+	return (user_statfs(td, USER_PTR_PATH(uap->path),
 	    USER_PTR_OBJ(uap->buf)));
 }
 
@@ -678,7 +678,7 @@ freebsd11_freebsd64_statfs(struct thread *td,
 	int error;
 
 	sfp = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, USER_PTR_STR(uap->path), UIO_USERSPACE, sfp);
+	error = kern_statfs(td, USER_PTR_PATH(uap->path), UIO_USERSPACE, sfp);
 	if (error == 0) {
 		freebsd11_freebsd64_cvtstatfs(sfp, &osb);
 		error = copyout(&osb, USER_PTR_OBJ(uap->buf), sizeof(osb));
@@ -805,26 +805,26 @@ freebsd11_freebsd64_cvtstatfs(struct statfs *nsp,
 int
 freebsd64_chdir(struct thread *td, struct freebsd64_chdir_args *uap)
 {
-	return (kern_chdir(td, USER_PTR_STR(uap->path), UIO_USERSPACE));
+	return (kern_chdir(td, USER_PTR_PATH(uap->path), UIO_USERSPACE));
 }
 
 int
 freebsd64_chroot(struct thread *td, struct freebsd64_chroot_args *uap)
 {
-	return (user_chroot(td, USER_PTR_STR(uap->path)));
+	return (user_chroot(td, USER_PTR_PATH(uap->path)));
 }
 
 int
 freebsd64_open(struct thread *td, struct freebsd64_open_args *uap)
 {
-	return (kern_openat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_openat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->flags, uap->mode));
 }
 
 int
 freebsd64_openat(struct thread *td, struct freebsd64_openat_args *uap)
 {
-	return (kern_openat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_openat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->flag, uap->mode));
 }
 
@@ -832,7 +832,7 @@ freebsd64_openat(struct thread *td, struct freebsd64_openat_args *uap)
 int
 freebsd64_mknodat(struct thread *td, struct freebsd64_mknodat_args *uap)
 {
-	return (kern_mknodat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_mknodat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->dev));
 }
 
@@ -841,7 +841,7 @@ int
 freebsd11_freebsd64_mknod(struct thread *td,
     struct freebsd11_freebsd64_mknod_args *uap)
 {
-	return (kern_mknodat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_mknodat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->dev));
 }
 
@@ -849,7 +849,7 @@ int
 freebsd11_freebsd64_mknodat(struct thread *td,
     struct freebsd11_freebsd64_mknodat_args *uap)
 {
-	return (kern_mknodat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_mknodat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->dev));
 }
 #endif /* COMPAT_FREEBSD11 */
@@ -857,97 +857,97 @@ freebsd11_freebsd64_mknodat(struct thread *td,
 int
 freebsd64_mkfifo(struct thread *td, struct freebsd64_mkfifo_args *uap)
 {
-	return (kern_mkfifoat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_mkfifoat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_mkfifoat(struct thread *td, struct freebsd64_mkfifoat_args *uap)
 {
-	return (kern_mkfifoat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_mkfifoat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_link(struct thread *td, struct freebsd64_link_args *uap)
 {
-	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, USER_PTR_STR(uap->path),
-	    USER_PTR_STR(uap->to), UIO_USERSPACE, AT_SYMLINK_FOLLOW));
+	return (kern_linkat(td, AT_FDCWD, AT_FDCWD, USER_PTR_PATH(uap->path),
+	    USER_PTR_PATH(uap->to), UIO_USERSPACE, AT_SYMLINK_FOLLOW));
 }
 
 int
 freebsd64_linkat(struct thread *td, struct freebsd64_linkat_args *uap)
 {
-	return (kern_linkat(td, uap->fd1, uap->fd2, USER_PTR_STR(uap->path1),
-	    USER_PTR_STR(uap->path2), UIO_USERSPACE, uap->flag));
+	return (kern_linkat(td, uap->fd1, uap->fd2, USER_PTR_PATH(uap->path1),
+	    USER_PTR_PATH(uap->path2), UIO_USERSPACE, uap->flag));
 }
 
 int
 freebsd64_symlink(struct thread *td, struct freebsd64_symlink_args *uap)
 {
-	return (kern_symlinkat(td, USER_PTR_STR(uap->path), AT_FDCWD,
-	    USER_PTR_STR(uap->link), UIO_USERSPACE));
+	return (kern_symlinkat(td, USER_PTR_PATH(uap->path), AT_FDCWD,
+	    USER_PTR_PATH(uap->link), UIO_USERSPACE));
 }
 
 int
 freebsd64_symlinkat(struct thread *td, struct freebsd64_symlinkat_args *uap)
 {
-	return (kern_symlinkat(td, USER_PTR_STR(uap->path1), uap->fd,
-	    USER_PTR_STR(uap->path2), UIO_USERSPACE));
+	return (kern_symlinkat(td, USER_PTR_PATH(uap->path1), uap->fd,
+	    USER_PTR_PATH(uap->path2), UIO_USERSPACE));
 }
 
 int
 freebsd64_undelete(struct thread *td, struct freebsd64_undelete_args *uap)
 {
-	return (kern_undelete(td, USER_PTR_STR(uap->path), UIO_USERSPACE));
+	return (kern_undelete(td, USER_PTR_PATH(uap->path), UIO_USERSPACE));
 }
 
 int
 freebsd64_unlink(struct thread *td, struct freebsd64_unlink_args *uap)
 {
-	return (kern_funlinkat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_funlinkat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    FD_NONE, UIO_USERSPACE, 0, 0));
 }
 
 int
 freebsd64_unlinkat(struct thread *td, struct freebsd64_unlinkat_args *uap)
 {
-	return (kern_funlinkat_ex(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_funlinkat_ex(td, uap->fd, USER_PTR_PATH(uap->path),
 	    FD_NONE, uap->flag, UIO_USERSPACE, 0));
 }
 
 int
 freebsd64_funlinkat(struct thread *td, struct freebsd64_funlinkat_args *uap)
 {
-	return (kern_funlinkat_ex(td, uap->dfd, USER_PTR_STR(uap->path),
+	return (kern_funlinkat_ex(td, uap->dfd, USER_PTR_PATH(uap->path),
 	    uap->fd, uap->flag, UIO_USERSPACE, 0));
 }
 
 int
 freebsd64_access(struct thread *td, struct freebsd64_access_args *uap)
 {
-	return (kern_accessat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_accessat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, 0, uap->amode));
 }
 
 int
 freebsd64_faccessat(struct thread *td, struct freebsd64_faccessat_args *uap)
 {
-	return (kern_accessat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_accessat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->flag, uap->amode));
 }
 
 int
 freebsd64_eaccess(struct thread *td, struct freebsd64_eaccess_args *uap)
 {
-	return (kern_accessat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_accessat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, AT_EACCESS, uap->amode));
 }
 
 int
 freebsd64_fstatat(struct thread *td, struct freebsd64_fstatat_args *uap)
 {
-	return (user_fstatat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (user_fstatat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    USER_PTR_OBJ(uap->buf), uap->flag));
 }
 
@@ -957,7 +957,7 @@ freebsd64_pathconf(struct thread *td, struct freebsd64_pathconf_args *uap)
 	long value;
 	int error;
 
-	error = kern_pathconf(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
+	error = kern_pathconf(td, USER_PTR_PATH(uap->path), UIO_USERSPACE,
 	    uap->name, FOLLOW, &value);
 	if (error == 0)
 		td->td_retval[0] = value;
@@ -970,7 +970,7 @@ freebsd64_lpathconf(struct thread *td, struct freebsd64_lpathconf_args *uap)
 	long value;
 	int error;
 
-	error = kern_pathconf(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
+	error = kern_pathconf(td, USER_PTR_PATH(uap->path), UIO_USERSPACE,
 	    uap->name, NOFOLLOW, &value);
 	if (error == 0)
 		td->td_retval[0] = value;
@@ -980,7 +980,7 @@ freebsd64_lpathconf(struct thread *td, struct freebsd64_lpathconf_args *uap)
 int
 freebsd64_readlink(struct thread *td, struct freebsd64_readlink_args *uap)
 {
-	return (kern_readlinkat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_readlinkat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, USER_PTR(uap->buf, uap->count), UIO_USERSPACE,
 	    uap->count));
 }
@@ -988,7 +988,7 @@ freebsd64_readlink(struct thread *td, struct freebsd64_readlink_args *uap)
 int
 freebsd64_readlinkat(struct thread *td, struct freebsd64_readlinkat_args *uap)
 {
-	return (kern_readlinkat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_readlinkat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, USER_PTR(uap->buf, uap->bufsize), UIO_USERSPACE,
 	    uap->bufsize));
 }
@@ -996,77 +996,77 @@ freebsd64_readlinkat(struct thread *td, struct freebsd64_readlinkat_args *uap)
 int
 freebsd64_chflags(struct thread *td, struct freebsd64_chflags_args *uap)
 {
-	return (kern_chflagsat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_chflagsat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->flags, 0));
 }
 
 int
 freebsd64_chflagsat(struct thread *td, struct freebsd64_chflagsat_args *uap)
 {
-	return (kern_chflagsat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_chflagsat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->flags, uap->atflag));
 }
 
 int
 freebsd64_lchflags(struct thread *td, struct freebsd64_lchflags_args *uap)
 {
-	return (kern_chflagsat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_chflagsat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->flags, AT_SYMLINK_NOFOLLOW));
 }
 
 int
 freebsd64_chmod(struct thread *td, struct freebsd64_chmod_args *uap)
 {
-	return (kern_fchmodat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_fchmodat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode, 0));
 }
 
 int
 freebsd64_fchmodat(struct thread *td, struct freebsd64_fchmodat_args *uap)
 {
-	return (kern_fchmodat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_fchmodat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode, uap->flag));
 }
 
 int
 freebsd64_lchmod(struct thread *td, struct freebsd64_lchmod_args *uap)
 {
-	return (kern_fchmodat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_fchmodat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode, AT_SYMLINK_NOFOLLOW));
 }
 
 int
 freebsd64_chown(struct thread *td, struct freebsd64_chown_args *uap)
 {
-	return (kern_fchownat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_fchownat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->uid, uap->gid, 0));
 }
 
 int
 freebsd64_fchownat(struct thread *td, struct freebsd64_fchownat_args *uap)
 {
-	return (kern_fchownat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_fchownat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->uid, uap->gid, uap->flag));
 }
 
 int
 freebsd64_lchown(struct thread *td, struct freebsd64_lchown_args *uap)
 {
-	return (kern_fchownat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_fchownat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->uid, uap->gid, AT_SYMLINK_NOFOLLOW));
 }
 
 int
 freebsd64_utimes(struct thread *td, struct freebsd64_utimes_args *uap)
 {
-	return (kern_utimesat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_utimesat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, USER_PTR_OBJ(uap->tptr), UIO_USERSPACE));
 }
 
 int
 freebsd64_futimesat(struct thread *td, struct freebsd64_futimesat_args *uap)
 {
-	return (kern_utimesat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_utimesat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, USER_PTR_OBJ(uap->times), UIO_USERSPACE));
 }
 
@@ -1095,7 +1095,7 @@ freebsd64_futimens(struct thread *td, struct freebsd64_futimens_args *uap)
 int
 freebsd64_utimensat(struct thread *td, struct freebsd64_utimensat_args *uap)
 {
-	return (kern_utimensat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_utimensat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, USER_PTR_OBJ(uap->times), UIO_USERSPACE,
 	    uap->flag));
 }
@@ -1103,7 +1103,7 @@ freebsd64_utimensat(struct thread *td, struct freebsd64_utimensat_args *uap)
 int
 freebsd64_truncate(struct thread *td, struct freebsd64_truncate_args *uap)
 {
-	return (kern_truncate(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
+	return (kern_truncate(td, USER_PTR_PATH(uap->path), UIO_USERSPACE,
 	    uap->length));
 }
 
@@ -1112,7 +1112,7 @@ freebsd64_truncate(struct thread *td, struct freebsd64_truncate_args *uap)
 int
 freebsd6_truncate(struct thread *td, struct freebsd6_truncate_args *uap)
 {
-	return (kern_truncate(td, USER_PTR_STR(uap->path), UIO_USERSPACE,
+	return (kern_truncate(td, USER_PTR_PATH(uap->path), UIO_USERSPACE,
 	    uap->length));
 }
 #endif
@@ -1120,35 +1120,35 @@ freebsd6_truncate(struct thread *td, struct freebsd6_truncate_args *uap)
 int
 freebsd64_rename(struct thread *td, struct freebsd64_rename_args *uap)
 {
-	return (kern_renameat(td, AT_FDCWD, USER_PTR_STR(uap->from),
-	    AT_FDCWD, USER_PTR_STR(uap->to), UIO_USERSPACE));
+	return (kern_renameat(td, AT_FDCWD, USER_PTR_PATH(uap->from),
+	    AT_FDCWD, USER_PTR_PATH(uap->to), UIO_USERSPACE));
 }
 
 int
 freebsd64_renameat(struct thread *td, struct freebsd64_renameat_args *uap)
 {
-	return (kern_renameat(td, uap->oldfd, USER_PTR_STR(uap->old),
-	    uap->newfd, USER_PTR_STR(uap->new), UIO_USERSPACE));
+	return (kern_renameat(td, uap->oldfd, USER_PTR_PATH(uap->old),
+	    uap->newfd, USER_PTR_PATH(uap->new), UIO_USERSPACE));
 }
 
 int
 freebsd64_mkdir(struct thread *td, struct freebsd64_mkdir_args *uap)
 {
-	return (kern_mkdirat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_mkdirat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_mkdirat(struct thread *td, struct freebsd64_mkdirat_args *uap)
 {
-	return (kern_mkdirat(td, uap->fd, USER_PTR_STR(uap->path),
+	return (kern_mkdirat(td, uap->fd, USER_PTR_PATH(uap->path),
 	    UIO_USERSPACE, uap->mode));
 }
 
 int
 freebsd64_rmdir(struct thread *td, struct freebsd64_rmdir_args *uap)
 {
-	return (kern_frmdirat(td, AT_FDCWD, USER_PTR_STR(uap->path),
+	return (kern_frmdirat(td, AT_FDCWD, USER_PTR_PATH(uap->path),
 	    FD_NONE, UIO_USERSPACE, 0));
 }
 
@@ -1164,20 +1164,20 @@ freebsd64_getdirentries(struct thread *td,
 int
 freebsd64_unmount(struct thread *td, struct freebsd64_unmount_args *uap)
 {
-	return (kern_unmount(td, USER_PTR_STR(uap->path), uap->flags));
+	return (kern_unmount(td, USER_PTR_PATH(uap->path), uap->flags));
 }
 
 int
 freebsd64_revoke(struct thread *td, struct freebsd64_revoke_args *uap)
 {
-	return (kern_revoke(td, USER_PTR_STR(uap->path), UIO_USERSPACE));
+	return (kern_revoke(td, USER_PTR_PATH(uap->path), UIO_USERSPACE));
 }
 
 int
 freebsd64_lgetfh(struct thread *td, struct freebsd64_lgetfh_args *uap)
 {
 	return (kern_getfhat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    USER_PTR_STR(uap->fname), UIO_USERSPACE,
+	    USER_PTR_PATH(uap->fname), UIO_USERSPACE,
 	    USER_PTR_OBJ(uap->fhp), UIO_USERSPACE));
 }
 
@@ -1185,7 +1185,7 @@ int
 freebsd64_getfh(struct thread *td, struct freebsd64_getfh_args *uap)
 {
 	return (kern_getfhat(td, AT_SYMLINK_NOFOLLOW, AT_FDCWD,
-	    USER_PTR_STR(uap->fname), UIO_USERSPACE,
+	    USER_PTR_PATH(uap->fname), UIO_USERSPACE,
 	    USER_PTR_OBJ(uap->fhp), UIO_USERSPACE));
 }
 
@@ -1193,21 +1193,21 @@ int
 freebsd64_getfhat(struct thread *td, struct freebsd64_getfhat_args *uap)
 {
 	return (kern_getfhat(td, uap->flags, uap->fd,
-	    USER_PTR_STR(uap->path), UIO_USERSPACE,
+	    USER_PTR_PATH(uap->path), UIO_USERSPACE,
 	    USER_PTR_OBJ(uap->fhp), UIO_USERSPACE));
 }
 
 int
 freebsd64_fhlink(struct thread *td, struct freebsd64_fhlink_args *uap)
 {
-	return (kern_fhlinkat(td, AT_FDCWD, USER_PTR_STR(uap->to),
+	return (kern_fhlinkat(td, AT_FDCWD, USER_PTR_PATH(uap->to),
 	    UIO_USERSPACE, USER_PTR_OBJ(uap->fhp)));
 }
 
 int
 freebsd64_fhlinkat(struct thread *td, struct freebsd64_fhlinkat_args *uap)
 {
-	return (kern_fhlinkat(td, uap->tofd, USER_PTR_STR(uap->to),
+	return (kern_fhlinkat(td, uap->tofd, USER_PTR_PATH(uap->to),
 	    UIO_USERSPACE, USER_PTR_OBJ(uap->fhp)));
 }
 

--- a/sys/compat/linux/linux_file.c
+++ b/sys/compat/linux/linux_file.c
@@ -99,7 +99,7 @@ int
 linux_creat(struct thread *td, struct linux_creat_args *args)
 {
 
-	return (kern_openat(td, AT_FDCWD, __USER_CAP_PATH(args->path),
+	return (kern_openat(td, AT_FDCWD, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, O_WRONLY | O_CREAT | O_TRUNC, args->mode));
 }
 #endif
@@ -604,7 +604,7 @@ linux_access(struct thread *td, struct linux_access_args *args)
 	if (args->amode & ~(F_OK | X_OK | W_OK | R_OK))
 		return (EINVAL);
 
-	return (kern_accessat(td, AT_FDCWD, __USER_CAP_PATH(args->path),
+	return (kern_accessat(td, AT_FDCWD, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, 0, args->amode));
 }
 #endif
@@ -620,7 +620,7 @@ linux_do_accessat(struct thread *td, int ldfd, const char *filename,
 		return (EINVAL);
 
 	dfd = (ldfd == LINUX_AT_FDCWD) ? AT_FDCWD : ldfd;
-	return (kern_accessat(td, dfd, __USER_CAP_PATH(filename),
+	return (kern_accessat(td, dfd, USER_PTR_PATH(filename),
 	    UIO_USERSPACE, flags, amode));
 }
 
@@ -662,11 +662,11 @@ linux_unlink(struct thread *td, struct linux_unlink_args *args)
 	int error;
 	struct stat st;
 
-	error = kern_funlinkat(td, AT_FDCWD, __USER_CAP_PATH(args->path),
+	error = kern_funlinkat(td, AT_FDCWD, USER_PTR_PATH(args->path),
 	    FD_NONE, UIO_USERSPACE, 0, 0);
 	if (error == EPERM) {
 		/* Introduce POSIX noncompliant behaviour of Linux */
-		if (kern_statat(td, 0, AT_FDCWD, __USER_CAP_PATH(args->path),
+		if (kern_statat(td, 0, AT_FDCWD, USER_PTR_PATH(args->path),
 		    UIO_USERSPACE, &st) == 0) {
 			if (S_ISDIR(st.st_mode))
 				error = EISDIR;
@@ -707,7 +707,7 @@ linux_unlinkat(struct thread *td, struct linux_unlinkat_args *args)
 		return (EINVAL);
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->dfd;
 	return (linux_unlinkat_impl(td, UIO_USERSPACE,
-	    __USER_CAP_PATH(args->pathname), dfd, args));
+	    USER_PTR_PATH(args->pathname), dfd, args));
 }
 
 int
@@ -1546,7 +1546,7 @@ linux_fchownat(struct thread *td, struct linux_fchownat_args *args)
 	    AT_EMPTY_PATH;
 
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD :  args->dfd;
-	return (kern_fchownat(td, dfd, __USER_CAP_PATH(args->filename),
+	return (kern_fchownat(td, dfd, USER_PTR_PATH(args->filename),
 	    UIO_USERSPACE, args->uid, args->gid, flag));
 }
 

--- a/sys/compat/linux/linux_ipc.c
+++ b/sys/compat/linux/linux_ipc.c
@@ -626,11 +626,11 @@ linux_semctl(struct thread *td, struct linux_semctl_args *args)
 		return (0);
 	case LINUX_GETALL:
 		cmd = GETALL;
-		semun.array = __USER_CAP_UNBOUND(PTRIN(args->arg.array));
+		semun.array = USER_PTR_UNBOUND(PTRIN(args->arg.array));
 		break;
 	case LINUX_SETALL:
 		cmd = SETALL;
-		semun.array = __USER_CAP_UNBOUND(PTRIN(args->arg.array));
+		semun.array = USER_PTR_UNBOUND(PTRIN(args->arg.array));
 		break;
 	default:
 		linux_msg(td, "ipc type %d is not implemented",

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -267,9 +267,9 @@ linux_select(struct thread *td, struct linux_select_args *args)
 	} else
 		tvp = NULL;
 
-	error = kern_select(td, args->nfds, __USER_CAP_UNBOUND(args->readfds),
-	    __USER_CAP_UNBOUND(args->writefds),
-	    __USER_CAP_UNBOUND(args->exceptfds), tvp, LINUX_NFDBITS);
+	error = kern_select(td, args->nfds, USER_PTR_UNBOUND(args->readfds),
+	    USER_PTR_UNBOUND(args->writefds),
+	    USER_PTR_UNBOUND(args->exceptfds), tvp, LINUX_NFDBITS);
 	if (error)
 		goto select_out;
 
@@ -2158,9 +2158,9 @@ linux_common_pselect6(struct thread *td, l_int nfds, l_fd_set *readfds,
 	} else
 		tvp = NULL;
 
-	error = kern_pselect(td, nfds, __USER_CAP_UNBOUND(readfds),
-	    __USER_CAP_UNBOUND(writefds),
-	    __USER_CAP_UNBOUND(exceptfds), tvp, ssp, LINUX_NFDBITS);
+	error = kern_pselect(td, nfds, USER_PTR_UNBOUND(readfds),
+	    USER_PTR_UNBOUND(writefds),
+	    USER_PTR_UNBOUND(exceptfds), tvp, ssp, LINUX_NFDBITS);
 
 	if (tsp != NULL) {
 		/*
@@ -2489,7 +2489,7 @@ linux_mincore(struct thread *td, struct linux_mincore_args *args)
 	if (args->start & PAGE_MASK)
 		return (EINVAL);
 	return (kern_mincore(td, args->start, args->len,
-	    __USER_CAP(args->vec, args->len)));
+	    USER_PTR(args->vec, args->len)));
 }
 
 #define	SYSLOG_TAG	"<6>"
@@ -2628,12 +2628,12 @@ get_argenv_ptr(l_uintptr_t * __capability *arrayp, void * __capability *ptrp)
 	if (fueword32(array, &ptr32) == -1)
 		return (EFAULT);
 	array += sizeof(ptr32);
-	*ptrp = __USER_CAP_STR((void *)(uintptr_t)ptr32);
+	*ptrp = USER_PTR_STR((void *)(uintptr_t)ptr32);
 #elif defined(COMPAT_LINUX64)
 	if (fueword64(array, &ptr64) == -1)
 		return (EFAULT);
 	array += sizeof(ptr64);
-	*ptrp = __USER_CAP_STR((void *)(uintptr_t)ptr64);
+	*ptrp = USER_PTR_STR((void *)(uintptr_t)ptr64);
 #else
 	if (fueptr(array, &ptr) == -1)
 		return (EFAULT);
@@ -2731,9 +2731,9 @@ linux_execve(struct thread *td, struct linux_execve_args *args)
 
 	LINUX_CTR(execve);
 
-	error = linux_exec_copyin_args(&eargs, __USER_CAP_PATH(args->path),
-	    UIO_USERSPACE, __USER_CAP_UNBOUND(args->argp),
-	    __USER_CAP_UNBOUND(args->envp));
+	error = linux_exec_copyin_args(&eargs, USER_PTR_PATH(args->path),
+	    UIO_USERSPACE, USER_PTR_UNBOUND(args->argp),
+	    USER_PTR_UNBOUND(args->envp));
 	if (error == 0)
 		error = linux_common_execve(td, &eargs);
 	AUDIT_SYSCALL_EXIT(error == EJUSTRETURN ? 0 : error, td);

--- a/sys/compat/linux/linux_socket.c
+++ b/sys/compat/linux/linux_socket.c
@@ -1285,7 +1285,7 @@ linux_sendto(struct thread *td, struct linux_sendto_args *args)
 		return (error);
 	so = fp->f_data;
 	if ((so->so_state & (SS_ISCONNECTED|SS_ISCONNECTING)) == 0) {
-		msg.msg_name = __USER_CAP(PTRIN(args->to), args->tolen);
+		msg.msg_name = USER_PTR(PTRIN(args->to), args->tolen);
 		msg.msg_namelen = args->tolen;
 	}
 	msg.msg_iov = &aiov;

--- a/sys/compat/linux/linux_stats.c
+++ b/sys/compat/linux/linux_stats.c
@@ -171,7 +171,7 @@ linux_newstat(struct thread *td, struct linux_newstat_args *args)
 	struct stat buf;
 	int error;
 
-	error = linux_kern_stat(td, __USER_CAP_PATH(args->path),
+	error = linux_kern_stat(td, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, &buf);
 	if (error)
 		return (error);
@@ -184,7 +184,7 @@ linux_newlstat(struct thread *td, struct linux_newlstat_args *args)
 	struct stat sb;
 	int error;
 
-	error = linux_kern_lstat(td, __USER_CAP_PATH(args->path),
+	error = linux_kern_lstat(td, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, &sb);
 	if (error)
 		return (error);
@@ -248,7 +248,7 @@ linux_stat(struct thread *td, struct linux_stat_args *args)
 	struct stat buf;
 	int error;
 
-	error = linux_kern_stat(td, __USER_CAP_PATH(args->path),
+	error = linux_kern_stat(td, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, &buf);
 	if (error) {
 		return (error);
@@ -262,7 +262,7 @@ linux_lstat(struct thread *td, struct linux_lstat_args *args)
 	struct stat buf;
 	int error;
 
-	error = linux_kern_lstat(td, __USER_CAP_PATH(args->path),
+	error = linux_kern_lstat(td, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, &buf);
 	if (error) {
 		return (error);
@@ -385,7 +385,7 @@ linux_statfs(struct thread *td, struct linux_statfs_args *args)
 	int error;
 
 	bsd_statfs = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, __USER_CAP_PATH(args->path),
+	error = kern_statfs(td, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, bsd_statfs);
 	if (error == 0)
 		error = bsd_to_linux_statfs(bsd_statfs, &linux_statfs);
@@ -426,7 +426,7 @@ linux_statfs64(struct thread *td, struct linux_statfs64_args *args)
 		return (EINVAL);
 
 	bsd_statfs = malloc(sizeof(struct statfs), M_STATFS, M_WAITOK);
-	error = kern_statfs(td, __USER_CAP_PATH(args->path),
+	error = kern_statfs(td, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, bsd_statfs);
 	if (error == 0)
 		bsd_to_linux_statfs64(bsd_statfs, &linux_statfs);
@@ -558,7 +558,7 @@ linux_stat64(struct thread *td, struct linux_stat64_args *args)
 	struct stat buf;
 	int error;
 
-	error = linux_kern_stat(td, __USER_CAP_PATH(args->filename),
+	error = linux_kern_stat(td, USER_PTR_PATH(args->filename),
 	    UIO_USERSPACE, &buf);
 	if (error)
 		return (error);
@@ -571,7 +571,7 @@ linux_lstat64(struct thread *td, struct linux_lstat64_args *args)
 	struct stat sb;
 	int error;
 
-	error = linux_kern_lstat(td, __USER_CAP_PATH(args->filename),
+	error = linux_kern_lstat(td, USER_PTR_PATH(args->filename),
 	    UIO_USERSPACE, &sb);
 	if (error)
 		return (error);
@@ -604,7 +604,7 @@ linux_fstatat64(struct thread *td, struct linux_fstatat64_args *args)
 
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->dfd;
 	error = linux_kern_statat(td, flags, dfd,
-	    __USER_CAP_PATH(args->pathname), UIO_USERSPACE, &buf);
+	    USER_PTR_PATH(args->pathname), UIO_USERSPACE, &buf);
 	if (error == 0)
 		error = stat64_copyout(&buf, args->statbuf);
 
@@ -626,7 +626,7 @@ linux_newfstatat(struct thread *td, struct linux_newfstatat_args *args)
 
 	dfd = (args->dfd == LINUX_AT_FDCWD) ? AT_FDCWD : args->dfd;
 	error = linux_kern_statat(td, flags, dfd,
-	    __USER_CAP_PATH(args->pathname), UIO_USERSPACE, &buf);
+	    USER_PTR_PATH(args->pathname), UIO_USERSPACE, &buf);
 	if (error == 0)
 		error = newstat_copyout(&buf, args->statbuf);
 

--- a/sys/compat/linux/linux_uid16.c
+++ b/sys/compat/linux/linux_uid16.c
@@ -70,7 +70,7 @@ int
 linux_chown16(struct thread *td, struct linux_chown16_args *args)
 {
 
-	return (kern_fchownat(td, AT_FDCWD, __USER_CAP_PATH(args->path),
+	return (kern_fchownat(td, AT_FDCWD, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, CAST_NOCHG(args->uid), CAST_NOCHG(args->gid), 0));
 }
 
@@ -78,7 +78,7 @@ int
 linux_lchown16(struct thread *td, struct linux_lchown16_args *args)
 {
 
-	return (kern_fchownat(td, AT_FDCWD, __USER_CAP_PATH(args->path),
+	return (kern_fchownat(td, AT_FDCWD, USER_PTR_PATH(args->path),
 	    UIO_USERSPACE, CAST_NOCHG(args->uid), CAST_NOCHG(args->gid),
 	    AT_SYMLINK_NOFOLLOW));
 }

--- a/sys/contrib/subrepo-openzfs/module/os/freebsd/spl/spl_misc.c
+++ b/sys/contrib/subrepo-openzfs/module/os/freebsd/spl/spl_misc.c
@@ -75,7 +75,7 @@ ddi_copyin(const void * __capability from, void *to, size_t len, int flags)
 		return (0);
 	}
 
-	return (copyincap(from, to, len));
+	return (copyinptr(from, to, len));
 }
 
 int
@@ -87,7 +87,7 @@ ddi_copyout(const void *from, void * __capability to, size_t len, int flags)
 		return (0);
 	}
 
-	return (copyoutcap(from, to, len));
+	return (copyoutptr(from, to, len));
 }
 
 void

--- a/sys/contrib/subrepo-openzfs/module/os/freebsd/zfs/kmod_core.c
+++ b/sys/contrib/subrepo-openzfs/module/os/freebsd/zfs/kmod_core.c
@@ -160,7 +160,7 @@ zfsdev_ioctl(struct cdev *dev, ulong_t zcmd, caddr_t arg, int flag,
 		zfs_cmd_legacy_to_ozfs(zcl, zc);
 	} else
 #endif
-	if (copyincap(uaddr, zc, sizeof (zfs_cmd_t))) {
+	if (copyinptr(uaddr, zc, sizeof (zfs_cmd_t))) {
 		error = SET_ERROR(EFAULT);
 		goto out;
 	}
@@ -172,7 +172,7 @@ zfsdev_ioctl(struct cdev *dev, ulong_t zcmd, caddr_t arg, int flag,
 	} else
 #endif
 	{
-		rc = copyoutcap(zc, uaddr, sizeof (*zc));
+		rc = copyoutptr(zc, uaddr, sizeof (*zc));
 	}
 	if (error == 0 && rc != 0)
 		error = SET_ERROR(EFAULT);

--- a/sys/dev/drm/core/drm_atomic_uapi.c
+++ b/sys/dev/drm/core/drm_atomic_uapi.c
@@ -465,7 +465,7 @@ static int drm_atomic_crtc_set_property(struct drm_crtc *crtc,
 		state->color_mgmt_changed |= replaced;
 		return ret;
 	} else if (property == config->prop_out_fence_ptr) {
-		s32 __user * __capability fence_ptr = __USER_CAP(val, sizeof(uint64_t));
+		s32 __user * __capability fence_ptr = USER_PTR(val, sizeof(uint64_t));
 
 		if (!fence_ptr)
 			return 0;
@@ -765,7 +765,7 @@ static int drm_atomic_connector_set_property(struct drm_connector *connector,
 			drm_framebuffer_put(fb);
 		return ret;
 	} else if (property == config->writeback_out_fence_ptr_property) {
-		s32 __user * __capability fence_ptr = __USER_CAP(val, sizeof(uint64_t));
+		s32 __user * __capability fence_ptr = USER_PTR(val, sizeof(uint64_t));
 
 		return set_out_fence_for_connector(state->state, connector,
 						   fence_ptr);
@@ -1309,10 +1309,10 @@ int drm_mode_atomic_ioctl(struct drm_device *dev,
 		CP(*arg64, *arg, count_objs);
 		CP(*arg64, *arg, user_data);
 		CP(*arg64, *arg, reserved);
-		arg->objs_ptr = (uintcap_t)__USER_CAP(
+		arg->objs_ptr = (uintcap_t)USER_PTR(
 		    arg64->objs_ptr,
 		    arg64->count_objs * sizeof(uint32_t));
-		arg->count_props_ptr = (uintcap_t)__USER_CAP(
+		arg->count_props_ptr = (uintcap_t)USER_PTR(
 		    arg64->count_props_ptr,
 		    arg64->count_objs * sizeof(uint32_t));
 	}
@@ -1386,9 +1386,9 @@ retry:
 
 #ifdef COMPAT_FREEBSD64
 		if (!SV_CURPROC_FLAG(SV_CHERI)) {
-			props_ptr = (uint32_t __user * __capability)__USER_CAP(arg64->props_ptr,
+			props_ptr = (uint32_t __user * __capability)USER_PTR(arg64->props_ptr,
 			    (copied_props + count_props) * sizeof(uint32_t));
-			prop_values_ptr = (uint64_t __user * __capability)__USER_CAP(arg64->prop_values_ptr,
+			prop_values_ptr = (uint64_t __user * __capability)USER_PTR(arg64->prop_values_ptr,
 			    (copied_props + count_props) * sizeof(uint64_t));
 		} else
 #endif

--- a/sys/dev/drm/core/drm_atomic_uapi.c
+++ b/sys/dev/drm/core/drm_atomic_uapi.c
@@ -26,8 +26,8 @@
  * Daniel Vetter <daniel.vetter@ffwll.ch>
  */
 
-#ifdef COMPAT_FREEBSD64
 #include <sys/abi_compat.h>
+#ifdef COMPAT_FREEBSD64
 #include <sys/sysent.h>
 #endif
 
@@ -465,6 +465,10 @@ static int drm_atomic_crtc_set_property(struct drm_crtc *crtc,
 		state->color_mgmt_changed |= replaced;
 		return ret;
 	} else if (property == config->prop_out_fence_ptr) {
+		/*
+		 * XXX-CHERI: this is a bug.  We need to be passing a
+		 * capability down from userspace.
+		 */
 		s32 __user * __capability fence_ptr = USER_PTR(val, sizeof(uint64_t));
 
 		if (!fence_ptr)

--- a/sys/dev/drm/core/drm_color_mgmt.c
+++ b/sys/dev/drm/core/drm_color_mgmt.c
@@ -274,10 +274,10 @@ int drm_mode_gamma_set_ioctl(struct drm_device *dev,
 		CP(*crtc_lut64, *crtc_lut, crtc_id);
 		CP(*crtc_lut64, *crtc_lut, gamma_size);
 		size = crtc_lut64->gamma_size * sizeof(uint16_t);
-		crtc_lut->red = (uintcap_t)__USER_CAP(crtc_lut64->red, size);
-		crtc_lut->green = (uintcap_t)__USER_CAP(crtc_lut64->green,
+		crtc_lut->red = (uintcap_t)USER_PTR(crtc_lut64->red, size);
+		crtc_lut->green = (uintcap_t)USER_PTR(crtc_lut64->green,
 		    size);
-		crtc_lut->blue = (uintcap_t)__USER_CAP(crtc_lut64->blue, size);
+		crtc_lut->blue = (uintcap_t)USER_PTR(crtc_lut64->blue, size);
 	}
 #endif
 
@@ -360,10 +360,10 @@ int drm_mode_gamma_get_ioctl(struct drm_device *dev,
 		CP(*crtc_lut64, *crtc_lut, crtc_id);
 		CP(*crtc_lut64, *crtc_lut, gamma_size);
 		size = crtc_lut64->gamma_size * sizeof(uint16_t);
-		crtc_lut->red = (uintcap_t)__USER_CAP(crtc_lut64->red, size);
-		crtc_lut->green = (uintcap_t)__USER_CAP(crtc_lut64->green,
+		crtc_lut->red = (uintcap_t)USER_PTR(crtc_lut64->red, size);
+		crtc_lut->green = (uintcap_t)USER_PTR(crtc_lut64->green,
 		    size);
-		crtc_lut->blue = (uintcap_t)__USER_CAP(crtc_lut64->blue, size);
+		crtc_lut->blue = (uintcap_t)USER_PTR(crtc_lut64->blue, size);
 	}
 #endif
 

--- a/sys/dev/drm/core/drm_connector.c
+++ b/sys/dev/drm/core/drm_connector.c
@@ -2284,16 +2284,16 @@ int drm_mode_getconnector(struct drm_device *dev, void *data,
 		CP(*out_resp64, *out_resp, mm_height);
 		CP(*out_resp64, *out_resp, subpixel);
 
-		out_resp->encoders_ptr = (uintcap_t)__USER_CAP(
+		out_resp->encoders_ptr = (uintcap_t)USER_PTR(
 		    out_resp64->encoders_ptr,
 		    out_resp64->count_encoders * sizeof(uint32_t));
-		out_resp->modes_ptr = (uintcap_t)__USER_CAP(
+		out_resp->modes_ptr = (uintcap_t)USER_PTR(
 		    out_resp64->modes_ptr,
 		    out_resp64->count_modes * sizeof(struct drm_mode_modeinfo));
-		out_resp->props_ptr = (uintcap_t)__USER_CAP(
+		out_resp->props_ptr = (uintcap_t)USER_PTR(
 		    out_resp64->props_ptr,
 		    out_resp64->count_props * sizeof(uint32_t));
-		out_resp->prop_values_ptr = (uintcap_t)__USER_CAP(
+		out_resp->prop_values_ptr = (uintcap_t)USER_PTR(
 		    out_resp64->prop_values_ptr,
 		    out_resp64->count_props * sizeof(uint64_t));
 	}

--- a/sys/dev/drm/core/drm_crtc.c
+++ b/sys/dev/drm/core/drm_crtc.c
@@ -589,7 +589,7 @@ int drm_mode_setcrtc(struct drm_device *dev, void *data,
 		CP(*crtc_req64, *crtc_req, mode_valid);
 		CP(*crtc_req64, *crtc_req, mode);
 
-		crtc_req->set_connectors_ptr = (uintcap_t)__USER_CAP(
+		crtc_req->set_connectors_ptr = (uintcap_t)USER_PTR(
 		    crtc_req64->set_connectors_ptr,
 		    crtc_req64->count_connectors * sizeof(uint32_t));
 	}

--- a/sys/dev/drm/core/drm_framebuffer.c
+++ b/sys/dev/drm/core/drm_framebuffer.c
@@ -724,7 +724,7 @@ int drm_mode_dirtyfb_ioctl(struct drm_device *dev,
 		CP(*r64, *r, flags);
 		CP(*r64, *r, color);
 		CP(*r64, *r, num_clips);
-		r->clips_ptr = (uintcap_t)__USER_CAP(r64->clips_ptr,
+		r->clips_ptr = (uintcap_t)USER_PTR(r64->clips_ptr,
 		    r64->num_clips * sizeof(uint64_t));
 	}
 #endif

--- a/sys/dev/drm/core/drm_ioctl.c
+++ b/sys/dev/drm/core/drm_ioctl.c
@@ -549,9 +549,9 @@ int drm_version(struct drm_device *dev, void *data,
 		CP(*version64, *version, name_len);
 		CP(*version64, *version, date_len);
 		CP(*version64, *version, desc_len);
-		version->name = __USER_CAP(version64->name, version->name_len);
-		version->date = __USER_CAP(version64->date, version->date_len);
-		version->desc = __USER_CAP(version64->desc, version->desc_len);
+		version->name = USER_PTR(version64->name, version->name_len);
+		version->date = USER_PTR(version64->date, version->date_len);
+		version->desc = USER_PTR(version64->desc, version->desc_len);
 	}
 #endif
 

--- a/sys/dev/drm/core/drm_mode_config.c
+++ b/sys/dev/drm/core/drm_mode_config.c
@@ -125,19 +125,19 @@ int drm_mode_getresources(struct drm_device *dev, void *data,
 		CP(*card_res64, *card_res, min_height);
 		CP(*card_res64, *card_res, max_height);
 
-		card_res->fb_id_ptr = (uintcap_t)__USER_CAP(
+		card_res->fb_id_ptr = (uintcap_t)USER_PTR(
 		    card_res64->fb_id_ptr,
 		    card_res64->count_fbs * sizeof(uint32_t));
 
-		card_res->crtc_id_ptr = (uintcap_t)__USER_CAP(
+		card_res->crtc_id_ptr = (uintcap_t)USER_PTR(
 		    card_res64->crtc_id_ptr,
 		    card_res64->count_crtcs * sizeof(uint32_t));
 
-		card_res->connector_id_ptr = (uintcap_t)__USER_CAP(
+		card_res->connector_id_ptr = (uintcap_t)USER_PTR(
 		    card_res64->connector_id_ptr,
 		    card_res64->count_connectors * sizeof(uint32_t));
 
-		card_res->encoder_id_ptr = (uintcap_t)__USER_CAP(
+		card_res->encoder_id_ptr = (uintcap_t)USER_PTR(
 		    card_res64->encoder_id_ptr,
 		    card_res64->count_encoders * sizeof(uint32_t));
 	}

--- a/sys/dev/drm/core/drm_mode_object.c
+++ b/sys/dev/drm/core/drm_mode_object.c
@@ -432,10 +432,10 @@ int drm_mode_obj_get_properties_ioctl(struct drm_device *dev, void *data,
 		CP(*arg64, *arg, count_props);
 		CP(*arg64, *arg, obj_id);
 		CP(*arg64, *arg, obj_type);
-		arg->props_ptr = (uintcap_t)__USER_CAP(
+		arg->props_ptr = (uintcap_t)USER_PTR(
 		    arg64->props_ptr,
 		    arg64->count_props * sizeof(uint32_t));
-		arg->prop_values_ptr = (uintcap_t)__USER_CAP(
+		arg->prop_values_ptr = (uintcap_t)USER_PTR(
 		    arg64->prop_values_ptr,
 		    arg64->count_props * sizeof(uint64_t));
 	}

--- a/sys/dev/drm/core/drm_plane.c
+++ b/sys/dev/drm/core/drm_plane.c
@@ -505,7 +505,7 @@ int drm_mode_getplane_res(struct drm_device *dev, void *data,
 		plane_resp64 = (struct drm_mode_get_plane_res64 *)data;
 		plane_resp = &local_plane_resp;
 		CP(*plane_resp64, *plane_resp, count_planes);
-		plane_resp->plane_id_ptr = (uintcap_t)__USER_CAP(
+		plane_resp->plane_id_ptr = (uintcap_t)USER_PTR(
 		    plane_resp64->plane_id_ptr,
 		    plane_resp64->count_planes * sizeof(uint32_t));
 	}
@@ -576,7 +576,7 @@ int drm_mode_getplane(struct drm_device *dev, void *data,
 
 #ifdef COMPAT_FREEBSD64
 	if (!SV_CURPROC_FLAG(SV_CHERI)) {
-		plane_resp->format_type_ptr = (uintcap_t)__USER_CAP(
+		plane_resp->format_type_ptr = (uintcap_t)USER_PTR(
 		    plane_resp64->format_type_ptr,
 		    plane->format_count * sizeof(uint32_t));
 	}

--- a/sys/dev/drm/core/drm_property.c
+++ b/sys/dev/drm/core/drm_property.c
@@ -488,10 +488,10 @@ int drm_mode_getproperty_ioctl(struct drm_device *dev,
 		CP(*out_resp64, *out_resp, flags);
 		CP(*out_resp64, *out_resp, count_values);
 		CP(*out_resp64, *out_resp, count_enum_blobs);
-		out_resp->values_ptr = (uintcap_t)__USER_CAP(
+		out_resp->values_ptr = (uintcap_t)USER_PTR(
 		    out_resp64->values_ptr,
 		    out_resp64->count_values * sizeof(uint64_t));
-		out_resp->enum_blob_ptr = (uintcap_t)__USER_CAP(
+		out_resp->enum_blob_ptr = (uintcap_t)USER_PTR(
 		    out_resp64->enum_blob_ptr,
 		    out_resp64->count_enum_blobs * sizeof(uint64_t));
 	}
@@ -810,7 +810,7 @@ int drm_mode_getblob_ioctl(struct drm_device *dev,
 		out_resp = &local_out_resp;
 		CP(*out_resp64, *out_resp, blob_id);
 		CP(*out_resp64, *out_resp, length);
-		out_resp->data = (uintcap_t)__USER_CAP(out_resp64->data,
+		out_resp->data = (uintcap_t)USER_PTR(out_resp64->data,
 		    out_resp64->length);
 	}
 #endif
@@ -858,7 +858,7 @@ int drm_mode_createblob_ioctl(struct drm_device *dev,
 		out_resp64 = (struct drm_mode_create_blob64 *)data;
 		out_resp = &local_out_resp;
 		CP(*out_resp64, *out_resp, length);
-		out_resp->data = (uintcap_t)__USER_CAP(out_resp64->data,
+		out_resp->data = (uintcap_t)USER_PTR(out_resp64->data,
 		    out_resp64->length);
 	}
 #endif

--- a/sys/dev/drm/core/drm_syncobj.c
+++ b/sys/dev/drm/core/drm_syncobj.c
@@ -1348,7 +1348,7 @@ drm_syncobj_wait_ioctl(struct drm_device *dev, void *data,
 		CP(*args64, *args, count_handles);
 		CP(*args64, *args, flags);
 		CP(*args64, *args, first_signaled);
-		args->handles = (uintcap_t)__USER_CAP(args64->handles,
+		args->handles = (uintcap_t)USER_PTR(args64->handles,
 		    args64->count_handles * sizeof(uint64_t));
 	}
 #endif
@@ -1407,9 +1407,9 @@ drm_syncobj_timeline_wait_ioctl(struct drm_device *dev, void *data,
 		CP(*args64, *args, count_handles);
 		CP(*args64, *args, flags);
 		CP(*args64, *args, first_signaled);
-		args->handles = (uintcap_t)__USER_CAP(args64->handles,
+		args->handles = (uintcap_t)USER_PTR(args64->handles,
 		    args64->count_handles * sizeof(uint64_t));
-		args->points = (uintcap_t)__USER_CAP(args64->points,
+		args->points = (uintcap_t)USER_PTR(args64->points,
 		    args64->count_handles * sizeof(uint64_t));
 	}
 #endif
@@ -1468,7 +1468,7 @@ drm_syncobj_reset_ioctl(struct drm_device *dev, void *data,
 		args64 = (struct drm_syncobj_array64 *)data;
 		args = &local_args;
 		CP(*args64, *args, count_handles);
-		args->handles = (uintcap_t)__USER_CAP(args64->handles,
+		args->handles = (uintcap_t)USER_PTR(args64->handles,
 		    args64->count_handles * sizeof(uint64_t));
 	}
 #endif
@@ -1515,7 +1515,7 @@ drm_syncobj_signal_ioctl(struct drm_device *dev, void *data,
 		args64 = (struct drm_syncobj_array64 *)data;
 		args = &local_args;
 		CP(*args64, *args, count_handles);
-		args->handles = (uintcap_t)__USER_CAP(args64->handles,
+		args->handles = (uintcap_t)USER_PTR(args64->handles,
 		    args64->count_handles * sizeof(uint64_t));
 	}
 #endif
@@ -1565,9 +1565,9 @@ drm_syncobj_timeline_signal_ioctl(struct drm_device *dev, void *data,
 		args = &local_args;
 		CP(*args64, *args, count_handles);
 		CP(*args64, *args, flags);
-		args->handles = (uintcap_t)__USER_CAP(args64->handles,
+		args->handles = (uintcap_t)USER_PTR(args64->handles,
 		    args64->count_handles * sizeof(uint64_t));
-		args->points = (uintcap_t)__USER_CAP(args64->points,
+		args->points = (uintcap_t)USER_PTR(args64->points,
 		    args64->count_handles * sizeof(uint64_t));
 	}
 #endif
@@ -1653,9 +1653,9 @@ int drm_syncobj_query_ioctl(struct drm_device *dev, void *data,
 		args = &local_args;
 		CP(*args64, *args, count_handles);
 		CP(*args64, *args, flags);
-		args->handles = (uintcap_t)__USER_CAP(args64->handles,
+		args->handles = (uintcap_t)USER_PTR(args64->handles,
 		    args64->count_handles * sizeof(uint64_t));
-		args->points = (uintcap_t)__USER_CAP(args64->points,
+		args->points = (uintcap_t)USER_PTR(args64->points,
 		    args64->count_handles * sizeof(uint64_t));
 		points = u64_to_user_ptr(args->points);
 	}

--- a/sys/dev/drm/drmkpi/drmcompat_compat.c
+++ b/sys/dev/drm/drmkpi/drmcompat_compat.c
@@ -58,14 +58,14 @@ int
 drmcompat_copyin(const void * __capability uaddr, void *kaddr, size_t len)
 {
 
-	return (-copyincap(uaddr, kaddr, len));
+	return (-copyinptr(uaddr, kaddr, len));
 }
 
 int
 drmcompat_copyout(const void *kaddr, void * __capability uaddr, size_t len)
 {
 
-	return (-copyoutcap(kaddr, uaddr, len));
+	return (-copyoutptr(kaddr, uaddr, len));
 }
 
 size_t

--- a/sys/dev/drm/panfrost/panfrost_drv.c
+++ b/sys/dev/drm/panfrost/panfrost_drv.c
@@ -281,10 +281,10 @@ panfrost_ioctl_submit(struct drm_device *dev, void *data,
 		CP(*args64, *args, requirements);
 
 		sz = args64->in_sync_count * sizeof(uint32_t);
-		args->in_syncs = (uintcap_t)__USER_CAP(args64->in_syncs, sz);
+		args->in_syncs = (uintcap_t)USER_PTR(args64->in_syncs, sz);
 
 		sz = args64->bo_handle_count * sizeof(uint32_t);
-		args->bo_handles = (uintcap_t)__USER_CAP(args64->bo_handles,sz);
+		args->bo_handles = (uintcap_t)USER_PTR(args64->bo_handles,sz);
 	}
 #endif
 

--- a/sys/dev/efidev/efidev.c
+++ b/sys/dev/efidev/efidev.c
@@ -100,7 +100,7 @@ efidev_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t addr,
 
 		cmd = _IOC_NEWTYPE(cmd, struct efi_get_table_ioc);
 		addr = (caddr_t)egtioc;
-		egtioc->buf = __USER_CAP(egtioc64->buf, egtioc64->buf_len);
+		egtioc->buf = USER_PTR(egtioc64->buf, egtioc64->buf_len);
 		CP(*egtioc64, *egtioc, uuid);
 		CP(*egtioc64, *egtioc, table_len);
 		CP(*egtioc64, *egtioc, buf_len);
@@ -115,11 +115,11 @@ efidev_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t addr,
 
 		cmd = _IOC_NEWTYPE(cmd, struct efi_var_ioc);
 		addr = (caddr_t)ev;
-		ev->name = __USER_CAP(ev64->name, ev64->namesize);
+		ev->name = USER_PTR(ev64->name, ev64->namesize);
 		CP(*ev64, *ev, namesize);
 		CP(*ev64, *ev, vendor);
 		CP(*ev64, *ev, attrib);
-		ev->data = __USER_CAP(ev64->data, ev64->datasize);
+		ev->data = USER_PTR(ev64->data, ev64->datasize);
 		CP(*ev64, *ev, datasize);
 		break;
 	}

--- a/sys/dev/evdev/uinput.c
+++ b/sys/dev/evdev/uinput.c
@@ -28,6 +28,7 @@
 #include "opt_evdev.h"
 
 #include <sys/param.h>
+#include <sys/abi_compat.h>
 #include <sys/conf.h>
 #include <sys/fcntl.h>
 #include <sys/kernel.h>

--- a/sys/dev/evdev/uinput.c
+++ b/sys/dev/evdev/uinput.c
@@ -591,7 +591,7 @@ uinput_ioctl_sub(struct uinput_cdev_state *state, u_long cmd, caddr_t data)
 
 #if __has_feature(capabilities)
 		if (!SV_CURPROC_FLAG(SV_CHERI))
-			cap = __USER_CAP_STR(*(uint64_t *)data);
+			cap = USER_PTR_STR(*(uint64_t *)data);
 		else
 #endif
 			cap = *(void * __capability *)data;
@@ -613,7 +613,7 @@ uinput_ioctl_sub(struct uinput_cdev_state *state, u_long cmd, caddr_t data)
 			return (EINVAL);
 #if __has_feature(capabilities)
 		if (!SV_CURPROC_FLAG(SV_CHERI))
-			cap = __USER_CAP_STR(*(uint64_t *)data);
+			cap = USER_PTR_STR(*(uint64_t *)data);
 		else
 #endif
 			cap = *(void * __capability *)data;

--- a/sys/dev/hid/hidraw.c
+++ b/sys/dev/hid/hidraw.c
@@ -664,7 +664,7 @@ hidraw_ioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag,
 		cmd = _IOC_NEWTYPE(cmd, struct hidraw_gen_descriptor);
 		hgd64 = (struct hidraw_gen_descriptor64 *)addr;
 		hgd = &local_hgd;
-		hgd->hgd_data = __USER_CAP(hgd64->hgd_data, hgd64->hgd_maxlen);
+		hgd->hgd_data = USER_PTR(hgd64->hgd_data, hgd64->hgd_maxlen);
 		CP(*hgd64, *hgd, hgd_lang_id);
 		CP(*hgd64, *hgd, hgd_maxlen);
 		CP(*hgd64, *hgd, hgd_actlen);

--- a/sys/dev/hwpmc/hwpmc_arm64_md.c
+++ b/sys/dev/hwpmc/hwpmc_arm64_md.c
@@ -118,7 +118,7 @@ pmc_save_user_callchain(uintptr_t *cc, int maxsamples,
 #ifdef COMPAT_FREEBSD64
 		if (SV_CURPROC_FLAG(SV_CHERI | SV_LP64) == SV_LP64) {
 			r = fp + sizeof(r64);
-			if (fueword64(__USER_CAP(r, sizeof(r64)), &r64) != 0)
+			if (fueword64(USER_PTR(r, sizeof(r64)), &r64) != 0)
 				break;
 			pc = r64;
 		} else
@@ -139,7 +139,7 @@ pmc_save_user_callchain(uintptr_t *cc, int maxsamples,
 		r = fp;
 #ifdef COMPAT_FREEBSD64
 		if (SV_CURPROC_FLAG(SV_CHERI | SV_LP64) == SV_LP64) {
-			if (fueword64(__USER_CAP(r, sizeof(r64)), &r64) != 0)
+			if (fueword64(USER_PTR(r, sizeof(r64)), &r64) != 0)
 				break;
 			fp = r64;
 		} else

--- a/sys/dev/hwpmc/hwpmc_arm64_md.c
+++ b/sys/dev/hwpmc/hwpmc_arm64_md.c
@@ -29,6 +29,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/pmc.h>
 #include <sys/sysent.h>
 

--- a/sys/dev/iicbus/iic.c
+++ b/sys/dev/iicbus/iic.c
@@ -343,7 +343,7 @@ iic_copyinmsgs32(struct iic_rdwr_data *d, struct iic_msg_user *buf)
 		CP(msg32, buf[i], slave);
 		CP(msg32, buf[i], flags);
 		CP(msg32, buf[i], len);
-		buf[i].buf = __USER_CAP(PTRIN(msg32.buf), msg32.len);
+		buf[i].buf = USER_PTR(PTRIN(msg32.buf), msg32.len);
 	}
 	return (0);
 }

--- a/sys/dev/iscsi/iscsi.c
+++ b/sys/dev/iscsi/iscsi.c
@@ -1758,7 +1758,7 @@ iscsi_ioctl_daemon_connect(struct iscsi_softc *sc,
 	sx_sunlock(&sc->sc_lock);
 
 	if (idc->idc_from_addrlen > 0) {
-		error = getsockaddr(&from_sa, __USER_CAP(idc->idc_from_addr,
+		error = getsockaddr(&from_sa, USER_PTR(idc->idc_from_addr,
 		    idc->idc_from_addrlen), idc->idc_from_addrlen);
 		if (error != 0) {
 			ISCSI_SESSION_WARN(is,
@@ -1768,7 +1768,7 @@ iscsi_ioctl_daemon_connect(struct iscsi_softc *sc,
 	} else {
 		from_sa = NULL;
 	}
-	error = getsockaddr(&to_sa, __USER_CAP(idc->idc_to_addr,
+	error = getsockaddr(&to_sa, USER_PTR(idc->idc_to_addr,
 	    idc->idc_to_addrlen), idc->idc_to_addrlen);
 	if (error != 0) {
 		ISCSI_SESSION_WARN(is, "getsockaddr failed with error %d",

--- a/sys/dev/kbd/kbd.c
+++ b/sys/dev/kbd/kbd.c
@@ -826,7 +826,7 @@ genkbd_commonioctl(keyboard_t *kbd, u_long cmd, caddr_t arg)
 	case GIO_KEYMAP:	/* get keyboard translation table */
 #if __has_feature(capabilities)
 		if (!SV_CURPROC_FLAG(SV_CHERI))
-			data = __USER_CAP_UNBOUND(*(uint64_t *)arg);
+			data = USER_PTR_UNBOUND(*(uint64_t *)arg);
 		else
 #endif
 			data = *(void * __capability *)arg;
@@ -868,7 +868,7 @@ genkbd_commonioctl(keyboard_t *kbd, u_long cmd, caddr_t arg)
 		{
 #if __has_feature(capabilities)
 			if (!SV_CURPROC_FLAG(SV_CHERI))
-				data = __USER_CAP_UNBOUND(*(uint64_t *)arg);
+				data = USER_PTR_UNBOUND(*(uint64_t *)arg);
 			else
 #endif
 				data = *(void * __capability *)arg;

--- a/sys/dev/kbd/kbd.c
+++ b/sys/dev/kbd/kbd.c
@@ -32,6 +32,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/kernel.h>
 #include <sys/lock.h>
 #include <sys/malloc.h>

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -1943,7 +1943,7 @@ mdctlioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 		if (mdio->md_version != MDIOVERSION)
 			return (EINVAL);
 		MD_IOCTL2REQ(mdio, &mdr);
-		mdr.md_file = USER_PTR_STR((void *)(uintptr_t)mdio->md_file);
+		mdr.md_file = USER_PTR_PATH((void *)(uintptr_t)mdio->md_file);
 		mdr.md_file_seg = UIO_USERSPACE;
 		mdr.md_label =
 		    USER_PTR_STR((void *)(uintptr_t)mdio->md_label);
@@ -1959,7 +1959,7 @@ mdctlioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 		if (mdio->md_version != MDIOVERSION)
 			return (EINVAL);
 		MD_IOCTL2REQ(mdio, &mdr);
-		mdr.md_file = USER_PTR_STR((void *)(uintptr_t)mdio->md_file);
+		mdr.md_file = USER_PTR_PATH((void *)(uintptr_t)mdio->md_file);
 		mdr.md_file_seg = UIO_USERSPACE;
 		mdr.md_label =
 		    USER_PTR_STR((void *)(uintptr_t)mdio->md_label);

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -62,6 +62,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/bio.h>
 #include <sys/buf.h>
 #include <sys/conf.h>

--- a/sys/dev/md/md.c
+++ b/sys/dev/md/md.c
@@ -1943,10 +1943,10 @@ mdctlioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 		if (mdio->md_version != MDIOVERSION)
 			return (EINVAL);
 		MD_IOCTL2REQ(mdio, &mdr);
-		mdr.md_file = __USER_CAP_STR((void *)(uintptr_t)mdio->md_file);
+		mdr.md_file = USER_PTR_STR((void *)(uintptr_t)mdio->md_file);
 		mdr.md_file_seg = UIO_USERSPACE;
 		mdr.md_label =
-		    __USER_CAP_STR((void *)(uintptr_t)mdio->md_label);
+		    USER_PTR_STR((void *)(uintptr_t)mdio->md_label);
 		break;
 	}
 #endif
@@ -1959,10 +1959,10 @@ mdctlioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 		if (mdio->md_version != MDIOVERSION)
 			return (EINVAL);
 		MD_IOCTL2REQ(mdio, &mdr);
-		mdr.md_file = __USER_CAP_STR((void *)(uintptr_t)mdio->md_file);
+		mdr.md_file = USER_PTR_STR((void *)(uintptr_t)mdio->md_file);
 		mdr.md_file_seg = UIO_USERSPACE;
 		mdr.md_label =
-		    __USER_CAP_STR((void *)(uintptr_t)mdio->md_label);
+		    USER_PTR_STR((void *)(uintptr_t)mdio->md_label);
 		break;
 	}
 #endif

--- a/sys/dev/mem/memdev.c
+++ b/sys/dev/mem/memdev.c
@@ -236,7 +236,7 @@ memioctl(struct cdev *dev, u_long cmd, caddr_t data, int flags,
 	case MEM_READ_CHERI_CAP64:
 		cap_arg64 = (const struct mem_cheri_cap_arg64 *)data;
 		cap_arg_thunk.vaddr = cap_arg64->vaddr;
-		cap_arg_thunk.buf = __USER_CAP(cap_arg64->buf, cap_arg64->len);
+		cap_arg_thunk.buf = USER_PTR(cap_arg64->buf, cap_arg64->len);
 		cap_arg_thunk.len = cap_arg64->len;
 		error = mem_read_cheri_caps(dev, &cap_arg_thunk);
 		break;

--- a/sys/dev/mem/memdev.c
+++ b/sys/dev/mem/memdev.c
@@ -28,6 +28,7 @@
  */
 
 #include <sys/param.h>
+#include <sys/abi_compat.h>
 #include <sys/conf.h>
 #include <sys/fcntl.h>
 #include <sys/ioccom.h>

--- a/sys/dev/mfi/mfi.c
+++ b/sys/dev/mfi/mfi.c
@@ -3272,7 +3272,7 @@ mfi_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 						/* 32bit on 64bit */
 						ioc32 = (struct mfi_ioc_packet32 *)ioc;
 						len = ioc32->mfi_sgl[i].iov_len;
-						addr = __USER_CAP(PTRIN(ioc32->mfi_sgl[i].iov_base), len);
+						addr = USER_PTR(PTRIN(ioc32->mfi_sgl[i].iov_base), len);
 						break;
 #endif
 #ifdef COMPAT_FREEBSD64
@@ -3280,7 +3280,7 @@ mfi_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 						/* 64bit on CHERI */
 						ioc64 = (struct mfi_ioc_packet64 *)ioc;
 						len = ioc64->mfi_sgl[i].iov_len;
-						addr = __USER_CAP(ioc64->mfi_sgl[i].iov_base, len);
+						addr = USER_PTR(ioc64->mfi_sgl[i].iov_base, len);
 						break;
 #endif
 					}
@@ -3340,14 +3340,14 @@ mfi_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 						/* 32bit on 64bit */
 						ioc32 = (struct mfi_ioc_packet32 *)ioc;
 						len = ioc32->mfi_sgl[i].iov_len;
-						addr = __USER_CAP(PTRIN(ioc32->mfi_sgl[i].iov_base), len);
+						addr = USER_PTR(PTRIN(ioc32->mfi_sgl[i].iov_base), len);
 #endif
 #ifdef COMPAT_FREEBSD64
 					case MFI_CMD64:
 						/* 64bit on CHERI */
 						ioc64 = (struct mfi_ioc_packet64 *)ioc;
 						len = ioc64->mfi_sgl[i].iov_len;
-						addr = __USER_CAP(ioc64->mfi_sgl[i].iov_base, len);
+						addr = USER_PTR(ioc64->mfi_sgl[i].iov_base, len);
 #endif
 					}
 					error = copyout(temp, addr, len);
@@ -3476,7 +3476,7 @@ out:
 		}
 		iop_swab.ioc_frame	= iop32->ioc_frame;
 		iop_swab.buf_size	= iop32->buf_size;
-		iop_swab.buf		= __USER_CAP(PTRIN(iop32->buf),
+		iop_swab.buf		= USER_PTR(PTRIN(iop32->buf),
 		    iop32->buf_size);
 		error = mfi_user_command(sc, &iop_swab);
 		iop32->ioc_frame = iop_swab.ioc_frame;
@@ -3490,7 +3490,7 @@ out:
 		}
 		iop_swab.ioc_frame	= iop64->ioc_frame;
 		iop_swab.buf_size	= iop64->buf_size;
-		iop_swab.buf		= __USER_CAP(iop64->buf,
+		iop_swab.buf		= USER_PTR(iop64->buf,
 		    iop64->buf_size);
 		error = mfi_user_command(sc, &iop_swab);
 		iop64->ioc_frame = iop_swab.ioc_frame;

--- a/sys/dev/mmc/mmcsd.c
+++ b/sys/dev/mmc/mmcsd.c
@@ -55,6 +55,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/bio.h>
 #include <sys/bus.h>
 #include <sys/conf.h>

--- a/sys/dev/mpi3mr/mpi3mr_app.c
+++ b/sys/dev/mpi3mr/mpi3mr_app.c
@@ -845,7 +845,7 @@ mpi3mr_app_mptcmds(struct cdev *dev, u_long cmd, void *uarg,
 		rval = ENOMEM;
 		goto out;
 	}
-	if (copyincap(karg->buf_entry_list, buffer_list, karg->buf_entry_list_size)) {
+	if (copyinptr(karg->buf_entry_list, buffer_list, karg->buf_entry_list_size)) {
 		printf(IOCNAME "failure at %s:%d/%s()!\n", sc->name,
 		       __FILE__, __LINE__, __func__);
 		rval = EFAULT;

--- a/sys/dev/mpt/mpt_user.c
+++ b/sys/dev/mpt/mpt_user.c
@@ -631,7 +631,7 @@ mpt_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 		page_req = &page_req_swab;
 		page_req->header = page_req32->header;
 		page_req->page_address = page_req32->page_address;
-		page_req->buf = __USER_CAP(PTRIN(page_req32->buf),
+		page_req->buf = USER_PTR(PTRIN(page_req32->buf),
 		    page_req32->len);
 		page_req->len = page_req32->len;
 		page_req->ioc_status = page_req32->ioc_status;
@@ -641,7 +641,7 @@ mpt_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 		ext_page_req = &ext_page_req_swab;
 		ext_page_req->header = ext_page_req32->header;
 		ext_page_req->page_address = ext_page_req32->page_address;
-		ext_page_req->buf = __USER_CAP(PTRIN(ext_page_req32->buf),
+		ext_page_req->buf = USER_PTR(PTRIN(ext_page_req32->buf),
 		    ext_page_req32->len);
 		ext_page_req->len = ext_page_req32->len;
 		ext_page_req->ioc_status = ext_page_req32->ioc_status;
@@ -653,7 +653,7 @@ mpt_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 		raid_act->volume_id = raid_act32->volume_id;
 		raid_act->phys_disk_num = raid_act32->phys_disk_num;
 		raid_act->action_data_word = raid_act32->action_data_word;
-		raid_act->buf = __USER_CAP(PTRIN(raid_act32->buf),
+		raid_act->buf = USER_PTR(PTRIN(raid_act32->buf),
 		    raid_act32->len);
 		raid_act->len = raid_act32->len;
 		raid_act->volume_status = raid_act32->volume_status;
@@ -677,7 +677,7 @@ mpt_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 		page_req = &page_req_swab;
 		page_req->header = page_req64->header;
 		page_req->page_address = page_req64->page_address;
-		page_req->buf = __USER_CAP(PTRIN(page_req64->buf),
+		page_req->buf = USER_PTR(PTRIN(page_req64->buf),
 		    page_req64->len);
 		page_req->len = page_req64->len;
 		page_req->ioc_status = page_req64->ioc_status;
@@ -687,7 +687,7 @@ mpt_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 		ext_page_req = &ext_page_req_swab;
 		ext_page_req->header = ext_page_req64->header;
 		ext_page_req->page_address = ext_page_req64->page_address;
-		ext_page_req->buf = __USER_CAP(PTRIN(ext_page_req64->buf),
+		ext_page_req->buf = USER_PTR(PTRIN(ext_page_req64->buf),
 		    ext_page_req64->len);
 		ext_page_req->len = ext_page_req64->len;
 		ext_page_req->ioc_status = ext_page_req64->ioc_status;
@@ -699,7 +699,7 @@ mpt_ioctl(struct cdev *dev, u_long cmd, caddr_t arg, int flag, struct thread *td
 		raid_act->volume_id = raid_act64->volume_id;
 		raid_act->phys_disk_num = raid_act64->phys_disk_num;
 		raid_act->action_data_word = raid_act64->action_data_word;
-		raid_act->buf = __USER_CAP(PTRIN(raid_act64->buf),
+		raid_act->buf = USER_PTR(PTRIN(raid_act64->buf),
 		    raid_act64->len);
 		raid_act->len = raid_act64->len;
 		raid_act->volume_status = raid_act64->volume_status;

--- a/sys/dev/mrsas/mrsas_ioctl.c
+++ b/sys/dev/mrsas/mrsas_ioctl.c
@@ -258,7 +258,7 @@ mrsas_passthru(struct mrsas_softc *sc, void *arg, u_long ioctlCmd)
 			kern_sge32[i].length = user_ioc32->sgl[i].iov_len;
 
 			iov_len = user_ioc32->sgl[i].iov_len;
-			iov_base_ptrin = __USER_CAP(PTRIN(
+			iov_base_ptrin = USER_PTR(PTRIN(
 			    user_ioc32->sgl[i].iov_base), iov_len);
 #endif
 		}
@@ -331,7 +331,7 @@ mrsas_passthru(struct mrsas_softc *sc, void *arg, u_long ioctlCmd)
 #ifdef COMPAT_FREEBSD32
 		} else {
 			iov_len = user_ioc32->sgl[i].iov_len;
-			iov_base_ptrin = __USER_CAP(PTRIN(
+			iov_base_ptrin = USER_PTR(PTRIN(
 			    user_ioc32->sgl[i].iov_base), iov_len);
 #endif
 		}
@@ -354,7 +354,7 @@ mrsas_passthru(struct mrsas_softc *sc, void *arg, u_long ioctlCmd)
 		sense_ptr = (unsigned long *)((uintptr_t)user_ioc->frame.raw +
 		    user_ioc->sense_off);
 		ret = copyout(ioctl_sense_mem,
-		    __USER_CAP((unsigned long *)(uintptr_t)*sense_ptr, user_ioc->sense_len),
+		    USER_PTR((unsigned long *)(uintptr_t)*sense_ptr, user_ioc->sense_len),
 		    user_ioc->sense_len);
 		if (ret) {
 			device_printf(sc->mrsas_dev, "IOCTL sense copyout failed!\n");

--- a/sys/dev/pci/pci_user.c
+++ b/sys/dev/pci/pci_user.c
@@ -768,11 +768,11 @@ pci_conf_io_init(struct pci_conf_io *cio, caddr_t data, u_long cmd)
 		cio32 = (struct pci_conf_io32 *)data;
 		cio->pat_buf_len = cio32->pat_buf_len;
 		cio->num_patterns = cio32->num_patterns;
-		cio->patterns = __USER_CAP((void *)(uintptr_t)cio32->patterns,
+		cio->patterns = USER_PTR((void *)(uintptr_t)cio32->patterns,
 		    cio32->pat_buf_len);
 		cio->match_buf_len = cio32->match_buf_len;
 		cio->num_matches = cio32->num_matches;
-		cio->matches = __USER_CAP((void *)(uintptr_t)cio32->matches,
+		cio->matches = USER_PTR((void *)(uintptr_t)cio32->matches,
 		    cio32->match_buf_len);
 		cio->offset = cio32->offset;
 		cio->generation = cio32->generation;
@@ -785,11 +785,11 @@ pci_conf_io_init(struct pci_conf_io *cio, caddr_t data, u_long cmd)
 		cio64 = (struct pci_conf_io64 *)data;
 		cio->pat_buf_len = cio64->pat_buf_len;
 		cio->num_patterns = cio64->num_patterns;
-		cio->patterns = __USER_CAP((void *)(uintptr_t)cio64->patterns,
+		cio->patterns = USER_PTR((void *)(uintptr_t)cio64->patterns,
 		    cio64->pat_buf_len);
 		cio->match_buf_len = cio64->match_buf_len;
 		cio->num_matches = cio64->num_matches;
-		cio->matches = __USER_CAP((void *)(uintptr_t)cio64->matches,
+		cio->matches = USER_PTR((void *)(uintptr_t)cio64->matches,
 		    cio64->match_buf_len);
 		cio->offset = cio64->offset;
 		cio->generation = cio64->generation;
@@ -1504,7 +1504,7 @@ getconfexit:
 			lvio = &lvios;
 			lvio->plvi_sel = lvio64->plvi_sel;
 			lvio->plvi_len = lvio64->plvi_len;
-			lvio->plvi_data = __USER_CAP(lvio64->plvi_data,
+			lvio->plvi_data = USER_PTR(lvio64->plvi_data,
 			    lvio64->plvi_len);
 		} else
 #endif
@@ -1534,7 +1534,7 @@ getconfexit:
 		if (cmd == PCIOCBARMMAP64) {
 			pbm64 = (struct pci_bar_mmap64 *)data;
 			pbm = &pbms;
-			pbm->pbm_map_base = __USER_CAP(pbm64->pbm_map_base,
+			pbm->pbm_map_base = USER_PTR(pbm64->pbm_map_base,
 			    pbm64->pbm_map_length);
 			CP(*pbm64, pbms, pbm_map_length);
 			CP(*pbm64, pbms, pbm_bar_length);

--- a/sys/dev/sound/pcm/sndstat.c
+++ b/sys/dev/sound/pcm/sndstat.c
@@ -1080,7 +1080,7 @@ sndstat_ioctl(
 	case SNDSTIOC_GET_DEVS64:
 		arg64 = (struct sndstioc_nv_arg64 *)data;
 		nbytes = arg64->nbytes;
-		err = sndstat_get_devs(pf, __USER_CAP(arg64->buf, nbytes),
+		err = sndstat_get_devs(pf, USER_PTR(arg64->buf, nbytes),
 		    &nbytes);
 		if (err == 0) {
 			arg64->nbytes = nbytes;
@@ -1101,7 +1101,7 @@ sndstat_ioctl(
 #ifdef COMPAT_FREEBSD64
 	case SNDSTIOC_ADD_USER_DEVS64:
 		arg64 = (struct sndstioc_nv_arg64 *)data;
-		err = sndstat_add_user_devs(pf, __USER_CAP(arg64->buf,
+		err = sndstat_add_user_devs(pf, USER_PTR(arg64->buf,
 		    arg64->nbytes), arg64->nbytes);
 		break;
 #endif

--- a/sys/dev/sound/pcm/sndstat.c
+++ b/sys/dev/sound/pcm/sndstat.c
@@ -40,6 +40,7 @@
 #endif
 
 #include <sys/param.h>
+#include <sys/abi_compat.h>
 #include <sys/lock.h>
 #include <sys/malloc.h>
 #include <sys/nv.h>

--- a/sys/dev/usb/usb_dev.c
+++ b/sys/dev/usb/usb_dev.c
@@ -1673,7 +1673,7 @@ usb_static_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int fflag,
 #endif
 #ifdef COMPAT_FREEBSD64
 		case USB_READ_DIR64:
-			err = usb_read_symlink(__USER_CAP(u.urd64->urd_data,
+			err = usb_read_symlink(USER_PTR(u.urd64->urd_data,
 			    u.urd64->urd_maxlen), u.urd64->urd_startentry,
 			    u.urd64->urd_maxlen);
 			break;

--- a/sys/dev/usb/usb_generic.c
+++ b/sys/dev/usb/usb_generic.c
@@ -1496,7 +1496,7 @@ ugen_fs_copyin(struct usb_fifo *f, uint8_t ep_index,
 
 	switch (f->fs_ep_sz) {
 	case sizeof(struct usb_fs_endpoint):
-		error = copyincap(ugen_fs_ep_uptr(f, ep_index), fs_ep,
+		error = copyinptr(ugen_fs_ep_uptr(f, ep_index), fs_ep,
 		    f->fs_ep_sz);
 		if (error != 0)
 			return (error);

--- a/sys/dev/usb/usb_generic.c
+++ b/sys/dev/usb/usb_generic.c
@@ -937,7 +937,7 @@ ugen_do_request64(struct usb_fifo *f, struct usb_ctl_request64 *ur64)
 	struct usb_ctl_request ur;
 	int error;
 
-	ur.ucr_data = __USER_CAP(ur64->ucr_data,
+	ur.ucr_data = USER_PTR(ur64->ucr_data,
 	    UGETW(ur64->ucr_request.wLength));
 	CP(*ur64, ur, ucr_flags);
 	CP(*ur64, ur, ucr_actlen);
@@ -1298,7 +1298,7 @@ ugen_fs_getbuffer(void * __capability *uptrp, struct usb_fifo *f,
 			return (EFAULT);
 		if (fueword32(lengths + n, &len32) != 0)
 			return (EFAULT);
-		*uptrp = __USER_CAP(uptr64, len32);
+		*uptrp = USER_PTR(uptr64, len32);
 		return (0);
 #endif
 	default:
@@ -1524,9 +1524,9 @@ ugen_fs_copyin(struct usb_fifo *f, uint8_t ep_index,
 		    f->fs_ep_sz);
 		if (error != 0)
 			return (error);
-		fs_ep->ppBuffer = __USER_CAP(fs_ep64.ppBuffer,
+		fs_ep->ppBuffer = USER_PTR(fs_ep64.ppBuffer,
 		    fs_ep64.nFrames * sizeof(uint64_t));
-		fs_ep->pLength = __USER_CAP(fs_ep64.pLength,
+		fs_ep->pLength = USER_PTR(fs_ep64.pLength,
 		    fs_ep64.nFrames * sizeof(uint32_t));
 		CP(fs_ep64, *fs_ep, nFrames);
 		CP(fs_ep64, *fs_ep, aFrames);
@@ -2555,7 +2555,7 @@ ugen_ioctl_post(struct usb_fifo *f, u_long cmd, void *addr, int fflags)
 #endif
 #ifdef COMPAT_FREEBSD64
 	case USB_FS_INIT64:
-		error = ugen_fs_init(f, __USER_CAP(u.pinit64->pEndpoints,
+		error = ugen_fs_init(f, USER_PTR(u.pinit64->pEndpoints,
 		    sizeof(struct usb_fs_endpoint64) * u.pinit64->ep_index_max),
 		    sizeof(struct usb_fs_endpoint64), fflags,
 		    u.pinit64->ep_index_max);
@@ -2683,7 +2683,7 @@ void
 usb_gen_descriptor_from64(struct usb_gen_descriptor *ugd,
     const struct usb_gen_descriptor64 *ugd64)
 {
-	ugd->ugd_data = __USER_CAP(ugd64->ugd_data, ugd64->ugd_maxlen);
+	ugd->ugd_data = USER_PTR(ugd64->ugd_data, ugd64->ugd_maxlen);
 	CP(*ugd64, *ugd, ugd_lang_id);
 	CP(*ugd64, *ugd, ugd_maxlen);
 	CP(*ugd64, *ugd, ugd_actlen);

--- a/sys/fs/cd9660/cd9660_vfsops.c
+++ b/sys/fs/cd9660/cd9660_vfsops.c
@@ -98,7 +98,7 @@ cd9660_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 	struct iso_args args;
 	int error;
 
-	error = copyincap(data, &args, sizeof args);
+	error = copyinptr(data, &args, sizeof args);
 	if (error)
 		return (error);
 

--- a/sys/fs/devfs/devfs_vnops.c
+++ b/sys/fs/devfs/devfs_vnops.c
@@ -39,6 +39,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/conf.h>
 #include <sys/dirent.h>
 #include <sys/eventhandler.h>

--- a/sys/fs/devfs/devfs_vnops.c
+++ b/sys/fs/devfs/devfs_vnops.c
@@ -903,12 +903,12 @@ fiodgname_buf_get_ptr(void *fgnp, u_long com)
 		return (fgnup->fgn.buf);
 #ifdef COMPAT_FREEBSD32
 	case FIODGNAME_32:
-		return (__USER_CAP((void *)(uintptr_t)fgnup->fgn32.buf,
+		return (USER_PTR((void *)(uintptr_t)fgnup->fgn32.buf,
 		    fgnup->fgn32.len));
 #endif
 #ifdef COMPAT_FREEBSD64
 	case FIODGNAME_64:
-		return (__USER_CAP((void *)(uintptr_t)fgnup->fgn64.buf,
+		return (USER_PTR((void *)(uintptr_t)fgnup->fgn64.buf,
 		    fgnup->fgn64.len));
 #endif
 	default:

--- a/sys/fs/msdosfs/msdosfs_vfsops.c
+++ b/sys/fs/msdosfs/msdosfs_vfsops.c
@@ -197,7 +197,7 @@ msdosfs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 
 	if (data == NULL)
 		return (EINVAL);
-	error = copyincap(data, &args, sizeof args);
+	error = copyinptr(data, &args, sizeof args);
 	if (error)
 		return (error);
 

--- a/sys/fs/nfs/nfs_commonport.c
+++ b/sys/fs/nfs/nfs_commonport.c
@@ -453,9 +453,9 @@ nfssvc_call(struct thread *p, struct nfssvc_args *uap, struct ucred *cred)
 
 	if (uap->flag & NFSSVC_IDNAME) {
 		if ((uap->flag & NFSSVC_NEWSTRUCT) != 0)
-			error = copyincap(uap->argp, &nid, sizeof(nid));
+			error = copyinptr(uap->argp, &nid, sizeof(nid));
 		else {
-			error = copyincap(uap->argp, &onid, sizeof(onid));
+			error = copyinptr(uap->argp, &onid, sizeof(onid));
 			if (error == 0) {
 				nid.nid_flag = onid.nid_flag;
 				nid.nid_uid = onid.nid_uid;

--- a/sys/fs/nfsclient/nfs_clport.c
+++ b/sys/fs/nfsclient/nfs_clport.c
@@ -1294,7 +1294,7 @@ nfssvc_nfscl(struct thread *td, struct nfssvc_args *uap)
 
 	NFSD_CURVNET_SET(NFSD_TD_TO_VNET(td));
 	if (uap->flag & NFSSVC_CBADDSOCK) {
-		error = copyincap(uap->argp, &nfscbdarg, sizeof(nfscbdarg));
+		error = copyinptr(uap->argp, &nfscbdarg, sizeof(nfscbdarg));
 		if (error)
 			goto out;
 		/*
@@ -1322,7 +1322,7 @@ nfssvc_nfscl(struct thread *td, struct nfssvc_args *uap)
 			error = EINVAL;
 			goto out;
 		}
-		error = copyincap(uap->argp, &nfscbdarg2, sizeof(nfscbdarg2));
+		error = copyinptr(uap->argp, &nfscbdarg2, sizeof(nfscbdarg2));
 		if (error)
 			goto out;
 		error = nfscbd_nfsd(td, &nfscbdarg2);

--- a/sys/fs/nfsserver/nfs_nfsdport.c
+++ b/sys/fs/nfsserver/nfs_nfsdport.c
@@ -3795,7 +3795,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 
 	NFSD_CURVNET_SET(NFSD_TD_TO_VNET(td));
 	if (uap->flag & NFSSVC_NFSDADDSOCK) {
-		error = copyincap(uap->argp, &sockarg, sizeof(sockarg));
+		error = copyinptr(uap->argp, &sockarg, sizeof(sockarg));
 		if (error)
 			goto out;
 		/*
@@ -3820,7 +3820,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 			goto out;
 		}
 		if ((uap->flag & NFSSVC_NEWSTRUCT) == 0) {
-			error = copyincap(uap->argp, &onfsdarg,
+			error = copyinptr(uap->argp, &onfsdarg,
 			    sizeof(onfsdarg));
 			if (error == 0) {
 				nfsdarg.principal = onfsdarg.principal;
@@ -3838,7 +3838,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 				nfsdarg.mirrorcnt = 1;
 			}
 		} else
-			error = copyincap(uap->argp, &nfsdarg, sizeof(nfsdarg));
+			error = copyinptr(uap->argp, &nfsdarg, sizeof(nfsdarg));
 		if (error)
 			goto out;
 		if (nfsdarg.addrlen > 0 && nfsdarg.addrlen < 10000 &&
@@ -3916,7 +3916,7 @@ nfssvc_nfsd(struct thread *td, struct nfssvc_args *uap)
 		free((__cheri_fromcap char *)nfsdarg.dspath, M_TEMP);
 		free((__cheri_fromcap char *)nfsdarg.mdspath, M_TEMP);
 	} else if (uap->flag & NFSSVC_PNFSDS) {
-		error = copyincap(uap->argp, &pnfsdarg, sizeof(pnfsdarg));
+		error = copyinptr(uap->argp, &pnfsdarg, sizeof(pnfsdarg));
 		if (error == 0 && (pnfsdarg.op == PNFSDOP_DELDSSERVER ||
 		    pnfsdarg.op == PNFSDOP_FORCEDELDS)) {
 			cp = malloc(PATH_MAX + 1, M_TEMP, M_WAITOK);
@@ -4020,7 +4020,7 @@ nfssvc_srvcall(struct thread *p, struct nfssvc_args *uap, struct ucred *cred)
 			nfs_pubfhset = 1;
 	} else if ((uap->flag & (NFSSVC_V4ROOTEXPORT | NFSSVC_NEWSTRUCT)) ==
 	    (NFSSVC_V4ROOTEXPORT | NFSSVC_NEWSTRUCT)) {
-		error = copyincap(uap->argp,(caddr_t)&export,
+		error = copyinptr(uap->argp,(caddr_t)&export,
 		    sizeof (struct nfsex_args));
 		if (!error) {
 			grps = NULL;
@@ -4106,7 +4106,7 @@ nfssvc_srvcall(struct thread *p, struct nfssvc_args *uap, struct ucred *cred)
 		if (!error)
 			error = nfsrv_adminrevoke(&adminrevoke, p);
 	} else if (uap->flag & NFSSVC_DUMPCLIENTS) {
-		error = copyincap(uap->argp, (caddr_t)&dumplist,
+		error = copyinptr(uap->argp, (caddr_t)&dumplist,
 		    sizeof (struct nfsd_dumplist));
 		if (!error && (dumplist.ndl_size < 1 ||
 			dumplist.ndl_size > NFSRV_MAXDUMPLIST))
@@ -4119,7 +4119,7 @@ nfssvc_srvcall(struct thread *p, struct nfssvc_args *uap, struct ucred *cred)
 		    free(dumpclients, M_TEMP);
 		}
 	} else if (uap->flag & NFSSVC_DUMPLOCKS) {
-		error = copyincap(uap->argp, (caddr_t)&dumplocklist,
+		error = copyinptr(uap->argp, (caddr_t)&dumplocklist,
 		    sizeof (struct nfsd_dumplocklist));
 		if (!error && (dumplocklist.ndllck_size < 1 ||
 			dumplocklist.ndllck_size > NFSRV_MAXDUMPLIST))

--- a/sys/geom/geom_ctl.c
+++ b/sys/geom/geom_ctl.c
@@ -175,7 +175,7 @@ geom_alloc_copyin(struct gctl_req *req, void * __capability uaddr, size_t len,
 
 	ptr = g_malloc(len, M_WAITOK);
 	if (preserve_tags)
-		req->nerror = copyincap(uaddr, ptr, len);
+		req->nerror = copyinptr(uaddr, ptr, len);
 	else
 		req->nerror = copyin(uaddr, ptr, len);
 	if (!req->nerror)

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1983,7 +1983,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	imgp->auxargs = NULL;
 	KASSERT(pos - argarray <= AT_COUNT, ("Too many auxargs"));
 
-	error = copyoutcap(argarray, (void * __capability)base,
+	error = copyoutptr(argarray, (void * __capability)base,
 	    sizeof(*argarray) * AT_COUNT);
 	free(argarray, M_TEMP);
 	return (error);

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -840,7 +840,7 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 	}
 	vm_map_unlock(vmm);
 
-	error = copyoutcap(&cres, shadow, sizeof(cres));
+	error = copyoutptr(&cres, shadow, sizeof(cres));
 
 	return (error);
 }

--- a/sys/kern/kern_context.c
+++ b/sys/kern/kern_context.c
@@ -71,7 +71,7 @@ sys_getcontext(struct thread *td, struct getcontext_args *uap)
 		PROC_LOCK(td->td_proc);
 		uc.uc_sigmask = td->td_sigmask;
 		PROC_UNLOCK(td->td_proc);
-		ret = copyoutcap(&uc, uap->ucp, UC_COPY_SIZE);
+		ret = copyoutptr(&uc, uap->ucp, UC_COPY_SIZE);
 	}
 	return (ret);
 }
@@ -85,7 +85,7 @@ sys_setcontext(struct thread *td, struct setcontext_args *uap)
 	if (uap->ucp == NULL)
 		ret = EINVAL;
 	else {
-		ret = copyincap(uap->ucp, &uc, UC_COPY_SIZE);
+		ret = copyinptr(uap->ucp, &uc, UC_COPY_SIZE);
 		if (ret == 0) {
 			ret = set_mcontext(td, &uc.uc_mcontext);
 			if (ret == 0) {
@@ -111,9 +111,9 @@ sys_swapcontext(struct thread *td, struct swapcontext_args *uap)
 		PROC_LOCK(td->td_proc);
 		uc.uc_sigmask = td->td_sigmask;
 		PROC_UNLOCK(td->td_proc);
-		ret = copyoutcap(&uc, uap->oucp, UC_COPY_SIZE);
+		ret = copyoutptr(&uc, uap->oucp, UC_COPY_SIZE);
 		if (ret == 0) {
-			ret = copyincap(uap->ucp, &uc, UC_COPY_SIZE);
+			ret = copyinptr(uap->ucp, &uc, UC_COPY_SIZE);
 			if (ret == 0) {
 				ret = set_mcontext(td, &uc.uc_mcontext);
 				if (ret == 0) {

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -1188,7 +1188,7 @@ kevent_copyout(void *arg, struct kevent *kevp, int count)
 	KASSERT(count <= KQ_NEVENTS, ("count (%d) > KQ_NEVENTS", count));
 	uap = (struct kevent_args *)arg;
 
-	error = copyoutcap(kevp, uap->eventlist, count * sizeof(*kevp));
+	error = copyoutptr(kevp, uap->eventlist, count * sizeof(*kevp));
 	if (error == 0)
 		uap->eventlist += count;
 	return (error);
@@ -1206,7 +1206,7 @@ kevent_copyin(void *arg, struct kevent *kevp, int count)
 	KASSERT(count <= KQ_NEVENTS, ("count (%d) > KQ_NEVENTS", count));
 	uap = (struct kevent_args *)arg;
 
-	error = copyincap(uap->changelist, kevp, count * sizeof(*kevp));
+	error = copyinptr(uap->changelist, kevp, count * sizeof(*kevp));
 	if (error == 0)
 		uap->changelist += count;
 	return (error);
@@ -1230,7 +1230,7 @@ kevent11_copyout(void *arg, struct kevent *kevp, int count)
 		kev11.fflags = kevp->fflags;
 		kev11.data = kevp->data;
 		kev11.udata = kevp->udata;
-		error = copyoutcap(&kev11, uap->eventlist, sizeof(kev11));
+		error = copyoutptr(&kev11, uap->eventlist, sizeof(kev11));
 		if (error != 0)
 			break;
 		uap->eventlist++;
@@ -1253,7 +1253,7 @@ kevent11_copyin(void *arg, struct kevent *kevp, int count)
 	uap = (struct freebsd11_kevent_args *)arg;
 
 	for (i = 0; i < count; i++) {
-		error = copyincap(uap->changelist, &kev11, sizeof(kev11));
+		error = copyinptr(uap->changelist, &kev11, sizeof(kev11));
 		if (error != 0)
 			break;
 		kevp->ident = kev11.ident;

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -34,6 +34,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/acct.h>
 #include <sys/asan.h>
 #include <sys/capsicum.h>

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1472,7 +1472,7 @@ get_argenv_ptr(void * __capability *arrayp, void * __capability *ptrp)
 		if (fueword32(array, &ptr32) == -1)
 			return (EFAULT);
 		array += sizeof(ptr32);
-		*ptrp = __USER_CAP_STR((void *)(uintptr_t)ptr32);
+		*ptrp = USER_PTR_STR((void *)(uintptr_t)ptr32);
 	} else
 #endif
 #ifdef COMPAT_FREEBSD64
@@ -1480,7 +1480,7 @@ get_argenv_ptr(void * __capability *arrayp, void * __capability *ptrp)
 		if (fueword64(array, &ptr64) == -1)
 			return (EFAULT);
 		array += sizeof(ptr64);
-		*ptrp = __USER_CAP_STR((void *)(uintptr_t)ptr64);
+		*ptrp = USER_PTR_STR((void *)(uintptr_t)ptr64);
 	} else
 #endif
 	{

--- a/sys/kern/kern_exit.c
+++ b/sys/kern/kern_exit.c
@@ -892,7 +892,7 @@ sys_wait6(struct thread *td, struct wait6_args *uap)
 	    uap->wrusage, sip);
 	if (uap->info != NULL && error == 0) {
 		/*
-		 * This does not use copyoutcap() as a fail-safe.  The
+		 * This does not use copyoutptr() as a fail-safe.  The
 		 * returned signal information object shouldn't
 		 * contain any capabilities as neither the si_addr nor
 		 * si_value fields are relevant for SIGCHLD.

--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -1528,7 +1528,7 @@ sys_kldsym(struct thread *td, struct kldsym_args *uap)
 	int error;
 
 	user_lookup = uap->data;
-	error = copyincap(user_lookup, &lookup, sizeof(lookup));
+	error = copyinptr(user_lookup, &lookup, sizeof(lookup));
 	if (error != 0)
 		return (error);
 	if (lookup.version != sizeof(lookup) ||

--- a/sys/kern/kern_module.c
+++ b/sys/kern/kern_module.c
@@ -542,7 +542,7 @@ freebsd32_modstat(struct thread *td, struct freebsd32_modstat_args *uap)
 	MOD_SUNLOCK;
 	stat32 = uap->stat;
 
-	if (fueword32(__USER_CAP_OBJ(&stat32->version), &version) != 0)
+	if (fueword32(USER_PTR_OBJ(&stat32->version), &version) != 0)
 		return (EFAULT);
 	is_v1v2 = (version == sizeof(struct module_stat_v1) ||
 	    version == sizeof(struct module_stat32_v2));

--- a/sys/kern/kern_procctl.c
+++ b/sys/kern/kern_procctl.c
@@ -1112,7 +1112,7 @@ struct procctl_cmd_info {
 	bool copyout_on_error : 1;
 	bool no_nonnull_data : 1;
 	bool need_candebug : 1;
-	bool copyincap : 1;
+	bool copyinptr : 1;
 	int copyin_sz;
 	int copyout_sz;
 	int (*exec)(struct thread *, struct proc *, void *);
@@ -1148,7 +1148,7 @@ static const struct procctl_cmd_info procctl_cmds_info[] = {
 	    { .lock_tree = PCTL_SLOCKED, .one_proc = true,
 	      .esrch_is_einval = false, .no_nonnull_data = false,
 	      .need_candebug = false,
-	      .copyincap = true,
+	      .copyinptr = true,
 	      .copyin_sz = sizeof(struct procctl_reaper_pids),
 	      .copyout_sz = 0,
 	      .exec = reap_getpids, .copyout_on_error = false, },
@@ -1319,8 +1319,8 @@ sys_procctl(struct thread *td, struct procctl_args *uap)
 	bzero(&x, sizeof(x));
 
 	if (cmd_info->copyin_sz > 0) {
-		if (cmd_info->copyincap)
-			error = copyincap(uap->data, &x, cmd_info->copyin_sz);
+		if (cmd_info->copyinptr)
+			error = copyinptr(uap->data, &x, cmd_info->copyin_sz);
 		else
 			error = copyin(uap->data, &x, cmd_info->copyin_sz);
 		if (error != 0)

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1271,7 +1271,7 @@ static int
 copyin_hdtr(const struct sf_hdtr * __capability uhdtr, struct sf_hdtr *hdtr)
 {
 
-	return (copyincap(uhdtr, hdtr, sizeof(*hdtr)));
+	return (copyinptr(uhdtr, hdtr, sizeof(*hdtr)));
 }
 
 int

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -966,13 +966,13 @@ sys_sigaction(struct thread *td, struct sigaction_args *uap)
 	actp = (uap->act != NULL) ? &act : NULL;
 	oactp = (uap->oact != NULL) ? &oact : NULL;
 	if (actp) {
-		error = copyincap(uap->act, &act, sizeof(act));
+		error = copyinptr(uap->act, &act, sizeof(act));
 		if (error)
 			return (error);
 	}
 	error = kern_sigaction(td, uap->sig, actp, oactp, 0);
 	if (oactp && !error)
-		error = copyoutcap(&oact, uap->oact, sizeof(oact));
+		error = copyoutptr(&oact, uap->oact, sizeof(oact));
 	return (error);
 }
 
@@ -1304,7 +1304,7 @@ static int
 copyout_siginfo(const siginfo_t *si, void * __capability info)
 {
 
-	return (copyoutcap(si, info, sizeof(*si)));
+	return (copyoutptr(si, info, sizeof(*si)));
 }
 
 int
@@ -1806,7 +1806,7 @@ sys_sigaltstack(struct thread *td, struct sigaltstack_args *uap)
 	int error;
 
 	if (uap->ss != NULL) {
-		error = copyincap(uap->ss, &ss, sizeof(ss));
+		error = copyinptr(uap->ss, &ss, sizeof(ss));
 		if (error)
 			return (error);
 	}
@@ -1815,7 +1815,7 @@ sys_sigaltstack(struct thread *td, struct sigaltstack_args *uap)
 	if (error)
 		return (error);
 	if (uap->oss != NULL)
-		error = copyoutcap(&oss, uap->oss, sizeof(stack_t));
+		error = copyoutptr(&oss, uap->oss, sizeof(stack_t));
 	return (error);
 }
 

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -2249,7 +2249,7 @@ sysctl_old_user(struct sysctl_req *req, const void *p, size_t l)
 			i = len - origidx;
 		if (req->lock == REQ_WIRED) {
 			if (req->flags & SCTL_PTROUT)
-				error = copyoutcap_nofault(p,
+				error = copyoutptr_nofault(p,
 				    (char * __capability)req->oldptr +
 				    origidx, i);
 			else
@@ -2258,7 +2258,7 @@ sysctl_old_user(struct sysctl_req *req, const void *p, size_t l)
 				    i);
 		} else
 			if (req->flags & SCTL_PTROUT)
-				error = copyoutcap(p,
+				error = copyoutptr(p,
 				    (char * __capability)req->oldptr + origidx,
 				    i);
 			else
@@ -2285,7 +2285,7 @@ sysctl_new_user(struct sysctl_req *req, void *p, size_t l)
 	WITNESS_WARN(WARN_GIANTOK | WARN_SLEEPOK, NULL,
 	    "sysctl_new_user()");
 	if (req->flags & SCTL_PTRIN)
-		error = copyincap((const char * __capability)req->newptr +
+		error = copyinptr((const char * __capability)req->newptr +
 		    req->newidx, p, l);
 	else
 		error = copyin((const char * __capability)req->newptr +

--- a/sys/kern/kern_thr.c
+++ b/sys/kern/kern_thr.c
@@ -119,7 +119,7 @@ sys_thr_create(struct thread *td, struct thr_create_args *uap)
 	struct thr_create_initthr_args args;
 	int error;
 
-	if ((error = copyincap(uap->ctx, &args.ctx, sizeof(args.ctx))))
+	if ((error = copyinptr(uap->ctx, &args.ctx, sizeof(args.ctx))))
 		return (error);
 	args.tid = uap->id;
 	return (thread_create(td, NULL, thr_create_initthr, &args));
@@ -135,7 +135,7 @@ sys_thr_new(struct thread *td, struct thr_new_args *uap)
 	if (uap->param_size < 0 || uap->param_size > sizeof(param))
 		return (EINVAL);
 	bzero(&param, sizeof(param));
-	if ((error = copyincap(uap->param, &param, uap->param_size)))
+	if ((error = copyinptr(uap->param, &param, uap->param_size)))
 		return (error);
 	return (kern_thr_new(td, &param));
 }

--- a/sys/kern/kern_time.c
+++ b/sys/kern/kern_time.c
@@ -1235,7 +1235,7 @@ sys_ktimer_create(struct thread *td, struct ktimer_create_args *uap)
 	if (uap->evp == NULL) {
 		evp = NULL;
 	} else {
-		error = copyincap(uap->evp, &ev, sizeof(ev));
+		error = copyinptr(uap->evp, &ev, sizeof(ev));
 		if (error != 0)
 			return (error);
 		evp = &ev;

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -4078,7 +4078,7 @@ __umtx_op_nwake_private_compat32(struct thread *td, struct _umtx_op_args *uap)
 		if (error != 0)
 			break;
 		for (i = 0; i < tocopy; ++i) {
-			kern_umtx_wake(td, __USER_CAP((void *)(uintptr_t)uaddrs[i], sizeof(void *)),
+			kern_umtx_wake(td, USER_PTR((void *)(uintptr_t)uaddrs[i], sizeof(void *)),
 			    INT_MAX, 1);
 		}
 		maybe_yield();
@@ -5112,19 +5112,19 @@ __umtx_op_lock_umtx64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 		ts = NULL;
 	else {
 		error = umtx_copyin_timeout(
-		    __USER_CAP(uap->uaddr2, sizeof(struct timespec)),
+		    USER_PTR(uap->uaddr2, sizeof(struct timespec)),
 		    &timeout);
 		if (error != 0)
 			return (error);
 		ts = &timeout;
 	}
-	return (do_lock_umtx(td, __USER_CAP_ADDR(uap->obj), uap->val, ts));
+	return (do_lock_umtx(td, USER_PTR_ADDR(uap->obj), uap->val, ts));
 }
 
 static int
 __umtx_op_unlock_umtx64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
-	return (do_unlock_umtx(td, __USER_CAP_ADDR(uap->obj), uap->val));
+	return (do_unlock_umtx(td, USER_PTR_ADDR(uap->obj), uap->val));
 }
 #endif	/* COMPAT_FREEBSD10 */
 
@@ -5145,13 +5145,13 @@ __umtx_op_wait64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		    (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_wait(td, __USER_CAP_ADDR(uap->obj), uap->val, tm_p,
+	return (do_wait(td, USER_PTR_ADDR(uap->obj), uap->val, tm_p,
 	    0, 0));
 }
 
@@ -5165,13 +5165,13 @@ __umtx_op_wait_uint64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		    (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_wait(td, __USER_CAP_ADDR(uap->obj), uap->val, tm_p,
+	return (do_wait(td, USER_PTR_ADDR(uap->obj), uap->val, tm_p,
 	    1, 0));
 }
 
@@ -5186,13 +5186,13 @@ __umtx_op_wait_uint_private64(struct thread *td,
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		    (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	return (do_wait(td, __USER_CAP_ADDR(uap->obj), uap->val, tm_p,
+	return (do_wait(td, USER_PTR_ADDR(uap->obj), uap->val, tm_p,
 	    1, 1));
 }
 
@@ -5201,7 +5201,7 @@ __umtx_op_wake64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (kern_umtx_wake(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), uap->val, 0));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), uap->val, 0));
 }
 
 static int
@@ -5211,7 +5211,7 @@ __umtx_op_nwake_private64(struct thread *td,
 	uint64_t uaddrs[BATCH_SIZE], * __capability upp;
 	int count, error, i, pos, tocopy;
 
-	upp = __USER_CAP(uap->obj, uap->val * sizeof(uint64_t));
+	upp = USER_PTR(uap->obj, uap->val * sizeof(uint64_t));
 	error = 0;
 	for (count = uap->val, pos = 0; count > 0; count -= tocopy,
 	    pos += tocopy) {
@@ -5221,7 +5221,7 @@ __umtx_op_nwake_private64(struct thread *td,
 			break;
 		for (i = 0; i < tocopy; ++i)
 			kern_umtx_wake(td,
-			    __USER_CAP(uaddrs[i], sizeof(struct umutex64)),
+			    USER_PTR(uaddrs[i], sizeof(struct umutex64)),
 			    INT_MAX, 1);
 		maybe_yield();
 	}
@@ -5233,7 +5233,7 @@ __umtx_op_wake_private64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (kern_umtx_wake(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), uap->val, 1));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), uap->val, 1));
 }
 
 static int
@@ -5247,14 +5247,14 @@ __umtx_op_lock_umutex64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		    (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
 	return (do_lock_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), tm_p, 0));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), tm_p, 0));
 }
 
 static int
@@ -5262,7 +5262,7 @@ __umtx_op_trylock_umutex64(struct thread *td, struct freebsd64__umtx_op_args *ua
 {
 
 	return (do_lock_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), NULL, _UMUTEX_TRY));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), NULL, _UMUTEX_TRY));
 }
 
 static int
@@ -5276,14 +5276,14 @@ __umtx_op_wait_umutex64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 		tm_p = NULL;
 	else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		    (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
 	return (do_lock_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), tm_p, _UMUTEX_WAIT));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), tm_p, _UMUTEX_WAIT));
 }
 
 static int
@@ -5291,7 +5291,7 @@ __umtx_op_wake_umutex64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (do_wake_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64))));
+	    USER_PTR(uap->obj, sizeof(struct umutex64))));
 }
 
 static int
@@ -5300,7 +5300,7 @@ __umtx_op_unlock_umutex64(struct thread *td,
 {
 
 	return (do_unlock_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), false));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), false));
 }
 
 static int
@@ -5308,8 +5308,8 @@ __umtx_op_set_ceiling64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (do_set_ceiling(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), uap->val,
-	    __USER_CAP(uap->uaddr1, sizeof(uint32_t))));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), uap->val,
+	    USER_PTR(uap->uaddr1, sizeof(uint32_t))));
 }
 
 static int
@@ -5323,14 +5323,14 @@ __umtx_op_cv_wait64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 		ts = NULL;
 	else {
 		error = umtx_copyin_timeout(
-		    __USER_CAP(uap->uaddr2, sizeof(struct timespec)),
+		    USER_PTR(uap->uaddr2, sizeof(struct timespec)),
 		    &timeout);
 		if (error != 0)
 			return (error);
 		ts = &timeout;
 	}
-	return (do_cv_wait(td, __USER_CAP(uap->obj, sizeof(struct ucond)),
-	    __USER_CAP(uap->uaddr1, sizeof(struct umutex64)), ts, uap->val));
+	return (do_cv_wait(td, USER_PTR(uap->obj, sizeof(struct ucond)),
+	    USER_PTR(uap->uaddr1, sizeof(struct umutex64)), ts, uap->val));
 }
 
 static int
@@ -5338,7 +5338,7 @@ __umtx_op_cv_signal64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (do_cv_signal(td,
-	    __USER_CAP(uap->obj, sizeof(struct ucond))));
+	    USER_PTR(uap->obj, sizeof(struct ucond))));
 }
 
 static int
@@ -5346,7 +5346,7 @@ __umtx_op_cv_broadcast64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (do_cv_broadcast(td,
-	    __USER_CAP(uap->obj, sizeof(struct ucond))));
+	    USER_PTR(uap->obj, sizeof(struct ucond))));
 }
 
 static int
@@ -5358,15 +5358,15 @@ __umtx_op_rw_rdlock64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 	/* Allow a null timespec (wait forever). */
 	if (uap->uaddr2 == NULL) {
 		error = do_rw_rdlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), uap->val, 0);
+		    USER_PTR(uap->obj, sizeof(struct urwlock)), uap->val, 0);
 	} else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		   (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 		error = do_rw_rdlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), uap->val,
+		    USER_PTR(uap->obj, sizeof(struct urwlock)), uap->val,
 		    &timeout);
 	}
 	return (error);
@@ -5381,16 +5381,16 @@ __umtx_op_rw_wrlock64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 	/* Allow a null timespec (wait forever). */
 	if (uap->uaddr2 == NULL) {
 		error = do_rw_wrlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), 0);
+		    USER_PTR(uap->obj, sizeof(struct urwlock)), 0);
 	} else {
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, (size_t)uap->uaddr1),
+		    USER_PTR(uap->uaddr2, (size_t)uap->uaddr1),
 		   (size_t)uap->uaddr1, &timeout);
 		if (error != 0)
 			return (error);
 
 		error = do_rw_wrlock(td,
-		    __USER_CAP(uap->obj, sizeof(struct urwlock)), &timeout);
+		    USER_PTR(uap->obj, sizeof(struct urwlock)), &timeout);
 	}
 	return (error);
 }
@@ -5400,7 +5400,7 @@ __umtx_op_rw_unlock64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (do_rw_unlock(td,
-	    __USER_CAP(uap->obj, sizeof(struct urwlock))));
+	    USER_PTR(uap->obj, sizeof(struct urwlock))));
 }
 
 static int
@@ -5408,7 +5408,7 @@ __umtx_op_wake2_umutex64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
 	return (do_wake2_umutex(td,
-	    __USER_CAP(uap->obj, sizeof(struct umutex64)), uap->val));
+	    USER_PTR(uap->obj, sizeof(struct umutex64)), uap->val));
 }
 
 static int
@@ -5425,18 +5425,18 @@ __umtx_op_sem2_wait64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 	} else {
 		uasize = (size_t)uap->uaddr1;
 		error = umtx_copyin_umtx_time(
-		    __USER_CAP(uap->uaddr2, uasize), uasize, &timeout);
+		    USER_PTR(uap->uaddr2, uasize), uasize, &timeout);
 		if (error != 0)
 			return (error);
 		tm_p = &timeout;
 	}
-	error = do_sem2_wait(td, __USER_CAP(uap->obj, sizeof(struct _usem2)),
+	error = do_sem2_wait(td, USER_PTR(uap->obj, sizeof(struct _usem2)),
 	    tm_p);
 	if (error == EINTR && uap->uaddr2 != NULL &&
 	    (timeout._flags & UMTX_ABSTIME) == 0 &&
 	    uasize >= sizeof(struct _umtx_time) + sizeof(struct timespec)) {
 		error = copyout(&timeout._timeout,
-		    __USER_CAP_UNBOUND((struct _umtx_time *)uap->uaddr2 + 1),
+		    USER_PTR_UNBOUND((struct _umtx_time *)uap->uaddr2 + 1),
 		    sizeof(struct timespec));
 		if (error == 0) {
 			error = EINTR;
@@ -5450,14 +5450,14 @@ static int
 __umtx_op_sem2_wake64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
-	return (do_sem2_wake(td, __USER_CAP(uap->obj, sizeof(struct _usem2))));
+	return (do_sem2_wake(td, USER_PTR(uap->obj, sizeof(struct _usem2))));
 }
 
 static int
 __umtx_op_shm64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 {
 
-	return (umtx_shm(td, __USER_CAP_UNBOUND(uap->uaddr1), uap->val));
+	return (umtx_shm(td, USER_PTR_UNBOUND(uap->uaddr1), uap->val));
 }
 
 struct umtx_robust_lists_params64 {
@@ -5475,15 +5475,15 @@ __umtx_op_robust_lists64(struct thread *td, struct freebsd64__umtx_op_args *uap)
 
 	if (uap->val > sizeof(rb64))
 		return (EINVAL);
-	error = copyin(__USER_CAP(uap->uaddr1, sizeof(rb64)), &rb64, uap->val);
+	error = copyin(USER_PTR(uap->uaddr1, sizeof(rb64)), &rb64, uap->val);
 	if (error != 0)
 		return (error);
 	rb.robust_list_offset =
-	    (intcap_t)__USER_CAP_UNBOUND(rb64.robust_list_offset);
+	    (intcap_t)USER_PTR_UNBOUND(rb64.robust_list_offset);
 	rb.robust_priv_list_offset =
-	    (intcap_t)__USER_CAP_UNBOUND(rb64.robust_priv_list_offset);
+	    (intcap_t)USER_PTR_UNBOUND(rb64.robust_priv_list_offset);
 	rb.robust_inact_offset =
-	    (intcap_t)__USER_CAP_UNBOUND(rb64.robust_inact_offset);
+	    (intcap_t)USER_PTR_UNBOUND(rb64.robust_inact_offset);
 
 	td->td_rb_list = rb.robust_list_offset;
 	td->td_rbp_list = rb.robust_priv_list_offset;
@@ -5534,14 +5534,14 @@ int
 freebsd10_freebsd64__umtx_lock(struct thread *td,
     struct freebsd10_freebsd64__umtx_lock_args *uap)
 {
-	return (do_lock_umtx(td, __USER_CAP_ADDR(uap->umtx), td->td_tid, NULL));
+	return (do_lock_umtx(td, USER_PTR_ADDR(uap->umtx), td->td_tid, NULL));
 }
 
 int
 freebsd10_freebsd64__umtx_unlock(struct thread *td,
     struct freebsd10_freebsd64__umtx_unlock_args *uap)
 {
-	return (do_unlock_umtx(td, __USER_CAP_ADDR(uap->umtx), td->td_tid));
+	return (do_unlock_umtx(td, USER_PTR_ADDR(uap->umtx), td->td_tid));
 }
 #endif /* COMPAT_FREEBSD10 */
 
@@ -5667,12 +5667,12 @@ umtx_read_rb_list(struct thread *td, union umutex_all *mu, uintcap_t *rb_list,
     bool compat32)
 {
 	if (compat32) {
-		*rb_list = (uintcap_t)__USER_CAP_UNBOUND(
+		*rb_list = (uintcap_t)USER_PTR_UNBOUND(
 		    (void *)(uintptr_t)mu->m32.m_rb_lnk);
 	} else
 #ifdef COMPAT_FREEBSD64
 	if (!SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
-		*rb_list = (uintcap_t)__USER_CAP_UNBOUND(
+		*rb_list = (uintcap_t)USER_PTR_UNBOUND(
 		    (void *)(uintptr_t)mu->m64.m_rb_lnk);
 	} else
 #endif

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -4051,7 +4051,7 @@ __umtx_op_nwake_private_native(struct thread *td, struct _umtx_op_args *uap)
 	for (count = uap->val, pos = 0; count > 0; count -= tocopy,
 	    pos += tocopy) {
 		tocopy = MIN(count, BATCH_SIZE);
-		error = copyincap(upp + pos, uaddrs,
+		error = copyinptr(upp + pos, uaddrs,
 		    tocopy * sizeof(char * __capability));
 		if (error != 0)
 			break;
@@ -5698,7 +5698,7 @@ umtx_handle_rb(struct thread *td, uintcap_t rbp, uintcap_t *rb_list, bool inact,
 	} else
 #endif
 
-		error = copyincap((void * __capability)rbp, &mu.m, sizeof(mu.m));
+		error = copyinptr((void * __capability)rbp, &mu.m, sizeof(mu.m));
 	if (error != 0)
 		return (error);
 	if (rb_list != NULL)

--- a/sys/kern/kern_xxx.c
+++ b/sys/kern/kern_xxx.c
@@ -400,7 +400,7 @@ freebsd4_getdomainname(struct thread *td,
 
 	name[0] = CTL_KERN;
 	name[1] = KERN_NISDOMAINNAME;
-	return (userland_sysctl(td, name, 2, __USER_CAP(uap->domainname, len),
+	return (userland_sysctl(td, name, 2, USER_PTR(uap->domainname, len),
 	    &len, 1, 0, 0, 0, 0));
 }
 
@@ -420,6 +420,6 @@ freebsd4_setdomainname(struct thread *td,
 	name[0] = CTL_KERN;
 	name[1] = KERN_NISDOMAINNAME;
 	return (userland_sysctl(td, name, 2, 0, 0, 0,
-	    __USER_CAP(uap->domainname, uap->len), uap->len, 0, 0));
+	    USER_PTR(uap->domainname, uap->len), uap->len, 0, 0));
 }
 #endif /* COMPAT_FREEBSD4 */

--- a/sys/kern/kern_xxx.c
+++ b/sys/kern/kern_xxx.c
@@ -31,6 +31,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/sysproto.h>
 #include <sys/kernel.h>
 #include <sys/priv.h>

--- a/sys/kern/subr_bus.c
+++ b/sys/kern/subr_bus.c
@@ -5824,7 +5824,7 @@ devctl2_ioctl(struct cdev *cdev, u_long cmd, caddr_t data, int fflag,
 		memset(&dr, 0, sizeof(dr));
 		memcpy(dr.dr_name, req64->dr_name, sizeof(dr.dr_name));
 		CP(*req64, dr, dr_flags);
-		dr.dr_data = __USER_CAP_STR(req64->dr_data);
+		dr.dr_data = USER_PTR_STR(req64->dr_data);
 		req = &dr;
 		cmd = _IOC_NEWTYPE(cmd, struct devreq);
 	} else

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -103,12 +103,12 @@ copyout_nofault(const void *kaddr, void * __capability udaddr, size_t len)
 
 #if __has_feature(capabilities)
 int
-copyoutcap_nofault(const void *kaddr, void * __capability udaddr, size_t len)
+copyoutptr_nofault(const void *kaddr, void * __capability udaddr, size_t len)
 {
 	int error, save;
 
 	save = vm_fault_disable_pagefaults();
-	error = copyoutcap(kaddr, udaddr, len);
+	error = copyoutptr(kaddr, udaddr, len);
 	vm_fault_enable_pagefaults(save);
 	return (error);
 }
@@ -277,10 +277,10 @@ uiomove_flags(void *cp, int n, struct uio *uio, bool nofault)
 			switch (uio->uio_rw) {
 #if __has_feature(capabilities)
 			case UIO_READ_CAP:
-				error = copyoutcap(cp, iov->iov_base, cnt);
+				error = copyoutptr(cp, iov->iov_base, cnt);
 				break;
 			case UIO_WRITE_CAP:
-				error = copyincap(iov->iov_base, cp, cnt);
+				error = copyinptr(iov->iov_base, cp, cnt);
 				break;
 #endif
 			case UIO_READ:
@@ -402,7 +402,7 @@ copyiniov(const struct iovec* __capability iovp, u_int iovcnt, struct iovec **io
 		return (error);
 	iovlen = iovcnt * sizeof(struct iovec);
 	iovs = malloc(iovlen, M_IOV, M_WAITOK);
-	error = copyincap(iovp, iovs, iovlen);
+	error = copyinptr(iovp, iovs, iovlen);
 	if (error != 0)
 		free(iovs, M_IOV);
 	*iov = iovs;
@@ -424,7 +424,7 @@ copyinuio(const struct iovec * __capability iovp, u_int iovcnt,
 	iovlen = iovcnt * sizeof(struct iovec);
 	uio = allocuio(iovcnt);
 	iov = uio->uio_iov;
-	error = copyincap(iovp, iov, iovlen);
+	error = copyinptr(iovp, iov, iovlen);
 	if (error != 0) {
 		freeuio(uio);
 		return (error);

--- a/sys/kern/sys_generic.c
+++ b/sys/kern/sys_generic.c
@@ -748,7 +748,7 @@ user_ioctl(struct thread *td, int fd, u_long ucom,
 		data = datap;
 	if (com & IOC_IN) {
 		if (copycaps)
-			error = copyincap(udata, data, size);
+			error = copyinptr(udata, data, size);
 		else
 			error = copyin(udata, data, size);
 		if (error != 0)
@@ -765,7 +765,7 @@ user_ioctl(struct thread *td, int fd, u_long ucom,
 
 	if (error == 0 && (com & IOC_OUT)) {
 		if (copycaps)
-			error = copyoutcap(data, udata, size);
+			error = copyoutptr(data, udata, size);
 		else
 			error = copyout(data, udata, size);
 	}

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -931,7 +931,7 @@ sys_ptrace(struct thread *td, struct ptrace_args *uap)
 		break;
 	case PT_GETREGSET:
 	case PT_SETREGSET:
-		error = copyincap(uap->addr, &r.vec, sizeof(r.vec));
+		error = copyinptr(uap->addr, &r.vec, sizeof(r.vec));
 		break;
 	case PT_SETREGS:
 		error = copyin(uap->addr, &r.reg, sizeof(r.reg));
@@ -954,10 +954,10 @@ sys_ptrace(struct thread *td, struct ptrace_args *uap)
 			error = copyin(uap->addr, &r.ptevents, uap->data);
 		break;
 	case PT_IO:
-		error = copyincap(uap->addr, &r.piod, sizeof(r.piod));
+		error = copyinptr(uap->addr, &r.piod, sizeof(r.piod));
 		break;
 	case PT_VM_ENTRY:
-		error = copyincap(uap->addr, &r.pve, sizeof(r.pve));
+		error = copyinptr(uap->addr, &r.pve, sizeof(r.pve));
 		break;
 	case PT_COREDUMP:
 		if (uap->data != sizeof(r.pc))
@@ -998,7 +998,7 @@ sys_ptrace(struct thread *td, struct ptrace_args *uap)
 	case PT_VM_ENTRY:
 		/*
 		 * Only copy out updated fields prior to pve_path to
-		 * avoid the use of copyoutcap.
+		 * avoid the use of copyoutptr.
 		 */
 		error = copyout(&r.pve, uap->addr,
 		    offsetof(struct ptrace_vm_entry, pve_path));
@@ -1006,7 +1006,7 @@ sys_ptrace(struct thread *td, struct ptrace_args *uap)
 	case PT_IO:
 		/*
 		 * Only copy out the updated piod_len to avoid the use
-		 * of copyoutcap.
+		 * of copyoutptr.
 		 */
 		error = copyout(&r.piod.piod_len, uap->addr +
 		    offsetof(struct ptrace_io_desc, piod_len),

--- a/sys/kern/sysv_msg.c
+++ b/sys/kern/sysv_msg.c
@@ -1831,7 +1831,7 @@ freebsd32_msgsnd(struct thread *td, struct freebsd32_msgsnd_args *uap)
 		return (error);
 	mtype = mtype32;
 	return (kern_msgsnd(td, uap->msqid,
-	    (const char * __capability)__USER_CAP(msgp, uap->msgsz) +
+	    (const char * __capability)USER_PTR(msgp, uap->msgsz) +
 	    sizeof(mtype32), uap->msgsz, uap->msgflg, mtype));
 }
 
@@ -1845,7 +1845,7 @@ freebsd32_msgrcv(struct thread *td, struct freebsd32_msgrcv_args *uap)
 
 	msgp = PTRIN(uap->msgp);
 	if ((error = kern_msgrcv(td, uap->msqid,
-	    (char * __capability)__USER_CAP(msgp, uap->msgsz) + sizeof(mtype32),
+	    (char * __capability)USER_PTR(msgp, uap->msgsz) + sizeof(mtype32),
 	    uap->msgsz, uap->msgtyp, uap->msgflg, &mtype)) != 0)
 		return (error);
 	mtype32 = (int32_t)mtype;
@@ -1864,7 +1864,7 @@ freebsd7_freebsd64_msgctl(struct thread *td,
 	int error;
 
 	if (uap->cmd == IPC_SET) {
-		error = copyin(__USER_CAP_OBJ(uap->buf), &msqbuf64,
+		error = copyin(USER_PTR_OBJ(uap->buf), &msqbuf64,
 		    sizeof(msqbuf64));
 		if (error)
 			return (error);
@@ -1894,7 +1894,7 @@ freebsd7_freebsd64_msgctl(struct thread *td,
 		CP(msqbuf, msqbuf64, msg_stime);
 		CP(msqbuf, msqbuf64, msg_rtime);
 		CP(msqbuf, msqbuf64, msg_ctime);
-		error = copyout(&msqbuf64, __USER_CAP_OBJ(uap->buf),
+		error = copyout(&msqbuf64, USER_PTR_OBJ(uap->buf),
 		    sizeof(struct msqid_ds64));
 	}
 	return (error);
@@ -1909,7 +1909,7 @@ freebsd64_msgctl(struct thread *td, struct freebsd64_msgctl_args *uap)
 	int error;
 
 	if (uap->cmd == IPC_SET) {
-		error = copyin(__USER_CAP_OBJ(uap->buf), &msqbuf64,
+		error = copyin(USER_PTR_OBJ(uap->buf), &msqbuf64,
 		    sizeof(msqbuf64));
 		if (error)
 			return (error);
@@ -1939,7 +1939,7 @@ freebsd64_msgctl(struct thread *td, struct freebsd64_msgctl_args *uap)
 		CP(msqbuf, msqbuf64, msg_stime);
 		CP(msqbuf, msqbuf64, msg_rtime);
 		CP(msqbuf, msqbuf64, msg_ctime);
-		error = copyout(&msqbuf64, __USER_CAP_OBJ(uap->buf),
+		error = copyout(&msqbuf64, USER_PTR_OBJ(uap->buf),
 		    sizeof(struct msqid_ds64));
 	}
 	return (error);
@@ -1951,11 +1951,11 @@ freebsd64_msgsnd(struct thread *td, struct freebsd64_msgsnd_args *uap)
 	long mtype;
 	int error;
 
-	if ((error = copyin(__USER_CAP(uap->msgp, sizeof(mtype)),
+	if ((error = copyin(USER_PTR(uap->msgp, sizeof(mtype)),
 	    &mtype, sizeof(mtype))) != 0)
 		return (error);
 	return (kern_msgsnd(td, uap->msqid,
-	    (const char * __capability)__USER_CAP(uap->msgp, uap->msgsz) +
+	    (const char * __capability)USER_PTR(uap->msgp, uap->msgsz) +
 	    sizeof(mtype), uap->msgsz, uap->msgflg, mtype));
 }
 
@@ -1966,10 +1966,10 @@ freebsd64_msgrcv(struct thread *td, struct freebsd64_msgrcv_args *uap)
 	int error;
 
 	if ((error = kern_msgrcv(td, uap->msqid,
-	    (char * __capability)__USER_CAP(uap->msgp, uap->msgsz) +
+	    (char * __capability)USER_PTR(uap->msgp, uap->msgsz) +
 	    sizeof(mtype), uap->msgsz, uap->msgtyp, uap->msgflg, &mtype)) != 0)
 		return (error);
-	return (copyout(&mtype, __USER_CAP(uap->msgp, sizeof(mtype)),
+	return (copyout(&mtype, USER_PTR(uap->msgp, sizeof(mtype)),
 	    sizeof(mtype)));
 }
 #endif /* COMPAT_FREEBSD64 */

--- a/sys/kern/sysv_sem.c
+++ b/sys/kern/sysv_sem.c
@@ -664,7 +664,7 @@ sys___semctl(struct thread *td, struct __semctl_args *uap)
 	case GETALL:
 	case SETVAL:
 	case SETALL:
-		error = copyincap(uap->arg, &arg, sizeof(arg));
+		error = copyinptr(uap->arg, &arg, sizeof(arg));
 		if (error)
 			return (error);
 		break;
@@ -1878,7 +1878,7 @@ freebsd7___semctl(struct thread *td, struct freebsd7___semctl_args *uap)
 	case GETALL:
 	case SETVAL:
 	case SETALL:
-		error = copyincap(uap->arg, &arg, sizeof(arg));
+		error = copyinptr(uap->arg, &arg, sizeof(arg));
 		if (error)
 			return (error);
 		break;
@@ -1923,7 +1923,7 @@ freebsd7___semctl(struct thread *td, struct freebsd7___semctl_args *uap)
 		CP(dsbuf, dsold, sem_nsems);
 		CP(dsbuf, dsold, sem_otime);
 		CP(dsbuf, dsold, sem_ctime);
-		error = copyoutcap(&dsold, arg.buf, sizeof(dsold));
+		error = copyoutptr(&dsold, arg.buf, sizeof(dsold));
 		break;
 	}
 

--- a/sys/kern/sysv_sem.c
+++ b/sys/kern/sysv_sem.c
@@ -2123,7 +2123,7 @@ freebsd7_freebsd64___semctl(struct thread *td,
 	case GETALL:
 	case SETVAL:
 	case SETALL:
-		error = copyin(__USER_CAP_OBJ(uap->arg), &arg, sizeof(arg));
+		error = copyin(USER_PTR_OBJ(uap->arg), &arg, sizeof(arg));
 		if (error)
 			return (error);
 		break;
@@ -2135,7 +2135,7 @@ freebsd7_freebsd64___semctl(struct thread *td,
 		semun.buf = &dsbuf;
 		break;
 	case IPC_SET:
-		error = copyin(__USER_CAP(arg.buf, sizeof(dsbuf64)), &dsbuf64,
+		error = copyin(USER_PTR(arg.buf, sizeof(dsbuf64)), &dsbuf64,
 		    sizeof(dsbuf64));
 		if (error)
 			return (error);
@@ -2148,7 +2148,7 @@ freebsd7_freebsd64___semctl(struct thread *td,
 		break;
 	case GETALL:
 	case SETALL:
-		semun.array = __USER_CAP(arg.array, seminfo.semmns *
+		semun.array = USER_PTR(arg.array, seminfo.semmns *
 		    sizeof(*semun.array));
 		break;
 	case SETVAL:
@@ -2170,7 +2170,7 @@ freebsd7_freebsd64___semctl(struct thread *td,
 		CP(dsbuf, dsbuf64, sem_nsems);
 		CP(dsbuf, dsbuf64, sem_otime);
 		CP(dsbuf, dsbuf64, sem_ctime);
-		error = copyout(&dsbuf64, __USER_CAP(arg.buf, sizeof(dsbuf64)),
+		error = copyout(&dsbuf64, USER_PTR(arg.buf, sizeof(dsbuf64)),
 		    sizeof(dsbuf64));
 		break;
 	}
@@ -2198,7 +2198,7 @@ freebsd64___semctl(struct thread *td, struct freebsd64___semctl_args *uap)
 	case GETALL:
 	case SETVAL:
 	case SETALL:
-		error = copyin(__USER_CAP_OBJ(uap->arg), &arg, sizeof(arg));
+		error = copyin(USER_PTR_OBJ(uap->arg), &arg, sizeof(arg));
 		if (error)
 			return (error);
 		break;
@@ -2210,7 +2210,7 @@ freebsd64___semctl(struct thread *td, struct freebsd64___semctl_args *uap)
 		semun.buf = &dsbuf;
 		break;
 	case IPC_SET:
-		error = copyin(__USER_CAP(arg.buf, sizeof(dsbuf64)), &dsbuf64,
+		error = copyin(USER_PTR(arg.buf, sizeof(dsbuf64)), &dsbuf64,
 		    sizeof(dsbuf64));
 		if (error)
 			return (error);
@@ -2223,7 +2223,7 @@ freebsd64___semctl(struct thread *td, struct freebsd64___semctl_args *uap)
 		break;
 	case GETALL:
 	case SETALL:
-		semun.array = __USER_CAP(arg.array, seminfo.semmns *
+		semun.array = USER_PTR(arg.array, seminfo.semmns *
 		    sizeof(*semun.array));
 		break;
 	case SETVAL:
@@ -2244,7 +2244,7 @@ freebsd64___semctl(struct thread *td, struct freebsd64___semctl_args *uap)
 		CP(dsbuf, dsbuf64, sem_nsems);
 		CP(dsbuf, dsbuf64, sem_otime);
 		CP(dsbuf, dsbuf64, sem_ctime);
-		error = copyout(&dsbuf64, __USER_CAP(arg.buf, sizeof(dsbuf64)),
+		error = copyout(&dsbuf64, USER_PTR(arg.buf, sizeof(dsbuf64)),
 		    sizeof(dsbuf64));
 		break;
 	}
@@ -2258,7 +2258,7 @@ int
 freebsd64_semop(struct thread *td, struct freebsd64_semop_args *uap)
 {
 	return (kern_semop(td, uap->semid,
-	    __USER_CAP_ARRAY(uap->sops, uap->nsops), uap->nsops, NULL));
+	    USER_PTR_ARRAY(uap->sops, uap->nsops), uap->nsops, NULL));
 }
 #endif /* COMPAT_FREEBSD64 */
 // CHERI CHANGES START

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -2033,7 +2033,7 @@ freebsd7_shmctl(struct thread *td, struct freebsd7_shmctl_args *uap)
 
 	/* IPC_SET needs to copyin the buffer before calling kern_shmctl */
 	if (uap->cmd == IPC_SET) {
-		if ((error = copyincap(uap->buf, &old, sizeof(old))))
+		if ((error = copyinptr(uap->buf, &old, sizeof(old))))
 			goto done;
 		ipcperm_old2new(&old.shm_perm, &buf.shm_perm);
 		CP(old, buf, shm_segsz);
@@ -2068,7 +2068,7 @@ freebsd7_shmctl(struct thread *td, struct freebsd7_shmctl_args *uap)
 		CP(buf, old, shm_dtime);
 		CP(buf, old, shm_ctime);
 		old.shm_internal = NULL;
-		error = copyoutcap(&old, uap->buf, sizeof(old));
+		error = copyoutptr(&old, uap->buf, sizeof(old));
 		break;
 	}
 

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -1858,14 +1858,14 @@ done:
 int
 freebsd64_shmat(struct thread *td, struct freebsd64_shmat_args *uap)
 {
-	return (kern_shmat(td, uap->shmid, __USER_CAP_UNBOUND(uap->shmaddr),
+	return (kern_shmat(td, uap->shmid, USER_PTR_UNBOUND(uap->shmaddr),
 	    uap->shmflg));
 }
 
 int
 freebsd64_shmdt(struct thread *td, struct freebsd64_shmdt_args *uap)
 {
-	return (kern_shmdt(td, __USER_CAP_UNBOUND(uap->shmaddr)));
+	return (kern_shmdt(td, USER_PTR_UNBOUND(uap->shmaddr)));
 }
 
 #ifdef COMPAT_FREEBSD7
@@ -1883,7 +1883,7 @@ freebsd7_freebsd64_shmctl(struct thread *td,
 	size_t sz;
 
 	if (uap->cmd == IPC_SET) {
-		if ((error = copyin(__USER_CAP_OBJ(uap->buf), &shmid_ds64,
+		if ((error = copyin(USER_PTR_OBJ(uap->buf), &shmid_ds64,
 		    sizeof(shmid_ds64))))
 			goto done;
 		ipcperm_old2new(&shmid_ds64.shm_perm, &u.shmid_ds.shm_perm);
@@ -1904,12 +1904,12 @@ freebsd7_freebsd64_shmctl(struct thread *td,
 	switch (uap->cmd) {
 	case IPC_INFO:
 		error = copyout(&u.shminfo,
-		    __USER_CAP(uap->buf, sizeof(u.shminfo)),
+		    USER_PTR(uap->buf, sizeof(u.shminfo)),
 		    sizeof(u.shminfo));
 		break;
 	case SHM_INFO:
 		error = copyout(&u.shm_info,
-		    __USER_CAP(uap->buf, sizeof(u.shm_info)),
+		    USER_PTR(uap->buf, sizeof(u.shm_info)),
 		    sizeof(u.shm_info));
 		break;
 	case SHM_STAT:
@@ -1924,7 +1924,7 @@ freebsd7_freebsd64_shmctl(struct thread *td,
 		CP(u.shmid_ds, shmid_ds64, shm_dtime);
 		CP(u.shmid_ds, shmid_ds64, shm_ctime);
 		shmid_ds64.shm_internal = 0;
-		error = copyout(&shmid_ds64, __USER_CAP_OBJ(uap->buf),
+		error = copyout(&shmid_ds64, USER_PTR_OBJ(uap->buf),
 		    sizeof(shmid_ds64));
 		break;
 	}
@@ -1951,7 +1951,7 @@ freebsd64_shmctl(struct thread *td, struct freebsd64_shmctl_args *uap)
 	size_t sz;
 
 	if (uap->cmd == IPC_SET) {
-		if ((error = copyin(__USER_CAP_OBJ(uap->buf), &shmid_ds64,
+		if ((error = copyin(USER_PTR_OBJ(uap->buf), &shmid_ds64,
 		    sizeof(shmid_ds64))))
 			goto done;
 		CP(shmid_ds64, u.shmid_ds, shm_perm);
@@ -1972,12 +1972,12 @@ freebsd64_shmctl(struct thread *td, struct freebsd64_shmctl_args *uap)
 	switch (uap->cmd) {
 	case IPC_INFO:
 		error = copyout(&u.shminfo,
-		    __USER_CAP(uap->buf, sizeof(u.shminfo)),
+		    USER_PTR(uap->buf, sizeof(u.shminfo)),
 		    sizeof(u.shminfo));
 		break;
 	case SHM_INFO:
 		error = copyout(&u.shm_info,
-		    __USER_CAP(uap->buf, sizeof(u.shm_info)),
+		    USER_PTR(uap->buf, sizeof(u.shm_info)),
 		    sizeof(u.shm_info));
 		break;
 	case SHM_STAT:
@@ -1990,7 +1990,7 @@ freebsd64_shmctl(struct thread *td, struct freebsd64_shmctl_args *uap)
 		CP(u.shmid_ds, shmid_ds64, shm_atime);
 		CP(u.shmid_ds, shmid_ds64, shm_dtime);
 		CP(u.shmid_ds, shmid_ds64, shm_ctime);
-		error = copyout(&shmid_ds64, __USER_CAP_OBJ(uap->buf),
+		error = copyout(&shmid_ds64, USER_PTR_OBJ(uap->buf),
 		    sizeof(shmid_ds64));
 		break;
 	}

--- a/sys/kern/uipc_ktls.c
+++ b/sys/kern/uipc_ktls.c
@@ -311,7 +311,7 @@ ktls_copyin_tls_enable(struct sockopt *sopt, struct tls_enable *tls)
 	uint8_t *cipher_key = NULL, *iv = NULL, *auth_key = NULL;
 
 	if (sopt->sopt_valsize == sizeof(tls_v0)) {
-		error = sooptcopyincap(sopt, &tls_v0, sizeof(tls_v0), sizeof(tls_v0));
+		error = sooptcopyinptr(sopt, &tls_v0, sizeof(tls_v0), sizeof(tls_v0));
 		if (error != 0)
 			goto done;
 		memset(tls, 0, sizeof(*tls));
@@ -327,7 +327,7 @@ ktls_copyin_tls_enable(struct sockopt *sopt, struct tls_enable *tls)
 		tls->tls_vmajor = tls_v0.tls_vmajor;
 		tls->tls_vminor = tls_v0.tls_vminor;
 	} else
-		error = sooptcopyincap(sopt, tls, sizeof(*tls), sizeof(*tls));
+		error = sooptcopyinptr(sopt, tls, sizeof(*tls), sizeof(*tls));
 
 	if (error != 0)
 		return (error);

--- a/sys/kern/uipc_mqueue.c
+++ b/sys/kern/uipc_mqueue.c
@@ -2851,7 +2851,7 @@ freebsd32_kmq_open(struct thread *td, struct freebsd32_kmq_open_args *uap)
 			return (error);
 		mq_attr_from32(&attr32, &attr);
 	}
-	return (kern_kmq_open(td, __USER_CAP_STR(uap->path), flags, uap->mode,
+	return (kern_kmq_open(td, USER_PTR_STR(uap->path), flags, uap->mode,
 	    uap->attr != NULL ? &attr : NULL));
 }
 
@@ -2964,39 +2964,39 @@ static struct syscall_helper_data mq32_syscalls[] = {
 int
 freebsd64_kmq_open(struct thread *td, struct freebsd64_kmq_open_args *uap)
 {
-	return (user_kmq_open(td, __USER_CAP_PATH(uap->path), uap->flags,
-	    uap->mode, __USER_CAP_OBJ(uap->attr)));
+	return (user_kmq_open(td, USER_PTR_PATH(uap->path), uap->flags,
+	    uap->mode, USER_PTR_OBJ(uap->attr)));
 }
 
 int
 freebsd64_kmq_unlink(struct thread *td, struct freebsd64_kmq_unlink_args *uap)
 {
-	return (kern_kmq_unlink(td, __USER_CAP_PATH(uap->path)));
+	return (kern_kmq_unlink(td, USER_PTR_PATH(uap->path)));
 }
 
 int
 freebsd64_kmq_setattr(struct thread *td, struct freebsd64_kmq_setattr_args *uap)
 {
-	return (user_kmq_setattr(td, uap->mqd, __USER_CAP_OBJ(uap->attr),
-	    __USER_CAP_OBJ(uap->oattr)));
+	return (user_kmq_setattr(td, uap->mqd, USER_PTR_OBJ(uap->attr),
+	    USER_PTR_OBJ(uap->oattr)));
 }
 
 int
 freebsd64_kmq_timedsend(struct thread *td,
     struct freebsd64_kmq_timedsend_args *uap)
 {
-	return (user_kmq_timedsend(td, uap->mqd, __USER_CAP(uap->msg_ptr,
+	return (user_kmq_timedsend(td, uap->mqd, USER_PTR(uap->msg_ptr,
 	    uap->msg_len), uap->msg_len, uap->msg_prio,
-	    __USER_CAP_OBJ(uap->abs_timeout)));
+	    USER_PTR_OBJ(uap->abs_timeout)));
 }
 
 int
 freebsd64_kmq_timedreceive(struct thread *td,
     struct freebsd64_kmq_timedreceive_args *uap)
 {
-	return (user_kmq_timedreceive(td, uap->mqd, __USER_CAP(uap->msg_ptr,
-	    uap->msg_len), uap->msg_len, __USER_CAP_OBJ(uap->msg_prio),
-	    __USER_CAP_OBJ(uap->abs_timeout)));
+	return (user_kmq_timedreceive(td, uap->mqd, USER_PTR(uap->msg_ptr,
+	    uap->msg_len), uap->msg_len, USER_PTR_OBJ(uap->msg_prio),
+	    USER_PTR_OBJ(uap->abs_timeout)));
 }
 
 int
@@ -3009,7 +3009,7 @@ freebsd64_kmq_notify(struct thread *td, struct freebsd64_kmq_notify_args *uap)
 	if (uap->sigev == NULL) {
 		evp = NULL;
 	} else {
-		error = copyin(__USER_CAP_OBJ(uap->sigev), &ev64,
+		error = copyin(USER_PTR_OBJ(uap->sigev), &ev64,
 		    sizeof(ev64));
 		if (error != 0)
 			return (error);

--- a/sys/kern/uipc_mqueue.c
+++ b/sys/kern/uipc_mqueue.c
@@ -2522,7 +2522,7 @@ sys_kmq_notify(struct thread *td, struct kmq_notify_args *uap)
 	if (uap->sigev == NULL) {
 		evp = NULL;
 	} else {
-		error = copyincap(uap->sigev, &ev, sizeof(ev));
+		error = copyinptr(uap->sigev, &ev, sizeof(ev));
 		if (error != 0)
 			return (error);
 		evp = &ev;

--- a/sys/kern/uipc_mqueue.c
+++ b/sys/kern/uipc_mqueue.c
@@ -2851,7 +2851,7 @@ freebsd32_kmq_open(struct thread *td, struct freebsd32_kmq_open_args *uap)
 			return (error);
 		mq_attr_from32(&attr32, &attr);
 	}
-	return (kern_kmq_open(td, USER_PTR_STR(uap->path), flags, uap->mode,
+	return (kern_kmq_open(td, USER_PTR_PATH(uap->path), flags, uap->mode,
 	    uap->attr != NULL ? &attr : NULL));
 }
 

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -109,6 +109,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/capsicum.h>
 #include <sys/fcntl.h>
 #include <sys/limits.h>

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -3742,7 +3742,7 @@ sooptcopyin(struct sockopt *sopt, void *buf, size_t len, size_t minlen)
 #if __has_feature(capabilities)
 /* Version of sooptcopyin that preserves tags. */
 int
-sooptcopyincap(struct sockopt *sopt, void *buf, size_t len, size_t minlen)
+sooptcopyinptr(struct sockopt *sopt, void *buf, size_t len, size_t minlen)
 {
 	size_t	valsize;
 
@@ -3752,7 +3752,7 @@ sooptcopyincap(struct sockopt *sopt, void *buf, size_t len, size_t minlen)
 		sopt->sopt_valsize = valsize = len;
 
 	if (sopt->sopt_td != NULL)
-		return (copyincap(sopt->sopt_val, buf, valsize));
+		return (copyinptr(sopt->sopt_val, buf, valsize));
 
 	bcopy((__cheri_fromcap void *)sopt->sopt_val, buf, valsize);
 	return (0);
@@ -3939,7 +3939,7 @@ sosetopt(struct socket *so, struct sockopt *sopt)
 				    tmpmac.m_buflen);
 			} else
 #endif
-				error = sooptcopyincap(sopt, &extmac,
+				error = sooptcopyinptr(sopt, &extmac,
 				    sizeof extmac, sizeof extmac);
 			if (error)
 				goto bad;
@@ -4219,7 +4219,7 @@ integer:
 				    tmpmac.m_buflen);
 			} else
 #endif
-				error = sooptcopyincap(sopt, &extmac,
+				error = sooptcopyinptr(sopt, &extmac,
 				    sizeof(extmac), sizeof(extmac));
 			if (error)
 				goto bad;
@@ -4250,7 +4250,7 @@ integer:
 				    tmpmac.m_buflen);
 			} else
 #endif
-				error = sooptcopyincap(sopt, &extmac,
+				error = sooptcopyinptr(sopt, &extmac,
 				    sizeof(extmac), sizeof(extmac));
 			if (error)
 				goto bad;

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -3935,7 +3935,7 @@ sosetopt(struct socket *so, struct sockopt *sopt)
 				error = sooptcopyin(sopt, &tmpmac,
 				    sizeof tmpmac, sizeof tmpmac);
 				extmac.m_buflen = tmpmac.m_buflen;
-				extmac.m_string = __USER_CAP(tmpmac.m_string,
+				extmac.m_string = USER_PTR(tmpmac.m_string,
 				    tmpmac.m_buflen);
 			} else
 #endif
@@ -4215,7 +4215,7 @@ integer:
 				error = sooptcopyin(sopt, &tmpmac,
 				    sizeof tmpmac, sizeof tmpmac);
 				extmac.m_buflen = tmpmac.m_buflen;
-				extmac.m_string = __USER_CAP(tmpmac.m_string,
+				extmac.m_string = USER_PTR(tmpmac.m_string,
 				    tmpmac.m_buflen);
 			} else
 #endif
@@ -4246,7 +4246,7 @@ integer:
 				error = sooptcopyin(sopt, &tmpmac,
 				    sizeof tmpmac, sizeof tmpmac);
 				extmac.m_buflen = tmpmac.m_buflen;
-				extmac.m_string = __USER_CAP(tmpmac.m_string,
+				extmac.m_string = USER_PTR(tmpmac.m_string,
 				    tmpmac.m_buflen);
 			} else
 #endif

--- a/sys/kern/uipc_syscalls.c
+++ b/sys/kern/uipc_syscalls.c
@@ -895,7 +895,7 @@ sys_sendmsg(struct thread *td, struct sendmsg_args *uap)
 	struct iovec *iov;
 	int error;
 
-	error = copyincap(uap->msg, &msg, sizeof(msg));
+	error = copyinptr(uap->msg, &msg, sizeof(msg));
 	if (error != 0)
 		return (error);
 	error = copyiniov(msg.msg_iov, msg.msg_iovlen, &iov, EMSGSIZE);
@@ -1192,7 +1192,7 @@ sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 	struct iovec * __capability uiov, *iov;
 	int error;
 
-	error = copyincap(uap->msg, &msg, sizeof(msg));
+	error = copyinptr(uap->msg, &msg, sizeof(msg));
 	if (error != 0)
 		return (error);
 	error = copyiniov(msg.msg_iov, msg.msg_iovlen, &iov, EMSGSIZE);
@@ -1208,7 +1208,7 @@ sys_recvmsg(struct thread *td, struct recvmsg_args *uap)
 	error = recvit(td, uap->s, &msg, NULL);
 	if (error == 0) {
 		msg.msg_iov = uiov;
-		error = copyoutcap(&msg, uap->msg, sizeof(msg));
+		error = copyoutptr(&msg, uap->msg, sizeof(msg));
 	}
 	free(iov, M_IOV);
 	return (error);

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -2958,7 +2958,7 @@ aiocb32_copyin_old_sigevent(void * __capability ujob,
 
 	CP(job32, *kcb, aio_fildes);
 	CP(job32, *kcb, aio_offset);
-	kcb->aio_buf = __USER_CAP(job32.aio_buf, job32.aio_nbytes);
+	kcb->aio_buf = USER_PTR(job32.aio_buf, job32.aio_nbytes);
 	CP(job32, *kcb, aio_nbytes);
 	CP(job32, *kcb, aio_lio_opcode);
 	CP(job32, *kcb, aio_reqprio);
@@ -2987,14 +2987,14 @@ aiocb32_copyin(void * __capability ujob, struct kaiocb *kjob, int type)
 		type = kcb->aio_lio_opcode;
 	if (type & LIO_VECTORED) {
 		CP(job32, *kcb, aio_iovcnt);
-		iov32 = __USER_CAP(job32.aio_iov, kcb->aio_iovcnt * sizeof(struct iovec32));
+		iov32 = USER_PTR(job32.aio_iov, kcb->aio_iovcnt * sizeof(struct iovec32));
 		/* malloc a uio and copy in the iovec */
 		error = freebsd32_copyinuio(iov32,
 		    kcb->aio_iovcnt, &kjob->uiop);
 		if (error)
 			return (error);
 	} else {
-		kcb->aio_buf = __USER_CAP(job32.aio_buf, job32.aio_nbytes);
+		kcb->aio_buf = USER_PTR(job32.aio_buf, job32.aio_nbytes);
 		CP(job32, *kcb, aio_nbytes);
 	}
 	CP(job32, *kcb, aio_reqprio);
@@ -3082,7 +3082,7 @@ int
 freebsd32_aio_return(struct thread *td, struct freebsd32_aio_return_args *uap)
 {
 
-	return (kern_aio_return(td, __USER_CAP_OBJ(uap->aiocbp), &aiocb32_ops));
+	return (kern_aio_return(td, USER_PTR_OBJ(uap->aiocbp), &aiocb32_ops));
 }
 
 int
@@ -3099,7 +3099,7 @@ freebsd32_aio_suspend(struct thread *td, struct freebsd32_aio_suspend_args *uap)
 
 	if (uap->timeout) {
 		/* Get timespec struct. */
-		if ((error = copyin(__USER_CAP_OBJ(uap->timeout), &ts32,
+		if ((error = copyin(USER_PTR_OBJ(uap->timeout), &ts32,
 		    sizeof(ts32))) != 0)
 			return (error);
 		CP(ts32, ts, tv_sec);
@@ -3114,7 +3114,7 @@ freebsd32_aio_suspend(struct thread *td, struct freebsd32_aio_suspend_args *uap)
 	    sizeof(ujoblist32[0]));
 	if (error == 0) {
 		for (i = uap->nent - 1; i >= 0; i--)
-			ujoblist[i] = __USER_CAP(PTRIN(ujoblist32[i]),
+			ujoblist[i] = USER_PTR(PTRIN(ujoblist32[i]),
 			    sizeof(struct aiocb32));
 
 		error = kern_aio_suspend(td, uap->nent, ujoblist, tsp);
@@ -3127,7 +3127,7 @@ int
 freebsd32_aio_cancel(struct thread *td, struct freebsd32_aio_cancel_args *uap)
 {
 
-	return(kern_aio_cancel(td, uap->fd, __USER_CAP_OBJ(uap->aiocbp),
+	return(kern_aio_cancel(td, uap->fd, USER_PTR_OBJ(uap->aiocbp),
 	    &aiocb32_ops));
 }
 
@@ -3145,7 +3145,7 @@ freebsd6_freebsd32_aio_read(struct thread *td,
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_READ, &aiocb32_ops_osigevent));
 }
 #endif
@@ -3155,7 +3155,7 @@ freebsd32_aio_read(struct thread *td, struct freebsd32_aio_read_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_READ, &aiocb32_ops));
 }
 
@@ -3174,7 +3174,7 @@ freebsd6_freebsd32_aio_write(struct thread *td,
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_WRITE, &aiocb32_ops_osigevent));
 }
 #endif
@@ -3184,7 +3184,7 @@ freebsd32_aio_write(struct thread *td, struct freebsd32_aio_write_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_WRITE, &aiocb32_ops));
 }
 
@@ -3201,7 +3201,7 @@ freebsd32_aio_mlock(struct thread *td, struct freebsd32_aio_mlock_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_MLOCK, &aiocb32_ops));
 }
 
@@ -3273,7 +3273,7 @@ freebsd6_freebsd32_lio_listio(struct thread *td,
 	}
 	acb_list = malloc(sizeof(acb_list[0]) * nent, M_LIO, M_WAITOK);
 	for (i = 0; i < nent; i++)
-		acb_list[i] = __USER_CAP(PTRIN(acb_list32[i]),
+		acb_list[i] = USER_PTR(PTRIN(acb_list32[i]),
 		    sizeof(struct aiocb32));
 	free(acb_list32, M_LIO);
 
@@ -3319,7 +3319,7 @@ freebsd32_lio_listio(struct thread *td, struct freebsd32_lio_listio_args *uap)
 	}
 	acb_list = malloc(sizeof(acb_list[0]) * nent, M_LIO, M_WAITOK);
 	for (i = 0; i < nent; i++)
-		acb_list[i] = __USER_CAP(PTRIN(acb_list32[i]),
+		acb_list[i] = USER_PTR(PTRIN(acb_list32[i]),
 		    sizeof(struct aiocb32));
 	free(acb_list32, M_LIO);
 
@@ -3415,7 +3415,7 @@ aiocb64_copyin_old_sigevent(void * __capability ujob,
 
 	CP(job64, *kcb, aio_fildes);
 	CP(job64, *kcb, aio_offset);
-	kcb->aio_buf = __USER_CAP(job64.aio_buf, job64.aio_nbytes);
+	kcb->aio_buf = USER_PTR(job64.aio_buf, job64.aio_nbytes);
 	CP(job64, *kcb, aio_nbytes);
 	CP(job64, *kcb, aio_lio_opcode);
 	CP(job64, *kcb, aio_reqprio);
@@ -3444,14 +3444,14 @@ aiocb64_copyin(void * __capability ujob, struct kaiocb *kjob, int type)
 		type = kcb->aio_lio_opcode;
 	if (type & LIO_VECTORED) {
 		CP(job64, *kcb, aio_iovcnt);
-		iov64 = __USER_CAP(job64.aio_iov, kcb->aio_iovcnt * sizeof(struct iovec64));
+		iov64 = USER_PTR(job64.aio_iov, kcb->aio_iovcnt * sizeof(struct iovec64));
 		/* malloc a uio and copy in the iovec */
 		error = freebsd64_copyinuio(iov64, kcb->aio_iovcnt,
 		    &kjob->uiop);
 		if (error)
 			return (error);
 	} else {
-		kcb->aio_buf = __USER_CAP(job64.aio_buf, job64.aio_nbytes);
+		kcb->aio_buf = USER_PTR(job64.aio_buf, job64.aio_nbytes);
 		CP(job64, *kcb, aio_nbytes);
 	}
 	CP(job64, *kcb, aio_reqprio);
@@ -3538,7 +3538,7 @@ int
 freebsd64_aio_return(struct thread *td, struct freebsd64_aio_return_args *uap)
 {
 
-	return (kern_aio_return(td, __USER_CAP_OBJ(uap->aiocbp), &aiocb64_ops));
+	return (kern_aio_return(td, USER_PTR_OBJ(uap->aiocbp), &aiocb64_ops));
 }
 
 int
@@ -3554,7 +3554,7 @@ freebsd64_aio_suspend(struct thread *td, struct freebsd64_aio_suspend_args *uap)
 
 	if (uap->timeout) {
 		/* Get timespec struct. */
-		if ((error = copyin(__USER_CAP_OBJ(uap->timeout), &ts,
+		if ((error = copyin(USER_PTR_OBJ(uap->timeout), &ts,
 		    sizeof(ts))) != 0)
 			return (error);
 		tsp = &ts;
@@ -3563,11 +3563,11 @@ freebsd64_aio_suspend(struct thread *td, struct freebsd64_aio_suspend_args *uap)
 
 	ujoblist = malloc(uap->nent * sizeof(ujoblist[0]), M_AIO, M_WAITOK);
 	ujoblist64 = (uint64_t *)ujoblist;
-	error = copyin(__USER_CAP_ARRAY(uap->aiocbp, uap->nent), ujoblist64,
+	error = copyin(USER_PTR_ARRAY(uap->aiocbp, uap->nent), ujoblist64,
 	    uap->nent * sizeof(ujoblist64[0]));
 	if (error == 0) {
 		for (i = uap->nent - 1; i >= 0; i--)
-			ujoblist[i] = __USER_CAP(ujoblist64[i],
+			ujoblist[i] = USER_PTR(ujoblist64[i],
 			    sizeof(struct aiocb64));
 
 		error = kern_aio_suspend(td, uap->nent, ujoblist, tsp);
@@ -3580,7 +3580,7 @@ int
 freebsd64_aio_cancel(struct thread *td, struct freebsd64_aio_cancel_args *uap)
 {
 
-	return(kern_aio_cancel(td, uap->fd, __USER_CAP_OBJ(uap->aiocbp),
+	return(kern_aio_cancel(td, uap->fd, USER_PTR_OBJ(uap->aiocbp),
 	    &aiocb64_ops));
 }
 
@@ -3588,7 +3588,7 @@ int
 freebsd64_aio_error(struct thread *td, struct freebsd64_aio_error_args *uap)
 {
 
-	return (kern_aio_error(td, __USER_CAP_OBJ(uap->aiocbp), &aiocb64_ops));
+	return (kern_aio_error(td, USER_PTR_OBJ(uap->aiocbp), &aiocb64_ops));
 }
 
 #ifdef COMPAT_FREEBSD6
@@ -3598,7 +3598,7 @@ freebsd6_freebsd64_aio_read(struct thread *td,
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_READ, &aiocb64_ops_osigevent));
 }
 #endif
@@ -3608,7 +3608,7 @@ freebsd64_aio_read(struct thread *td, struct freebsd64_aio_read_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_READ, &aiocb64_ops));
 }
 
@@ -3616,7 +3616,7 @@ int
 freebsd64_aio_readv(struct thread *td, struct freebsd64_aio_readv_args *uap)
 {
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp), NULL,
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp), NULL,
 	    LIO_READV, &aiocb64_ops));
 }
 
@@ -3627,7 +3627,7 @@ freebsd6_freebsd64_aio_write(struct thread *td,
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_WRITE, &aiocb64_ops_osigevent));
 }
 #endif
@@ -3637,7 +3637,7 @@ freebsd64_aio_write(struct thread *td, struct freebsd64_aio_write_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_WRITE, &aiocb64_ops));
 }
 
@@ -3645,7 +3645,7 @@ int
 freebsd64_aio_writev(struct thread *td, struct freebsd64_aio_writev_args *uap)
 {
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp), NULL,
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp), NULL,
 	    LIO_WRITEV, &aiocb64_ops));
 }
 
@@ -3654,7 +3654,7 @@ freebsd64_aio_mlock(struct thread *td, struct freebsd64_aio_mlock_args *uap)
 {
 
 	return (aio_aqueue(td,
-	    (struct aiocb * __capability)__USER_CAP_OBJ(uap->aiocbp),
+	    (struct aiocb * __capability)USER_PTR_OBJ(uap->aiocbp),
 	    NULL, LIO_MLOCK, &aiocb64_ops));
 }
 
@@ -3667,14 +3667,14 @@ freebsd64_aio_waitcomplete(struct thread *td,
 
 	if (uap->timeout) {
 		/* Get timespec struct. */
-		error = copyin(__USER_CAP_OBJ(uap->timeout), &ts, sizeof(ts));
+		error = copyin(USER_PTR_OBJ(uap->timeout), &ts, sizeof(ts));
 		if (error)
 			return (error);
 		tsp = &ts;
 	} else
 		tsp = NULL;
 
-	return (kern_aio_waitcomplete(td, __USER_CAP_OBJ(uap->aiocbp), tsp,
+	return (kern_aio_waitcomplete(td, USER_PTR_OBJ(uap->aiocbp), tsp,
 	    &aiocb64_ops));
 }
 
@@ -3682,7 +3682,7 @@ int
 freebsd64_aio_fsync(struct thread *td, struct freebsd64_aio_fsync_args *uap)
 {
 
-	return (kern_aio_fsync(td, uap->op, __USER_CAP_OBJ(uap->aiocbp),
+	return (kern_aio_fsync(td, uap->op, USER_PTR_OBJ(uap->aiocbp),
 	    &aiocb64_ops));
 }
 
@@ -3723,7 +3723,7 @@ freebsd6_freebsd64_lio_listio(struct thread *td,
 	}
 	acb_list = malloc(sizeof(acb_list[0]) * nent, M_LIO, M_WAITOK);
 	for (i = 0; i < nent; i++)
-		acb_list[i] = __USER_CAP(acb_list64[i], sizeof(struct aiocb64));
+		acb_list[i] = USER_PTR(acb_list64[i], sizeof(struct aiocb64));
 	free(acb_list64, M_LIO);
 
 	error = kern_lio_listio(td, uap->mode, (intcap_t)uap->acb_list,
@@ -3750,7 +3750,7 @@ freebsd64_lio_listio(struct thread *td, struct freebsd64_lio_listio_args *uap)
 		return (EINVAL);
 
 	if (uap->sig && (uap->mode == LIO_NOWAIT)) {
-		error = copyin(__USER_CAP_OBJ(uap->sig), &sig64, sizeof(sig64));
+		error = copyin(USER_PTR_OBJ(uap->sig), &sig64, sizeof(sig64));
 		if (error)
 			return (error);
 		error = convert_sigevent64(&sig64, &sig);
@@ -3761,7 +3761,7 @@ freebsd64_lio_listio(struct thread *td, struct freebsd64_lio_listio_args *uap)
 		sigp = NULL;
 
 	acb_list64 = malloc(sizeof(acb_list64[0]) * nent, M_LIO, M_WAITOK);
-	error = copyin(__USER_CAP_ARRAY(uap->acb_list, nent), acb_list64,
+	error = copyin(USER_PTR_ARRAY(uap->acb_list, nent), acb_list64,
 	    nent * sizeof(acb_list64[0]));
 	if (error) {
 		free(acb_list64, M_LIO);
@@ -3769,7 +3769,7 @@ freebsd64_lio_listio(struct thread *td, struct freebsd64_lio_listio_args *uap)
 	}
 	acb_list = malloc(sizeof(acb_list[0]) * nent, M_LIO, M_WAITOK);
 	for (i = 0; i < nent; i++)
-		acb_list[i] = __USER_CAP(acb_list64[i], sizeof(struct aiocb64));
+		acb_list[i] = USER_PTR(acb_list64[i], sizeof(struct aiocb64));
 	free(acb_list64, M_LIO);
 
 	error = kern_lio_listio(td, uap->mode, (intcap_t)uap->acb_list,

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1403,7 +1403,7 @@ aiocb_copyin_old_sigevent(void * __capability ujob, struct kaiocb *kjob,
 	int error;
 
 	bzero(kcb, sizeof(struct aiocb));
-	error = copyincap(ujob, kcb, sizeof(struct oaiocb));
+	error = copyinptr(ujob, kcb, sizeof(struct oaiocb));
 	if (error)
 		return (error);
 	/* No need to copyin aio_iov, because it did not exist in FreeBSD 6 */
@@ -1418,7 +1418,7 @@ aiocb_copyin(void * __capability ujob, struct kaiocb *kjob, int type)
 	struct aiocb *kcb = &kjob->uaiocb;
 	int error;
 
-	error = copyincap(ujob, kcb, sizeof(struct aiocb));
+	error = copyinptr(ujob, kcb, sizeof(struct aiocb));
 	if (error)
 		return (error);
 	if (type == LIO_NOP)
@@ -2058,7 +2058,7 @@ sys_aio_suspend(struct thread *td, struct aio_suspend_args *uap)
 		tsp = NULL;
 
 	ujoblist = malloc(uap->nent * sizeof(ujoblist[0]), M_AIO, M_WAITOK);
-	error = copyincap(uap->aiocbp, ujoblist, uap->nent * sizeof(ujoblist[0]));
+	error = copyinptr(uap->aiocbp, ujoblist, uap->nent * sizeof(ujoblist[0]));
 	if (error == 0)
 		error = kern_aio_suspend(td, uap->nent, ujoblist, tsp);
 	free(ujoblist, M_AIO);
@@ -2438,7 +2438,7 @@ freebsd6_lio_listio(struct thread *td, struct freebsd6_lio_listio_args *uap)
 		sigp = NULL;
 
 	acb_list = malloc(sizeof(acb_list[0]) * nent, M_LIO, M_WAITOK);
-	error = copyincap(uap->acb_list, acb_list, nent * sizeof(acb_list[0]));
+	error = copyinptr(uap->acb_list, acb_list, nent * sizeof(acb_list[0]));
 	if (error == 0)
 		error = kern_lio_listio(td, uap->mode,
 		    (intcap_t)uap->acb_list, acb_list, nent, sigp,
@@ -2464,7 +2464,7 @@ sys_lio_listio(struct thread *td, struct lio_listio_args *uap)
 		return (EINVAL);
 
 	if (uap->sig && (uap->mode == LIO_NOWAIT)) {
-		error = copyincap(uap->sig, &sig, sizeof(sig));
+		error = copyinptr(uap->sig, &sig, sizeof(sig));
 		if (error)
 			return (error);
 		sigp = &sig;
@@ -2472,7 +2472,7 @@ sys_lio_listio(struct thread *td, struct lio_listio_args *uap)
 		sigp = NULL;
 
 	acb_list = malloc(sizeof(acb_list[0]) * nent, M_LIO, M_WAITOK);
-	error = copyincap(uap->acb_list, acb_list, nent * sizeof(acb_list[0]));
+	error = copyinptr(uap->acb_list, acb_list, nent * sizeof(acb_list[0]));
 	if (error == 0)
 		error = kern_lio_listio(td, uap->mode, (intcap_t)uap->acb_list,
 		    acb_list, nent, sigp, &aiocb_ops);

--- a/sys/kern/vfs_mount.c
+++ b/sys/kern/vfs_mount.c
@@ -375,7 +375,7 @@ vfs_buildopts(struct uio *auio, struct vfsoptlist **options)
 				    auio->uio_iov[i + 1].iov_base, opt->value,
 				    optlen);
 			} else {
-				error = copyincap(auio->uio_iov[i + 1].iov_base,
+				error = copyinptr(auio->uio_iov[i + 1].iov_base,
 				    opt->value, optlen);
 				if (error)
 					goto bad;

--- a/sys/kern/vfs_subr.c
+++ b/sys/kern/vfs_subr.c
@@ -44,6 +44,7 @@
 
 #include <sys/param.h>
 #include <sys/systm.h>
+#include <sys/abi_compat.h>
 #include <sys/asan.h>
 #include <sys/bio.h>
 #include <sys/buf.h>

--- a/sys/libkern/iconv.c
+++ b/sys/libkern/iconv.c
@@ -444,14 +444,14 @@ iconv_sysctl_add(SYSCTL_HANDLER_ARGS)
 #ifdef COMPAT_FREEBSD32
 	if (req->flags & SCTL_MASK32) {
 		error = SYSCTL_IN(req, &du.din32, sizeof(du.din32));
-		ia_data = __USER_CAP((void*)(uintptr_t)du.din32.ia_data,
+		ia_data = USER_PTR((void*)(uintptr_t)du.din32.ia_data,
 		    du.din32.ia_datalen);
 	} else
 #endif
 #ifdef COMPAT_FREEBSD64
 	if (req->flags & SCTL_MASK64) {
 		error = SYSCTL_IN(req, &du.din64, sizeof(du.din64));
-		ia_data = __USER_CAP((void*)(uintptr_t)du.din64.ia_data,
+		ia_data = USER_PTR((void*)(uintptr_t)du.din64.ia_data,
 		    du.din64.ia_datalen);
 	} else
 #endif

--- a/sys/libkern/iconv.c
+++ b/sys/libkern/iconv.c
@@ -29,6 +29,7 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/kernel.h>
+#include <sys/abi_compat.h>
 #include <sys/iconv.h>
 #include <sys/malloc.h>
 #include <sys/mount.h>

--- a/sys/net/bpf.c
+++ b/sys/net/bpf.c
@@ -1950,13 +1950,13 @@ bf_insns_get_ptr(void *fpp)
 	fpup = fpp;
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
-		return (__USER_CAP(
+		return (USER_PTR(
 		    (struct bpf_insn *)(uintptr_t)fpup->fp32.bf_insns,
 		    fpup->fp32.bf_len * sizeof(struct bpf_insn)));
 #endif
 #ifdef COMPAT_FREEBSD64
 	if (!SV_CURPROC_FLAG(SV_CHERI))
-		return (__USER_CAP(
+		return (USER_PTR(
 		    (struct bpf_insn *)(uintptr_t)fpup->fp64.bf_insns,
 		    fpup->fp64.bf_len * sizeof(struct bpf_insn)));
 #endif
@@ -2910,12 +2910,12 @@ bfl_list_get_ptr(void *bflp)
 	bflup = bflp;
 #ifdef COMPAT_FREEBSD32
 	if (SV_CURPROC_FLAG(SV_ILP32))
-		return (__USER_CAP((u_int *)(uintptr_t)bflup->bfl32.bfl_list,
+		return (USER_PTR((u_int *)(uintptr_t)bflup->bfl32.bfl_list,
 		    bflup->bfl32.bfl_len * sizeof(u_int)));
 #endif
 #ifdef COMPAT_FREEBSD64
 	if (!SV_CURPROC_FLAG(SV_CHERI))
-		return (__USER_CAP((u_int *)(uintptr_t)bflup->bfl64.bfl_list,
+		return (USER_PTR((u_int *)(uintptr_t)bflup->bfl64.bfl_list,
 		    bflup->bfl64.bfl_len * sizeof(u_int)));
 #endif
 	return (bflup->bfl.bfl_list);

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -2352,11 +2352,11 @@ ifr_buffer_get_buffer(u_long cmd, void *data)
 	case sizeof(struct ifreq64):
 #ifdef COMPAT_FREEBSD32
 		if (SV_CURPROC_FLAG(SV_ILP32))
-			return (__USER_CAP(
+			return (USER_PTR(
 			    ifrup->ifr32.ifr_ifru.ifru_buffer.buffer,
 			    ifrup->ifr32.ifr_ifru.ifru_buffer.length));
 #endif
-		return (__USER_CAP(ifrup->ifr64.ifr_ifru.ifru_buffer.buffer,
+		return (USER_PTR(ifrup->ifr64.ifr_ifru.ifru_buffer.buffer,
 		    ifrup->ifr64.ifr_ifru.ifru_buffer.length));
 #endif
 	case sizeof(struct ifreq):
@@ -2471,10 +2471,10 @@ ifr_data_get_ptr(u_long cmd, void *ifrp)
 	case sizeof(struct ifreq64):
 #ifdef COMPAT_FREEBSD32
 		if (SV_CURPROC_FLAG(SV_ILP32))
-			return (__USER_CAP_UNBOUND(
+			return (USER_PTR_UNBOUND(
 			    ifrup->ifr32.ifr_ifru.ifru_data));
 #endif
-		return (__USER_CAP_UNBOUND(ifrup->ifr64.ifr_ifru.ifru_data));
+		return (USER_PTR_UNBOUND(ifrup->ifr64.ifr_ifru.ifru_data));
 #endif
 	case sizeof(struct ifreq):
 #if !__has_feature(capabilities) && defined(COMPAT_FREEBSD32)
@@ -3101,7 +3101,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 	case SIOCGIFCONF32:
 		ifc32 = (struct ifconf32 *)data;
 		thunk.ifc.ifc_len = ifc32->ifc_len;
-		thunk.ifc.ifc_buf = __USER_CAP(ifc32->ifc_buf, ifc32->ifc_len);
+		thunk.ifc.ifc_buf = USER_PTR(ifc32->ifc_buf, ifc32->ifc_len);
 		data = (caddr_t)&thunk.ifc;
 		cmd = SIOCGIFCONF;
 		break;
@@ -3112,7 +3112,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		    sizeof(thunk.ifd.ifd_name));
 		thunk.ifd.ifd_cmd = ifd32->ifd_cmd;
 		thunk.ifd.ifd_len = ifd32->ifd_len;
-		thunk.ifd.ifd_data = __USER_CAP(ifd32->ifd_data,
+		thunk.ifd.ifd_data = USER_PTR(ifd32->ifd_data,
 		    ifd32->ifd_len);
 		data = (caddr_t)&thunk.ifd;
 		cmd = _IOC_NEWTYPE(cmd, struct ifdrv);
@@ -3133,7 +3133,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 			break;
 		case SIOCGIFGROUP32:
 		case SIOCGIFGMEMB32:
-			thunk.ifgr.ifgr_groups = __USER_CAP(ifgr32->ifgr_groups,
+			thunk.ifgr.ifgr_groups = USER_PTR(ifgr32->ifgr_groups,
 			    ifgr32->ifgr_len);
 			break;
 		}
@@ -3150,7 +3150,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		thunk.ifmr.ifm_status = ifmr32->ifm_status;
 		thunk.ifmr.ifm_active = ifmr32->ifm_active;
 		thunk.ifmr.ifm_count = ifmr32->ifm_count;
-		thunk.ifmr.ifm_ulist = __USER_CAP(ifmr32->ifm_ulist,
+		thunk.ifmr.ifm_ulist = USER_PTR(ifmr32->ifm_ulist,
 		    ifmr32->ifm_count * sizeof(int));
 		data = (caddr_t)&thunk.ifmr;
 		cmd = _IOC_NEWTYPE(cmd, struct ifmediareq);
@@ -3160,7 +3160,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 	case SIOCGIFCONF64:
 		ifc64 = (struct ifconf64 *)data;
 		thunk.ifc.ifc_len = ifc64->ifc_len;
-		thunk.ifc.ifc_buf = __USER_CAP(ifc64->ifc_buf, ifc64->ifc_len);
+		thunk.ifc.ifc_buf = USER_PTR(ifc64->ifc_buf, ifc64->ifc_len);
 		data = (caddr_t)&thunk.ifc;
 		cmd = SIOCGIFCONF;
 		break;
@@ -3171,7 +3171,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		    sizeof(thunk.ifd.ifd_name));
 		thunk.ifd.ifd_cmd = ifd64->ifd_cmd;
 		thunk.ifd.ifd_len = ifd64->ifd_len;
-		thunk.ifd.ifd_data = __USER_CAP(ifd64->ifd_data,
+		thunk.ifd.ifd_data = USER_PTR(ifd64->ifd_data,
 		    ifd64->ifd_len);
 		data = (caddr_t)&thunk.ifd;
 		cmd = _IOC_NEWTYPE(cmd, struct ifdrv);
@@ -3192,7 +3192,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 			break;
 		case SIOCGIFGROUP64:
 		case SIOCGIFGMEMB64:
-			thunk.ifgr.ifgr_groups = __USER_CAP(ifgr64->ifgr_groups,
+			thunk.ifgr.ifgr_groups = USER_PTR(ifgr64->ifgr_groups,
 			    ifgr64->ifgr_len);
 			break;
 		}
@@ -3209,7 +3209,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		thunk.ifmr.ifm_status = ifmr64->ifm_status;
 		thunk.ifmr.ifm_active = ifmr64->ifm_active;
 		thunk.ifmr.ifm_count = ifmr64->ifm_count;
-		thunk.ifmr.ifm_ulist = __USER_CAP(ifmr64->ifm_ulist,
+		thunk.ifmr.ifm_ulist = USER_PTR(ifmr64->ifm_ulist,
 		    ifmr64->ifm_count * sizeof(int));
 		data = (caddr_t)&thunk.ifmr;
 		cmd = _IOC_NEWTYPE(cmd, struct ifmediareq);
@@ -3218,7 +3218,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 		ifcr64 = (struct if_clonereq64 *)data;
 		thunk.ifcr.ifcr_total = ifcr64->ifcr_total;
 		thunk.ifcr.ifcr_count = ifcr64->ifcr_count;
-		thunk.ifcr.ifcr_buffer = __USER_CAP(ifcr64->ifcr_buffer,
+		thunk.ifcr.ifcr_buffer = USER_PTR(ifcr64->ifcr_buffer,
 		    ifcr64->ifcr_count * IFNAMSIZ);
 		data = (caddr_t)&thunk.ifmr;
 		cmd = SIOCIFGCLONERS;

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -36,6 +36,7 @@
 #include "opt_ddb.h"
 
 #include <sys/param.h>
+#include <sys/abi_compat.h>
 #include <sys/capsicum.h>
 #include <sys/conf.h>
 #include <sys/eventhandler.h>

--- a/sys/net/if_bridge.c
+++ b/sys/net/if_bridge.c
@@ -944,7 +944,7 @@ bridge_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 			if (error)
 				break;
 		} else if (bc->bc_flags & BC_F_COPYINCAP) {
-			error = copyincap(ifd->ifd_data, &args, ifd->ifd_len);
+			error = copyinptr(ifd->ifd_data, &args, ifd->ifd_len);
 			if (error)
 				break;
 		}
@@ -964,7 +964,7 @@ bridge_ioctl(struct ifnet *ifp, u_long cmd, caddr_t data)
 		if (bc->bc_flags & BC_F_COPYOUT)
 			error = copyout(&args, ifd->ifd_data, ifd->ifd_len);
 		else if (bc->bc_flags & BC_F_COPYOUTCAP)
-			error = copyoutcap(&args, ifd->ifd_data, ifd->ifd_len);
+			error = copyoutptr(&args, ifd->ifd_data, ifd->ifd_len);
 
 		break;
 

--- a/sys/netinet/sctp_syscalls.c
+++ b/sys/netinet/sctp_syscalls.c
@@ -282,9 +282,9 @@ freebsd64_sctp_generic_sendmsg(struct thread *td,
 {
 
 	return (kern_sys_sctp_generic_sendmsg(td, uap->sd,
-	    __USER_CAP(uap->msg, uap->mlen), uap->mlen,
-	    __USER_CAP(uap->to, uap->tolen), uap->tolen,
-	    __USER_CAP_OBJ(uap->sinfo), uap->flags));
+	    USER_PTR(uap->msg, uap->mlen), uap->mlen,
+	    USER_PTR(uap->to, uap->tolen), uap->tolen,
+	    USER_PTR_OBJ(uap->sinfo), uap->flags));
 }
 #endif
 
@@ -416,9 +416,9 @@ freebsd32_sctp_generic_sendmsg_iov(struct thread *td,
 {
 
 	return (kern_sctp_generic_sendmsg_iov(td, uap->sd,
-	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
-	    uap->iovlen, __USER_CAP(uap->to, uap->tolen), uap->tolen,
-	    __USER_CAP_OBJ(uap->sinfo), uap->flags, freebsd32_copyiniov));
+	    (struct iovec * __capability)USER_PTR_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, USER_PTR(uap->to, uap->tolen), uap->tolen,
+	    USER_PTR_OBJ(uap->sinfo), uap->flags, freebsd32_copyiniov));
 }
 #endif
 
@@ -429,9 +429,9 @@ freebsd64_sctp_generic_sendmsg_iov(struct thread *td,
 {
 
 	return (kern_sctp_generic_sendmsg_iov(td, uap->sd,
-	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
-	    uap->iovlen, __USER_CAP(uap->to, uap->tolen), uap->tolen,
-	    __USER_CAP_OBJ(uap->sinfo), uap->flags, freebsd64_copyiniov));
+	    (struct iovec * __capability)USER_PTR_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, USER_PTR(uap->to, uap->tolen), uap->tolen,
+	    USER_PTR_OBJ(uap->sinfo), uap->flags, freebsd64_copyiniov));
 }
 #endif
 
@@ -577,10 +577,10 @@ freebsd32_sctp_generic_recvmsg(struct thread *td,
 {
 
 	return (kern_sctp_generic_recvmsg(td, uap->sd,
-	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
-	    uap->iovlen, __USER_CAP_UNBOUND(uap->from),
-	    __USER_CAP_OBJ(uap->fromlenaddr), __USER_CAP_OBJ(uap->sinfo),
-	    __USER_CAP_OBJ(uap->msg_flags), freebsd32_copyiniov));
+	    (struct iovec * __capability)USER_PTR_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, USER_PTR_UNBOUND(uap->from),
+	    USER_PTR_OBJ(uap->fromlenaddr), USER_PTR_OBJ(uap->sinfo),
+	    USER_PTR_OBJ(uap->msg_flags), freebsd32_copyiniov));
 }
 #endif
 
@@ -591,10 +591,10 @@ freebsd64_sctp_generic_recvmsg(struct thread *td,
 {
 
 	return (kern_sctp_generic_recvmsg(td, uap->sd,
-	    (struct iovec * __capability)__USER_CAP_ARRAY(uap->iov, uap->iovlen),
-	    uap->iovlen, __USER_CAP_UNBOUND(uap->from),
-	    __USER_CAP_OBJ(uap->fromlenaddr), __USER_CAP_OBJ(uap->sinfo),
-	    __USER_CAP_OBJ(uap->msg_flags), freebsd64_copyiniov));
+	    (struct iovec * __capability)USER_PTR_ARRAY(uap->iov, uap->iovlen),
+	    uap->iovlen, USER_PTR_UNBOUND(uap->from),
+	    USER_PTR_OBJ(uap->fromlenaddr), USER_PTR_OBJ(uap->sinfo),
+	    USER_PTR_OBJ(uap->msg_flags), freebsd64_copyiniov));
 }
 #endif
 

--- a/sys/netpfil/ipfilter/netinet/fil.c
+++ b/sys/netpfil/ipfilter/netinet/fil.c
@@ -4669,7 +4669,7 @@ frrequest(ipf_main_softc_t *softc, int unit, ioctlcmd_t req, caddr_t data,
 				 * changes.
 				 */
 #ifndef __CHERI_PURE_CAPABILITY__
-				error = COPYIN(__USER_CAP(uptr, fp->fr_dsize), ptr, fp->fr_dsize);
+				error = COPYIN(USER_PTR(uptr, fp->fr_dsize), ptr, fp->fr_dsize);
 #else
 				error = COPYIN(uptr, ptr, fp->fr_dsize);
 #endif
@@ -4913,7 +4913,7 @@ frrequest(ipf_main_softc_t *softc, int unit, ioctlcmd_t req, caddr_t data,
 			if (error == 0) {
 				if ((f->fr_dsize != 0) && (uptr != NULL)) {
 #ifndef __CHERI_PURE_CAPABILITY__
-					error = COPYOUT(f->fr_data, __USER_CAP(uptr, f->fr_dsize),
+					error = COPYOUT(f->fr_data, USER_PTR(uptr, f->fr_dsize),
 							f->fr_dsize);
 #else
 					error = COPYOUT(f->fr_data, uptr,

--- a/sys/netpfil/ipfilter/netinet/fil.c
+++ b/sys/netpfil/ipfilter/netinet/fil.c
@@ -18,6 +18,7 @@
 #include <sys/errno.h>
 #include <sys/types.h>
 #include <sys/param.h>
+#include <sys/abi_compat.h>
 #include <sys/time.h>
 #if defined(_KERNEL) && defined(__FreeBSD__)
 #  if !defined(IPFILTER_LKM)

--- a/sys/netpfil/ipfilter/netinet/fil.c
+++ b/sys/netpfil/ipfilter/netinet/fil.c
@@ -4050,7 +4050,7 @@ ipf_sync(ipf_main_softc_t *softc, void *ifp)
  * end up being unaligned) and on the kernel's local stack.
  */
 /* ------------------------------------------------------------------------ */
-/* Function:    copyinptr                                                   */
+/* Function:    copyin_indirect                                             */
 /* Returns:     int - 0 = success, else failure                             */
 /* Parameters:  src(I)  - pointer to the source address                     */
 /*              dst(I)  - destination address                               */
@@ -4061,7 +4061,7 @@ ipf_sync(ipf_main_softc_t *softc, void *ifp)
 /* NB: src - pointer to user space pointer, dst - kernel space pointer      */
 /* ------------------------------------------------------------------------ */
 int
-copyinptr(ipf_main_softc_t *softc, void *src, void *dst, size_t size)
+copyin_indirect(ipf_main_softc_t *softc, void *src, void *dst, size_t size)
 {
 	char * __capability ca;
 	int error;
@@ -4083,7 +4083,7 @@ copyinptr(ipf_main_softc_t *softc, void *src, void *dst, size_t size)
 
 
 /* ------------------------------------------------------------------------ */
-/* Function:    copyoutptr                                                  */
+/* Function:    copyout_indirect                                            */
 /* Returns:     int - 0 = success, else failure                             */
 /* Parameters:  src(I)  - pointer to the source address                     */
 /*              dst(I)  - destination address                               */
@@ -4094,7 +4094,7 @@ copyinptr(ipf_main_softc_t *softc, void *src, void *dst, size_t size)
 /* NB: src - kernel space pointer, dst - pointer to user space pointer.     */
 /* ------------------------------------------------------------------------ */
 int
-copyoutptr(ipf_main_softc_t *softc, void *src, void *dst, size_t size)
+copyout_indirect(ipf_main_softc_t *softc, void *src, void *dst, size_t size)
 {
 	char * __capability ca;
 	int error;

--- a/sys/netpfil/ipfilter/netinet/ip_auth.c
+++ b/sys/netpfil/ipfilter/netinet/ip_auth.c
@@ -1015,7 +1015,7 @@ ipf_auth_ioctlloop:
 
 			for (t = auth.fra_buf; m && (len > 0); ) {
 				i = MIN(M_LEN(m), len);
-				error = copyoutptr(softc, MTOD(m, char *),
+				error = copyout_indirect(softc, MTOD(m, char *),
 						   &t, i);
 				len -= i;
 				t += i;

--- a/sys/netpfil/ipfilter/netinet/ip_fil.h
+++ b/sys/netpfil/ipfilter/netinet/ip_fil.h
@@ -1677,8 +1677,8 @@ extern	char	*getifname(struct ifnet *);
 extern	int	ipfattach(ipf_main_softc_t *);
 extern	int	ipfdetach(ipf_main_softc_t *);
 extern	u_short	ipf_cksum(u_short *, int);
-extern	int	copyinptr(ipf_main_softc_t *, void *, void *, size_t);
-extern	int	copyoutptr(ipf_main_softc_t *, void *, void *, size_t);
+extern	int	copyin_indirect(ipf_main_softc_t *, void *, void *, size_t);
+extern	int	copyout_indirect(ipf_main_softc_t *, void *, void *, size_t);
 extern	int	ipf_fastroute(mb_t *, mb_t **, fr_info_t *, frdest_t *);
 extern	int	ipf_inject(fr_info_t *, mb_t *);
 extern	int	ipf_inobj(ipf_main_softc_t *, void *, ipfobj_t *,

--- a/sys/netpfil/ipfilter/netinet/ip_proxy.c
+++ b/sys/netpfil/ipfilter/netinet/ip_proxy.c
@@ -702,8 +702,8 @@ ipf_proxy_ioctl(ipf_main_softc_t *softc, caddr_t data, ioctlcmd_t cmd,
 				IPFERROR(80003);
 				error = ENOMEM;
 			} else {
-				error = copyinptr(softc, &ctl.apc_udata, ptr,
-						  ctl.apc_dsize);
+				error = copyin_indirect(softc, &ctl.apc_udata,
+							ptr, ctl.apc_dsize);
 				if (error == 0)
 					ctl.apc_data = ptr;
 			}

--- a/sys/netpfil/ipfilter/netinet/ip_scan.c
+++ b/sys/netpfil/ipfilter/netinet/ip_scan.c
@@ -106,7 +106,7 @@ ipf_scan_add(caddr_t data)
 		return (ENOMEM);
 	}
 
-	err = copyinptr(data, isc, sizeof(*isc));
+	err = copyin_indirect(data, isc, sizeof(*isc));
 	if (err) {
 		KFREE(isc);
 		return (err);
@@ -150,7 +150,7 @@ ipf_scan_remove(caddr_t data)
 	ipscan_t isc, *i;
 	int err;
 
-	err = copyinptr(data, &isc, sizeof(isc));
+	err = copyin_indirect(data, &isc, sizeof(isc));
 	if (err)
 		return (err);
 

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -332,10 +332,10 @@ smbioc_ossn32_to_ossn(struct smbioc_ossn *ossn, const void *data)
 	ossn32 = data;
 	ossn->ioc_opt = ossn32->ioc_opt;
 	ossn->ioc_svlen = ossn32->ioc_svlen;
-	ossn->ioc_server = __USER_CAP((void *)(uintptr_t)ossn32->ioc_server,
+	ossn->ioc_server = USER_PTR((void *)(uintptr_t)ossn32->ioc_server,
 	    ossn32->ioc_svlen);
 	ossn->ioc_lolen = ossn32->ioc_lolen;
-	ossn->ioc_local = __USER_CAP((void *)(uintptr_t)ossn32->ioc_local,
+	ossn->ioc_local = USER_PTR((void *)(uintptr_t)ossn32->ioc_local,
 	    ossn32->ioc_lolen);
 	/* Do not include padding */
 	copysize = min(
@@ -353,13 +353,13 @@ smbioc_rq32_to_rq(struct smbioc_rq *rq, const void *data)
 	rq32 = data;
 	rq->ioc_cmd = rq32->ioc_cmd;
 	rq->ioc_twc = rq32->ioc_twc;
-	rq->ioc_twords = __USER_CAP((void *)(uintptr_t)rq32->ioc_twords,
+	rq->ioc_twords = USER_PTR((void *)(uintptr_t)rq32->ioc_twords,
 	    rq32->ioc_twc);
 	rq->ioc_tbc = rq32->ioc_tbc;
-	rq->ioc_tbytes = __USER_CAP((void *)(uintptr_t)rq32->ioc_tbytes,
+	rq->ioc_tbytes = USER_PTR((void *)(uintptr_t)rq32->ioc_tbytes,
 	    rq32->ioc_tbc);
 	rq->ioc_rpbufsz = rq32->ioc_rpbufsz;
-	rq->ioc_rpbuf = __USER_CAP((char *)(uintptr_t)rq32->ioc_rpbuf,
+	rq->ioc_rpbuf = USER_PTR((char *)(uintptr_t)rq32->ioc_rpbuf,
 	    rq32->ioc_rpbufsz);
 	memcpy(&rq->ioc_rwc, &rq32->ioc_rwc,
 	    sizeof(*rq) - offsetof(struct smbioc_rq, ioc_rwc));
@@ -389,18 +389,18 @@ smbioc_t2rq32_to_t2rq(struct smbioc_t2rq *t2rq, const void *data)
 	memset(t2rq, 0, sizeof(*t2rq));
 	memcpy(&t2rq->ioc_setup, &t2rq32->ioc_setup, sizeof(t2rq->ioc_setup));
 	t2rq->ioc_setupcnt = t2rq32->ioc_setupcnt;
-	t2rq->ioc_name = __USER_CAP_STR((char *)(uintptr_t)t2rq32->ioc_name);
+	t2rq->ioc_name = USER_PTR_STR((char *)(uintptr_t)t2rq32->ioc_name);
 	t2rq->ioc_tparamcnt = t2rq32->ioc_tparamcnt;
-	t2rq->ioc_tparam = __USER_CAP((void *)(uintptr_t)t2rq32->ioc_tparam,
+	t2rq->ioc_tparam = USER_PTR((void *)(uintptr_t)t2rq32->ioc_tparam,
 	    t2rq32->ioc_tparamcnt);
 	t2rq->ioc_tdatacnt = t2rq32->ioc_tdatacnt;
-	t2rq->ioc_tdata = __USER_CAP((void *)(uintptr_t)t2rq32->ioc_tdata,
+	t2rq->ioc_tdata = USER_PTR((void *)(uintptr_t)t2rq32->ioc_tdata,
 	    t2rq32->ioc_tdatacnt);
 	t2rq->ioc_rparamcnt = t2rq32->ioc_rparamcnt;
-	t2rq->ioc_rparam = __USER_CAP((void *)(uintptr_t)t2rq32->ioc_rparam,
+	t2rq->ioc_rparam = USER_PTR((void *)(uintptr_t)t2rq32->ioc_rparam,
 	    t2rq32->ioc_rparamcnt);
 	t2rq->ioc_rdatacnt = t2rq32->ioc_rdatacnt;
-	t2rq->ioc_rdata = __USER_CAP((void *)(uintptr_t)t2rq32->ioc_rdata,
+	t2rq->ioc_rdata = USER_PTR((void *)(uintptr_t)t2rq32->ioc_rdata,
 	    t2rq32->ioc_rdatacnt);
 }
 
@@ -440,7 +440,7 @@ smbioc_rw32_to_rw(struct smbioc_rw *rw, const void *data)
 	rw32 = data;
 	memset(rw, 0, sizeof(*rw));
 	rw->ioc_fh = rw32->ioc_fh;
-	rw->ioc_base = __USER_CAP((char *)(uintptr_t)rw32->ioc_base,
+	rw->ioc_base = USER_PTR((char *)(uintptr_t)rw32->ioc_base,
 	    rw32->ioc_cnt);
 	rw->ioc_offset = rw32->ioc_offset;
 	rw->ioc_cnt = rw32->ioc_cnt;
@@ -469,10 +469,10 @@ smbioc_ossn64_to_ossn(struct smbioc_ossn *ossn, const void *data)
 	ossn64 = data;
 	ossn->ioc_opt = ossn64->ioc_opt;
 	ossn->ioc_svlen = ossn64->ioc_svlen;
-	ossn->ioc_server = __USER_CAP((void *)(uintptr_t)ossn64->ioc_server,
+	ossn->ioc_server = USER_PTR((void *)(uintptr_t)ossn64->ioc_server,
 	    ossn64->ioc_svlen);
 	ossn->ioc_lolen = ossn64->ioc_lolen;
-	ossn->ioc_local = __USER_CAP((void *)(uintptr_t)ossn64->ioc_local,
+	ossn->ioc_local = USER_PTR((void *)(uintptr_t)ossn64->ioc_local,
 	    ossn64->ioc_lolen);
 	/* Do not include padding */
 	copysize = min(
@@ -490,13 +490,13 @@ smbioc_rq64_to_rq(struct smbioc_rq *rq, const void *data)
 	rq64 = data;
 	rq->ioc_cmd = rq64->ioc_cmd;
 	rq->ioc_twc = rq64->ioc_twc;
-	rq->ioc_twords = __USER_CAP((void *)(uintptr_t)rq64->ioc_twords,
+	rq->ioc_twords = USER_PTR((void *)(uintptr_t)rq64->ioc_twords,
 	    rq64->ioc_twc);
 	rq->ioc_tbc = rq64->ioc_tbc;
-	rq->ioc_tbytes = __USER_CAP((void *)(uintptr_t)rq64->ioc_tbytes,
+	rq->ioc_tbytes = USER_PTR((void *)(uintptr_t)rq64->ioc_tbytes,
 	    rq64->ioc_tbc);
 	rq->ioc_rpbufsz = rq64->ioc_rpbufsz;
-	rq->ioc_rpbuf = __USER_CAP((char *)(uintptr_t)rq64->ioc_rpbuf,
+	rq->ioc_rpbuf = USER_PTR((char *)(uintptr_t)rq64->ioc_rpbuf,
 	    rq64->ioc_rpbufsz);
 	memcpy(&rq->ioc_rwc, &rq64->ioc_rwc,
 	    sizeof(*rq) - offsetof(struct smbioc_rq, ioc_rwc));
@@ -526,18 +526,18 @@ smbioc_t2rq64_to_t2rq(struct smbioc_t2rq *t2rq, const void *data)
 	memset(t2rq, 0, sizeof(*t2rq));
 	memcpy(&t2rq->ioc_setup, &t2rq64->ioc_setup, sizeof(t2rq->ioc_setup));
 	t2rq->ioc_setupcnt = t2rq64->ioc_setupcnt;
-	t2rq->ioc_name = __USER_CAP_STR((char *)(uintptr_t)t2rq64->ioc_name);
+	t2rq->ioc_name = USER_PTR_STR((char *)(uintptr_t)t2rq64->ioc_name);
 	t2rq->ioc_tparamcnt = t2rq64->ioc_tparamcnt;
-	t2rq->ioc_tparam = __USER_CAP((void *)(uintptr_t)t2rq64->ioc_tparam,
+	t2rq->ioc_tparam = USER_PTR((void *)(uintptr_t)t2rq64->ioc_tparam,
 	    t2rq64->ioc_tparamcnt);
 	t2rq->ioc_tdatacnt = t2rq64->ioc_tdatacnt;
-	t2rq->ioc_tdata = __USER_CAP((void *)(uintptr_t)t2rq64->ioc_tdata,
+	t2rq->ioc_tdata = USER_PTR((void *)(uintptr_t)t2rq64->ioc_tdata,
 	    t2rq64->ioc_tdatacnt);
 	t2rq->ioc_rparamcnt = t2rq64->ioc_rparamcnt;
-	t2rq->ioc_rparam = __USER_CAP((void *)(uintptr_t)t2rq64->ioc_rparam,
+	t2rq->ioc_rparam = USER_PTR((void *)(uintptr_t)t2rq64->ioc_rparam,
 	    t2rq64->ioc_rparamcnt);
 	t2rq->ioc_rdatacnt = t2rq64->ioc_rdatacnt;
-	t2rq->ioc_rdata = __USER_CAP((void *)(uintptr_t)t2rq64->ioc_rdata,
+	t2rq->ioc_rdata = USER_PTR((void *)(uintptr_t)t2rq64->ioc_rdata,
 	    t2rq64->ioc_rdatacnt);
 }
 
@@ -577,7 +577,7 @@ smbioc_rw64_to_rw(struct smbioc_rw *rw, const void *data)
 	rw64 = data;
 	memset(rw, 0, sizeof(*rw));
 	rw->ioc_fh = rw64->ioc_fh;
-	rw->ioc_base = __USER_CAP((char *)(uintptr_t)rw64->ioc_base,
+	rw->ioc_base = USER_PTR((char *)(uintptr_t)rw64->ioc_base,
 	    rw64->ioc_cnt);
 	rw->ioc_offset = rw64->ioc_offset;
 	rw->ioc_cnt = rw64->ioc_cnt;

--- a/sys/netsmb/smb_dev.c
+++ b/sys/netsmb/smb_dev.c
@@ -28,6 +28,7 @@
 
 #include <sys/param.h>
 #include <sys/kernel.h>
+#include <sys/abi_compat.h>
 #include <sys/capsicum.h>
 #include <sys/module.h>
 #include <sys/systm.h>

--- a/sys/riscv/riscv/copyinout.S
+++ b/sys/riscv/riscv/copyinout.S
@@ -350,10 +350,10 @@ END(copyinstr)
 /*
  * Copies from a kernel to user address preserving tags
  *
- * int copyoutcap(const void *kaddr, void * __capability udaddr, size_t len)
+ * int copyoutptr(const void *kaddr, void * __capability udaddr, size_t len)
  */
-ENTRY(copyoutcap)
-	beqz	a2, copyoutcap_end	/* If len == 0 then skip loop */
+ENTRY(copyoutptr)
+	beqz	a2, copyoutptr_end	/* If len == 0 then skip loop */
 	add	a3, a1, a2
 	li	a4, VM_MAXUSER_ADDRESS
 	bgeu	a3, a4, copyio_fault_nopcb
@@ -366,18 +366,18 @@ ENTRY(copyoutcap)
 
 	copycapcommon
 
-copyoutcap_end:
+copyoutptr_end:
 	li	a0, 0		/* return 0 */
 	RETURN
-END(copyoutcap)
+END(copyoutptr)
 
 /*
  * Copies from a user to kernel address preserving tags
  *
- * int copyincap(const void * __capability uaddr, void *kaddr, size_t len)
+ * int copyinptr(const void * __capability uaddr, void *kaddr, size_t len)
  */
-ENTRY(copyincap)
-	beqz	a2, copyincap_end	/* If len == 0 then skip loop */
+ENTRY(copyinptr)
+	beqz	a2, copyinptr_end	/* If len == 0 then skip loop */
 	add	a3, a0, a2
 	li	a4, VM_MAXUSER_ADDRESS
 	bgeu	a3, a4, copyio_fault_nopcb
@@ -390,10 +390,10 @@ ENTRY(copyincap)
 
 	copycapcommon
 
-copyincap_end:
+copyinptr_end:
 	li	a0, 0		/* return 0 */
 	RETURN
-END(copyincap)
+END(copyinptr)
 #endif
 
 /*

--- a/sys/riscv/riscv/exec_machdep.c
+++ b/sys/riscv/riscv/exec_machdep.c
@@ -554,7 +554,7 @@ sys_sigreturn(struct thread *td, struct sigreturn_args *uap)
 	ucontext_t uc;
 	int error;
 
-	if (copyincap(uap->sigcntxp, &uc, sizeof(uc)))
+	if (copyinptr(uap->sigcntxp, &uc, sizeof(uc)))
 		return (EFAULT);
 
 	error = set_mcontext(td, &uc.uc_mcontext);
@@ -627,7 +627,7 @@ sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	PROC_UNLOCK(td->td_proc);
 
 	/* Copy the sigframe out to the user's stack. */
-	if (copyoutcap(&frame, fp, sizeof(*fp)) != 0) {
+	if (copyoutptr(&frame, fp, sizeof(*fp)) != 0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td,
 				(__cheri_addr ptraddr_t)fp);

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -189,7 +189,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 
 	memset(&mc, 0, sizeof(mc));
 	if (mcp->mc_flags & _MC_CAP_VALID) {
-		error = copyincap(USER_PTR(mcp->mc_capregs,
+		error = copyinptr(USER_PTR(mcp->mc_capregs,
 		    sizeof(mc.mc_capregs)), &mc.mc_capregs,
 		    sizeof(mc.mc_capregs));
 		if (error)
@@ -282,7 +282,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	PROC_UNLOCK(td->td_proc);
 
 	/* Copy the capability registers out to the user's stack. */
-	if (copyoutcap(&mc.mc_capregs, USER_PTR(capregs,
+	if (copyoutptr(&mc.mc_capregs, USER_PTR(capregs,
 	    sizeof(mc.mc_capregs)), sizeof(mc.mc_capregs)) != 0) {
 		PROC_LOCK(p);
 		printf("pid %d, tid %d: could not copy out cap registers\n",
@@ -292,7 +292,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	}
 
 	/* Copy the sigframe out to the user's stack. */
-	if (copyoutcap(&frame, USER_PTR(fp, sizeof(frame)), sizeof(frame)) !=
+	if (copyoutptr(&frame, USER_PTR(fp, sizeof(frame)), sizeof(frame)) !=
 	    0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td, fp);
@@ -327,7 +327,7 @@ freebsd64_sigreturn(struct thread *td, struct freebsd64_sigreturn_args *uap)
 	ucontext64_t uc;
 	int error;
 
-	error = copyincap(USER_PTR_OBJ(uap->sigcntxp), &uc, sizeof(uc));
+	error = copyinptr(USER_PTR_OBJ(uap->sigcntxp), &uc, sizeof(uc));
 	if (error != 0)
 		return (error);
 

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -189,7 +189,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 
 	memset(&mc, 0, sizeof(mc));
 	if (mcp->mc_flags & _MC_CAP_VALID) {
-		error = copyincap(__USER_CAP(mcp->mc_capregs,
+		error = copyincap(USER_PTR(mcp->mc_capregs,
 		    sizeof(mc.mc_capregs)), &mc.mc_capregs,
 		    sizeof(mc.mc_capregs));
 		if (error)
@@ -282,7 +282,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	PROC_UNLOCK(td->td_proc);
 
 	/* Copy the capability registers out to the user's stack. */
-	if (copyoutcap(&mc.mc_capregs, __USER_CAP(capregs,
+	if (copyoutcap(&mc.mc_capregs, USER_PTR(capregs,
 	    sizeof(mc.mc_capregs)), sizeof(mc.mc_capregs)) != 0) {
 		PROC_LOCK(p);
 		printf("pid %d, tid %d: could not copy out cap registers\n",
@@ -292,7 +292,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	}
 
 	/* Copy the sigframe out to the user's stack. */
-	if (copyoutcap(&frame, __USER_CAP(fp, sizeof(frame)), sizeof(frame)) !=
+	if (copyoutcap(&frame, USER_PTR(fp, sizeof(frame)), sizeof(frame)) !=
 	    0) {
 		/* Process has trashed its stack. Kill it. */
 		CTR2(KTR_SIG, "sendsig: sigexit td=%p fp=%p", td, fp);
@@ -327,7 +327,7 @@ freebsd64_sigreturn(struct thread *td, struct freebsd64_sigreturn_args *uap)
 	ucontext64_t uc;
 	int error;
 
-	error = copyincap(__USER_CAP_OBJ(uap->sigcntxp), &uc, sizeof(uc));
+	error = copyincap(USER_PTR_OBJ(uap->sigcntxp), &uc, sizeof(uc));
 	if (error != 0)
 		return (error);
 

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -66,6 +66,7 @@
 
 #include <cheri/cheric.h>
 
+#include <compat/freebsd64/freebsd64.h>
 #include <compat/freebsd64/freebsd64_proto.h>
 #include <compat/freebsd64/freebsd64_syscall.h>
 #include <compat/freebsd64/freebsd64_util.h>

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -100,10 +100,10 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 			switch (uio->uio_rw) {
 #if __has_feature(capabilities)
 			case UIO_READ_CAP:
-				error = copyoutcap(cp, iov->iov_base, cnt);
+				error = copyoutptr(cp, iov->iov_base, cnt);
 				break;
 			case UIO_WRITE_CAP:
-				error = copyincap(iov->iov_base, cp, cnt);
+				error = copyinptr(iov->iov_base, cp, cnt);
 				break;
 #endif
 			case UIO_READ:

--- a/sys/security/mac/mac_framework.c
+++ b/sys/security/mac/mac_framework.c
@@ -778,7 +778,7 @@ copyin_mac(const void * const __capability mac_p, struct mac *mac)
 			return (error);
 
 		mac->m_buflen = tmpmac.m_buflen;
-		mac->m_string = __USER_CAP(tmpmac.m_string, tmpmac.m_buflen);
+		mac->m_string = USER_PTR(tmpmac.m_string, tmpmac.m_buflen);
 		return (0);
 	}
 #endif

--- a/sys/security/mac/mac_framework.c
+++ b/sys/security/mac/mac_framework.c
@@ -782,7 +782,7 @@ copyin_mac(const void * const __capability mac_p, struct mac *mac)
 		return (0);
 	}
 #endif
-	error = copyincap(mac_p, mac, sizeof(*mac));
+	error = copyinptr(mac_p, mac, sizeof(*mac));
 	return (error);
 }
 

--- a/sys/sys/abi_compat.h
+++ b/sys/sys/abi_compat.h
@@ -72,4 +72,55 @@
 	*(uint64_t *)&(dst).fld.frac[0] = (src).fld.frac;	\
 } while (0)
 
+/*
+ * Macros to create userspace capabilities from virtual addresses.
+ * Addresses are assumed to be relative to the current userspace
+ * thread's address space and are created from the DDC or PCC of
+ * the current PCB.
+ */
+#if __has_feature(capabilities)
+/*
+ * Derive out-of-bounds and small values from NULL.  This allows common
+ * sentinel values to work.
+ */
+#define ___USER_CFROMPTR(ptr, cap)					\
+    ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
+     ((vm_offset_t)(ptr) < 4096 ||					\
+      (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
+	(void * __capability)(__uintcap_t)(ptraddr_t)(ptr) :		\
+	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))
+
+#define	USER_PTR_UNBOUND(ptr)						\
+	___USER_CFROMPTR((ptr), __USER_DDC)
+
+#define	USER_CODE_PTR(ptr)						\
+	___USER_CFROMPTR((ptr), __USER_PCC)
+
+#define	USER_PTR(ptr, len)						\
+({									\
+	void * __capability unbound = USER_PTR_UNBOUND(ptr);		\
+	(security_cheri_bound_legacy_capabilities &&			\
+	    __builtin_cheri_tag_get(unbound) ?				\
+	    __builtin_cheri_bounds_set(unbound, (len)) : unbound);	\
+})
+
+#else /* !has_feature(capabilities) */
+
+#define	USER_PTR_UNBOUND(ptr)	((void *)(uintptr_t)(ptr))
+#define	USER_CODE_PTR(ptr)	((void *)(uintptr_t)(ptr))
+#define	USER_PTR(ptr, len)	((void *)(uintptr_t)(ptr))
+
+#endif /* !has_feature(capabilities) */
+
+#define	USER_PTR_ADDR(ptr)	USER_PTR_UNBOUND(ptr)
+#define	USER_PTR_ARRAY(objp, cnt) \
+     USER_PTR((objp), sizeof(*(objp)) * (cnt))
+#define	USER_PTR_OBJ(objp)	USER_PTR((objp), sizeof(*(objp)))
+/*
+ * NOTE: we can't place tigher bounds because we don't know what the
+ * length is until after we use it.
+ */
+#define	USER_PTR_STR(strp)	USER_PTR_UNBOUND(strp)
+#define	USER_PTR_PATH(path)	USER_PTR((path), MAXPATHLEN)
+
 #endif /* !_COMPAT_H_ */

--- a/sys/sys/mount.h
+++ b/sys/sys/mount.h
@@ -746,7 +746,7 @@ struct vfsquery {
 /* Point a sysctl request at a vfsidctl's data. */
 #define VCTLTOREQ(vc, req)						\
 	do {								\
-		(req)->newptr = __USER_CAP((vc)->vc_ptr, (vc)->vc_len);	\
+		(req)->newptr = USER_PTR((vc)->vc_ptr, (vc)->vc_len);	\
 		(req)->newlen = (vc)->vc_len;				\
 		(req)->newidx = 0;					\
 	} while (0)

--- a/sys/sys/sockopt.h
+++ b/sys/sys/sockopt.h
@@ -62,10 +62,10 @@ int	sosetopt(struct socket *so, struct sockopt *sopt);
 int	sogetopt(struct socket *so, struct sockopt *sopt);
 int	sooptcopyin(struct sockopt *sopt, void *buf, size_t len, size_t minlen);
 #if __has_feature(capabilities)
-int	sooptcopyincap(struct sockopt *sopt, void *buf, size_t len,
+int	sooptcopyinptr(struct sockopt *sopt, void *buf, size_t len,
     size_t minlen);
 #else
-#define	sooptcopyincap	sooptcopyin
+#define	sooptcopyinptr	sooptcopyin
 #endif
 int	sooptcopyout(struct sockopt *sopt, const void *buf, size_t len);
 int	soopt_getm(struct sockopt *sopt, struct mbuf **mp);

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -117,55 +117,6 @@ extern bool scheduler_stopped;
  */
 #define	SCHEDULER_STOPPED()	__predict_false(scheduler_stopped)
 
-/*
- * Macros to create userspace capabilities from virtual addresses.
- * Addresses are assumed to be relative to the current userspace
- * thread's address space and are created from the DDC or PCC of
- * the current PCB.
- */
-#if __has_feature(capabilities)
-/*
- * Derive out-of-bounds and small values from NULL.  This allows common
- * sentinel values to work.
- */
-#define ___USER_CFROMPTR(ptr, cap)					\
-    ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
-     ((vm_offset_t)(ptr) < 4096 ||					\
-      (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
-	(void * __capability)(uintcap_t)(ptraddr_t)(ptr) :		\
-	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))
-
-#define	USER_PTR_UNBOUND(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_DDC)
-
-#define	USER_CODE_PTR(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_PCC)
-
-#define	USER_PTR(ptr, len)						\
-({									\
-	void * __capability unbound = USER_PTR_UNBOUND(ptr);		\
-	(security_cheri_bound_legacy_capabilities &&			\
-	    __builtin_cheri_tag_get(unbound) ?				\
-	    __builtin_cheri_bounds_set(unbound, (len)) : unbound);	\
-})
-
-#else /* !has_feature(capabilities) */
-#define	USER_PTR_UNBOUND(ptr)	((void *)(uintptr_t)(ptr))
-#define	USER_CODE_PTR(ptr)	((void *)(uintptr_t)(ptr))
-#define	USER_PTR(ptr, len)	((void *)(uintptr_t)(ptr))
-#endif /* !has_feature(capabilities) */
-
-#define	USER_PTR_ADDR(ptr)	USER_PTR_UNBOUND(ptr)
-#define	USER_PTR_ARRAY(objp, cnt) \
-     USER_PTR((objp), sizeof(*(objp)) * (cnt))
-#define	USER_PTR_OBJ(objp)	USER_PTR((objp), sizeof(*(objp)))
-/*
- * NOTE: we can't place tigher bounds because we don't know what the
- * length is until after we use it.
- */
-#define	USER_PTR_STR(strp)	USER_PTR_UNBOUND(strp)
-#define	USER_PTR_PATH(path)	USER_PTR((path), MAXPATHLEN)
-
 extern const int osreldate;
 
 extern const void *zero_region;	/* address space maps to a zeroed page	*/

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -396,10 +396,10 @@ int __result_use_check copyinstr(const void * __restrict __capability udaddr,
 int __result_use_check copyin(const void * __restrict __capability udaddr,
     void * _Nonnull __restrict kaddr, size_t len);
 #if __has_feature(capabilities)
-int __result_use_check copyincap(const void * __restrict __capability udaddr,
+int __result_use_check copyinptr(const void * __restrict __capability udaddr,
     void * _Nonnull __restrict kaddr, size_t len);
 #else
-#define	copyincap	copyin
+#define	copyinptr	copyin
 #endif
 int __result_use_check copyin_nofault(
     const void * __capability __restrict udaddr,
@@ -407,21 +407,21 @@ int __result_use_check copyin_nofault(
 int __result_use_or_ignore_check copyout(const void * _Nonnull __restrict kaddr,
     void * __restrict __capability udaddr, size_t len);
 #if __has_feature(capabilities)
-int __result_use_or_ignore_check copyoutcap(
+int __result_use_or_ignore_check copyoutptr(
     const void * _Nonnull __restrict kaddr,
     void * __capability __restrict udaddr, size_t len);
 #else
-#define	copyoutcap	copyout
+#define	copyoutptr	copyout
 #endif
 int __result_use_or_ignore_check copyout_nofault(
     const void * _Nonnull __restrict kaddr,
     void * __capability __restrict udaddr, size_t len);
 #if __has_feature(capabilities)
-int __result_use_or_ignore_check copyoutcap_nofault(
+int __result_use_or_ignore_check copyoutptr_nofault(
     const void * _Nonnull __restrict kaddr,
     void * __capability __restrict udaddr, size_t len);
 #else
-#define	copyoutcap_nofault	copyout_nofault
+#define	copyoutptr_nofault	copyout_nofault
 #endif
 
 #ifdef SAN_NEEDS_INTERCEPTORS

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -135,36 +135,36 @@ extern bool scheduler_stopped;
 	(void * __capability)(uintcap_t)(ptraddr_t)(ptr) :		\
 	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))
 
-#define	__USER_CAP_UNBOUND(ptr)						\
+#define	USER_PTR_UNBOUND(ptr)						\
 	___USER_CFROMPTR((ptr), __USER_DDC)
 
 #define	__USER_CODE_CAP(ptr)						\
 	___USER_CFROMPTR((ptr), __USER_PCC)
 
-#define	__USER_CAP(ptr, len)						\
+#define	USER_PTR(ptr, len)						\
 ({									\
-	void * __capability unbound = __USER_CAP_UNBOUND(ptr);		\
+	void * __capability unbound = USER_PTR_UNBOUND(ptr);		\
 	(security_cheri_bound_legacy_capabilities &&			\
 	    __builtin_cheri_tag_get(unbound) ?				\
 	    __builtin_cheri_bounds_set(unbound, (len)) : unbound);	\
 })
 
 #else /* !has_feature(capabilities) */
-#define	__USER_CAP_UNBOUND(ptr)	((void *)(uintptr_t)(ptr))
+#define	USER_PTR_UNBOUND(ptr)	((void *)(uintptr_t)(ptr))
 #define	__USER_CODE_CAP(ptr)	((void *)(uintptr_t)(ptr))
-#define	__USER_CAP(ptr, len)	((void *)(uintptr_t)(ptr))
+#define	USER_PTR(ptr, len)	((void *)(uintptr_t)(ptr))
 #endif /* !has_feature(capabilities) */
 
-#define	__USER_CAP_ADDR(ptr)	__USER_CAP_UNBOUND(ptr)
-#define	__USER_CAP_ARRAY(objp, cnt) \
-     __USER_CAP((objp), sizeof(*(objp)) * (cnt))
-#define	__USER_CAP_OBJ(objp)	__USER_CAP((objp), sizeof(*(objp)))
+#define	USER_PTR_ADDR(ptr)	USER_PTR_UNBOUND(ptr)
+#define	USER_PTR_ARRAY(objp, cnt) \
+     USER_PTR((objp), sizeof(*(objp)) * (cnt))
+#define	USER_PTR_OBJ(objp)	USER_PTR((objp), sizeof(*(objp)))
 /*
  * NOTE: we can't place tigher bounds because we don't know what the
  * length is until after we use it.
  */
-#define	__USER_CAP_STR(strp)	__USER_CAP_UNBOUND(strp)
-#define	__USER_CAP_PATH(path)	__USER_CAP((path), MAXPATHLEN)
+#define	USER_PTR_STR(strp)	USER_PTR_UNBOUND(strp)
+#define	USER_PTR_PATH(path)	USER_PTR((path), MAXPATHLEN)
 
 extern const int osreldate;
 

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -138,7 +138,7 @@ extern bool scheduler_stopped;
 #define	USER_PTR_UNBOUND(ptr)						\
 	___USER_CFROMPTR((ptr), __USER_DDC)
 
-#define	__USER_CODE_CAP(ptr)						\
+#define	USER_CODE_PTR(ptr)						\
 	___USER_CFROMPTR((ptr), __USER_PCC)
 
 #define	USER_PTR(ptr, len)						\
@@ -151,7 +151,7 @@ extern bool scheduler_stopped;
 
 #else /* !has_feature(capabilities) */
 #define	USER_PTR_UNBOUND(ptr)	((void *)(uintptr_t)(ptr))
-#define	__USER_CODE_CAP(ptr)	((void *)(uintptr_t)(ptr))
+#define	USER_CODE_PTR(ptr)	((void *)(uintptr_t)(ptr))
 #define	USER_PTR(ptr, len)	((void *)(uintptr_t)(ptr))
 #endif /* !has_feature(capabilities) */
 

--- a/sys/ufs/ffs/ffs_alloc.c
+++ b/sys/ufs/ffs/ffs_alloc.c
@@ -3304,7 +3304,7 @@ sysctl_ffs_fsck(SYSCTL_HANDLER_ARGS)
 		CP(cmd_compat, cmd, version);
 		CP(cmd_compat, cmd, handle);
 		if (oidp->oid_number == FFS_UNLINK)
-			cmd.value = (uintcap_t)__USER_CAP_STR(cmd_compat.value);
+			cmd.value = (uintcap_t)USER_PTR_STR(cmd_compat.value);
 		else
 			CP(cmd_compat, cmd, value);
 		CP(cmd_compat, cmd, size);

--- a/sys/ufs/ffs/ffs_vfsops.c
+++ b/sys/ufs/ffs/ffs_vfsops.c
@@ -721,7 +721,7 @@ ffs_cmount(struct mntarg *ma, void * __capability data, uint64_t flags)
 
 	if (data == NULL)
 		return (EINVAL);
-	error = copyincap(data, &args, sizeof args);
+	error = copyinptr(data, &args, sizeof args);
 	if (error)
 		return (error);
 

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -1380,7 +1380,7 @@ vm_cheri_revoke_publish_epochs(
 	    &info_page->pub.epochs;
 	int res __diagused;
 
-	res = copyoutcap(ip, target, sizeof(*target));
+	res = copyoutptr(ip, target, sizeof(*target));
 	KASSERT(res == 0, ("%s: bad copyout %d\n", __func__, res));
 }
 


### PR DESCRIPTION
- Rename `__USER_CAP*` and drop the `__` prefix following the model of PTRIN. (See #2485)
- Rename copy{in,out}cap variants to ptr
- Document copy{in,out}cap variants
