### PR TITLE
Chase ISAv9 and remove support for DDC offsetting

### DIFF
--- a/sys/arm64/include/cheri.h
+++ b/sys/arm64/include/cheri.h
@@ -43,12 +43,6 @@
     (void * __capability)READ_SPECIALREG_CAP(rddc_el0))
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_elr)
 
-/* Does the current thread add the base in CToPtr */
-#define __USER_DDC_OFFSET_ENABLED	\
-    (READ_SPECIALREG(cctlr_el0) & CCTLR_DDCBO_MASK)
-#define __USER_PCC_OFFSET_ENABLED	\
-    (READ_SPECIALREG(cctlr_el0) & CCTLR_PCCBO_MASK)
-
 /*
  * Special marker NOPs for the Morello FVP to start / stop region of interest
  * in trace.

--- a/sys/riscv/include/cheri.h
+++ b/sys/riscv/include/cheri.h
@@ -38,10 +38,6 @@
 #define	__USER_DDC	((void * __capability)curthread->td_frame->tf_ddc)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_sepc)
 
-/* Since ISAv9, RISC-V does not add the base in CToPtr */
-#define	__USER_DDC_OFFSET_ENABLED	0
-#define	__USER_PCC_OFFSET_ENABLED	0
-
 /*
  * CHERI-RISC-V-specific kernel utility functions.
  */

--- a/sys/riscv/include/cheri.h
+++ b/sys/riscv/include/cheri.h
@@ -38,9 +38,9 @@
 #define	__USER_DDC	((void * __capability)curthread->td_frame->tf_ddc)
 #define	__USER_PCC	((void * __capability)curthread->td_frame->tf_sepc)
 
-/* RISC-V always adds the base in CToPtr */
-#define	__USER_DDC_OFFSET_ENABLED	1
-#define	__USER_PCC_OFFSET_ENABLED	1
+/* Since ISAv9, RISC-V does not add the base in CToPtr */
+#define	__USER_DDC_OFFSET_ENABLED	0
+#define	__USER_PCC_OFFSET_ENABLED	0
 
 /*
  * CHERI-RISC-V-specific kernel utility functions.

--- a/sys/riscv/include/cheric.h
+++ b/sys/riscv/include/cheric.h
@@ -37,12 +37,4 @@
 #define	cheri_capmode(cap)	cheri_setflags(cap, CHERI_FLAGS_CAP_MODE)
 #endif
 
-#ifdef _KERNEL
-/* XXX: Convert faulting CBuildCap into tag-stripping. */
-extern void * __capability cheri_buildcap_safe(void * __capability, intcap_t);
-
-#undef cheri_buildcap
-#define	cheri_buildcap(x, y)	cheri_buildcap_safe((x), (y))
-#endif
-
 #endif /* !_MACHINE_CHERIC_H_ */

--- a/sys/riscv/riscv/support.S
+++ b/sys/riscv/riscv/support.S
@@ -464,42 +464,6 @@ ENTRY(sucap)
 END(sucap)
 #endif
 
-#if __has_feature(capabilities)
-/*
- * cheri_buildcap_safe failed, return untagged input
- */
-ENTRY(cbuildcap_fault)
-#ifdef __CHERI_PURE_CAPABILITY__
-	SET_FAULT_HANDLER(cnull, ca2)	/* Reset the handler function */
-#else
-	SET_FAULT_HANDLER(x0, a2)	/* Reset the handler function */
-#endif
-	ccleartag ca0, ca1
-	RETURN
-END(cbuildcap_fault)
-
-/*
- * void * __capability cheri_buildcap_safe(volatile void * __capability,
- *	intcap_t)
- */
-ENTRY(cheri_buildcap_safe)
-#ifdef __CHERI_PURE_CAPABILITY__
-	clgc	ca6, cbuildcap_fault	/* Load the fault handler */
-	SET_FAULT_HANDLER(ca6, ca2)	/* And set it */
-#else
-	la	a6, cbuildcap_fault	/* Load the fault handler */
-	SET_FAULT_HANDLER(a6, a2)	/* And set it */
-#endif
-	cbuildcap ca0, ca0, ca1
-#ifdef __CHERI_PURE_CAPABILITY__
-	SET_FAULT_HANDLER(cnull, ca2)	/* Reset the fault handler */
-#else
-	SET_FAULT_HANDLER(x0, a2)	/* Reset the fault handler */
-#endif
-	RETURN
-END(cheri_buildcap_safe)
-#endif
-
 ENTRY(setjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* Store the stack pointer */

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -128,20 +128,18 @@ extern bool scheduler_stopped;
  * Derive out-of-bounds and small values from NULL.  This allows common
  * sentinel values to work.
  */
-#define ___USER_CFROMPTR(ptr, cap, is_offset)				\
+#define ___USER_CFROMPTR(ptr, cap)					\
     ((void *)(uintptr_t)(ptr) == NULL ? NULL :				\
      ((vm_offset_t)(ptr) < 4096 ||					\
       (vm_offset_t)(ptr) > VM_MAXUSER_ADDRESS) ?			\
 	(void * __capability)(uintcap_t)(ptraddr_t)(ptr) :		\
-	(is_offset) ?							\
-	__builtin_cheri_offset_set((cap), (ptraddr_t)(ptr)) :		\
 	__builtin_cheri_address_set((cap), (ptraddr_t)(ptr)))
 
 #define	__USER_CAP_UNBOUND(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_DDC, __USER_DDC_OFFSET_ENABLED)
+	___USER_CFROMPTR((ptr), __USER_DDC)
 
 #define	__USER_CODE_CAP(ptr)						\
-	___USER_CFROMPTR((ptr), __USER_PCC, __USER_PCC_OFFSET_ENABLED)
+	___USER_CFROMPTR((ptr), __USER_PCC)
 
 #define	__USER_CAP(ptr, len)						\
 ({									\


### PR DESCRIPTION
- CBuildCap no longer faults so we don't need to wrap it
- Default to address mode for DDC on RISC-V as platforms we care about have moved on
- Remove support for DDC offsetting in user pointers entirely (I'm less sure about this one, but I don't see signs of code to set the necessary bits)

Requested by @bsdjhb 