### PR TITLE
arm64: dmap_base_cap -> dmap_capability

### DIFF
--- a/sys/arm64/arm64/mem.c
+++ b/sys/arm64/arm64/mem.c
@@ -80,7 +80,7 @@ memrw(struct cdev *dev, struct uio *uio, int flags)
 			if (VIRT_IN_DMAP(v)) {
 #ifdef __CHERI_PURE_CAPABILITY__
 				error = uiomove(cheri_bounds_set_exact(
-				    cheri_address_set(dmap_base_cap, v), cnt),
+				    cheri_address_set(dmap_capability, v), cnt),
 				    cnt, uio);
 #else
 				error = uiomove((void *)v, cnt, uio);

--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -354,7 +354,7 @@ vm_paddr_t dmap_phys_base;	/* The start of the dmap region */
 vm_paddr_t dmap_phys_max;	/* The limit of the dmap region */
 vm_offset_t dmap_max_addr;	/* The virtual address limit of the dmap */
 #ifdef __CHERI_PURE_CAPABILITY__
-void *dmap_base_cap;		/* Capability for the direct map region */
+void *dmap_capability;		/* Capability for the direct map region */
 #endif
 
 extern pt_entry_t pagetable_l0_ttbr1[];
@@ -1400,10 +1400,10 @@ pmap_bootstrap_dmap(void)
 	}
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	dmap_base_cap = cheri_address_set(kernel_root_cap, DMAP_MIN_ADDRESS);
-	dmap_base_cap = cheri_bounds_set(dmap_base_cap,
+	dmap_capability = cheri_address_set(kernel_root_cap, DMAP_MIN_ADDRESS);
+	dmap_capability = cheri_bounds_set(dmap_capability,
 	    dmap_phys_max - dmap_phys_base);
-	dmap_base_cap = cheri_perms_and(dmap_base_cap,
+	dmap_capability = cheri_perms_and(dmap_capability,
 	    CHERI_PERMS_KERNEL_DATA);
 #endif
 

--- a/sys/arm64/include/vmparam.h
+++ b/sys/arm64/include/vmparam.h
@@ -256,14 +256,14 @@
 /* True if va is in the dmap range */
 #ifdef __CHERI_PURE_CAPABILITY__
 #define	VIRT_IN_DMAP(va)					\
-    cheri_is_address_inbounds(dmap_base_cap, (va))
+    cheri_is_address_inbounds(dmap_capability, (va))
 #else
 #define	VIRT_IN_DMAP(va)	((va) >= DMAP_MIN_ADDRESS &&	\
     (va) < (dmap_max_addr))
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#define	_DMAP_BASE dmap_base_cap
+#define	_DMAP_BASE dmap_capability
 #else
 #define	_DMAP_BASE (void *)DMAP_MIN_ADDRESS
 #endif
@@ -328,7 +328,7 @@ extern vm_paddr_t dmap_phys_base;
 extern vm_paddr_t dmap_phys_max;
 extern vm_offset_t dmap_max_addr;
 #ifdef __CHERI_PURE_CAPABILITY__
-extern void *dmap_base_cap;
+extern void *dmap_capability;
 #endif
 
 #endif


### PR DESCRIPTION
Rename dmap_base_cap to dmap_capability to align with RISC-V.

Both names are fine, but have two different ones seems unnecessary.