### PR TITLE
Drop stale CHERI CHANGES annotations

### DIFF
--- a/cddl/contrib/opensolaris/tools/ctf/common/utils.c
+++ b/cddl/contrib/opensolaris/tools/ctf/common/utils.c
@@ -20,16 +20,6 @@
  * CDDL HEADER END
  */
 /*
- * CHERI CHANGES START
- * {
- *   "updated": 20230509,
- *   "target_type": "lib",
- *   "changes": [],
- *   "change_comment": "duplicate definition of vwarn()"
- * }
- * CHERI CHANGES END
- */
-/*
  * Copyright (c) 1998-2001 by Sun Microsystems, Inc.
  * All rights reserved.
  */

--- a/contrib/atf/atf-c/check.c
+++ b/contrib/atf/atf-c/check.c
@@ -22,19 +22,6 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221128,
- *   "target_type": "lib",
- *   "changes": [
- *     "integer_provenance"
- *   ],
- *   "change_comment": "",
- *   "hybrid_specific": true
- * }
- * CHERI CHANGES END
- */
 
 #include "atf-c/check.h"
 

--- a/contrib/atf/atf-c/detail/process.c
+++ b/contrib/atf/atf-c/detail/process.c
@@ -22,18 +22,6 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221128,
- *   "target_type": "lib",
- *   "changes": [
- *     "integer_provenance"
- *   ],
- *   "hybrid_specific": true
- * }
- * CHERI CHANGES END
- */
 
 #include "atf-c/detail/process.h"
 

--- a/contrib/atf/atf-c/tc.c
+++ b/contrib/atf/atf-c/tc.c
@@ -22,18 +22,6 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221128,
- *   "target_type": "lib",
- *   "changes": [
- *     "integer_provenance"
- *   ],
- *   "hybrid_specific": true
- * }
- * CHERI CHANGES END
- */
 
 #include "atf-c/tc.h"
 

--- a/contrib/less/cmdbuf.c
+++ b/contrib/less/cmdbuf.c
@@ -6,17 +6,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 
 /*

--- a/contrib/less/command.c
+++ b/contrib/less/command.c
@@ -7,17 +7,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 
 /*

--- a/contrib/less/less.h
+++ b/contrib/less/less.h
@@ -6,17 +6,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 #define NEWBOT 1
 

--- a/contrib/less/line.c
+++ b/contrib/less/line.c
@@ -6,17 +6,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 /*
  * Routines to manipulate the "line buffer".

--- a/contrib/less/option.c
+++ b/contrib/less/option.c
@@ -6,17 +6,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 
 /*

--- a/contrib/less/screen.c
+++ b/contrib/less/screen.c
@@ -6,17 +6,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 
 /*

--- a/contrib/less/tags.c
+++ b/contrib/less/tags.c
@@ -6,17 +6,6 @@
  *
  * For more information, see the README file.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "prog",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 
 #include "less.h"

--- a/contrib/ntp/libntp/work_thread.c
+++ b/contrib/ntp/libntp/work_thread.c
@@ -1,18 +1,6 @@
 /*
  * work_thread.c - threads implementation for blocking worker child.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181113,
- *   "target_type": "lib",
- *   "changes": [
- *     "pointer_as_integer"
- *   ],
- *   "accepted_upstream": true
- * }
- * CHERI CHANGES END
- */
 #include <config.h>
 #include "ntp_workimpl.h"
 

--- a/lib/libc/sys/creat.c
+++ b/lib/libc/sys/creat.c
@@ -28,17 +28,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20181121,
- *   "target_type": "lib",
- *   "changes": [
- *     "calling_convention"
- *   ]
- * }
- * CHERI CHANGES END
- */
 
 #include "namespace.h"
 #include <fcntl.h>

--- a/lib/libthr/thread/thr_ctrdtr.c
+++ b/lib/libthr/thread/thr_ctrdtr.c
@@ -25,18 +25,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-/*
- * CHERI CHANGES START
- * {
- *   "updated": 20221129,
- *   "target_type": "lib",
- *   "changes": [
- *     "pointer_shape"
- *   ],
- *   "change_comment": "TLS alignment"
- * }
- * CHERI CHANGES END
- */
 
 #include <sys/types.h>
 #include <rtld_tls.h>

--- a/lib/libufs/sblock.c
+++ b/lib/libufs/sblock.c
@@ -289,13 +289,3 @@ use_pwrite(void *devfd, off_t loc, void *buf, int size)
 		return (EIO);
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20221129,
-//   "target_type": "lib",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ],
-//   "change_comment": "embedded pointer storage in superblock"
-// }
-// CHERI CHANGES END

--- a/sbin/dumpfs/dumpfs.c
+++ b/sbin/dumpfs/dumpfs.c
@@ -532,13 +532,3 @@ usage(void)
 	(void)fprintf(stderr, "usage: dumpfs [-flm] filesys | device\n");
 	exit(1);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20221129,
