### PR TITLE
vfs_bio.c: fix bounding of buf

### DIFF
--- a/sys/kern/vfs_bio.c
+++ b/sys/kern/vfs_bio.c
@@ -1201,12 +1201,8 @@ kern_vfs_bio_buffer_alloc(caddr_t v, long physmem_est)
 
 	/*
 	 * Reserve space for the buffer cache buffers
-	 * When we are called the first time, the capability is invalid
-	 * so we can not set bounds.
 	 */
-	if (cheri_kern_tag_get(v))
-		buf = (void *)cheri_kern_bounds_set(v, nbuf * STRUCT_BUF_ALLOCATION);
-	buf = (char *)v;
+	buf = (void *)cheri_kern_bounds_set(v, nbuf * STRUCT_BUF_ALLOCATION);
 	v = (caddr_t)v + STRUCT_BUF_ALLOCATION * nbuf;
 
 	return (v);


### PR DESCRIPTION
Bound unconditionally (no-op on non-purecap) since setting bounds on an untagged value is non-trapped.

Don't immediately discard the bounds by assigning the unbounded value to buf again.