### PR TITLE
Declare ptraddr_t in (sys/)stddef.h and not in stdint.h

### DIFF
--- a/contrib/ntp/sntp/libopts/enum.c
+++ b/contrib/ntp/sntp/libopts/enum.c
@@ -47,6 +47,8 @@
  *  13aa749a5b0a454917a944ed8fffc530b784f5ead522b1aacaf4ec8aa55a6239  COPYING.mbsd
  */
 
+#include <stddef.h>
+
 static void
 enum_err(tOptions * pOpts, tOptDesc * pOD,
          char const * const * paz_names, int name_ct)

--- a/contrib/ntp/sntp/libopts/proto.h
+++ b/contrib/ntp/sntp/libopts/proto.h
@@ -6,6 +6,7 @@
 #ifndef AUTOOPTS_PROTO_H_GUARD
 #define AUTOOPTS_PROTO_H_GUARD 1
 
+#include <stddef.h>
 
 /*
  * Static declarations from alias.c

--- a/crypto/heimdal/base/baselocl.h
+++ b/crypto/heimdal/base/baselocl.h
@@ -53,6 +53,7 @@
 #include <sys/select.h>
 #endif
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/libc/csu/libc_start1.c
+++ b/lib/libc/csu/libc_start1.c
@@ -41,6 +41,7 @@
 #include <sys/param.h>
 #include <sys/elf.h>
 #include <sys/elf_common.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include "libc_private.h"
 

--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -40,6 +40,9 @@
 #include <libsys.h>
 
 #include <stdbool.h>
+#ifdef CHERI_LIB_C18N
+#include <stddef.h>
+#endif
 
 extern char **environ;
 

--- a/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic.h
+++ b/lib/libcheribsdtest_dynamic/cheribsdtest_dynamic.h
@@ -26,6 +26,8 @@
 #ifndef _CHERIBSDTEST_DYNAMIC_H_
 #define _CHERIBSDTEST_DYNAMIC_H_
 
+#include <stddef.h>
+
 void cheribsdtest_dynamic_dummy_func(void);
 void (*cheribsdtest_dynamic_get_dummy_fptr(void))(void);
 ptraddr_t cheribsdtest_dynamic_get_dummy_fptr_addr(void);

--- a/lib/libpmcstat/libpmcstat.h
+++ b/lib/libpmcstat/libpmcstat.h
@@ -34,6 +34,7 @@
 #include <sys/_cpuset.h>
 #include <sys/queue.h>
 
+#include <stddef.h>
 #include <stdio.h>
 #include <gelf.h>
 

--- a/lib/librt/sigev_thread.c
+++ b/lib/librt/sigev_thread.c
@@ -46,6 +46,7 @@
 #include <ucontext.h>
 #include <sys/thr.h>
 #include <stdatomic.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sbin/kldstat/kldstat.c
+++ b/sbin/kldstat/kldstat.c
@@ -45,6 +45,7 @@
 
 #include <err.h>
 #include <libutil.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>

--- a/sys/cheri/cheri_cap_relocs.c
+++ b/sys/cheri/cheri_cap_relocs.c
@@ -30,6 +30,7 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/stddef.h>
 #include <sys/types.h>
 #include <cheri_init_globals.h>
 

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -33,6 +33,7 @@
 #define	_SYS_CHERIC_H_
 
 #include <sys/cdefs.h>
+#include <sys/stddef.h>
 #include <sys/types.h>
 
 #if __has_feature(capabilities)

--- a/sys/cheri/revoke.h
+++ b/sys/cheri/revoke.h
@@ -34,6 +34,8 @@
 #ifndef __SYS_CHERI_REVOKE_H__
 #define	__SYS_CHERI_REVOKE_H__
 
+#include <sys/stddef.h>
+
 #if __has_feature(capabilities)
 #include <cheri/cherireg.h> /* For CHERI_OTYPE_BITS */
 #endif

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -81,6 +81,18 @@ convert_sigevent64(const struct sigevent64 *sig64, struct sigevent *sig)
 	return (0);
 }
 
