### PR TITLE
Consolidate explicit capability checks

### DIFF
--- a/sys/arm64/arm64/db_trace.c
+++ b/sys/arm64/arm64/db_trace.c
@@ -102,7 +102,7 @@ db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 #ifdef __CHERI_PURE_CAPABILITY__
 			if (!cheri_can_access(tf,
 			    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
-			    (ptraddr_t)tf, sizeof(*tf))) {
+			    sizeof(*tf))) {
 				db_printf("--- invalid trapframe %#p\n", tf);
 				break;
 			}

--- a/sys/arm64/arm64/unwind.c
+++ b/sys/arm64/arm64/unwind.c
@@ -41,7 +41,7 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (!cheri_can_access((void *)fp, CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
-	    (ptraddr_t)fp, sizeof(fp) * 2))
+	    sizeof(fp) * 2))
 		return (false);
 #endif
 

--- a/sys/cddl/dev/dtrace/aarch64/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/aarch64/dtrace_isa.c
@@ -146,7 +146,7 @@ dtrace_getustack_common(uint64_t *pcstack, int pcstack_limit, uintptr_t pc,
 #if __has_feature(capabilities)
 		if (!cheri_can_access((void * __capability)fp,
 		    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
-		    (ptraddr_t)fp, sizeof (struct unwind_state)))
+		    sizeof(struct unwind_state)))
 			break;
 		pc = dtrace_fucap(
 		    (void * __capability)(fp + sizeof (uintcap_t)));

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -185,21 +185,6 @@ cheri_is_address_inbounds(const void * __capability cap, ptraddr_t addr)
 	return (addr >= cheri_base_get(cap) && addr < cheri_top_get(cap));
 }
 
-#ifdef _KERNEL
-/*
- * Check if the capability is valid, unsealed, has the given permissions and
- * grants access to length bytes at address base.
- */
-static inline bool
-cheri_can_access(const void * __capability cap, ptraddr_t perms, ptraddr_t base,
-    size_t length)
-{
-	return (cheri_tag_get(cap) && !cheri_is_sealed(cap) &&
-	    (cheri_perms_get(cap) & perms) == perms &&
-	    base >= cheri_base_get(cap) && base + length <= cheri_top_get(cap));
-}
-#endif
-
 static inline size_t
 cheri_bytes_remaining(const void * __capability cap)
 {
@@ -207,6 +192,22 @@ cheri_bytes_remaining(const void * __capability cap)
 		return 0;
 	return cheri_length_get(cap) - cheri_offset_get(cap);
 }
