### PR TITLE
Prototype support to monitor mrs(3) from libprocstat/procstat.

### DIFF
--- a/lib/libc/stdlib/malloc/mrs/Makefile.inc
+++ b/lib/libc/stdlib/malloc/mrs/Makefile.inc
@@ -15,4 +15,4 @@ MLINKS+= \
 
 CFLAGS.mrs.c+=-Wno-error=gnu-folding-constant
 
-CFLAGS.mrs.c+=	-DMRS_REAL_PREFIX=${MRS_REAL_PREFIX}
+CFLAGS.mrs.c+=	-DMRS_REAL_PREFIX=${MRS_REAL_PREFIX} -DMRS_STATS

--- a/lib/libc/stdlib/malloc/mrs/mrs.3
+++ b/lib/libc/stdlib/malloc/mrs/mrs.3
@@ -2,11 +2,17 @@
 .\" SPDX-License-Identifier: BSD-2-Clause
 .\"
 .\" Copyright (c) 2023 SRI International
+.\" Copyright (c) 2026 Capabilities Limited
 .\"
 .\" This software was developed by SRI International, the University of
 .\" Cambridge Computer Laboratory (Department of Computer Science and
 .\" Technology), and Capabilities Limited under Defense Advanced Research
 .\" Projects Agency (DARPA) Contract No. HR001123C0031 ("MTSS").
+.\"
+.\" This software was developed by SRI International, the University of
+.\" Cambridge Computer Laboratory (Department of Computer Science and
+.\" Technology), and Capabilities Limited under Defense Advanced Research
+.\" Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -29,7 +35,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 12, 2023
+.Dd July 18, 2026
 .Dt MRS 3
 .Os
 .Sh NAME
@@ -164,6 +170,36 @@ This produces output like:
 .Dl  21593 101243 git      USER  mrs_free(0x45e00000)
 .Dl  21593 101243 git      USER  quarantine_insert(0x45e00000, 57344)
 .Dl  21593 101242 git      USER  quarantine_flush()
+.Sh STATISTICS
+.Nm
+can optionally collect statistics on its operation, at some minor cost to its
+operation.
+These statistics are exposed via the
+.Xr procstat 1
+command's
+.Ar mrs
+argument, and can also be be dumped to a file when a process exits cleanly.
+This functionality is controlled by the following environmental variables:
+.Pp
+.Bl -tag -width XXX -compact
+.It Dv _RUNTIME_QUARANTINE_STATS_DISABLE
+Disable statistics gathering (the default) overrides
+.Dv _RUNTIME_QUARANTINE_STATS_ENABLE
+if also set.
+.Pp
+.It Dv _RUNTIME_QUARANTINE_STATS_ENABLE
+Enable statistics gathering; overriden by
+.Dv _RUNTIME_QUARANTINE_STATS_DISABLE
+if also set.
+.Pp
+.It Dv _RUNTIME_QUARANTINE_STATS_FILE
+If present, defines a filesystem path prefix where statistics should be
+dumped on process termination, which will be appended with the process ID.
+.Pp
+.El
+When a process terminates uncleanly -- for example due to receiving a
+.Dv SIGSEGV
+signal -- then the statistics file may not be written.
 .Sh IMPLEMENTATION NOTES
 .Nm
 requires that allocators be extended to provide a

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -339,10 +339,12 @@ static bool mrs_initialized = false;
 static unsigned int quarantine_denominator = QUARANTINE_DENOMINATOR;
 static unsigned int quarantine_numerator = QUARANTINE_NUMERATOR;
 
+#ifdef MRS_STATS
 static const char *mrs_statfile_name = NULL;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 static struct cheri_mrs_stats *cmsp;
+#endif
 #endif
 
 static spinlock_t mrs_init_lock = _SPINLOCK_INITIALIZER;
@@ -621,11 +623,13 @@ increment_allocated_size(void *allocated)
 	if (allocated_size > max_allocated_size) {
 		max_allocated_size = allocated_size;
 	}
+#ifdef MRS_STATS
 	if (cmsp != NULL) {
 		atomic_store(&cmsp->cms_mrs_allocated_size, allocated_size);
 		atomic_store(&cmsp->cms_mrs_max_allocated_size,
 		    max_allocated_size);
 	}
+#endif
 }
 
 static inline void
@@ -861,9 +865,11 @@ app_quarantine_revoke_async(void)
 	mrs_unlock(&app_quarantine_lock);
 
 	(void)cheri_revoke(CHERI_REVOKE_ASYNC, epoch, NULL);
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL)
 		atomic_store(&cmsp->cms_mrs_epoch, epoch);
+#endif
 #endif
 
 	/*
@@ -1060,6 +1066,7 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 
 	size_t utrace_allocated_size = 0;
 	if (prev != NULL) {
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL) {
 			atomic_fetch_add(&cmsp->cms_mrs_count_returned, 1);
@@ -1070,6 +1077,7 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 			atomic_fetch_sub(&cmsp->cms_mrs_bytes_inquarantine,
 			    quarantine->size);
 		}
+#endif
 #endif
 
 		/* Free the quarantined descriptors. */
@@ -1083,10 +1091,12 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 		utrace_allocated_size += quarantine->size;
 		quarantine->size = 0;
 
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL)
 			atomic_store(&cmsp->cms_mrs_allocated_size,
 			    allocated_size);
+#endif
 #endif
 	}
 	mrs_debug_printf("quarantine_flush: flushed, allocated_size %zu quarantine->size %zu\n",
@@ -1117,9 +1127,11 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		cyc_init = cheri_revoke_get_cyc();
 		(void)cheri_revoke(CHERI_REVOKE_TAKE_STATS, epoch, &crsi);
 		cyc_fini = cheri_revoke_get_cyc();
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL)
 			atomic_store(&cmsp->cms_mrs_epoch, epoch);
+#endif
 #endif
 		print_cheri_revoke_stats("load-barrier", &crsi,
 		    cyc_fini - cyc_init);
@@ -1137,9 +1149,11 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		(void)cheri_revoke(
 		    CHERI_REVOKE_LAST_PASS | CHERI_REVOKE_TAKE_STATS,
 		    start_epoch, NULL);
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL)
 			atomic_store(&cmsp->cms_mrs_epoch, start_epoch);
+#endif
 #endif
 # endif /* !PRINT_CAPREVOKE */
 	}
@@ -1346,6 +1360,7 @@ spawn_background(void)
 }
 #endif /* OFFLOAD_QUARANTINE */
 
+#ifdef MRS_STATS
 static void
 mrs_statfile_dump(void)
 {
@@ -1406,6 +1421,7 @@ mrs_statfile_dump(void)
 	(void)write(fd, buf, strlen(buf));
 	(void)close(fd);
 }
+#endif
 
 static void
 mrs_init_impl_locked(void)
@@ -1562,6 +1578,7 @@ mrs_init_impl_locked(void)
 	 * Initial export of stats, to be updated on various allocation/etc.
 	 * events.
 	 */
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (secure_getenv(MALLOC_QUARANTINE_STATS_DISABLE_ENV) == NULL &&
 	    secure_getenv(MALLOC_QUARANTINE_STATS_ENABLE_ENV) != NULL) {
@@ -1582,11 +1599,13 @@ mrs_init_impl_locked(void)
 		if (bound_pointers)
 			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
 		clock_gettime(CLOCK_REALTIME, &cmsp->cms_mrs_ts_start);
+		cmsp->cms_mrs_flags |= CHERI_MFS_FLAGS_INITIALIZED;
 	}
 	if ((mrs_statfile_name =
 	    secure_getenv(MALLOC_QUARANTINE_STATS_FILE_ENV)) != NULL) {
 		atexit(mrs_statfile_dump);
 	}
+#endif
 #endif
 
 nosys:
@@ -1689,6 +1708,7 @@ mrs_malloc(size_t size)
 	/*mrs_debug_printf("mrs_malloc: called size 0x%zx, allocation %#p\n",
 	    size, allocated_region);*/
 
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
@@ -1698,6 +1718,7 @@ mrs_malloc(size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(allocated_region));
 	}
+#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, allocated_region);
 	return (allocated_region);
@@ -1757,6 +1778,7 @@ mrs_calloc(size_t number, size_t size)
 	 */
 	/*mrs_debug_printf("mrs_calloc: exit called %d size 0x%zx address %p\n", number, size, allocated_region);*/
 
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
@@ -1766,6 +1788,7 @@ mrs_calloc(size_t number, size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(allocated_region));
 	}
+#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_CALLOC, NULL, size, number, allocated_region);
 	return (allocated_region);
@@ -1809,6 +1832,7 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 
 	increment_allocated_size(*ptr);
 
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
@@ -1818,6 +1842,7 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(*ptr));
 	}
+#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_POSIX_MEMALIGN, NULL, size, alignment, *ptr);
 	return (ret);
@@ -1858,6 +1883,7 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 
 	increment_allocated_size(allocated_region);
 
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
@@ -1867,6 +1893,7 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(allocated_region));
 	}
+#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_ALIGNED_ALLOC, NULL, size, alignment,
 	    allocated_region);
@@ -1964,6 +1991,7 @@ mrs_free(void *ptr)
 	bzero(cheri_offset_set(ptr, 0), cheri_length_get(ptr));
 #endif
 
+#ifdef MRS_STATS
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_freed, 1);
@@ -1977,6 +2005,7 @@ mrs_free(void *ptr)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inquarantine,
 		    cheri_length_get(ins));
 	}
+#endif
 #endif
 
 	mrs_lock(&app_quarantine_lock);

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1043,6 +1043,20 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 			clear_region(iter->slab[i].ptr,
 			    cheri_length_get(iter->slab[i].ptr));
 #endif /* CLEAR_ON_RETURN */