+static inline bool
+is_magic_sighandler_constant(ptraddr_t handler)
+{
+	/*
+	 * Instead of enumerating all the SIG_* constants, just check if
+	 * it is a small (positive or negative) integer so that this doesn't
+	 * break if someone adds a new SIG_* constant. The manual checks that
+	 * we were using before weren't handling SIG_HOLD.
+	 */
+	return (handler < 64);
+}
+
 int
 freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 {

--- a/sys/contrib/ck/include/ck_pr.h
+++ b/sys/contrib/ck/include/ck_pr.h
@@ -31,6 +31,7 @@
 #include <ck_cc.h>
 #include <ck_limits.h>
 #include <ck_md.h>
+#include <ck_stddef.h>
 #include <ck_stdint.h>
 #include <ck_stdbool.h>
 

--- a/sys/contrib/subrepo-openzfs/.gitrepo
+++ b/sys/contrib/subrepo-openzfs/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/CTSRD-CHERI/zfs.git
 	branch = cheri-hybrid
-	commit = 8f189d6b8c008de8239d4cfc3999ec727764ac4c
-	parent = 6e1ce05f46983c6817e8580bda84801ce65ed7b5
+	commit = ce3793d09eb67fdbae68b6d6e7fe0f5959bab119
+	parent = 0fc9de0d5d9f25271dc077748e3d718d1acd9ce6
 	method = merge
 	cmdver = 0.4.6

--- a/sys/contrib/subrepo-openzfs/cmd/zinject/zinject.c
+++ b/sys/contrib/subrepo-openzfs/cmd/zinject/zinject.c
@@ -453,11 +453,10 @@ print_data_handler(int id, const char *pool, zinject_record_t *record,
 
 
 	(void) printf("%3d  %-15s  %-6llu  %-6llu  %-8s  %-3d  0x%02x  %-15s  "
-	    "%6llu  %6llu\n", id, pool, (u_longlong_t)record->zi_objset,
+	    "%6lu  %6lu\n", id, pool, (u_longlong_t)record->zi_objset,
 	    (u_longlong_t)record->zi_object, type_to_name(record->zi_type),
 	    record->zi_level, record->zi_dvas, rangebuf,
-	    (u_longlong_t)record->zi_match_count,
-	    (u_longlong_t)record->zi_inject_count);
+	    record->zi_match_count, record->zi_inject_count);
 
 	return (0);
 }
@@ -491,10 +490,9 @@ print_device_handler(int id, const char *pool, zinject_record_t *record,
 	    (((double)record->zi_freq) / ZI_PERCENTAGE_MAX) * 100.0f;
 
 	(void) printf("%3d  %-15s  %llx  %-5s  %-10s  %8.4f%%  "
-	    "%6llu  %6llu\n", id, pool, (u_longlong_t)record->zi_guid,
+	    "%6lu  %6lu\n", id, pool, (u_longlong_t)record->zi_guid,
 	    iotype_to_str(record->zi_iotype), err_to_str(record->zi_error),
-	    freq, (u_longlong_t)record->zi_match_count,
-	    (u_longlong_t)record->zi_inject_count);
+	    freq, record->zi_match_count, record->zi_inject_count);
 
 	return (0);
 }
@@ -527,11 +525,10 @@ print_delay_handler(int id, const char *pool, zinject_record_t *record,
 	    (((double)record->zi_freq) / ZI_PERCENTAGE_MAX) * 100.0f;
 
 	(void) printf("%3d  %-15s  %llx  %10llu  %5llu  %8.4f%%  "
-	    "%6llu  %6llu\n", id, pool, (u_longlong_t)record->zi_guid,
+	    "%6lu  %6lu\n", id, pool, (u_longlong_t)record->zi_guid,
 	    (u_longlong_t)NSEC2MSEC(record->zi_timer),
-	    (u_longlong_t)record->zi_nlanes, freq,
-	    (u_longlong_t)record->zi_match_count,
-	    (u_longlong_t)record->zi_inject_count);
+	    (u_longlong_t)record->zi_nlanes,
+	    freq, record->zi_match_count, record->zi_inject_count);
 
 	return (0);
 }

