### PR TITLE
Revert "newsyslog: Wrap months when parsing 'W' rules."

### DIFF
--- a/usr.sbin/newsyslog/ptimes.c
+++ b/usr.sbin/newsyslog/ptimes.c
@@ -275,7 +275,7 @@ parseDWM(struct ptime_data *ptime, const char *s)
 				tm.tm_mday += save;
 
 				if (tm.tm_mday > daysmon) {
-					tm.tm_mon = (tm.tm_mon + 1) % 12;
+					tm.tm_mon++;
 					tm.tm_mday = tm.tm_mday - daysmon;
 					if (tm.tm_mon >= 12) {
 						tm.tm_mon = 0;


### PR DESCRIPTION
This was fixed differently by upstream commit
b7b447fd4ca327faa99b2f16e6cbd61c86c75f04.

This reverts commit 12f1b3ac3299e5b0df4ea67152531bc08669ed8f.