+#ifdef MRS_STATS
+#ifdef __CHERI_PURE_CAPABILITY__
+			if (cmsp != NULL) {
+				atomic_fetch_add(
+				    &cmsp->cms_mrs_count_returned, 1);
+				atomic_fetch_add(
+				    &cmsp->cms_mrs_bytes_returned, len);
+				atomic_fetch_sub(
+				    &cmsp->cms_mrs_count_inquarantine, 1);
+				atomic_fetch_sub(
+				    &cmsp->cms_mrs_bytes_inquarantine, len);
+			}
+#endif
+#endif
 
 			/*
 			 * We have a VMEM-bearing cap from
@@ -1066,20 +1080,6 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 
 	size_t utrace_allocated_size = 0;
 	if (prev != NULL) {
-#ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
-		if (cmsp != NULL) {
-			atomic_fetch_add(&cmsp->cms_mrs_count_returned, 1);
-			atomic_fetch_add(&cmsp->cms_mrs_bytes_returned,
-			    quarantine->size);
-
-			atomic_fetch_sub(&cmsp->cms_mrs_count_inquarantine, 1);
-			atomic_fetch_sub(&cmsp->cms_mrs_bytes_inquarantine,
-			    quarantine->size);
-		}
-#endif
-#endif
-
 		/* Free the quarantined descriptors. */
 		prev->next = free_descriptor_slabs;
 		while (!atomic_compare_exchange_weak(&free_descriptor_slabs,

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2019 Brett F. Gutstein
- * Copyright (c) 2025 Capabilities Limited
+ * Copyright (c) 2025-2026 Capabilities Limited
  *
  * This software was developed by SRI International and the University of
  * Cambridge Computer Laboratory (Department of Computer Science and
@@ -55,6 +55,7 @@
 #include <cheriintrin.h>
 #include <dlfcn.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <malloc_np.h>
 #include <pthread.h>
@@ -156,6 +157,9 @@ extern void snmalloc_flush_message_queue(void);
 	"_RUNTIME_QUARANTINE_STATS_DISABLE"
 #define	MALLOC_QUARANTINE_STATS_ENABLE_ENV \
 	"_RUNTIME_QUARANTINE_STATS_ENABLE"
+
+#define	MALLOC_QUARANTINE_STATS_FILE_ENV \
+	"_RUNTIME_QUARANTINE_STATS_FILE"
 
 /*
  * Different allocators give their strong symbols different names.  Hide
@@ -334,6 +338,8 @@ static bool mrs_initialized = false;
 
 static unsigned int quarantine_denominator = QUARANTINE_DENOMINATOR;
 static unsigned int quarantine_numerator = QUARANTINE_NUMERATOR;
+
+static const char *mrs_statfile_name = NULL;
 
 #ifdef __CHERI_PURE_CAPABILITY__
 static struct cheri_mrs_stats *cmsp;
@@ -1341,6 +1347,58 @@ spawn_background(void)
 #endif /* OFFLOAD_QUARANTINE */
 
 static void
+mrs_statfile_dump(void)
+{
+	char buf[PATH_MAX];
+	int fd;
+
+	if (cmsp == NULL || mrs_statfile_name == NULL)
+		return;
+	(void)snprintf(buf, sizeof(buf), "%s.%d", mrs_statfile_name,
+	    getpid());
+	fd = open(buf, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd < 0)
+		return;
+
+	/*
+	 * Data presentation modeled on proctat(1)'s mrs mode.
+	 */
+	(void)snprintf(buf, sizeof(buf), "PID: %d\n"
+	    "COMM: %s\n"
+	    "FLAGS: %c%c%c%c%c\n"
+	    "%%TQR: %u\n"
+	    "%%MQR: %zu\n"
+	    "CHEAP: %zu\n"
+	    "BHEAP: %zu\n"
+	    "CQUAR: %zu\n"
+	    "BQUAR: %zu\n"
+	    "ASIZE: %zu\n"
+	    "MAXASIZE: %zu\n"
+	    "MINRVK: %u\n"
+	    "UEPOCH: %zu\n",
+	    getpid(), getprogname(),
+	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_ASYNCREVOKE) ? 'a' : '-',
+	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_BOUNDPTRS) ? 'b' : '-',
+	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_EVERYFREE) ? 'e' : '-',
+	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_ABORTONFAIL) ? 'f' : '-',
+	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_QUARANTINING) ? 'q' : '-',
+            (100 * cmsp->cms_mrs_quarantine_numerator) /
+            cmsp->cms_mrs_quarantine_denominator,
+            (100 * cmsp->cms_mrs_bytes_inquarantine) /
+            (cmsp->cms_mrs_bytes_inquarantine + cmsp->cms_mrs_bytes_inheap),
+            cmsp->cms_mrs_count_inheap,
+            cmsp->cms_mrs_bytes_inheap,
+            cmsp->cms_mrs_count_inquarantine,
+            cmsp->cms_mrs_bytes_inquarantine,
+	    cmsp->cms_mrs_allocated_size,
+	    cmsp->cms_mrs_max_allocated_size,
+	    cmsp->cms_mrs_revocation_minimum,
+	    cmsp->cms_mrs_epoch);
+	(void)write(fd, buf, strlen(buf));
+	(void)close(fd);
+}
+
+static void
 mrs_init_impl_locked(void)
 {
 	initialize_lock(app_quarantine_lock);
@@ -1496,8 +1554,8 @@ mrs_init_impl_locked(void)
 	 * events.
 	 */
 #ifdef __CHERI_PURE_CAPABILITY__
-	if (getenv(MALLOC_QUARANTINE_STATS_DISABLE_ENV) == NULL &&
-	    getenv(MALLOC_QUARANTINE_STATS_ENABLE_ENV) != NULL) {
+	if (secure_getenv(MALLOC_QUARANTINE_STATS_DISABLE_ENV) == NULL &&
+	    secure_getenv(MALLOC_QUARANTINE_STATS_ENABLE_ENV) != NULL) {
 		if (_elf_aux_info(AT_CHERI_MRS, &cmsp, sizeof(cmsp)) < 0)
 			mrs_puts("error getting AT_CHERI_MRS\n");
 		cmsp->cms_mrs_arenas = APP_QUARANTINE_ARENAS;
@@ -1514,6 +1572,11 @@ mrs_init_impl_locked(void)
 			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ABORTONFAIL;
 		if (bound_pointers)
 			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
+
+	}
+	if ((mrs_statfile_name =
+	    secure_getenv(MALLOC_QUARANTINE_STATS_FILE_ENV)) != NULL) {
+		atexit(mrs_statfile_dump);
 	}
 #endif
 

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1,10 +1,16 @@
 /*-
  * Copyright (c) 2019 Brett F. Gutstein
+ * Copyright (c) 2025 Capabilities Limited
  *
  * This software was developed by SRI International and the University of
  * Cambridge Computer Laboratory (Department of Computer Science and
  * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
  * DARPA SSITH research programme.
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +35,7 @@
  */
 
 #include <sys/param.h>
+#include <sys/auxv.h>
 #include <sys/ktrace.h>
 #include <sys/mman.h>
 #include <sys/tree.h>
@@ -37,8 +44,10 @@
 #include <sys/queue.h>
 #include <sys/sysctl.h>
 
+#include <cheri/cheric.h>
 #include <cheri/revoke.h>
 #include <cheri/libcaprevoke.h>
+#include <cheri/cheri_mrs.h>
 
 #include <machine/vmparam.h>
 
@@ -321,6 +330,11 @@ static bool mrs_initialized = false;
 static unsigned int quarantine_denominator = QUARANTINE_DENOMINATOR;
 static unsigned int quarantine_numerator = QUARANTINE_NUMERATOR;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+static struct cheri_mrs_stats cheri_mrs_stats_dummy;
+static struct cheri_mrs_stats *cmsp = &cheri_mrs_stats_dummy;
+#endif
+
 static spinlock_t mrs_init_lock = _SPINLOCK_INITIALIZER;
 #define	MRS_LOCK(x)	__extension__ ({	\
 	if (__isthreaded)			\
@@ -597,6 +611,8 @@ increment_allocated_size(void *allocated)
 	if (allocated_size > max_allocated_size) {
 		max_allocated_size = allocated_size;
 	}
+	atomic_store(&cmsp->cms_mrs_allocated_size, allocated_size);
+	atomic_store(&cmsp->cms_mrs_max_allocated_size, max_allocated_size);
 }
 
 static inline void
@@ -832,6 +848,9 @@ app_quarantine_revoke_async(void)
 	mrs_unlock(&app_quarantine_lock);
 
 	(void)cheri_revoke(CHERI_REVOKE_ASYNC, epoch, NULL);
+#ifdef __CHERI_PURE_CAPABILITY__
+	atomic_store(&cmsp->cms_mrs_epoch, epoch);
+#endif
 
 	/*
 	 * Is it possible that some of the pending revocation work has finished?
@@ -1027,6 +1046,15 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 
 	size_t utrace_allocated_size = 0;
 	if (prev != NULL) {
+#ifdef __CHERI_PURE_CAPABILITY__
+		atomic_fetch_add(&cmsp->cms_mrs_count_returned, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_returned, quarantine->size);
+
+		atomic_fetch_sub(&cmsp->cms_mrs_count_inquarantine, 1);
+		atomic_fetch_sub(&cmsp->cms_mrs_bytes_inquarantine,
+		    quarantine->size);
+#endif
+
 		/* Free the quarantined descriptors. */
 		prev->next = free_descriptor_slabs;
 		while (!atomic_compare_exchange_weak(&free_descriptor_slabs,
@@ -1037,6 +1065,10 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 		allocated_size -= quarantine->size;
 		utrace_allocated_size += quarantine->size;
 		quarantine->size = 0;
+
+#ifdef __CHERI_PURE_CAPABILITY__
+		atomic_store(&cmsp->cms_mrs_allocated_size, allocated_size);
+#endif
 	}
 	mrs_debug_printf("quarantine_flush: flushed, allocated_size %zu quarantine->size %zu\n",
 	    allocated_size, quarantine->size);
@@ -1066,6 +1098,9 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		cyc_init = cheri_revoke_get_cyc();
 		(void)cheri_revoke(CHERI_REVOKE_TAKE_STATS, epoch, &crsi);
 		cyc_fini = cheri_revoke_get_cyc();
+#ifdef __CHERI_PURE_CAPABILITY__
+		atomic_store(&cmsp->cms_mrs_epoch, epoch);
+#endif
 		print_cheri_revoke_stats("load-barrier", &crsi,
 		    cyc_fini - cyc_init);
 
@@ -1082,6 +1117,9 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		(void)cheri_revoke(
 		    CHERI_REVOKE_LAST_PASS | CHERI_REVOKE_TAKE_STATS,
 		    start_epoch, NULL);
+#ifdef __CHERI_PURE_CAPABILITY__
+		atomic_store(&cmsp->cms_mrs_epoch, start_epoch);
+#endif
 # endif /* !PRINT_CAPREVOKE */
 	}
 	MRS_UTRACE(UTRACE_MRS_QUARANTINE_REVOKE_DONE, NULL, 0, 0, NULL);
@@ -1438,6 +1476,29 @@ mrs_init_impl_locked(void)
 	}
 	app_quarantine = &app_quarantine_store[0];
 
+	/*
+	 * Initial export of stats, to be updated on various allocation/etc.
+	 * events.
+	 */
+#ifdef __CHERI_PURE_CAPABILITY__
+	if (_elf_aux_info(AT_CHERI_MRS, &cmsp, sizeof(cmsp)) < 0)
+		mrs_puts("error getting AT_CHERI_MRS\n");
+	cmsp->cms_mrs_arenas = APP_QUARANTINE_ARENAS;
+	cmsp->cms_mrs_quarantine_numerator = quarantine_numerator;
+	cmsp->cms_mrs_quarantine_denominator = quarantine_denominator;
+	cmsp->cms_mrs_revocation_minimum = MIN_REVOKE_HEAP_SIZE;
+	if (quarantining)
+		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_QUARANTINING;
+	if (revoke_every_free)
+		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_EVERYFREE;
+	if (revoke_async)
+		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ASYNCREVOKE;
+	if (abort_on_validation_failure)
+		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ABORTONFAIL;
+	if (bound_pointers)
+		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
+#endif
+
 nosys:
 	mrs_initialized = true;
 
@@ -1538,6 +1599,14 @@ mrs_malloc(size_t size)
 	/*mrs_debug_printf("mrs_malloc: called size 0x%zx, allocation %#p\n",
 	    size, allocated_region);*/
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+	    cheri_length_get(allocated_region));
+	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+	    cheri_length_get(allocated_region));
+#endif
 	MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, allocated_region);
 	return (allocated_region);
 }
@@ -1596,6 +1665,14 @@ mrs_calloc(size_t number, size_t size)
 	 */
 	/*mrs_debug_printf("mrs_calloc: exit called %d size 0x%zx address %p\n", number, size, allocated_region);*/
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+	    cheri_length_get(allocated_region));
+	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+	    cheri_length_get(allocated_region));
+#endif
 	MRS_UTRACE(UTRACE_MRS_CALLOC, NULL, size, number, allocated_region);
 	return (allocated_region);
 }
@@ -1638,6 +1715,12 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 
 	increment_allocated_size(*ptr);
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated, cheri_length_get(*ptr));
+	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap, cheri_length_get(*ptr));
+#endif
 	MRS_UTRACE(UTRACE_MRS_POSIX_MEMALIGN, NULL, size, alignment, *ptr);
 	return (ret);
 }
@@ -1677,6 +1760,14 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 
 	increment_allocated_size(allocated_region);
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+	    cheri_length_get(allocated_region));
+	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+	    cheri_length_get(allocated_region));
+#endif
 	MRS_UTRACE(UTRACE_MRS_ALIGNED_ALLOC, NULL, size, alignment,
 	    allocated_region);
 	return (allocated_region);