--- a/sys/contrib/subrepo-openzfs/include/os/freebsd/spl/sys/sysmacros.h
+++ b/sys/contrib/subrepo-openzfs/include/os/freebsd/spl/sys/sysmacros.h
@@ -364,6 +364,25 @@ highbit64(uint64_t i)
 #endif
 }
 
+#if !defined(__CHERI__) && !defined(__CHERI_HYBRID__)
+#ifndef copyinptr
+#define	copyinptr	copyin
+#endif
+#ifndef copyoutptr
+#define	copyoutptr	copyout
+#endif
+
+#ifndef __capability
+#define	__capability
+#endif
+#ifndef __cheri_fromcap
+#define	__cheri_fromcap
+#endif
+#ifndef PTR2CAP
+#define	PTR2CAP(x)	(x)
+#endif
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/sys/contrib/subrepo-openzfs/include/os/linux/spl/sys/sysmacros.h
+++ b/sys/contrib/subrepo-openzfs/include/os/linux/spl/sys/sysmacros.h
@@ -213,4 +213,16 @@ makedev(unsigned int major, unsigned int minor)
 #define	offsetof(s, m)  ((size_t)(&(((s *)0)->m)))
 #endif
 
+#if !defined(__CHERI__) && !defined(__CHERI_HYBRID__)
+#ifndef __capability
+#define	__capability
+#endif
+#ifndef __cheri_fromcap
+#define	__cheri_fromcap
+#endif
+#ifndef PTR2CAP
+#define	PTR2CAP(x)	(x)
+#endif
+#endif
+
 #endif  /* _SPL_SYSMACROS_H */

--- a/sys/contrib/subrepo-openzfs/include/sys/types.h
+++ b/sys/contrib/subrepo-openzfs/include/sys/types.h
@@ -1,21 +1,39 @@
 #include_next <sys/types.h>
+#pragma once
 
+/* XXX: belongs in stddef.h */
 #ifndef _PTRADDR_T_DECLARED
-#ifdef __PTRADDR_TYPE__
-typedef __PTRADDR_TYPE__        __ptraddr_t;
-#else
-typedef size_t     __ptraddr_t;
-#endif
-typedef __ptraddr_t             ptraddr_t;
+typedef size_t     ptraddr_t;
 #define	_PTRADDR_T_DECLARED
 #endif
 
 #ifndef _INT64PTR_T_DECLARED
-typedef	long long		int64ptr_t;
+#ifdef __ILP32_
+typedef	long long	int64ptr_t;
+#else
+typedef	long		int64ptr_t;
+#endif
 #define	_INT64PTR_T_DECLARED
 #endif
 
 #ifndef _UINT64PTR_T_DECLARED
+#ifdef __ILP32_
 typedef	unsigned long long	uint64ptr_t;
+#else
+typedef	unsigned long	uint64ptr_t;
+#endif
 #define	_UINT64PTR_T_DECLARED
+#endif
+
+#ifndef __SIZEOF_INTCAP__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wtypedef-redefinition"
+typedef	uintptr_t	__uintcap_t;
+#pragma GCC diagnostic pop
+#endif
+
+#ifndef _KUINT64CAP_T_DECLARED
+typedef uint64ptr_t		kuint64cap_t;
+#define _KUINT64CAP_T_DECLARED
 #endif