+
+#ifdef _KERNEL
+/*
+ * Check if the capability is valid, unsealed, has the given permissions and
+ * grants access to length bytes at the current address
+ */
+static inline bool
+cheri_can_access(const void * __capability cap, ptraddr_t perms,
+    size_t length)
+{
+	return (cheri_tag_get(cap) && !cheri_is_sealed(cap) &&
+	    (cheri_perms_get(cap) & perms) == perms &&
+	    cheri_address_get(cap) >= cheri_base_get(cap) &&
+	    length <= cheri_bytes_remaining(cap));
+}
+#endif
 
 #define	cheri_stack_get()	__builtin_cheri_stack_get()
 

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -1438,8 +1438,7 @@ linux_file_read(struct file *file, struct uio *uio, struct ucred *active_cred,
 	linux_get_fop(filp, &fop, &ldev);
 	if (fop->read != NULL) {
 		bytes = OPW(file, td, fop->read(filp,
-		    __DECAP_CHECK(uio->uio_iov->iov_base,
-		    uio->uio_iov->iov_len),
+		    (__cheri_fromcap void *)uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset));
 		if (bytes >= 0) {
 			IOVEC_ADVANCE(uio->uio_iov, bytes);
@@ -1478,8 +1477,7 @@ linux_file_write(struct file *file, struct uio *uio, struct ucred *active_cred,
 	linux_get_fop(filp, &fop, &ldev);
 	if (fop->write != NULL) {
 		bytes = OPW(file, td, fop->write(filp,
-		    __DECAP_CHECK(uio->uio_iov->iov_base,
-		    uio->uio_iov->iov_len),
+		    (__cheri_fromcap void *)uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset));
 		if (bytes >= 0) {
 			IOVEC_ADVANCE(uio->uio_iov, bytes);

--- a/sys/compat/linuxkpi/common/src/linux_page.c
+++ b/sys/compat/linuxkpi/common/src/linux_page.c
@@ -240,7 +240,7 @@ __get_user_pages_fast(void * __capability addr, int nr_pages, int write,
 	prot = write ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
 	len = ptoa((vm_offset_t)nr_pages);
 #if __has_feature(capabilities)
-	if (!__CAP_CHECK(addr, len) || !vm_cap_allows_prot(addr, prot))
+	if (!cheri_can_access(addr, vm_map_prot2perms(prot), len))
 		return (-1);
 #endif
 	MPASS(pages != NULL);

--- a/sys/kern/kern_physio.c
+++ b/sys/kern/kern_physio.c
@@ -179,8 +179,7 @@ physio(struct cdev *dev, struct uio *uio, int ioflag)
 					bp->bio_flags |= BIO_UNMAPPED;
 				}
 			} else
-				bp->bio_data = __DECAP_CHECK(base,
-				    bp->bio_length);
+				bp->bio_data = (__cheri_fromcap caddr_t)base;
 
 			csw->d_strategy(bp);
 			if (uio->uio_rw == UIO_READ)

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2545,8 +2545,7 @@ sysctl_kern_proc_c18n(SYSCTL_HANDLER_ARGS)
 		goto out;
 	}
 
-	if (!cheri_can_access(info.stats, CHERI_PERM_LOAD,
-	    (__cheri_addr ptraddr_t)info.stats, info.stats_size)) {
+	if (!cheri_can_access(info.stats, CHERI_PERM_LOAD, info.stats_size)) {
 		error = EPROT;
 		goto out;
 	}
@@ -2578,8 +2577,7 @@ proc_read_string_properly(struct thread *td, struct proc *p,
 	if (len < 1)
 		return (EFAULT);
 	valid = MIN(len, cheri_bytes_remaining(sptr));
-	if (!cheri_can_access(sptr, CHERI_PERM_LOAD,
-	    (__cheri_addr ptraddr_t)sptr, valid))
+	if (!cheri_can_access(sptr, CHERI_PERM_LOAD, valid))
 		return (EPROT);
 	readlen = proc_readmem(td, p, (__cheri_addr ptraddr_t)sptr, buf, valid);
 	if (readlen <= 0)
@@ -2665,7 +2663,6 @@ sysctl_kern_proc_c18n_compartments(SYSCTL_HANDLER_ARGS)
 	 */
 	if (!cheri_can_access(info.comparts,
 	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
-	    (__cheri_addr vm_offset_t)info.comparts,
 	    info.comparts_size * info.comparts_entry_size)) {
 		error = EPROT;
 		goto out;

--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -2309,7 +2309,9 @@ sysctl_wire_old_buffer(struct sysctl_req *req, size_t len)
 	if (req->lock != REQ_WIRED && req->oldptr &&
 	    req->oldfunc == sysctl_old_user) {
 		if (wiredlen != 0) {
-			ret = vslock(req->oldptr, wiredlen);
+			ret = vslock(req->oldptr, wiredlen, VM_PROT_WRITE |
+			    ((req->flags & SCTL_PTROUT) != 0 ?
+			    VM_PROT_WRITE_CAP : 0));
 			if (ret != 0) {
 				if (ret != ENOMEM)
 					return (ret);

--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -894,13 +894,15 @@ umtx_key_get(const void * __capability addr, int type, int share,
 	vm_prot_t prot;
 	boolean_t wired;
 
+#if __has_feature(capabilities)
 	/*
 	 * Make sure the capability point to something valid.  This
 	 * ensures that capabilities from non-CheriABI binaries are
 	 * inside the bounds of the correct DDC.
 	 */
-	if (!__CAP_CHECK(__DECONST_CAP(void * __capability, addr), 0))
+	if (!cheri_can_access(addr, CHERI_PERM_LOAD, 1))
 		return (EPROT);
+#endif
 	key->type = type;
 	if (share == THREAD_SHARE) {
 		key->shared = 0;

--- a/sys/kern/subr_bus_dma.c
+++ b/sys/kern/subr_bus_dma.c
@@ -307,7 +307,16 @@ _bus_dmamap_load_uio(bus_dma_tag_t dmat, bus_dmamap_t map, struct uio *uio,
 		 */
 
 		minlen = resid < iov[i].iov_len ? resid : iov[i].iov_len;
-		addr = __DECAP_CHECK(iov[i].iov_base, minlen);
+#if __has_feature(capabilities)
+		/*
+		 * XXX: In principle, we could derive required permissions
+		 * from uio_rw, but callers don't (and some cases e.g.,
+		 * mpt(4) can't) set uio_rw to a sensible value.
+		 */
+		if (!cheri_can_access(iov[i].iov_base, 0, minlen))
+			return (EPROT);
+#endif
+		addr = (__cheri_fromcap char *)iov[i].iov_base;
 		if (minlen > 0) {
 			error = _bus_dmamap_load_buffer(dmat, map, addr,
 			    minlen, pmap, flags, NULL, nsegs);

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -984,8 +984,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			if (p == NULL)
 				p = "(null)";
 #ifdef __CHERI_PURE_CAPABILITY__
-			else if (!cheri_can_access(p, CHERI_PERM_LOAD,
-			    (ptraddr_t)p, 1))
+			else if (!cheri_can_access(p, CHERI_PERM_LOAD, 1))
 				p = "(invalid)";
 #endif
 			if (!dot)

--- a/sys/kern/subr_sglist.c
+++ b/sys/kern/subr_sglist.c
@@ -114,8 +114,15 @@ _sglist_append_buf(struct sglist *sg, void * __capability buf, size_t len,
 	size_t seglen;
 	int error;
 
-	if (!__CAP_CHECK(buf, len))
+#if __has_feature(capabilities)
+	/*
+	 * The memory at *buf will be accessed via physical addressing
+	 * (typically DMA).  The caller should verify the capability
+	 * permissions.
+	 */
+	if (!cheri_can_access(buf, 0, len))
 		return (EPROT);
+#endif
 
 	if (donep)
 		*donep = 0;

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -371,12 +371,14 @@ kern_shmdt_locked(struct thread *td, const void * __capability shmaddr)
 		return (EINVAL);
 	shmseg = &shmsegs[IPCID_TO_IX(shmmap_s->shmid)];
 #if __has_feature(capabilities)
-	if (!__CAP_CHECK(shmaddr, shmseg->u.shm_segsz)) {
-		KASSERT(SV_PROC_FLAG(td->td_proc, SV_CHERI),
-		    ("!__CAP_CHECK(%#lp, %zx) for non-CheriABI program",
-		    shmaddr, shmseg->u.shm_segsz));
+	/*
+	 * Ideally we'd check CHERI_PERM_STORE when this wasn't attached
+	 * with SHM_RDONLY, but that information isn't available here.
+	 */
+	if (SV_PROC_FLAG(td->td_proc, SV_CHERI) &&
+	    !cheri_can_access(shmaddr, CHERI_PERM_SW_VMEM | CHERI_PERM_LOAD,
+	    shmseg->u.shm_segsz))
 		return (EPROT);
-	}
 #endif
 #ifdef MAC
 	error = mac_sysvshm_check_shmdt(td->td_ucred, shmseg);
@@ -396,16 +398,6 @@ sys_shmdt(struct thread *td, struct shmdt_args *uap)
 {
 	const void * __capability shmaddr = uap->shmaddr;
 
-#if __has_feature(capabilities)
-	/*
-	 * Require a valid, unsealed, SW_VMEM bearing capability or NULL.
-	 * length is checked after we find our mapping.
-	 */
-	if (shmaddr != NULL &&
-	    (!cheri_tag_get(shmaddr) || cheri_is_sealed(shmaddr) ||
-	    (cheri_perms_get(shmaddr) & CHERI_PERM_SW_VMEM) == 0))
-		return (EPROT);
-#endif
 	return (kern_shmdt(td, shmaddr));
 }
 
@@ -504,24 +496,21 @@ kern_shmat_locked(struct thread *td, int shmid,
 			if ((shmflg & SHM_REMAP) == 0)
 				return (EINVAL);
 
-			reqperm = CHERI_PERM_LOAD;
+			reqperm = CHERI_PERM_SW_VMEM | CHERI_PERM_LOAD;
 			if ((shmflg & SHM_RDONLY) == 0)
 				reqperm |= CHERI_PERM_STORE;
-			if ((cheri_perms_get(shmaddr) & reqperm) != reqperm)
-				return (EPROT);
 
 			/* XXX: require that a reservation exists. */
 			/* Handle any rounding above */
 			shmaddr = cheri_address_set(shmaddr, attach_va);
-			if (!__CAP_CHECK(shmaddr, size))
-				return (EINVAL);
+			if (!cheri_can_access(shmaddr, reqperm, size))
+				return (EPROT);
 		} else {
 			/* As with mmap, untagged implies exclusive. */
 			if ((shmflg & SHM_REMAP) != 0)
 				return (EINVAL);
 			shmaddr = cheri_address_set(userspace_root_cap,
 			    attach_va);
-
 		}
 #endif
 		if ((shmflg & SHM_REMAP) != 0)

--- a/sys/kern/vfs_aio.c
+++ b/sys/kern/vfs_aio.c
@@ -1940,8 +1940,11 @@ kern_aio_return(struct thread *td, void * __capability ujob,
 	struct kaioinfo *ki;
 	long status, error;
 
-	if (!__CAP_CHECK(ujob, ops->size()))
+#if __has_feature(capabilities)
+	if (!cheri_can_access(ujob, CHERI_PERM_LOAD | CHERI_PERM_STORE,
+	    ops->size()))
 		return (EINVAL);
+#endif
 	ki = p->p_aioinfo;
 	if (ki == NULL)
 		return (EINVAL);
@@ -2099,10 +2102,13 @@ kern_aio_cancel(struct thread *td, int fd, void * __capability ujob,
 		}
 	}
 
-	if (!__CAP_CHECK(ujob, ops->size())) {
+#if __has_feature(capabilities)
+	if (ujob != NULL && !cheri_can_access(ujob,
+	    CHERI_PERM_LOAD | CHERI_PERM_STORE, ops->size())) {
 		td->td_retval[0] = AIO_NOTCANCELED;
 		return (0);
 	}
+#endif
 	AIO_LOCK(ki);
 	TAILQ_FOREACH_SAFE(job, &ki->kaio_jobqueue, plist, jobn) {
 		if ((fd == job->uaiocb.aio_fildes) &&
@@ -2171,10 +2177,13 @@ kern_aio_error(struct thread *td, struct aiocb * __capability ujob,
 		return (0);
 	}
 
-	if (!__CAP_CHECK(ujob, ops->size())) {
+#if __has_feature(capabilities)
+	if (!cheri_can_access(ujob, CHERI_PERM_LOAD | CHERI_PERM_STORE,
+	    ops->size())) {
 		td->td_retval[0] = EINVAL;
 		return (0);
 	}
+#endif
 	AIO_LOCK(ki);
 	TAILQ_FOREACH(job, &ki->kaio_all, allist) {
 		if (job->ujob == ujob) {

--- a/sys/netpfil/ipfw/ip_fw_sockopt.c
+++ b/sys/netpfil/ipfw/ip_fw_sockopt.c
@@ -3747,7 +3747,8 @@ ipfw_ctl3(struct sockopt *sopt)
 
 			if (size < valsize) {
 				/* We have to wire user buffer */
-				error = vslock(sopt->sopt_val, valsize);
+				error = vslock(sopt->sopt_val, valsize,
+				    VM_PROT_WRITE);
 				if (error != 0)
 					return (error);
 				locked = 1;

--- a/sys/opencrypto/criov.c
+++ b/sys/opencrypto/criov.c
@@ -663,8 +663,7 @@ cuio_apply(struct uio *uio, int off, int len,
 		KASSERT(iol >= 0, ("%s: empty", __func__));
 		count = min(iov->iov_len - off, len);
 		rval = (*f)(arg,
-		    __DECAP_CHECK(((char * __capability)iov->iov_base) + off,
-		    count), count);
+		    ((__cheri_fromcap char *)iov->iov_base) + off, count);
 		if (rval)
 			return (rval);
 		len -= count;

--- a/sys/riscv/riscv/db_trace.c
+++ b/sys/riscv/riscv/db_trace.c
@@ -86,7 +86,7 @@ db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 #ifdef __CHERI_PURE_CAPABILITY__
 			if (!cheri_can_access(tf,
 			    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
-			    (ptraddr_t)tf, sizeof(*tf))) {
+			    sizeof(*tf))) {
 				db_printf("--- invalid trapframe %#p\n", tf);
 				break;
 			}

--- a/sys/riscv/riscv/unwind.c
+++ b/sys/riscv/riscv/unwind.c
@@ -46,8 +46,8 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 	fp = frame->fp;
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	if (!cheri_can_access((void *)fp, CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
-	    (ptraddr_t)fp - sizeof(fp) * 2, sizeof(fp) * 2))
+	if (!cheri_can_access((void *)(fp - sizeof(fp) * 2),
+	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP, sizeof(fp) * 2))
 		return (false);
 #endif
 

--- a/sys/sys/cdefs.h
+++ b/sys/sys/cdefs.h
@@ -610,35 +610,6 @@
 #define	__DEQUALIFY_CAP		__DEQUALIFY
 #endif
 
-#ifndef __CAP_CHECK
-#if __has_feature(capabilities)
-#define __CAP_CHECK(cap, len) ({					\
-	int ret = __builtin_cheri_tag_get(cap);				\
-	size_t caplen = __builtin_cheri_length_get(cap);		\
-	size_t capoff = __builtin_cheri_offset_get(cap);		\
-	if (capoff < 0 || capoff > caplen || caplen - capoff < (len))	\
-		ret = 0;						\
-	ret;								\
-})
-#else
-#define	__CAP_CHECK(cap, len)	1
-#endif
-#endif
-
-#ifndef __DECAP_CHECK
-#if __has_feature(capabilities)
-#define __DECAP_CHECK(cap, len)						\
-({									\
-	void * __capability tmpcap = (cap);				\
-	if (!__CAP_CHECK((cap), (len)))					\
-		tmpcap = NULL;						\
-	(__cheri_fromcap void *)(tmpcap);				\
-})
-#else
-#define __DECAP_CHECK(cap, len) (cap)
-#endif
-#endif
-
 #if !defined(_STANDALONE) && !defined(_KERNEL)
 #define	__RENAME(x)	__asm(__STRING(x))
 #else /* _STANDALONE || _KERNEL */

--- a/sys/vm/vm_extern.h
+++ b/sys/vm/vm_extern.h
@@ -128,7 +128,7 @@ uint64_t vmspace_cid_alloc(struct vmspace *);
 #endif
 void vnode_pager_setsize(struct vnode *, vm_ooffset_t);
 void vnode_pager_purge_range(struct vnode *, vm_ooffset_t, vm_ooffset_t);
-int vslock(void * __capability, size_t);
+int vslock(void * __capability, size_t, vm_prot_t);
 void vsunlock(void * __capability, size_t);
 struct sf_buf *vm_imgact_map_page(vm_object_t object, vm_ooffset_t offset);
 void vm_imgact_unmap_page(struct sf_buf *sf);

--- a/sys/vm/vm_fault.c
+++ b/sys/vm/vm_fault.c
@@ -2367,7 +2367,7 @@ vm_fault_quick_hold_pages(vm_map_t map, void * __capability addr, vm_size_t len,
 	if (len == 0)
 		return (0);
 #if __has_feature(capabilities)
-	if (!__CAP_CHECK(addr, len) || !vm_cap_allows_prot(addr, prot))
+	if (!cheri_can_access(addr, vm_map_prot2perms(prot), len))
 		return (-1);
 #endif
 	start = (__cheri_addr vm_offset_t)trunc_page(addr);

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -171,7 +171,7 @@ useracc(void * __capability cap, int len, int rw)
 	    ("illegal ``rw'' argument to useracc (%x)\n", rw));
 	prot = rw;
 #if __has_feature(capabilities)
-	if (!__CAP_CHECK(cap, len) || !vm_cap_allows_prot(cap, prot))
+	if (!cheri_can_access(cap, vm_map_prot2perms(prot), len))
 		return (false);
 #endif
 	addr = (__cheri_addr vm_offset_t)cap;
@@ -193,8 +193,11 @@ vslock(void * __capability addr, size_t len, vm_prot_t prot __unused)
 	vm_size_t npages;
 	int error;
 
-	if (!__CAP_CHECK(addr, len))
+#if __has_feature(capabilities)
+	if (!cheri_can_access(addr,
+	    vm_map_prot2perms(prot | VM_PROT_NO_IMPLY_CAP), len))
 		return (EPROT);
+#endif
 	vaddr = (__cheri_addr vm_offset_t)addr;
 	last = vaddr + len;
 	start = trunc_page(vaddr);

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -187,7 +187,7 @@ useracc(void * __capability cap, int len, int rw)
 }
 
 int
-vslock(void * __capability addr, size_t len)
+vslock(void * __capability addr, size_t len, vm_prot_t prot __unused)
 {
 	vm_offset_t end, last, start, vaddr;
 	vm_size_t npages;

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -138,7 +138,8 @@ cap_covers_pages(const void * __capability cap, size_t size)
 	size += pageoff;
 	size = (vm_size_t)round_page(size);
 
-	return (__CAP_CHECK(__DECONST_CAP(void * __capability, addr), size));
+	/* Individual syscalls check perms */
+	return (cheri_can_access(addr, 0, size));
 }
 
 static uintcap_t


### PR DESCRIPTION
Previously we had __CAP_CHECK (which checked the tag and there was a certain amount of space after the cursor), __DECAP_CHECK (which checked the capability with __CAP_CHECK and returned a pointer), and cheri_can_access (which checked the pointer was tagged, unsealed, had the requested permissions, and had sufficient space and the given base address).  Simplify cheri_can_access by removing the base address argument since it was almost always simply the capability at the current position and consolidate all checks to use cheri_can_access.

A few cases use `0` for the requested permissions which could presumably be improved, but this should be strictly an improvement in that I've general added permissions and we're now checking that capability aren't sealed.  The latter is a security issue for usecases where capabilities to secrets are sealed and passed around, but that's not currently a common pattern so I'm not in a tearing hurry to fix it in older releases.