@@ -1771,6 +1862,17 @@ mrs_free(void *ptr)
 
 #ifdef CLEAR_ON_FREE
 	bzero(cheri_offset_set(ptr, 0), cheri_length_get(ptr));
+#endif
+
+#ifdef __CHERI_PURE_CAPABILITY__
+	atomic_fetch_add(&cmsp->cms_mrs_count_freed, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_freed, cheri_length_get(ins));
+
+	atomic_fetch_sub(&cmsp->cms_mrs_count_inheap, 1);
+	atomic_fetch_sub(&cmsp->cms_mrs_bytes_inheap, cheri_length_get(ins));
+	atomic_fetch_add(&cmsp->cms_mrs_count_inquarantine, 1);
+	atomic_fetch_add(&cmsp->cms_mrs_bytes_inquarantine,
+	    cheri_length_get(ins));
 #endif
 
 	mrs_lock(&app_quarantine_lock);

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -341,10 +341,7 @@ static unsigned int quarantine_numerator = QUARANTINE_NUMERATOR;
 
 #ifdef MRS_STATS
 static const char *mrs_statfile_name = NULL;
-
-#ifdef __CHERI_PURE_CAPABILITY__
 static struct cheri_mrs_stats *cmsp;
-#endif
 #endif
 
 static spinlock_t mrs_init_lock = _SPINLOCK_INITIALIZER;
@@ -866,10 +863,8 @@ app_quarantine_revoke_async(void)
 
 	(void)cheri_revoke(CHERI_REVOKE_ASYNC, epoch, NULL);
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL)
 		atomic_store(&cmsp->cms_mrs_epoch, epoch);
-#endif
 #endif
 
 	/*
@@ -1044,7 +1039,6 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 			    cheri_length_get(iter->slab[i].ptr));
 #endif /* CLEAR_ON_RETURN */
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 			if (cmsp != NULL) {
 				atomic_fetch_add(
 				    &cmsp->cms_mrs_count_returned, 1);
@@ -1055,7 +1049,6 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 				atomic_fetch_sub(
 				    &cmsp->cms_mrs_bytes_inquarantine, len);
 			}
-#endif
 #endif
 
 			/*
@@ -1092,11 +1085,9 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 		quarantine->size = 0;
 
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL)
 			atomic_store(&cmsp->cms_mrs_allocated_size,
 			    allocated_size);
-#endif
 #endif
 	}
 	mrs_debug_printf("quarantine_flush: flushed, allocated_size %zu quarantine->size %zu\n",
@@ -1128,10 +1119,8 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		(void)cheri_revoke(CHERI_REVOKE_TAKE_STATS, epoch, &crsi);
 		cyc_fini = cheri_revoke_get_cyc();
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL)
 			atomic_store(&cmsp->cms_mrs_epoch, epoch);
-#endif
 #endif
 		print_cheri_revoke_stats("load-barrier", &crsi,
 		    cyc_fini - cyc_init);
@@ -1150,10 +1139,8 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		    CHERI_REVOKE_LAST_PASS | CHERI_REVOKE_TAKE_STATS,
 		    start_epoch, NULL);
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 		if (cmsp != NULL)
 			atomic_store(&cmsp->cms_mrs_epoch, start_epoch);
-#endif
 #endif
 # endif /* !PRINT_CAPREVOKE */
 	}
@@ -1579,7 +1566,6 @@ mrs_init_impl_locked(void)
 	 * events.
 	 */
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (secure_getenv(MALLOC_QUARANTINE_STATS_DISABLE_ENV) == NULL &&
 	    secure_getenv(MALLOC_QUARANTINE_STATS_ENABLE_ENV) != NULL) {
 		if (_elf_aux_info(AT_CHERI_MRS, &cmsp, sizeof(cmsp)) < 0)
@@ -1605,7 +1591,6 @@ mrs_init_impl_locked(void)
 	    secure_getenv(MALLOC_QUARANTINE_STATS_FILE_ENV)) != NULL) {
 		atexit(mrs_statfile_dump);
 	}
-#endif
 #endif
 
 nosys:
@@ -1709,7 +1694,6 @@ mrs_malloc(size_t size)
 	    size, allocated_region);*/
 
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
@@ -1718,7 +1702,6 @@ mrs_malloc(size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(allocated_region));
 	}
-#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, allocated_region);
 	return (allocated_region);
@@ -1779,7 +1762,6 @@ mrs_calloc(size_t number, size_t size)
 	/*mrs_debug_printf("mrs_calloc: exit called %d size 0x%zx address %p\n", number, size, allocated_region);*/
 
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
@@ -1788,7 +1770,6 @@ mrs_calloc(size_t number, size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(allocated_region));
 	}
-#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_CALLOC, NULL, size, number, allocated_region);
 	return (allocated_region);
@@ -1833,7 +1814,6 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 	increment_allocated_size(*ptr);
 
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
@@ -1842,7 +1822,6 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(*ptr));
 	}
-#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_POSIX_MEMALIGN, NULL, size, alignment, *ptr);
 	return (ret);
@@ -1884,7 +1863,6 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 	increment_allocated_size(allocated_region);
 
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
@@ -1893,7 +1871,6 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
 		    cheri_length_get(allocated_region));
 	}
-#endif
 #endif
 	MRS_UTRACE(UTRACE_MRS_ALIGNED_ALLOC, NULL, size, alignment,
 	    allocated_region);
@@ -1992,7 +1969,6 @@ mrs_free(void *ptr)
 #endif
 
 #ifdef MRS_STATS
-#ifdef __CHERI_PURE_CAPABILITY__
 	if (cmsp != NULL) {
 		atomic_fetch_add(&cmsp->cms_mrs_count_freed, 1);
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_freed,
@@ -2005,7 +1981,6 @@ mrs_free(void *ptr)
 		atomic_fetch_add(&cmsp->cms_mrs_bytes_inquarantine,
 		    cheri_length_get(ins));
 	}
-#endif
 #endif
 
 	mrs_lock(&app_quarantine_lock);

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1349,6 +1349,7 @@ spawn_background(void)
 static void
 mrs_statfile_dump(void)
 {
+	struct timespec ts_end;
 	char buf[PATH_MAX];
 	int fd;
 
@@ -1363,8 +1364,12 @@ mrs_statfile_dump(void)
 	/*
 	 * Data presentation modeled on proctat(1)'s mrs mode.
 	 */
-	(void)snprintf(buf, sizeof(buf), "PID: %d\n"
+	(void)clock_gettime(CLOCK_REALTIME, &ts_end);
+	(void)snprintf(buf, sizeof(buf),
+	    "PID: %d\n"
 	    "COMM: %s\n"
+	    "TS_START: %zu.%09zu\n"
+	    "TS_END: %zu.%09zu\n"
 	    "FLAGS: %c%c%c%c%c\n"
 	    "%%TQR: %u\n"
 	    "%%MQR: %zu\n"
@@ -1377,6 +1382,10 @@ mrs_statfile_dump(void)
 	    "MINRVK: %u\n"
 	    "UEPOCH: %zu\n",
 	    getpid(), getprogname(),
+	    cmsp->cms_mrs_ts_start.tv_sec,
+	    cmsp->cms_mrs_ts_start.tv_nsec,
+	    ts_end.tv_sec,
+	    ts_end.tv_nsec,
 	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_ASYNCREVOKE) ? 'a' : '-',
 	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_BOUNDPTRS) ? 'b' : '-',
 	    (cmsp->cms_mrs_flags & CHERI_MRS_FLAGS_EVERYFREE) ? 'e' : '-',
@@ -1572,7 +1581,7 @@ mrs_init_impl_locked(void)
 			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ABORTONFAIL;
 		if (bound_pointers)
 			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
-
+		clock_gettime(CLOCK_REALTIME, &cmsp->cms_mrs_ts_start);
 	}
 	if ((mrs_statfile_name =
 	    secure_getenv(MALLOC_QUARANTINE_STATS_FILE_ENV)) != NULL) {

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -1599,7 +1599,7 @@ mrs_init_impl_locked(void)
 		if (bound_pointers)
 			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
 		clock_gettime(CLOCK_REALTIME, &cmsp->cms_mrs_ts_start);
-		cmsp->cms_mrs_flags |= CHERI_MFS_FLAGS_INITIALIZED;
+		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_INITIALIZED;
 	}
 	if ((mrs_statfile_name =
 	    secure_getenv(MALLOC_QUARANTINE_STATS_FILE_ENV)) != NULL) {

--- a/lib/libc/stdlib/malloc/mrs/mrs.c
+++ b/lib/libc/stdlib/malloc/mrs/mrs.c
@@ -152,6 +152,11 @@ extern void snmalloc_flush_message_queue(void);
 #define	MALLOC_QUARANTINE_NUMERATOR_ENV \
 	"_RUNTIME_QUARANTINE_NUMERATOR"
 
+#define	MALLOC_QUARANTINE_STATS_DISABLE_ENV \
+	"_RUNTIME_QUARANTINE_STATS_DISABLE"
+#define	MALLOC_QUARANTINE_STATS_ENABLE_ENV \
+	"_RUNTIME_QUARANTINE_STATS_ENABLE"
+
 /*
  * Different allocators give their strong symbols different names.  Hide
  * this implementation detail being the REAL() macro.
@@ -331,8 +336,7 @@ static unsigned int quarantine_denominator = QUARANTINE_DENOMINATOR;
 static unsigned int quarantine_numerator = QUARANTINE_NUMERATOR;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-static struct cheri_mrs_stats cheri_mrs_stats_dummy;
-static struct cheri_mrs_stats *cmsp = &cheri_mrs_stats_dummy;
+static struct cheri_mrs_stats *cmsp;
 #endif
 
 static spinlock_t mrs_init_lock = _SPINLOCK_INITIALIZER;
@@ -611,8 +615,11 @@ increment_allocated_size(void *allocated)
 	if (allocated_size > max_allocated_size) {
 		max_allocated_size = allocated_size;
 	}
-	atomic_store(&cmsp->cms_mrs_allocated_size, allocated_size);
-	atomic_store(&cmsp->cms_mrs_max_allocated_size, max_allocated_size);
+	if (cmsp != NULL) {
+		atomic_store(&cmsp->cms_mrs_allocated_size, allocated_size);
+		atomic_store(&cmsp->cms_mrs_max_allocated_size,
+		    max_allocated_size);
+	}
 }
 
 static inline void
@@ -849,7 +856,8 @@ app_quarantine_revoke_async(void)
 
 	(void)cheri_revoke(CHERI_REVOKE_ASYNC, epoch, NULL);
 #ifdef __CHERI_PURE_CAPABILITY__
-	atomic_store(&cmsp->cms_mrs_epoch, epoch);
+	if (cmsp != NULL)
+		atomic_store(&cmsp->cms_mrs_epoch, epoch);
 #endif
 
 	/*
@@ -1047,12 +1055,15 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 	size_t utrace_allocated_size = 0;
 	if (prev != NULL) {
 #ifdef __CHERI_PURE_CAPABILITY__
-		atomic_fetch_add(&cmsp->cms_mrs_count_returned, 1);
-		atomic_fetch_add(&cmsp->cms_mrs_bytes_returned, quarantine->size);
+		if (cmsp != NULL) {
+			atomic_fetch_add(&cmsp->cms_mrs_count_returned, 1);
+			atomic_fetch_add(&cmsp->cms_mrs_bytes_returned,
+			    quarantine->size);
 
-		atomic_fetch_sub(&cmsp->cms_mrs_count_inquarantine, 1);
-		atomic_fetch_sub(&cmsp->cms_mrs_bytes_inquarantine,
-		    quarantine->size);
+			atomic_fetch_sub(&cmsp->cms_mrs_count_inquarantine, 1);
+			atomic_fetch_sub(&cmsp->cms_mrs_bytes_inquarantine,
+			    quarantine->size);
+		}
 #endif
 
 		/* Free the quarantined descriptors. */
@@ -1067,7 +1078,9 @@ quarantine_flush(struct mrs_quarantine *quarantine)
 		quarantine->size = 0;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-		atomic_store(&cmsp->cms_mrs_allocated_size, allocated_size);
+		if (cmsp != NULL)
+			atomic_store(&cmsp->cms_mrs_allocated_size,
+			    allocated_size);
 #endif
 	}
 	mrs_debug_printf("quarantine_flush: flushed, allocated_size %zu quarantine->size %zu\n",
@@ -1099,7 +1112,8 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		(void)cheri_revoke(CHERI_REVOKE_TAKE_STATS, epoch, &crsi);
 		cyc_fini = cheri_revoke_get_cyc();
 #ifdef __CHERI_PURE_CAPABILITY__
-		atomic_store(&cmsp->cms_mrs_epoch, epoch);
+		if (cmsp != NULL)
+			atomic_store(&cmsp->cms_mrs_epoch, epoch);
 #endif
 		print_cheri_revoke_stats("load-barrier", &crsi,
 		    cyc_fini - cyc_init);
@@ -1118,7 +1132,8 @@ quarantine_revoke(struct mrs_quarantine *quarantine)
 		    CHERI_REVOKE_LAST_PASS | CHERI_REVOKE_TAKE_STATS,
 		    start_epoch, NULL);
 #ifdef __CHERI_PURE_CAPABILITY__
