### PR TITLE
kern: rename memcpynocap, etc. to memcpy_data

### DIFF
--- a/sys/arm64/arm64/pmap.c
+++ b/sys/arm64/arm64/pmap.c
@@ -7367,7 +7367,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		}
 #if __has_feature(capabilities)
 		if (clear_tags)
-			bcopynocap(a_cp, b_cp, cnt);
+			bcopy_data(a_cp, b_cp, cnt);
 		else
 #endif
 			bcopy(a_cp, b_cp, cnt);

--- a/sys/arm64/arm64/uio_machdep.c
+++ b/sys/arm64/arm64/uio_machdep.c
@@ -127,10 +127,10 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 				break;
 #endif
 			case UIO_READ:
-				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
+				bcopy_data_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;
 			case UIO_WRITE:
-				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopy_data_c(iov->iov_base, PTR2CAP(cp), cnt);
 				break;
 			}
 			break;

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -2121,7 +2121,7 @@ sysctl_old_kernel(struct sysctl_req *req, const void *p, size_t l)
 				    req->oldidx, PTR2CAP(p), i);
 			else
 #endif
-				memcpynocap_c((char * __capability)req->oldptr +
+				memcpy_data_c((char * __capability)req->oldptr +
 				    req->oldidx, PTR2CAP(p), i);
 		}
 	}
@@ -2144,7 +2144,7 @@ sysctl_new_kernel(struct sysctl_req *req, void *p, size_t l)
 		    (const char * __capability)req->newptr + req->newidx, l);
 	else
 #endif
-		memcpynocap_c(PTR2CAP(p),
+		memcpy_data_c(PTR2CAP(p),
 		    (const char * __capability)req->newptr + req->newidx, l);
 	req->newidx += l;
 	return (0);

--- a/sys/kern/subr_uio.c
+++ b/sys/kern/subr_uio.c
@@ -305,10 +305,10 @@ uiomove_flags(void *cp, int n, struct uio *uio, bool nofault)
 				break;
 #endif
 			case UIO_READ:
-				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
+				bcopy_data_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;
 			case UIO_WRITE:
-				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopy_data_c(iov->iov_base, PTR2CAP(cp), cnt);
 				break;
 			}
 			break;

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -3736,7 +3736,7 @@ sooptcopyin(struct sockopt *sopt, void *buf, size_t len, size_t minlen)
 	if (sopt->sopt_td != NULL)
 		return (copyin(sopt->sopt_val, buf, valsize));
 
-	bcopynocap((__cheri_fromcap void *)sopt->sopt_val, buf, valsize);
+	bcopy_data((__cheri_fromcap void *)sopt->sopt_val, buf, valsize);
 	return (0);
 }
 
@@ -4070,7 +4070,7 @@ sooptcopyout(struct sockopt *sopt, const void *buf, size_t len)
 		if (sopt->sopt_td != NULL)
 			error = copyout(buf, sopt->sopt_val, valsize);
 		else
-			bcopynocap(buf, (__cheri_fromcap void *)sopt->sopt_val,
+			bcopy_data(buf, (__cheri_fromcap void *)sopt->sopt_val,
 			    valsize);
 	}
 	return (error);

--- a/sys/libkern/bcopy.c
+++ b/sys/libkern/bcopy.c
@@ -164,12 +164,12 @@ __strong_reference(memcpy, memmove);
 
 #if __has_feature(capabilities)
 void *
-memcpynocap(void *dst0, const void *src0, size_t length)
+memcpy_data(void *dst0, const void *src0, size_t length)
 {
 	return _memcpy(dst0, src0, length, false);
 }
 
-__strong_reference(memcpynocap, memmovenocap);
+__strong_reference(memcpy_data, memmove_data);
 #endif
 // CHERI CHANGES START
 // {

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -140,13 +140,13 @@ memcpy_c(void * __capability dst0, const void * __capability src0, size_t len)
 __strong_reference(memcpy_c, memmove_c);
 
 void * __capability