-//   "target_type": "prog",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ],
-//   "change_comment": "embedded pointer storage in superblock"
-// }
-// CHERI CHANGES END

--- a/sbin/newfs/mkfs.c
+++ b/sbin/newfs/mkfs.c
@@ -1228,13 +1228,3 @@ newfs_random(void)
 		return (nextnum++);
 	return (arc4random());
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20221129,
-//   "target_type": "prog",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ],
-//   "change_comment": "embedded pointer storage in superblock"
-// }
-// CHERI CHANGES END

--- a/sys/compat/freebsd32/freebsd32_signal.h
+++ b/sys/compat/freebsd32/freebsd32_signal.h
@@ -64,12 +64,3 @@ int convert_sigevent32(struct sigevent32 *sig32, struct sigevent *sig);
 void siginfo_to_siginfo32(const siginfo_t *src, struct __siginfo32 *dst);
 
 #endif /* !_COMPAT_FREEBSD32_SIGNAL_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "header",
-//   "changes": [
-//     "kernel_sig_types"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/compat/linux/linux_getcwd.c
+++ b/sys/compat/linux/linux_getcwd.c
@@ -77,12 +77,3 @@ linux_getcwd(struct thread *td, struct linux_getcwd_args *uap)
 	free(buf, M_TEMP);
 	return (error);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/usb/controller/dwc_otg.c
+++ b/sys/dev/usb/controller/dwc_otg.c
@@ -4968,12 +4968,3 @@ static const struct usb_bus_methods dwc_otg_bus_methods =
 	.device_resume = &dwc_otg_device_resume,
 	.device_suspend = &dwc_otg_device_suspend,
 };
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes_purecap": [
-//     "pointer_as_integer"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/dev/usb/usb_pf.c
+++ b/sys/dev/usb/usb_pf.c
@@ -529,12 +529,3 @@ usbpf_xfertap(struct usb_xfer *xfer, int type)
 
 	free(buf, M_TEMP);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/geom/journal/g_journal_ufs.c