-		atomic_store(&cmsp->cms_mrs_epoch, start_epoch);
+		if (cmsp != NULL)
+			atomic_store(&cmsp->cms_mrs_epoch, start_epoch);
 #endif
 # endif /* !PRINT_CAPREVOKE */
 	}
@@ -1481,22 +1496,25 @@ mrs_init_impl_locked(void)
 	 * events.
 	 */
 #ifdef __CHERI_PURE_CAPABILITY__
-	if (_elf_aux_info(AT_CHERI_MRS, &cmsp, sizeof(cmsp)) < 0)
-		mrs_puts("error getting AT_CHERI_MRS\n");
-	cmsp->cms_mrs_arenas = APP_QUARANTINE_ARENAS;
-	cmsp->cms_mrs_quarantine_numerator = quarantine_numerator;
-	cmsp->cms_mrs_quarantine_denominator = quarantine_denominator;
-	cmsp->cms_mrs_revocation_minimum = MIN_REVOKE_HEAP_SIZE;
-	if (quarantining)
-		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_QUARANTINING;
-	if (revoke_every_free)
-		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_EVERYFREE;
-	if (revoke_async)
-		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ASYNCREVOKE;
-	if (abort_on_validation_failure)
-		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ABORTONFAIL;
-	if (bound_pointers)
-		cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
+	if (getenv(MALLOC_QUARANTINE_STATS_DISABLE_ENV) == NULL &&
+	    getenv(MALLOC_QUARANTINE_STATS_ENABLE_ENV) != NULL) {
+		if (_elf_aux_info(AT_CHERI_MRS, &cmsp, sizeof(cmsp)) < 0)
+			mrs_puts("error getting AT_CHERI_MRS\n");
+		cmsp->cms_mrs_arenas = APP_QUARANTINE_ARENAS;
+		cmsp->cms_mrs_quarantine_numerator = quarantine_numerator;
+		cmsp->cms_mrs_quarantine_denominator = quarantine_denominator;
+		cmsp->cms_mrs_revocation_minimum = MIN_REVOKE_HEAP_SIZE;
+		if (quarantining)
+			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_QUARANTINING;
+		if (revoke_every_free)
+			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_EVERYFREE;
+		if (revoke_async)
+			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ASYNCREVOKE;
+		if (abort_on_validation_failure)
+			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_ABORTONFAIL;
+		if (bound_pointers)
+			cmsp->cms_mrs_flags |= CHERI_MRS_FLAGS_BOUNDPTRS;
+	}
 #endif
 
 nosys:
@@ -1600,12 +1618,14 @@ mrs_malloc(size_t size)
 	    size, allocated_region);*/
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
-	    cheri_length_get(allocated_region));
-	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
-	    cheri_length_get(allocated_region));
+	if (cmsp != NULL) {
+		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+		    cheri_length_get(allocated_region));
+		atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+		    cheri_length_get(allocated_region));
+	}
 #endif
 	MRS_UTRACE(UTRACE_MRS_MALLOC, NULL, size, 0, allocated_region);
 	return (allocated_region);
@@ -1666,12 +1686,14 @@ mrs_calloc(size_t number, size_t size)
 	/*mrs_debug_printf("mrs_calloc: exit called %d size 0x%zx address %p\n", number, size, allocated_region);*/
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
-	    cheri_length_get(allocated_region));
-	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
-	    cheri_length_get(allocated_region));
+	if (cmsp != NULL) {
+		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+		    cheri_length_get(allocated_region));
+		atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+		    cheri_length_get(allocated_region));
+	}
 #endif
 	MRS_UTRACE(UTRACE_MRS_CALLOC, NULL, size, number, allocated_region);
 	return (allocated_region);
@@ -1716,10 +1738,14 @@ mrs_posix_memalign(void **ptr, size_t alignment, size_t size)
 	increment_allocated_size(*ptr);
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated, cheri_length_get(*ptr));
-	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap, cheri_length_get(*ptr));
+	if (cmsp != NULL) {
+		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+		    cheri_length_get(*ptr));
+		atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+		    cheri_length_get(*ptr));
+	}
 #endif
 	MRS_UTRACE(UTRACE_MRS_POSIX_MEMALIGN, NULL, size, alignment, *ptr);
 	return (ret);
@@ -1761,12 +1787,14 @@ mrs_aligned_alloc(size_t alignment, size_t size)
 	increment_allocated_size(allocated_region);
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
-	    cheri_length_get(allocated_region));
-	atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
-	    cheri_length_get(allocated_region));
+	if (cmsp != NULL) {
+		atomic_fetch_add(&cmsp->cms_mrs_count_allocated, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_allocated,
+		    cheri_length_get(allocated_region));
+		atomic_fetch_add(&cmsp->cms_mrs_count_inheap, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_inheap,
+		    cheri_length_get(allocated_region));
+	}
 #endif
 	MRS_UTRACE(UTRACE_MRS_ALIGNED_ALLOC, NULL, size, alignment,
 	    allocated_region);
@@ -1865,14 +1893,18 @@ mrs_free(void *ptr)
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	atomic_fetch_add(&cmsp->cms_mrs_count_freed, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_freed, cheri_length_get(ins));
+	if (cmsp != NULL) {
+		atomic_fetch_add(&cmsp->cms_mrs_count_freed, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_freed,
+		    cheri_length_get(ins));
 
-	atomic_fetch_sub(&cmsp->cms_mrs_count_inheap, 1);
-	atomic_fetch_sub(&cmsp->cms_mrs_bytes_inheap, cheri_length_get(ins));
-	atomic_fetch_add(&cmsp->cms_mrs_count_inquarantine, 1);
-	atomic_fetch_add(&cmsp->cms_mrs_bytes_inquarantine,
-	    cheri_length_get(ins));
+		atomic_fetch_sub(&cmsp->cms_mrs_count_inheap, 1);
+		atomic_fetch_sub(&cmsp->cms_mrs_bytes_inheap,
+		    cheri_length_get(ins));
+		atomic_fetch_add(&cmsp->cms_mrs_count_inquarantine, 1);
+		atomic_fetch_add(&cmsp->cms_mrs_bytes_inquarantine,
+		    cheri_length_get(ins));
+	}
 #endif
 
 	mrs_lock(&app_quarantine_lock);

--- a/lib/libprocstat/Makefile
+++ b/lib/libprocstat/Makefile
@@ -44,6 +44,7 @@ MLINKS+=libprocstat.3 procstat_close.3 \
 		libprocstat.3 procstat_getfiles.3 \
 		libprocstat.3 procstat_getgroups.3 \
 		libprocstat.3 procstat_getkstack.3 \
+		libprocstat.3 procstat_getmrs.3 \
 		libprocstat.3 procstat_getosrel.3 \
 		libprocstat.3 procstat_getpathname.3 \
 		libprocstat.3 procstat_getprocs.3 \

--- a/lib/libprocstat/Symbol.map
+++ b/lib/libprocstat/Symbol.map
@@ -56,6 +56,7 @@ FBSD_1.7 {
 
 FBSD_1.8 {
 	 procstat_get_kqueue_info;
+	 procstat_getmrs;
 	 procstat_getrlimitusage;
 	 procstat_freekqinfo;
 	 procstat_freerlimitusage;

--- a/lib/libprocstat/libprocstat.3
+++ b/lib/libprocstat/libprocstat.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2024 Capabilities Limited
+.\" Copyright (c) 2024-2025 Capabilities Limited
 .\" Copyright (c) 2011 Sergey Kandaurov <pluknet@FreeBSD.org>
 .\" All rights reserved.
 .\"
@@ -59,6 +59,7 @@
 .Nm procstat_getfiles ,
 .Nm procstat_getgroups ,
 .Nm procstat_getkstack ,
+.Nm procstat_getmrs ,
 .Nm procstat_getosrel ,
 .Nm procstat_getpathname ,
 .Nm procstat_getprocs ,
@@ -77,6 +78,7 @@
 .In sys/queue.h
 .In sys/socket.h
 .In cheri/c18n.h
+.In cheri/cheri_mrs.h
 .In libprocstat.h
 .Ft void
 .Fn procstat_close "struct procstat *procstat"
@@ -216,6 +218,12 @@
 .Fa "struct procstat *procstat"
 .Fa "struct kinfo_proc *kp"
 .Fa "unsigned int *count"
+.Fc
+.Ft "int"
+.Fo procstat_getmrs
+.Fa "struct procstat *procstat"
+.Fa "struct kinfo_proc *kp"
+.Fa "struct cheri_mrs_stat *stats"
 .Fc
 .Ft int
 .Fo procstat_getosrel
@@ -615,6 +623,12 @@ On return, the compartment list is terminated with a compartment ID of
 .Dv CHERI_C18N_COMPART_LAST .
 If a terminating entry is not found in the returned array, then there was
 insufficient space, and the caller should allocate a larger array and retry.
+.Pp
+Th
+.Fn procstat_getmrs
+function retrieves heap and
+.Xr mrs
+statistics relating to allocation and revocation.
 .Sh SEE ALSO
 .Xr fstat 1 ,
 .Xr fuser 1 ,

--- a/lib/libprocstat/libprocstat.c
+++ b/lib/libprocstat/libprocstat.c
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-4-Clause
  *
- * Copyright (c) 2024 Capabilities Limited
+ * Copyright (c) 2024-2025 Capabilities Limited
  * Copyright (c) 2017 Dell EMC
  * Copyright (c) 2009 Stanislav Sedov <stas@FreeBSD.org>
  * Copyright (c) 1988, 1993
@@ -1080,6 +1080,53 @@ procstat_getfiles_sysctl(struct procstat *procstat, struct kinfo_proc *kp,
 	}
 fail:
 	return (head);
+}
+
+int
+procstat_getmrs(struct procstat *procstat, struct kinfo_proc *kp,
+    struct cheri_mrs_stats *stats)
+{
+	int name[4];
+	size_t len = CHERI_MRS_STATS_MAX_SIZE;
+	_Alignas(struct cheri_mrs_stats) char buf[CHERI_MRS_STATS_MAX_SIZE];
+	struct cheri_mrs_stats *mrsstatsp = (struct cheri_mrs_stats *)buf;
+
+	if (mrsstatsp == NULL)
+		goto out;
+
+	switch (procstat->type) {
+	case PROCSTAT_KVM:
+		warnx("kvm method is not supported");
+		goto out;
+
+	case PROCSTAT_SYSCTL:
+		break;
+
+	case PROCSTAT_CORE:
+		warnx("core method is not supported");
+		goto out;
+
+	default:
+		warnx("unknown access method: %d", procstat->type);
+		goto out;
+	}
+
+	name[0] = CTL_KERN;
+	name[1] = KERN_PROC;
+	name[2] = KERN_PROC_CHERI_MRS_STATS;
+	name[3] = kp->ki_pid;
+	if (sysctl(name, nitems(name), buf, &len, NULL, 0) != 0) {
+		if (errno != ESRCH && errno != EPERM && errno != ENOEXEC)
+			warn("sysctl(kern.proc.cheri_mrs_stats)");
+		goto out;
+	}
+	if (len < sizeof(*mrsstatsp) ||
+	    mrsstatsp->cms_version != CHERI_MRS_STATS_VERSION)
+		goto out;
+	*stats = *mrsstatsp;
+	return (0);
+out:
+	return (-1);
 }
 
 int

--- a/lib/libprocstat/libprocstat.h
+++ b/lib/libprocstat/libprocstat.h
@@ -39,6 +39,7 @@
 #endif
 #include <sys/caprights.h>
 #include <cheri/c18n.h>
+#include <cheri/cheri_mrs.h>
 
 /*
  * Vnode types.
@@ -225,6 +226,8 @@ int	procstat_getcompartments(struct procstat *procstat,
     size_t *ncomparts);
 struct filestat_list	*procstat_getfiles(struct procstat *procstat,
     struct kinfo_proc *kp, int mmapped);
+int	procstat_getmrs(struct procstat *procstat, struct kinfo_proc *kp,
+    struct cheri_mrs_stats *stats);
 struct kinfo_proc	*procstat_getprocs(struct procstat *procstat,
     int what, int arg, unsigned int *count);
 struct kinfo_knote	*procstat_get_kqueue_info(struct procstat *procstat,

--- a/lib/libsys/auxv.c
+++ b/lib/libsys/auxv.c
@@ -105,6 +105,10 @@ static void _init_aux_powerpc_fixup(void);
 int _powerpc_elf_aux_info(int, void *, int);
 #endif
 
+#ifdef __CHERI_PURE_CAPABILITY__
+static void *cheri_mrs_statsp;
+#endif
+
 /*
  * This function might be called and actual body executed more than
  * once in multithreading environment.  Due to this, it is and must
@@ -194,6 +198,11 @@ init_aux(void)
 		 */
 		case AT_STACKPROT:	/* 23 */
 			powerpc_new_auxv_format = 1;
+			break;
+#endif
+#ifdef __CHERI_PURE_CAPABILITY__
+		case AT_CHERI_MRS:
+			cheri_mrs_statsp = aux->a_un.a_ptr;
 			break;
 #endif
 		}
