### PR TITLE
Migrate to cheriintrin.h macro names to access compiler builtins

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -46,15 +46,13 @@
 #include <sys/ucontext.h>
 #include <sys/wait.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <machine/frame.h>
 #include <machine/trap.h>
 
 #include <machine/sysarch.h>
 
 #include <assert.h>
+#include <cheriintrin.h>
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -33,11 +33,15 @@
 #ifndef _CHERIBSDTEST_H_
 #define	_CHERIBSDTEST_H_
 
+#include <sys/types.h>
 #include <sys/linker_set.h>
 
-#include <string.h>
+#include <cheri/cherireg.h>
 
-#include <cheri/cheric.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <cheriintrin.h>
 
 #include "cheribsdtest_md.h"
 

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -336,6 +336,30 @@ _cheribsdtest_check_errno(const char *context, int actual, int expected)
 		    expected_errno);					\
 	} while (0)
 
+#define cheri_ptr(ptr, len)    \
+	cheri_bounds_set(    \
+	    (__cheri_tocap __typeof__((ptr)[0]) *__capability)ptr, len)
+
+#define cheri_ptrperm(ptr, len, perm)	\
+	cheri_perms_and(cheri_ptr(ptr, len), perm | CHERI_PERM_GLOBAL)
+
+/*
+ * Return whether the two pointers are equal, including capability metadata if
+ * in purecap mode.
+ */
+static inline bool
+cheri_ptr_equal_exact(void *x, void *y)
+{
+#ifdef __CHERI_PURE_CAPABILITY__
+	/* For purecap compare the entire capability including metadata */
+	return (cheri_is_equal_exact(x, y));
+#else
+	/* In hybrid mode void * is just an address */
+	return (x == y);
+#endif
+}
+
+
 /* For libc_memcpy and libc_memset tests and the unaligned copy tests: */
 extern void *cheribsdtest_memcpy(void *dst, const void *src, size_t n);
 extern void *cheribsdtest_memmove(void *dst, const void *src, size_t n);

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -241,13 +241,13 @@ _cheribsdtest_check_cap_eq(void *__capability a, void *__capability b,
 	CHERIBSDTEST_VERIFY2(accessor(a) == accessor(b),			\
 	    __STRING(accessor) "(%s) (" fmt ") == " __STRING(accessor)		\
 	    "(%s) (" fmt ") failed!", a_str, accessor(a), b_str, accessor(b))
-	CHECK_CAP_ATTR(cheri_getaddress, "0x%lx");
-	CHECK_CAP_ATTR(cheri_gettag, "%d");
-	CHECK_CAP_ATTR(cheri_getoffset, "0x%lx");
-	CHECK_CAP_ATTR(cheri_getlength, "0x%lx");
-	CHECK_CAP_ATTR(cheri_getperm, "0x%lx");
-	CHECK_CAP_ATTR(cheri_gettype, "%ld");
-	CHECK_CAP_ATTR(cheri_getflags, "0x%lx");
+	CHECK_CAP_ATTR(cheri_address_get, "0x%lx");
+	CHECK_CAP_ATTR(cheri_tag_get, "%d");
+	CHECK_CAP_ATTR(cheri_offset_get, "0x%lx");
+	CHECK_CAP_ATTR(cheri_length_get, "0x%lx");
+	CHECK_CAP_ATTR(cheri_perms_get, "0x%x");
+	CHECK_CAP_ATTR(cheri_type_get, "%ld");
+	CHECK_CAP_ATTR(cheri_flags_get, "0x%lx");
 #undef CHECK_CAP_ATTR
 }
 #define CHERIBSDTEST_CHECK_EQ_CAP(a, b)	\
@@ -267,8 +267,8 @@ _cheribsdtest_check_cap_bounds_precise(void *__capability c,
 {
 	size_t len, offset;
 
-	offset = cheri_getoffset(c);
-	len = cheri_getlen(c);
+	offset = cheri_offset_get(c);
+	len = cheri_length_get(c);
 
 	/* Confirm precise lower bound: offset of zero. */
 	CHERIBSDTEST_VERIFY2(offset == 0,

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -38,7 +38,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #include <err.h>

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -92,15 +92,15 @@
 static void
 test_bounds_impl(void *__capability allocation, void *__capability global_ptr, size_t size)
 {
-	size_t allocation_offset = cheri_getoffset(allocation);
-	size_t allocation_len = cheri_getlen(allocation);
-	size_t pointer_offset = cheri_getoffset(global_ptr);
-	size_t pointer_len = cheri_getlen(global_ptr);
+	size_t allocation_offset = cheri_offset_get(allocation);
+	size_t allocation_len = cheri_length_get(allocation);
+	size_t pointer_offset = cheri_offset_get(global_ptr);
+	size_t pointer_len = cheri_length_get(global_ptr);
 	size_t rounded_size = CHERI_REPRESENTABLE_LENGTH(size);
 
 	/* Both the local cast and the global pointer should be tagged */
-	CHERIBSDTEST_VERIFY(cheri_gettag(allocation));
-	CHERIBSDTEST_VERIFY(cheri_gettag(global_ptr));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(allocation));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(global_ptr));
 
 	/* Global offset. */
 	if (allocation_offset != 0)

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals_x.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals_x.c
@@ -38,9 +38,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest_bounds_heap.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_heap.c
@@ -65,9 +65,9 @@ CHERIBSDTEST(bounds_calloc,
 		calloc_allocation = calloc(1, sizes[i]);
 		if (calloc_allocation == NULL)
 			cheribsdtest_failure_err("calloc failed");
-		if (cheri_getoffset(calloc_allocation) != 0)
+		if (cheri_offset_get(calloc_allocation) != 0)
 			cheribsdtest_failure_errx("non-zero offset returned");
-		if (cheri_getlen(calloc_allocation) < sizes[i])
+		if (cheri_length_get(calloc_allocation) < sizes[i])
 			cheribsdtest_failure_errx("returned length too small");
 		free((void *)calloc_allocation);
 	}

--- a/bin/cheribsdtest/cheribsdtest_bounds_heap.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_heap.c
@@ -38,9 +38,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -73,7 +73,7 @@ test_bounds_precise(void * __capability c, size_t expected_len)
 #ifndef __CHERI_PURE_CAPABILITY__
 	size_t len;
 
-	len = cheri_getlen(c);
+	len = cheri_length_get(c);
 
 	/*
 	 * In hybrid mode we do not set bounds on capabilities created

--- a/bin/cheribsdtest/cheribsdtest_bounds_stack.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_stack.c
@@ -43,11 +43,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
-#include <machine/sysarch.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest_bounds_subobject.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_subobject.c
@@ -42,9 +42,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest_bounds_subobject.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_subobject.c
@@ -273,8 +273,8 @@ CHERIBSDTEST(bounds_subobject_union_two_chararrays,
 
 	chararray16p = &twoarrays.chararray16;
 	chararray32p = &twoarrays.chararray32;
-	CHERIBSDTEST_VERIFY(cheri_getlength(chararray16p) == sizeof(twoarrays));
-	CHERIBSDTEST_VERIFY(cheri_getlength(chararray32p) == sizeof(twoarrays));
+	CHERIBSDTEST_VERIFY(cheri_length_get(chararray16p) == sizeof(twoarrays));
+	CHERIBSDTEST_VERIFY(cheri_length_get(chararray32p) == sizeof(twoarrays));
 	cheribsdtest_success();
 }
 
@@ -342,7 +342,7 @@ CHERIBSDTEST(bounds_subobject_struct_exempt_char,
 	 */
 	cp = &sec.c;
 	refcp = &sec;
-	CHERIBSDTEST_VERIFY(cheri_getoffset(cp) ==
+	CHERIBSDTEST_VERIFY(cheri_offset_get(cp) ==
 	    offsetof(struct struct_exempt_char, c));
 	cp = (void *)((intptr_t)cp - offsetof(struct struct_exempt_char, c));
 	CHERIBSDTEST_CHECK_EQ_CAP(cp, refcp);

--- a/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_varargs.c
@@ -38,9 +38,6 @@
 #include <machine/frame.h>
 #include <machine/trap.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 #include <errno.h>
 #include <stdarg.h>

--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -84,22 +84,22 @@ CHERIBSDTEST(cheriabi_mincore,
 	 */
 
 	/* No VMEM */
-	cap = cheri_andperm(pages, ~CHERI_PERM_SW_VMEM);
+	cap = cheri_perms_and(pages, ~CHERI_PERM_SW_VMEM);
 	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
 	    "whole allocation from mmap without VMEM perm");
 
 	/* Execute-only */
-	cap = cheri_andperm(pages, CHERI_PERM_EXECUTE | CHERI_PERM_GLOBAL);
+	cap = cheri_perms_and(pages, CHERI_PERM_EXECUTE | CHERI_PERM_GLOBAL);
 	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
 	    "whole allocation from mmap with only CHERI_PERM_EXECUTE");
 
 	/* Read-only */
-	cap = cheri_andperm(pages, CHERI_PERM_LOAD | CHERI_PERM_GLOBAL);
+	cap = cheri_perms_and(pages, CHERI_PERM_LOAD | CHERI_PERM_GLOBAL);
 	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
 	    "whole allocation from mmap with only CHERI_PERM_LOAD");
 
 	/* Write-only */
-	cap = cheri_andperm(pages, CHERI_PERM_STORE | CHERI_PERM_GLOBAL);
+	cap = cheri_perms_and(pages, CHERI_PERM_STORE | CHERI_PERM_GLOBAL);
 	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cap, pages_len, vec),
 	    "whole allocation from mmap with only CHERI_PERM_STORE");
 
@@ -108,7 +108,7 @@ CHERIBSDTEST(cheriabi_mincore,
 	 * Restrict bounds to cover a single byte of the first and last
 	 * pages.
 	 */
-	cap = trunc_page(cheri_setbounds(pages + page_sz - 1,
+	cap = trunc_page(cheri_bounds_set(pages + page_sz - 1,
 	    pages_len - 2 * (PAGE_SIZE - 1)));
 
 	/* The whole thing */
@@ -127,10 +127,10 @@ CHERIBSDTEST(cheriabi_mincore,
 	/*
 	 * FreeBSD (nonportably) allows under-aligned address and length.
 	 */
-	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cheri_setoffset(cap, 0), 1, vec),
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cheri_offset_set(cap, 0), 1, vec),
 	    "last byte of first page");
-	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cheri_setoffset(cap, 0),
-	    cheri_getlen(cap), vec), "whole in-bounds region");
+	CHERIBSDTEST_CHECK_SYSCALL2(mincore(cheri_offset_set(cap, 0),
+	    cheri_length_get(cap), vec), "whole in-bounds region");
 #endif
 
 	cheribsdtest_success();
@@ -160,10 +160,10 @@ CHERIBSDTEST(cheriabi_mmap_unrepresentable,
 
 		cheribsdtest_failure_errx("mmap() failed to return a pointer "
 		   "when given an unrepresentable length (%zu)", len);
-	if (cheri_getlen(cap) != expected_len)
+	if (cheri_length_get(cap) != expected_len)
 		cheribsdtest_failure_errx("mmap() returned a pointer with "
 		    "an unexpected length (%zu vs %zu) when given an "
-		    "unrepresentable length (%zu): %#p", cheri_getlen(cap),
+		    "unrepresentable length (%zu): %#p", cheri_length_get(cap),
 		    expected_len, len, cap);
 
 	cheribsdtest_success();
@@ -222,24 +222,24 @@ create_adjacent_mappings(struct adjacent_mappings *mappings)
 	requested_addr = (void *)(uintcap_t)find_address_space_gap(len * 3, 0);
 	mappings->first = CHERIBSDTEST_CHECK_SYSCALL(mmap(requested_addr, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0));
-	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->first));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(mappings->first));
 	/* Try to create a mapping immediately following the latest one. */
 	requested_addr =
-	    (void *)(uintcap_t)(cheri_getaddress(mappings->first) + len);
+	    (void *)(uintcap_t)(cheri_address_get(mappings->first) + len);
 	mappings->middle = CHERIBSDTEST_CHECK_SYSCALL2(mmap(requested_addr, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0),
 	    "Failed to create mapping at address %p", requested_addr);
 	CHERIBSDTEST_CHECK_EQ_LONG((ptraddr_t)mappings->middle,
 	    (ptraddr_t)mappings->first + len);
 	requested_addr =
-	    (void *)(uintcap_t)(cheri_getaddress(mappings->middle) + len);
-	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->middle));
+	    (void *)(uintcap_t)(cheri_address_get(mappings->middle) + len);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(mappings->middle));
 	mappings->last = CHERIBSDTEST_CHECK_SYSCALL2(mmap(requested_addr, len,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0),
 	    "Failed to create mapping at address %p", requested_addr);
 	CHERIBSDTEST_CHECK_EQ_LONG((ptraddr_t)mappings->last,
 	    (ptraddr_t)mappings->middle + len);
-	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->last));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(mappings->last));
 	mappings->maplen = len;
 }
 
@@ -268,7 +268,7 @@ CHERIBSDTEST(cheriabi_munmap_invalid_ptr,
 
 	/* munmap() with an in-bounds but untagged capability should fail. */
 	CHERIBSDTEST_CHECK_CALL_ERROR(
-	    munmap(cheri_cleartag(mappings.middle), mappings.maplen), EPROT);
+	    munmap(cheri_tag_clear(mappings.middle), mappings.maplen), EPROT);
 	mappings.middle[0] = 'a'; /* Check that the mapping is still valid */
 
 	/* munmap() with an out-of-bounds capability should fail. */
@@ -335,7 +335,7 @@ CHERIBSDTEST(cheriabi_mprotect_downgrade_prot_cap,
 	/* Downgrade and attempt to load a capability */
 	CHERIBSDTEST_CHECK_SYSCALL(mprotect(__DEVOLATILE(void *, p), PAGE_SIZE,
 	    PROT_READ | PROT_MAX(PROT_READ)));
-	CHERIBSDTEST_VERIFY(cheri_gettag(*p));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(*p));
 
 	/* Try a store.  This should fault. */
 	cheribsdtest_set_expected_si_addr(
@@ -361,7 +361,7 @@ CHERIBSDTEST(cheriabi_mprotect_invalid_ptr,
 	mappings.middle[0] = 'a'; /* Check that it still has PROT_WRITE */
 
 	/* mprotect() with an in-bounds but untagged capability should fail. */
-	CHERIBSDTEST_CHECK_CALL_ERROR(mprotect(cheri_cleartag(mappings.middle),
+	CHERIBSDTEST_CHECK_CALL_ERROR(mprotect(cheri_tag_clear(mappings.middle),
 	    mappings.maplen, PROT_NONE), EPROT);
 	mappings.middle[0] = 'a'; /* Check that it still has PROT_WRITE */
 
@@ -398,7 +398,7 @@ CHERIBSDTEST(cheriabi_minherit_invalid_ptr,
 	    mappings.maplen + 1, INHERIT_NONE), EPROT);
 
 	/* minherit() with an in-bounds but untagged capability should fail. */
-	CHERIBSDTEST_CHECK_CALL_ERROR(minherit(cheri_cleartag(mappings.middle),
+	CHERIBSDTEST_CHECK_CALL_ERROR(minherit(cheri_tag_clear(mappings.middle),
 	    mappings.maplen, INHERIT_NONE), EPROT);
 
 	/* minherit() with an out-of-bounds capability should fail. */
@@ -436,24 +436,24 @@ create_adjacent_mappings_shm(struct adjacent_mappings *mappings)
 	requested_addr = (void *)(uintcap_t)find_address_space_gap(len * 3, 0);
 	mappings->first = CHERIBSDTEST_CHECK_SYSCALL(shmat(shmid,
 	    requested_addr, 0));
-	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->first));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(mappings->first));
 	/* Try to create a mapping immediately following the latest one. */
 	requested_addr =
-	    (void *)(uintcap_t)(cheri_getaddress(mappings->first) + len);
+	    (void *)(uintcap_t)(cheri_address_get(mappings->first) + len);
 	mappings->middle = CHERIBSDTEST_CHECK_SYSCALL2(
 	    shmat(shmid, requested_addr, 0),
 	    "Failed to create mapping at address %p", requested_addr);
 	CHERIBSDTEST_CHECK_EQ_LONG((ptraddr_t)mappings->middle,
 	    (ptraddr_t)requested_addr);
-	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->middle));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(mappings->middle));
 	requested_addr =
-	    (void *)(uintcap_t)(cheri_getaddress(mappings->middle) + len);
+	    (void *)(uintcap_t)(cheri_address_get(mappings->middle) + len);
 	mappings->last = CHERIBSDTEST_CHECK_SYSCALL2(
 	    shmat(shmid, requested_addr, 0),
 	    "Failed to create mapping at address %p", requested_addr);
 	CHERIBSDTEST_CHECK_EQ_LONG((ptraddr_t)mappings->last,
 	    (ptraddr_t)requested_addr);
-	CHERIBSDTEST_VERIFY(cheri_gettag(mappings->last));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(mappings->last));
 	mappings->maplen = len;
 }
 
@@ -474,7 +474,7 @@ CHERIBSDTEST(cheriabi_shmdt_invalid_ptr,
 
 	/* shmdt() with an in-bounds but untagged capability should fail. */
 	CHERIBSDTEST_CHECK_CALL_ERROR(
-	    shmdt(cheri_cleartag(mappings.middle)), EPROT);
+	    shmdt(cheri_tag_clear(mappings.middle)), EPROT);
 	mappings.middle[0] = 'a'; /* Check that the mapping is still valid */
 
 	/* shmdt() with an out-of-bounds capability should fail. */

--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -43,11 +43,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
-#include <machine/sysarch.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest_cheriabi_libc.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_libc.c
@@ -34,9 +34,6 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <string.h>
 
 #include "cheribsdtest.h"

