### PR TITLE
tcpdump: Potential Vulnerability in Cloned Code

### DIFF
--- a/contrib/tcpdump/print-nfs.c
+++ b/contrib/tcpdump/print-nfs.c
@@ -987,7 +987,11 @@ xid_map_enter(netdissect_options *ndo,
 		UNALIGNED_MEMCPY(&xmep->server, ip6->ip6_dst,
 				 sizeof(ip6->ip6_dst));
 	}
+	if (!ND_TTEST(rp->rm_call.cb_proc))
+		return (0);
 	xmep->proc = GET_BE_U_4(&rp->rm_call.cb_proc);
+	if (!ND_TTEST(rp->rm_call.cb_vers))
+		return (0);
 	xmep->vers = GET_BE_U_4(&rp->rm_call.cb_vers);
 	return (1);
 }


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in contrib/tcpdump/print-nfs.c which was cloned from the-tcpdump-group/tcpdump but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2017-13005.

### Proposed Fix
Apply the same patch as the one in the-tcpdump-group/tcpdump to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2017-13005
https://github.com/the-tcpdump-group/tcpdump/commit/b45a9a167ca6a3ef2752ae9d48d56ac14b001bfd