### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/sys/ofed/drivers/infiniband/core/ib_uverbs_main.c
+++ b/sys/ofed/drivers/infiniband/core/ib_uverbs_main.c
@@ -796,6 +796,8 @@ void uverbs_user_mmap_disassociate(struct ib_uverbs_file *ufile)
 		 * will only be one mm, so no big deal.
 		 */
 		down_read(&mm->mmap_sem);
+		if (!mmget_still_valid(mm))
+			goto skip_mm;
 		mutex_lock(&ufile->umap_lock);
 		list_for_each_entry_safe (priv, next_priv, &ufile->umaps,
 					  list) {
@@ -809,6 +811,7 @@ void uverbs_user_mmap_disassociate(struct ib_uverbs_file *ufile)
 				     vma->vm_end - vma->vm_start);
 		}
 		mutex_unlock(&ufile->umap_lock);
+	skip_mm:
 		up_read(&mm->mmap_sem);
 		mmput(mm);
 	}


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in sys/ofed/drivers/infiniband/core/ib_uverbs_main.c which was cloned from torvalds/linux but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2019-11599.

### Proposed Fix
Apply the same patch as the one in torvalds/linux to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2019-11599
https://github.com/torvalds/linux/commit/04f5866e41fb70690e28397487d8bd8eea7d712a