### PR TITLE
Revert "Work around a linker or rtld issue."

### DIFF
--- a/lib/libc/gen/errlst.c
+++ b/lib/libc/gen/errlst.c
@@ -169,7 +169,6 @@ const char *const sys_errlist[] = {
 	"Integrity check failed",		/* 97 - EINTEGRITY */
 	"Memory protection violation",		/* 98 - EPROT */
 
-#ifndef __CHERI_PURE_CAPABILITY__
 /*
  * Reserved space in sys_errlist, take the next slot for a next error code.
  * Reserve prevents the array size from changing for some time.
@@ -226,7 +225,6 @@ const char *const sys_errlist[] = {
 	__uprefix,				/* 148 */
 	__uprefix,				/* 149 */
 	__uprefix,				/* 150 */
-#endif
 };
 const int sys_nerr = ELAST + 1;
 


### PR DESCRIPTION
This is no longer needed.

Spotted while adding EPROT to my patch set.