@@ -435,6 +444,18 @@ _elf_aux_info(int aux, void *buf, int buflen)
 		} else
 			res = EINVAL;
 		break;
+#ifdef __CHERI_PURE_CAPABILITY__
+	case AT_CHERI_MRS:
+		if (buflen == sizeof(void *)) {
+			if (cheri_mrs_statsp != NULL) {
+				*(void **)buf = cheri_mrs_statsp;
+				res = 0;
+			} else
+				res = ENOENT;
+		} else
+			res = EINVAL;
+		break;
+#endif
 	default:
 		res = ENOENT;
 		break;

--- a/libexec/rtld-elf/Symbol.map
+++ b/libexec/rtld-elf/Symbol.map
@@ -24,6 +24,7 @@ FBSD_1.3 {
 FBSD_1.8 {
     rtld_get_var;
     rtld_set_var;
+    rtld_cheri_mrs_statsp;
 };
 
 FBSDprivate_1.0 {

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -53,6 +53,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,6 +72,8 @@
 #ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif
+
+#include <cheri/cheri_mrs.h>
 
 /* Types. */
 typedef void (*func_ptr_type)(void);
@@ -341,6 +344,8 @@ static int stack_prot = PROT_READ | PROT_WRITE;
 static int stack_prot = PROT_READ | PROT_WRITE | PROT_EXEC;
 static int max_stack_flags;
 #endif
+
+struct cheri_mrs_stats *rtld_cheri_mrs_statsp __exported;
 
 void *rtld_bind_fptr = &_rtld_bind;
 void *tls_get_addr_common_fptr = &tls_get_addr_common;
@@ -1018,6 +1023,15 @@ _rtld(Elf_Addr *sp, func_ptr_type *exit_proc, Obj_Entry **objp)
 		obj_rtld.path = xstrdup(obj_main->interp);
 		__progname = obj_rtld.path;
 	}
+#endif
+#ifdef __CHERI_PURE_CAPABILITY__
+    if (aux_info[AT_CHERI_MRS] != NULL) {
+        rtld_cheri_mrs_statsp = aux_info[AT_CHERI_MRS]->a_un.a_ptr;
+	bzero(rtld_cheri_mrs_statsp, sizeof(*rtld_cheri_mrs_statsp));
+        rtld_cheri_mrs_statsp->cms_size = sizeof(*rtld_cheri_mrs_statsp);
+        atomic_store_explicit(&rtld_cheri_mrs_statsp->cms_version,
+            CHERI_MRS_STATS_VERSION, memory_order_release);
+    }
 #endif
 
 	if (!digest_dynamic(obj_main, 0))

--- a/sys/cheri/cheri_mrs.h
+++ b/sys/cheri/cheri_mrs.h
@@ -1,0 +1,97 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __SYS_CHERI_MRS_H__
+#define	__SYS_CHERI_MRS_H__
+
+#define CHERI_MRS_STATS_VERSION		1
+#define CHERI_MRS_STATS_MAX_SIZE	256
+
+#define	CHERI_MRS_FLAGS_QUARANTINING	0x00000001	/* Quarantining. */
+#define	CHERI_MRS_FLAGS_EVERYFREE	0x00000002	/* Revoke every free. */
+#define	CHERI_MRS_FLAGS_ASYNCREVOKE	0x00000004	/* Async revocation. */
+#define	CHERI_MRS_FLAGS_ABORTONFAIL	0x00000008	/* Abort on failure. */
+#define	CHERI_MRS_FLAGS_BOUNDPTRS	0x00000010	/* Bound pointers. */
+
+/*
+ * Statistics gathered by the heap allocator and mrs.  The version field
+ * doubles as a synchronisation flag where a non-zero value indicates that the
+ * other fields have been initialised.
+ */
+struct cheri_mrs_stats {
+	size_t		cms_size;
+	_Atomic(size_t)	cms_version;
+
+	/* Counts of events since inception. */
+	_Atomic(size_t)	cms_mrs_count_allocated;
+	_Atomic(size_t)	cms_mrs_count_freed;	/* .. by the caller. */
+	_Atomic(size_t)	cms_mrs_count_returned;	/* .. to the allocator. */
+
+	/* Running totals of outstanding and quarantined memory allocations. */
+	_Atomic(size_t)	cms_mrs_count_inheap;	/* Allocated but not freed. */
+	_Atomic(size_t)	cms_mrs_count_inquarantine; /* Freed but not revoked. */
+
+	/* Byte totals for allocator since inception. */
+	_Atomic(size_t)	cms_mrs_bytes_allocated;
+	_Atomic(size_t)	cms_mrs_bytes_freed;	/* .. by the caller. */
+	_Atomic(size_t)	cms_mrs_bytes_returned;	/* .. to the allocator. */
+
+	/* Running totals of outstanding and quarantined memory in bytes. */
+	_Atomic(size_t)	cms_mrs_bytes_inheap;	/* Allocated but not freed. */
+	_Atomic(size_t)	cms_mrs_bytes_inquarantine; /* Freed but not revoked. */
+
+	/* 32-bit mrs parameters. */
+	uint32_t	cms_mrs_arenas;
+	uint32_t	cms_mrs_quarantine_numerator;
+	uint32_t	cms_mrs_quarantine_denominator;
+	uint32_t	cms_mrs_revocation_minimum;
+
+	/* Status flags. */
+	uint32_t	cms_mrs_flags;
+	uint32_t	_cms_mrs_pad0;
+
+	/* 64-bit mrs global state. */
+	_Atomic(size_t)	cms_mrs_allocated_size;
+	_Atomic(size_t)	cms_mrs_max_allocated_size;
+
+	/* 64-bit mrs parameters. */
+	_Atomic(uint64_t)	cms_mrs_epoch;
+
+	/* Padding to a sensible size for future non-disruptive growth. */
+	size_t		_cms_pad1[6];
+};
+
+#ifndef _KERNEL
+extern struct cheri_mrs_stats *rtld_cheri_mrs_statsp;
+#endif
+
+#endif /* __SYS_CHERI_MRS_H__ */

--- a/sys/cheri/cheri_mrs.h
+++ b/sys/cheri/cheri_mrs.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (c) 2025 Capabilities Limited
+ * Copyright (c) 2025-2026 Capabilities Limited
  *
  * This software was developed by SRI International, the University of
  * Cambridge Computer Laboratory (Department of Computer Science and
@@ -32,6 +32,8 @@
 
 #ifndef __SYS_CHERI_MRS_H__
 #define	__SYS_CHERI_MRS_H__
+
+#include <sys/_timespec.h>
 
 #define CHERI_MRS_STATS_VERSION		1
 #define CHERI_MRS_STATS_MAX_SIZE	256
@@ -86,8 +88,11 @@ struct cheri_mrs_stats {
 	/* 64-bit mrs parameters. */
 	_Atomic(uint64_t)	cms_mrs_epoch;
 
+	/* Timestamps associated with these stats. */
+	struct timespec	cms_mrs_ts_start;	/* Earliest moment. */
+
 	/* Padding to a sensible size for future non-disruptive growth. */
-	size_t		_cms_pad1[6];
+	size_t		_cms_pad1[4];
 };
 
 #ifndef _KERNEL

--- a/sys/cheri/cheri_mrs.h
+++ b/sys/cheri/cheri_mrs.h
@@ -38,11 +38,12 @@
 #define CHERI_MRS_STATS_VERSION		1
 #define CHERI_MRS_STATS_MAX_SIZE	256
 
-#define	CHERI_MRS_FLAGS_QUARANTINING	0x00000001	/* Quarantining. */
-#define	CHERI_MRS_FLAGS_EVERYFREE	0x00000002	/* Revoke every free. */
-#define	CHERI_MRS_FLAGS_ASYNCREVOKE	0x00000004	/* Async revocation. */
-#define	CHERI_MRS_FLAGS_ABORTONFAIL	0x00000008	/* Abort on failure. */
-#define	CHERI_MRS_FLAGS_BOUNDPTRS	0x00000010	/* Bound pointers. */
+#define	CHERI_MFS_FLAGS_INITIALIZED	0x00000001	/* Structure live. */
+#define	CHERI_MRS_FLAGS_QUARANTINING	0x00000002	/* Quarantining. */
+#define	CHERI_MRS_FLAGS_EVERYFREE	0x00000004	/* Revoke every free. */
+#define	CHERI_MRS_FLAGS_ASYNCREVOKE	0x00000008	/* Async revocation. */
+#define	CHERI_MRS_FLAGS_ABORTONFAIL	0x00000010	/* Abort on failure. */
+#define	CHERI_MRS_FLAGS_BOUNDPTRS	0x00000020	/* Bound pointers. */
 
 /*
  * Statistics gathered by the heap allocator and mrs.  The version field

--- a/sys/cheri/cheri_mrs.h
+++ b/sys/cheri/cheri_mrs.h
@@ -38,7 +38,7 @@
 #define CHERI_MRS_STATS_VERSION		1
 #define CHERI_MRS_STATS_MAX_SIZE	256
 
-#define	CHERI_MFS_FLAGS_INITIALIZED	0x00000001	/* Structure live. */
+#define	CHERI_MRS_FLAGS_INITIALIZED	0x00000001	/* Structure live. */
 #define	CHERI_MRS_FLAGS_QUARANTINING	0x00000002	/* Quarantining. */
 #define	CHERI_MRS_FLAGS_EVERYFREE	0x00000004	/* Revoke every free. */
 #define	CHERI_MRS_FLAGS_ASYNCREVOKE	0x00000008	/* Async revocation. */

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1983,6 +1983,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	stacksz = imgp->proc->p_limit->pl_rlimit[RLIMIT_STACK].rlim_cur;
 	AUXARGS_ENTRY(pos, AT_USRSTACKLIM, stacksz);
 	AUXARGS_ENTRY_PTR(pos, AT_CHERI_C18N, imgp->c18n_info);
+	AUXARGS_ENTRY_PTR(pos, AT_CHERI_MRS, imgp->cheri_mrs_stats);
 	AUXARGS_ENTRY(pos, AT_NULL, 0);
 
 	free(imgp->auxargs, M_TEMP);

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -102,6 +102,7 @@
 #include <cheri/cheri.h>
 #include <cheri/cheric.h>
 #include <cheri/cherireg.h>
+#include <cheri/cheri_mrs.h>
 #endif
 
 #ifdef KDTRACE_HOOKS
@@ -2046,6 +2047,16 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	    cheri_bounds_set_exact(destp, sizeof(*imgp->c18n_info));
 	p->p_c18n_info =
 	    (__cheri_fromcap struct cheri_c18n_info *)imgp->c18n_info;
+
+	/*
+	 * Allocate the mrs statistics header.
+	 */
+	destp -= sizeof(*imgp->cheri_mrs_stats);
+	destp = rounddown2(destp, sizeof(void * __capability));
+	imgp->cheri_mrs_stats = (struct cheri_mrs_stats * __kerncap)
+	    cheri_bounds_set_exact(destp, sizeof(*imgp->cheri_mrs_stats));
+	p->p_cheri_mrs_stats =
+	    (__cheri_fromcap struct cheri_mrs_stats *)imgp->cheri_mrs_stats;
 #endif
 
 	if (imgp->auxargs) {

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -111,6 +111,7 @@
 #if __has_feature(capabilities)
 #include <cheri/c18n.h>
 #include <cheri/cheric.h>
+#include <cheri/cheri_mrs.h>
 #endif
 
 SDT_PROVIDER_DEFINE(proc);
@@ -2766,6 +2767,58 @@ out:
 	PRELE(p);
 	return (error);
 }
+
+/*
+ * Return heap and mrs statistics block from the target process.
+ *
+ * XXXRW: Probably storage for 'stats' should be heap allocated, not stack
+ * allocated, in case of substantial future growth.
+ */
+static int
+sysctl_kern_proc_cheri_mrs_stats(SYSCTL_HANDLER_ARGS)
+{
+	int *name = (int *)arg1;
+	u_int namelen = arg2;
+	struct proc *p;
+	struct cheri_mrs_stats stats;
+	int error;
+	ssize_t n;
+
+	if (namelen != 1)
+		return (EINVAL);
+
+	error = pget((pid_t)name[0], PGET_WANTREAD, &p);
+	if (error != 0)
+		return (error);
+
+	if ((p->p_flag & P_SYSTEM) != 0 ||
+	    SV_PROC_FLAG(p, SV_CHERI) == 0 ||
+	    p->p_cheri_mrs_stats == NULL)
+		goto out;
+
+	n = proc_readmem(curthread, p, (vm_offset_t)p->p_cheri_mrs_stats,
+	    &stats, sizeof(stats));
+	if (n != sizeof(stats)) {
+		error = EFAULT;
+		goto out;
+	}
+
+	/*
+	 * If there is a version mismatch or the statistics block is oversized,
+	 * error out.
+	 */
+	if (stats.cms_version != CHERI_MRS_STATS_VERSION ||
+	    stats.cms_size == 0 ||
+	    stats.cms_size > CHERI_MRS_STATS_MAX_SIZE) {
+		error = ENOEXEC;
+		goto out;
+	}
+
+	error = SYSCTL_OUT(req, &stats, stats.cms_size);
+out:
+	PRELE(p);
+	return (error);
+}
 #endif
 
 /*
@@ -4010,6 +4063,10 @@ static SYSCTL_NODE(_kern_proc, KERN_PROC_C18N_STATS, c18n, CTLFLAG_RD |
 static SYSCTL_NODE(_kern_proc, KERN_PROC_C18N_COMPARTS, c18n_compartments,
 	CTLFLAG_RD | CTLFLAG_MPSAFE, sysctl_kern_proc_c18n_compartments,
 	"Compartment list");
+
+static SYSCTL_NODE(_kern_proc, KERN_PROC_CHERI_MRS_STATS, cheri_mrs_stats,
+	CTLFLAG_RD | CTLFLAG_MPSAFE, sysctl_kern_proc_cheri_mrs_stats,
+	"Heap and mrs statistics");
 #endif
 
 static SYSCTL_NODE(_kern_proc, KERN_PROC_PATHNAME, pathname, CTLFLAG_RD |

--- a/sys/sys/elf_common.h
+++ b/sys/sys/elf_common.h
@@ -1048,8 +1048,9 @@ typedef struct {
 #define	AT_USRSTACKBASE	35	/* Top of user stack */
 #define	AT_USRSTACKLIM	36	/* Grow limit of user stack */
 #define	AT_CHERI_C18N	37	/* Compartment info block */
+#define	AT_CHERI_MRS	38	/* Heap and mrs info block */
 
-#define	AT_COUNT	38	/* Count of defined aux entry types. */
+#define	AT_COUNT	39	/* Count of defined aux entry types. */
 
 /*
  * Relocation types.

--- a/sys/sys/imgact.h
+++ b/sys/sys/imgact.h
@@ -87,6 +87,7 @@ struct image_params {
 	void * __capability pagesizes;
 	int pagesizeslen;
 	struct cheri_c18n_info * __kerncap c18n_info;
+	struct cheri_mrs_stats * __kerncap cheri_mrs_stats;
 	void * __capability stack;
 	vm_prot_t stack_prot;
 	u_long stack_sz;

--- a/sys/sys/proc.h
+++ b/sys/sys/proc.h
@@ -752,6 +752,7 @@ struct proc {
 	vm_offset_t	p_psstrings;
 #if __has_feature(capabilities)
 	struct cheri_c18n_info	*p_c18n_info;	/* (x) Compartment info block */
+	struct cheri_mrs_stats	*p_cheri_mrs_stats; /* (x) Heap/mrs info block */
 #endif
 /* End area that is copied on creation. */
 #define	p_endcopy	p_xexit

--- a/sys/sys/sysctl.h
+++ b/sys/sys/sysctl.h
@@ -1070,6 +1070,7 @@ TAILQ_HEAD(sysctl_ctx_list, sysctl_ctx_entry);
 #define	KERN_PROC_REVOKER_EPOCH	102	/* revoker epoch */
 #define	KERN_PROC_C18N_STATS	103	/* compartmentalisation statistics */
 #define	KERN_PROC_C18N_COMPARTS	104	/* compartment list */
+#define	KERN_PROC_CHERI_MRS_STATS	105	/* heap and mrs statistics */
 
 /*
  * KERN_IPC identifiers

--- a/usr.bin/procstat/Makefile
+++ b/usr.bin/procstat/Makefile
@@ -16,6 +16,7 @@ SRCS=	procstat.c		\
 	procstat_files.c	\
 	procstat_kqueue.c	\
 	procstat_kstack.c	\
+	procstat_mrs.c		\
 	procstat_penv.c		\
 	procstat_ptlwpinfo.c	\
 	procstat_pwdx.c		\
@@ -25,6 +26,8 @@ SRCS=	procstat.c		\
 	procstat_sigs.c		\
 	procstat_threads.c	\
 	procstat_vm.c
+
+SRCS+=	cheri_helpers.c
 
 MLINKS+=	procstat.1 pargs.1
 MLINKS+=	procstat.1 penv.1

--- a/usr.bin/procstat/cheri_helpers.c
+++ b/usr.bin/procstat/cheri_helpers.c
@@ -12,8 +12,7 @@
  * This software was developed by SRI International, the University of
  * Cambridge Computer Laboratory (Department of Computer Science and
  * Technology), and Capabilities Limited under Defense Advanced Research
- * Projects Agency / Air Force Research Laboratory (DARPA/AFRL) Contract
- * No. FA8750-24-C-B047 ("DEC").
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,71 +51,71 @@
 
 #include "procstat.h"
 
-static char get_abi_cheri(struct kinfo_proc *kipp);
-static const char *get_c18n(struct procstat *procstat,
-    struct kinfo_proc *kipp);
-
-void
-procstat_cheri(struct procstat *procstat, struct kinfo_proc *kipp)
+const char *
+get_quarantining(struct procstat *procstat, struct kinfo_proc *kipp)
 {
-	char abi_cheri;
+	int quarantining;
 
-	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
-		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
-			xo_emit("{T:/%5s %-19s %c %4s %5s}\n",
-			    "PID", "COMM", 'C', "QUAR", "C18N");
-		else
-			xo_emit("{T:/%5s %-19s %c %4s %7s %34s %5s}\n",
-			    "PID", "COMM", 'C', "QUAR", "RSTATE", "EPOCH",
-			    "C18N");
+	if (procstat_getquarantining(procstat, kipp, &quarantining) == 0) {
+		switch (quarantining) {
+		case 0:
+			return ("no");
+		case 1:
+			return ("yes");
+		case -1:
+			return ("!");
+		default:
+			warnx("%s: unknown quarantining status", __func__);
+			return ("?");
+		}
+	} else {
+		return ("-");
 	}
-
-	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
-	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
-	abi_cheri = get_abi_cheri(kipp);
-	xo_emit(" {:abi_cheri_support/%c/%c}", abi_cheri);
-	xo_emit(" {:quarantining/%4s/%s}", abi_cheri == 'P' ?
-	    get_quarantining(procstat, kipp) : "-");
-	if ((procstat_opts & PS_OPT_VERBOSE) != 0) {
-		xo_emit(" {:revoker_state/%7s/%s}", abi_cheri == 'P' ?
-		    get_revoker_state(procstat, kipp) : "-");
-		xo_emit(" {:revoker_epoch/%34s/%s}", abi_cheri == 'P' ?
-		    get_revoker_epoch(procstat, kipp) : "-");
-	}
-	xo_emit(" {:compartments/%5s/%s}", get_c18n(procstat, kipp));
-	xo_emit("\n");
 }
 
-static struct {
-	const char *emul;
-	char abi;
-} abis[] = {
-	{ "FreeBSD ELF64C", 'P' },
-	{ "FreeBSD ELF64CB", 'P' },
-	{ "FreeBSD ELF64", 'H' },
-	{ "FreeBSD ELF32", '!' },
-	{ "Linux ELF64", '!' },
-	{ "Linux ELF32", '!' },
-};
-
-static char
-get_abi_cheri(struct kinfo_proc *kipp)
+const char *
+get_revoker_epoch(struct procstat *procstat, struct kinfo_proc *kipp)
 {
-	for (size_t i = 0; i < nitems(abis); i++)
-		if (strcmp(abis[i].emul, kipp->ki_emul) == 0)
-			return (abis[i].abi);
-	return ('?');
+	uint64_t epoch;
+	static char revoker_epoch_buf[2*16 + 2 + 1]; /* 0x + number + NUL */
+
+	if (procstat_get_revoker_epoch(procstat, kipp, &epoch) == 0) {
+		switch (epoch) {
+		case (uint64_t)-1:
+			return ("na");
+		default:
+			snprintf(revoker_epoch_buf, sizeof(revoker_epoch_buf),
+			    "%ju", (uintmax_t)epoch);
+			return (revoker_epoch_buf);
+		}
+	} else {
+		return ("-");
+	}
+
 }
 
-static const char *
-get_c18n(struct procstat *procstat, struct kinfo_proc *kipp)
+const char *
+get_revoker_state(struct procstat *procstat, struct kinfo_proc *kipp)
 {
-	static char c18n_buf[6];
-	struct rtld_c18n_stats rcs;
+	int state;
 
-	if (procstat_getc18n(procstat, kipp, &rcs) != 0)
-		snprintf(c18n_buf, sizeof(c18n_buf), "-");
-	else
-		snprintf(c18n_buf, sizeof(c18n_buf), "%5zu", rcs.rcs_compart);
-	return (c18n_buf);
+	if (procstat_get_revoker_state(procstat, kipp, &state) == 0) {
+		switch (state) {
+		case CHERI_REVOKE_ST_NONE:
+			return ("none");
+		case CHERI_REVOKE_ST_INITING:
+			return ("initing");
+		case CHERI_REVOKE_ST_INITED:
+			return ("inited");
+		case CHERI_REVOKE_ST_CLOSING:
+			return ("closing");
+		case -1:
+			return ("!");
+		default:
+			warnx("%s: unknown quarantining status", __func__);
+			return ("?");
+		}
+	} else {
+		return ("-");
+	}
 }

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -1,6 +1,12 @@
 .\"-
 .\" Copyright (c) 2007-2009 Robert N. M. Watson
+.\" Copyright (c) 2025-2026 Capabilities Limited
 .\" All rights reserved.
+.\"
+.\" This software was developed by SRI International, the University of
+.\" Cambridge Computer Laboratory (Department of Computer Science and
+.\" Technology), and Capabilities Limited under Defense Advanced Research
+.\" Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -194,6 +200,10 @@ Display security credential information for the process.
 Substring commands are accepted.
 .It Ar cpuset | Ar cs | Fl S
 Display the cpuset information for the thread.
+.It Ar mrs
+Display CHERI heap revocation information exported by
+.Xr mrs 3 --
+the Memory Revocation Shim.
 .It Ar environment | Fl e
 Display environment variables for the process.
 .Pp
@@ -451,6 +461,63 @@ The following compartment flags may be displayed:
 .It D
 contains a library loaded via
 .Xr dlopen 3
+.El
+.Ss CHERI heap revocation information
+Display CHERI heap revocation information from the Memory Revocation Shim (see
+.Xr mrs 3 ) :
+.Pp
+.Bl -tag -width "MAXASIZE" -compact
+.It PID
+process ID
+.It COMM
+command
+.It FLAGS
+mrs flags
+.It %TQR
+percentage target quarantine (of total memory managed by mrs)
+.It %MQR
+percentage measured quarantine (of total memory managed by mrs)
+.It CHEAP
+count of active heap allocations managed by mrs
+.It BHEAP
+bytes of active heap allocations managed by mrs
+.It CQUAR
+count of quarantined heap allocations managed by mrs
+.It BQUAR
+bytes of quarantined heap allocations managed by mrs
+.It ASIZE
+bytes of memory managed by mrs, made up of active and quarantined heap
+allocations
+.It MAXSIZE
+high watermark on bytes of memory managed by mrs, made up of active and
+quarantined heap allocations
+.It MINRVK
+minimum number of bytes of memory managed by mrs below which revocation will
+not take place
+.It UEPOCH
+revocation epoch last passed to
+.Xr cheri_revoke 2
+by mrs, as tracked by mrs
+.It KEPOCH
+revocation epoch as tracked by the kernel
+.El
+.Pp
+The following
+.Xr mrs 3
+flags may be displayed:
+.Pp
+.Bl -tag -width X -compact
+.It a
+asynchronous revocation is enabled
+.It b
+.Xr mrs 3
+set the most strict possible bounds on allocation
+.It e
+revoke following every free
+.It f
+abort on pointer validation failure
+.It q
+quarantining and revocation enabled
 .El
 .Ss Environment Variables
 Display the process ID, command, and environment variables:
@@ -1003,10 +1070,12 @@ procstat: procstat_getprocs()
 .Xr sockstat 1 ,
 .Xr cap_enter 2 ,
 .Xr cap_rights_limit 2 ,
+.Xr cheri_revoke 2 ,
 .Xr mlock 2 ,
 .Xr mlockall 2 ,
 .Xr libprocstat 3 ,
 .Xr libxo 3 ,
+.Xr mrs 3 ,
 .Xr signal 3 ,
 .Xr xo_parse_args 3 ,
 .Xr ddb 4 ,

--- a/usr.bin/procstat/procstat.1
+++ b/usr.bin/procstat/procstat.1
@@ -500,6 +500,10 @@ revocation epoch last passed to
 by mrs, as tracked by mrs
 .It KEPOCH
 revocation epoch as tracked by the kernel
+.It START
+start time stamp for
+.Xr mrs 3
+statistics gathering
 .El
 .Pp
 The following

--- a/usr.bin/procstat/procstat.c
+++ b/usr.bin/procstat/procstat.c
@@ -114,6 +114,7 @@ static const struct procstat_cmd cmd_table[] = {
 	    PS_CMP_PLURAL },
 	{ "kstack", "kstack", "[-v]", &procstat_kstack, &cmdopt_verbose,
 	    PS_CMP_NORMAL },
+	{ "mrs", "mrs", "[-v]", &procstat_mrs, &cmdopt_verbose, PS_CMP_NORMAL },
 	{ "pargs", "args", NULL, &procstat_pargs, &cmdopt_none,
 	    PS_CMP_NORMAL },
 	{ "penv", "env", NULL, &procstat_penv, &cmdopt_none,

--- a/usr.bin/procstat/procstat.h
+++ b/usr.bin/procstat/procstat.h
@@ -70,6 +70,7 @@ void	procstat_env(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_files(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_kqueues(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_kstack(struct procstat *prstat, struct kinfo_proc *kipp);
+void	procstat_mrs(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_rlimitusage(struct procstat *procstat,
 	    struct kinfo_proc *kipp);
 void	procstat_pargs(struct procstat *prstat, struct kinfo_proc *kipp);
@@ -84,5 +85,16 @@ void	procstat_sigs(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_threads(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_threads_sigs(struct procstat *prstat, struct kinfo_proc *kipp);
 void	procstat_vm(struct procstat *prstat, struct kinfo_proc *kipp);
+
+/*
+ * Helper functions from procstat_cheri.c to be used in other CHERI-centric
+ * modes.
+ */
+const char *get_quarantining(struct procstat *procstat,
+	    struct kinfo_proc *kipp);
+const char *get_revoker_epoch(struct procstat *procstat,
+	    struct kinfo_proc *kipp);
+const char *get_revoker_state(struct procstat *procstat,
+	    struct kinfo_proc *kipp);
 
 #endif /* !PROCSTAT_H */

--- a/usr.bin/procstat/procstat_auxv.c
+++ b/usr.bin/procstat/procstat_auxv.c
@@ -291,6 +291,13 @@ procstat_auxv(struct procstat *procstat, struct kinfo_proc *kipp)
 			    fmt_ptr(auxv[i].a_un.a_ptr));
 			break;
 #endif
+#ifdef AT_CHERI_MRS
+		case AT_CHERI_MRS:
+			xo_emit("{dw:/%s}{Lw:/%-16s/%s}{:AT_CHERI_MRS/%s}\n",
+			    prefix, "AT_CHERI_MRS",
+			    fmt_ptr(auxv[i].a_un.a_ptr));
+			break;
+#endif
 		default:
 			xo_emit("{dw:/%s}{Lw:/%16ld/%ld}{:UNKNOWN/%#lx}\n",
 			    prefix, auxv[i].a_type, auxv[i].a_un.a_val);

--- a/usr.bin/procstat/procstat_mrs.c
+++ b/usr.bin/procstat/procstat_mrs.c
@@ -1,0 +1,122 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Capabilities Limited
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/user.h>
+
+#include <cheri/cheri_mrs.h>
+
+#include <err.h>
+#include <libprocstat.h>
+
+#include "procstat.h"
+
+void
+procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
+{
+	struct cheri_mrs_stats cms;
+	const char *kernel_epoch;
+
+	/* XXXRW: Implement variable-length strings for byte counts. */
+	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
+		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
+			xo_emit(
+			    "{T:/%5s %-19s %5s %4s %4s %7s %9s %7s %9s}\n",
+			    "PID", "COMM", "FLAGS", "%TQR", "%MQR",
+			    "CHEAP", "BHEAP", "CQUAR", "BQUAR");
+		else
+			xo_emit(
+			    "{T:/%5s %-19s %5s %4s %4s %7s %9s %7s %9s "
+			    "%9s %9s %9s %6s %6s}\n",
+			    "PID", "COMM", "FLAGS", "%TQR", "%MQR",
+			    "CHEAP", "BHEAP", "CQUAR", "BQUAR",
+			    "ASIZE", "MAXASIZE", "MINRVK", "UEPOCH", "KEPOCH");
+	}
+
+	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
+	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
+
+	if (procstat_getmrs(procstat, kipp, &cms) != 0 ||
+	    cms.cms_version != CHERI_MRS_STATS_VERSION) {
+		xo_emit(" {:mrs_flags/%5s/%s}", "-----");
+		xo_emit(" {:mrs_max_ratio/%4s/%s}", "-");
+		xo_emit(" {:mrs_ratio/%4s/%s}", "-");
+		xo_emit(" {:mrs_count_inheap/%7s/%s}", "-");
+		xo_emit(" {:mrs_bytes_inheap/%9s/%s}", "-");
+		xo_emit(" {:mrs_count_inquarantine/%7s/%s}", "-");
+		xo_emit(" {:mrs_bytes_inquarantine/%9s/%s}", "-");
+		if ((procstat_opts & PS_OPT_VERBOSE) != 0) {
+			xo_emit(" {:mrs_allocated_size/%9s/%s}", "-");
+			xo_emit(" {:mrs_max_allocated_size/%9s/%s}", "-");
+			xo_emit(" {:mrs_revocation_minimum/%9s/%s}", "-");
+			xo_emit(" {:mrs_epoch/%6s/%s}", "-");
+			xo_emit(" {:kernel_epoch/%6s/%s}", "-");
+		}
+		xo_emit("\n");
+		return;
+	}
+	xo_emit(" {:mrs_flags/%c%c%c%c%c/%c%c%c%c%c%c}",
+	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_ASYNCREVOKE) ? 'a' : '-',
+	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_BOUNDPTRS) ? 'b' : '-',
+	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_EVERYFREE) ? 'e' : '-',
+	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_ABORTONFAIL) ? 'f' : '-',
+	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_QUARANTINING) ? 'q' : '-');
+	xo_emit(" {:mrs_max_ratio/%4zu/%s}",
+	    (100 * cms.cms_mrs_quarantine_numerator) /
+	    cms.cms_mrs_quarantine_denominator);
+	xo_emit(" {:mrs_ratio/%4zu/%s}",
+	    (100 * cms.cms_mrs_bytes_inquarantine) /
+	    (cms.cms_mrs_bytes_inquarantine +
+	    cms.cms_mrs_bytes_inheap));
+	xo_emit(" {:mrs_count_inheap/%7zu/%s}",
+	    cms.cms_mrs_count_inheap);
+	xo_emit(" {:mrs_bytes_inheap/%9zu/%s}",
+	    cms.cms_mrs_bytes_inheap);
+	xo_emit(" {:mrs_count_inquarantine/%7zu/%s}",
+	    cms.cms_mrs_count_inquarantine);
+	xo_emit(" {:mrs_bytes_inquarantine/%9zu/%s}",
+	    cms.cms_mrs_bytes_inquarantine);
+	if ((procstat_opts & PS_OPT_VERBOSE) != 0) {
+		xo_emit(" {:mrs_allocated_size/%9zu/%s}",
+		    cms.cms_mrs_allocated_size);
+		xo_emit(" {:mrs_max_allocated_size/%9zu/%s}",
+		    cms.cms_mrs_max_allocated_size);
+		xo_emit(" {:mrs_revocation_minimum/%9zu/%s}",
+		    cms.cms_mrs_revocation_minimum);
+		xo_emit(" {:mrs_epoch/%6zu/%s}",
+		    cms.cms_mrs_epoch);
+		kernel_epoch = get_revoker_epoch(procstat, kipp);
+		xo_emit(" {:kernel_epoch/%6s/%s}",
+		    kernel_epoch != NULL ? kernel_epoch : "-");
+	}
+	xo_emit("\n");
+}

--- a/usr.bin/procstat/procstat_mrs.c
+++ b/usr.bin/procstat/procstat_mrs.c
@@ -68,7 +68,7 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 
 	if (procstat_getmrs(procstat, kipp, &cms) != 0 ||
 	    cms.cms_version != CHERI_MRS_STATS_VERSION ||
-	    !(cms.cms_mrs_flags & CHERI_MFS_FLAGS_INITIALIZED)) {
+	    !(cms.cms_mrs_flags & CHERI_MRS_FLAGS_INITIALIZED)) {
 		xo_emit(" {:mrs_flags/%5s/%s}", "-----");
 		xo_emit(" {:mrs_max_ratio/%4s/%s}", "-");
 		xo_emit(" {:mrs_ratio/%4s/%s}", "-");

--- a/usr.bin/procstat/procstat_mrs.c
+++ b/usr.bin/procstat/procstat_mrs.c
@@ -63,7 +63,7 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 			    "START");
 	}
 
