### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/sys/contrib/openzfs/module/lua/ldo.c
+++ b/sys/contrib/openzfs/module/lua/ldo.c
@@ -287,7 +287,7 @@ static int stackinuse (lua_State *L) {
 
 void luaD_shrinkstack (lua_State *L) {
   int inuse = stackinuse(L);
-  int goodsize = inuse + (inuse / 8) + 2*EXTRA_STACK;
+  int goodsize = inuse + BASIC_STACK_SIZE;
   if (goodsize > LUAI_MAXSTACK) goodsize = LUAI_MAXSTACK;
   if (inuse > LUAI_MAXSTACK ||  /* handling stack overflow? */
       goodsize >= L->stacksize)  /* would grow instead of shrink? */


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `luaD_shrinkstack` that was cloned from `https://github.com/lua/lua` but did not receive the security patch.

### Details:
Affected File(s): 
- sys/contrib/openzfs/module/lua/ldo.c

Original Fix: https://github.com/lua/lua/commit/6298903e35217ab69c279056f925fb72900ce0b7

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/lua/lua/commit/6298903e35217ab69c279056f925fb72900ce0b7
- https://nvd.nist.gov/vuln/detail/CVE-2020-15888

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.