--- a/sys/contrib/subrepo-openzfs/lib/libspl/include/os/freebsd/sys/sysmacros.h
+++ b/sys/contrib/subrepo-openzfs/lib/libspl/include/os/freebsd/sys/sysmacros.h
@@ -1,1 +1,18 @@
-/* keep me */
+#if !defined(__CHERI__) && !defined(__CHERI_HYBRID__)
+#ifndef copyinptr
+#define        copyinptr       copyin
+#endif
+#ifndef copyoutptr
+#define        copyoutptr      copyout
+#endif
+
+#ifndef __capability
+#define        __capability
+#endif
+#ifndef __cheri_fromcap
+#define        __cheri_fromcap
+#endif
+#ifndef PTR2CAP
+#define        PTR2CAP(x)      (x)
+#endif
+#endif

--- a/sys/contrib/subrepo-openzfs/lib/libspl/include/os/linux/sys/sysmacros.h
+++ b/sys/contrib/subrepo-openzfs/lib/libspl/include/os/linux/sys/sysmacros.h
@@ -99,4 +99,16 @@
 #define	offsetof(s, m)	((size_t)(&(((s *)0)->m)))
 #endif
 
+#if !defined(__CHERI__) && !defined(__CHERI_HYBRID__)
+#ifndef __capability
+#define	__capability
+#endif
+#ifndef __cheri_fromcap
+#define	__cheri_fromcap
+#endif
+#ifndef PTR2CAP
+#define	PTR2CAP(x)	(x)
+#endif
+#endif
+
 #endif /* _LIBSPL_SYS_SYSMACROS_H */