-	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
+	xo_emit("{:process_id/%5d/%d}", kipp->ki_pid);
 	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
 
 	if (procstat_getmrs(procstat, kipp, &cms) != 0 ||
@@ -86,40 +86,40 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 		xo_emit("\n");
 		return;
 	}
-	xo_emit(" {:mrs_flags/%c%c%c%c%c/%c%c%c%c%c%c}",
+	xo_emit(" {:mrs_flags/%c%c%c%c%c/%c%c%c%c%c}",
 	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_ASYNCREVOKE) ? 'a' : '-',
 	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_BOUNDPTRS) ? 'b' : '-',
 	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_EVERYFREE) ? 'e' : '-',
 	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_ABORTONFAIL) ? 'f' : '-',
 	    (cms.cms_mrs_flags & CHERI_MRS_FLAGS_QUARANTINING) ? 'q' : '-');
-	xo_emit(" {:mrs_max_ratio/%4zu/%s}",
+	xo_emit(" {:mrs_max_ratio/%4zu/%zu}",
 	    (100 * cms.cms_mrs_quarantine_numerator) /
 	    cms.cms_mrs_quarantine_denominator);
-	xo_emit(" {:mrs_ratio/%4zu/%s}",
+	xo_emit(" {:mrs_ratio/%4zu/%zu}",
 	    (100 * cms.cms_mrs_bytes_inquarantine) /
 	    (cms.cms_mrs_bytes_inquarantine +
 	    cms.cms_mrs_bytes_inheap));
-	xo_emit(" {:mrs_count_inheap/%7zu/%s}",
+	xo_emit(" {:mrs_count_inheap/%7zu/%zu",
 	    cms.cms_mrs_count_inheap);
-	xo_emit(" {:mrs_bytes_inheap/%9zu/%s}",
+	xo_emit(" {:mrs_bytes_inheap/%9zu/%zu}",
 	    cms.cms_mrs_bytes_inheap);
-	xo_emit(" {:mrs_count_inquarantine/%7zu/%s}",
+	xo_emit(" {:mrs_count_inquarantine/%7zu/%zu}",
 	    cms.cms_mrs_count_inquarantine);
-	xo_emit(" {:mrs_bytes_inquarantine/%9zu/%s}",
+	xo_emit(" {:mrs_bytes_inquarantine/%9zu/%zu}",
 	    cms.cms_mrs_bytes_inquarantine);
 	if ((procstat_opts & PS_OPT_VERBOSE) != 0) {
-		xo_emit(" {:mrs_allocated_size/%9zu/%s}",
+		xo_emit(" {:mrs_allocated_size/%9zu/%zu}",
 		    cms.cms_mrs_allocated_size);
-		xo_emit(" {:mrs_max_allocated_size/%9zu/%s}",
+		xo_emit(" {:mrs_max_allocated_size/%9zu/%zu}",
 		    cms.cms_mrs_max_allocated_size);
-		xo_emit(" {:mrs_revocation_minimum/%9zu/%s}",
+		xo_emit(" {:mrs_revocation_minimum/%9zu/%zu}",
 		    cms.cms_mrs_revocation_minimum);
-		xo_emit(" {:mrs_epoch/%6zu/%s}",
+		xo_emit(" {:mrs_epoch/%6zu/%zu}",
 		    cms.cms_mrs_epoch);
 		kernel_epoch = get_revoker_epoch(procstat, kipp);
 		xo_emit(" {:kernel_epoch/%6s/%s}",
 		    kernel_epoch != NULL ? kernel_epoch : "-");
-		xo_emit(" {:mrs_s_start/%10u.%09u}",
+		xo_emit(" {:mrs_s_start/%10u.%09u/%10u.%09u}",
 		    cms.cms_mrs_ts_start.tv_sec,
 		    cms.cms_mrs_ts_start.tv_nsec);
 	}

--- a/usr.bin/procstat/procstat_mrs.c
+++ b/usr.bin/procstat/procstat_mrs.c
@@ -50,13 +50,13 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 	if ((procstat_opts & PS_OPT_NOHEADER) == 0) {
 		if ((procstat_opts & PS_OPT_VERBOSE) == 0)
 			xo_emit(
-			    "{T:/%5s %-19s %5s %4s %4s %7s %9s %7s %9s}\n",
+			    "{T:/%5s %-19s %5s %4s %4s %8s %9s %8s %9s}\n",
 			    "PID", "COMM", "FLAGS", "%TQR", "%MQR",
 			    "CHEAP", "BHEAP", "CQUAR", "BQUAR");
 		else
 			xo_emit(
-			    "{T:/%5s %-19s %5s %4s %4s %7s %9s %7s %9s "
-			    "%9s %9s %9s %6s %6s %10u.%09u}\n",
+			    "{T:/%5s %-19s %5s %4s %4s %8s %9s %8s %9s "
+			    "%9s %9s %9s %6s %6s %20s}\n",
 			    "PID", "COMM", "FLAGS", "%TQR", "%MQR",
 			    "CHEAP", "BHEAP", "CQUAR", "BQUAR",
 			    "ASIZE", "MAXASIZE", "MINRVK", "UEPOCH", "KEPOCH",
@@ -67,13 +67,14 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 	xo_emit(" {:command/%-19s/%s}", kipp->ki_comm);
 
 	if (procstat_getmrs(procstat, kipp, &cms) != 0 ||
-	    cms.cms_version != CHERI_MRS_STATS_VERSION) {
+	    cms.cms_version != CHERI_MRS_STATS_VERSION ||
+	    !(cms.cms_mrs_flags & CHERI_MFS_FLAGS_INITIALIZED)) {
 		xo_emit(" {:mrs_flags/%5s/%s}", "-----");
 		xo_emit(" {:mrs_max_ratio/%4s/%s}", "-");
 		xo_emit(" {:mrs_ratio/%4s/%s}", "-");
-		xo_emit(" {:mrs_count_inheap/%7s/%s}", "-");
+		xo_emit(" {:mrs_count_inheap/%8s/%s}", "-");
 		xo_emit(" {:mrs_bytes_inheap/%9s/%s}", "-");
-		xo_emit(" {:mrs_count_inquarantine/%7s/%s}", "-");
+		xo_emit(" {:mrs_count_inquarantine/%8s/%s}", "-");
 		xo_emit(" {:mrs_bytes_inquarantine/%9s/%s}", "-");
 		if ((procstat_opts & PS_OPT_VERBOSE) != 0) {
 			xo_emit(" {:mrs_allocated_size/%9s/%s}", "-");
@@ -99,11 +100,11 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 	    (100 * cms.cms_mrs_bytes_inquarantine) /
 	    (cms.cms_mrs_bytes_inquarantine +
 	    cms.cms_mrs_bytes_inheap));
-	xo_emit(" {:mrs_count_inheap/%7zu/%zu",
+	xo_emit(" {:mrs_count_inheap/%8zu/%zu}",
 	    cms.cms_mrs_count_inheap);
 	xo_emit(" {:mrs_bytes_inheap/%9zu/%zu}",
 	    cms.cms_mrs_bytes_inheap);
-	xo_emit(" {:mrs_count_inquarantine/%7zu/%zu}",
+	xo_emit(" {:mrs_count_inquarantine/%8zu/%zu}",
 	    cms.cms_mrs_count_inquarantine);
 	xo_emit(" {:mrs_bytes_inquarantine/%9zu/%zu}",
 	    cms.cms_mrs_bytes_inquarantine);

--- a/usr.bin/procstat/procstat_mrs.c
+++ b/usr.bin/procstat/procstat_mrs.c
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (c) 2025 Capabilities Limited
+ * Copyright (c) 2025-2026 Capabilities Limited
  *
  * This software was developed by SRI International, the University of
  * Cambridge Computer Laboratory (Department of Computer Science and
@@ -56,10 +56,11 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 		else
 			xo_emit(
 			    "{T:/%5s %-19s %5s %4s %4s %7s %9s %7s %9s "
-			    "%9s %9s %9s %6s %6s}\n",
+			    "%9s %9s %9s %6s %6s %10u.%09u}\n",
 			    "PID", "COMM", "FLAGS", "%TQR", "%MQR",
 			    "CHEAP", "BHEAP", "CQUAR", "BQUAR",
-			    "ASIZE", "MAXASIZE", "MINRVK", "UEPOCH", "KEPOCH");
+			    "ASIZE", "MAXASIZE", "MINRVK", "UEPOCH", "KEPOCH",
+			    "START");
 	}
 
 	xo_emit("{k:process_id/%5d/%d}", kipp->ki_pid);
@@ -80,6 +81,7 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 			xo_emit(" {:mrs_revocation_minimum/%9s/%s}", "-");
 			xo_emit(" {:mrs_epoch/%6s/%s}", "-");
 			xo_emit(" {:kernel_epoch/%6s/%s}", "-");
+			xo_emit(" {:mrs_ts_start/%20s}", "-");
 		}
 		xo_emit("\n");
 		return;
@@ -117,6 +119,9 @@ procstat_mrs(struct procstat *procstat, struct kinfo_proc *kipp)
 		kernel_epoch = get_revoker_epoch(procstat, kipp);
 		xo_emit(" {:kernel_epoch/%6s/%s}",
 		    kernel_epoch != NULL ? kernel_epoch : "-");
+		xo_emit(" {:mrs_s_start/%10u.%09u}",
+		    cms.cms_mrs_ts_start.tv_sec,
+		    cms.cms_mrs_ts_start.tv_nsec);
 	}
 	xo_emit("\n");
 }


### PR DESCRIPTION
This prototype allows `mrs(3)` to export internal state / statistics to the kernel via a new ELF auxarg type, which alongside a new sysctl for process monitoring allows the information to be extracted by libprocstat/procstat for monitoring purposes.

This prototype contains many limitations including the use of atomics for statistics gathering in `mrs(3)` that may either be too heavy weight, unnecessary due to the existing global lock in mrs, or possibly both.  This also lifts an approach from our c18n monitoring that, while very functional in practice, appeals for generalisation.  It's not clear that we are capturing all the information we want from mrs.  And in the absence of context from jemalloc/etc about underlying fragmentation, interpreting this data may be challenging.

However, it's very useful to get useful insight into mrs behaviour in practice.