+++ b/sys/geom/journal/g_journal_ufs.c
@@ -108,12 +108,3 @@ const struct g_journal_desc g_journal_ufs = {
 
 MODULE_DEPEND(g_journal, ufs, 1, 1, 1);
 MODULE_VERSION(geom_journal, 0);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/geom/label/g_label_ufs.c
+++ b/sys/geom/label/g_label_ufs.c
@@ -204,12 +204,3 @@ G_LABEL_INIT(ufsid, g_label_ufs_id, "Create device nodes for UFS file system IDs
 G_LABEL_INIT(ufs, g_label_ufs_volume, "Create device nodes for UFS volume names");
 
 MODULE_DEPEND(g_label, ufs, 1, 1, 1);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/kern/subr_busdma_bufalloc.c
+++ b/sys/kern/subr_busdma_bufalloc.c
@@ -165,12 +165,3 @@ busdma_bufalloc_free_uncacheable(void *item, vm_size_t size, uint8_t pflag)
 
 	kmem_free(item, size);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes_purecap": [
-//     "pointer_as_integer"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/kern/sys_socket.c
+++ b/sys/kern/sys_socket.c
@@ -845,12 +845,3 @@ soo_aio_queue(struct file *fp, struct kaiocb *job)
 	SOCK_BUF_UNLOCK(so, which);
 	return (0);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "iovec-macros"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/net/if_enc.c
+++ b/sys/net/if_enc.c
@@ -447,12 +447,3 @@ static moduledata_t enc_mod = {
 
 DECLARE_MODULE(if_enc, enc_mod, SI_SUB_PSEUDO, SI_ORDER_ANY);
 MODULE_VERSION(if_enc, 1);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/net/if_epair.c
+++ b/sys/net/if_epair.c
@@ -929,12 +929,3 @@ static moduledata_t epair_mod = {
 
 DECLARE_MODULE(if_epair, epair_mod, SI_SUB_PSEUDO, SI_ORDER_MIDDLE);
 MODULE_VERSION(if_epair, 3);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/net/if_llatbl.h
+++ b/sys/net/if_llatbl.h
@@ -307,12 +307,3 @@ enum {
 typedef void (*lle_event_fn)(void *, struct llentry *, int);
 EVENTHANDLER_DECLARE(lle_event, lle_event_fn);
 #endif  /* _NET_IF_LLATBL_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "header",
-//   "changes_purecap": [
-//     "subobject_bounds"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/net/if_vxlan.c
+++ b/sys/net/if_vxlan.c
@@ -3693,12 +3693,3 @@ static moduledata_t vxlan_mod = {
 
 DECLARE_MODULE(if_vxlan, vxlan_mod, SI_SUB_PSEUDO, SI_ORDER_ANY);
 MODULE_VERSION(if_vxlan, 1);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/net/ifdi_if.m
+++ b/sys/net/ifdi_if.m
@@ -364,12 +364,3 @@ METHOD bool needs_restart {
 	if_ctx_t _ctx;
 	enum iflib_restart_event _event;
 } DEFAULT null_needs_restart;
-# CHERI CHANGES START
-# {
-#   "updated": 20230509,
-#   "target_type": "kernel",
-#   "changes": [
-#     "user_capabilities"
-#   ]
-# }
-# CHERI CHANGES END

--- a/sys/net/route/route_ctl.c
+++ b/sys/net/route/route_ctl.c
@@ -1579,12 +1579,3 @@ rib_print_family(int family)
 	return ("unknown");
 }
 
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes_purecap": [
-//     "subobject_bounds"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/net80211/ieee80211_freebsd.c
+++ b/sys/net80211/ieee80211_freebsd.c
@@ -1191,12 +1191,3 @@ MODULE_DEPEND(wlan, ether, 1, 1, 1);
 #ifdef	IEEE80211_ALQ
 MODULE_DEPEND(wlan, alq, 1, 1, 1);
 #endif	/* IEEE80211_ALQ */
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/netinet/in_pcb.h
+++ b/sys/netinet/in_pcb.h
@@ -739,15 +739,3 @@ void	in_pcboutput_eagain(struct inpcb *);
 #endif /* _KERNEL */
 
 #endif /* !_NETINET_IN_PCB_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "header",
-//   "changes": [
-//     "integer_provenance"
-//   ],
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/netinet/tcp_subr.c
+++ b/sys/netinet/tcp_subr.c
@@ -4776,12 +4776,3 @@ tcp_account_for_send(struct tcpcb *tp, uint32_t len, uint8_t is_rxt,
 	}
 #endif
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes_purecap": [
-//     "subobject_bounds"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/netpfil/pf/if_pflog.c
+++ b/sys/netpfil/pf/if_pflog.c
@@ -360,12 +360,3 @@ static moduledata_t pflog_mod = { pflogname, pflog_modevent, 0 };
 DECLARE_MODULE(pflog, pflog_mod, SI_SUB_PROTO_FIREWALL, SI_ORDER_ANY);
 MODULE_VERSION(pflog, PFLOG_MODVER);
 MODULE_DEPEND(pflog, pf, PF_MODVER, PF_MODVER, PF_MODVER);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/opencrypto/cryptosoft.c
+++ b/sys/opencrypto/cryptosoft.c
@@ -1752,13 +1752,3 @@ extern int crypto_modevent(struct module *, int, void *);
 DRIVER_MODULE(cryptosoft, nexus, swcr_driver, crypto_modevent, NULL);
 MODULE_VERSION(cryptosoft, 1);
 MODULE_DEPEND(cryptosoft, crypto, 1, 1, 1);
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "iovec-macros",
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/security/mac/mac_internal.h
+++ b/sys/security/mac/mac_internal.h
@@ -525,12 +525,3 @@ int	vn_setlabel(struct vnode *vp, struct label *intlabel,
 } while (0)
 
 #endif /* !_SECURITY_MAC_MAC_INTERNAL_H_ */
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "header",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/sys/security/mac/mac_socket.c
+++ b/sys/security/mac/mac_socket.c
@@ -638,12 +638,3 @@ mac_getsockopt_peerlabel(struct ucred *cred, struct socket *so,
 
 	return (error);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20230509,
-//   "target_type": "kernel",
-//   "changes": [
-//     "user_capabilities"
-//   ]
-// }
-// CHERI CHANGES END

--- a/usr.sbin/makefs/ffs/ffs_alloc.c
+++ b/usr.sbin/makefs/ffs/ffs_alloc.c
@@ -674,13 +674,3 @@ ffs_clusteracct(struct fs *fs, struct cg *cgp, int32_t blkno, int cnt)
 			break;
 	fs->fs_maxcluster[ufs_rw32(cgp->cg_cgx, needswap)] = i;
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20190628,
-//   "target_type": "prog",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ],
-//   "change_comment": "embedded pointer storage in superblock"
-// }
-// CHERI CHANGES END

--- a/usr.sbin/makefs/ffs/mkfs.c
+++ b/usr.sbin/makefs/ffs/mkfs.c
@@ -871,13 +871,3 @@ ilog2(int val)
 			return (n);
 	errx(1, "%s: %d is not a power of 2", __func__, val);
 }
-// CHERI CHANGES START
-// {
-//   "updated": 20190628,
-//   "target_type": "prog",
-//   "changes_purecap": [
-//     "pointer_shape"
-//   ],
-//   "change_comment": "embedded pointer storage in superblock"
-// }
-// CHERI CHANGES END

--- a/usr.sbin/mountd/mountd.c
+++ b/usr.sbin/mountd/mountd.c
@@ -31,17 +31,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-// CHERI CHANGES START
-// {
-//   "updated": 20200721,
-//   "target_type": "prog",
-//   "changes": [
-//     "other"
-//   ],
-//   "change_comment": "Fix buffer underread"
-// }
-// CHERI CHANGES END
-
 
 #include <sys/param.h>
 #include <sys/conf.h>


### PR DESCRIPTION
The annotations are the only downstream diff in all of these files.
