### PR TITLE
arm64: Make VM_SET_REGISTER preserve PCC's capability metadata

### DIFF
--- a/sys/arm64/vmm/vmm.c
+++ b/sys/arm64/vmm/vmm.c
@@ -1663,20 +1663,28 @@ vm_set_register(struct vcpu *vcpu, int reg, uintcap_t val)
 	if (reg >= VM_REG_LAST)
 		return (EINVAL);
 	error = vmmops_setreg(vcpu->cookie, reg, val);
-	if (error || reg != VM_REG_GUEST_PC)
+	if (error)
 		return (error);
 
+	switch (reg) {
+	case VM_REG_GUEST_PC:
 #if __has_feature(capabilities)
-#ifdef __CHERI_PURE_CAPABILITY__
-	vcpu->nextpc = (uintcap_t)cheri_perms_and(
-	    cheri_address_set(vmm_gva_root_cap, val),
-	    cheri_perms_get(cheri_pcc_get()));
-#else
-	vcpu->nextpc = (uintcap_t)cheri_address_set(cheri_pcc_get(), val);
+	case VM_REG_GUEST_PCC:
 #endif
+		error = vmmops_getreg(vcpu->cookie,
+#if __has_feature(capabilities)
+		    VM_REG_GUEST_PCC,
 #else
-	vcpu->nextpc = val;
+		    VM_REG_GUEST_PC,
 #endif
+		    &vcpu->nextpc);
+		if (error != 0)
+			panic("%s: error %d updating nextpc", __func__,
+			    error);
+		break;
+	default:
+		break;
+	}
 
 	return (0);
 }

--- a/sys/arm64/vmm/vmm_arm64.c
+++ b/sys/arm64/vmm/vmm_arm64.c
@@ -1449,14 +1449,7 @@ vmmops_setreg(void *vcpui, int reg, uintcap_t val)
 	switch (reg) {
 	case VM_REG_GUEST_PC:
 #ifdef __CHERI_PURE_CAPABILITY__
-		/*
-		 * This register is set by bhyve when booting and
-		 * starting secondary vCPUs.  Userspace does not hold a
-		 * capability for the entire guest virtual address
-		 * space, so we must derive a capability here.
-		 */
-		*(uintcap_t *)regp = (uintcap_t)
-		    cheri_address_set(kernel_root_cap, val);
+		*(uintcap_t *)regp = cheri_address_set(*(uintcap_t *)regp, val);
 		break;
 #endif
 	case VM_REG_GUEST_LR:

--- a/sys/arm64/vmm/vmm_reset.c
+++ b/sys/arm64/vmm/vmm_reset.c
@@ -113,6 +113,7 @@ reset_vm_el01_regs(void *vcpu)
 	memset(el2ctx->pmevtyper_el0, 0, sizeof(el2ctx->pmevtyper_el0));
 
 #if __has_feature(capabilities)
+	el2ctx->tf.tf_elr = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);
 	el2ctx->tf.tf_ddc = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);
 	el2ctx->ddc_el0 = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);
 	el2ctx->rddc_el0 = (uintcap_t)cheri_address_set(vmm_gva_root_cap, 0);


### PR DESCRIPTION
Currently setting PC rederives a fresh reset PCC with the given address,
which is ok for initialisation but not when bhyve sets PC after a
breakpoint its hit. This has gone unnoticed as things work when you're
not doing anything interesting with PCC in the guest, but if you're
using restricted mode then suddenly the guest will end up in executive
mode.

Instead, initialise CELR_EL1 with a reset capability on reset and just
modify the address for PC. Then also make sure nextpc is kept in sync
with this, which we can do by just querying the resulting PCC. Note that
the old code was particularly weird and used the host PCC's permissions
for the guests's new nextpc.