--- a/sys/contrib/subrepo-openzfs/lib/libzfs/libzfs_util.c
+++ b/sys/contrib/subrepo-openzfs/lib/libzfs/libzfs_util.c
@@ -1256,7 +1256,7 @@ zcmd_write_src_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, nvlist_t *nvl)
 int
 zcmd_read_dst_nvlist(libzfs_handle_t *hdl, zfs_cmd_t *zc, nvlist_t **nvlp)
 {
-	if (nvlist_unpack((__cheri_fromcap void *)(uintcap_t)zc->zc_nvlist_dst,
+	if (nvlist_unpack((__cheri_fromcap void *)(__uintcap_t)zc->zc_nvlist_dst,
 	    zc->zc_nvlist_dst_size, nvlp, 0) != 0)
 		return (no_memory(hdl));
 

--- a/sys/contrib/subrepo-openzfs/module/nvpair/nvpair.c
+++ b/sys/contrib/subrepo-openzfs/module/nvpair/nvpair.c
@@ -56,7 +56,7 @@
 
 #define	skip_whitespace(p)	while ((*(p) == ' ') || (*(p) == '\t')) (p)++
 
-#if __has_feature(capabilities)
+#if defined(__CHERI__) || defined(__CHERI_HYBRID__)
 #define NVPAIR_OVER_ALLOCATE_DECODE
 #endif
 
@@ -3263,7 +3263,7 @@ nvs_xdr_nvp_##type(XDR *xdrs, void *ptr)	\
 	return (xdr_##type(xdrs, ptr));		\
 }
 
-#elif !defined(_KERNEL) && defined(__FreeBSD__)
+#elif !defined(_KERNEL) && defined(__FreeBSD__) && defined(__CheriBSD_version)
 
 #define	NVS_BUILD_XDRPROC_T(type)				\
 static int							\

--- a/sys/contrib/subrepo-openzfs/module/os/freebsd/spl/spl_uio.c
+++ b/sys/contrib/subrepo-openzfs/module/os/freebsd/spl/spl_uio.c
@@ -129,7 +129,7 @@ zfs_uio_page_aligned(zfs_uio_t *uio)
 	const struct iovec *iov = GET_UIO_STRUCT(uio)->uio_iov;
 
 	for (int i = zfs_uio_iovcnt(uio); i > 0; iov++, i--) {
-		uintcap_t addr = (uintcap_t)iov->iov_base;
+		__uintcap_t addr = (__uintcap_t)iov->iov_base;
 		size_t size = iov->iov_len;
 		if ((addr & (PAGE_SIZE - 1)) || (size & (PAGE_SIZE - 1))) {
 				return (B_FALSE);
@@ -183,8 +183,13 @@ zfs_uio_hold_pages(void * __capability start, size_t len, int nr_pages,
 	ASSERT3S(len, >, 0);
 
 	prot = rw == UIO_READ ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
+#ifdef __CheriBSD_version
 	count = vm_fault_quick_hold_pages(map, start, len, prot, pages,
 	    nr_pages);
+#else
+	count = vm_fault_quick_hold_pages(map, (uintptr_t)start, len, prot, pages,
+	    nr_pages);
+#endif
 
 	return (count);
 }

--- a/sys/contrib/subrepo-openzfs/module/os/freebsd/zfs/kmod_core.c
+++ b/sys/contrib/subrepo-openzfs/module/os/freebsd/zfs/kmod_core.c
@@ -140,7 +140,7 @@ zfsdev_ioctl(struct cdev *dev, ulong_t zcmd, caddr_t arg, int flag,
 	if (len != sizeof (zfs_iocparm_t))
 		return (EINVAL);
 
-	uaddr = (void * __capability)(uintcap_t)zp->zfs_cmd;
+	uaddr = (void * __capability)(__uintcap_t)zp->zfs_cmd;
 	zc = vmem_zalloc(sizeof (zfs_cmd_t), KM_SLEEP);
 #ifdef ZFS_LEGACY_SUPPORT
 	/*

--- a/sys/contrib/subrepo-openzfs/module/zfs/zfs_ioctl.c
+++ b/sys/contrib/subrepo-openzfs/module/zfs/zfs_ioctl.c
@@ -281,7 +281,8 @@ static int zfs_check_clearable(const char *dataset, nvlist_t *props,
 static int zfs_fill_zplprops_root(uint64_t, nvlist_t *, nvlist_t *,
     boolean_t *);
 int zfs_set_prop_nvlist(const char *, zprop_source_t, nvlist_t *, nvlist_t *);
-static int get_nvlist(uintcap_t nvl, uint64_t size, int iflag, nvlist_t **nvp);
+static int get_nvlist(__uintcap_t nvl, uint64_t size, int iflag,
+    nvlist_t **nvp);
 
 static void
 history_str_free(char *buf)
@@ -298,7 +299,7 @@ history_str_get(zfs_cmd_t *zc)
 		return (NULL);
 
 	buf = kmem_alloc(HIS_MAX_RECORD_LEN, KM_SLEEP);
-	if (copyinstr((const void * __capability)(uintcap_t)zc->zc_history,
+	if (copyinstr((const void * __capability)(__uintcap_t)zc->zc_history,
 	    buf, HIS_MAX_RECORD_LEN, NULL) != 0) {
 		history_str_free(buf);
 		return (NULL);
@@ -1264,7 +1265,7 @@ zfs_secpolicy_change_key(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
  * Returns the nvlist as specified by the user in the zfs_cmd_t.
  */
 static int
-get_nvlist(uintcap_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
+get_nvlist(__uintcap_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
 {
 	char *packed;
 	int error;
@@ -1346,7 +1347,7 @@ put_nvlist(zfs_cmd_t *zc, nvlist_t *nvl)
 		error = SET_ERROR(ENOMEM);
 	} else {
 		packed = fnvlist_pack(nvl, &size);
-		if (ddi_copyout(packed, (void * __capability)(uintcap_t)zc->zc_nvlist_dst,
+		if (ddi_copyout(packed, (void * __capability)(__uintcap_t)zc->zc_nvlist_dst,
 		    size, zc->zc_iflags) != 0)
 			error = SET_ERROR(EFAULT);
 		fnvlist_pack_free(packed, size);
@@ -1787,7 +1788,7 @@ zfs_ioc_pool_get_history(zfs_cmd_t *zc)
 	if ((error = spa_history_get(spa, &zc->zc_history_offset,
 	    &zc->zc_history_len, hist_buf)) == 0) {
 		error = ddi_copyout(hist_buf,
-		    (void * __capability)(uintcap_t)zc->zc_history,
+		    (void * __capability)(__uintcap_t)zc->zc_history,
 		    zc->zc_history_len, zc->zc_iflags);
 	}
 
@@ -5975,7 +5976,7 @@ zfs_ioc_error_log(zfs_cmd_t *zc)
 	if ((error = spa_open(zc->zc_name, &spa, FTAG)) != 0)
 		return (error);
 
-	error = spa_get_errlog(spa, (void * __capability)(uintcap_t)zc->zc_nvlist_dst,
+	error = spa_get_errlog(spa, (void * __capability)(__uintcap_t)zc->zc_nvlist_dst,
 	    &zc->zc_nvlist_dst_size);
 
 	spa_close(spa, FTAG);
@@ -6250,7 +6251,7 @@ zfs_ioc_userspace_many(zfs_cmd_t *zc)
 
 	if (error == 0) {
 		error = xcopyout(buf,
-		    (void * __capability)(uintcap_t)zc->zc_nvlist_dst,
+		    (void * __capability)(__uintcap_t)zc->zc_nvlist_dst,
 		    zc->zc_nvlist_dst_size);
 	}
 	vmem_free(buf, bufsize);

--- a/sys/contrib/subrepo-openzfs/tests/zfs-tests/cmd/nvlist_packed.c
+++ b/sys/contrib/subrepo-openzfs/tests/zfs-tests/cmd/nvlist_packed.c
@@ -613,7 +613,7 @@ nvpair_value_equal(nvpair_t *nvp_a, nvpair_t *nvp_b)
 		break;
 
 	case DATA_TYPE_STRING: {
-		char *str_a, *str_b;
+		const char *str_a, *str_b;
 		nvpair_value_string(nvp_a, &str_a);
 		nvpair_value_string(nvp_b, &str_b);
 		if (strcmp(str_a, str_b) == 0)
@@ -621,7 +621,7 @@ nvpair_value_equal(nvpair_t *nvp_a, nvpair_t *nvp_b)
 		break;
 	}
 	case DATA_TYPE_STRING_ARRAY: {
-		char **stra_a, **stra_b;
+		const char **stra_a, **stra_b;
 		uint_t nelem_a, nelem_b;
 		nvpair_value_string_array(nvp_a, &stra_a, &nelem_a);
 		nvpair_value_string_array(nvp_b, &stra_b, &nelem_b);

--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -127,12 +127,6 @@ typedef	__ptraddr_t		ptraddr_t;
 /* Limits of ptraddr_t. */
 #define	PTRADDR_MAX		SIZE_MAX
 
-#ifndef _VADDR_T_DECLARED
-__attribute__((__deprecated__("use ptraddr_t instead")))
-typedef	ptraddr_t		vaddr_t;
-#define	_VADDR_T_DECLARED
-#endif
-
 #endif /* !_SYS__STDINT_H_ */
 // CHERI CHANGES START
 // {

--- a/sys/sys/_stdint.h
+++ b/sys/sys/_stdint.h
@@ -119,11 +119,6 @@ typedef	kuintcap_t		kuint64cap_t;
 #define	_KUINT64CAP_T_DECLARED
 #endif
 
-#ifndef _PTRADDR_T_DECLARED
-typedef	__ptraddr_t		ptraddr_t;
-#define	_PTRADDR_T_DECLARED
-#endif
-
 /* Limits of ptraddr_t. */
 #define	PTRADDR_MAX		SIZE_MAX
 

--- a/sys/sys/atomic_common.h
+++ b/sys/sys/atomic_common.h
@@ -34,6 +34,7 @@
 #error do not include this header, use machine/atomic.h
 #endif
 
+#include <sys/stddef.h>
 #include <sys/types.h>
 
 #define	__atomic_load_bool_relaxed(p)	(*(const volatile _Bool *)(p))

--- a/sys/sys/link_elf.h
+++ b/sys/sys/link_elf.h
@@ -113,6 +113,11 @@ const char *rtld_get_var(const char *name);
 int rtld_set_var(const char *name, const char *val);
 
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(__aarch64__)
+#ifdef _KERNEL
+#include <sys/stddef.h>
+#else
+#include <stddef.h>
+#endif
 #include <machine/c18n.h>
 void *dl_c18n_get_trusted_stack(uintptr_t);
 void dl_c18n_unwind_trusted_stack(void *, void *);

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -35,6 +35,7 @@
 
 #include <machine/elf.h>
 #include <sys/kobj.h>
+#include <sys/stddef.h>
 
 #ifdef MALLOC_DECLARE
 MALLOC_DECLARE(M_LINKER);

--- a/sys/sys/memrange.h
+++ b/sys/sys/memrange.h
@@ -6,6 +6,7 @@
 #define	_SYS_MEMRANGE_H_
 
 #include <sys/ioccom.h>
+#include <sys/stddef.h>
 
 /* Memory range attributes */
 #define MDF_UNCACHEABLE		(1<<0)	/* region not cached */

--- a/sys/sys/pcpu.h
+++ b/sys/sys/pcpu.h
@@ -45,6 +45,7 @@
 #include <sys/queue.h>
 #include <sys/_rmlock.h>
 #include <sys/resource.h>
+#include <sys/stddef.h>
 #include <machine/pcpu.h>
 
 #define	DPCPU_SETNAME		"set_pcpu"

--- a/sys/sys/pmclog.h
+++ b/sys/sys/pmclog.h
@@ -34,6 +34,7 @@
 #define	_SYS_PMCLOG_H_
 
 #include <sys/pmc.h>
+#include <sys/stddef.h>
 
 enum pmclog_type {
 	/* V1 ABI */

--- a/sys/sys/signal.h
+++ b/sys/sys/signal.h
@@ -540,19 +540,6 @@ __BEGIN_DECLS
 __sighandler_t *signal(int, __sighandler_t *);
 __END_DECLS
 
-#if defined(_KERNEL) && defined(COMPAT_FREEBSD64)
-static inline bool
-is_magic_sighandler_constant(ptraddr_t handler) {
-	/*
-	 * Instead of enumerating all the SIG_* constants, just check if
-	 * it is a small (positive or negative) integer so that this doesn't
-	 * break if someone adds a new SIG_* constant. The manual checks that
-	 * we were using before weren't handling SIG_HOLD.
-	 */
-	return (handler < 64);
-}
-#endif
-
 #endif /* !_SYS_SIGNAL_H_ */
 // CHERI CHANGES START
 // {

--- a/sys/sys/tree.h
+++ b/sys/sys/tree.h
@@ -33,8 +33,10 @@
 
 #include <sys/cdefs.h>
 #ifdef _KERNEL
+#include <sys/stddef.h>
 #include <sys/stdint.h>
 #else
+#include <stddef.h>
 #include <stdint.h>
 #endif
 

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -43,6 +43,7 @@
 #include <sys/ucred.h>
 #include <sys/uio.h>
 #include <sys/queue.h>
+#include <sys/stddef.h>
 #include <sys/_lock.h>
 #include <sys/_mutex.h>
 #include <sys/proc.h>

--- a/sys/vm/uma_int.h
+++ b/sys/vm/uma_int.h
@@ -29,6 +29,7 @@
  */
 
 #include <sys/counter.h>
+#include <sys/stddef.h>
 #include <sys/_bitset.h>
 #include <sys/_domainset.h>
 #include <sys/_task.h>

--- a/usr.bin/truss/setup.c
+++ b/usr.bin/truss/setup.c
@@ -47,6 +47,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
We need to pick one place for ptraddr_t and I've upstreamed it to stddef.h matching the various CHERI LLVM ports. I've removed the definition from stdint.h and removed the long unused vaddr_t while here.