### PR TITLE
cheri/cheric.h: update cheri_kern_ macros to follow cheriintrin.h

### DIFF
--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -413,7 +413,7 @@ init_proc0(vm_pointer_t kstack)
 
 	/* XXX-AM: We need to set bounds on pcb and kstack here as in MIPS */
 	proc_linkup0(&proc0, &thread0);
-	thread0.td_kstack = cheri_kern_andperm(kstack, CHERI_PERMS_KERNEL_DATA);
+	thread0.td_kstack = cheri_kern_perms_and(kstack, CHERI_PERMS_KERNEL_DATA);
 	thread0.td_kstack_pages = KSTACK_PAGES;
 #if defined(PERTHREAD_SSP)
 	thread0.td_md.md_canary = boot_canary;

--- a/sys/arm64/arm64/machdep_boot.c
+++ b/sys/arm64/arm64/machdep_boot.c
@@ -186,7 +186,7 @@ linux_parse_boot_param(struct arm64_bootparams *abp)
 		return (0);
 	/* Test if modulep point to valid DTB. */
 	dtb_ptr = (struct fdt_header *)abp->modulep;
-	dtb_ptr = cheri_kern_andperm(dtb_ptr,
+	dtb_ptr = cheri_kern_perms_and(dtb_ptr,
 	    CHERI_PERMS_KERNEL_RODATA & CHERI_PERMS_KERNEL_DATA_NOCAP);
 	if (fdt_check_header(dtb_ptr) != 0)
 		return (0);
@@ -211,7 +211,7 @@ freebsd_parse_boot_param(struct arm64_bootparams *abp)
 		return (0);
 
 	preload_metadata = (caddr_t)(uintptr_t)(abp->modulep);
-	preload_metadata = cheri_kern_andperm(preload_metadata,
+	preload_metadata = cheri_kern_perms_and(preload_metadata,
 	    CHERI_PERMS_KERNEL_DATA & CHERI_PERMS_KERNEL_DATA_NOCAP);
 	kmdp = preload_search_by_type("elf kernel");
 	if (kmdp == NULL)

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -1526,7 +1526,7 @@ pmap_bootstrap(vm_size_t kernlen)
 
 	virtual_avail = preinit_map_va + PMAP_PREINIT_MAPPING_SIZE;
 	virtual_avail = roundup2(virtual_avail, L1_SIZE);
-	virtual_end = cheri_kern_setaddress(virtual_avail,
+	virtual_end = cheri_kern_address_set(virtual_avail,
 	    VM_MAX_KERNEL_ADDRESS - PMAP_MAPDEV_EARLY_SIZE);
 	kernel_vm_end = virtual_avail;
 
@@ -1760,7 +1760,7 @@ pmap_init_pv_table(void)
 		seg = &vm_phys_segs[i];
 		used_pvd = pmap_l2_pindex(roundup2(seg->end, L2_SIZE)) -
 		    pmap_l2_pindex(seg->start);
-		seg->md_first = cheri_kern_setbounds(pvd,
+		seg->md_first = cheri_kern_bounds_set(pvd,
 		    used_pvd * sizeof(*pvd));
 		pvd += used_pvd;
 
@@ -9769,7 +9769,7 @@ pmap_sync_icache(pmap_t pmap, vm_offset_t va, vm_size_t sz)
 			/* Extract the physical address & find it in the DMAP */
 			pa = pmap_extract(pmap, va);
 			if (pa != 0)
-				cpu_icache_sync_range((void *)cheri_kern_setbounds(
+				cpu_icache_sync_range((void *)cheri_kern_bounds_set(
 				    PHYS_TO_DMAP(pa), len), len);
 
 			/* Move to the next page */

--- a/sys/arm64/include/sf_buf.h
+++ b/sys/arm64/include/sf_buf.h
@@ -43,7 +43,7 @@ static inline vm_pointer_t
 sf_buf_kva(struct sf_buf *sf)
 {
 
-	return (cheri_kern_setbounds(
+	return (cheri_kern_bounds_set(
 	    PHYS_TO_DMAP(VM_PAGE_TO_PHYS((vm_page_t)sf)), PAGE_SIZE));
 }
 

--- a/sys/arm64/vmm/vmm.c
+++ b/sys/arm64/vmm/vmm.c
@@ -1588,7 +1588,7 @@ _vm_gpa_hold(struct vm *vm, vm_paddr_t gpa, size_t len, int reqprot,
 
 	if (count == 1) {
 		*cookie = m;
-		return (cheri_kern_setboundsexact(
+		return (cheri_kern_bounds_set_exact(
 		    (void *)(PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m)) + pageoff), len));
 	} else {
 		*cookie = NULL;

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -214,19 +214,19 @@ cheri_bytes_remaining(const void * __capability cap)
 
 #ifdef _KERNEL
 #ifdef __CHERI_PURE_CAPABILITY__
-#define	cheri_kern_gettag(x)		cheri_tag_get(x)
-#define	cheri_kern_setbounds(x, y)	cheri_bounds_set(x, y)
-#define	cheri_kern_setboundsexact(x, y)	cheri_bounds_set_exact(x, y)
-#define	cheri_kern_setaddress(x, y)	cheri_address_set(x, y)
-#define	cheri_kern_getaddress(x)	cheri_address_get(x)
-#define	cheri_kern_andperm(x, y)	cheri_perms_and(x, y)
+#define	cheri_kern_tag_get(x)		cheri_tag_get(x)
+#define	cheri_kern_bounds_set(x, y)	cheri_bounds_set(x, y)
+#define	cheri_kern_bounds_set_exact(x, y)	cheri_bounds_set_exact(x, y)
+#define	cheri_kern_address_set(x, y)	cheri_address_set(x, y)
+#define	cheri_kern_address_get(x)	cheri_address_get(x)
+#define	cheri_kern_perms_and(x, y)	cheri_perms_and(x, y)
 #else
-#define	cheri_kern_gettag(x)		1
-#define	cheri_kern_setbounds(x, y)	(x)
-#define	cheri_kern_setboundsexact(x, y)	(x)
-#define	cheri_kern_setaddress(x, y)	((__typeof__(x))(y))
-#define	cheri_kern_getaddress(x)	((uintptr_t)(x))
-#define	cheri_kern_andperm(x, y)	(x)
+#define	cheri_kern_tag_get(x)		1
+#define	cheri_kern_bounds_set(x, y)	(x)
+#define	cheri_kern_bounds_set_exact(x, y)	(x)
+#define	cheri_kern_address_set(x, y)	((__typeof__(x))(y))
+#define	cheri_kern_address_get(x)	((uintptr_t)(x))
+#define	cheri_kern_perms_and(x, y)	(x)
 #endif	/* __CHERI_PURE_CAPABILITY__ */
 #endif	/* _KERNEL */
 

--- a/sys/dev/ata/ata-lowlevel.c
+++ b/sys/dev/ata/ata-lowlevel.c
@@ -839,7 +839,7 @@ ata_pio_read(struct ata_request *request, int length)
 				    bio->bio_ma[moff / PAGE_SIZE]);
 				moff %= PAGE_SIZE;
 				size = min(size, PAGE_SIZE - moff);
-				addr = (uint8_t *)cheri_kern_setbounds(page + off, size);
+				addr = (uint8_t *)cheri_kern_bounds_set(page + off, size);
 			}
 		} else
 			panic("ata_pio_read: Unsupported CAM data type %x\n",
@@ -925,7 +925,7 @@ ata_pio_write(struct ata_request *request, int length)
 				    bio->bio_ma[moff / PAGE_SIZE]);
 				moff %= PAGE_SIZE;
 				size = min(size, PAGE_SIZE - moff);
-				addr = (uint8_t *)cheri_kern_setbounds(page + moff, size);
+				addr = (uint8_t *)cheri_kern_bounds_set(page + moff, size);
 			}
 		} else
 			panic("ata_pio_write: Unsupported CAM data type %x\n",

--- a/sys/kern/kern_environment.c
+++ b/sys/kern/kern_environment.c
@@ -549,7 +549,7 @@ _getenv_static_from(char *chkenv, const char *name)
 		len = ep - cp;
 		ep++;
 		if (!strncmp(name, cp, len) && name[len] == 0)
-			return (cheri_kern_setbounds(ep, strlen(ep) + 1));
+			return (cheri_kern_bounds_set(ep, strlen(ep) + 1));
 	}
 	return (NULL);
 }

--- a/sys/kern/kern_mbuf.c
+++ b/sys/kern/kern_mbuf.c
@@ -734,7 +734,7 @@ mb_ctor_clust(void *mem, int size, void *arg, int how)
 
 	m = (struct mbuf *)arg;
 	if (m != NULL) {
-		m->m_ext.ext_buf = cheri_kern_setbounds(mem, size);
+		m->m_ext.ext_buf = cheri_kern_bounds_set(mem, size);
 		m->m_data = m->m_ext.ext_buf;
 		m->m_flags |= M_EXT;
 		m->m_ext.ext_free = NULL;
@@ -1566,7 +1566,7 @@ m_extadd(struct mbuf *mb, char *buf, u_int size, m_ext_free_t freef,
 	KASSERT(type != EXT_CLUSTER, ("%s: EXT_CLUSTER not allowed", __func__));
 
 	mb->m_flags |= (M_EXT | flags);
-	mb->m_ext.ext_buf = cheri_kern_setbounds(buf, size);
+	mb->m_ext.ext_buf = cheri_kern_bounds_set(buf, size);
 	mb->m_data = mb->m_ext.ext_buf;
 	mb->m_ext.ext_size = size;
 	mb->m_ext.ext_free = freef;

--- a/sys/kern/kern_sendfile.c
+++ b/sys/kern/kern_sendfile.c
@@ -1082,7 +1082,7 @@ retry_space:
 			}
 
 			m0 = m_get(M_WAITOK, MT_DATA);
-			m0->m_ext.ext_buf = (char *)cheri_kern_setbounds(
+			m0->m_ext.ext_buf = (char *)cheri_kern_bounds_set(
 			    sf_buf_kva(sf), PAGE_SIZE);
 			m0->m_ext.ext_size = PAGE_SIZE;
 			m0->m_ext.ext_arg1 = sf;

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -547,14 +547,14 @@ link_elf_init(void* arg)
 		ctors_sizep = (Elf_Size *)preload_search_info(modptr,
 			MODINFO_METADATA | MODINFOMD_CTORS_SIZE);
 		if (ctors_addrp != NULL && ctors_sizep != NULL) {
-			linker_kernel_file->ctors_addr = cheri_kern_setbounds(
+			linker_kernel_file->ctors_addr = cheri_kern_bounds_set(
 			    ef->address + *ctors_addrp, *ctors_sizep);
 			linker_kernel_file->ctors_size = *ctors_sizep;
 		}
 	}
 
 	/* Set the bounds on load address */
-	linker_kernel_file->address = cheri_kern_setbounds(
+	linker_kernel_file->address = cheri_kern_bounds_set(
 	    linker_kernel_file->address, linker_kernel_file->size);
 #ifdef __CHERI_PURE_CAPABILITY__
 	ef->mapbase = linker_kernel_file->address;
@@ -603,13 +603,13 @@ link_elf_preload_parse_symbols(elf_file_t ef)
 		return (0);
 	esym = *(vm_offset_t *)pointer;
 
-	base = cheri_kern_setbounds(cheri_kern_setaddress(ef->address, ssym),
+	base = cheri_kern_bounds_set(cheri_kern_address_set(ef->address, ssym),
 	    esym - ssym);
 
 	symcnt = *(long *)base;
 	base += sizeof(long);
 	size = roundup(symcnt, sizeof(long));
-	symtab = (Elf_Sym *)cheri_kern_setbounds(base, size);
+	symtab = (Elf_Sym *)cheri_kern_bounds_set(base, size);
 	base += size;
 
 	if ((ptraddr_t)base > esym || (ptraddr_t)base < ssym) {
@@ -620,7 +620,7 @@ link_elf_preload_parse_symbols(elf_file_t ef)
 	strcnt = *(long *)base;
 	base += sizeof(long);
 	size = roundup(strcnt, sizeof(long));
-	strtab = cheri_kern_setbounds(base, size);
+	strtab = cheri_kern_bounds_set(base, size);
 	base += size;
 
 	if ((ptraddr_t)base > esym || (ptraddr_t)base < ssym) {
@@ -651,9 +651,9 @@ parse_dynamic(elf_file_t ef)
 			    ef_address(ef, dp->d_un.d_ptr);
 			ef->nbuckets = hashtab[0];
 			ef->nchains = hashtab[1];
-			ef->buckets = cheri_kern_setbounds(hashtab + 2,
+			ef->buckets = cheri_kern_bounds_set(hashtab + 2,
 			    ef->nbuckets * sizeof(Elf_Hashelt));
-			ef->chains = cheri_kern_setbounds(hashtab + 2 + ef->nbuckets,
+			ef->chains = cheri_kern_bounds_set(hashtab + 2 + ef->nbuckets,
 			    ef->nchains * sizeof(Elf_Hashelt));
 			break;
 		}
@@ -728,19 +728,19 @@ parse_dynamic(elf_file_t ef)
 	 * If we are not a cheri kernel these are no-ops.
 	 */
 	if (ef->strtab != NULL)
-		ef->strtab = cheri_kern_setbounds(ef->strtab, ef->strsz);
+		ef->strtab = cheri_kern_bounds_set(ef->strtab, ef->strsz);
 	if (ef->rel != NULL)
-		ef->rel = cheri_kern_setbounds(ef->rel, ef->relsize);
+		ef->rel = cheri_kern_bounds_set(ef->rel, ef->relsize);
 	if (ef->pltrel != NULL)
-		ef->pltrel = cheri_kern_setbounds(ef->pltrel, ef->pltrelsize);
+		ef->pltrel = cheri_kern_bounds_set(ef->pltrel, ef->pltrelsize);
 	if (ef->rela != NULL)
-		ef->rela = cheri_kern_setbounds(ef->rela, ef->relasize);
+		ef->rela = cheri_kern_bounds_set(ef->rela, ef->relasize);
 	if (ef->symtab != NULL)
-		ef->symtab = cheri_kern_setbounds(ef->symtab,
+		ef->symtab = cheri_kern_bounds_set(ef->symtab,
 		    ef->nchains * sizeof(Elf_Sym));
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(DT_CHERI___CAPRELOCS)
 	if (ef->caprelocs != NULL)
-		ef->caprelocs = cheri_kern_setbounds(ef->caprelocs,
+		ef->caprelocs = cheri_kern_bounds_set(ef->caprelocs,
 		    ef->caprelocssize);
 #endif
 
@@ -1036,7 +1036,7 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	if (ctors_addrp != NULL && ctors_sizep != NULL) {
 		lf->ctors_addr = ef_address(ef, *ctors_addrp);
 		lf->ctors_size = *ctors_sizep;
-		lf->ctors_addr = cheri_kern_setbounds(lf->ctors_addr,
+		lf->ctors_addr = cheri_kern_bounds_set(lf->ctors_addr,
 		    lf->ctors_size);
 	}
 
@@ -1431,7 +1431,7 @@ link_elf_load_file(linker_class_t cls, const char* filename,
 			/* Record relocated address and size of .ctors. */
 			lf->ctors_addr = mapbase + shdr[i].sh_addr - base_vaddr;
 			lf->ctors_size = shdr[i].sh_size;
-			lf->ctors_addr = cheri_kern_setbounds(lf->ctors_addr,
+			lf->ctors_addr = cheri_kern_bounds_set(lf->ctors_addr,
 			    lf->ctors_size);
 		}
 	}

--- a/sys/kern/subr_module.c
+++ b/sys/kern/subr_module.c
@@ -193,7 +193,7 @@ preload_search_info(caddr_t mod, int inf)
 	 * data.
 	 */
 	if (hdr[0] == inf)
-	    return (cheri_kern_setbounds(curp + (sizeof(uint32_t) * 2),
+	    return (cheri_kern_bounds_set(curp + (sizeof(uint32_t) * 2),
 	        hdr[1]));
 
 	/* skip to next field */

--- a/sys/kern/subr_sfbuf.c
+++ b/sys/kern/subr_sfbuf.c
@@ -97,7 +97,7 @@ sf_buf_init(void *arg)
 	sf_bufs = malloc(nsfbufs * sizeof(struct sf_buf), M_TEMP,
 	    M_WAITOK | M_ZERO);
 	for (i = 0; i < nsfbufs; i++) {
-		sf_bufs[i].kva = cheri_kern_setbounds(
+		sf_bufs[i].kva = cheri_kern_bounds_set(
 		    sf_base + i * PAGE_SIZE, PAGE_SIZE);
 		TAILQ_INSERT_TAIL(&sf_buf_freelist, &sf_bufs[i], free_entry);
 	}

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -483,7 +483,7 @@ allocuio(u_int iovcnt)
 		uio->uio_iov = uio->uio_ext_iov;
 		uio->uio_flags |= UIO_EXT_IOVEC;
 	} else {
-		uio->uio_iov = cheri_kern_setboundsexact(uio->uio_iov,
+		uio->uio_iov = cheri_kern_bounds_set_exact(uio->uio_iov,
 		    iovcnt * sizeof(struct iovec));
 	}
 	uio->uio_iovcnt = iovcnt;

--- a/sys/kern/subr_vmem.c
+++ b/sys/kern/subr_vmem.c
@@ -1038,7 +1038,7 @@ vmem_fit(const bt_t *bt, vmem_size_t size, vmem_size_t align,
 		MPASS(maxaddr == 0 || start + size - 1 <= maxaddr);
 		MPASS((vmem_offset_t)bt->bt_start <= start);
 		MPASS((vmem_offset_t)BT_END(bt) - start >= size - 1);
-		*addrp = cheri_kern_setaddress(bt->bt_start, start);
+		*addrp = cheri_kern_address_set(bt->bt_start, start);
 
 		return (0);
 	}

--- a/sys/kern/uipc_ktls.c
+++ b/sys/kern/uipc_ktls.c
@@ -456,7 +456,7 @@ ktls_buffer_import(void *arg, void **store, int count, int domain, int flags)
 		if (m == NULL)
 			break;
 		store[i] = (void *)PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
-		store[i] = cheri_kern_setbounds(store[i], ktls_maxlen);
+		store[i] = cheri_kern_bounds_set(store[i], ktls_maxlen);
 	}
 	return (i);
 }
@@ -483,7 +483,7 @@ ktls_free_mext_contig(struct mbuf *m)
 
 	M_ASSERTEXTPG(m);
 	epg = (void *)PHYS_TO_DMAP(m->m_epg_pa[0]);
-	uma_zfree(ktls_buffer_zone, cheri_kern_setbounds(epg, ktls_maxlen));
+	uma_zfree(ktls_buffer_zone, cheri_kern_bounds_set(epg, ktls_maxlen));
 }
 
 static int

--- a/sys/kern/uipc_mbuf.c
+++ b/sys/kern/uipc_mbuf.c
@@ -411,7 +411,7 @@ m_pkthdr_init(struct mbuf *m, int how)
 #ifdef MAC
 	int error;
 #endif
-	m->m_data = cheri_kern_setbounds(m->m_pktdat, MHLEN);
+	m->m_data = cheri_kern_bounds_set(m->m_pktdat, MHLEN);
 	bzero(&m->m_pkthdr, sizeof(m->m_pkthdr));
 #ifdef NUMA
 	m->m_pkthdr.numa_domain = M_NODOM;
@@ -451,7 +451,7 @@ m_move_pkthdr(struct mbuf *to, struct mbuf *from)
 	to->m_flags = (from->m_flags & M_COPYFLAGS) |
 	    (to->m_flags & (M_EXT | M_EXTPG));
 	if ((to->m_flags & M_EXT) == 0)
-		to->m_data = cheri_kern_setbounds(to->m_pktdat, MHLEN);
+		to->m_data = cheri_kern_bounds_set(to->m_pktdat, MHLEN);
 	to->m_pkthdr = from->m_pkthdr;		/* especially tags */
 	SLIST_INIT(&from->m_pkthdr.tags);	/* purge tags from src */
 	from->m_flags &= ~M_PKTHDR;
@@ -490,7 +490,7 @@ m_dup_pkthdr(struct mbuf *to, const struct mbuf *from, int how)
 	to->m_flags = (from->m_flags & M_COPYFLAGS) |
 	    (to->m_flags & (M_EXT | M_EXTPG));
 	if ((to->m_flags & M_EXT) == 0)
-		to->m_data = cheri_kern_setbounds(to->m_pktdat, MHLEN);
+		to->m_data = cheri_kern_bounds_set(to->m_pktdat, MHLEN);
 	to->m_pkthdr = from->m_pkthdr;
 	if (from->m_pkthdr.csum_flags & CSUM_SND_TAG)
 		m_snd_tag_ref(from->m_pkthdr.snd_tag);
@@ -624,7 +624,7 @@ m_copypacket(struct mbuf *m, int how)
 		n->m_data = m->m_data;
 		mb_dupcl(n, m);
 	} else {
-		n->m_data = cheri_kern_setbounds(n->m_pktdat, MHLEN) +
+		n->m_data = cheri_kern_bounds_set(n->m_pktdat, MHLEN) +
 		    (m->m_data - m->m_pktdat);
 		bcopy(mtod(m, char *), mtod(n, char *), n->m_len);
 	}
@@ -1400,7 +1400,7 @@ m_apply_extpg_one(struct mbuf *m, int off, int len,
 		if (off < pglen) {
 			count = min(pglen - off, len);
 			p = (void *)PHYS_TO_DMAP(m->m_epg_pa[i] + pgoff + off);
-			p = cheri_kern_setboundsexact(p, count);
+			p = cheri_kern_bounds_set_exact(p, count);
 			rval = f(arg, p, count);
 			if (rval)
 				return (rval);

--- a/sys/kern/vfs_bio.c
+++ b/sys/kern/vfs_bio.c
@@ -1204,8 +1204,8 @@ kern_vfs_bio_buffer_alloc(caddr_t v, long physmem_est)
 	 * When we are called the first time, the capability is invalid
 	 * so we can not set bounds.
 	 */
-	if (cheri_kern_gettag(v))
-		buf = (void *)cheri_kern_setbounds(v, nbuf * STRUCT_BUF_ALLOCATION);
+	if (cheri_kern_tag_get(v))
+		buf = (void *)cheri_kern_bounds_set(v, nbuf * STRUCT_BUF_ALLOCATION);
 	buf = (char *)v;
 	v = (caddr_t)v + STRUCT_BUF_ALLOCATION * nbuf;
 
@@ -1241,7 +1241,7 @@ bufinit(void)
 
 	/* finally, initialize each buffer header and stick on empty q */
 	for (i = 0; i < nbuf; i++) {
-		bp = cheri_kern_setboundsexact(nbufp(i), STRUCT_BUF_ALLOCATION);
+		bp = cheri_kern_bounds_set_exact(nbufp(i), STRUCT_BUF_ALLOCATION);
 		bzero(bp, STRUCT_BUF_ALLOCATION);
 		bp->b_flags = B_INVAL;
 		bp->b_rcred = NOCRED;

--- a/sys/riscv/include/sf_buf.h
+++ b/sys/riscv/include/sf_buf.h
@@ -43,7 +43,7 @@ sf_buf_kva(struct sf_buf *sf)
 
 	m = (vm_page_t)sf;
 	va = PHYS_TO_DMAP(VM_PAGE_TO_PHYS(m));
-	va = cheri_kern_setboundsexact(va, PAGE_SIZE);
+	va = cheri_kern_bounds_set_exact(va, PAGE_SIZE);
 	return (va);
 }
 

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -1003,7 +1003,7 @@ pmap_bootstrap(vm_paddr_t kernstart, vm_size_t kernlen)
 
 	/* Mark the bounds of our available virtual address space */
 	kernel_vm_end = virtual_avail = freeva;
-	virtual_end = cheri_kern_setaddress(virtual_avail, DEVMAP_MIN_VADDR);
+	virtual_end = cheri_kern_address_set(virtual_avail, DEVMAP_MIN_VADDR);
 
 	/* Exclude the reserved physical memory from allocations. */
 	physmem_exclude_region(kernstart, freemempos - kernstart,
@@ -1375,8 +1375,8 @@ pmap_map(vm_pointer_t *virt, vm_paddr_t start, vm_paddr_t end, int prot)
 	vm_pointer_t p;
 
 	p = PHYS_TO_DMAP(start);
-	p = cheri_kern_setbounds(p, end - start);
-	p = cheri_kern_andperm(p, vm_map_prot2perms(prot) |
+	p = cheri_kern_bounds_set(p, end - start);
+	p = cheri_kern_perms_and(p, vm_map_prot2perms(prot) |
 	    ~CHERI_PROT2PERM_MASK);
 
 	return (p);
@@ -5513,7 +5513,7 @@ void *
 pmap_mapbios(vm_paddr_t pa, vm_size_t size)
 {
 
-        return (cheri_kern_setbounds((void *)PHYS_TO_DMAP(pa), size));
+        return (cheri_kern_bounds_set((void *)PHYS_TO_DMAP(pa), size));
 }
 
 void

--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -925,7 +925,7 @@ m_extaddref(struct mbuf *m, char *buf, u_int size, u_int *ref_cnt,
 
 	atomic_add_int(ref_cnt, 1);
 	m->m_flags |= M_EXT;
-	m->m_ext.ext_buf = cheri_kern_setbounds(buf, size);
+	m->m_ext.ext_buf = cheri_kern_bounds_set(buf, size);
 	m->m_ext.ext_cnt = ref_cnt;
 	m->m_data = m->m_ext.ext_buf;
 	m->m_ext.ext_size = size;
@@ -975,7 +975,7 @@ m_init(struct mbuf *m, int how, short type, int flags)
 
 	m->m_next = NULL;
 	m->m_nextpkt = NULL;
-	m->m_data = cheri_kern_setbounds(m->m_dat, MLEN);
+	m->m_data = cheri_kern_bounds_set(m->m_dat, MLEN);
 	m->m_len = 0;
 	m->m_flags = flags;
 	m->m_type = type;
@@ -1081,7 +1081,7 @@ m_cljset(struct mbuf *m, void *cl, int type)
 		break;
 	}
 
-	m->m_data = m->m_ext.ext_buf = cheri_kern_setbounds(cl, size);
+	m->m_data = m->m_ext.ext_buf = cheri_kern_bounds_set(cl, size);
 	m->m_ext.ext_free = m->m_ext.ext_arg1 = m->m_ext.ext_arg2 = NULL;
 	m->m_ext.ext_size = size;
 	m->m_ext.ext_type = type;

--- a/sys/sys/pcpu.h
+++ b/sys/sys/pcpu.h
@@ -272,7 +272,7 @@ extern struct pcpu *cpuid_to_pcpu[];
 /* Accessor to elements allocated via UMA_ZONE_PCPU zone. */
 #define	_zpcpu_get_obj(base, offset, size) ({				\
 	__typeof(base) _ptr = (void *)((char *)(base) + offset);	\
-	cheri_kern_setbounds(_ptr, size);				\
+	cheri_kern_bounds_set(_ptr, size);				\
 })
 
 #define	zpcpu_get(base)							\

--- a/sys/vm/uma_core.c
+++ b/sys/vm/uma_core.c
@@ -1923,7 +1923,7 @@ startup_alloc(uma_zone_t zone, vm_size_t bytes, int domain, uint8_t *pflag,
 	/* Allocate KVA and indirectly advance bootmem. */
 	mem = (void *)pmap_map(&bootmem, m->phys_addr,
 	    m->phys_addr + (pages * PAGE_SIZE), VM_PROT_READ | VM_PROT_WRITE);
-	return (cheri_kern_setboundsexact(mem, bytes));
+	return (cheri_kern_bounds_set_exact(mem, bytes));
 }
 
 static void
@@ -2095,7 +2095,7 @@ noobj_alloc(uma_zone_t zone, vm_size_t bytes, int domain, uint8_t *flags,
 #ifdef __CHERI_PURE_CAPABILITY__
 	KASSERT(cheri_tag_get(retkva), ("Expected valid capability"));
 #endif
-	return (cheri_kern_setboundsexact((void *)retkva, bytes));
+	return (cheri_kern_bounds_set_exact((void *)retkva, bytes));
 }
 
 /*

--- a/sys/vm/vm_kern.c
+++ b/sys/vm/vm_kern.c
@@ -155,7 +155,7 @@ kva_alloc(vm_size_t size)
 	if (vmem_xalloc(kernel_arena, size, 0, 0, 0, VMEM_ADDR_MIN,
 	    VMEM_ADDR_MAX, M_BESTFIT | M_NOWAIT, &addr))
 		return (0);
-	addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
+	addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_DATA);
 #ifdef __CHERI_PURE_CAPABILITY__
 	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
 #endif
@@ -180,7 +180,7 @@ kva_alloc_aligned(vm_size_t size, vm_size_t align)
 	if (vmem_xalloc(kernel_arena, size, align, 0, 0, VMEM_ADDR_MIN,
 	    VMEM_ADDR_MAX, M_BESTFIT | M_NOWAIT, &addr))
 		return (0);
-	addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
+	addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_DATA);
 #ifdef __CHERI_PURE_CAPABILITY__
 	KASSERT(cheri_tag_get(addr), ("Expected valid capability"));
 #endif
@@ -286,9 +286,9 @@ kmem_alloc_attr_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 	pflags = malloc2vm_flags(flags) | VM_ALLOC_WIRED;
 	prot = (flags & M_EXEC) != 0 ? VM_PROT_RWX : VM_PROT_RW;
 	if ((flags & M_EXEC) == 0)
-		addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
+		addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_DATA);
 	else
-		addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_CODE |
+		addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_CODE |
 		    CHERI_PERMS_KERNEL_DATA);
 
 	/* XXX: Do we want a M_CAP? */
@@ -394,7 +394,7 @@ kmem_alloc_contig_domain(int domain, vm_size_t size, int flags, vm_paddr_t low,
 	vmem = vm_dom[domain].vmd_kernel_arena;
 	if (vmem_alloc(vmem, asize, flags | M_BESTFIT, &addr))
 		return (NULL);
-	addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
+	addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_DATA);
 	offset = addr - VM_MIN_KERNEL_ADDRESS;
 	pflags = malloc2vm_flags(flags) | VM_ALLOC_WIRED;
 	npages = atop(asize);
@@ -534,9 +534,9 @@ kmem_malloc_domain(int domain, vm_size_t size, int flags)
 	if (vmem_alloc(arena, asize, flags | M_BESTFIT, &addr))
 		return (0);
 	if ((flags & M_EXEC) == 0)
-		addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_DATA);
+		addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_DATA);
 	else
-		addr = cheri_kern_andperm(addr, CHERI_PERMS_KERNEL_CODE |
+		addr = cheri_kern_perms_and(addr, CHERI_PERMS_KERNEL_CODE |
 		    CHERI_PERMS_KERNEL_DATA);
 
 	rv = kmem_back_domain(domain, kernel_object, addr, asize, flags);
@@ -929,7 +929,7 @@ kmem_init(vm_pointer_t start, vm_pointer_t end)
 #endif
 
 	vm_map_init_system(kernel_map, kernel_pmap,
-	    cheri_kern_setaddress(start, VM_MIN_KERNEL_ADDRESS), end);
+	    cheri_kern_address_set(start, VM_MIN_KERNEL_ADDRESS), end);
 #ifdef __CHERI_PURE_CAPABILITY__
 	kernel_map->flags |= MAP_RESERVATIONS;
 #endif

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5687,12 +5687,12 @@ retry:
 	stack_reservation = vm_map_buildcap(map, gap_entry->start,
 	    stack_entry->end - gap_entry->start, prot);
 
-	grow_start = (vm_pointer_t)cheri_kern_setaddress(stack_reservation,
+	grow_start = (vm_pointer_t)cheri_kern_address_set(stack_reservation,
 	    gap_entry->end - grow_amount);
 	if (gap_entry->start + grow_amount == gap_entry->end) {
-		gap_start = (vm_pointer_t)cheri_kern_setaddress(
+		gap_start = (vm_pointer_t)cheri_kern_address_set(
 		    stack_reservation, gap_entry->start);
-		gap_end = (vm_pointer_t)cheri_kern_setaddress(
+		gap_end = (vm_pointer_t)cheri_kern_address_set(
 		    stack_reservation, gap_entry->end);
 		vm_map_entry_delete(map, gap_entry);
 		gap_deleted = true;

--- a/sys/vm/vm_param.h
+++ b/sys/vm/vm_param.h
@@ -142,7 +142,7 @@ struct xswdev {
 	KASSERT(is_aligned(pa, PAGE_SIZE),				\
 	    ("%s: PA is not page aligned, PA: 0x%jx", __func__,		\
 	    (uintmax_t)(pa)));						\
-	cheri_kern_setboundsexact(PHYS_TO_DMAP(pa), PAGE_SIZE);		\
+	cheri_kern_bounds_set_exact(PHYS_TO_DMAP(pa), PAGE_SIZE);		\
 })
 
 #define	PHYS_TO_DMAP_LEN(pa, len)					\
@@ -153,7 +153,7 @@ struct xswdev {
 	KASSERT(trunc_page(pa) == trunc_page((pa) + (len) - 1),		\
 	    ("%s: PA chunk crosses page boundary, PA: [0x%jx, 0x%jx)",	\
 	    __func__, (uintmax_t)(pa), (uintmax_t)((pa) + (len))));	\
-	cheri_kern_setboundsexact(PHYS_TO_DMAP(pa), (len));		\
+	cheri_kern_bounds_set_exact(PHYS_TO_DMAP(pa), (len));		\
 })
 
 #ifndef ASSEMBLER

--- a/sys/vm/vm_reserv.c
+++ b/sys/vm/vm_reserv.c
@@ -504,7 +504,7 @@ vm_reserv_from_page(vm_page_t m)
 	seg = &vm_phys_segs[m->segind];
 	rv = seg->first_reserv + ((VM_PAGE_TO_PHYS(m) >> VM_LEVEL_0_SHIFT) -
 	    (seg->start >> VM_LEVEL_0_SHIFT));
-	return (cheri_kern_setboundsexact(rv, sizeof(*rv)));
+	return (cheri_kern_bounds_set_exact(rv, sizeof(*rv)));
 #else
 	return (&vm_reserv_array[VM_PAGE_TO_PHYS(m) >> VM_LEVEL_0_SHIFT]);
 #endif
@@ -1077,7 +1077,7 @@ vm_reserv_init(void)
 #else
 		rv_slice = vm_reserv_array + (seg->start >> VM_LEVEL_0_SHIFT);
 #endif
-		seg->first_reserv = cheri_kern_setbounds(rv_slice,
+		seg->first_reserv = cheri_kern_bounds_set(rv_slice,
 		    nreserv * sizeof(*rv_slice));
 		paddr = roundup2(seg->start, VM_LEVEL_0_SIZE);
 		rv = seg->first_reserv + (paddr >> VM_LEVEL_0_SHIFT) -


### PR DESCRIPTION
Chase the switch to newer macro names.