### PR TITLE
bsd.compat.mk: Use correct OS version for LIB64(C(B)) triples

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -107,7 +107,7 @@ LIB64_MACHINE_ARCH=aarch64
 LIB64WMAKEENV=	MACHINE_CPU="arm64 cheri"
 LIB64WMAKEFLAGS= LD="${XLD}" CPUTYPE=morello
 # XXX: clang specific
-LIB64CPUFLAGS=	-target aarch64-unknown-freebsd13.0
+LIB64CPUFLAGS=	-target aarch64-unknown-freebsd${OS_REVISION}
 LIB64CPUFLAGS+=	-march=morello -mabi=aapcs
 .endif
 
@@ -119,7 +119,7 @@ LIB64_MACHINE_ARCH=riscv64
 LIB64WMAKEENV=	MACHINE_CPU="riscv cheri"
 LIB64WMAKEFLAGS= LD="${XLD}" CPUTYPE=cheri
 # XXX: clang specific
-LIB64CPUFLAGS=	-target riscv64-unknown-freebsd13.0
+LIB64CPUFLAGS=	-target riscv64-unknown-freebsd${OS_REVISION}
 LIB64CPUFLAGS+=	-march=${LIB64_RISCV_MARCH} -mabi=${LIB64_RISCV_ABI}
 .endif
 
@@ -136,14 +136,14 @@ LIB64_MACHINE_ABI=	${MACHINE_ABI:Npurecap:Nptr*} ptr64
 HAS_COMPAT+=	64C
 LIB64C_MACHINE=	arm64
 LIB64C_MACHINE_ARCH=	aarch64c
-LIB64CCPUFLAGS=	-target aarch64-unknown-freebsd13.0
+LIB64CCPUFLAGS=	-target aarch64-unknown-freebsd${OS_REVISION}
 LIB64CCPUFLAGS+=	-march=morello -mabi=purecap
 .elif ${COMPAT_ARCH:Mriscv64*} && !${COMPAT_ARCH:Mriscv64*c*}
 HAS_COMPAT+=	64C
 LIB64C_MACHINE=	riscv
 LIB64C_MACHINE_ARCH=	${COMPAT_ARCH}c
 LIB64CWMAKEFLAGS=	CPUTYPE=cheri
-LIB64CCPUFLAGS=	-target riscv64-unknown-freebsd13.0
+LIB64CCPUFLAGS=	-target riscv64-unknown-freebsd${OS_REVISION}
 LIB64C_RISCV_ABI=	l64pc128d
 LIB64CCPUFLAGS+=	-march=${LIB64C_RISCV_MARCH} -mabi=${LIB64C_RISCV_ABI}
 .endif	# ${COMPAT_ARCH:Mriscv64*}
@@ -195,7 +195,7 @@ LIB64CCFLAGS+=	-mllvm -cheri-subobject-bounds-clear-swperm=2
 HAS_COMPAT+=	64CB
 LIB64CB_MACHINE=	arm64
 LIB64CB_MACHINE_ARCH=aarch64cb
-LIB64CBCPUFLAGS=	-target aarch64-unknown-freebsd13.0
+LIB64CBCPUFLAGS=	-target aarch64-unknown-freebsd${OS_REVISION}
 LIB64CBCPUFLAGS+=	-march=morello -mabi=purecap-benchmark
 LIB64CB_MACHINE_ABI=	${MACHINE_ABI:Nptr*:Npurecap} purecap ptr128c benchmark
 


### PR DESCRIPTION
These were originally correct, but were not bumped for 14.0, nor
switched to use $(OS_REVISION} in order to automatically pick up the
newvers.sh bump to 15.0.

Fixes:	5aa52ff0bcd4 ("Bump CURRENT to 14.0")
Fixes:	5e6a057733b7 ("build target triple variable from sys/conf/newvers.sh")