-memcpynocap_c(void * __capability dst, const void *  __capability src,
+memcpy_data_c(void * __capability dst, const void *  __capability src,
     size_t len)
 {
 	return (memcpy_c(dst, cheri_perms_and(src, ~CHERI_PERM_LOAD_CAP), len));
 }
 
-__strong_reference(memcpynocap_c, memmovenocap_c);
+__strong_reference(memcpy_data_c, memmove_data_c);
 /*
  * CHERI CHANGES START
  * {

--- a/sys/riscv/riscv/pmap.c
+++ b/sys/riscv/riscv/pmap.c
@@ -4692,7 +4692,7 @@ pmap_copy_pages(vm_page_t ma[], vm_offset_t a_offset, vm_page_t mb[],
 		}
 #if __has_feature(capabilities)
 		if (clear_tags)
-			bcopynocap(a_cp, b_cp, cnt);
+			bcopy_data(a_cp, b_cp, cnt);
 		else
 #endif
 			bcopy(a_cp, b_cp, cnt);

--- a/sys/riscv/riscv/uio_machdep.c
+++ b/sys/riscv/riscv/uio_machdep.c
@@ -127,10 +127,10 @@ uiomove_fromphys(vm_page_t ma[], vm_offset_t offset, int n, struct uio *uio)
 				break;
 #endif
 			case UIO_READ:
-				bcopynocap_c(PTR2CAP(cp), iov->iov_base, cnt);
+				bcopy_data_c(PTR2CAP(cp), iov->iov_base, cnt);
 				break;
 			case UIO_WRITE:
-				bcopynocap_c(iov->iov_base, PTR2CAP(cp), cnt);
+				bcopy_data_c(iov->iov_base, PTR2CAP(cp), cnt);
 				break;
 			}
 			break;

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -267,31 +267,31 @@ void	*memcpy(void * _Nonnull to, const void * _Nonnull from, size_t len);
 void	*memmove(void * _Nonnull dest, const void * _Nonnull src, size_t n);
 int	memcmp(const void *b1, const void *b2, size_t len);
 #if __has_feature(capabilities)
-void	*memcpynocap(void * _Nonnull to, const void * _Nonnull from,
+void	*memcpy_data(void * _Nonnull to, const void * _Nonnull from,
     size_t len);
-void	*memmovenocap(void * _Nonnull dest, const void * _Nonnull src,
+void	*memmove_data(void * _Nonnull dest, const void * _Nonnull src,
     size_t n);
 #else
-#define	memcpynocap	memcpy
-#define	memmovenocap	memmove
+#define	memcpy_data	memcpy
+#define	memmove_data	memmove
 #endif
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 void	* __capability memset_c(void * _Nonnull __capability buf, int c,
 	    size_t len);
 void	* __capability memcpy_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
-void	* __capability memcpynocap_c(void * _Nonnull __capability to,
+void	* __capability memcpy_data_c(void * _Nonnull __capability to,
 	    const void * _Nonnull __capability from, size_t len);
 void	* __capability memmove_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
-void	* __capability memmovenocap_c(void * _Nonnull __capability dest,
+void	* __capability memmove_data_c(void * _Nonnull __capability dest,
 	    const void * _Nonnull __capability src, size_t n);
 #else
 #define	memset_c	memset
 #define	memcpy_c	memcpy
-#define	memcpynocap_c	memcpynocap
+#define	memcpy_data_c	memcpy_data
 #define	memmove_c	memmove
-#define	memmovenocap_c	memmovenocap
+#define	memmove_data_c	memmove_data
 #endif
 
 #ifdef SAN_NEEDS_INTERCEPTORS
@@ -321,8 +321,8 @@ int	SAN_INTERCEPTOR(memcmp)(const void *, const void *, size_t);
 #endif /* SAN_NEEDS_INTERCEPTORS */
 
 #define bcopy_c(from, to, len)		memmove_c((to), (from), (len))
-#define bcopynocap(from, to, len)	memmovenocap((to), (from), (len))
-#define bcopynocap_c(from, to, len)	memmovenocap_c((to), (from), (len))
+#define bcopy_data(from, to, len)	memmove_data((to), (from), (len))
+#define bcopy_data_c(from, to, len)	memmove_data_c((to), (from), (len))
 
 void	*memset_early(void * _Nonnull buf, int c, size_t len);
 #define bzero_early(buf, len) memset_early((buf), 0, (len))


### PR DESCRIPTION
This better reflects the fact that we're copying provenance free data rather than objects which may contain pointers.  It also avoids sounding like the slang "no cap" which doesn't particularly fit here.