--- a/bin/cheribsdtest/cheribsdtest_cheriabi_libc.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_libc.c
@@ -62,7 +62,7 @@ CHERIBSDTEST(cheriabi_libc_memchr,
 	 * This means the implementation needs to not trust the supplied
 	 * length when doing optimized word-wise reads and compares.
 	 */
-	CHERIBSDTEST_CHECK_EQ_INT(*(char *)memchr(cheri_setbounds(string,
+	CHERIBSDTEST_CHECK_EQ_INT(*(char *)memchr(cheri_bounds_set(string,
 	    sizeof(string) - 1), 'e', sizeof(string)), 'e');
 
 	cheribsdtest_success();

--- a/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
@@ -150,7 +150,7 @@ CHERIBSDTEST(cheriabi_open_bad_len,
 	char *path;
 	int fd;
 
-	path = cheri_setbounds(pathbuf, strlen(pathbuf));
+	path = cheri_bounds_set(pathbuf, strlen(pathbuf));
 
 	fd = open(path, O_RDONLY);
 	if (fd > 0)
@@ -168,7 +168,7 @@ CHERIBSDTEST(cheriabi_open_bad_len_2, "Path with offset past its bounds")
 	char *path;
 	int fd;
 
-	path = cheri_setbounds(pathbuf, 3);
+	path = cheri_bounds_set(pathbuf, 3);
 	path += 4;
 
 	fd = open(path, O_RDONLY);
@@ -187,7 +187,7 @@ CHERIBSDTEST(cheriabi_open_bad_tag, "Path with tag bit missing")
 	char *path;
 	int fd;
 
-	path = cheri_cleartag(pathbuf);
+	path = cheri_tag_clear(pathbuf);
 
 	fd = open(path, O_RDONLY);
 	if (fd > 0)
@@ -206,7 +206,7 @@ CHERIBSDTEST(cheriabi_open_bad_perm,
 	char *path;
 	int fd;
 
-	path = cheri_andperm(pathbuf, ~CHERI_PERM_LOAD);
+	path = cheri_perms_and(pathbuf, ~CHERI_PERM_LOAD);
 
 	fd = open(path, O_RDONLY);
 	if (fd > 0)

--- a/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi_open.c
@@ -38,9 +38,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/bin/cheribsdtest/cheribsdtest_cidcap.c
+++ b/bin/cheribsdtest/cheribsdtest_cidcap.c
@@ -59,43 +59,43 @@ check_cidcap(uintcap_t cidcap, size_t base, size_t length, size_t offset)
 
 	if (base != (size_t)-1) {
 		/* Base. */
-		v = cheri_getbase(cidcap);
+		v = cheri_base_get(cidcap);
 		if (v != base)
 			cheribsdtest_failure_errx("base %jx (expected %jx)", v,
 			    (uintmax_t)base);
 	}
 
 	/* Length. */
-	v = cheri_getlen(cidcap);
+	v = cheri_length_get(cidcap);
 	if (v != length)
 		cheribsdtest_failure_errx("length 0x%jx (expected 0x%jx)", v,
 		    (uintmax_t)length);
 
 	/* Offset. */
-	v = cheri_getoffset(cidcap);
+	v = cheri_offset_get(cidcap);
 	if (v != offset)
 		cheribsdtest_failure_errx("offset %jx (expected %jx)", v,
 		    (uintmax_t)offset);
 
 	/* Type -- should have unsealed type. */
-	v = cheri_gettype(cidcap);
+	v = cheri_type_get(cidcap);
 	if (v != (u_register_t)CHERI_OTYPE_UNSEALED)
 		cheribsdtest_failure_errx("otype %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_OTYPE_UNSEALED);
 
 	/* Permissions. */
-	v = cheri_getperm(cidcap);
+	v = cheri_perms_get(cidcap);
 	if (v != CHERI_COMPARTMENT_ID_USERSPACE_PERMS)
 		cheribsdtest_failure_errx("perms %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_COMPARTMENT_ID_USERSPACE_PERMS);
 
 	/* Sealed bit. */
-	v = cheri_getsealed(cidcap);
+	v = cheri_is_sealed(cidcap);
 	if (v != 0)
 		cheribsdtest_failure_errx("sealed %jx (expected 0)", v);
 
 	/* Tag bit. */
-	v = cheri_gettag(cidcap);
+	v = cheri_tag_get(cidcap);
 	if (v != 1)
 		cheribsdtest_failure_errx("tag %jx (expected 1)", v);
 }

--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -42,9 +42,6 @@
 #include <machine/frame.h>
 #include <machine/trap.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -127,10 +127,10 @@ CHERIBSDTEST(illegal_perm_seal,
 	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
 	    NULL, 0) < 0)
 		cheribsdtest_failure_err("sysctlbyname(security.cheri.sealcap)");
-	sealcap = cheri_andperm(sealcap, ~CHERI_PERM_SEAL);
+	sealcap = cheri_perms_and(sealcap, ~CHERI_PERM_SEAL);
 	sealed = cheri_seal(ip, sealcap);
 	/* cheri_seal() should tag-clear on failure on all architectures. */
-	if (!cheri_gettag(sealed)) {
+	if (!cheri_tag_get(sealed)) {
 #if CHERI_SEAL_VIOLATION_EXCEPTION
 		/*
 		 * For the transition period from trapping to tag-clearing
@@ -183,13 +183,13 @@ CHERIBSDTEST(illegal_perm_unseal,
 	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size,
 	    NULL, 0) < 0)
 		cheribsdtest_failure_err("sysctlbyname(security.cheri.sealcap)");
-	if ((cheri_getperm(sealcap) & CHERI_PERM_SEAL) == 0)
+	if ((cheri_perms_get(sealcap) & CHERI_PERM_SEAL) == 0)
 		cheribsdtest_failure_errx("unexpected !seal perm on sealcap");
 	sealed = cheri_seal(ip, sealcap);
-	sealcap = cheri_andperm(sealcap, ~CHERI_PERM_UNSEAL);
+	sealcap = cheri_perms_and(sealcap, ~CHERI_PERM_UNSEAL);
 	unsealed = cheri_unseal(sealed, sealcap);
 	/* cheri_unseal() should tag-clear on failure on all architectures. */
-	if (!cheri_gettag(unsealed)) {
+	if (!cheri_tag_get(unsealed)) {
 #if CHERI_SEAL_VIOLATION_EXCEPTION
 		/*
 		 * For the transition period from trapping to tag-clearing
@@ -214,7 +214,7 @@ CHERIBSDTEST(fault_tag, "Store via untagged capability",
 	char ch;
 	char * __capability chp = cheri_ptr(&ch, sizeof(ch));
 
-	chp = cheri_cleartag(chp);
+	chp = cheri_tag_clear(chp);
 	*chp = '\0';
 }
 

--- a/bin/cheribsdtest/cheribsdtest_flag_captured.c
+++ b/bin/cheribsdtest/cheribsdtest_flag_captured.c
@@ -115,6 +115,6 @@ CHERIBSDTEST(flag_captured_empty,
 {
 	char buf[] = "";
 
-	call_flag_captured(cheri_setbounds(buf, 0), CORRECT_KEY);
+	call_flag_captured(cheri_bounds_set(buf, 0), CORRECT_KEY);
 }
 #endif

--- a/bin/cheribsdtest/cheribsdtest_fs.c
+++ b/bin/cheribsdtest/cheribsdtest_fs.c
@@ -81,7 +81,7 @@ CHERIBSDTEST(tmpfs_rw_nocaps,
 
 	/* Just some pointer */
 	c = &fd;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(c) != 0, "tag set on source");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(c) != 0, "tag set on source");
 
 	rv = CHERIBSDTEST_CHECK_SYSCALL(pwrite(fd, &c, sizeof(c), 0));
 	CHERIBSDTEST_CHECK_EQ_SIZE(rv, sizeof(c));
@@ -89,8 +89,8 @@ CHERIBSDTEST(tmpfs_rw_nocaps,
 	rv = CHERIBSDTEST_CHECK_SYSCALL(pread(fd, &d, sizeof(d), 0));
 	CHERIBSDTEST_CHECK_EQ_SIZE(rv, sizeof(d));
 
-	CHERIBSDTEST_VERIFY2(cheri_gettag(d) == 0, "tag read");
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(c), d),
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(d) == 0, "tag read");
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(cheri_tag_clear(c), d),
 	    "untagged value not read");
 
 	CHERIBSDTEST_CHECK_SYSCALL(close(fd));

--- a/bin/cheribsdtest/cheribsdtest_fs.c
+++ b/bin/cheribsdtest/cheribsdtest_fs.c
@@ -37,8 +37,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <cheri/cheric.h>
-
 #include "cheribsdtest.h"
 
 static const char *

--- a/bin/cheribsdtest/cheribsdtest_ipc.c
+++ b/bin/cheribsdtest/cheribsdtest_ipc.c
@@ -39,9 +39,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <netinet/in.h>
 
 #include <err.h>

--- a/bin/cheribsdtest/cheribsdtest_ipc.c
+++ b/bin/cheribsdtest/cheribsdtest_ipc.c
@@ -102,7 +102,7 @@ CHERIBSDTEST(ipc_pipe_nocaps,
 	buffer = calloc(1, len);
 	buffer2 = calloc(1, len);
 	buffer[0] = (__cheri_tocap void * __capability)buffer;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(buffer[0]) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(buffer[0]) != 0,
 	    "pretest: tag missing");
 
 	CHERIBSDTEST_CHECK_SYSCALL(pipe(fds));
@@ -111,11 +111,11 @@ CHERIBSDTEST(ipc_pipe_nocaps,
 	rv = CHERIBSDTEST_CHECK_SYSCALL(read(fds[0], buffer2, len));
 	CHERIBSDTEST_CHECK_EQ_SIZE(rv, len);
 
-	CHERIBSDTEST_VERIFY2(cheri_gettag(buffer[0]) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(buffer[0]) != 0,
 	    "posttest: source tag missing");
-	CHERIBSDTEST_VERIFY2(cheri_gettag(buffer2[0]) == 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(buffer2[0]) == 0,
 	    "posttest: destination tag present");
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(buffer[0]),
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(cheri_tag_clear(buffer[0]),
 	     buffer2[0]), "untagged value not copied");
 
 	CHERIBSDTEST_CHECK_SYSCALL(close(fds[0]));

--- a/bin/cheribsdtest/cheribsdtest_lazy_bind.c
+++ b/bin/cheribsdtest/cheribsdtest_lazy_bind.c
@@ -25,9 +25,6 @@
 
 #include <sys/types.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <err.h>
 
 #include <cheribsdtest_dynamic.h>

--- a/bin/cheribsdtest/cheribsdtest_local_global.c
+++ b/bin/cheribsdtest/cheribsdtest_local_global.c
@@ -64,7 +64,7 @@ CHERIBSDTEST(store_local_allowed,
 	    strcmp(STR_VAL, (__cheri_fromcap char *)target) == 0);
 
 	/* Make cap local */
-	cap = cheri_andperm(cap, ~CHERI_PERM_GLOBAL);
+	cap = cheri_perms_and(cap, ~CHERI_PERM_GLOBAL);
 
 	/* Store local cap through cap with store-local permission */
 	*targetp = cap;
@@ -92,10 +92,10 @@ CHERIBSDTEST(store_local_disallowed,
 	    strcmp(STR_VAL, (__cheri_fromcap char *)target) == 0);
 
 	/* Make cap local */
-	cap = cheri_andperm(cap, ~CHERI_PERM_GLOBAL);
+	cap = cheri_perms_and(cap, ~CHERI_PERM_GLOBAL);
 
 	/* Store local cap through cap without store-local permission */
-	targetp = cheri_andperm(targetp, ~CHERI_PERM_STORE_LOCAL_CAP);
+	targetp = cheri_perms_and(targetp, ~CHERI_PERM_STORE_LOCAL_CAP);
 	/* This should fault */
 	*targetp = cap;
 

--- a/bin/cheribsdtest/cheribsdtest_local_global.c
+++ b/bin/cheribsdtest/cheribsdtest_local_global.c
@@ -38,9 +38,6 @@
 
 #include <sys/param.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/bin/cheribsdtest/cheribsdtest_malloc.c
+++ b/bin/cheribsdtest/cheribsdtest_malloc.c
@@ -86,9 +86,9 @@ CHERIBSDTEST(malloc_revoke_basic,
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	malloc_revoke();
 #pragma GCC diagnostic pop
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(ptr),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(ptr),
 	    "revoked ptr not revoked %#lp", ptr);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(eptr),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(eptr),
 	    "revoked eptr not revoked %#lp", eptr);
 
 	cheribsdtest_success();
@@ -110,9 +110,9 @@ CHERIBSDTEST(malloc_revoke_quarantine_force_flush_basic,
 
 	CHERIBSDTEST_VERIFY2((ret = malloc_revoke_quarantine_force_flush()) == 0,
 	    "malloc_revoke_quarantine_force_flush returned %d", ret);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(ptr),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(ptr),
 	    "revoked ptr not revoked %#lp", ptr);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(eptr),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(eptr),
 	    "revoked eptr not revoked %#lp", eptr);
 
 	cheribsdtest_success();
@@ -138,18 +138,18 @@ CHERIBSDTEST(malloc_revoke_quarantine_force_flush_twice,
 
 	CHERIBSDTEST_VERIFY2((ret = malloc_revoke_quarantine_force_flush()) == 0,
 	    "malloc_revoke_quarantine_force_flush returned %d", ret);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(ptr1),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(ptr1),
 	    "revoked ptr1 not revoked %#lp", ptr1);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(eptr1),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(eptr1),
 	    "revoked eptr1 not revoked %#lp", eptr1);
 
 	free(__DEVOLATILE(void *, ptr2));
 
 	CHERIBSDTEST_VERIFY2((ret = malloc_revoke_quarantine_force_flush()) == 0,
 	    "malloc_revoke_quarantine_force_flush returned %d", ret);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(ptr2),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(ptr2),
 	    "revoked ptr2 not revoked %#lp", ptr2);
-	CHERIBSDTEST_VERIFY2(!cheri_gettag(eptr2),
+	CHERIBSDTEST_VERIFY2(!cheri_tag_get(eptr2),
 	    "revoked eptr2 not revoked %#lp", eptr2);
 
 	cheribsdtest_success();

--- a/bin/cheribsdtest/cheribsdtest_printf.c
+++ b/bin/cheribsdtest/cheribsdtest_printf.c
@@ -36,9 +36,6 @@
 #error "This code requires a CHERI-aware compiler"
 #endif
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/bin/cheribsdtest/cheribsdtest_printf.c
+++ b/bin/cheribsdtest/cheribsdtest_printf.c
@@ -67,38 +67,38 @@ test_printf_cap_one(void * __capability p, int expected_tokens,
 		cheribsdtest_failure_errx("Mismatched tokens for %s, "
 		    "expected %d got %d", descr, expected_tokens, tokens);
 
-	if (addr != cheri_getaddress(p))
+	if (addr != cheri_address_get(p))
 		cheribsdtest_failure_errx("Mismatched address for %s", descr);
 
 	if (tokens == 1)
 		return;
 
 	permsp = perms;
-	if ((cheri_getperm(p) & CHERI_PERM_LOAD) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_LOAD) != 0) {
 		if (*permsp != 'r')
 			cheribsdtest_failure_errx("Missing 'r' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_STORE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_STORE) != 0) {
 		if (*permsp != 'w')
 			cheribsdtest_failure_errx("Missing 'w' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_EXECUTE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_EXECUTE) != 0) {
 		if (*permsp != 'x')
 			cheribsdtest_failure_errx("Missing 'x' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_LOAD) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_LOAD) != 0) {
 		if (*permsp != 'R')
 			cheribsdtest_failure_errx("Missing 'R' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_STORE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_STORE) != 0) {
 		if (*permsp != 'W')
 			cheribsdtest_failure_errx("Missing 'W' permission for %s",
 			    descr);
@@ -108,15 +108,15 @@ test_printf_cap_one(void * __capability p, int expected_tokens,
 		cheribsdtest_failure_errx("Extra permissions '%s' for %s", permsp,
 		    descr);
 
-	if (base != cheri_getbase(p))
+	if (base != cheri_base_get(p))
 		cheribsdtest_failure_errx("Mismatched base for %s", descr);
-	if (top != cheri_getbase(p) + cheri_getlength(p))
+	if (top != cheri_base_get(p) + cheri_length_get(p))
 		cheribsdtest_failure_errx("Mismatched top for %s", descr);
 
 	if (tokens == 4)
 		return;
 
-	if (cheri_gettag(p)) {
+	if (cheri_tag_get(p)) {
 		if (strstr(attr, "invalid") != NULL)
 			cheribsdtest_failure_errx("Tagged cap marked invalid "
 			    "for %s", descr);
@@ -126,7 +126,7 @@ test_printf_cap_one(void * __capability p, int expected_tokens,
 			    "invalid for %s", descr);
 	}
 
-	switch (cheri_gettype(p)) {
+	switch (cheri_type_get(p)) {
 	case CHERI_OTYPE_UNSEALED:
 		if (strstr(attr, "sealed") != NULL)
 			cheribsdtest_failure_errx("Unsealed cap marked as "
@@ -198,7 +198,7 @@ CHERIBSDTEST(printf_cap, "Various checks of %#p")
 
 	test_printf_cap_one(datap, 4, "stack array");
 
-	test_printf_cap_one(cheri_cleartag(datap), 5, "untagged stack array");
+	test_printf_cap_one(cheri_tag_clear(datap), 5, "untagged stack array");
 
 	cheribsdtest_success();
 }

--- a/bin/cheribsdtest/cheribsdtest_ptrace.c
+++ b/bin/cheribsdtest/cheribsdtest_ptrace.c
@@ -44,8 +44,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <cheri/cheric.h>
-
 #include "cheribsdtest.h"
 
 /*

--- a/bin/cheribsdtest/cheribsdtest_ptrace.c
+++ b/bin/cheribsdtest/cheribsdtest_ptrace.c
@@ -103,8 +103,8 @@ CHERIBSDTEST(ptrace_readcap, "Basic tests of PIOD_READ_CHERI_CAP")
 	pp[0] = (uintcap_t)(__cheri_tocap void * __capability)&piod;
 	pp[1] = 42;
 
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[0]) != 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[1]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[0]) != 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[1]) == 0);
 
 	pid = fork_child();
 
@@ -118,12 +118,12 @@ CHERIBSDTEST(ptrace_readcap, "Basic tests of PIOD_READ_CHERI_CAP")
 	CHERIBSDTEST_VERIFY2(capbuf[0][0] == 1,
 	    "Tag not set in returned buffer");
 	memcpy(&cap, &capbuf[0][1], sizeof(cap));
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(pp[0]), cap),
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(cheri_tag_clear(pp[0]), cap),
 	    "Mismatch in non-tag bits of first capability");
 	CHERIBSDTEST_VERIFY2(capbuf[1][0] == 0,
 	    "Tag set in returned buffer");
 	memcpy(&cap, &capbuf[1][1], sizeof(cap));
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(pp[1], cap),
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(pp[1], cap),
 	    "Mismatch in non-tag bits of second capability");
 
 	finish_child(pid);
@@ -145,14 +145,14 @@ CHERIBSDTEST(ptrace_readtags, "Basic test of PIOD_READ_CHERI_TAGS")
 	pp[0] = (uintcap_t)(__cheri_tocap void * __capability)&piod;
 	pp[2] = (uintcap_t)(__cheri_tocap void * __capability)tagbuf;
 
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[0]) != 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[1]) == 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[2]) != 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[3]) == 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[4]) == 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[5]) == 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[6]) == 0);
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[7]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[0]) != 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[1]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[2]) != 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[3]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[4]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[5]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[6]) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[7]) == 0);
 
 	pid = fork_child();
 
@@ -186,7 +186,7 @@ CHERIBSDTEST(ptrace_readcap_pageend,
 	last_index = (page_size / sizeof(uintcap_t)) - 1;
 	pp[last_index] = (uintcap_t)(__cheri_tocap void * __capability)&piod;
 
-	CHERIBSDTEST_VERIFY(cheri_gettag(pp[last_index]) != 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(pp[last_index]) != 0);
 
 	pid = fork_child();
 
@@ -200,8 +200,9 @@ CHERIBSDTEST(ptrace_readcap_pageend,
 	CHERIBSDTEST_VERIFY2(capbuf[0] == 1,
 	    "Tag not set in returned buffer");
 	memcpy(&cap, &capbuf[1], sizeof(cap));
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(pp[last_index]),
-	    cap), "Mismatch in non-tag bits of first capability");
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(
+	    cheri_tag_clear(pp[last_index]), cap),
+	    "Mismatch in non-tag bits of first capability");
 
 	finish_child(pid);
 
@@ -246,13 +247,14 @@ CHERIBSDTEST(ptrace_writecap, "Basic tests of PIOD_WRITE_CHERI_CAP")
 
 	CHERIBSDTEST_VERIFY(piod.piod_len == sizeof(capbuf));
 
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map[0]) == 1,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map[0]) == 1,
 	    "Tag not set in first injected capability");
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(map[0]), pp[0]),
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(
+	    cheri_tag_clear(map[0]), pp[0]),
 	    "Mismatch in non-tag bits of first capability");
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map[1]) == 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map[1]) == 0,
 	    "Tag set in second injected capability");
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(map[1], pp[1]),
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(map[1], pp[1]),
 	    "Mismatch in non-tag bits of second capability");
 
 	finish_child(pid);

--- a/bin/cheribsdtest/cheribsdtest_registers.c
+++ b/bin/cheribsdtest/cheribsdtest_registers.c
@@ -47,7 +47,6 @@
 #include <machine/pte.h>
 #include <machine/vmparam.h>
 
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #include <err.h>

--- a/bin/cheribsdtest/cheribsdtest_sealcap.c
+++ b/bin/cheribsdtest/cheribsdtest_sealcap.c
@@ -53,31 +53,31 @@ CHERIBSDTEST(sealcap_sysctl, "Retrieve sealcap using sysctl(3)")
 	sealcap = get_sealcap();
 
 	/* Base. */
-	v = cheri_getbase(sealcap);
+	v = cheri_base_get(sealcap);
 	if (v != CHERI_SEALCAP_USERSPACE_BASE)
 		cheribsdtest_failure_errx("base %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_SEALCAP_USERSPACE_BASE);
 
 	/* Length. */
-	v = cheri_getlen(sealcap);
+	v = cheri_length_get(sealcap);
 	if (v != CHERI_SEALCAP_USERSPACE_LENGTH)
 		cheribsdtest_failure_errx("length 0x%jx (expected 0x%jx)", v,
 		    (uintmax_t)CHERI_SEALCAP_USERSPACE_LENGTH);
 
 	/* Offset. */
-	v = cheri_getoffset(sealcap);
+	v = cheri_offset_get(sealcap);
 	if (v != CHERI_SEALCAP_USERSPACE_OFFSET)
 		cheribsdtest_failure_errx("offset %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_SEALCAP_USERSPACE_OFFSET);
 
 	/* Type -- should have unsealed type. */
-	v = cheri_gettype(sealcap);
+	v = cheri_type_get(sealcap);
 	if (v != (u_register_t)CHERI_OTYPE_UNSEALED)
 		cheribsdtest_failure_errx("otype %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_OTYPE_UNSEALED);
 
 	/* Permissions. */
-	v = cheri_getperm(sealcap);
+	v = cheri_perms_get(sealcap);
 	if (v != CHERI_SEALCAP_USERSPACE_PERMS)
 		cheribsdtest_failure_errx("perms %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_SEALCAP_USERSPACE_PERMS);
@@ -132,12 +132,12 @@ CHERIBSDTEST(sealcap_sysctl, "Retrieve sealcap using sysctl(3)")
 		cheribsdtest_failure_errx("perms %jx (swperms present)", v);
 
 	/* Sealed bit. */
-	v = cheri_getsealed(sealcap);
+	v = cheri_is_sealed(sealcap);
 	if (v != 0)
 		cheribsdtest_failure_errx("sealed %jx (expected 0)", v);
 
 	/* Tag bit. */
-	v = cheri_gettag(sealcap);
+	v = cheri_tag_get(sealcap);
 	if (v != 1)
 		cheribsdtest_failure_errx("tag %jx (expected 1)", v);
 	cheribsdtest_success();
@@ -158,44 +158,44 @@ CHERIBSDTEST(sealcap_seal, "Use sealcap to seal a capability")
 	sealed = cheri_seal(sealdatap, sealcap);
 
 	/* Base. */
-	v = cheri_getbase(sealed);
-	if (v != cheri_getbase(sealdatap))
+	v = cheri_base_get(sealed);
+	if (v != cheri_base_get(sealdatap))
 		cheribsdtest_failure_errx("base %jx (expected %jx)", v,
-		    (uintmax_t)cheri_getbase(sealdatap));
+		    (uintmax_t)cheri_base_get(sealdatap));
 
 	/* Length. */
-	v = cheri_getlen(sealed);
-	if (v != cheri_getlen(sealdatap))
+	v = cheri_length_get(sealed);
+	if (v != cheri_length_get(sealdatap))
 		cheribsdtest_failure_errx("length 0x%jx (expected 0x%jx)", v,
-		    (uintmax_t)cheri_getlen(sealdatap));
+		    (uintmax_t)cheri_length_get(sealdatap));
 
 	/* Offset. */
-	v = cheri_getoffset(sealed);
-	if (v != cheri_getoffset(sealdatap))
+	v = cheri_offset_get(sealed);
+	if (v != cheri_offset_get(sealdatap))
 		cheribsdtest_failure_errx("offset %jx (expected %jx)", v,
-		    (uintmax_t)cheri_getoffset(sealdatap));
+		    (uintmax_t)cheri_offset_get(sealdatap));
 
 	/* Type. */
-	v = cheri_gettype(sealed);
-	if (v != cheri_getaddress(sealcap))
+	v = cheri_type_get(sealed);
+	if (v != cheri_address_get(sealcap))
 		cheribsdtest_failure_errx("otype %jx (expected %jx)", v,
-		    (uintmax_t)cheri_getaddress(sealcap));
+		    (uintmax_t)cheri_address_get(sealcap));
 
 	/* Sealed bit. */
-	v = cheri_getsealed(sealed);
+	v = cheri_is_sealed(sealed);
 	if (v != 1)
 		cheribsdtest_failure_errx("sealed %jx (expected 0)", v);
 
 	/* Tag bit. */
-	v = cheri_gettag(sealed);
+	v = cheri_tag_get(sealed);
 	if (v != 1)
 		cheribsdtest_failure_errx("tag %jx (expected 1)", v);
 
 	/* Permissions. */
-	v = cheri_getperm(sealed);
-	if (v != cheri_getperm(sealdatap))
+	v = cheri_perms_get(sealed);
+	if (v != cheri_perms_get(sealdatap))
 		cheribsdtest_failure_errx("perms %jx (expected %jx)", v,
-		    cheri_getperm(sealdatap));
+		    (uintmax_t)cheri_perms_get(sealdatap));
 
 	cheribsdtest_success();
 }
@@ -216,44 +216,44 @@ CHERIBSDTEST(sealcap_seal_unseal,
 	unsealed = cheri_unseal(sealed, sealcap);
 
 	/* Base. */
-	v = cheri_getbase(unsealed);
-	if (v != cheri_getbase(sealdatap))
+	v = cheri_base_get(unsealed);
+	if (v != cheri_base_get(sealdatap))
 		cheribsdtest_failure_errx("base %jx (expected %jx)", v,
-		    (uintmax_t)cheri_getbase(sealdatap));
+		    (uintmax_t)cheri_base_get(sealdatap));
 
 	/* Length. */
-	v = cheri_getlen(unsealed);
-	if (v != cheri_getlen(sealdatap))
+	v = cheri_length_get(unsealed);
+	if (v != cheri_length_get(sealdatap))
 		cheribsdtest_failure_errx("length 0x%jx (expected 0x%jx)", v,
-		    (uintmax_t)cheri_getlen(sealdatap));
+		    (uintmax_t)cheri_length_get(sealdatap));
 
 	/* Offset. */
-	v = cheri_getoffset(unsealed);
-	if (v != cheri_getoffset(sealdatap))
+	v = cheri_offset_get(unsealed);
+	if (v != cheri_offset_get(sealdatap))
 		cheribsdtest_failure_errx("offset %jx (expected %jx)", v,
-		    (uintmax_t)cheri_getoffset(sealdatap));
+		    (uintmax_t)cheri_offset_get(sealdatap));
 
 	/* Type -- should have unsealed type. */
-	v = cheri_gettype(unsealed);
+	v = cheri_type_get(unsealed);
 	if (v != (u_register_t)CHERI_OTYPE_UNSEALED)
 		cheribsdtest_failure_errx("otype %jx (expected %jx)", v,
 		    (uintmax_t)CHERI_OTYPE_UNSEALED);
 
 	/* Sealed bit. */
-	v = cheri_getsealed(unsealed);
+	v = cheri_is_sealed(unsealed);
 	if (v != 0)
 		cheribsdtest_failure_errx("sealed %jx (expected 0)", v);
 
 	/* Tag bit. */
-	v = cheri_gettag(unsealed);
+	v = cheri_tag_get(unsealed);
 	if (v != 1)
 		cheribsdtest_failure_errx("tag %jx (expected 1)", v);
 
 	/* Permissions. */
-	v = cheri_getperm(unsealed);
-	if (v != cheri_getperm(sealdatap))
+	v = cheri_perms_get(unsealed);
+	if (v != cheri_perms_get(sealdatap))
 		cheribsdtest_failure_errx("perms %jx (expected %jx)", v,
-		    cheri_getperm(sealdatap));
+		    (uintmax_t)cheri_perms_get(sealdatap));
 
 	cheribsdtest_success();
 }

--- a/bin/cheribsdtest/cheribsdtest_sentries.c
+++ b/bin/cheribsdtest/cheribsdtest_sentries.c
@@ -51,9 +51,9 @@ check_fptr(uintptr_t fptr)
 {
 	register_t perms;
 
-	perms = cheri_getperm((void *)fptr);
+	perms = cheri_perms_get((void *)fptr);
 
-	CHERIBSDTEST_VERIFY(cheri_gettag((void *)fptr));
+	CHERIBSDTEST_VERIFY(cheri_tag_get((void *)fptr));
 	/* Check that execute is present and store permissions aren't */
 	CHERIBSDTEST_VERIFY2((perms & CHERI_PERM_EXECUTE) == CHERI_PERM_EXECUTE,
 	    "perms %jx (execute missing)", (uintmax_t)perms);
@@ -64,8 +64,8 @@ check_fptr(uintptr_t fptr)
 	CHERIBSDTEST_VERIFY2((perms & CHERI_PERM_STORE_LOCAL_CAP) == 0,
 	    "perms %jx (store_local_cap present)", (uintmax_t)perms);
 
-	CHERIBSDTEST_VERIFY2(cheri_gettype((void *)fptr) == CHERI_OTYPE_SENTRY,
-	    "otype %jx (expected %jx)", cheri_gettype((void *)fptr),
+	CHERIBSDTEST_VERIFY2(cheri_type_get((void *)fptr) == CHERI_OTYPE_SENTRY,
+	    "otype %jx (expected %jx)", cheri_type_get((void *)fptr),
 	    (uintmax_t)CHERI_OTYPE_SENTRY);
 
 	cheribsdtest_success();

--- a/bin/cheribsdtest/cheribsdtest_signal.c
+++ b/bin/cheribsdtest/cheribsdtest_signal.c
@@ -262,7 +262,7 @@ CHERIBSDTEST(signal_returncap,
 		                       strerror(errno));
 
 	/* Length. */
-	v = cheri_getlen(handler_returncap);
+	v = cheri_length_get(handler_returncap);
 #ifdef __ARM_MORELLO_PURECAP_BENCHMARK_ABI
 	/* The purecap benchmark ABI does not bound PCC capabilities. */
 	expect = CHERI_CAP_USER_CODE_LENGTH;
@@ -277,18 +277,18 @@ CHERIBSDTEST(signal_returncap,
 	    v, expect);
 
 	/* Type -- should be a sentry capability. */
-	v = cheri_gettype(handler_returncap);
+	v = cheri_type_get(handler_returncap);
 	CHERIBSDTEST_VERIFY2(v == (uintmax_t)CHERI_OTYPE_SENTRY,
 	    "otype %jx (expected %jx)", v, (uintmax_t)CHERI_OTYPE_SENTRY);
 
 	/* Sealed bit. */
-	CHERIBSDTEST_VERIFY(cheri_getsealed(handler_returncap));
+	CHERIBSDTEST_VERIFY(cheri_is_sealed(handler_returncap));
 
 	/* Tag bit. */
-	CHERIBSDTEST_VERIFY(cheri_gettag(handler_returncap));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(handler_returncap));
 
 	/* Permissions -- should have execute but no store permissions. */
-	v = cheri_getperm(handler_returncap);
+	v = cheri_perms_get(handler_returncap);
 	CHERIBSDTEST_VERIFY2((v & CHERI_PERM_EXECUTE) == CHERI_PERM_EXECUTE,
 	    "perms %jx (execute missing)", v);
 	CHERIBSDTEST_VERIFY2((v & CHERI_PERM_STORE) == 0,

--- a/bin/cheribsdtest/cheribsdtest_signal.c
+++ b/bin/cheribsdtest/cheribsdtest_signal.c
@@ -38,8 +38,6 @@
 
 #include <machine/vmparam.h>
 
-#include <cheri/cheri.h>
-
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>

--- a/bin/cheribsdtest/cheribsdtest_strfcap.c
+++ b/bin/cheribsdtest/cheribsdtest_strfcap.c
@@ -38,7 +38,6 @@
 
 #include <sys/param.h>
 
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #include <assert.h>

--- a/bin/cheribsdtest/cheribsdtest_strfcap.c
+++ b/bin/cheribsdtest/cheribsdtest_strfcap.c
@@ -68,45 +68,45 @@ test_strfcap_C_cap_one(void * __capability p, int expected_tokens,
 		cheribsdtest_failure_errx("Mismatched tokens for %s, "
 		    "expected %d got %d", descr, expected_tokens, tokens);
 
-	if (addr != cheri_getaddress(p))
+	if (addr != cheri_address_get(p))
 		cheribsdtest_failure_errx("Mismatched address for %s", descr);
 
 	if (tokens == 1)
 		return;
 
 	permsp = perms;
-	if ((cheri_getperm(p) & CHERI_PERM_LOAD) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_LOAD) != 0) {
 		if (*permsp != 'r')
 			cheribsdtest_failure_errx("Missing 'r' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_STORE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_STORE) != 0) {
 		if (*permsp != 'w')
 			cheribsdtest_failure_errx("Missing 'w' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_EXECUTE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_EXECUTE) != 0) {
 		if (*permsp != 'x')
 			cheribsdtest_failure_errx("Missing 'x' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_LOAD) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_LOAD) != 0) {
 		if (*permsp != 'R')
 			cheribsdtest_failure_errx("Missing 'R' permission for %s",
 			    descr);
 		permsp++;
 	}
-	if ((cheri_getperm(p) & CHERI_PERM_STORE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_STORE) != 0) {
 		if (*permsp != 'W')
 			cheribsdtest_failure_errx("Missing 'W' permission for %s",
 			    descr);
 		permsp++;
 	}
 #ifdef __aarch64__
-	if ((cheri_getperm(p) & CHERI_PERM_EXECUTIVE) != 0) {
+	if ((cheri_perms_get(p) & CHERI_PERM_EXECUTIVE) != 0) {
 		if (*permsp != 'E')
 			cheribsdtest_failure_errx("Missing 'E' permission for %s",
 			    descr);
@@ -117,15 +117,15 @@ test_strfcap_C_cap_one(void * __capability p, int expected_tokens,
 		cheribsdtest_failure_errx("Extra permissions '%s' for %s", permsp,
 		    descr);
 
-	if (base != cheri_getbase(p))
+	if (base != cheri_base_get(p))
 		cheribsdtest_failure_errx("Mismatched base for %s", descr);
-	if (top != cheri_getbase(p) + cheri_getlength(p))
+	if (top != cheri_base_get(p) + cheri_length_get(p))
 		cheribsdtest_failure_errx("Mismatched top for %s", descr);
 
 	if (tokens == 4)
 		return;
 
-	if (cheri_gettag(p)) {
+	if (cheri_tag_get(p)) {
 		if (strstr(attr, "invalid") != NULL)
 			cheribsdtest_failure_errx("Tagged cap marked invalid "
 			    "for %s", descr);
@@ -135,7 +135,7 @@ test_strfcap_C_cap_one(void * __capability p, int expected_tokens,
 			    "invalid for %s", descr);
 	}
 
-	switch (cheri_gettype(p)) {
+	switch (cheri_type_get(p)) {
 	case CHERI_OTYPE_UNSEALED:
 		if (strstr(attr, "sealed") != NULL)
 			cheribsdtest_failure_errx("Unsealed cap marked as "
@@ -163,8 +163,8 @@ test_strfcap_C_cap_one(void * __capability p, int expected_tokens,
 	}
 
 #ifdef CHERI_FLAGS_CAP_MODE
-	if ((cheri_getperm(p) & CHERI_PERM_EXECUTE) != 0 &&
-	    cheri_getflags(p) == CHERI_FLAGS_CAP_MODE) {
+	if ((cheri_perms_get(p) & CHERI_PERM_EXECUTE) != 0 &&
+	    cheri_flags_get(p) == CHERI_FLAGS_CAP_MODE) {
 		if (strstr(attr, "capmode") == NULL)
 			cheribsdtest_failure_errx("Capability mode code cap "
 			    "not marked capmode for %s", descr);
@@ -216,15 +216,15 @@ test_strfcap_number_one_cap(uintcap_t cap, const char *cap_desc)
 			ret_s = strfcap(str_s, sizeof(str_s), format, cap);
 
 			switch (*scp) {
-			case 'a':	value = cheri_getaddress(cap); break;
-			case 'b':	value = cheri_getbase(cap); break;
-			case 'l':	value = cheri_getlength(cap); break;
-			case 'o':	value = cheri_getoffset(cap); break;
-			case 'p':	value = cheri_getperm(cap); break;
-			case 's':	value = cheri_gettype(cap); break;
-			case 'S':	value = cheri_gettype(cap); break;
-			case 't':	value = cheri_gettop(cap); break;
-			case 'v':	value = cheri_gettag(cap); break;
+			case 'a':	value = cheri_address_get(cap); break;
+			case 'b':	value = cheri_base_get(cap); break;
+			case 'l':	value = cheri_length_get(cap); break;
+			case 'o':	value = cheri_offset_get(cap); break;
+			case 'p':	value = cheri_perms_get(cap); break;
+			case 's':	value = cheri_type_get(cap); break;
+			case 'S':	value = cheri_type_get(cap); break;
+			case 't':	value = cheri_top_get(cap); break;
+			case 'v':	value = cheri_tag_get(cap); break;
 			default:
 				cheribsdtest_failure_errx("Internal error: "
 				    "unknown specifier %c", *scp);
@@ -276,7 +276,7 @@ CHERIBSDTEST(strfcap_numbers, "Checks of formats of a single number")
 
 	test_strfcap_number_one_cap((uintcap_t)foop, "stack array");
 
-	test_strfcap_number_one_cap((uintcap_t)cheri_cleartag(foop),
+	test_strfcap_number_one_cap((uintcap_t)cheri_tag_clear(foop),
 	    "stack array");
 
 	test_strfcap_number_one_cap(
@@ -294,12 +294,12 @@ CHERIBSDTEST(strfcap_T, "Check of tag in format")
 	char * __capability cap = (__cheri_tocap char * __capability)str_t;
 
 	strfcap(str_t, sizeof(str_t), "%C", (uintcap_t)cap);
-	strfcap(str_u, sizeof(str_u), "%C", (uintcap_t)cheri_cleartag(cap));
+	strfcap(str_u, sizeof(str_u), "%C", (uintcap_t)cheri_tag_clear(cap));
 	if (strcmp(str_t, str_u) == 0)
 		cheribsdtest_failure_errx("Tagged (%s) and untagged (%s) %%C "
 		    "formatted output is identical", str_t, str_u);
 
-	strfcap(str_u, sizeof(str_u), "%T%C", (uintcap_t)cheri_cleartag(cap));
+	strfcap(str_u, sizeof(str_u), "%T%C", (uintcap_t)cheri_tag_clear(cap));
 	if (strcmp(str_t, str_u) != 0)
 		cheribsdtest_failure_errx("Tagged (%s) and untagged (%s) "
 		    "differs when untagged formatted with %%T%%C",
@@ -332,7 +332,7 @@ CHERIBSDTEST(strfcap_textual, "Checks of %? and %%")
 		    fmt, str);
 
 	fmt = "%?12345%A";
-	strfcap(str, sizeof(str), fmt, (uintcap_t)cheri_cleartag(cap));
+	strfcap(str, sizeof(str), fmt, (uintcap_t)cheri_tag_clear(cap));
 	if (strncmp(str, "12345", 5) != 0)
 		cheribsdtest_failure_errx("(%s) of untagged cap did not "
 		    "include 12345 (%s)", fmt, str);
@@ -380,17 +380,17 @@ CHERIBSDTEST(strfcap_C, "Various checks of %C (%A and %P indirectly)")
 
 #ifdef CHERI_FLAGS_CAP_MODE
 #ifdef __CHERI_PURE_CAPABILITY__
-	pcc_alt = cheri_setflags(pcc_alt, 0);
+	pcc_alt = cheri_flags_set(pcc_alt, 0);
 	test_strfcap_C_cap_one(pcc_alt, 4, "non-capability mode PCC");
 #else
-	pcc_alt = cheri_setflags(pcc_alt, CHERI_FLAGS_CAP_MODE);
+	pcc_alt = cheri_flags_set(pcc_alt, CHERI_FLAGS_CAP_MODE);
 	test_strfcap_C_cap_one(pcc_alt, 5, "capability mode PCC");
 #endif
 #endif
 
 	test_strfcap_C_cap_one(datap, 4, "stack array");
 
-	test_strfcap_C_cap_one(cheri_cleartag(datap), 5, "untagged stack array");
+	test_strfcap_C_cap_one(cheri_tag_clear(datap), 5, "untagged stack array");
 
 	cheribsdtest_success();
 }

--- a/bin/cheribsdtest/cheribsdtest_string.c
+++ b/bin/cheribsdtest/cheribsdtest_string.c
@@ -37,9 +37,6 @@
 
 #include <sys/types.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <string.h>
 
 #include "cheribsdtest.h"

--- a/bin/cheribsdtest/cheribsdtest_string.c
+++ b/bin/cheribsdtest/cheribsdtest_string.c
@@ -87,7 +87,7 @@ check(struct Test *t1, int start, int end)
 	if (t1->y != expected_y)
 		cheribsdtest_failure_errx("(start = %d, end %d) t1->y != t1",
 		    start, end);
-	if (!cheri_gettag(t1->y))
+	if (!cheri_tag_get(t1->y))
 		cheribsdtest_failure_errx("(start = %d, end %d) t1->y is untagged",
 		     start, end);
 	for (i = 0 ; i < end ; i++)
@@ -159,7 +159,7 @@ CHERIBSDTEST(string_memcpy_c, "Test explicit capability memcpy")
 	if ((__cheri_fromcap void*)cpy != &t2)
 		cheribsdtest_failure_errx("memcpy_c did not return dst (&t2)");
 	/* This should have invalidated the capability */
-	if (cheri_gettag(t2.y) != 0)
+	if (cheri_tag_get(t2.y) != 0)
 		cheribsdtest_failure_errx("dst has capability after unaligned "
 		    "write");
 	for (i = 0; i < 31; i++) {
@@ -258,7 +258,7 @@ CHERIBSDTEST(string_memcpy, "Test implicit capability memcpy")
 	copy = memcpy(&t2, &t1.pad0[1], sizeof(t1) - 1);
 	if (copy != &t2)
 		cheribsdtest_failure_errx("copy != &t2");
-	if (cheri_gettag(t2.y) != 0)
+	if (cheri_tag_get(t2.y) != 0)
 		cheribsdtest_failure_errx("dst has capability after unaligned "
 		    "write");
 	for (i = 0; i < 31; i++) {
@@ -320,7 +320,7 @@ CHERIBSDTEST(string_memmove_c, "Test explicit capability memmove")
 	if ((__cheri_fromcap void*)cpy != &t2)
 		cheribsdtest_failure_errx("memmove_c did not return dst (&t2)");
 	/* This should have invalidated the capability */
-	if (cheri_gettag(t2.y) != 0)
+	if (cheri_tag_get(t2.y) != 0)
 		cheribsdtest_failure_errx("dst has capability after unaligned "
 		    "write");
 	for (i = 0; i < 31; i++) {
@@ -418,7 +418,7 @@ CHERIBSDTEST(string_memmove, "Test implicit capability memmove")
 	copy = memmove(&t2, &t1.pad0[1], sizeof(t1) - 1);
 	if (copy != &t2)
 		cheribsdtest_failure_errx("copy != &t2");
-	if (cheri_gettag(t2.y) != 0)
+	if (cheri_tag_get(t2.y) != 0)
 		cheribsdtest_failure_errx("dst has capability after unaligned "
 		    "write");
 	for (i = 0; i < 31; i++) {
@@ -451,22 +451,22 @@ CHERIBSDTEST(unaligned_capability_copy_memcpy,
 	CHERIBSDTEST_VERIFY(__builtin_is_aligned((void*)dest_buffer, sizeof(void* __capability)));
 	CHERIBSDTEST_VERIFY(__builtin_is_aligned((void*)src_buffer, sizeof(void * __capability)));
 
-	src_buffer[0] = cheri_setoffset(NULL, 0x1234);
-	src_buffer[1] = cheri_setoffset(NULL, 0x4321);
-	CHERIBSDTEST_VERIFY(!cheri_gettag(src_buffer[0]));
-	CHERIBSDTEST_VERIFY(!cheri_gettag(src_buffer[1]));
+	src_buffer[0] = cheri_offset_set(NULL, 0x1234);
+	src_buffer[1] = cheri_offset_set(NULL, 0x4321);
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(src_buffer[0]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(src_buffer[1]));
 	/* This should succeed */
 	cheribsdtest_memcpy(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
 	/* TODO: verify the contents of the buffer? */
 
 	/* Even if we have a valid cap and operate misaligned, we should not fault. */
 	src_buffer[1] = (__cheri_tocap void* __capability)&expected_y;
-	CHERIBSDTEST_VERIFY(!cheri_gettag(src_buffer[0]));
-	CHERIBSDTEST_VERIFY(cheri_gettag(src_buffer[1]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(src_buffer[0]));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(src_buffer[1]));
 
 	cheribsdtest_memcpy(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
-	CHERIBSDTEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[0]));
-	CHERIBSDTEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[1]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(((void * __capability *)dest_buffer)[0]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(((void * __capability *)dest_buffer)[1]));
 	/* TODO: verify the contents of the buffer? */
 
 	cheribsdtest_success();
@@ -485,22 +485,22 @@ CHERIBSDTEST(unaligned_capability_copy_memmove,
 	CHERIBSDTEST_VERIFY(__builtin_is_aligned((void*)dest_buffer, sizeof(void* __capability)));
 	CHERIBSDTEST_VERIFY(__builtin_is_aligned((void*)src_buffer, sizeof(void * __capability)));
 
-	src_buffer[0] = cheri_setoffset(NULL, 0x1234);
-	src_buffer[1] = cheri_setoffset(NULL, 0x4321);
-	CHERIBSDTEST_VERIFY(!cheri_gettag(src_buffer[0]));
-	CHERIBSDTEST_VERIFY(!cheri_gettag(src_buffer[1]));
+	src_buffer[0] = cheri_offset_set(NULL, 0x1234);
+	src_buffer[1] = cheri_offset_set(NULL, 0x4321);
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(src_buffer[0]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(src_buffer[1]));
 	/* This should succeed */
 	cheribsdtest_memmove(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
 	/* TODO: verify the contents of the buffer? */
 
 	/* Even if we have a valid cap and operate misaligned, we should not fault. */
 	src_buffer[1] = (__cheri_tocap void* __capability)&expected_y;
-	CHERIBSDTEST_VERIFY(!cheri_gettag(src_buffer[0]));
-	CHERIBSDTEST_VERIFY(cheri_gettag(src_buffer[1]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(src_buffer[0]));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(src_buffer[1]));
 
 	cheribsdtest_memmove(dest_buffer + 1 /* unaligned! */, src_buffer, sizeof(src_buffer));
-	CHERIBSDTEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[0]));
-	CHERIBSDTEST_VERIFY(!cheri_gettag(((void * __capability *)dest_buffer)[1]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(((void * __capability *)dest_buffer)[0]));
+	CHERIBSDTEST_VERIFY(!cheri_tag_get(((void * __capability *)dest_buffer)[1]));
 	/* TODO: verify the contents of the buffer? */
 
 	cheribsdtest_success();
@@ -544,7 +544,7 @@ CHERIBSDTEST(string_kern_memcpy_c,
 	if ((__cheri_fromcap void*)cpy != &t2)
 		cheribsdtest_failure_errx("kern_memcpy_c did not return dst (&t2)");
 	/* This should have invalidated the capability */
-	if (cheri_gettag(t2.y) != 0)
+	if (cheri_tag_get(t2.y) != 0)
 		cheribsdtest_failure_errx("dst has capability after unaligned "
 		    "write");
 	for (i = 0; i < 31; i++) {
@@ -632,7 +632,7 @@ CHERIBSDTEST(string_kern_memmove_c,
 	if ((__cheri_fromcap void*)cpy != &t2)
 		cheribsdtest_failure_errx("kern_memmove_c did not return dst (&t2)");
 	/* This should have invalidated the capability */
-	if (cheri_gettag(t2.y) != 0)
+	if (cheri_tag_get(t2.y) != 0)
 		cheribsdtest_failure_errx("dst has capability after unaligned "
 		    "write");
 	for (i = 0; i < 31; i++) {

--- a/bin/cheribsdtest/cheribsdtest_syscall.c
+++ b/bin/cheribsdtest/cheribsdtest_syscall.c
@@ -43,11 +43,6 @@
 #include <sys/time.h>
 #include <sys/ptrace.h>
 
-#include <machine/sysarch.h>
-
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include <assert.h>
 #include <err.h>
 #include <errno.h>

--- a/bin/cheribsdtest/cheribsdtest_tls.c
+++ b/bin/cheribsdtest/cheribsdtest_tls.c
@@ -36,8 +36,6 @@
 
 #include <sys/types.h>
 
-#include <cheri/cheri.h>
-
 #ifdef CHERIBSD_DYNAMIC_TESTS
 #include <cheribsdtest_dynamic.h>
 #include <dlfcn.h>

--- a/bin/cheribsdtest/cheribsdtest_tls_threads.c
+++ b/bin/cheribsdtest/cheribsdtest_tls_threads.c
@@ -36,8 +36,6 @@
 
 #include <sys/types.h>
 
-#include <cheri/cheri.h>
-
 #include <pthread.h>
 #include <string.h>
 

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -58,7 +58,6 @@
 #include <machine/trap.h>
 #include <machine/vmparam.h>
 
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #include <err.h>

--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -106,7 +106,7 @@ mmap_and_check_tag_stored(int fd, int protflags, int mapflags)
 	cp_value = cheri_ptr(&v, sizeof(v));
 	*cp = cp_value;
 	cp_value = *cp;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp_value) != 0, "tag lost");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp_value) != 0, "tag lost");
 	CHERIBSDTEST_CHECK_SYSCALL(munmap(__DEVOLATILE(void *, cp), getpagesize()));
 	if (fd != -1)
 		CHERIBSDTEST_CHECK_SYSCALL(close(fd));
@@ -228,14 +228,14 @@ CHERIBSDTEST(vm_tag_shm_open_anon_shared2x,
 
 	/* Verify that no capability present */
 	c2 = *map2;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(c2) == 0, "tag exists on first read");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(c2) == 0, "tag exists on first read");
 	CHERIBSDTEST_VERIFY2(c2 == NULL, "Initial read NULL");
 
 	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE, MAP_SHARED);
 
 	/* And now verify that it is, thanks to the aliased maps */
 	c2 = *map2;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(c2) != 0, "tag lost on second read");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(c2) != 0, "tag lost on second read");
 	CHERIBSDTEST_VERIFY2(c2 != NULL, "Second read not NULL");
 
 	cheribsdtest_success();
@@ -290,7 +290,7 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 		if (verbose)
 			fprintf(stderr, "rx cap: %#lp\n", c);
 
-		tag = cheri_gettag(c);
+		tag = cheri_tag_get(c);
 		CHERIBSDTEST_VERIFY2(tag == 0, "tag read");
 
 		CHERIBSDTEST_CHECK_SYSCALL(munmap(map, getpagesize()));
@@ -323,7 +323,7 @@ CHERIBSDTEST(vm_shm_open_anon_unix_surprise,
 		/* Just some pointer */
 		*map = &fd;
 		c = *map;
-		CHERIBSDTEST_VERIFY2(cheri_gettag(c) != 0, "tag written");
+		CHERIBSDTEST_VERIFY2(cheri_tag_get(c) != 0, "tag written");
 
 		if (verbose)
 			fprintf(stderr, "tx cap: %#lp\n", c);
@@ -374,13 +374,13 @@ CHERIBSDTEST(shm_open_read_nocaps,
 	/* Just some pointer */
 	*map = &fd;
 	c = *map;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(c) != 0, "tag written");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(c) != 0, "tag written");
 
 	rv = CHERIBSDTEST_CHECK_SYSCALL(read(fd, &c, sizeof(c)));
 	CHERIBSDTEST_CHECK_EQ_SIZE(rv, sizeof(c));
 
-	CHERIBSDTEST_VERIFY2(cheri_gettag(c) == 0, "tag read");
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(*map), c),
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(c) == 0, "tag read");
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(cheri_tag_clear(*map), c),
 	    "untagged value not read");
 
 	CHERIBSDTEST_CHECK_SYSCALL(close(fd));
@@ -403,13 +403,13 @@ CHERIBSDTEST(shm_open_write_nocaps,
 
 	/* Just some pointer */
 	c = &fd;
-	CHERIBSDTEST_VERIFY2(cheri_gettag(c) != 0, "tag set on source");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(c) != 0, "tag set on source");
 
 	rv = CHERIBSDTEST_CHECK_SYSCALL(write(fd, &c, sizeof(c)));
 	CHERIBSDTEST_CHECK_EQ_SIZE(rv, sizeof(c));
 
-	CHERIBSDTEST_VERIFY2(cheri_gettag(*map) == 0, "tag written");
-	CHERIBSDTEST_VERIFY2(cheri_equal_exact(cheri_cleartag(c), *map),
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(*map) == 0, "tag written");
+	CHERIBSDTEST_VERIFY2(cheri_is_equal_exact(cheri_tag_clear(c), *map),
 	    "untagged value not written");
 
 	CHERIBSDTEST_CHECK_SYSCALL(close(fd));
@@ -446,7 +446,7 @@ CHERIBSDTEST(vm_cap_share_fd_kqueue,
 		CHERIBSDTEST_VERIFY2(oke.ident == 0x2BAD, "Bad identifier from kqueue");
 		CHERIBSDTEST_VERIFY2(oke.filter == EVFILT_USER, "Bad filter from kqueue");
 
-		exit(cheri_gettag(oke.udata));
+		exit(cheri_tag_get(oke.udata));
 	} else {
 		int res;
 		struct kevent ike;
@@ -530,7 +530,7 @@ CHERIBSDTEST(vm_cap_share_sigaction,
 		/* Flags should be zero on read */
 		CHERIBSDTEST_CHECK_EQ_LONG(sa.sa_flags, 0);
 
-		if (cheri_gettag(sa.sa_handler)) {
+		if (cheri_tag_get(sa.sa_handler)) {
 			cheribsdtest_failure_errx("tag transfer");
 		} else {
 			cheribsdtest_success();
@@ -676,14 +676,14 @@ CHERIBSDTEST(vm_cow_read,
 	cp = cheri_ptr(&fd, sizeof(fd));
 	cp_real[0] = cp;
 	cp = cp_real[0];
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp) != 0, "pretest: tag missing");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp) != 0, "pretest: tag missing");
 
 	/*
 	 * Read in tagged capability via copy-on-write mapping.  Confirm it
 	 * has a tag.
 	 */
 	cp = cp_copy[0];
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp) != 0, "tag missing, cp_real");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp) != 0, "tag missing, cp_real");
 
 	/*
 	 * Clean up.
@@ -725,14 +725,14 @@ CHERIBSDTEST(vm_cow_write,
 	cp = cheri_ptr(&fd, sizeof(fd));
 	cp_real[0] = cp;
 	cp = cp_real[0];
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp) != 0, "pretest: tag missing");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp) != 0, "pretest: tag missing");
 
 	/*
 	 * Read in tagged capability via copy-on-write mapping.  Confirm it
 	 * has a tag.
 	 */
 	cp = cp_copy[0];
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp) != 0, "tag missing, cp_real");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp) != 0, "tag missing, cp_real");
 
 	/*
 	 * Diverge from cheribsdtest_vm_cow_read(): write via the second mapping
@@ -745,10 +745,10 @@ CHERIBSDTEST(vm_cow_write,
 	 * Confirm that the tag is still present on the 'real' page.
 	 */
 	cp = cp_real[0];
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp) != 0, "tag missing after COW, cp_real");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp) != 0, "tag missing after COW, cp_real");
 
 	cp = cp_copy[0];
-	CHERIBSDTEST_VERIFY2(cheri_gettag(cp) != 0, "tag missing after COW, cp_copy");
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(cp) != 0, "tag missing after COW, cp_copy");
 
 	/*
 	 * Clean up.
@@ -793,8 +793,8 @@ static void *test_bufferp = (void *)&test_buffer;
 CHERIBSDTEST(vm_sw_perm_on_capreloc,
 	     "Check that the SW_VMEM permission is not present on globals.")
 {
-	CHERIBSDTEST_VERIFY(cheri_gettag(test_bufferp));
-	CHERIBSDTEST_VERIFY((cheri_getperm(test_bufferp) & CHERI_PERM_SW_VMEM) == 0);
+	CHERIBSDTEST_VERIFY(cheri_tag_get(test_bufferp));
+	CHERIBSDTEST_VERIFY((cheri_perms_get(test_bufferp) & CHERI_PERM_SW_VMEM) == 0);
 
 	cheribsdtest_success();
 }
@@ -819,11 +819,11 @@ CHERIBSDTEST(vm_reservation_access_fault,
 	    "exceed one page, found %lx", len, expected_len);
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, len, PROT_READ | PROT_WRITE,
 	    MAP_ANON, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0, "mmap() failed to return "
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0, "mmap() failed to return "
 	    "a pointer when given unrepresentable length (%zu)", len);
-	CHERIBSDTEST_VERIFY2(cheri_getlen(map) == expected_len,
+	CHERIBSDTEST_VERIFY2(cheri_length_get(map) == expected_len,
 	    "mmap() returned a pointer with an unrepresentable length "
-	    "(%zu vs %zu): %#p", cheri_getlen(map), expected_len, map);
+	    "(%zu vs %zu): %#p", cheri_length_get(map), expected_len, map);
 
 	padding = (int *)((uintcap_t)map + expected_len - sizeof(int));
 	sink = *padding;
@@ -843,7 +843,7 @@ CHERIBSDTEST(vm_reservation_reuse,
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, PAGE_SIZE * 2,
 	    PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0, "mmap() failed to return "
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0, "mmap() failed to return "
 	    "a pointer");
 
 	CHERIBSDTEST_CHECK_SYSCALL(munmap((char *)map + PAGE_SIZE, PAGE_SIZE));
@@ -1013,7 +1013,7 @@ CHERIBSDTEST(vm_reservation_mmap_shared,
 
 	CHERIBSDTEST_VERIFY2(((ptraddr_t)(map) & align_mask) == 0,
 	    "mmap failed to align shared regiont for representability");
-	CHERIBSDTEST_VERIFY2(cheri_getlen(map) == expected_len,
+	CHERIBSDTEST_VERIFY2(cheri_length_get(map) == expected_len,
 	    "mmap returned pointer with unrepresentable length");
 
 	cheribsdtest_success();
@@ -1026,8 +1026,7 @@ CHERIBSDTEST(vm_reservation_mmap_shared,
 CHERIBSDTEST(vm_mmap_invalid_cap,
     "check that mmap with invalid capability hint fails")
 {
-	void *invalid = cheri_cleartag(cheri_setaddress(
-	    cheri_getpcc(), 0x4300beef));
+	void *invalid = cheri_tag_clear(cheri_address_set(cheri_pcc_get(), 0x4300beef));
 	void *map;
 
 	map = mmap(invalid, PAGE_SIZE, PROT_READ | PROT_WRITE,
@@ -1048,8 +1047,7 @@ CHERIBSDTEST(vm_mmap_invalid_cap,
 CHERIBSDTEST(vm_mmap_invalid_cap_fixed,
     "check that mmap MAP_FIXED with invalid capability hint fails")
 {
-	void *invalid = cheri_cleartag(cheri_setaddress(
-	    cheri_getpcc(), 0x4300beef));
+	void *invalid = cheri_tag_clear(cheri_address_set(cheri_pcc_get(), 0x4300beef));
 	void *map;
 
 	map = mmap(invalid, PAGE_SIZE, PROT_READ | PROT_WRITE,
@@ -1078,7 +1076,7 @@ CHERIBSDTEST(vm_reservation_mmap_invalid_cap,
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
 
-	invalid = cheri_cleartag(map);
+	invalid = cheri_tag_clear(map);
 
 	map = mmap(invalid, PAGE_SIZE, PROT_READ | PROT_WRITE,
 	    MAP_ANON, -1, 0);
@@ -1103,7 +1101,7 @@ CHERIBSDTEST(vm_reservation_mmap,
 	hint = find_address_space_gap(PAGE_SIZE, 0);
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap((void *)hint, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0,
 	    "mmap with null-derived hint failed to return valid capability");
 
 	cheribsdtest_success();
@@ -1125,7 +1123,7 @@ CHERIBSDTEST(vm_reservation_mmap_fixed_unreserved,
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap((void *)(hint + PAGE_SIZE),
 	    PAGE_SIZE, PROT_MAX(PROT_READ | PROT_WRITE), MAP_ANON | MAP_FIXED,
 	    -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0,
 	    "mmap fixed with NULL-derived hint failed to return "
 	    "valid capability");
 
@@ -1152,7 +1150,7 @@ CHERIBSDTEST(vm_reservation_mmap_insert_null_derived,
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, 3 * PAGE_SIZE,
 	    PROT_MAX(PROT_READ | PROT_WRITE), MAP_GUARD, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0,
 	    "mmap failed to return valid capability");
 
 	map = mmap((void *)(uintptr_t)(ptraddr_t)map, PAGE_SIZE,
@@ -1174,14 +1172,14 @@ CHERIBSDTEST(vm_reservation_mmap_fixed_insert,
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, 3 * PAGE_SIZE,
 	    PROT_MAX(PROT_READ | PROT_WRITE), MAP_GUARD, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0,
 	    "mmap failed to return valid capability");
-	CHERIBSDTEST_VERIFY2(cheri_getperm(map) & CHERI_PERM_SW_VMEM,
+	CHERIBSDTEST_VERIFY2(cheri_perms_get(map) & CHERI_PERM_SW_VMEM,
 	    "mmap failed to return capability with VMEM perm");
 
 	CHERIBSDTEST_CHECK_SYSCALL(mmap((char *)(map) + PAGE_SIZE, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0,
 	    "mmap fixed failed to return valid capability");
 
 	cheribsdtest_success();
@@ -1197,12 +1195,12 @@ CHERIBSDTEST(vm_reservation_mmap_fixed_insert_noperm,
 
 	map = CHERIBSDTEST_CHECK_SYSCALL(mmap(NULL, 3 * PAGE_SIZE,
 	    PROT_MAX(PROT_READ | PROT_WRITE), MAP_GUARD, -1, 0));
-	CHERIBSDTEST_VERIFY2(cheri_gettag(map) != 0,
+	CHERIBSDTEST_VERIFY2(cheri_tag_get(map) != 0,
 	    "mmap failed to return valid capability");
-	CHERIBSDTEST_VERIFY2(cheri_getperm(map) & CHERI_PERM_SW_VMEM,
+	CHERIBSDTEST_VERIFY2(cheri_perms_get(map) & CHERI_PERM_SW_VMEM,
 	    "mmap failed to return capability with VMEM perm");
 
-	not_enough_perm = cheri_andperm(map, ~CHERI_PERM_SW_VMEM);
+	not_enough_perm = cheri_perms_and(map, ~CHERI_PERM_SW_VMEM);
 	map2 = mmap((char *)(not_enough_perm) + PAGE_SIZE, PAGE_SIZE,
 	    PROT_READ | PROT_WRITE, MAP_ANON | MAP_FIXED, -1, 0);
 	CHERIBSDTEST_VERIFY2(map2 == MAP_FAILED,
@@ -1255,30 +1253,30 @@ CHERIBSDTEST(vm_shm_largepage_basic,
 		    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
 
 		/* Verify mmap output */
-		CHERIBSDTEST_VERIFY2(cheri_gettag(addr) != 0,
+		CHERIBSDTEST_VERIFY2(cheri_tag_get(addr) != 0,
 		    "mmap invalid capability for psind=%d", psind);
-		CHERIBSDTEST_VERIFY2(cheri_getlen(addr) == ps[psind],
+		CHERIBSDTEST_VERIFY2(cheri_length_get(addr) == ps[psind],
 		    "mmap wrong capability length for psind=%d "
 		    "expected %jx found %jx",
-		    psind, ps[psind], cheri_getlen(addr));
-		CHERIBSDTEST_VERIFY2((cheri_getperm(addr) & perms) == perms,
+		    psind, ps[psind], cheri_length_get(addr));
+		CHERIBSDTEST_VERIFY2((cheri_perms_get(addr) & perms) == perms,
 		    "mmap missing permission expected %jx found %jx",
-		    (uintmax_t)perms, (uintmax_t)cheri_getperm(addr));
+		    (uintmax_t)perms, (uintmax_t) cheri_perms_get(addr));
 
 		/* Try to store capabilities in the SHM region */
 		map_buffer = (void * volatile *)addr;
 		*map_buffer = &v;
-		CHERIBSDTEST_VERIFY2(cheri_gettag(*map_buffer) != 0, "tag lost");
+		CHERIBSDTEST_VERIFY2(cheri_tag_get(*map_buffer) != 0, "tag lost");
 
 		map_buffer = (void * volatile *)((uintptr_t)addr +
 		    ps[psind] / 2);
 		*map_buffer = &v;
-		CHERIBSDTEST_VERIFY2(cheri_gettag(*map_buffer) != 0, "tag lost");
+		CHERIBSDTEST_VERIFY2(cheri_tag_get(*map_buffer) != 0, "tag lost");
 
 		map_buffer = (void * volatile *)((uintptr_t)addr +
 		    ps[psind] - PAGE_SIZE);
 		*map_buffer = &v;
-		CHERIBSDTEST_VERIFY2(cheri_gettag(*map_buffer) != 0, "tag lost");
+		CHERIBSDTEST_VERIFY2(cheri_tag_get(*map_buffer) != 0, "tag lost");
 
 		CHERIBSDTEST_CHECK_SYSCALL(munmap(addr, ps[psind]));
 		CHERIBSDTEST_CHECK_SYSCALL(close(fd));
@@ -1376,8 +1374,8 @@ skip_need_quarantine_unmapped_reservations(
 static int
 check_revoked(void *r)
 {
-	return (cheri_gettag(r) == 0) ||
-	    ((cheri_gettype(r) == -1L) && (cheri_getperm(r) == 0));
+	return (cheri_tag_get(r) == 0) ||
+	    ((cheri_type_get(r) == -1L) && (cheri_perms_get(r) == 0));
 }
 
 /*
@@ -1421,7 +1419,7 @@ check_kqueue_cap(int kq, int pfd[2], unsigned int valid)
 	CHERIBSDTEST_CHECK_SYSCALL(kevent(kq, &ike, 1, NULL, 0, NULL));
 	CHERIBSDTEST_CHECK_SYSCALL(kevent(kq, NULL, 0, &oke, 1, NULL));
 	CHERIBSDTEST_VERIFY2(
-	    __builtin_cheri_equal_exact(oke.ident, &install_kqueue_cap),
+	    cheri_is_equal_exact(oke.ident, &install_kqueue_cap),
 	    "Bad identifier from kqueue");
 	CHERIBSDTEST_VERIFY2(oke.filter == EVFILT_USER,
 	    "Bad filter from kqueue");
@@ -1474,7 +1472,7 @@ CHERIBSDTEST(cheri_revoke_lightly, "A gentle test of capability revocation",
 	 * the 0th granule of the map, spill it to the 1st granule,
 	 * stash it in the kqueue, and mark it as revoked in the shadow.
 	 */
-	revme = cheri_andperm(mb, ~CHERI_PERM_SW_VMEM);
+	revme = cheri_perms_and(mb, ~CHERI_PERM_SW_VMEM);
 	((void **)mb)[1] = revme;
 	install_kqueue_cap(kq, pfd, revme);
 
@@ -1503,7 +1501,7 @@ CHERIBSDTEST(cheri_revoke_lightly, "A gentle test of capability revocation",
 	 * the path through the commutation diagram that doesn't share an
 	 * edge with the derivation above.
 	 */
-	revme = cheri_andperm(mb + 1, ~CHERI_PERM_SW_VMEM);
+	revme = cheri_perms_and(mb + 1, ~CHERI_PERM_SW_VMEM);
 	CHERIBSDTEST_VERIFY2(!check_revoked(revme), "Tag clear on 2nd revme?");
 	((void **)mb)[1] = revme;
 	install_kqueue_cap(kq, pfd, revme);
@@ -1563,7 +1561,7 @@ CHERIBSDTEST(cheri_revoke_loadside, "Test load-side revoker",
 	    CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL,
 	    __DEQUALIFY_CAP(void **, &cri)));
 
-	revme = cheri_andperm(mb, ~CHERI_PERM_SW_VMEM);
+	revme = cheri_perms_and(mb, ~CHERI_PERM_SW_VMEM);
 	((void **)mb)[1] = revme;
 	((uint8_t *)sh)[0] = 1;
 
@@ -1623,7 +1621,7 @@ CHERIBSDTEST(cheri_revoke_loadside, "Test load-side revoker",
 	    (mcv[1] & MINCORE_CAPSTORE) != 0, "page 1 capstore 2.1");
 
 	/* Re-dirty page 0 but not page 1 */
-	revme = cheri_andperm(mb + 1, ~CHERI_PERM_SW_VMEM);
+	revme = cheri_perms_and(mb + 1, ~CHERI_PERM_SW_VMEM);
 	CHERIBSDTEST_VERIFY2(!check_revoked(revme), "Tag clear on 2nd revme?");
 	((void **)mb)[1] = revme;
 
@@ -1693,7 +1691,7 @@ CHERIBSDTEST(cheri_revoke_async,
 	CHERIBSDTEST_CHECK_SYSCALL(cheri_revoke_get_shadow(
 	    CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL, __DEQUALIFY(void **, &cri)));
 
-	mb[1] = cheri_andperm(mb, ~CHERI_PERM_SW_VMEM);
+	mb[1] = cheri_perms_and(mb, ~CHERI_PERM_SW_VMEM);
 	((uint8_t *)sh)[0] = 1;
 	epoch = cri->epochs.dequeue;
 
@@ -1779,7 +1777,7 @@ CHERIBSDTEST(cheri_revoke_async_fork,
 	CHERIBSDTEST_CHECK_SYSCALL(cheri_revoke_get_shadow(
 	    CHERI_REVOKE_SHADOW_INFO_STRUCT, NULL, __DEQUALIFY(void **, &cri)));
 
-	mb[1] = cheri_andperm(mb, ~CHERI_PERM_SW_VMEM);
+	mb[1] = cheri_perms_and(mb, ~CHERI_PERM_SW_VMEM);
 	((uint8_t *)sh)[0] = 1;
 	epoch = cri->epochs.dequeue;
 
@@ -1851,8 +1849,7 @@ cheribsdtest_cheri_revoke_lib_init(size_t bigblock_caps, void *** obigblock,
 	for (size_t ix = 0; ix < bigblock_caps; ix++) {
 		/* Create self-referential SW_VMEM-free capabilities */
 
-		bigblock[ix] = cheri_andperm(cheri_setbounds(&bigblock[ix], 16),
-		    ~CHERI_PERM_SW_VMEM);
+		bigblock[ix] = cheri_perms_and(cheri_bounds_set(&bigblock[ix], 16), ~CHERI_PERM_SW_VMEM);
 	}
 	*obigblock = bigblock;
 
@@ -1908,8 +1905,7 @@ cheribsdtest_cheri_revoke_lib_run(int paranoia, int mode, size_t bigblock_caps,
 			    bigblock_caps - bigblock_offset, csz);
 		}
 
-		void **chunk = cheri_setbounds(bigblock + bigblock_offset,
-		    csz * sizeof(void *));
+		void **chunk = cheri_bounds_set(bigblock + bigblock_offset, csz * sizeof(void *));
 
 		if (verbose > 1) {
 			fprintf(stderr, "chunk: %#.16lp\n", chunk);
@@ -1932,11 +1928,9 @@ cheribsdtest_cheri_revoke_lib_run(int paranoia, int mode, size_t bigblock_caps,
 			fprintf(stderr,
 			    "premrk fwo=%lx lwo=%lx fw=%p *fw=%016lx "
 			    "(fwm=%016lx) *lw=%016lx (lwm=%016lx)\n",
-			    fwo, lwo, cheri_setaddress(shadow, sbase + fwo),
-			    *(uint64_t *)(cheri_setaddress(shadow,
-			    sbase + fwo)), fwm,
-			    *(uint64_t *)(cheri_setaddress(shadow,
-			    sbase + lwo)), lwm);
+			    fwo, lwo, cheri_address_set(shadow, sbase + fwo),
+			    *(uint64_t *)(cheri_address_set(shadow, sbase + fwo)), fwm,
+			    *(uint64_t *)(cheri_address_set(shadow, sbase + lwo)), lwm);
 		}
 
 		/* Mark the chunk for revocation */
@@ -1954,11 +1948,9 @@ cheribsdtest_cheri_revoke_lib_run(int paranoia, int mode, size_t bigblock_caps,
 			fprintf(stderr,
 			    "marked fwo=%lx lwo=%lx fw=%p *fw=%016lx "
 			    "*lw=%016lx\n",
-			    fwo, lwo, cheri_setaddress(shadow, sbase + fwo),
-			    *(uint64_t *)(cheri_setaddress(shadow,
-			    sbase + fwo)),
-			    *(uint64_t *)(cheri_setaddress(shadow,
-			    sbase + lwo)));
+			    fwo, lwo, cheri_address_set(shadow, sbase + fwo),
+			    *(uint64_t *)(cheri_address_set(shadow, sbase + fwo)),
+			    *(uint64_t *)(cheri_address_set(shadow, sbase + lwo)));
 		}
 
 		{
@@ -2022,9 +2014,7 @@ load_split_fini:
 
 		for (size_t ix = 0; ix < csz; ix++) {
 			/* Put everything back */
-			chunk[ix] = cheri_andperm(
-			    cheri_setbounds(&chunk[ix], 16),
-			    ~CHERI_PERM_SW_VMEM);
+			chunk[ix] = cheri_perms_and(cheri_bounds_set(&chunk[ix], 16), ~CHERI_PERM_SW_VMEM);
 		}
 	}
 }
@@ -2562,11 +2552,10 @@ CHERIBSDTEST(cheri_revoke_cow_mapping,
 	block = mmap(NULL, blocksz, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0);
 	CHERIBSDTEST_VERIFY(block != MAP_FAILED);
 
-	torev = cheri_setbounds(block + 2 * PAGE_SIZE / sizeof(void *),
-	    PAGE_SIZE);
-	cap1 = cheri_setbounds(&block[0], PAGE_SIZE);
-	cap2 = cheri_setbounds(&block[PAGE_SIZE / sizeof(void *)], PAGE_SIZE);
-	*cap1 = *cap2 = cheri_andperm(torev, ~CHERI_PERM_SW_VMEM);
+	torev = cheri_bounds_set(block + 2 * PAGE_SIZE / sizeof(void *), PAGE_SIZE);
+	cap1 = cheri_bounds_set(&block[0], PAGE_SIZE);
+	cap2 = cheri_bounds_set(&block[PAGE_SIZE / sizeof(void *)], PAGE_SIZE);
+	*cap1 = *cap2 = cheri_perms_and(torev, ~CHERI_PERM_SW_VMEM);
 
 	child = fork();
 	if (child == -1)
@@ -2578,7 +2567,7 @@ CHERIBSDTEST(cheri_revoke_cow_mapping,
 		if (cheri_revoke_get_shadow(CHERI_REVOKE_SHADOW_NOVMEM,
 		    torev, &shadow) != 0)
 			_exit(1);
-		memset(shadow, 0xff, cheri_getlen(shadow));
+		memset(shadow, 0xff, cheri_length_get(shadow));
 
 		/*
 		 * Remove the first page from our page tables without modifying
@@ -2651,7 +2640,7 @@ CHERIBSDTEST(cheri_revoke_cow_mapping,
 	 */
 	CHERIBSDTEST_CHECK_SYSCALL(cheri_revoke_get_shadow(
 	    CHERI_REVOKE_SHADOW_NOVMEM, torev, &shadow));
-	memset(shadow, 0xff, cheri_getlen(shadow));
+	memset(shadow, 0xff, cheri_length_get(shadow));
 
 	/*
 	 * Remove the first page from our page tables without modifying the
@@ -2709,7 +2698,7 @@ CHERIBSDTEST(cheri_revoke_shm_anon_hoard_unmapped,
 
 	to_revoke = malloc(1);
 	*map = to_revoke;
-	CHERIBSDTEST_VERIFY(cheri_gettag(*map));
+	CHERIBSDTEST_VERIFY(cheri_tag_get(*map));
 
 	munmap(__DEVOLATILE(void *, map), getpagesize());
 
@@ -2796,7 +2785,7 @@ CHERIBSDTEST(cheri_revoke_shm_anon_hoard_closed,
 
 		to_revoke = malloc(1);
 		*map = to_revoke;
-		CHERIBSDTEST_VERIFY(cheri_gettag(*map));
+		CHERIBSDTEST_VERIFY(cheri_tag_get(*map));
 
 		CHERIBSDTEST_CHECK_SYSCALL(munmap(__DEVOLATILE(void *, map),
 		    getpagesize()));
@@ -2875,7 +2864,7 @@ CHERIBSDTEST(mmap_insert_stack,
 	 * due to trying to insert a reservation inside an existing one.
 	 * This is now rejected outright.
 	 */
-	CHERIBSDTEST_CHECK_CALL_ERROR(mmap(cheri_setaddress(p, 0x20ffc000),
+	CHERIBSDTEST_CHECK_CALL_ERROR(mmap(cheri_address_set(p, 0x20ffc000),
 	    0x2000, PROT_WRITE | PROT_READ, MAP_STACK | MAP_FIXED, -1, 0),
 	    ENOMEM);
 
@@ -2883,7 +2872,7 @@ CHERIBSDTEST(mmap_insert_stack,
 	 * This would trigger a panic by trying to remove an unmapped
 	 * entry left by the previous mmap.
 	 */
-	CHERIBSDTEST_CHECK_SYSCALL(munmap(cheri_setaddress(p, 0x20ffc000),
+	CHERIBSDTEST_CHECK_SYSCALL(munmap(cheri_address_set(p, 0x20ffc000),
 	    0x3000));
 
 	cheribsdtest_success();

--- a/bin/cheribsdtest/cheribsdtest_vm_swap.c
+++ b/bin/cheribsdtest/cheribsdtest_vm_swap.c
@@ -39,9 +39,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
-
 #include "cheribsdtest.h"
 
 #define	NPAGES		1000

--- a/bin/cheribsdtest/cheribsdtest_vm_swap.c
+++ b/bin/cheribsdtest/cheribsdtest_vm_swap.c
@@ -86,7 +86,7 @@ CHERIBSDTEST(vm_swap,
     .ct_check_skip = skip_swap_required})
 {
 
-	if (cheri_getdefault() == NULL)
+	if (cheri_ddc_get() == NULL)
 		cheribsdtest_failure_errx("test depends on non-NULL DDC");
 
 	(void)dotest(1);
@@ -100,13 +100,13 @@ caps2(const char *nam, void * __capability p)
 	snprintf(s, sizeof(s),
 	    "%s: b=%zx l=%zx o=%zx t=%d s=%d ty=%zx p=%zx",
 	    nam,
-	    (size_t)cheri_getbase(p),
-	    (size_t)cheri_getlen(p),
-	    (size_t)cheri_getoffset(p),
-	    (int)cheri_gettag(p),
-	    (int)cheri_getsealed(p),
-	    (size_t)cheri_gettype(p),
-	    (size_t)cheri_getperm(p));
+	    (size_t) cheri_base_get(p),
+	    (size_t) cheri_length_get(p),
+	    (size_t) cheri_offset_get(p),
+	    (int) cheri_tag_get(p),
+	    (int) cheri_is_sealed(p),
+	    (size_t) cheri_type_get(p),
+	    (size_t) cheri_perms_get(p));
 
 	return (s);
 }
@@ -115,13 +115,13 @@ static int
 cne2(void * __capability p1, void * __capability p2)
 {
 
-	if (cheri_gettag(p1) != cheri_gettag(p2) ||
-	    cheri_getbase(p1) != cheri_getbase(p2) ||
-	    cheri_getlen(p1) != cheri_getlen(p2) ||
-	    cheri_getoffset(p1) != cheri_getoffset(p2) ||
-	    cheri_getsealed(p1) != cheri_getsealed(p2) ||
-	    cheri_gettype(p1) != cheri_gettype(p2) ||
-	    cheri_getperm(p1) != cheri_getperm(p2))
+	if (cheri_tag_get(p1) != cheri_tag_get(p2) ||
+	    cheri_base_get(p1) != cheri_base_get(p2) ||
+	    cheri_length_get(p1) != cheri_length_get(p2) ||
+	    cheri_offset_get(p1) != cheri_offset_get(p2) ||
+	    cheri_is_sealed(p1) != cheri_is_sealed(p2) ||
+	    cheri_type_get(p1) != cheri_type_get(p2) ||
+	    cheri_perms_get(p1) != cheri_perms_get(p2))
 		return (1);
 
 	return (0);
@@ -270,7 +270,7 @@ dotest(int force_pageout)
 			sealer = cheri_ptr(				\
 			    (void*)(((hash & ~0xFFULL) | j) & 0x007FFFFF),\
 			    ((j << 8) | i | 0x000F0000) & 0x00FFFFFF);	\
-			sealer = cheri_setoffset(sealer, i);		\
+			sealer = cheri_offset_set(sealer, i);		\
 			tmp = cheri_seal(tmp, sealer);			\
 			nsealed++;					\
 		}							\
@@ -337,7 +337,7 @@ dotest(int force_pageout)
 
 		LOOP_INNER;
 
-		if (cheri_gettag(p[i]))
+		if (cheri_tag_get(p[i]))
 			found_tags |= (1ULL << (uint64_t)(j - 1));
 
 		if (CNE(p[i], tmp)) {

--- a/bin/cheribsdtest/cheribsdtest_zlib.c
+++ b/bin/cheribsdtest/cheribsdtest_zlib.c
@@ -37,8 +37,6 @@
 
 #include <sys/types.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
+++ b/contrib/jemalloc/include/jemalloc/internal/extent_inlines.h
@@ -379,7 +379,7 @@ extent_init(extent_t *extent, arena_t *arena, void *addr, size_t size,
     bool committed, bool dumpable, extent_head_state_t is_head) {
 	assert(addr == PAGE_ADDR2BASE(addr) || !slab);
 #ifdef __CHERI_PURE_CAPABILITY__
-	assert(cheri_getoffset(extent) == 0 && "extent offset must be zero for packing in rtree");
+	assert(cheri_offset_get(extent) == 0 && "extent offset must be zero for packing in rtree");
 #endif
 	extent_arena_set(extent, arena);
 	extent_addr_set(extent, addr);

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_includes.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_includes.h
@@ -76,7 +76,7 @@
 /******************************************************************************/
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <cheri/cheric.h>
+#include <cheriintrin.h>
 #endif
 
 #include "jemalloc/internal/jemalloc_internal_inlines_a.h"

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -98,13 +98,13 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 	 * metadata is required to prevent attacks where bounds are
 	 * manipulated.
 	 */
-	if (unlikely(!cheri_gettag(ptr))) {
+	if (unlikely(!cheri_tag_get(ptr))) {
 		return NULL;
 	}
-	if (unlikely(cheri_getoffset(ptr) != 0)) {
+	if (unlikely(cheri_offset_get(ptr) != 0)) {
 		return NULL;
 	}
-	if (unlikely(cheri_getsealed(ptr))) {
+	if (unlikely(cheri_is_sealed(ptr))) {
 		return NULL;
 	}
 
@@ -112,7 +112,7 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 	extent = rtree_extent_read(tsdn, &extents_rtree,
 	    rtree_ctx, (uintptr_t)ptr, true);
 	assert(extent != NULL);
-	ubptr = cheri_setaddress(extent->e_addr, (ptraddr_t)ptr);
+	ubptr = cheri_address_set(extent->e_addr, (ptraddr_t)ptr);
 	/*
 	 * Compare pointer addresses to work around an issue where
 	 * LLVM's GVN pass replaces ubptr with ptr in the assert
@@ -122,8 +122,8 @@ unbound_ptr(tsdn_t *tsdn, void *ptr) {
 	 * https://github.com/CTSRD-CHERI/llvm-project/issues/619
 	 */
 	assert((ptraddr_t)ptr == (ptraddr_t)ubptr);
-	assert(cheri_getbase(ubptr) == cheri_getbase(extent->e_addr));
-	assert(cheri_getlen(ubptr) == cheri_getlen(extent->e_addr));
+	assert(cheri_base_get(ubptr) == cheri_base_get(extent->e_addr));
+	assert(cheri_length_get(ubptr) == cheri_length_get(extent->e_addr));
 #endif
 	return (ubptr);
 }

--- a/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_macros.h
+++ b/contrib/jemalloc/include/jemalloc/internal/jemalloc_internal_macros.h
@@ -119,7 +119,7 @@ JEMALLOC_DIAGNOSTIC_DISABLE_SPURIOUS
 	typeof(ptr) _ptr = (ptr);					\
 	size_t _size = (size);						\
 	(_ptr == NULL ? NULL :						\
-	 cheri_andperm(cheri_setboundsexact(_ptr,			\
+	 cheri_perms_and(cheri_bounds_set_exact(_ptr,			\
 	     _size == 0 ? 1 : _size),					\
 	     CHERI_PERMS_USERSPACE_DATA & ~CHERI_PERM_SW_VMEM));	\
 })

--- a/contrib/jemalloc/src/arena.c
+++ b/contrib/jemalloc/src/arena.c
@@ -486,7 +486,7 @@ arena_extent_alloc_large(tsdn_t *tsdn, arena_t *arena, size_t usize,
 	}
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	assert(cheri_getoffset(extent) == 0 && "extent offset must be zero for packing in rtree");
+	assert(cheri_offset_get(extent) == 0 && "extent offset must be zero for packing in rtree");
 #endif
 	return extent;
 }

--- a/contrib/jemalloc/src/base.c
+++ b/contrib/jemalloc/src/base.c
@@ -489,7 +489,7 @@ base_alloc_extent(tsdn_t *tsdn, base_t *base) {
 	extent_esn_set(extent, esn);
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Ensure we return an extent with offset zero for rtree packing */
-	extent = cheri_setboundsexact(extent, sizeof(*extent));
+	extent = cheri_bounds_set_exact(extent, sizeof(*extent));
 #endif
 	return extent;
 }

--- a/contrib/jemalloc/src/extent.c
+++ b/contrib/jemalloc/src/extent.c
@@ -201,7 +201,7 @@ extent_alloc(tsdn_t *tsdn, arena_t *arena) {
 	malloc_mutex_unlock(tsdn, &arena->extent_avail_mtx);
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Ensure we return an extent with offset zero for rtree packing */
-	extent = cheri_setboundsexact(extent, sizeof(*extent));
+	extent = cheri_bounds_set_exact(extent, sizeof(*extent));
 #endif
 	return extent;
 }
@@ -564,7 +564,7 @@ extents_alloc(tsdn_t *tsdn, arena_t *arena, extent_hooks_t **r_extent_hooks,
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Ensure we return an extent with offset zero for rtree packing */
 	if (extent != NULL)
-		extent = cheri_setboundsexact(extent, sizeof(*extent));
+		extent = cheri_bounds_set_exact(extent, sizeof(*extent));
 #endif
 	return extent;
 }
@@ -1506,7 +1506,7 @@ extent_alloc_retained(tsdn_t *tsdn, arena_t *arena,
 	}
 	malloc_mutex_assert_not_owner(tsdn, &arena->extent_grow_mtx);
 #ifdef __CHERI_PURE_CAPABILITY__
-	assert(cheri_getoffset(extent) == 0 && "extent offset must be zero for packing in rtree");
+	assert(cheri_offset_get(extent) == 0 && "extent offset must be zero for packing in rtree");
 #endif
 	return extent;
 }
@@ -1577,7 +1577,7 @@ extent_alloc_wrapper(tsdn_t *tsdn, arena_t *arena,
 
 	assert(extent == NULL || extent_dumpable_get(extent));
 #ifdef __CHERI_PURE_CAPABILITY__
-	assert(cheri_getoffset(extent) == 0 && "extent offset must be zero for packing in rtree");
+	assert(cheri_offset_get(extent) == 0 && "extent offset must be zero for packing in rtree");
 #endif
 	return extent;
 }

--- a/contrib/jemalloc/src/jemalloc.c
+++ b/contrib/jemalloc/src/jemalloc.c
@@ -3774,8 +3774,8 @@ je_malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *ptr) {
 			ret = isalloc(tsdn, ptr);
 		}
 #ifdef __CHERI_PURE_CAPABILITY__
-		if (ret != 0 && cheri_gettag(ptr)) {
-			ret = MIN(ret, cheri_getlen(ptr));
+		if (ret != 0 && cheri_tag_get(ptr)) {
+			ret = MIN(ret, cheri_length_get(ptr));
 		}
 #endif
 	}

--- a/contrib/jemalloc/src/pages.c
+++ b/contrib/jemalloc/src/pages.c
@@ -23,10 +23,6 @@
 #include "jemalloc/internal/assert.h"
 #include "jemalloc/internal/malloc_io.h"
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#include <cheri/cheric.h>
-#endif
-
 #ifdef JEMALLOC_SYSCTL_VM_OVERCOMMIT
 #include <sys/sysctl.h>
 #ifdef __FreeBSD__

--- a/lib/csu/aarch64/caprel.h
+++ b/lib/csu/aarch64/caprel.h
@@ -15,7 +15,8 @@
 #include <sys/types.h>
 #include <machine/elf.h>
 
-#include <cheri/cheric.h>
+#include <cheri/cherireg.h>
+#include <cheriintrin.h>
 
 #define	FUNC_PTR_REMOVE_PERMS						\
 	(CHERI_PERM_SEAL | CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |	\

--- a/lib/csu/aarch64/caprel.h
+++ b/lib/csu/aarch64/caprel.h
@@ -46,15 +46,15 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)text_rodata_cap : (uintcap_t)data_cap;
-	cap = cheri_setaddress(cap, base_addr + address);
-	cap = cheri_clearperm(cap, CAP_RELOC_REMOVE_PERMS);
+	cap = cheri_address_set(cap, base_addr + address);
+	cap = cheri_perms_clear(cap, CAP_RELOC_REMOVE_PERMS);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
-		cap = cheri_clearperm(cap, FUNC_PTR_REMOVE_PERMS);
+		cap = cheri_perms_clear(cap, FUNC_PTR_REMOVE_PERMS);
 	}
 	if (perms == MORELLO_FRAG_RWDATA || perms == MORELLO_FRAG_RODATA) {
-		cap = cheri_clearperm(cap, DATA_PTR_REMOVE_PERMS);
-		cap = cheri_setbounds(cap, len);
+		cap = cheri_perms_clear(cap, DATA_PTR_REMOVE_PERMS);
+		cap = cheri_bounds_set(cap, len);
 	}
 
 	cap += addend;
@@ -64,7 +64,7 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 		 * TODO tight bounds: lower bound and len should be set
 		 * with LSB == 0 for C64 code.
 		 */
-		cap = cheri_sealentry(cap);
+		cap = cheri_sentry_create(cap);
 	}
 
 	return (cap);
@@ -83,7 +83,7 @@ elf_reloc(const Elf_Rela *rela, void * __capability data_cap,
 
 	addr = relocbase + rela->r_offset;
 #ifdef __CHERI_PURE_CAPABILITY__
-	where = cheri_setaddress(data_cap, addr);
+	where = cheri_address_set(data_cap, addr);
 #else
 	where = (Elf_Addr *)addr;
 #endif

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -37,7 +37,8 @@
 #include "libc_private.h"
 #include "csu_common.h"
 
-#include <cheri/cheric.h>
+#include <cheri/cherireg.h>
+#include <cheriintrin.h>
 
 /*
  * For -pie executables rtld will process the __cap_relocs, so we don't need

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -101,7 +101,7 @@ _start(void *auxv,
 		__builtin_trap(); /* RTLD missing? Wrong *crt1.o linked? */
 #endif
 
-	if (cheri_getdefault() != NULL)
+	if (cheri_ddc_get() != NULL)
 		__builtin_trap(); /* $ddc should be NULL */
 
 	/*

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -33,7 +33,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <cheri/cheric.h>
+#include <cheri/cherireg.h>
+#include <cheriintrin.h>
 
 #ifdef PIC
 #error "PIEs never need to initialise their own globals"

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -53,12 +53,12 @@ crt_init_rela(const Elf_Phdr *phdr __unused)
 #ifdef __CHERI_PURE_CAPABILITY__
 	data_cap = __DECONST(void *, phdr);
 #else
-	data_cap = cheri_getdefault();
+	data_cap = cheri_ddc_get();
 #endif
-	data_cap = cheri_clearperm(data_cap,
+	data_cap = cheri_perms_clear(data_cap,
 	    CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
 
-	code_cap = cheri_getpcc();
+	code_cap = cheri_pcc_get();
 
 	rela = RODATA_PTR(__rela_dyn_start);
 	relalim = RODATA_PTR(__rela_dyn_end);
@@ -181,30 +181,30 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 #ifdef __CHERI_PURE_CAPABILITY__
 		data_cap = __DECONST(void *, phdr);
 #else
-		data_cap = cheri_getdefault();
+		data_cap = cheri_ddc_get();
 #endif
-		data_cap = cheri_clearperm(data_cap,
+		data_cap = cheri_perms_clear(data_cap,
 		   CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
 
-		code_cap = cheri_getpcc();
-		rodata_cap = cheri_clearperm(data_cap,
+		code_cap = cheri_pcc_get();
+		rodata_cap = cheri_perms_clear(data_cap,
 		    CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
 		    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
 
-		data_cap = cheri_setaddress(data_cap, writable_start);
-		rodata_cap = cheri_setaddress(rodata_cap, readonly_start);
+		data_cap = cheri_address_set(data_cap, writable_start);
+		rodata_cap = cheri_address_set(rodata_cap, readonly_start);
 
 		/* TODO: should we use exact setbounds? */
 		data_cap =
-		    cheri_setbounds(data_cap, writable_end - writable_start);
+		    cheri_bounds_set(data_cap, writable_end - writable_start);
 		rodata_cap =
-		    cheri_setbounds(rodata_cap, readonly_end - readonly_start);
+		    cheri_bounds_set(rodata_cap, readonly_end - readonly_start);
 
-		if (!cheri_gettag(data_cap))
+		if (!cheri_tag_get(data_cap))
 			__builtin_trap();
-		if (!cheri_gettag(rodata_cap))
+		if (!cheri_tag_get(rodata_cap))
 			__builtin_trap();
-		if (!cheri_gettag(code_cap))
+		if (!cheri_tag_get(code_cap))
 			__builtin_trap();
 	}
 	cheri_init_globals_3(data_cap, code_cap, rodata_cap);

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -37,7 +37,7 @@
 #include "libc_private.h"
 #include "csu_common.h"
 
-#include <cheri/cheric.h>
+#include <cheriintrin.h>
 
 /*
  * For -pie executables rtld will process the __cap_relocs, so we don't need

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -88,7 +88,7 @@ _start(void *auxv,
 		__builtin_trap(); /* RTLD missing? Wrong *crt1.o linked? */
 #endif
 
-	if (cheri_getdefault() != NULL)
+	if (cheri_ddc_get() != NULL)
 		__builtin_trap(); /* $ddc should be NULL */
 
 	/*

--- a/lib/libc/cheri/strfcap.c
+++ b/lib/libc/cheri/strfcap.c
@@ -78,10 +78,10 @@ _strfcap(char * __restrict buf, size_t maxsize, const char * __restrict format,
 	} while (0)
 
 	orig_buf = buf;
-	have_attributes = !tag || cheri_getsealed(cap);
+	have_attributes = !tag || cheri_is_sealed(cap);
 #ifdef CHERI_FLAGS_CAP_MODE
-	if ((cheri_getperm(cap) & CHERI_PERM_EXECUTE) != 0 &&
-	    cheri_getflags(cap) == CHERI_FLAGS_CAP_MODE) {
+	if ((cheri_perms_get(cap) & CHERI_PERM_EXECUTE) != 0 &&
+	    cheri_flags_get(cap) == CHERI_FLAGS_CAP_MODE) {
 		capmode = true;
 		have_attributes = true;
 	}
@@ -125,7 +125,7 @@ more_spec:
 			goto more_spec;
 
 		case 'a':
-			number = cheri_getaddress(cap);
+			number = cheri_address_get(cap);
 			break;
 
 		case 'A':
@@ -136,7 +136,7 @@ more_spec:
 					OUT("invalid");
 					comma = true;
 				}
-				switch cheri_gettype(cap) {
+				switch (cheri_type_get(cap)) {
 				case CHERI_OTYPE_UNSEALED:
 					break;
 				case CHERI_OTYPE_SENTRY:
@@ -165,7 +165,7 @@ more_spec:
 			continue;
 
 		case 'b':
-			number = cheri_getbase(cap);
+			number = cheri_base_get(cap);
 			break;
 
 		case 'B':
@@ -184,7 +184,7 @@ more_spec:
 			if (cheri_is_null_derived(cap)) {
 				alt = true;
 				number_fmt = 'x';
-				number = cheri_getaddress(cap);
+				number = cheri_address_get(cap);
 				break;
 			}
 			ret = _strfcap(buf,
@@ -196,40 +196,40 @@ more_spec:
 		}
 
 		case 'l':
-			number = cheri_getlength(cap);
+			number = cheri_length_get(cap);
 			break;
 
 		case 'o':
-			number = cheri_getoffset(cap);
+			number = cheri_offset_get(cap);
 			break;
 
 		case 'p':
-			number = cheri_getperm(cap);
+			number = cheri_perms_get(cap);
 			break;
 
 		case 'P':
-			if (cheri_getperm(cap) & CHERI_PERM_LOAD)
+			if (cheri_perms_get(cap) & CHERI_PERM_LOAD)
 				OUT("r");
-			if (cheri_getperm(cap) & CHERI_PERM_STORE)
+			if (cheri_perms_get(cap) & CHERI_PERM_STORE)
 				OUT("w");
-			if (cheri_getperm(cap) & CHERI_PERM_EXECUTE)
+			if (cheri_perms_get(cap) & CHERI_PERM_EXECUTE)
 				OUT("x");
-			if (cheri_getperm(cap) & CHERI_PERM_LOAD_CAP)
+			if (cheri_perms_get(cap) & CHERI_PERM_LOAD_CAP)
 				OUT("R");
-			if (cheri_getperm(cap) & CHERI_PERM_STORE_CAP)
+			if (cheri_perms_get(cap) & CHERI_PERM_STORE_CAP)
 				OUT("W");
 #ifdef CHERI_PERM_EXECUTIVE
-			if (cheri_getperm(cap) & CHERI_PERM_EXECUTIVE)
+			if (cheri_perms_get(cap) & CHERI_PERM_EXECUTIVE)
 				OUT("E");
 #endif
 			continue;
 
 		case 's':
-			number = cheri_gettype(cap);
+			number = cheri_type_get(cap);
 			break;
 
 		case 'S':
-			switch cheri_gettype(cap) {
+			switch (cheri_type_get(cap)) {
 			case CHERI_OTYPE_UNSEALED:
 				OUT("<unsealed>");
 				continue;
@@ -237,11 +237,11 @@ more_spec:
 				OUT("<sentry>");
 				continue;
 			}
-			number = cheri_gettype(cap);
+			number = cheri_type_get(cap);
 			break;
 
 		case 't':
-			number = cheri_gettop(cap);
+			number = cheri_top_get(cap);
 			break;
 
 		case 'T':
@@ -249,7 +249,7 @@ more_spec:
 			continue;
 
 		case 'v':
-			number = cheri_gettag(cap);
+			number = cheri_tag_get(cap);
 			break;
 
 		case 'x':
@@ -299,5 +299,5 @@ ssize_t
 strfcap(char * __restrict buf, size_t maxsize, const char * __restrict format,
     uintcap_t cap)
 {
-	return (_strfcap(buf, maxsize, format, cap, cheri_gettag(cap)));
+	return (_strfcap(buf, maxsize, format, cap, cheri_tag_get(cap)));
 }

--- a/lib/libc/csu/aarch64/reloc.c
+++ b/lib/libc/csu/aarch64/reloc.c
@@ -33,7 +33,8 @@ ifunc_init(const Elf_Auxinfo *aux __unused)
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <cheri/cheric.h>
+#include <cheri/cherireg.h>
+#include <cheriintrin.h>
 
 /*
  * Fragments consist of a 64-bit address followed by a 56-bit length and an

--- a/lib/libc/csu/aarch64/reloc.c
+++ b/lib/libc/csu/aarch64/reloc.c
@@ -54,18 +54,18 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)text_rodata_cap : (uintcap_t)data_cap;
-	cap = cheri_setaddress(cap, base_addr + address);
-	cap = cheri_clearperm(cap, CHERI_PERM_SW_VMEM);
+	cap = cheri_address_set(cap, base_addr + address);
+	cap = cheri_perms_clear(cap, CHERI_PERM_SW_VMEM);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
-		cap = cheri_clearperm(cap, CHERI_PERM_SEAL |
+		cap = cheri_perms_clear(cap, CHERI_PERM_SEAL |
 		    CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
 		    CHERI_PERM_STORE_LOCAL_CAP);
 	}
 	if (perms == MORELLO_FRAG_RWDATA || perms == MORELLO_FRAG_RODATA) {
-		cap = cheri_clearperm(cap, CHERI_PERM_SEAL |
+		cap = cheri_perms_clear(cap, CHERI_PERM_SEAL |
 		    CHERI_PERM_EXECUTE);
-		cap = cheri_setbounds(cap, len);
+		cap = cheri_bounds_set(cap, len);
 	}
 
 	cap += addend;
@@ -75,7 +75,7 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 		 * TODO tight bounds: lower bound and len should be set
 		 * with LSB == 0 for C64 code.
 		 */
-		cap = cheri_sealentry(cap);
+		cap = cheri_sentry_create(cap);
 	}
 
 	return (cap);

--- a/lib/libc/csu/riscv/reloc.c
+++ b/lib/libc/csu/riscv/reloc.c
@@ -37,7 +37,7 @@ ifunc_init(const Elf_Auxinfo *aux)
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <cheri/cheric.h>
+#include <cheriintrin.h>
 
 #include <cheri_init_globals.h>
 

--- a/lib/libc/csu/riscv/reloc.c
+++ b/lib/libc/csu/riscv/reloc.c
@@ -58,12 +58,12 @@ crt1_handle_capreloc(const struct capreloc *r, void *data_cap,
 	if (r->permissions == (function_reloc_flag | indirect_reloc_flag)) {
 		where = (uintptr_t *)((uintptr_t)data_cap +
 		    (r->capability_location - (ptraddr_t)data_cap));
-		ptr = (uintptr_t)cheri_andperm(code_cap,
+		ptr = (uintptr_t)cheri_perms_and(code_cap,
 		    function_pointer_permissions_mask);
-		ptr = cheri_setaddress(ptr, r->object);
+		ptr = cheri_address_set(ptr, r->object);
 		/* TODO: tight bounds */
 		ptr += r->offset;
-		ptr = cheri_sealentry(ptr);
+		ptr = cheri_sentry_create(ptr);
 		target = ((ifunc_resolver_t)ptr)(elf_hwcap,
 		    0, 0, 0, 0, 0, 0, 0);
 		*where = target;

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -223,7 +223,7 @@ dl_init_phdr_info(void)
 			phdr_info.dlpi_phdr =
 #ifdef __CHERI_PURE_CAPABILITY__
 			    /* XXXAR: currently needs load_cap for libunwind */
-			    (const Elf_Phdr *)cheri_andperm(auxp->a_un.a_ptr,
+			    (const Elf_Phdr *)cheri_perms_and(auxp->a_un.a_ptr,
 			        CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP);
 #else
 			    (const Elf_Phdr *)auxp->a_un.a_ptr;

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -35,7 +35,7 @@
 #include <sys/mman.h>
 #include <machine/atomic.h>
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <cheri/cheric.h>
+#include <cheriintrin.h>
 #endif
 #include <assert.h>
 #include <dlfcn.h>

--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -433,7 +433,7 @@ _init_tls(void)
 #ifndef __CHERI_PURE_CAPABILITY__
 			libc_tls_init = (void *)phdr[i].p_vaddr;
 #else
-			libc_tls_init = cheri_setbounds(cheri_setaddress(phdr,
+			libc_tls_init = cheri_bounds_set(cheri_address_set(phdr,
 			    phdr[i].p_vaddr), libc_tls_init_size);
 #endif
 			break;

--- a/lib/libc/gen/tls.c
+++ b/lib/libc/gen/tls.c
@@ -47,7 +47,7 @@
 #include <sys/param.h>
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#include <cheri/cheric.h>
+#include <cheriintrin.h>
 #endif
 
 #include <assert.h>

--- a/lib/libc/stdio/printfcommon.h
+++ b/lib/libc/stdio/printfcommon.h
@@ -329,15 +329,15 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 	if (cheri_is_null_derived(pointer))
 		goto address;
 
-	tagged = cheri_gettag(pointer);
+	tagged = cheri_tag_get(pointer);
 	have_attributes = !tagged;
-	if (cheri_gettype(pointer) != CHERI_OTYPE_UNSEALED)
+	if (cheri_type_get(pointer) != CHERI_OTYPE_UNSEALED)
 		have_attributes = true;
 
 #ifdef CHERI_FLAGS_CAP_MODE
 	capmode = false;
-	if ((cheri_getperm(pointer) & CHERI_PERM_EXECUTE) != 0 &&
-	    cheri_getflags(pointer) == CHERI_FLAGS_CAP_MODE) {
+	if ((cheri_perms_get(pointer) & CHERI_PERM_EXECUTE) != 0 &&
+	    cheri_flags_get(pointer) == CHERI_FLAGS_CAP_MODE) {
 		capmode = true;
 		have_attributes = true;
 	}
@@ -357,7 +357,7 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 		if (capmode)
 			PREPEND_ATTR(cp, "capmode");
 #endif
-		switch (cheri_gettype(pointer)) {
+		switch (cheri_type_get(pointer)) {
 		case CHERI_OTYPE_UNSEALED:
 			break;
 		case CHERI_OTYPE_SENTRY:
@@ -381,7 +381,7 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 	*--cp = ']';
 
 	/* top */
-	ujval = cheri_gettop(pointer);
+	ujval = cheri_top_get(pointer);
 	scp = cp;
 	cp = __ujtoa(ujval, cp, 16, 0, xdigs);
 	size = scp - cp;
@@ -396,7 +396,7 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 	*--cp = '-';
 
 	/* base */
-	ujval = cheri_getbase(pointer);
+	ujval = cheri_base_get(pointer);
 	scp = cp;
 	cp = __ujtoa(ujval, cp, 16, 0, xdigs);
 	size = scp - cp;
@@ -411,7 +411,7 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 	*--cp = ',';
 
 	/* permissions */
-	ujval = cheri_getperm(pointer);
+	ujval = cheri_perms_get(pointer);
 	if (ujval & CHERI_PERM_STORE_CAP)
 		*--cp = 'W';
 	if (ujval & CHERI_PERM_LOAD_CAP)
@@ -428,7 +428,7 @@ __cheri_ptr_alt(void * __capability pointer, CHAR *cp, const char *xdigs,
 
 address:
 	/* address */
-	ujval = cheri_getaddress(pointer);
+	ujval = cheri_address_get(pointer);
 	scp = cp;
 	cp = __ujtoa(ujval, cp, 16, 0, xdigs);
 	size = scp - cp;

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -918,7 +918,7 @@ fp_common:
 #endif
 			{
 				cap = GETARG(void * __capability);
-				ujval = cheri_getaddress(cap);
+				ujval = cheri_address_get(cap);
 			}
 			if (flags & ALT) {
 				cp = buf + BUF;

--- a/lib/libc/stdio/vfprintf.c
+++ b/lib/libc/stdio/vfprintf.c
@@ -58,7 +58,6 @@
 #include <sys/types.h>
 
 #if __has_feature(capabilities)
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 #endif
 

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -59,7 +59,6 @@
 #include <sys/types.h>
 
 #if __has_feature(capabilities)
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 #endif
 

--- a/lib/libc/stdio/vfwprintf.c
+++ b/lib/libc/stdio/vfwprintf.c
@@ -967,7 +967,7 @@ fp_common:
 #endif
 			{
 				cap = GETARG(void * __capability);
-				ujval = cheri_getaddress(cap);
+				ujval = cheri_address_get(cap);
 			}
 			if (flags & ALT) {
 				cp = buf + BUF;

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -37,14 +37,13 @@
 #include <sys/queue.h>
 #include <sys/sysctl.h>
 
-#include <cheri/cheri.h>
-#include <cheri/cheric.h>
 #include <cheri/revoke.h>
 #include <cheri/libcaprevoke.h>
 
 #include <machine/vmparam.h>
 
 #include <assert.h>
+#include <cheriintrin.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <inttypes.h>

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -348,7 +348,7 @@ static void *
 mrs_bound_pointer(void *p, size_t size)
 {
 	if (p != NULL && bound_pointers && size > 0)
-		p = cheri_setbounds(p, size);
+		p = cheri_bounds_set(p, size);
 	return (p);
 }
 
@@ -592,7 +592,7 @@ alloc_descriptor_slab(void)
 static inline void
 increment_allocated_size(void *allocated)
 {
-	allocated_size += cheri_getlen(allocated);
+	allocated_size += cheri_length_get(allocated);
 	if (allocated_size > max_allocated_size) {
 		max_allocated_size = allocated_size;
 	}
@@ -674,7 +674,7 @@ validate_freed_pointer(void *ptr)
 	 * catches NULL and other invalid caps that may cause a rude
 	 * implementation of malloc_underlying_allocation() to crash.
 	 */
-	if (!cheri_gettag(ptr)) {
+	if (!cheri_tag_get(ptr)) {
 		mrs_debug_printf("validate_freed_pointer: untagged capability addr %p\n",
 		    ptr);
 		return (NULL);
@@ -748,8 +748,8 @@ validate_freed_pointer(void *ptr)
 	 * aligned.
 	 */
 	if (caprev_shadow_nomap_set_len(cri->base_mem_nomap, entire_shadow,
-	    cheri_getbase(ptr),
-	    __builtin_align_up(cheri_getlen(underlying_allocation),
+	    cheri_base_get(ptr),
+	    __builtin_align_up(cheri_length_get(underlying_allocation),
 	    CAPREVOKE_BITMAP_ALIGNMENT), ptr)) {
 		mrs_debug_printf("validate_freed_pointer: setting bitmap failed\n");
 		return (NULL);
@@ -984,11 +984,11 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 			 * 16-byte aligned.
 			 */
 			size_t len = __builtin_align_up(
-			    cheri_getlen(iter->slab[i].ptr),
+			    cheri_length_get(iter->slab[i].ptr),
 			    CAPREVOKE_BITMAP_ALIGNMENT);
 			caprev_shadow_nomap_clear_len(
 			    cri->base_mem_nomap, entire_shadow,
-			    cheri_getbase(iter->slab[i].ptr), len);
+			    cheri_base_get(iter->slab[i].ptr), len);
 
 			/*
 			 * Don't construct a pointer to a
@@ -999,7 +999,7 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 
 #ifdef CLEAR_ON_RETURN
 			clear_region(iter->slab[i].ptr,
-			    cheri_getlen(iter->slab[i].ptr));
+			    cheri_length_get(iter->slab[i].ptr));
 #endif /* CLEAR_ON_RETURN */
 
 			/*
@@ -1527,7 +1527,7 @@ mrs_malloc(size_t size)
 	}
 
 #ifdef CLEAR_ON_ALLOC
-	clear_region(allocated_region, cheri_getlen(allocated_region));
+	clear_region(allocated_region, cheri_length_get(allocated_region));
 #endif /* CLEAR_ON_ALLOC */
 
 	increment_allocated_size(allocated_region);
@@ -1630,7 +1630,7 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 	}
 
 #ifdef CLEAR_ON_ALLOC
-	clear_region(*ptr, cheri_getlen(*ptr));
+	clear_region(*ptr, cheri_length_get(*ptr));
 #endif /* CLEAR_ON_ALLOC */
 
 	increment_allocated_size(*ptr);
@@ -1669,7 +1669,7 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 	}
 
 #ifdef CLEAR_ON_ALLOC
-	clear_region(allocated_region, cheri_getlen(allocated_region));
+	clear_region(allocated_region, cheri_length_get(allocated_region));
 #endif /* CLEAR_ON_ALLOC */
 
 	increment_allocated_size(allocated_region);
@@ -1699,7 +1699,7 @@ mrs_realloc(void *ptr, size_t size)
 	if (!quarantining)
 		return (mrs_real_realloc(ptr, size));
 
-	size_t old_size = cheri_getlen(ptr);
+	size_t old_size = cheri_length_get(ptr);
 	mrs_debug_printf("mrs_realloc: called ptr %p ptr size %zu new size %zu\n",
 	    ptr, old_size, size);
 
@@ -1714,7 +1714,7 @@ mrs_realloc(void *ptr, size_t size)
 	 * power-of-two buckets by 1K) and we especially want to avoid
 	 * copying such cases.
 	 */
-	if (ptr != NULL && cheri_gettag(ptr) && cheri_getoffset(ptr) == 0 &&
+	if (ptr != NULL && cheri_tag_get(ptr) && cheri_offset_get(ptr) == 0 &&
 	    size <= old_size && old_size - size <= (old_size >> 1))
 		return (ptr);
 
@@ -1767,11 +1767,11 @@ mrs_free(void *ptr)
 #endif /* !OFFLOAD_QUARANTINE */
 
 #ifdef CLEAR_ON_FREE
-	bzero(cheri_setoffset(ptr, 0), cheri_getlen(ptr));
+	bzero(cheri_offset_set(ptr, 0), cheri_length_get(ptr));
 #endif
 
 	mrs_lock(&app_quarantine_lock);
-	quarantine_insert(app_quarantine, ins, cheri_getlen(ins));
+	quarantine_insert(app_quarantine, ins, cheri_length_get(ins));
 	mrs_unlock(&app_quarantine_lock);
 
 	check_and_perform_flush(true);
@@ -1802,7 +1802,7 @@ mrs_mallocx(size_t size, int flags)
 #ifndef CLEAR_ON_ALLOC
 	/* Clear if requested and we aren't clearing above. */
 	if (ret != NULL && (flags & MALLOCX_ZERO) != 0)
-		clear_region(ret, cheri_getlen(ret));
+		clear_region(ret, cheri_length_get(ret));
 #endif
 	return (ret);
 }
@@ -1825,7 +1825,7 @@ mrs_rallocx(void *ptr, size_t size, int flags)
 		return (mrs_real_rallocx(ptr, size, flags));
 
 	assert(ptr != NULL);
-	old_size = cheri_getlen(ptr);
+	old_size = cheri_length_get(ptr);
 
 	mrs_debug_printf("%s: called ptr %p ptr size %zu new size %zu\n",
 	    __func__, ptr, old_size, size);

--- a/lib/libcheri_caprevoke/libcheri_caprevoke.c
+++ b/lib/libcheri_caprevoke/libcheri_caprevoke.c
@@ -172,7 +172,7 @@ caprev_shadow_nomap_common_pfx(ptraddr_t sbase, uint64_t * __capability sb,
     uint64_t * __capability *fw)
 {
 	caprev_shadow_nomap_offsets(ob, len, fwo, lwo);
-	*fw = cheri_setaddress(sb, sbase + *fwo);
+	*fw = cheri_address_set(sb, sbase + *fwo);
 }
 
 /*
@@ -245,7 +245,7 @@ caprev_shadow_nomap_set_len(ptraddr_t sbase, uint64_t * __capability sb,
 		 * special handling.
 		 */
 
-		lw = cheri_setaddress(sb, sbase + lwo);
+		lw = cheri_address_set(sb, sbase + lwo);
 		lwm = caprev_shadow_nomap_last_word_mask(ob, len);
 
 		/*
@@ -312,7 +312,7 @@ caprev_shadow_nomap_set(ptraddr_t sbase, uint64_t * __capability sb,
     void * __capability priv_obj, void * __capability user_obj)
 {
 	return (caprev_shadow_nomap_set_len(sbase, sb,
-	    (__cheri_addr ptraddr_t)priv_obj, cheri_getlen(priv_obj),
+	    (__cheri_addr ptraddr_t)priv_obj, cheri_length_get(priv_obj),
 	    user_obj));
 }
 
@@ -345,7 +345,7 @@ caprev_shadow_nomap_clear_len(ptraddr_t sbase, uint64_t * __capability sb,
 		uint64_t * __capability sbo;
 		ptrdiff_t wo;
 
-		lw = cheri_setaddress(sb, sbase + lwo);
+		lw = cheri_address_set(sb, sbase + lwo);
 		lwm = ~caprev_shadow_nomap_last_word_mask(ob, len);
 
 		/*
@@ -388,7 +388,7 @@ caprev_shadow_nomap_clear(ptraddr_t sbase, uint64_t * __capability sb,
     void * __capability obj)
 {
 	return (caprev_shadow_nomap_clear_len(sbase, sb,
-	    (__cheri_addr ptraddr_t)obj, cheri_getlen(obj)));
+	    (__cheri_addr ptraddr_t)obj, cheri_length_get(obj)));
 }
 
 /*
@@ -411,7 +411,7 @@ caprev_shadow_nomap_set_raw(ptraddr_t sbase, uint64_t * __capability sb,
 
 	caprev_shadow_nomap_offsets(heap_start, len, &fwo, &lwo);
 
-	fw = cheri_setaddress(sb, sbase + fwo);
+	fw = cheri_address_set(sb, sbase + fwo);
 	*fw |= caprev_shadow_nomap_first_word_mask(heap_start, len);
 
 	if (lwo != fwo) {
@@ -422,7 +422,7 @@ caprev_shadow_nomap_set_raw(ptraddr_t sbase, uint64_t * __capability sb,
 			*w = ~(uint64_t)0;
 		}
 
-		w = cheri_setaddress(sb, sbase + lwo);
+		w = cheri_address_set(sb, sbase + lwo);
 		*w |= caprev_shadow_nomap_last_word_mask(heap_start, len);
 	}
 }
@@ -437,7 +437,7 @@ caprev_shadow_nomap_clear_raw(ptraddr_t sbase, uint64_t * __capability sb,
 
 	caprev_shadow_nomap_offsets(heap_start, len, &fwo, &lwo);
 
-	fw = cheri_setaddress(sb, sbase + fwo);
+	fw = cheri_address_set(sb, sbase + fwo);
 	*fw &= ~caprev_shadow_nomap_first_word_mask(heap_start, len);
 
 	if (lwo != fwo) {
@@ -448,7 +448,7 @@ caprev_shadow_nomap_clear_raw(ptraddr_t sbase, uint64_t * __capability sb,
 			*w = 0;
 		}
 
-		w = cheri_setaddress(sb, sbase + lwo);
+		w = cheri_address_set(sb, sbase + lwo);
 		*w &= ~caprev_shadow_nomap_last_word_mask(heap_start, len);
 	}
 }

--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -48,7 +48,6 @@ static char *rcsid = "$FreeBSD$";
 #include <sys/types.h>
 #include <sys/mman.h>
 
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #ifdef CAPREVOKE

--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -148,8 +148,8 @@ __rederive_pointer(void *ptr)
 	pp = curpp;
 	while (pp != NULL) {
 		char *pool = (char *)pp;
-		if (cheri_is_address_inbounds(pool, cheri_getbase(ptr)))
-			return (cheri_setaddress(pool, cheri_getaddress(ptr)));
+		if (cheri_is_address_inbounds(pool, cheri_base_get(ptr)))
+			return (cheri_address_set(pool, cheri_address_get(ptr)));
 		pp = pp->ph_next;
 	}
 
@@ -163,7 +163,7 @@ __paint_shadow(void *mem, size_t size)
 {
 	struct pagepool_header *pp;
 
-	pp = cheri_setoffset(mem, 0);
+	pp = cheri_offset_set(mem, 0);
 	/*
 	 * Defer initializing ph_shadow since odds are good we'll never
 	 * need it.
@@ -181,7 +181,7 @@ __clear_shadow(void *mem, size_t size)
 {
 	struct pagepool_header *pp;
 
-	pp = cheri_setoffset(mem, 0);
+	pp = cheri_offset_set(mem, 0);
 	caprev_shadow_nomap_clear_raw(cri->base_mem_nomap,
 	    pp->ph_shadow, (ptraddr_t)mem, size);
 }

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -55,7 +55,6 @@ static char *rcsid = "$FreeBSD$";
 #ifdef CAPREVOKE
 #include <cheri/libcaprevoke.h>
 #endif
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 
 #include <assert.h>

--- a/lib/libmalloc_simple/malloc.c
+++ b/lib/libmalloc_simple/malloc.c
@@ -155,8 +155,8 @@ bound_ptr(void *mem, size_t nbytes)
 {
 	void *ptr;
 
-	ptr = cheri_setbounds(mem, nbytes);
-	ptr = cheri_andperm(ptr,
+	ptr = cheri_bounds_set(mem, nbytes);
+	ptr = cheri_perms_and(ptr,
 	    CHERI_PERMS_USERSPACE_DATA & ~CHERI_PERM_SW_VMEM);
 	return (ptr);
 }
@@ -409,7 +409,7 @@ morecore(int bucket)
 		if (__morepages(amt/pagesz) == 0)
 			return;
 
-	buf = cheri_setbounds(pagepool_start, amt);
+	buf = cheri_bounds_set(pagepool_start, amt);
 	pagepool_start += amt;
 
 	/*
@@ -417,7 +417,7 @@ morecore(int bucket)
 	 * free list for this hash bucket.
 	 */
 	for (; nblks > 0; nblks--) {
-		op = (struct overhead *)(void *)cheri_setbounds(buf, sz);
+		op = (struct overhead *)(void *)cheri_bounds_set(buf, sz);
 		SLIST_INSERT_HEAD(&nextf[bucket], op, ov_next);
 		buf += sz;
 	}
@@ -428,7 +428,7 @@ find_overhead(void * cp)
 {
 	struct overhead *op;
 
-	if (!cheri_gettag(cp))
+	if (!cheri_tag_get(cp))
 		return (NULL);
 	op = __rederive_pointer(cp);
 	if (op == NULL) {
@@ -439,7 +439,7 @@ find_overhead(void * cp)
 
 	if (op->ov_magic == MAGIC_OFFSET
 #ifdef __CHERI_PURE_CAPABILITY__
-	    && !cheri_gettag(op->ov_real_allocation)
+	    && !cheri_tag_get(op->ov_real_allocation)
 #endif
 	    )
 		op = (struct overhead *)((uintptr_t)op - op->ov_offset);
@@ -453,13 +453,13 @@ find_overhead(void * cp)
 	 *  - Be an internal allocator pointer (have the VMMAP permision).
 	 *  - Point somewhere before us and within the current pagepool.
 	 */
-	if (cheri_gettag(op->ov_real_allocation) &&
-	    (cheri_getperm(op->ov_real_allocation) & CHERI_PERM_SW_VMEM) != 0) {
+	if (cheri_tag_get(op->ov_real_allocation) &&
+	    (cheri_perms_get(op->ov_real_allocation) & CHERI_PERM_SW_VMEM) != 0) {
 		ptraddr_t base, pp_base;
 
-		pp_base = cheri_getbase(op);
-		base = cheri_getbase(op->ov_real_allocation);
-		if (base >= pp_base && base < cheri_getaddress(op)) {
+		pp_base = cheri_base_get(op);
+		base = cheri_base_get(op->ov_real_allocation);
+		if (base >= pp_base && base < cheri_address_get(op)) {
 			op = op->ov_real_allocation;
 			op--;
 		}
@@ -551,7 +551,7 @@ __simple_realloc(void *cp, size_t nbytes)
 	 */
 	memcpy(res, cp, (nbytes <= cheri_bytes_remaining(cp)) ?
 	    nbytes : cheri_bytes_remaining(cp));
-	res = cheri_andperm(res, cheri_getperm(cp));
+	res = cheri_perms_and(res, cheri_perms_get(cp));
 	__simple_free(cp);
 	return (res);
 }

--- a/lib/libproc/proc_regs.c
+++ b/lib/libproc/proc_regs.c
@@ -121,7 +121,7 @@ proc_regset(struct proc_handle *phdl, proc_reg_t reg, unsigned long regvalue)
 	switch (reg) {
 	case REG_PC:
 #if defined(__aarch64__) && defined(__CHERI_PURE_CAPABILITY__)
-		capregs.celr = cheri_setaddress(capregs.celr, regvalue);
+		capregs.celr = cheri_address_set(capregs.celr, regvalue);
 		tagmask |= 1ul <<
 		    (__offsetof(struct capreg, celr) / sizeof(uintcap_t));
 #elif defined(__aarch64__)
@@ -140,7 +140,7 @@ proc_regset(struct proc_handle *phdl, proc_reg_t reg, unsigned long regvalue)
 		break;
 	case REG_SP:
 #if defined(__aarch64__) && defined(__CHERI_PURE_CAPABILITY__)
-		capregs.csp = cheri_setaddress(capregs.csp, regvalue);
+		capregs.csp = cheri_address_set(capregs.csp, regvalue);
 		tagmask |= 1ul <<
 		    (__offsetof(struct capreg, csp) / sizeof(uintcap_t));
 #elif defined(__aarch64__)

--- a/lib/libproc/proc_regs.c
+++ b/lib/libproc/proc_regs.c
@@ -33,7 +33,7 @@
 #include <sys/reg.h>
 
 #if defined(__aarch64__) && defined(__CHERI_PURE_CAPABILITY__)
-#include <cheri/cheric.h>
+#include <cheriintrin.h>
 #endif
 
 #include <err.h>

--- a/lib/libsimple_printf/simple_printf.c
+++ b/lib/libsimple_printf/simple_printf.c
@@ -356,7 +356,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 					PCHAR(*cap_repr++);
 				break;
 			} else {
-				num = cheri_getaddress(cap);
+				num = cheri_address_get(cap);
 			}
 #else
 			num = (uintmax_t)(uintptr_t)va_arg(ap, void *);

--- a/lib/libsys/mmap_c18n.c
+++ b/lib/libsys/mmap_c18n.c
@@ -11,7 +11,8 @@
 
 #include <sys/mman.h>
 
-#include <cheri/cheric.h>
+#include <cheri/cherireg.h>
+#include <cheriintrin.h>
 
 #include "libc_private.h"
 

--- a/lib/libsys/mmap_c18n.c
+++ b/lib/libsys/mmap_c18n.c
@@ -29,7 +29,7 @@ __mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset)
 #ifdef __aarch64__
 		perms |= CHERI_PERM_EXECUTIVE;
 #endif
-		ret = cheri_clearperm(ret, perms);
+		ret = cheri_perms_clear(ret, perms);
 	}
 #endif
 	return (ret);

--- a/lib/libthr/thread/thr_attr.c
+++ b/lib/libthr/thread/thr_attr.c
@@ -302,7 +302,7 @@ _pthread_attr_getstack(const pthread_attr_t * __restrict attr,
 	 * XXX-AR: maybe we should allow this and simply treat
 	 * pthread_attr_getstack() as an unsafe API.
 	 */
-	cheri_cleartag(*stackaddr);
+	cheri_tag_clear(*stackaddr);
 #endif
 	*stacksize = (*attr)->stacksize_attr;
 	return (0);
@@ -327,7 +327,7 @@ _thr_attr_getstackaddr(const pthread_attr_t *attr, void **stackaddr)
 	 * XXX-AR: maybe we should allow this and simply treat
 	 * pthread_attr_getstackaddr() as an unsafe API
 	 */
-	cheri_cleartag(*stackaddr);
+	cheri_tag_clear(*stackaddr);
 #endif
 	return (0);
 }

--- a/lib/libthr/thread/thr_create.c
+++ b/lib/libthr/thread/thr_create.c
@@ -197,9 +197,9 @@ _pthread_create(pthread_t * __restrict thread,
 	param.stack_base = new_thread->attr.stackaddr_attr;
 	param.stack_size = new_thread->attr.stacksize_attr;
 #ifdef __CHERI_PURE_CAPABILITY__
-	THR_ASSERT(cheri_gettag(param.stack_base) == 1,
+	THR_ASSERT(cheri_tag_get(param.stack_base) == 1,
 	    "stack_base must be a valid capability");
-	THR_ASSERT(cheri_getlen(param.stack_base) == param.stack_size,
+	THR_ASSERT(cheri_length_get(param.stack_base) == param.stack_size,
 	    "param.stack_base length should be param.stack_size!");
 #endif
 	param.tls_base = (char *)new_thread->tcb;

--- a/lib/libthr/thread/thr_init.c
+++ b/lib/libthr/thread/thr_init.c
@@ -464,8 +464,8 @@ __thr_get_main_stack_base(char **base)
 	 * whole thing for the initial thread and take our values from
 	 * there.
 	 */
-	char *sp = (char *)cheri_getstack();
-	*base = cheri_setoffset(sp, cheri_getlen(sp));
+	char *sp = (char *)cheri_stack_get();
+	*base = cheri_offset_set(sp, cheri_length_get(sp));
 	return (true);
 #else
 	size_t len;
@@ -489,7 +489,7 @@ __thr_get_main_stack_lim(size_t *lim)
 {
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* See above. */
-	*lim = cheri_getlen(cheri_getstack());
+	*lim = cheri_length_get(cheri_stack_get());
 	return (true);
 #else
 	struct rlimit rlim;

--- a/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_machdep.c
@@ -68,7 +68,7 @@ tramp_compile(char **entry, const struct tramp_data *data)
 	size_t hook_off, count_off;
 	size_t header_off, target_off, landing_off, unused_regs;
 	compart_id_t callee;
-	bool executive = cheri_getperm(data->target) & CHERI_PERM_EXECUTIVE;
+	bool executive = cheri_perms_get(data->target) & CHERI_PERM_EXECUTIVE;
 	bool count = ld_compartment_switch_count != NULL;
 	bool hook = ld_compartment_utrace != NULL ||
 	    ld_compartment_overhead != NULL;

--- a/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
@@ -64,15 +64,15 @@ make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 
 	ret = pcc_cap(defobj, def->st_value);
 	/* Remove store and seal permissions */
-	ret = cheri_clearperm(ret, FUNC_PTR_REMOVE_PERMS);
+	ret = cheri_perms_clear(ret, FUNC_PTR_REMOVE_PERMS);
 	if (tight_bounds) {
-		ret = cheri_setbounds(ret, def->st_size);
+		ret = cheri_bounds_set(ret, def->st_size);
 	}
 	/*
 	 * Note: The addend is required for C++ exceptions since capabilities
 	 * for catch blocks point to the middle of a function.
 	 */
-	ret = cheri_incoffset(ret, addend);
+	ret = cheri_offset_inc(ret, addend);
 	/* All code pointers should be sentries: */
 	ret = __builtin_cheri_seal_entry(ret);
 	return __DECONST_CAP(dlfunc_t __capability, ret);
@@ -101,21 +101,21 @@ make_data_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj)
 	void * __capability ret;
 	ret = get_datasegment_cap(defobj) + def->st_value;
 	/* Remove execute and seal permissions */
-	ret = cheri_clearperm(ret, DATA_PTR_REMOVE_PERMS);
-	ret = cheri_setbounds(ret, def->st_size);
+	ret = cheri_perms_clear(ret, DATA_PTR_REMOVE_PERMS);
+	ret = cheri_bounds_set(ret, def->st_size);
 	return ret;
 }
 
 #define set_bounds_if_nonnull(cap, size)	\
-	do { if (cap) { cap = cheri_setbounds(cap, size); } } while(0)
+	do { if (cap) { cap = cheri_bounds_set(cap, size); } } while(0)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 static inline void
 fix_obj_mapping_cap_permissions(Obj_Entry *obj, const char *path __unused)
 {
-	obj->text_rodata_cap = (const char*)cheri_clearperm(obj->text_rodata_cap, FUNC_PTR_REMOVE_PERMS);
-	obj->relocbase = (char*)cheri_clearperm(obj->relocbase, DATA_PTR_REMOVE_PERMS);
-	obj->mapbase = (char*)cheri_clearperm(obj->mapbase, DATA_PTR_REMOVE_PERMS);
+	obj->text_rodata_cap = (const char*)cheri_perms_clear(obj->text_rodata_cap, FUNC_PTR_REMOVE_PERMS);
+	obj->relocbase = (char*)cheri_perms_clear(obj->relocbase, DATA_PTR_REMOVE_PERMS);
+	obj->mapbase = (char*)cheri_perms_clear(obj->mapbase, DATA_PTR_REMOVE_PERMS);
 }
 #endif
 

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -152,21 +152,21 @@ process_r_cheri_capability(Obj_Entry *obj, Elf_Word r_symndx,
 #endif
 	} else {
 		/* Remove execute permissions and set bounds */
-		symval = cheri_incoffset(make_data_cap(def, defobj), addend);
+		symval = cheri_offset_inc(make_data_cap(def, defobj), addend);
 	}
 #ifdef DEBUG
 	// FIXME: this warning breaks some tests that expect clean stdout/stderr
 	// FIXME: See https://github.com/CTSRD-CHERI/cheribsd/issues/257
 	// TODO: or use this approach:
 	// https://github.com/CTSRD-CHERI/cheribsd/commit/c1920496c0086d9c5214fb0f491e4d6cdff3828e?
-	if (__predict_false(symval != NULL && cheri_getlen(symval) <= 0)) {
+	if (__predict_false(symval != NULL && cheri_length_get(symval) <= 0)) {
 		rtld_fdprintf(STDERR_FILENO,
 		    "Warning: created zero length "
 		    "capability for %s (in %s): %#lp\n",
 		    symname(obj, r_symndx), obj->path, symval);
 	}
 #endif
-	if (__predict_false(!cheri_gettag(symval) && !is_undef_weak)) {
+	if (__predict_false(!cheri_tag_get(symval) && !is_undef_weak)) {
 		_rtld_error("%s: constructed invalid capability for %s: %#lp",
 		    obj->path, symname(obj, r_symndx), symval);
 		return -1;

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -125,7 +125,7 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 			break;
 		}
 	}
-	caprelocs = cheri_setbounds(caprelocs, caprelocssz);
+	caprelocs = cheri_bounds_set(caprelocs, caprelocssz);
 	caprelocslim = (const struct capreloc *)((const char *)caprelocs + caprelocssz);
 	pcc = __builtin_cheri_program_counter_get();
 	/* TODO: allow using tight bounds for RTLD */

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -549,16 +549,16 @@ void dump_Elf_Rela(Obj_Entry *, const Elf_Rela *, u_long);
 
 #ifdef __CHERI_PURE_CAPABILITY__
 #define get_datasegment_cap(obj)				\
-	(cheri_clearperm((obj)->relocbase, CAP_RELOC_REMOVE_PERMS))
+	(cheri_perms_clear((obj)->relocbase, CAP_RELOC_REMOVE_PERMS))
 #elif __has_feature(capabilities)
 #define pcc_cap(obj, offset)					\
-	(const char * __capability)cheri_setbounds(		\
-	    cheri_setaddress(cheri_getpcc(),			\
+	(const char * __capability)cheri_bounds_set(		\
+	    cheri_address_set(cheri_pcc_get(),			\
 	        (ptraddr_t)(uintptr_t)obj->mapbase + (offset)),	\
 	    obj->mapsize)
 #define get_datasegment_cap(obj)				\
-	(char * __capability)cheri_setbounds(			\
-	    cheri_setaddress(cheri_getdefault(),		\
+	(char * __capability)cheri_bounds_set(			\
+	    cheri_address_set(cheri_ddc_get(),		\
 	        (ptraddr_t)(uintptr_t)obj->mapbase),		\
 	    obj->mapsize)
 #endif

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -54,7 +54,6 @@
 #include <stddef.h>
 
 #if __has_feature(capabilities)
-#include <cheri/cheri.h>
 #include <cheri/cheric.h>
 #endif
 

--- a/share/man/man9/Makefile
+++ b/share/man/man9/Makefile
@@ -836,30 +836,30 @@ MLINKS+=callout.9 callout_active.9 \
 	callout.9 callout_schedule_sbt_on.9 \
 	callout.9 callout_stop.9 \
 	callout.9 callout_when.9
-MLINKS+=cheric.9 cheri_andperm.9 \
+MLINKS+=cheric.9 cheri_address_get.9 \
+	cheric.9 cheri_address_set.9 \
+	cheric.9 cheri_base_get.9 \
+	cheric.9 cheri_bounds_set.9 \
 	cheric.9 cheri_clear_low_ptr_bits.9 \
-	cheric.9 cheri_setbounds.9 \
+	cheric.9 cheri_ddc_get.9 \
 	cheric.9 cheri_fromint.9 \
 	cheric.9 cheri_get_low_ptr_bits.9 \
-	cheric.9 cheri_getaddress.9 \
-	cheric.9 cheri_getbase.9 \
-	cheric.9 cheri_getdefault.9 \
-	cheric.9 cheri_getlen.9 \
-	cheric.9 cheri_getoffset.9 \
-	cheric.9 cheri_getpcc.9 \
-	cheric.9 cheri_getperm.9 \
-	cheric.9 cheri_getsealed.9 \
-	cheric.9 cheri_getstack.9 \
-	cheric.9 cheri_gettop.9 \
-	cheric.9 cheri_gettag.9 \
-	cheric.9 cheri_gettype.9 \
-	cheric.9 cheri_clearperm.9 \
-	cheric.9 cheri_cleartag.9 \
-	cheric.9 cheri_incoffset.9 \
+	cheric.9 cheri_is_sealed.9 \
+	cheric.9 cheri_length_get.9 \
+	cheric.9 cheri_offset_get.9 \
+	cheric.9 cheri_offset_inc.9 \
+	cheric.9 cheri_offset_set.9 \
+	cheric.9 cheri_pcc_get.9 \
+	cheric.9 cheri_perms_and.9 \
+	cheric.9 cheri_perms_clear.9 \
+	cheric.9 cheri_perms_get.9 \
 	cheric.9 cheri_seal.9 \
 	cheric.9 cheri_set_low_ptr_bits.9 \
-	cheric.9 cheri_setaddress.9 \
-	cheric.9 cheri_setoffset.9 \
+	cheric.9 cheri_stack_get.9 \
+	cheric.9 cheri_tag_clear.9 \
+	cheric.9 cheri_tag_get.9 \
+	cheric.9 cheri_top_get.9 \
+	cheric.9 cheri_type_get.9 \
 	cheric.9 cheri_unseal.9
 MLINKS+=cnv.9 cnvlist.9 \
 	cnv.9 cnvlist_free_binary.9 \

--- a/share/man/man9/cheric.9
+++ b/share/man/man9/cheric.9
@@ -29,89 +29,88 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 17, 2019
+.Dd December 12, 2025
 .Dt CHERIC 9
 .Os
 .Sh NAME
-.Nm cheri_andperm
-.Nm cheri_clear_low_ptr_bits
-.Nm cheri_setbounds
+.Nm cheri_address_get
+.Nm cheri_address_set
+.Nm cheri_base_get
+.Nm cheri_bounds_set
+.Nm cheri_ddc_get
 .Nm cheri_fromint
-.Nm cheri_get_low_ptr_bits
-.Nm cheri_getaddress
-.Nm cheri_getbase
-.Nm cheri_getdefault
-.Nm cheri_getlen
-.Nm cheri_getoffset
-.Nm cheri_getpcc
-.Nm cheri_getperm
-.Nm cheri_getsealed
-.Nm cheri_getstack
-.Nm cheri_gettop
-.Nm cheri_gettag
-.Nm cheri_gettype
-.Nm cheri_clearperm
-.Nm cheri_cleartag
-.Nm cheri_incoffset
+.Nm cheri_is_sealed
+.Nm cheri_length_get
+.Nm cheri_offset_get
+.Nm cheri_offset_inc
+.Nm cheri_offset_set
+.Nm cheri_pcc_get
+.Nm cheri_perms_and
+.Nm cheri_perms_clear
+.Nm cheri_perms_get
 .Nm cheri_seal
-.Nm cheri_set_low_ptr_bits
-.Nm cheri_setaddress
-.Nm cheri_setoffset
+.Nm cheri_stack_get
+.Nm cheri_tag_clear
+.Nm cheri_tag_get
+.Nm cheri_top_get
+.Nm cheri_type_get
 .Nm cheri_unseal
+.Nm cheri_clear_low_ptr_bits
+.Nm cheri_get_low_ptr_bits
+.Nm cheri_set_low_ptr_bits
 .Nd CHERI C built-in functions
 .Sh SYNOPSIS
-.In cheri/cheri.h
 .In cheri/cheric.h
+.Ft ptraddr_t
+.Fn cheri_address_get "void * __capability c"
 .Ft void * __capability
-.Fn cheri_andperm "void * __capability c" "size_t mask"
+.Fn cheri_address_set "void * __capability c" "ptraddr_t address"
+.Ft ptraddr_t
+.Fn cheri_base_get "void * __capability c"
 .Ft void * __capability
-.Fn cheri_clear_low_ptr_bits "void * __capability c" "size_t mask"
+.Fn cheri_bounds_set "void * __capability c" "size_t length"
 .Ft void * __capability
-.Fn cheri_setbounds "void * __capability c" "size_t length"
+.Fn cheri_ddc_get "void"
 .Ft void * __capability
 .Fn cheri_fromint "ptraddr_t"
+.Ft bool
+.Fn cheri_is_sealed "void * __capability c"
 .Ft size_t
-.Fn cheri_get_low_ptr_bits "void * __capability c" "size_t mask"
-.Ft ptraddr_t
-.Fn cheri_getaddress "void * __capability c"
-.Ft ptraddr_t
-.Fn cheri_getbase "void * __capability c"
-.Ft void * __capability
-.Fn cheri_getdefault "void"
+.Fn cheri_length_get "void * __capability c"
 .Ft size_t
-.Fn cheri_getlen "void * __capability c"
+.Fn cheri_offset_get "void * __capability c"
+.Ft void * __capability
+.Fn cheri_offset_inc "void * __capability c" "size_t offset"
+.Ft void * __capability
+.Fn cheri_offset_set "void * __capability c" "size_t offset"
+.Ft void * __capability
+.Fn cheri_pcc_get "void"
+.Ft void * __capability
+.Fn cheri_perms_and "void * __capability c" "size_t mask"
+.Ft void * __capability
+.Fn cheri_perms_clear "void * __capability c" "size_t mask"
 .Ft size_t
-.Fn cheri_getoffset "void * __capability c"
-.Ft void * __capability
-.Fn cheri_getpcc "void"
-.Ft size_t
-.Fn cheri_getperm "void * __capability c"
-.Ft _Bool
-.Fn cheri_getsealed "void * __capability c"
-.Ft void * __capability
-.Fn cheri_getstack "void"
-.Ft ptraddr_t
-.Fn cheri_gettop "void * __capability c"
-.Ft _Bool
-.Fn cheri_gettag "void * __capability c"
-.Ft ptraddr_t
-.Fn cheri_gettype "void * __capability c"
-.Ft void * __capability
-.Fn cheri_clearperm "void * __capability c" "size_t mask"
-.Ft void * __capability
-.Fn cheri_cleartag "void * __capability c"
-.Ft void * __capability
-.Fn cheri_incoffset "void * __capability c" "size_t offset"
+.Fn cheri_perms_get "void * __capability c"
 .Ft void * __capability
 .Fn cheri_seal "void * __capability c" "void * __capability typecap"
 .Ft void * __capability
-.Fn cheri_set_low_ptr_bits "void * __capability c" "size_t mask"
+.Fn cheri_stack_get "void"
 .Ft void * __capability
-.Fn cheri_setaddress "void * __capability c" "ptraddr_t address"
-.Ft void * __capability
-.Fn cheri_setoffset "void * __capability c" "size_t offset"
+.Fn cheri_tag_clear "void * __capability c"
+.Ft bool
+.Fn cheri_tag_get "void * __capability c"
+.Ft ptraddr_t
+.Fn cheri_top_get "void * __capability c"
+.Ft ptraddr_t
+.Fn cheri_type_get "void * __capability c"
 .Ft void * __capability
 .Fn cheri_unseal "void * __capability c" "void * __capability typecap"
+.Ft void * __capability
+.Fn cheri_clear_low_ptr_bits "void * __capability c" "size_t mask"
+.Ft size_t
+.Fn cheri_get_low_ptr_bits "void * __capability c" "size_t mask"
+.Ft void * __capability
+.Fn cheri_set_low_ptr_bits "void * __capability c" "size_t mask"
 .Sh DESCRIPTION
 The
 .Xr cheric 9
@@ -123,31 +122,31 @@ applied.
 The following APIs allow capability fields to be queried:
 .Pp
 .Bl -tag -width short
-.It Fn cheri_getaddress "c"
+.It Fn cheri_address_get "c"
 Return the address field of the capability
 .Fa c .
 This value will normally be the the same as the integer cast of a capability
 pointer.
-.It Fn cheri_getbase "c"
+.It Fn cheri_base_get "c"
 Return the base (bottom) address associated with the capability
 .Fa c ;
 this is its lower bound.
-.It Fn cheri_getoffset "c"
+.It Fn cheri_offset_get "c"
 Return the offset associated with capability
 .Fa c ;
 this is the difference between its address and its lower bound.
-.It Fn cheri_getperm "c"
+.It Fn cheri_perms_get "c"
 Return the permissions associated with the capability
 .Fa c .
-.It Fn cheri_getsealed "c"
+.It Fn cheri_is_sealed "c"
 Return a boolean indicating whether the capability
 .Fa c
 is sealed.
-.It Fn cheri_gettag "c"
+.It Fn cheri_tag_get "c"
 Return a boolean indicating whether the capability
 .Fa c
 has a valid tag.
-.It Fn cheri_gettype "c"
+.It Fn cheri_type_get "c"
 Return the object type of the capability
 .Fa c .
 .El
@@ -156,23 +155,23 @@ The following APIs allow capability fields to be set, with a new capability
 returned:
 .Pp
 .Bl -tag -width short
-.It Fn cheri_andperm "c" "mask"
+.It Fn cheri_perms_and "c" "mask"
 Return a capability derived from
 .Fa c
 that has its permissions mask bit-wise AND'd with the value of
 .Fa mask .
-.It Fn cheri_cleartag "c"
+.It Fn cheri_tag_clear "c"
 Return a capability derived from
 .Fa c
 that has its validity tag cleared.
-.It Fn cheri_setbounds "c" "length"
+.It Fn cheri_bounds_set "c" "length"
 Return a capability derived from
 .Fa c
 that has its base set to the current address of
 .Fa c ,
 and length set to
 .Fa length .
-.It Fn cheri_incoffset "c" "offset"
+.It Fn cheri_offset_inc "c" "offset"
 Return a capability derived from
 .Fa c
 that has its offset incremented by
@@ -182,7 +181,7 @@ Return a capability derived from
 .Fa c
 that is sealed using capability
 .Fa typecap .
-.It Fn cheri_setoffset "c" "offset"
+.It Fn cheri_offset_set "c" "offset"
 Return a capability derived from
 .Fa c
 that has its offset field set to
@@ -216,11 +215,11 @@ To be added.
 The following APIs return capability pointers for certain well-defined
 capabilities in the run-time environment:
 .Bl -tag -width short
-.It Fn cheri_getdefault "void"
+.It Fn cheri_ddc_get "void"
 Return the Default Data Capability (DDC).
-.It Fn cheri_getpcc "void"
+.It Fn cheri_pcc_get "void"
 Return the Program-Counter Capability (PCC).
-.It Fn cheri_getstack "void"
+.It Fn cheri_stack_get "void"
 Return the current stack capability.
 .El
 .Sh AUTHORS

--- a/sys/arm64/arm64/cheri_revoke_machdep_tests.c
+++ b/sys/arm64/arm64/cheri_revoke_machdep_tests.c
@@ -52,7 +52,7 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 	uint8_t bmbits;
 	const uint8_t * __capability bmloc;
 
-	ptraddr_t va = cheri_getbase(cut);
+	ptraddr_t va = cheri_base_get(cut);
 
 	bmloc = crshadow - VM_CHERI_REVOKE_BSZ_OTYPE -
 	    (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
@@ -89,7 +89,7 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 	uint8_t bmbits;
 	const uint8_t * __capability bmloc;
 
-	ptraddr_t va = cheri_getbase(cut);
+	ptraddr_t va = cheri_base_get(cut);
 
 	bmloc = crshadow + (va / VM_CHERI_REVOKE_GSZ_MEM_NOMAP / 8);
 
@@ -118,7 +118,7 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 static inline unsigned
 vm_cheri_revoke_test_range(vm_offset_t start, vm_offset_t end, uintcap_t cut)
 {
-	ptraddr_t va = cheri_getbase(cut);
+	ptraddr_t va = cheri_base_get(cut);
 
 	return (va >= start && va < end);
 }

--- a/sys/arm64/arm64/freebsd64_machdep.c
+++ b/sys/arm64/arm64/freebsd64_machdep.c
@@ -182,7 +182,7 @@ mcontext_to_mcontext64(mcontext_t *mc, mcontext64_t *mc64)
 	greg = (register_t *)&mc64->mc_gpregs;
 	for (i = 0; i < CONTEXT64_COPYREGS; i++)
 		greg[i] = (register_t)creg[i];
-	mc64->mc_gpregs.gp_elr = cheri_getoffset(mc->mc_capregs.cap_elr);
+	mc64->mc_gpregs.gp_elr = cheri_offset_get(mc->mc_capregs.cap_elr);
 	mc64->mc_gpregs.gp_spsr = mc->mc_spsr;
 	mc64->mc_flags = mc->mc_flags;
 	if (mc->mc_flags & _MC_FP_VALID)
@@ -224,7 +224,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 		/* XXX: Permit userland to change GPRs for sigreturn? */
 
 		/* Honor 64-bit PC. */
-		mc.mc_capregs.cap_elr = cheri_setoffset(mc.mc_capregs.cap_elr,
+		mc.mc_capregs.cap_elr = cheri_offset_set(mc.mc_capregs.cap_elr,
 		    mcp->mc_gpregs.gp_elr);
 	} else {
 		creg = (uintcap_t *)&mc.mc_capregs;
@@ -232,7 +232,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 		for (i = 0; i < CONTEXT64_COPYREGS; i++)
 			creg[i] = (uintcap_t)greg[i];
 
-		mc.mc_capregs.cap_elr = cheri_setoffset(td->td_frame->tf_elr,
+		mc.mc_capregs.cap_elr = cheri_offset_set(td->td_frame->tf_elr,
 		    mcp->mc_gpregs.gp_elr);
 		mc.mc_capregs.cap_ddc = td->td_frame->tf_ddc;
 	}
@@ -332,7 +332,7 @@ freebsd64_sendsig(sig_t catcher, ksiginfo_t *ksi, sigset_t *mask)
 	tf->tf_x[2] = (uintcap_t)fp + offsetof(struct sigframe64, sf_uc);
 	tf->tf_x[8] = (uintcap_t)catcher;
 	tf->tf_sp = (uintcap_t)fp;
-	trapframe_set_elr(tf, (uintcap_t)cheri_setaddress(catcher,
+	trapframe_set_elr(tf, (uintcap_t)cheri_address_set(catcher,
 	    PROC_SIGCODE(p)));
 
 	CTR3(KTR_SIG, "sendsig: return td=%p pc=%#x sp=%#x", td, tf->tf_elr,

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -759,9 +759,9 @@ try_load_dtb(caddr_t kmdp)
 	dtbp = MD_FETCH(kmdp, MODINFOMD_DTBP, vm_offset_t);
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (dtbp != (vm_pointer_t)NULL) {
-		dtbp = (vm_pointer_t)cheri_andperm(cheri_setaddress(
+		dtbp = (vm_pointer_t)cheri_perms_and(cheri_address_set(
 		    kernel_root_cap, dtbp), CHERI_PERMS_KERNEL_DATA);
-		dtbp = cheri_setbounds(dtbp, fdt_totalsize((void *)dtbp));
+		dtbp = cheri_bounds_set(dtbp, fdt_totalsize((void *)dtbp));
 	}
 #endif
 

--- a/sys/arm64/arm64/machdep_boot.c
+++ b/sys/arm64/arm64/machdep_boot.c
@@ -93,8 +93,8 @@ fake_preload_metadata(void *dtb_ptr, size_t dtb_size)
 	size_t size;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	lastaddr = (vm_pointer_t)cheri_setaddress(
-	    cheri_andperm(kernel_root_cap,
+	lastaddr = (vm_pointer_t)cheri_address_set(
+	    cheri_perms_and(kernel_root_cap,
 		CHERI_PERMS_KERNEL_DATA_NOCAP),
 	    (vm_offset_t)&end);
 #else
@@ -225,9 +225,9 @@ freebsd_parse_boot_param(struct arm64_bootparams *abp)
 	env_addr = MD_FETCH(kmdp, MODINFOMD_ENVP, vm_offset_t);
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (env_addr != 0) {
-		env_addr = (vm_pointer_t)cheri_setaddress(kernel_root_cap,
+		env_addr = (vm_pointer_t)cheri_address_set(kernel_root_cap,
 		    env_addr);
-		env_addr = cheri_andperm(env_addr,
+		env_addr = cheri_perms_and(env_addr,
 		    CHERI_PERMS_KERNEL_DATA_NOCAP);
 	}
 #endif
@@ -238,13 +238,13 @@ freebsd_parse_boot_param(struct arm64_bootparams *abp)
 	ksym_start = MD_FETCH(kmdp, MODINFOMD_SSYM, vm_offset_t);
 	ksym_end = MD_FETCH(kmdp, MODINFOMD_ESYM, vm_offset_t);
 #ifdef __CHERI_PURE_CAPABILITY__
-	ksym_start = (vm_pointer_t)cheri_setaddress(kernel_root_cap,
+	ksym_start = (vm_pointer_t)cheri_address_set(kernel_root_cap,
 	    ksym_start);
-	ksym_start = cheri_setbounds(ksym_start,
+	ksym_start = cheri_bounds_set(ksym_start,
 	    (ptraddr_t)ksym_end - (ptraddr_t)ksym_start);
-	ksym_start = cheri_andperm(ksym_start,
+	ksym_start = cheri_perms_and(ksym_start,
 	    CHERI_PERMS_KERNEL_DATA_NOCAP);
-	ksym_end = cheri_setaddress(ksym_start, ksym_end);
+	ksym_end = cheri_address_set(ksym_start, ksym_end);
 #endif
 	db_fetch_ksymtab(ksym_start, ksym_end, 0);
 #endif

--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -79,8 +79,8 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			/* If the address is in the DMAP just copy it */
 			if (VIRT_IN_DMAP(v)) {
 #ifdef __CHERI_PURE_CAPABILITY__
-				error = uiomove(cheri_setboundsexact(
-				    cheri_setaddress(dmap_base_cap, v), cnt),
+				error = uiomove(cheri_bounds_set_exact(
+				    cheri_address_set(dmap_base_cap, v), cnt),
 				    cnt, uio);
 #else
 				error = uiomove((void *)v, cnt, uio);

--- a/sys/arm64/arm64/trap.c
+++ b/sys/arm64/arm64/trap.c
@@ -294,12 +294,12 @@ external_abort(struct thread *td, struct trapframe *frame, uint64_t esr,
 	 */
 	if (test_bs_fault((uintcap_t)frame->tf_elr)) {
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-		frame->tf_elr = cheri_setaddress(frame->tf_elr,
+		frame->tf_elr = cheri_address_set(frame->tf_elr,
 		    (ptraddr_t)generic_bs_fault);
 #elif defined(__CHERI_PURE_CAPABILITY__)
 		trapframe_set_elr(frame, (uintptr_t)generic_bs_fault);
 #elif __has_feature(capabilities)
-		trapframe_set_elr(frame, cheri_setaddress(frame->tf_elr,
+		trapframe_set_elr(frame, cheri_address_set(frame->tf_elr,
 		    (ptraddr_t)generic_bs_fault));
 #else
 		frame->tf_elr = (uint64_t)generic_bs_fault;
@@ -325,12 +325,12 @@ cap_abort(struct thread *td, struct trapframe *frame, uint64_t esr,
 		    pcb->pcb_onfault != 0) {
 			frame->tf_x[0] = EPROT;
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-			frame->tf_elr = cheri_setaddress(frame->tf_elr,
+			frame->tf_elr = cheri_address_set(frame->tf_elr,
 			    pcb->pcb_onfault);
 #elif defined(__CHERI_PURE_CAPABILITY__)
 			trapframe_set_elr(frame, pcb->pcb_onfault);
 #else
-			trapframe_set_elr(frame, cheri_setaddress(frame->tf_elr,
+			trapframe_set_elr(frame, cheri_address_set(frame->tf_elr,
 			    pcb->pcb_onfault));
 #endif
 			return;
@@ -530,12 +530,12 @@ bad_far:
 			if (td->td_intr_nesting_level == 0 &&
 			    pcb->pcb_onfault != 0) {
 #if defined(__ARM_MORELLO_PURECAP_BENCHMARK_ABI)
-				frame->tf_elr = cheri_setaddress(frame->tf_elr,
+				frame->tf_elr = cheri_address_set(frame->tf_elr,
 				    pcb->pcb_onfault);
 #elif defined(__CHERI_PURE_CAPABILITY__)
 				trapframe_set_elr(frame, pcb->pcb_onfault);
 #elif __has_feature(capabilities)
-				trapframe_set_elr(frame, cheri_setaddress(
+				trapframe_set_elr(frame, cheri_address_set(
 				    frame->tf_elr, pcb->pcb_onfault));
 #else
 				frame->tf_elr = pcb->pcb_onfault;

--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -248,7 +248,7 @@ cpu_set_upcall(struct thread *td, void (* __capability entry)(void *),
 #if __has_feature(capabilities)
 	if (SV_PROC_FLAG(td->td_proc, SV_CHERI)) {
 		if (SV_PROC_FLAG(td->td_proc, SV_UNBOUND_PCC))
-			tf->tf_elr = cheri_setaddress(tf->tf_elr,
+			tf->tf_elr = cheri_address_set(tf->tf_elr,
 			    (__cheri_addr ptraddr_t)entry);
 		else
 			trapframe_set_elr(tf, (uintcap_t)entry);

--- a/sys/arm64/cheri/cheri_machdep.c
+++ b/sys/arm64/cheri/cheri_machdep.c
@@ -57,30 +57,30 @@ cheri_init_capabilities(void * __capability kroot)
 {
 	void * __capability ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_KERNEL_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_KERNEL_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_KERNEL_PERMS);
+	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_KERNEL_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_KERNEL_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_SEALCAP_KERNEL_PERMS);
 	kernel_root_sealcap = ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_CAP_USER_DATA_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |
+	ctemp = cheri_address_set(kroot, CHERI_CAP_USER_DATA_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_CAP_USER_DATA_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
 	userspace_root_cap = ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_USERSPACE_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
+	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_USERSPACE_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
 	userspace_root_sealcap = ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_COMPARTMENT_ID_USERSPACE_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_COMPARTMENT_ID_USERSPACE_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_COMPARTMENT_ID_USERSPACE_PERMS);
+	ctemp = cheri_address_set(kroot, CHERI_COMPARTMENT_ID_USERSPACE_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_COMPARTMENT_ID_USERSPACE_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_COMPARTMENT_ID_USERSPACE_PERMS);
 	userspace_root_cidcap = (uintcap_t)ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_OTYPE_SENTRY);
-	ctemp = cheri_setbounds(ctemp, 1);
-	ctemp = cheri_andperm(ctemp, CHERI_PERM_GLOBAL | CHERI_PERM_UNSEAL);
+	ctemp = cheri_address_set(kroot, CHERI_OTYPE_SENTRY);
+	ctemp = cheri_bounds_set(ctemp, 1);
+	ctemp = cheri_perms_and(ctemp, CHERI_PERM_GLOBAL | CHERI_PERM_UNSEAL);
 	sentry_unsealcap = ctemp;
 
 	smccc_ddc_el0 = kroot;
@@ -89,22 +89,22 @@ cheri_init_capabilities(void * __capability kroot)
 
 	vmm_gva_root_cap = kroot;
 
-	vmm_gpa_root_cap = cheri_setaddress(kroot, HYP_GPA_MIN_ADDRESS);
-	vmm_gpa_root_cap = cheri_setbounds(vmm_gpa_root_cap,
+	vmm_gpa_root_cap = cheri_address_set(kroot, HYP_GPA_MIN_ADDRESS);
+	vmm_gpa_root_cap = cheri_bounds_set(vmm_gpa_root_cap,
 	    HYP_GPA_MAX_ADDRESS - HYP_GPA_MIN_ADDRESS);
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	ctemp = cheri_setaddress(kroot, VM_MAX_KERNEL_ADDRESS -
+	ctemp = cheri_address_set(kroot, VM_MAX_KERNEL_ADDRESS -
 	    PMAP_MAPDEV_EARLY_SIZE);
-	ctemp = cheri_setboundsexact(ctemp, PMAP_MAPDEV_EARLY_SIZE);
-	ctemp = cheri_andperm(ctemp, CHERI_PERMS_KERNEL_DATA);
+	ctemp = cheri_bounds_set_exact(ctemp, PMAP_MAPDEV_EARLY_SIZE);
+	ctemp = cheri_perms_and(ctemp, CHERI_PERMS_KERNEL_DATA);
 	devmap_init_capability(ctemp);
 
-	kernel_root_cap = cheri_andperm(kroot,
+	kernel_root_cap = cheri_perms_and(kroot,
 	    ~(CHERI_PERM_SEAL | CHERI_PERM_UNSEAL));
 
-	vmm_el2_root_cap = cheri_setaddress(kroot, HYP_VM_MIN_ADDRESS);
-	vmm_el2_root_cap = cheri_setbounds(vmm_el2_root_cap,
+	vmm_el2_root_cap = cheri_address_set(kroot, HYP_VM_MIN_ADDRESS);
+	vmm_el2_root_cap = cheri_bounds_set(vmm_el2_root_cap,
 	    HYP_VM_MAX_ADDRESS - HYP_VM_MIN_ADDRESS);
 #endif
 }

--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef _KERNEL
-#define	__USER_DDC ((cheri_getperm(__USER_PCC) & CHERI_PERM_EXECUTIVE) ? \
+#define	__USER_DDC ((cheri_perms_get(__USER_PCC) & CHERI_PERM_EXECUTIVE) ? \
     (void * __capability)curthread->td_frame->tf_ddc :			\
     (void * __capability)READ_SPECIALREG_CAP(rddc_el0))
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)

--- a/sys/arm64/include/cheric.h
+++ b/sys/arm64/include/cheric.h
@@ -43,7 +43,7 @@ trapframe_set_elr(struct trapframe *tf, uintcap_t elr)
 {
 	extern void * __capability sentry_unsealcap;
 
-	if (cheri_getsealed(elr))
+	if (cheri_is_sealed(elr))
 		elr = cheri_unseal(elr, sentry_unsealcap);
 
 	if (elr & 0x1) {

--- a/sys/arm64/include/cherireg.h
+++ b/sys/arm64/include/cherireg.h
@@ -37,6 +37,7 @@
 #define	CHERICAP_SIZE   16
 #define	CHERICAP_SHIFT	4
 
+#ifdef _KERNEL
 /*
  * CHERI ISA-defined constants for capabilities -- suitable for inclusion from
  * assembly source code.
@@ -61,6 +62,19 @@
 #define	CHERI_PERM_EXECUTE			(1 << 15)	/* 0x00008000 */
 #define	CHERI_PERM_STORE			(1 << 16)	/* 0x00010000 */
 #define	CHERI_PERM_LOAD				(1 << 17)	/* 0x00020000 */
+#else
+/*
+ * These should be defined in cheriintrin.h, but aren't yet.
+ */
+#define	CHERI_PERM_EXECUTIVE			(1 << 1)	/* 0x00000002 */
+#define	CHERI_PERM_SW0				(1 << 2)	/* 0x00000004 */
+#define	CHERI_PERM_SW1				(1 << 3)	/* 0x00000008 */
+#define	CHERI_PERM_SW2				(1 << 4)	/* 0x00000010 */
+#define	CHERI_PERM_SW3				(1 << 5)	/* 0x00000020 */
+#define	CHERI_PERM_MUTABLE_LOAD			(1 << 6)	/* 0x00000040 */
+#define	CHERI_PERM_BRANCH_SEALED_PAIR		(1 << 8)	/* 0x00000100 */
+#define	CHERI_PERM_INVOKE CHERI_PERM_BRANCH_SEALED_PAIR
+#endif
 
 /*
  * Macros defining initial permission sets:
@@ -192,9 +206,11 @@
 #define	CHERI_OTYPE_ISKERN(x)	(((x) & CHERI_OTYPE_KERN_FLAG) != 0)
 #define	CHERI_OTYPE_ISUSER(x)	(!(CHERI_OTYPE_ISKERN(x)))
 
+#ifdef _KERNEL
 /* Reserved CHERI object types: */
 #define	CHERI_OTYPE_UNSEALED	(0l)
 #define	CHERI_OTYPE_SENTRY	(1l)
+#endif
 
 /*
  * Root compartment ID capablity for userspace.

--- a/sys/arm64/vmm/vmm_reset.c
+++ b/sys/arm64/vmm/vmm_reset.c
@@ -113,9 +113,9 @@ reset_vm_el01_regs(void *vcpu)
 	memset(el2ctx->pmevtyper_el0, 0, sizeof(el2ctx->pmevtyper_el0));
 
 #if __has_feature(capabilities)
-	el2ctx->tf.tf_ddc = (uintcap_t)cheri_setaddress(vmm_gva_root_cap, 0);
-	el2ctx->ddc_el0 = (uintcap_t)cheri_setaddress(vmm_gva_root_cap, 0);
-	el2ctx->rddc_el0 = (uintcap_t)cheri_setaddress(vmm_gva_root_cap, 0);
+	el2ctx->tf.tf_ddc = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);
+	el2ctx->ddc_el0 = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);
+	el2ctx->rddc_el0 = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);
 #endif
 }
 

--- a/sys/cddl/dev/dtrace/dtrace_ioctl.c
+++ b/sys/cddl/dev/dtrace/dtrace_ioctl.c
@@ -520,7 +520,7 @@ dtrace_ioctl(struct cdev *dev, u_long cmd, caddr_t addr,
 			bcopy(&act->dta_rec, &rec, sizeof (dtrace_recdesc_t));
 #ifdef __CHERI_PURE_CAPABILITY__
 			/* Avoid leaking kernel capabilities to userspace. */
-			rec.dtrd_arg = cheri_cleartag(rec.dtrd_arg);
+			rec.dtrd_arg = cheri_tag_clear(rec.dtrd_arg);
 #endif
 			bcopy(&rec, (void *)dest, sizeof (dtrace_recdesc_t));
 			dest += sizeof (dtrace_recdesc_t);

--- a/sys/cddl/dev/fbt/aarch64/fbt_isa.c
+++ b/sys/cddl/dev/fbt/aarch64/fbt_isa.c
@@ -93,19 +93,19 @@ fbt_make_tracepoint_capability(uint32_t *instr)
 	fbt_patchval_t *cap;
 	ptraddr_t addr;
 
-	if (cheri_getsealed(instr))
+	if (cheri_is_sealed(instr))
 		return (NULL);
-	if (!cheri_gettag(instr))
+	if (!cheri_tag_get(instr))
 		return (NULL);
 	addr = (ptraddr_t)instr;
 	if (addr + INSN_SIZE < addr ||
-	    addr < cheri_getbase(instr) ||
-	    addr + INSN_SIZE > cheri_getbase(instr) + cheri_getlength(instr))
+	    addr < cheri_base_get(instr) ||
+	    addr + INSN_SIZE > cheri_base_get(instr) + cheri_length_get(instr))
 		return (NULL);
 
-	cap = cheri_setaddress(kernel_root_cap, addr);
-	cap = cheri_setbounds(cap, INSN_SIZE);
-	cap = cheri_andperm(cap, CHERI_PERM_STORE);
+	cap = cheri_address_set(kernel_root_cap, addr);
+	cap = cheri_bounds_set(cap, INSN_SIZE);
+	cap = cheri_perms_and(cap, CHERI_PERM_STORE);
 	return (cap);
 }
 
@@ -121,7 +121,7 @@ fbt_unseal_symval(linker_symval_t *sym)
 	uintcap_t val;
 
 	val = cheri_unseal((uintcap_t)sym->value, sentry_unsealcap);
-	val = cheri_andperm(val, CHERI_PERM_LOAD);
+	val = cheri_perms_and(val, CHERI_PERM_LOAD);
 	return (val);
 }
 #endif

--- a/sys/cddl/dev/kinst/aarch64/kinst_isa.c
+++ b/sys/cddl/dev/kinst/aarch64/kinst_isa.c
@@ -300,19 +300,19 @@ kinst_make_tracepoint_capability(uint32_t *instr)
 	kinst_patchval_t *cap;
 	ptraddr_t addr;
 
-	if (cheri_getsealed(instr))
+	if (cheri_is_sealed(instr))
 		return (NULL);
-	if (!cheri_gettag(instr))
+	if (!cheri_tag_get(instr))
 		return (NULL);
 	addr = (ptraddr_t)instr;
 	if (addr + INSN_SIZE < addr ||
-	    addr < cheri_getbase(instr) ||
-	    addr + INSN_SIZE > cheri_getbase(instr) + cheri_getlength(instr))
+	    addr < cheri_base_get(instr) ||
+	    addr + INSN_SIZE > cheri_base_get(instr) + cheri_length_get(instr))
 		return (NULL);
 
-	cap = cheri_setaddress(kernel_root_cap, addr);
-	cap = cheri_setbounds(cap, INSN_SIZE);
-	cap = cheri_andperm(cap, CHERI_PERM_STORE);
+	cap = cheri_address_set(kernel_root_cap, addr);
+	cap = cheri_bounds_set(cap, INSN_SIZE);
+	cap = cheri_perms_and(cap, CHERI_PERM_STORE);
 	return (cap);
 }
 
@@ -328,7 +328,7 @@ kinst_unseal_symval(linker_symval_t *sym)
 	uintcap_t val;
 
 	val = cheri_unseal((uintcap_t)sym->value, sentry_unsealcap);
-	val = cheri_andperm(val, CHERI_PERM_LOAD);
+	val = cheri_perms_and(val, CHERI_PERM_LOAD);
 	return (val);
 }
 #endif

--- a/sys/cddl/dev/sdt/sdt.c
+++ b/sys/cddl/dev/sdt/sdt.c
@@ -414,10 +414,10 @@ sdt_kld_load_probes(struct linker_file *lf)
 				continue;
 			}
 #ifdef __CHERI_PURE_CAPABILITY__
-			tp->patchpoint = (uintcap_t)cheri_setbounds(
-			    cheri_setaddress(kernel_root_cap, tp->patchpoint),
+			tp->patchpoint = (uintcap_t)cheri_bounds_set(
+			    cheri_address_set(kernel_root_cap, tp->patchpoint),
 			    INSN_SIZE);
-			tp->patchpoint = cheri_andperm(tp->patchpoint,
+			tp->patchpoint = cheri_perms_and(tp->patchpoint,
 			    CHERI_PERM_STORE | CHERI_PERM_SEAL);
 #endif
 			STAILQ_INSERT_TAIL(&tp->probe->tracepoint_list, tp,

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -39,21 +39,6 @@
 #include <sys/types.h>
 #include <cheri/cherireg.h>
 
-/*
- * Canonical C-language representation of a CHERI object capability -- code and
- * data capabilities in registers or memory.
- */
-struct cheri_object {
-	void * __capability	co_codecap;
-	void * __capability	co_datacap;
-};
-
-#if !defined(_KERNEL) && __has_feature(capabilities)
-#define	CHERI_OBJECT_INIT_NULL	{NULL, NULL}
-#define	CHERI_OBJECT_ISNULL(co)	\
-    ((co).co_codecap == NULL && (co).co_datacap == NULL)
-#endif
-
 #ifdef _KERNEL
 /*
  * Functions to construct userspace capabilities.

--- a/sys/cheri/cheri_cidcap.c
+++ b/sys/cheri/cheri_cidcap.c
@@ -59,10 +59,10 @@ kern_cheri_cidcap_alloc(struct thread *td, uintcap_t * __capability cidp)
 	uintcap_t cidcap;
 
 	cid = vmspace_cid_alloc(td->td_proc->p_vmspace);
-	cidcap = (uintcap_t)cheri_setbounds(
-	    cheri_setaddress(userspace_root_cidcap, cid), 1);
+	cidcap = (uintcap_t)cheri_bounds_set(
+	    cheri_address_set(userspace_root_cidcap, cid), 1);
 
-	KASSERT(cheri_gettag(cidcap), ("untagged cidcap allocated"));
+	KASSERT(cheri_tag_get(cidcap), ("untagged cidcap allocated"));
 
 	return (copyoutptr(&cidcap, cidp, sizeof(cidcap)));
 }

--- a/sys/cheri/cheri_exec.c
+++ b/sys/cheri/cheri_exec.c
@@ -102,12 +102,12 @@ cheri_sigcode_capability(struct thread *td)
 		    CHERI_CAP_USER_CODE_LENGTH,
 		    PROC_SIGCODE(p) - CHERI_CAP_USER_CODE_BASE));
 
-	tmpcap = (void * __capability)cheri_setboundsexact(
-	    cheri_andperm(PROC_SIGCODE(p), CHERI_CAP_USER_CODE_PERMS),
+	tmpcap = (void * __capability)cheri_bounds_set_exact(
+	    cheri_perms_and(PROC_SIGCODE(p), CHERI_CAP_USER_CODE_PERMS),
 	    *sv->sv_szsigcode);
 
 	if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
 		tmpcap = cheri_capmode(tmpcap);
 
-	return (cheri_sealentry(tmpcap));
+	return (cheri_sentry_create(tmpcap));
 }

--- a/sys/cheri/cheri_otype.c
+++ b/sys/cheri/cheri_otype.c
@@ -71,9 +71,9 @@ cheri_maketype(void * __capability root_type, register_t type)
 	void * __capability c;
 
 	c = root_type;
-	c = cheri_setoffset(c, type);	/* Set type as desired. */
-	c = cheri_setbounds(c, 1);	/* ISA implies length of 1. */
-	c = cheri_andperm(c, CHERI_PERM_GLOBAL | CHERI_PERM_SEAL); /* Perms. */
+	c = cheri_offset_set(c, type);	/* Set type as desired. */
+	c = cheri_bounds_set(c, 1);	/* ISA implies length of 1. */
+	c = cheri_perms_and(c, CHERI_PERM_GLOBAL | CHERI_PERM_SEAL); /* Perms. */
 	return (c);
 }
 
@@ -100,7 +100,7 @@ cheri_otype_free(otype_t cap)
 {
 	u_int type;
 
-	type = cheri_getbase(cap);
+	type = cheri_base_get(cap);
 	free_unr(cheri_otypes, type);
 }
 
@@ -112,7 +112,7 @@ uintcap_t
 cheri_revoke_sealed(uintcap_t c)
 {
 	c = cheri_unseal(c, kernel_root_sealcap);
-	c = cheri_andperm(c, 0);
+	c = cheri_perms_and(c, 0);
 	return c;
 }
 

--- a/sys/cheri/cheri_otype.c
+++ b/sys/cheri/cheri_otype.c
@@ -57,6 +57,27 @@ cheri_otype_init(void *dummy __unused)
 }
 SYSINIT(cheri_otype_init, SI_SUB_LOCK, SI_ORDER_FIRST, cheri_otype_init, NULL);
 
+/*
+ * Construct a capability suitable to describe a type identified by 'ptr';
+ * set it to zero-length with the offset equal to the base.  The caller must
+ * provide a root sealing capability.
+ *
+ * The caller may wish to assert various properties about the returned
+ * capability, including that CHERI_PERM_SEAL is set.
+ */
+static otype_t
+cheri_maketype(void * __capability root_type, register_t type)
+{
+	void * __capability c;
+
+	c = root_type;
+	c = cheri_setoffset(c, type);	/* Set type as desired. */
+	c = cheri_setbounds(c, 1);	/* ISA implies length of 1. */
+	c = cheri_andperm(c, CHERI_PERM_GLOBAL | CHERI_PERM_SEAL); /* Perms. */
+	return (c);
+}
+
+
 otype_t
 cheri_otype_alloc(void)
 {

--- a/sys/cheri/cheri_syscall.c
+++ b/sys/cheri/cheri_syscall.c
@@ -41,5 +41,5 @@ int
 cheri_syscall_authorize(struct thread *td)
 {
 	return (!security_cheri_check_perm_syscall ||
-	    (cheri_getperm(__USER_PCC) & CHERI_PERM_SYSCALL) != 0);
+	    (cheri_perms_get(__USER_PCC) & CHERI_PERM_SYSCALL) != 0);
 }

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -207,12 +207,6 @@ cheri_maketype(void * __capability root_type, register_t type)
 	return (c);
 }
 
-static inline void * __capability
-cheri_zerocap(void)
-{
-	return (void * __capability)0;
-}
-
 static inline size_t
 cheri_bytes_remaining(const void * __capability cap)
 {
@@ -398,14 +392,8 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #define	CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) \
 	__builtin_cheri_representable_alignment_mask(len)
 
-/*
- * These should be avoided on CHERI MIPS and RISCV64 since count
- * leading/trailing zeroes is expensive.
- */
 #define	CHERI_ALIGN_SHIFT(l)	\
 	__builtin_ctzll(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
-#define	CHERI_SEAL_ALIGN_SHIFT(l)	\
-	__builtin_ctzll(CHERI_SEALABLE_ALIGNMENT_MASK(l))
 
 #else /* !__has_feature(capabilities) */
 #define	CHERI_REPRESENTABLE_LENGTH(len) (len)
@@ -425,24 +413,6 @@ __cheri_clear_low_ptr_bits(uintptr_t ptr, size_t bits_mask) {
 #define	CHERI_REPRESENTABLE_ALIGN_UP(base, len) (base)
 #endif
 
-/* Backwards compat. */
-#define	CHERI_REPRESENTABLE_BASE	CHERI_REPRESENTABLE_ALIGNMENT_DOWN
-
-/*
- * In the current encoding sealed and unsealed capabilities have the same
- * alignment constraints.
- */
-#define	CHERI_SEALABLE_LENGTH(len)	\
-	CHERI_REPRESENTABLE_LENGTH(len)
-#define	CHERI_SEALABLE_ALIGNMENT_MASK(len)	\
-	CHERI_REPRESENTABLE_ALIGNMENT_MASK(len)
-#define	CHERI_SEALABLE_ALIGNMENT(len)	\
-	CHERI_REPRESENTABLE_ALIGNMENT(len)
-#define	CHERI_SEALABLE_BASE(base, len)	\
-	CHERI_REPRESENTABLE_ALIGN_DOWN(base, len)
-
-/* A mask for the lower bits, i.e. the negated alignment mask */
-#define	CHERI_SEAL_ALIGN_MASK(l)	~(CHERI_SEALABLE_ALIGNMENT_MASK(l))
 #define	CHERI_ALIGN_MASK(l)		~(CHERI_REPRESENTABLE_ALIGNMENT_MASK(l))
 
 #if __has_feature(capabilities)

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -142,35 +142,6 @@ cheri_can_access(const void * __capability cap, ptraddr_t perms, ptraddr_t base,
 	    base >= cheri_getbase(cap) && base + length <= cheri_top_get(cap));
 }
 
-/*
- * Construct a capability suitable to describe a type identified by 'ptr';
- * set it to zero-length with the offset equal to the base.  The caller must
- * provide a root sealing capability.
- *
- * The caller may wish to assert various properties about the returned
- * capability, including that CHERI_PERM_SEAL is set.
- */
-static inline otype_t
-cheri_maketype(void * __capability root_type, register_t type)
-{
-	void * __capability c;
-
-	c = root_type;
-	c = cheri_setoffset(c, type);	/* Set type as desired. */
-	c = cheri_setbounds(c, 1);	/* ISA implies length of 1. */
-	c = cheri_andperm(c, CHERI_PERM_GLOBAL | CHERI_PERM_SEAL); /* Perms. */
-	return (c);
-}
-
-static inline size_t
-cheri_bytes_remaining(const void * __capability cap)
-{
-	if (cheri_getoffset(cap) >= cheri_getlen(cap))
-		return 0;
-	return cheri_getlen(cap) - cheri_getoffset(cap);
-}
-
-
 
 #endif	/* __has_feature(capabilities) */
 

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -728,9 +728,9 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	    ("%s: stack != strings", __func__));
 
 	destp = (uintcap_t)imgp->strings;
-	destp = cheri_setaddress(destp, PROC_PS_STRINGS(p));
+	destp = cheri_address_set(destp, PROC_PS_STRINGS(p));
 	arginfo = (struct freebsd64_ps_strings * __capability)
-	    cheri_setboundsexact(destp, sizeof(*arginfo));
+	    cheri_bounds_set_exact(destp, sizeof(*arginfo));
 	imgp->ps_strings = arginfo;
 
 	/*
@@ -754,7 +754,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		destp -= execpath_len;
 		destp = rounddown2(destp, sizeof(uint64_t));
 		imgp->execpathp = (void * __capability)
-		    cheri_setboundsexact(destp, execpath_len);
+		    cheri_bounds_set_exact(destp, execpath_len);
 		error = copyout(imgp->execpath, imgp->execpathp, execpath_len);
 		if (error != 0)
 			return (error);
@@ -765,7 +765,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	arc4rand(canary, sizeof(canary), 0);
 	destp -= sizeof(canary);
-	imgp->canary = (void * __capability)cheri_setboundsexact(destp,
+	imgp->canary = (void * __capability)cheri_bounds_set_exact(destp,
 	    sizeof(canary));
 	error = copyout(canary, imgp->canary, sizeof(canary));
 	if (error != 0)
@@ -778,7 +778,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	imgp->pagesizeslen = sizeof(pagesizes[0]) * MAXPAGESIZES;
 	destp -= imgp->pagesizeslen;
 	destp = rounddown2(destp, sizeof(uint64_t));
-	imgp->pagesizes = (void * __capability)cheri_setboundsexact(destp,
+	imgp->pagesizes = (void * __capability)cheri_bounds_set_exact(destp,
 	    imgp->pagesizeslen);
 	error = copyout(pagesizes, imgp->pagesizes, imgp->pagesizeslen);
 	if (error != 0)
@@ -789,7 +789,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 */
 	destp -= ARG_MAX - imgp->args->stringspace;
 	destp = rounddown2(destp, sizeof(uint64_t));
-	ustringp = cheri_setbounds(destp, ARG_MAX - imgp->args->stringspace);
+	ustringp = cheri_bounds_set(destp, ARG_MAX - imgp->args->stringspace);
 
 	if (imgp->auxargs) {
 		/*
@@ -828,7 +828,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	/*
 	 * Fill in "ps_strings" struct for ps, w, etc.
 	 */
-	imgp->argv = cheri_setbounds(vectp, (argc + 1) * sizeof(*vectp));
+	imgp->argv = cheri_bounds_set(vectp, (argc + 1) * sizeof(*vectp));
 	if (suword(&arginfo->ps_argvstr, (__cheri_addr uint64_t)vectp) != 0 ||
 	    suword32(&arginfo->ps_nargvstr, argc) != 0)
 		return (EFAULT);
@@ -848,7 +848,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	if (suword(vectp++, 0) != 0)
 		return (EFAULT);
 
-	imgp->envv = cheri_setbounds(vectp, (envc + 1) * sizeof(*vectp));
+	imgp->envv = cheri_bounds_set(vectp, (envc + 1) * sizeof(*vectp));
 	if (suword(&arginfo->ps_envstr, (__cheri_addr uint64_t)vectp) != 0 ||
 	    suword32(&arginfo->ps_nenvstr, envc) != 0)
 		return (EFAULT);
@@ -870,7 +870,7 @@ freebsd64_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 
 	if (imgp->auxargs) {
 		vectp++;
-		imgp->auxv = cheri_setbounds(vectp,
+		imgp->auxv = cheri_bounds_set(vectp,
 		    AT_COUNT * sizeof(Elf64_Auxinfo));
 		error = imgp->sysent->sv_copyout_auxargs(imgp,
 		    (uintcap_t)imgp->auxv);

--- a/sys/ddb/db_main.c
+++ b/sys/ddb/db_main.c
@@ -218,8 +218,8 @@ db_fetch_ksymtab(vm_pointer_t ksym_start, vm_pointer_t ksym_end,
 			    = 0;
 		} else {
 #ifdef __CHERI_PURE_CAPABILITY__
-			ksymtab = cheri_setbounds(ksymtab, ksymtab_size);
-			kstrtab = cheri_setbounds(kstrtab, strsz);
+			ksymtab = cheri_bounds_set(ksymtab, ksymtab_size);
+			kstrtab = cheri_bounds_set(kstrtab, strsz);
 #endif
 		}
 	}
@@ -244,8 +244,8 @@ db_init(void)
 	}
 	db_add_symbol_table(NULL, NULL, "kld", NULL);
 #ifdef __CHERI_PURE_CAPABILITY__
-	db_code_cap = cheri_andperm(kernel_root_cap, CHERI_PERMS_KERNEL_CODE);
-	db_data_cap = cheri_andperm(kernel_root_cap, CHERI_PERMS_KERNEL_DATA);
+	db_code_cap = cheri_perms_and(kernel_root_cap, CHERI_PERMS_KERNEL_CODE);
+	db_data_cap = cheri_perms_and(kernel_root_cap, CHERI_PERMS_KERNEL_DATA);
 #endif
 	return (1);	/* We're the default debugger. */
 }
@@ -321,19 +321,19 @@ db_trace_thread_wrapper(struct thread *td)
 void *
 db_code_ptr(db_addr_t addr)
 {
-	return (cheri_setaddress(db_code_cap, addr));
+	return (cheri_address_set(db_code_cap, addr));
 }
 
 void *
 db_data_ptr_unbound(db_addr_t addr)
 {
-	return (cheri_setaddress(db_data_cap, addr));
+	return (cheri_address_set(db_data_cap, addr));
 }
 
 void *
 db_data_ptr(db_addr_t addr, size_t len)
 {
-	return (cheri_setbounds(db_data_ptr_unbound(addr), len));
+	return (cheri_bounds_set(db_data_ptr_unbound(addr), len));
 }
 #endif
 // CHERI CHANGES START

--- a/sys/dev/efidev/efirt.c
+++ b/sys/dev/efidev/efirt.c
@@ -194,8 +194,8 @@ efi_init(void)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 #define	EFI_ST_ARRAY(table, name, num)					\
-    ((struct efi_##name *)cheri_andperm(cheri_setbounds(		\
-	    cheri_setaddress(kernel_root_cap, (table)->st_##name),	\
+    ((struct efi_##name *)cheri_perms_and(cheri_bounds_set(		\
+	    cheri_address_set(kernel_root_cap, (table)->st_##name),	\
 	    sizeof(struct efi_##name) * (num)), CHERI_PERMS_KERNEL_DATA))
 #else
 #define	EFI_ST_ARRAY(table, name, num)					\
@@ -563,8 +563,8 @@ efi_call(struct efirt_callinfo *ecp)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 #define	EFI_RT_METHOD_PA(method)				\
-    ((uintptr_t)cheri_sealentry(cheri_andperm(			\
-	cheri_setaddress(kernel_root_cap,			\
+    ((uintptr_t)cheri_sentry_create(cheri_perms_and(			\
+	cheri_address_set(kernel_root_cap,			\
 	    ((struct efi_rt *)efi_phys_to_kva((uintptr_t)	\
 	    efi_runtime, sizeof(struct efi_rt)))->method),	\
 	CHERI_PERMS_KERNEL_CODE)))

--- a/sys/dev/mem/memdev.c
+++ b/sys/dev/mem/memdev.c
@@ -170,7 +170,7 @@ mem_read_cheri_caps(struct cdev *dev, const struct mem_cheri_cap_arg *arg)
 
 		src = (uintcap_t *)((char *)mapped_ptr + page_off);
 		while (todo != 0) {
-			capbuf[0] = cheri_gettag(*src);
+			capbuf[0] = cheri_tag_get(*src);
 			memcpy(capbuf + 1, src, sizeof(*src));
 
 			error = copyout(capbuf, dst, sizeof(capbuf));

--- a/sys/dev/pci/pci_user.c
+++ b/sys/dev/pci/pci_user.c
@@ -981,10 +981,10 @@ pci_bar_mmap(device_t pcidev, struct pci_bar_mmap *pbm)
 	flags = MAP_SHARED;
 #if __has_feature(capabilities)
 	/* Enforce the same policy as for sys_mmap() */
-	if (cheri_gettag(pbm->pbm_map_base)) {
+	if (cheri_tag_get(pbm->pbm_map_base)) {
 		if ((pbm->pbm_flags & PCIIO_BAR_MMAP_FIXED) == 0)
 			return (EPROT);
-		if ((cheri_getperm(pbm->pbm_map_base) &
+		if ((cheri_perms_get(pbm->pbm_map_base) &
 		    CHERI_PERM_SW_VMEM) == 0)
 			return (EACCES);
 	} else {

--- a/sys/dev/vmm/vmm_dev.c
+++ b/sys/dev/vmm/vmm_dev.c
@@ -306,7 +306,7 @@ vm_get_register_set(struct vcpu *vcpu, unsigned int count, int *regnum,
 		if (error)
 			break;
 #if __has_feature(capabilities)
-		regval[i] = cheri_cleartag(regval[i]);
+		regval[i] = cheri_tag_clear(regval[i]);
 #endif
 	}
 	return (error);
@@ -551,7 +551,7 @@ vmmdev_ioctl(struct cdev *cdev, u_long cmd, caddr_t data, int fflag,
 		error = vm_get_register(vcpu, vmreg->regnum, &vmreg->regval);
 #if __has_feature(capabilities)
 		if (error == 0)
-			vmreg->regval = cheri_cleartag(vmreg->regval);
+			vmreg->regval = cheri_tag_clear(vmreg->regval);
 #endif
 		break;
 	}

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -652,15 +652,15 @@ proc0_init(void *dummy __unused)
 	 * we strip all access permission because proc0 is not
 	 * expected to enter usermode.
 	 */
-	caddr_t minuser_cap = cheri_setaddress(userspace_root_cap,
+	caddr_t minuser_cap = cheri_address_set(userspace_root_cap,
 	    p->p_sysent->sv_minuser);
-	minuser_cap = cheri_setbounds(minuser_cap,
+	minuser_cap = cheri_bounds_set(minuser_cap,
 	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser);
-	minuser_cap = cheri_andperm(minuser_cap, 0);
+	minuser_cap = cheri_perms_and(minuser_cap, 0);
 
 	vm_map_init(&vmspace0.vm_map, vmspace_pmap(&vmspace0),
 	    (vm_pointer_t)minuser_cap,
-	    (vm_pointer_t)minuser_cap + cheri_getlen(minuser_cap));
+	    (vm_pointer_t)minuser_cap + cheri_length_get(minuser_cap));
 	vmspace0.vm_map.flags |= MAP_RESERVATIONS;
 #endif
 

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -779,16 +779,16 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 	switch (sel) {
 	case CHERI_REVOKE_SHADOW_NOVMEM:
 
-		if (cheri_gettag(arena) == 0)
+		if (cheri_tag_get(arena) == 0)
 			return (EINVAL);
 
-		arena_perms = cheri_getperm(arena);
+		arena_perms = cheri_perms_get(arena);
 
 		if ((arena_perms & CHERI_PERM_SW_VMEM) == 0)
 			return (EPERM);
 
-		base = cheri_getbase(arena);
-		size = cheri_getlen(arena);
+		base = cheri_base_get(arena);
+		size = cheri_length_get(arena);
 
 		cres = vm_cheri_revoke_shadow_cap(curproc->p_sysent,
 			sel, base, size, arena_perms);
@@ -799,18 +799,18 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 	    {
 		int reqperms;
 
-		if (cheri_gettag(arena) == 0)
+		if (cheri_tag_get(arena) == 0)
 			return (EINVAL);
 
 		/* XXX Require all of SW_VMEM, SEAL, and UNSEAL permissions? */
 		reqperms = CHERI_PERM_SEAL | CHERI_PERM_UNSEAL |
 		    CHERI_PERM_SW_VMEM;
-		arena_perms = cheri_getperm(arena);
+		arena_perms = cheri_perms_get(arena);
 		if ((arena_perms & reqperms) != reqperms)
 			return (EPERM);
 
-		base = cheri_getbase(arena);
-		size = cheri_getlen(arena);
+		base = cheri_base_get(arena);
+		size = cheri_length_get(arena);
 
 		cres = vm_cheri_revoke_shadow_cap(curproc->p_sysent,
 			sel, base, size, 0);
@@ -829,7 +829,7 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 		return (EINVAL);
 	}
 
-	if (!cheri_gettag(cres))
+	if (!cheri_tag_get(cres))
 		return (EINVAL);
 
 	vm = td->td_proc->p_vmspace;

--- a/sys/kern/kern_environment.c
+++ b/sys/kern/kern_environment.c
@@ -360,7 +360,7 @@ init_static_kenv(char *buf, size_t len)
 		md_env_len = len;
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (len != 0)
-			KASSERT(cheri_getlen(md_envp) == len,
+			KASSERT(cheri_length_get(md_envp) == len,
 			    ("unbounded static kenv"));
 #endif
 		md_env_pos = 0;

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -2882,9 +2882,9 @@ kqueue_cheri_revoke_note(const struct vm_cheri_revoke_cookie *crc,
 	CHERI_REVOKE_STATS_FOR(crst, crc);
 	int res = 1;
 
-	if (!cheri_gettag(id)) {
+	if (!cheri_tag_get(id)) {
 		; /* nothing to be done */
-	} else if (__builtin_cheri_equal_exact(id, kn->kn_kevent.ident)) {
+	} else if (cheri_is_equal_exact(id, kn->kn_kevent.ident)) {
 		CHERI_REVOKE_STATS_BUMP(crst, caps_cleared);
 		kn->kn_kevent.ident = (kuintcap_t)cheri_revoke_cap(id);
 	} else {
@@ -2895,9 +2895,9 @@ kqueue_cheri_revoke_note(const struct vm_cheri_revoke_cookie *crc,
 		res = 0;
 	}
 
-	if (!cheri_gettag(ud)) {
+	if (!cheri_tag_get(ud)) {
 		;
-	} else if (__builtin_cheri_equal_exact(ud, kn->kn_kevent.udata)) {
+	} else if (cheri_is_equal_exact(ud, kn->kn_kevent.udata)) {
 		CHERI_REVOKE_STATS_BUMP(crst, caps_cleared);
 		kn->kn_kevent.udata = (void * __capability)cheri_revoke_cap(ud);
 	} else {
@@ -2928,13 +2928,13 @@ kqueue_cheri_revoke_list(struct kqueue *kq,
 
 		uintcap_t ud = (uintcap_t)kn->kn_kevent.udata;
 		uintcap_t id = kn->kn_kevent.ident;
-		if (!cheri_gettag(ud) && !cheri_gettag(id)) {
+		if (!cheri_tag_get(ud) && !cheri_tag_get(id)) {
 			continue;
 		} else {
-			if (cheri_gettag(id)) {
+			if (cheri_tag_get(id)) {
 				CHERI_REVOKE_STATS_BUMP(crst, caps_found);
 			}
-			if (cheri_gettag(ud)) {
+			if (cheri_tag_get(ud)) {
 				CHERI_REVOKE_STATS_BUMP(crst, caps_found);
 			}
 		}

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1312,7 +1312,7 @@ exec_map_stack(struct image_params *imgp)
 	perms = (~CHERI_PROT2PERM_MASK | vm_map_prot2perms(stack_prot)) &
 	    CHERI_CAP_USER_DATA_PERMS;
 #ifdef __CHERI_PURE_CAPABILITY__
-	imgp->stack = (void *)cheri_andperm(stack_top, perms);
+	imgp->stack = (void *)cheri_perms_and(stack_top, perms);
 #else
 	if (sv->sv_flags & SV_CHERI)
 		imgp->stack = cheri_capability_build_user_data(perms,
@@ -1830,7 +1830,7 @@ exec_args_get_begin_envv(struct image_args *args)
  * and env vector tables. Return a pointer to the base so that it can be used
  * as the initial stack pointer.
  *
- * XXX: We may want a wrapper of cheri_setbounds() that warns about
+ * XXX: We may want a wrapper of cheri_bounds_set() that warns about
  * capabilities that are overly broad.
  */
 int
@@ -1856,8 +1856,8 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	if (imgp->stack != imgp->strings)
 		strings_on_stack = false;
 	destp = (uintcap_t)imgp->strings;
-	destp = cheri_setaddress(destp, PROC_PS_STRINGS(p));
-	arginfo = (struct ps_strings * __capability)cheri_setboundsexact(destp,
+	destp = cheri_address_set(destp, PROC_PS_STRINGS(p));
+	arginfo = (struct ps_strings * __capability)cheri_bounds_set_exact(destp,
 	    sizeof(*arginfo));
 #else
 	destp = (uintptr_t)PROC_PS_STRINGS(p);
@@ -1887,7 +1887,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
 		imgp->execpathp = (void * __capability)
-		    cheri_setboundsexact(destp, execpath_len);
+		    cheri_bounds_set_exact(destp, execpath_len);
 #else
 		imgp->execpathp = (void *)destp;
 #endif
@@ -1902,7 +1902,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	arc4rand(canary, sizeof(canary), 0);
 	destp -= sizeof(canary);
 #if __has_feature(capabilities)
-	imgp->canary = (void * __capability)cheri_setboundsexact(destp,
+	imgp->canary = (void * __capability)cheri_bounds_set_exact(destp,
 	    sizeof(canary));
 #else
 	imgp->canary = (void *)destp;
@@ -1919,7 +1919,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	destp -= imgp->pagesizeslen;
 	destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
-	imgp->pagesizes = (void * __capability)cheri_setboundsexact(destp,
+	imgp->pagesizes = (void * __capability)cheri_bounds_set_exact(destp,
 	    imgp->pagesizeslen);
 #else
 	imgp->pagesizes = (void *)destp;
@@ -1934,7 +1934,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	destp -= ARG_MAX - imgp->args->stringspace;
 	destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
-	ustringp = cheri_setbounds(destp, ARG_MAX - imgp->args->stringspace);
+	ustringp = cheri_bounds_set(destp, ARG_MAX - imgp->args->stringspace);
 #else
 	ustringp = destp;
 #endif
@@ -1946,7 +1946,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	destp -= sizeof(*imgp->c18n_info);
 	destp = rounddown2(destp, sizeof(void * __capability));
 	imgp->c18n_info = (struct cheri_c18n_info * __kerncap)
-	    cheri_setboundsexact(destp, sizeof(*imgp->c18n_info));
+	    cheri_bounds_set_exact(destp, sizeof(*imgp->c18n_info));
 	p->p_c18n_info =
 	    (__cheri_fromcap struct cheri_c18n_info *)imgp->c18n_info;
 #endif
@@ -1993,7 +1993,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 * Fill in "ps_strings" struct for ps, w, etc.
 	 */
 #if __has_feature(capabilities)
-	imgp->argv = cheri_setbounds(vectp, (argc + 1) * sizeof(*vectp));
+	imgp->argv = cheri_bounds_set(vectp, (argc + 1) * sizeof(*vectp));
 #else
 	imgp->argv = vectp;
 #endif
@@ -2007,7 +2007,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	for (; argc > 0; --argc) {
 		len = strlen(stringp) + 1;
 #if __has_feature(capabilities)
-		if (sucap(vectp++, cheri_setbounds(ustringp, len)) != 0)
+		if (sucap(vectp++, cheri_bounds_set(ustringp, len)) != 0)
 			return (EFAULT);
 #else
 		if (suptr(vectp++, ustringp) != 0)
@@ -2022,7 +2022,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		return (EFAULT);
 
 #if __has_feature(capabilities)
-	imgp->envv = cheri_setbounds(vectp, (envc + 1) * sizeof(*vectp));
+	imgp->envv = cheri_bounds_set(vectp, (envc + 1) * sizeof(*vectp));
 #else
 	imgp->envv = vectp;
 #endif
@@ -2036,7 +2036,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	for (; envc > 0; --envc) {
 		len = strlen(stringp) + 1;
 #if __has_feature(capabilities)
-		if (sucap(vectp++, cheri_setbounds(ustringp, len)) != 0)
+		if (sucap(vectp++, cheri_bounds_set(ustringp, len)) != 0)
 			return (EFAULT);
 #else
 		if (suptr(vectp++, ustringp) != 0)
@@ -2053,7 +2053,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	if (imgp->auxargs) {
 		vectp++;
 #if __has_feature(capabilities)
-		imgp->auxv = cheri_setbounds(vectp,
+		imgp->auxv = cheri_bounds_set(vectp,
 		    AT_COUNT * sizeof(Elf_Auxinfo));
 #else
 		imgp->auxv = vectp;

--- a/sys/kern/kern_flag.c
+++ b/sys/kern/kern_flag.c
@@ -135,7 +135,7 @@ flag_captured(const char *message, uint32_t key)
 	if (message == NULL)
 		strlcpy(msg_buf, "<null>", sizeof(msg_buf));
 #ifdef __CHERI_PURE_CAPABILITY__
-	else if (!cheri_gettag(message))
+	else if (!cheri_tag_get(message))
 		snprintf(msg_buf, sizeof(msg_buf), "<untagged> %#p", message);
 #endif
 	else

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -2111,7 +2111,7 @@ sys_sigqueue(struct thread *td, struct sigqueue_args *uap)
 		 * CheriABI processess? (Would have to happen in
 		 * delivery code to avoid a race).
 		 */
-		if (cheri_gettag(uap->value))
+		if (cheri_tag_get(uap->value))
 			return (EPROT);
 		memset(&sv2, 0, sizeof(sv2));
 		sv2.sival_int = sv.sival_int;

--- a/sys/kern/subr_devmap.c
+++ b/sys/kern/subr_devmap.c
@@ -233,7 +233,7 @@ devmap_ptov(vm_paddr_t pa, vm_size_t size)
 			 * representable. This must be enforced when inserting
 			 * entries.
 			 */
-			return (cheri_setboundsexact(cheri_setaddress(
+			return (cheri_bounds_set_exact(cheri_address_set(
 			    devmap_capability, pd->pd_va + (pa - pd->pd_pa)),
 			    size));
 #else
@@ -302,9 +302,9 @@ pmap_mapdev(vm_paddr_t pa, vm_size_t size)
 		akva_devmap_vaddr =
 		    CHERI_REPRESENTABLE_ALIGN_DOWN(akva_devmap_vaddr, size);
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr);
-		va = (vm_pointer_t)cheri_setboundsexact(cheri_setaddress(
+		va = (vm_pointer_t)cheri_bounds_set_exact(cheri_address_set(
 		    devmap_capability, akva_devmap_vaddr), size);
-		KASSERT(va + cheri_getlen((void *)va) <= oldva,
+		KASSERT(va + cheri_length_get((void *)va) <= oldva,
 		    ("%s: early devmap overlaps", __func__));
 #else
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr - size);
@@ -355,9 +355,9 @@ pmap_mapdev_attr(vm_paddr_t pa, vm_size_t size, vm_memattr_t ma)
 		akva_devmap_vaddr =
 		    CHERI_REPRESENTABLE_ALIGN_DOWN(akva_devmap_vaddr, size);
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr);
-		va = (vm_pointer_t)cheri_setboundsexact(cheri_setaddress(
+		va = (vm_pointer_t)cheri_bounds_set_exact(cheri_address_set(
 		    devmap_capability, akva_devmap_vaddr), size);
-		KASSERT(va + cheri_getlen((void *)va) <= oldva,
+		KASSERT(va + cheri_length_get((void *)va) <= oldva,
 		    ("%s: early devmap overlaps", __func__));
 #else
 		akva_devmap_vaddr = trunc_page(akva_devmap_vaddr - size);
@@ -412,9 +412,9 @@ devmap_init_capability(void * __capability cap)
 	devmap_capability = cap;
 
 	/* XXX: Too early to panic? */
-	KASSERT(cheri_gettop(cap) == DEVMAP_MAX_VADDR,
+	KASSERT(cheri_top_get(cap) == DEVMAP_MAX_VADDR,
 	    ("devmap capability end doesn't match DEVMAP_MAX_VADDR"));
-	KASSERT(cheri_getlen(cap) == PMAP_MAPDEV_EARLY_SIZE,
+	KASSERT(cheri_length_get(cap) == PMAP_MAPDEV_EARLY_SIZE,
 	    ("devmap capability length doesn't match PMAP_MAPDEV_EARLY_SIZE"));
 }
 #endif

--- a/sys/kern/subr_module.c
+++ b/sys/kern/subr_module.c
@@ -269,7 +269,7 @@ preload_fetch_addr(caddr_t mod)
 #ifdef __CHERI_PURE_CAPABILITY__
 	mod_size = preload_fetch_size(mod);
 	/* XXX-AM: Which permission do we leave? */
-	return (cheri_setbounds(cheri_setaddress(kernel_root_cap,
+	return (cheri_bounds_set(cheri_address_set(kernel_root_cap,
 	    *mdp + preload_addr_relocate), mod_size));
 #else
 	return ((void *)(*mdp + preload_addr_relocate));

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -835,7 +835,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 #endif
 			{
 				cap = va_arg(ap, void * __capability);
-				num = cheri_getaddress(cap);
+				num = cheri_address_get(cap);
 			}
 			if (sharpflag) {
 				int orig_dwidth;
@@ -847,7 +847,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				orig_dwidth = dwidth;
 
 				/* address */
-				num = cheri_getaddress(cap);
+				num = cheri_address_get(cap);
 				PCHAR('0');
 				PCHAR('x');
 				p = ksprintn(nbuf, num, 16, &n, 0);
@@ -869,7 +869,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				PCHAR('[');
 
 				/* permissions */
-				num = cheri_getperm(cap);
+				num = cheri_perms_get(cap);
 				if (num & CHERI_PERM_LOAD)
 					PCHAR('r');
 				if (num & CHERI_PERM_STORE)
@@ -883,7 +883,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				PCHAR(',');
 
 				/* bounds */
-				num = cheri_getbase(cap);
+				num = cheri_base_get(cap);
 				PCHAR('0');
 				PCHAR('x');
 				p = ksprintn(nbuf, num, 16, &n, 0);
@@ -895,7 +895,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 
 				PCHAR('-');
 
-				num += cheri_getlen(cap);
+				num += cheri_length_get(cap);
 				PCHAR('0');
 				PCHAR('x');
 				p = ksprintn(nbuf, num, 16, &n, 0);
@@ -908,16 +908,16 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				PCHAR(']');
 
 				/* attributes */
-				tagged = cheri_gettag(cap);
+				tagged = cheri_tag_get(cap);
 				have_attributes = !tagged;
-				if (cheri_gettype(cap) != CHERI_OTYPE_UNSEALED)
+				if (cheri_type_get(cap) != CHERI_OTYPE_UNSEALED)
 					have_attributes = true;
 
 #ifdef CHERI_FLAGS_CAP_MODE
 				capmode = false;
-				if ((cheri_getperm(cap) &
+				if ((cheri_perms_get(cap) &
 				    CHERI_PERM_EXECUTE) != 0 &&
-				    cheri_getflags(cap) ==
+				    cheri_flags_get(cap) ==
 				    CHERI_FLAGS_CAP_MODE) {
 					capmode = true;
 					have_attributes = true;
@@ -942,7 +942,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 
 				if (!tagged)
 					PATTR("invalid");
-				switch (cheri_gettype(cap)) {
+				switch (cheri_type_get(cap)) {
 				case CHERI_OTYPE_UNSEALED:
 					break;
 				case CHERI_OTYPE_SENTRY:

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -471,7 +471,7 @@ allocuio(u_int iovcnt)
 	    ("Requested %u iovecs exceed UIO_MAXIOV", iovcnt));
 	uio = uma_zalloc_arg(uio_zone, (void *)(uintptr_t)iovcnt, M_WAITOK);
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(__CHERI_SUBOBJECT_BOUNDS__)
-	KASSERT(cheri_getlen(uio->uio_inline_iov) ==
+	KASSERT(cheri_length_get(uio->uio_inline_iov) ==
 	    UIO_INLINE_IOV * sizeof(struct iovec),
 	    ("Malformed UIO structure, uio_inline_iov is not representable"));
 #endif

--- a/sys/kern/sys_process.c
+++ b/sys/kern/sys_process.c
@@ -629,7 +629,7 @@ proc_read_cheri_cap_page(vm_map_t map, vm_offset_t va, struct uio *uio)
 	src = (uintcap_t *)PHYS_TO_DMAP_PAGE(VM_PAGE_TO_PHYS(m)) + pageoff /
 	    sizeof(uintcap_t);
 	while (todo > 0) {
-		capbuf[0] = cheri_gettag(*src);
+		capbuf[0] = cheri_tag_get(*src);
 		memcpy(capbuf + 1, src, sizeof(*src));
 
 		error = uiomove(capbuf, sizeof(capbuf), uio);

--- a/sys/libkern/bcopy.c
+++ b/sys/libkern/bcopy.c
@@ -108,7 +108,7 @@ _memcpy(void *dst0, const void *src0, size_t length, bool keeptags)
 		t = length / wsize;
 #if __has_feature(capabilities)
 		if (!keeptags) {
-			TLOOP(*(word *)dst = (word)cheri_cleartag(
+			TLOOP(*(word *)dst = (word)cheri_tag_clear(
 			        (void * __capability)*(const word *)src);
 			    src += wsize; dst += wsize);
 		} else
@@ -141,7 +141,7 @@ _memcpy(void *dst0, const void *src0, size_t length, bool keeptags)
 #if __has_feature(capabilities)
 		if (!keeptags) {
 			TLOOP(src -= wsize; dst -= wsize;
-			    *(word *)dst = (word)cheri_cleartag(
+			    *(word *)dst = (word)cheri_tag_clear(
 			        (void * __capability)*(const word *)src));
 		} else
 #endif

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -143,7 +143,7 @@ void * __capability
 memcpynocap_c(void * __capability dst, const void *  __capability src,
     size_t len)
 {
-	return (memcpy_c(dst, cheri_andperm(src, ~CHERI_PERM_LOAD_CAP), len));
+	return (memcpy_c(dst, cheri_perms_and(src, ~CHERI_PERM_LOAD_CAP), len));
 }
 
 __strong_reference(memcpynocap_c, memmovenocap_c);

--- a/sys/libkern/strlen.c
+++ b/sys/libkern/strlen.c
@@ -108,7 +108,7 @@ size_t
 
 	/* Scan the rest of the string using word sized operation */
 #ifdef __CHERI_PURE_CAPABILITY__
-	for (; cheri_getlen(lp) - cheri_getoffset(lp) >= sizeof(long); lp++)
+	for (; cheri_length_get(lp) - cheri_offset_get(lp) >= sizeof(long); lp++)
 #else
 	for (; ; lp++)
 #endif
@@ -132,7 +132,7 @@ size_t
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Check if we need to scan byte-by-byte at the end of the string */
-	if ((ptraddr_t)lp != cheri_gettop(lp)) {
+	if ((ptraddr_t)lp != cheri_top_get(lp)) {
 		for (p = (const char *)lp; ; p++)
 			if (*p == '\0')
 				return (p - str);

--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -3288,7 +3288,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct thread *td)
 			thunk.ifr.ifr_phys = ifr64->ifr_phys;
 			break;
 		case IFREQ64(SIOCGI2C):
-			thunk.ifr.ifr_ifru.ifru_data = cheri_setbounds(
+			thunk.ifr.ifr_ifru.ifru_data = cheri_bounds_set(
 			    ifr_data_get_ptr(cmd, ifr64),
 			    sizeof(struct ifi2creq));
 			break;

--- a/sys/net/vnet.h
+++ b/sys/net/vnet.h
@@ -311,7 +311,7 @@ extern struct sx vnet_sxlock;
  * See https://github.com/CTSRD-CHERI/llvm-project/issues/495
  */
 #define	_VNET_PTR(b, n)							\
-	cheri_setbounds((__typeof(VNET_NAME(n)) *)((b) +		\
+	cheri_bounds_set((__typeof(VNET_NAME(n)) *)((b) +		\
 	    ((ptraddr_t)&VNET_NAME(n) - (ptraddr_t)VNET_START)),	\
 	    sizeof(VNET_NAME(n)))
 #else

--- a/sys/netlink/netlink_message_parser.h
+++ b/sys/netlink/netlink_message_parser.h
@@ -54,7 +54,7 @@ lb_alloc(struct linear_buffer *lb, int len)
 		return (NULL);
 	lb->offset = (data + len) - lb->base;
 #ifdef __CHERI_PURE_CAPABILITY__
-	return (cheri_setboundsexact(data, len));
+	return (cheri_bounds_set_exact(data, len));
 #else
 	return (data);
 #endif

--- a/sys/netlink/netlink_snl.h
+++ b/sys/netlink/netlink_snl.h
@@ -107,7 +107,7 @@ lb_allocz(struct linear_buffer *lb, int len)
 		return (NULL);
 	lb->offset = (data + len) - lb->base;
 #ifdef __CHERI_PURE_CAPABILITY__
-	return (cheri_setboundsexact(data, len));
+	return (cheri_bounds_set_exact(data, len));
 #else
 	return (data);
 #endif

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -52,32 +52,32 @@ cheri_init_capabilities(void * __capability kroot)
 {
 	void * __capability ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_KERNEL_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_KERNEL_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_KERNEL_PERMS);
+	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_KERNEL_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_KERNEL_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_SEALCAP_KERNEL_PERMS);
 	kernel_root_sealcap = ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_CAP_USER_DATA_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_CAP_USER_DATA_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_CAP_USER_DATA_PERMS |
+	ctemp = cheri_address_set(kroot, CHERI_CAP_USER_DATA_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_CAP_USER_DATA_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
 	userspace_root_cap = ctemp;
 
-	ctemp = cheri_setaddress(kroot, CHERI_SEALCAP_USERSPACE_BASE);
-	ctemp = cheri_setbounds(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
-	ctemp = cheri_andperm(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
+	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_USERSPACE_BASE);
+	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
+	ctemp = cheri_perms_and(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
 	userspace_root_sealcap = ctemp;
 
 	swap_restore_cap = kroot;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	ctemp = cheri_setaddress(kroot, VM_MAX_KERNEL_ADDRESS -
+	ctemp = cheri_address_set(kroot, VM_MAX_KERNEL_ADDRESS -
 	    PMAP_MAPDEV_EARLY_SIZE);
-	ctemp = cheri_setboundsexact(ctemp, PMAP_MAPDEV_EARLY_SIZE);
-	ctemp = cheri_andperm(ctemp, CHERI_PERMS_KERNEL_DATA);
+	ctemp = cheri_bounds_set_exact(ctemp, PMAP_MAPDEV_EARLY_SIZE);
+	ctemp = cheri_perms_and(ctemp, CHERI_PERMS_KERNEL_DATA);
 	devmap_init_capability(ctemp);
 
-	kernel_root_cap = cheri_andperm(kroot,
+	kernel_root_cap = cheri_perms_and(kroot,
 	    ~(CHERI_PERM_SEAL | CHERI_PERM_UNSEAL));
 #endif
 }

--- a/sys/riscv/include/cheric.h
+++ b/sys/riscv/include/cheric.h
@@ -34,7 +34,7 @@
 #define	_MACHINE_CHERIC_H_
 
 #if __has_feature(capabilities)
-#define	cheri_capmode(cap)	cheri_setflags(cap, CHERI_FLAGS_CAP_MODE)
+#define	cheri_capmode(cap)	cheri_flags_set(cap, CHERI_FLAGS_CAP_MODE)
 #endif
 
 #endif /* !_MACHINE_CHERIC_H_ */

--- a/sys/riscv/include/cherireg.h
+++ b/sys/riscv/include/cherireg.h
@@ -43,6 +43,7 @@
 
 #define	CHERICAP_SIZE		__SIZEOF_CHERI_CAPABILITY__
 
+#ifdef _KERNEL
 /*
  * CHERI ISA-defined constants for capabilities -- suitable for inclusion from
  * assembly source code.
@@ -68,6 +69,17 @@
 #define	CHERI_PERM_SW1			(1 << 16)	/* 0x00010000 */
 #define	CHERI_PERM_SW2			(1 << 17)	/* 0x00020000 */
 #define	CHERI_PERM_SW3			(1 << 18)	/* 0x00040000 */
+#else /* !_KERNEL */
+/*
+ * These should be defined in cheriintrin.h, but aren't yet.
+ */
+#define	CHERI_PERM_SET_CID		(1 << 11)	/* 0x00000800 */
+#define	CHERI_PERM_SW0			(1 << 15)	/* 0x00008000 */
+#define	CHERI_PERM_SW1			(1 << 16)	/* 0x00010000 */
+#define	CHERI_PERM_SW2			(1 << 17)	/* 0x00020000 */
+#define	CHERI_PERM_SW3			(1 << 18)	/* 0x00040000 */
+#endif /* !_KERNEL */
+
 
 /*
  * CHERI_PERMS_SWALL: Mask of all available software-defined permissions
@@ -179,9 +191,11 @@
 #define	CHERI_OTYPE_ISKERN(x)	(((x) & CHERI_OTYPE_KERN_FLAG) != 0)
 #define	CHERI_OTYPE_ISUSER(x)	(!(CHERI_OTYPE_ISKERN(x)))
 
+#ifdef _KERNEL
 /* Reserved CHERI object types: */
 #define	CHERI_OTYPE_UNSEALED	(-1l)
 #define	CHERI_OTYPE_SENTRY	(-2l)
+#endif
 
 /*
  * List of CHERI capability cause code constants.

--- a/sys/riscv/riscv/cheri_revoke_machdep.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep.c
@@ -94,7 +94,7 @@ vm_do_cheri_revoke(int *res, const struct vm_cheri_revoke_cookie *crc,
     uintcap_t * __capability cutp, uintcap_t cut, vm_offset_t start,
     vm_offset_t end)
 {
-	int perms = cheri_getperm(cut);
+	int perms = cheri_perms_get(cut);
 	CHERI_REVOKE_STATS_FOR(crst, crc);
 
 	if (perms == 0) {
@@ -108,7 +108,7 @@ vm_do_cheri_revoke(int *res, const struct vm_cheri_revoke_cookie *crc,
 		 */
 
 		CHERI_REVOKE_STATS_BUMP(crst, caps_found_revoked);
-	} else if (cheri_gettag(cut) && ctp(crshadow, cut, perms, start, end)) {
+	} else if (cheri_tag_get(cut) && ctp(crshadow, cut, perms, start, end)) {
 		void * __capability cscratch;
 		int ok;
 
@@ -150,7 +150,7 @@ again:
 		if (__builtin_expect((uintcap_t)cutr == 0, 1)) {
 			CHERI_REVOKE_STATS_BUMP(crst, caps_cleared);
 			/* Don't count a revoked cap as HASCAPS */
-		} else if (!cheri_gettag(cscratch)) {
+		} else if (!cheri_tag_get(cscratch)) {
 			/* Data; don't sweat it */
 		} else if (cheri_revoke_is_revoked(cscratch)) {
 			/* Revoked cap; don't worry about it */
@@ -297,7 +297,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 	}
 #endif
 
-	for (; cheri_getaddress(mvu) < mve; mvu += _cloadtags_stride) {
+	for (; cheri_address_get(mvu) < mve; mvu += _cloadtags_stride) {
 		uintcap_t * __capability mvt = mvu;
 
 		nexttags =
@@ -334,10 +334,10 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 #else /* no CLOADTAGS */
 	/* TODO: lines_scan approximation for CHERI_REVOKE_STATS? */
 
-	for (; cheri_getaddress(mvu) < mve; mvu++) {
+	for (; cheri_address_get(mvu) < mve; mvu++) {
 		uintcap_t cut = *mvu;
 
-		if (cheri_gettag(cut)) {
+		if (cheri_tag_get(cut)) {
 			if (cb(&res, crc, crshadow, ctp, mvu, cut, start, end))
 				goto out;
 		}
@@ -355,7 +355,7 @@ out:
 int
 vm_cheri_revoke_test(const struct vm_cheri_revoke_cookie *crc, uintcap_t cut)
 {
-	if (cheri_gettag(cut)) {
+	if (cheri_tag_get(cut)) {
 		int res;
 		vm_offset_t start, end;
 
@@ -372,7 +372,7 @@ vm_cheri_revoke_test(const struct vm_cheri_revoke_cookie *crc, uintcap_t cut)
 		enable_user_memory_access();
 #endif
 		res = crc->map->vm_cheri_revoke_test(crc->crshadow, cut,
-		    cheri_getperm(cut), start, end);
+		    cheri_perms_get(cut), start, end);
 #ifdef CHERI_CAPREVOKE_FAST_COPYIN
 		disable_user_memory_access();
 		curthread->td_pcb->pcb_onfault = prev_onfault;
@@ -406,7 +406,7 @@ vm_cheri_revoke_page_rw(const struct vm_cheri_revoke_cookie *crc, vm_page_t m)
 	mva = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
 	mve = mva + PAGE_SIZE;
 
-	mvu = cheri_setbounds(cheri_setaddress(kdc, mva), PAGE_SIZE);
+	mvu = cheri_bounds_set(cheri_address_set(kdc, mva), PAGE_SIZE);
 
 	res = vm_cheri_revoke_page_iter(crc, vm_do_cheri_revoke, mvu, mve);
 
@@ -432,12 +432,12 @@ vm_cheri_revoke_page_ro_adapt(int *res,
     vm_offset_t end)
 {
 	/* If the thing has no permissions, we don't need to scan it later */
-	if ((cheri_gettag(cut) == 0) || (cheri_getperm(cut) == 0))
+	if ((cheri_tag_get(cut) == 0) || (cheri_perms_get(cut) == 0))
 		return (0);
 
 	*res |= VM_CHERI_REVOKE_PAGE_HASCAPS;
 
-	if (ctp(crshadow, cut, cheri_getperm(cut), start, end)) {
+	if (ctp(crshadow, cut, cheri_perms_get(cut), start, end)) {
 		*res |= VM_CHERI_REVOKE_PAGE_DIRTY;
 
 		/* One dirty answer is as good as any other; stop eary */
@@ -485,7 +485,7 @@ vm_cheri_revoke_page_ro(const struct vm_cheri_revoke_cookie *crc, vm_page_t m)
 	mva = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
 	mve = mva + PAGE_SIZE;
 
-	mvu = cheri_setbounds(cheri_setaddress(kdc, mva), PAGE_SIZE);
+	mvu = cheri_bounds_set(cheri_address_set(kdc, mva), PAGE_SIZE);
 
 	res = vm_cheri_revoke_page_iter(crc, vm_cheri_revoke_page_ro_adapt, mvu,
 	    mve);

--- a/sys/riscv/riscv/cheri_revoke_machdep_tests.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep_tests.c
@@ -52,7 +52,7 @@ vm_cheri_revoke_test_mem_map(const uint8_t * __capability crshadow,
 	uint8_t bmbits;
 	const uint8_t * __capability bmloc;
 
-	ptraddr_t va = cheri_getbase(cut);
+	ptraddr_t va = cheri_base_get(cut);
 
 	bmloc = crshadow - VM_CHERI_REVOKE_BSZ_OTYPE -
 	    (va / VM_CHERI_REVOKE_GSZ_MEM_MAP / 8);
@@ -90,7 +90,7 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 	uint8_t bmbits;
 	const uint8_t * __capability bmloc;
 
-	ptraddr_t va = cheri_getbase(cut);
+	ptraddr_t va = cheri_base_get(cut);
 
 	bmloc = crshadow + (va / VM_CHERI_REVOKE_GSZ_MEM_NOMAP / 8);
 
@@ -120,7 +120,7 @@ vm_cheri_revoke_test_mem_nomap(const uint8_t * __capability crshadow,
 static inline unsigned
 vm_cheri_revoke_test_range(vm_offset_t start, vm_offset_t end, uintcap_t cut)
 {
-	ptraddr_t va = cheri_getbase(cut);
+	ptraddr_t va = cheri_base_get(cut);
 
 	return (va >= start && va < end);
 }

--- a/sys/riscv/riscv/elf_machdep.c
+++ b/sys/riscv/riscv/elf_machdep.c
@@ -596,7 +596,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		 * the lookup function instead.
 		 */
 		if (addend != 0) {
-			KASSERT(!cheri_getsealed(addr),
+			KASSERT(!cheri_is_sealed(addr),
 			    ("%s: sentry %#p with non-zero addend %#lx",
 			    __func__, (void *)addr, addend));
 

--- a/sys/riscv/riscv/freebsd64_machdep.c
+++ b/sys/riscv/riscv/freebsd64_machdep.c
@@ -199,7 +199,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 		/* XXX: Permit userland to change GPRs for sigreturn? */
 
 		/* Honor 64-bit PC. */
-		mc.mc_capregs.cp_sepcc = cheri_setoffset(
+		mc.mc_capregs.cp_sepcc = cheri_offset_set(
 		    mc.mc_capregs.cp_sepcc, mcp->mc_gpregs.gp_sepc);
 	} else {
 		creg = (uintcap_t *)&mc.mc_capregs;
@@ -207,7 +207,7 @@ freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp)
 		for (i = 0; i < CONTEXT64_GPREGS; i++)
 			creg[i] = (uintcap_t)greg[i];
 
-		mc.mc_capregs.cp_sepcc = cheri_setoffset(
+		mc.mc_capregs.cp_sepcc = cheri_offset_set(
 		    td->td_frame->tf_sepc, mcp->mc_gpregs.gp_sepc);
 		mc.mc_capregs.cp_ddc = td->td_frame->tf_ddc;
 		mc.mc_capregs.cp_sstatus = mcp->mc_gpregs.gp_sstatus;

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -357,9 +357,9 @@ try_load_dtb(caddr_t kmdp)
 	dtbp = MD_FETCH(kmdp, MODINFOMD_DTBP, vm_offset_t);
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (dtbp != (vm_pointer_t)NULL) {
-		dtbp = (vm_pointer_t)cheri_andperm(cheri_setaddress(
+		dtbp = (vm_pointer_t)cheri_perms_and(cheri_address_set(
 		    kernel_root_cap, dtbp), CHERI_PERMS_KERNEL_DATA);
-		dtbp = cheri_setbounds(dtbp, fdt_totalsize((void *)dtbp));
+		dtbp = cheri_bounds_set(dtbp, fdt_totalsize((void *)dtbp));
 	}
 #endif
 
@@ -434,7 +434,7 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	 */
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	const void *dtbp_virt = cheri_setaddress(kernel_root_cap,
+	const void *dtbp_virt = cheri_address_set(kernel_root_cap,
 	    rvbp->dtbp_phys);
 	dtb_size = fdt_totalsize(dtbp_virt);
 	lastaddr = CHERI_REPRESENTABLE_ALIGN_UP(lastaddr, dtb_size);
@@ -451,10 +451,10 @@ fake_preload_metadata(struct riscv_bootparams *rvbp)
 	PRELOAD_PUSH_VALUE(uint32_t, sizeof(vm_offset_t));
 	PRELOAD_PUSH_VALUE(vm_offset_t, lastaddr);
 #ifdef __CHERI_PURE_CAPABILITY__
-	void *dtbp = cheri_setbounds(cheri_setaddress(kernel_root_cap,
+	void *dtbp = cheri_bounds_set(cheri_address_set(kernel_root_cap,
 	    lastaddr), dtb_size);
 	memmove(dtbp, dtbp_virt, dtb_size);
-	lastaddr = roundup(lastaddr + cheri_getlen(dtbp), sizeof(int));
+	lastaddr = roundup(lastaddr + cheri_length_get(dtbp), sizeof(int));
 #else
 	memmove((void *)lastaddr, (const void *)rvbp->dtbp_phys, dtb_size);
 	lastaddr = roundup(lastaddr + dtb_size, sizeof(int));

--- a/sys/riscv/riscv/mem.c
+++ b/sys/riscv/riscv/mem.c
@@ -86,8 +86,8 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 				 * Note that cnt <= PAGE_SIZE, exact setbounds
 				 * is guaranteed to work.
 				 */
-				error = uiomove(cheri_setboundsexact(
-				    cheri_setaddress(dmap_capability, v), cnt),
+				error = uiomove(cheri_bounds_set_exact(
+				    cheri_address_set(dmap_capability, v), cnt),
 				    cnt, uio);
 #else
 				error = uiomove((void *)v, cnt, uio);

--- a/sys/riscv/riscv/ptrace_machdep.c
+++ b/sys/riscv/riscv/ptrace_machdep.c
@@ -70,7 +70,7 @@ ptrace_set_pc(struct thread *td, u_long addr)
 	    !cheri_is_address_inbounds(
 	    (void * __capability)td->td_frame->tf_sepc, addr))
 		return (EINVAL);
-	td->td_frame->tf_sepc = cheri_setaddress(td->td_frame->tf_sepc, addr);
+	td->td_frame->tf_sepc = cheri_address_set(td->td_frame->tf_sepc, addr);
 #else
 	td->td_frame->tf_sepc = addr;
 #endif

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -435,7 +435,7 @@ skip_pmap:
 			if (pcb->pcb_onfault != 0) {
 				frame->tf_a[0] = error;
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
-				frame->tf_sepc = cheri_setaddress(
+				frame->tf_sepc = cheri_address_set(
 				    frame->tf_sepc, pcb->pcb_onfault);
 #else
 				frame->tf_sepc = pcb->pcb_onfault;
@@ -540,7 +540,7 @@ do_trap_supervisor(struct trapframe *frame)
 		if (curthread->td_pcb->pcb_onfault != 0) {
 			frame->tf_a[0] = EPROT;
 #ifndef __CHERI_PURE_CAPABILITY__
-			frame->tf_sepc = cheri_setaddress(frame->tf_sepc,
+			frame->tf_sepc = cheri_address_set(frame->tf_sepc,
 			    curthread->td_pcb->pcb_onfault);
 #else
 			frame->tf_sepc = curthread->td_pcb->pcb_onfault;
@@ -670,9 +670,9 @@ do_trap_user(struct trapframe *frame)
 		if (!SV_PROC_FLAG(td->td_proc, SV_CHERI) &&
 		    TVAL_CAP_CAUSE(frame->tf_stval) == CHERI_EXCCODE_LENGTH) {
 			if (TVAL_CAP_IDX(frame->tf_stval) == 32 /* PCC */ &&
-			    cheri_getbase(frame->tf_sepc) ==
+			    cheri_base_get(frame->tf_sepc) ==
 			    CHERI_CAP_USER_DATA_BASE &&
-			    cheri_getlen(frame->tf_sepc) ==
+			    cheri_length_get(frame->tf_sepc) ==
 			    CHERI_CAP_USER_DATA_LENGTH) {
 				call_trapsignal(td, SIGSEGV, SEGV_MAPERR,
 				    (ptraddr_t)frame->tf_sepc,
@@ -689,9 +689,9 @@ do_trap_user(struct trapframe *frame)
 			 * that would have been raised.
 			 */
 			if (TVAL_CAP_IDX(frame->tf_stval) == 33 /* DDC */ &&
-			    cheri_getbase(frame->tf_ddc) ==
+			    cheri_base_get(frame->tf_ddc) ==
 			    CHERI_CAP_USER_DATA_BASE &&
-			    cheri_getlen(frame->tf_ddc) ==
+			    cheri_length_get(frame->tf_ddc) ==
 			    CHERI_CAP_USER_DATA_LENGTH) {
 				call_trapsignal(td, SIGSEGV, SEGV_MAPERR,
 				    0 /* XXX */,

--- a/sys/sys/pcpu.h
+++ b/sys/sys/pcpu.h
@@ -128,7 +128,7 @@ extern uintptr_t dpcpu_off[];
 #ifdef __CHERI_PURE_CAPABILITY__
 #define	DPCPU_BIAS	0
 #define	_DPCPU_PTR(b, n)						\
-	cheri_setboundsexact((__typeof(DPCPU_NAME(n)) *)((b) +		\
+	cheri_bounds_set_exact((__typeof(DPCPU_NAME(n)) *)((b) +		\
 	    ((ptraddr_t)&DPCPU_NAME(n) - (ptraddr_t)DPCPU_START)),	\
 	    CHERI_REPRESENTABLE_LENGTH(sizeof(DPCPU_NAME(n))))
 #else /* __CHERI_PURE_CAPABILITY__ */

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -2370,9 +2370,9 @@ cheri_restore_tag(void * __capability *cp)
 
 	cap = (uintcap_t)*cp;
 
-	newcap = cheri_buildcap(swap_restore_cap, cap);
-	sealcap = cheri_copytype(swap_restore_cap, cap);
-	newcap = cheri_condseal(newcap, sealcap);
+	newcap = cheri_cap_build(swap_restore_cap, cap);
+	sealcap = cheri_type_copy(swap_restore_cap, cap);
+	newcap = cheri_seal_conditionally(newcap, sealcap);
 
 	*cp = newcap;
 }

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -1474,7 +1474,7 @@ vm_cheri_revoke_cap(const struct vm_cheri_revoke_cookie *crc, uintcap_t *p)
 
 	uintcap_t v = *p;
 
-	if (!cheri_gettag(v))
+	if (!cheri_tag_get(v))
 		return;
 
 	CHERI_REVOKE_STATS_BUMP(crst, caps_found);

--- a/sys/vm/vm_cheri_revoke.h
+++ b/sys/vm/vm_cheri_revoke.h
@@ -66,13 +66,13 @@ static __always_inline uintcap_t
 cheri_revoke_cap(uintcap_t c)
 {
 #ifndef CHERI_CAPREVOKE_CLEARTAGS
-	if (__builtin_expect(cheri_gettype(c) == -1, 1)) {
-		return cheri_andperm(c, 0);
+	if (__builtin_expect(cheri_type_get(c) == -1, 1)) {
+		return cheri_perms_and(c, 0);
 	}
 	return cheri_revoke_sealed(c);
 #else
 	/* No need to handle sealed things specially */
-	return cheri_cleartag(c);
+	return cheri_tag_clear(c);
 
 	/* TODO: Also replace-with-NULL */
 #endif

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -875,7 +875,7 @@ vm_cap_allows_prot(const void * __capability cap, vm_prot_t prot)
 		reqperm |= CHERI_PERM_STORE_CAP;
 	if (prot & VM_PROT_EXECUTE)
 		reqperm |= CHERI_PERM_EXECUTE;
-	if ((cheri_getperm(cap) & reqperm) != reqperm)
+	if ((cheri_perms_get(cap) & reqperm) != reqperm)
 		return (false);
 	return (true);
 }

--- a/sys/vm/vm_init.c
+++ b/sys/vm/vm_init.c
@@ -241,9 +241,9 @@ again:
 #endif
 	firstaddr = (caddr_t)kva_alloc(size);
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_getlen(firstaddr) == size,
+	KASSERT(cheri_length_get(firstaddr) == size,
 	    ("Inexact bounds expected %zx found %zx",
-	    (size_t)size, (size_t)cheri_getlen(firstaddr)));
+	    (size_t)size, (size_t)cheri_length_get(firstaddr)));
 #endif
 	kmi->buffer_sva = (vm_pointer_t)firstaddr;
 	kmi->buffer_eva = kmi->buffer_sva + size;
@@ -261,9 +261,9 @@ again:
 #endif
 		firstaddr = (caddr_t)kva_alloc(size);
 #ifdef __CHERI_PURE_CAPABILITY__
-		KASSERT(cheri_getlen(firstaddr) == size,
+		KASSERT(cheri_length_get(firstaddr) == size,
 		    ("Inexact bounds expected %zx found %zx",
-		    (size_t)size, (size_t)cheri_getlen(firstaddr)));
+		    (size_t)size, (size_t)cheri_length_get(firstaddr)));
 #endif
 		kmi->transient_sva = (vm_pointer_t)firstaddr;
 		kmi->transient_eva = kmi->transient_sva + size;

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -157,7 +157,7 @@ kva_alloc(vm_size_t size)
 		return (0);
 	addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
 #endif
 	TSEXIT();
 
@@ -182,7 +182,7 @@ kva_alloc_aligned(vm_size_t size, vm_size_t align)
 		return (0);
 	addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
 #endif
 	TSEXIT();
 
@@ -318,10 +318,10 @@ kmem_alloc_attr_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 	VM_OBJECT_WUNLOCK(object);
 	kmem_alloc_san(addr, size, asize, flags);
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(addr), ("Expected valid capability"));
-	KASSERT(cheri_getlen(addr) == asize,
+	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
+	KASSERT(cheri_length_get(addr) == asize,
 	    ("Inexact bounds expected %zx found %zx",
-	    (size_t)asize, (size_t)cheri_getlen(addr)));
+	    (size_t)asize, (size_t)cheri_length_get(addr)));
 #endif
 	return ((void *)addr);
 }
@@ -424,10 +424,10 @@ kmem_alloc_contig_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 	VM_OBJECT_WUNLOCK(object);
 	kmem_alloc_san(addr, size, asize, flags);
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(addr), ("Expected valid capability"));
-	KASSERT(cheri_getlen(addr) == asize,
+	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
+	KASSERT(cheri_length_get(addr) == asize,
 	    ("Inexact bounds expected %zx found %zx",
-	    (size_t)asize, (size_t)cheri_getlen(addr)));
+	    (size_t)asize, (size_t)cheri_length_get(addr)));
 #endif
 	return ((void *)addr);
 }
@@ -491,8 +491,8 @@ kmem_subinit(vm_map_t map, vm_map_t parent, vm_pointer_t *min, vm_pointer_t *max
 	int ret;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(min), ("Expected valid capability min"));
-	KASSERT(cheri_gettag(max), ("Expected valid capability max"));
+	KASSERT(cheri_tag_get(min), ("Expected valid capability min"));
+	KASSERT(cheri_tag_get(max), ("Expected valid capability max"));
 #endif
 	size = round_page(size);
 
@@ -546,7 +546,7 @@ kmem_malloc_domain(int domain, vm_size_t size, int flags)
 	}
 	kasan_mark((void *)addr, size, asize, KASAN_KMEM_REDZONE);
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
 #endif
 	return ((void *)addr);
 }
@@ -601,7 +601,7 @@ kmem_back_domain(int domain, vm_object_t object, vm_pointer_t addr,
 	KASSERT(object == kernel_object,
 	    ("kmem_back_domain: only supports kernel object."));
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(addr), ("Expected valid capability"));
+	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
 #endif
 
 	offset = addr - VM_MIN_KERNEL_ADDRESS;
@@ -924,8 +924,8 @@ kmem_init(vm_pointer_t start, vm_pointer_t end)
 	vm_size_t size;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	KASSERT(cheri_gettag(start), ("Expected valid start capability"));
-	KASSERT(cheri_gettag(end), ("Expected valid end capability"));
+	KASSERT(cheri_tag_get(start), ("Expected valid start capability"));
+	KASSERT(cheri_tag_get(end), ("Expected valid end capability"));
 #endif
 
 	vm_map_init_system(kernel_map, kernel_pmap,

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -196,7 +196,7 @@ vm_map_entry_system_wired_count(vm_map_entry_t entry)
  * To support optimization as to which bitmap(s) we look at, given revocation
  * runs may use different predicates on capabilities under test.
  *
- * Takes cutperm = cheri_getperm(cut) as an argument for optimization reasons.
+ * Takes cutperm = cheri_perms_get(cut) as an argument for optimization reasons.
  *
  * Returns any nonzero value to indicate revocation required.
  */

--- a/usr.sbin/bhyve/gdb.c
+++ b/usr.sbin/bhyve/gdb.c
@@ -65,8 +65,6 @@
 #include <unistd.h>
 #include <vmmapi.h>
 
-#include <cheri/cheric.h>
-
 #include "bhyverun.h"
 #include "config.h"
 #include "debug.h"


### PR DESCRIPTION
This is annoyingly disruptive to large downstream patches, but we're approaching the point of no return and need to do this sooner rather than later if we're going to.