### PR TITLE
c18n: Rename trampoline reflection functions

### DIFF
--- a/lib/libc/gen/elf_utils.c
+++ b/lib/libc/gen/elf_utils.c
@@ -52,7 +52,7 @@ __elf_phdr_match_addr(struct dl_phdr_info *phdr_info, void *addr)
 #ifdef CHERI_LIB_C18N
 	ptraddr_t target;
 
-	target = _rtld_tramp_reflect(addr);
+	target = dl_c18n_get_trampoline_target(addr);
 	if (target != 0)
 		addr = (void *)(uintptr_t)target;
 #endif

--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -398,7 +398,6 @@ int __strerror_rl(int errnum, char *strerrbuf, size_t buflen,
 
 #ifdef CHERI_LIB_C18N
 bool	_rtld_c18n_is_enabled(void);
-ptraddr_t	_rtld_tramp_reflect(const void *);
 void	_rtld_thr_exit(long *);
 int	_rtld_sigaction(int, const struct sigaction *, struct sigaction *);
 #endif

--- a/libexec/rtld-elf/Symbol-c18n.map
+++ b/libexec/rtld-elf/Symbol-c18n.map
@@ -16,6 +16,7 @@ FBSD_1.0 {
     dl_c18n_get_trusted_stack;
     dl_c18n_unwind_trusted_stack;
     dl_c18n_is_trampoline;
+    dl_c18n_get_trampoline_target;
 };
 
 FBSD_1.1 {

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3523,7 +3523,7 @@ obj_from_addr(const void *addr)
     struct tramp_header *header;
 
     if (C18N_ENABLED) {
-	header = tramp_reflect(addr);
+	header = tramp_get_header(addr);
 	if (header != NULL)
 	    return (__DECONST(Obj_Entry *, header->defobj));
     }

--- a/libexec/rtld-elf/rtld_c18n.h
+++ b/libexec/rtld-elf/rtld_c18n.h
@@ -227,7 +227,7 @@ void tramp_hook(void);
 size_t tramp_compile(char **, const struct tramp_data *);
 
 void *tramp_intern(const Plt_Entry *, compart_id_t, const struct tramp_data *);
-struct tramp_header *tramp_reflect(const void *);
+struct tramp_header *tramp_get_header(const void *);
 struct func_sig sigtab_get(const Obj_Entry *, unsigned long);
 
 static inline long

--- a/libexec/rtld-elf/rtld_c18n_policy.txt
+++ b/libexec/rtld-elf/rtld_c18n_policy.txt
@@ -49,7 +49,6 @@ trust
 callee [RTLD]
 export to [TCB]
 	_rtld_c18n_is_enabled
-	_rtld_tramp_reflect
 	_rtld_thread_start_init
 	_rtld_thread_start
 	_rtld_thr_exit

--- a/sys/sys/link_elf.h
+++ b/sys/sys/link_elf.h
@@ -118,6 +118,7 @@ void *dl_c18n_get_trusted_stack(uintptr_t);
 void dl_c18n_unwind_trusted_stack(void *, void *);
 int dl_c18n_is_trampoline(uintptr_t, void *);
 void *dl_c18n_pop_trusted_stack(struct dl_c18n_compart_state *, void *);
+ptraddr_t dl_c18n_get_trampoline_target(const void *);
 #endif
 
 #ifdef __ARM_EABI__


### PR DESCRIPTION
Rename trampoline reflection functions to more specific names about getting the header or the target.