### PR TITLE
Sub-object c18n test

### DIFF
--- a/bin/cheribsdtest/Makefile.cheribsdtest
+++ b/bin/cheribsdtest/Makefile.cheribsdtest
@@ -35,6 +35,12 @@ SRCS+=	cheribsdtest_bounds_subobject.c					\
 	cheribsdtest_bounds_varargs.c					\
 	cheribsdtest_malloc.c						\
 	cheribsdtest_sentries.c
+
+.if ${MK_COMPARTMENT_POLICY} != "no"
+SRCS+=	cheribsdtest_compartments.c
+CFLAGS.cheribsdtest_compartments.c+=-ffunction-sections
+COMPARTMENT_POLICY=	${CHERIBSDTEST_DIR}/compartments.json
+.endif
 .endif
 
 CHERIBSDTEST_DIR:=	${.PARSEDIR}

--- a/bin/cheribsdtest/cheribsdtest_compartments.c
+++ b/bin/cheribsdtest/cheribsdtest_compartments.c
@@ -1,0 +1,46 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 John Baldwin
+ *
+ * This software was developed by SRI International, the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology), and Capabilities Limited under Defense Advanced Research
+ * Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
+ */
+
+#include <cheri/cheric.h>
+
+#include "cheribsdtest.h"
+
+static void
+compartment_one_foo(void)
+{
+}
+
+static void
+compartment_two_foo(void)
+{
+}
+
+static void
+assert_disjoint_bounds(void *one, void *two, const char *label_one,
+    const char *label_two)
+{
+	CHERIBSDTEST_VERIFY2(
+	    !cheri_is_address_inbounds(one, cheri_base_get(two)) &&
+	    !cheri_is_address_inbounds(two, cheri_base_get(one)),
+	    "%#p (%s) and %#p (%s) overlap", one, label_one, two, label_two);
+}
+
+CHERIBSDTEST(compartment_pcc_bounds,
+    "Check that PCC bounds of sub-object compartments are disjoint")
+{
+	assert_disjoint_bounds(&compartment_one_foo, &compartment_two_foo,
+	    "compartment_one_foo", "compartment_two_foo");
+	assert_disjoint_bounds(&compartment_one_foo, &compartment_pcc_bounds,
+	    "compartment_one_foo", "compartment_pcc_bounds");
+	assert_disjoint_bounds(&compartment_two_foo, &compartment_pcc_bounds,
+	    "compartment_two_foo", "compartment_pcc_bounds");
+	cheribsdtest_success();
+}

--- a/bin/cheribsdtest/compartments.json
+++ b/bin/cheribsdtest/compartments.json
@@ -1,0 +1,14 @@
+{
+  "compartments": {
+    "one": {
+      "symbols": [
+        "compartment_one_foo"
+      ]
+    },
+    "two": {
+      "symbols": [
+        "compartment_two_foo"
+      ]
+    }
+  }
+}

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -153,6 +153,31 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 		}
 	}
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	/*
+	 * Pure capability executables with multiple compartments
+	 * might have multiple writable and executable segments.
+	 * However, the capabilities for `phdr` and the current PCC
+	 * should be constrained to the executable.  Trust relocations
+	 * to further narrow bounds as needed.
+	 *
+	 * XXX: Once PT_CHERI_PCC is required for pure capability
+	 * binaries, the purecap version of this function should be
+	 * simplified such that the phdrs are only examined for
+	 * hybrid.
+	 */
+	if (use_code_bounds) {
+		code_cap = cheri_pcc_get();
+		data_cap = __DECONST(void *, phdr);
+		data_cap = cheri_perms_clear(data_cap,
+		    CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
+		rodata_cap = cheri_perms_clear(data_cap,
+		    CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
+		    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
+		goto handle_relocs;
+	}
+#endif
+
 	if (!have_text_segment) {
 		/* No text segment??? Must be an error somewhere else. */
 		__builtin_trap();
@@ -221,6 +246,9 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 			__builtin_trap();
 	}
 
+#ifdef __CHERI_PURE_CAPABILITY__
+handle_relocs:
+#endif
 	start_relocs = CHERI_RODATA_PTR(__start___cap_relocs);
 	stop_relocs = CHERI_RODATA_PTR(__stop___cap_relocs);
 


### PR DESCRIPTION
- **csu: Don't require a single segment of each type for purecap**
- **cheribsdtest: Add initial sub-object compartments test**
