### PR TITLE
Various ace2 fixes

### DIFF
--- a/share/man/man4/ace2.4
+++ b/share/man/man4/ace2.4
@@ -24,12 +24,13 @@ module provides the following character devices in
 .It Pa ace2-ace-data
 Permits reading and writing arbitrary scalar data.
 The offset of the read or write operation specifies the starting kernel
-virtual address similar to
-.Pa /dev/kmem .
+virtual address as an offset relative to
+.Dv VM_MIN_KERNEL_ADDRESS .
 .It Pa ace2-ace-capability
 Permits reading and writing capability addresses.
 The offset of the read or write operation specifies the starting kernel
-virtual address.
+virtual address as an offset relative to
+.Dv VM_MIN_KERNEL_ADDRESS .
 The length of the user request only covers the address portion of capabilities,
 so on CHERI systems it will be half of the address range examined.
 Reads return the addresses of capability in the requested range,
@@ -41,8 +42,9 @@ if the new address is unrepresentable.
 Each write operation copies a single capability from one kernel address to
 another.
 The offset of the write operation specifies the destination kernel virtual
-address.
-The write payload contains the source kernel virtual address
+address as an offset relative to
+.Dv VM_MIN_KERNEL_ADDRESS .
+The write payload contains the absolute source kernel virtual address
 (as a binary
 .Vt ptraddr_t
 value) of the capability to copy.
@@ -55,6 +57,9 @@ value) of the capability to copy.
 .It Pa /dev/ace2-ace-data
 .Sh DIAGNOSTICS
 .Bl -diag
+.It "ace2: ACE2_BASE %p"
+Offsets to read and write operations are treated as relative offsets to
+the given kernel address.
 .It "ace2: ACE2_COPY_CAPABILITY from %p to %p"
 A capability was copied from the first address to the second address.
 .It "ace2: ACE2_READ_CAPABILITY %zu pointers at %p"

--- a/share/man/man4/ace2.4
+++ b/share/man/man4/ace2.4
@@ -7,7 +7,7 @@
 .\" Technology), and Capabilities Limited under Defense Advanced Research
 .\" Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
 .\"
-.Dd December 2, 2025
+.Dd February 5, 2026
 .Dt ACE2 4
 .Os
 .Sh NAME
@@ -53,4 +53,27 @@ value) of the capability to copy.
 .It Pa /dev/ace2-ace-capability
 .It Pa /dev/ace2-ace-copycap
 .It Pa /dev/ace2-ace-data
+.Sh DIAGNOSTICS
+.Bl -diag
+.It "ace2: ACE2_COPY_CAPABILITY from %p to %p"
+A capability was copied from the first address to the second address.
+.It "ace2: ACE2_READ_CAPABILITY %zu pointers at %p"
+The addresses for an array of capabilities were read from the given address.
+.It "ace2: ACE2_READ_CAPABILITY EFAULT %zu pointers at %p"
+An attempt to read the addresses of an array of capabilities from the given
+address failed.
+.It "ace2: ACE2_READ_DATA %zu bytes at %p"
+An array of bytes were read from the given address.
+.It "ace2: ACE2_READ_DATA EFAULT %zu bytes at %p"
+An attempt to read an array of bytes from the given address failed.
+.It "ace2: ACE2_WRITE_CAPABILITY %zu pointers at %p"
+New addresses were set for an array of capabilities at the given address.
+.It "ace2: ACE2_WRITE_CAPABILITY EFAULT %zu pointers at %p"
+An attempt to set the addresses for an array of capabilities at the given
+address failed.
+.It "ace2: ACE2_WRITE_DATA %zu bytes at %p"
+An array of bytes were written to the given address.
+.It "ace2: ACE2_WRITE_DATA EFAULT %zu bytes at %p"
+An attempt to write an array of bytes to the given address failed.
+.El
 .El

--- a/share/man/man4/ace2_syncpoint.4
+++ b/share/man/man4/ace2_syncpoint.4
@@ -7,7 +7,7 @@
 .\" Technology), and Capabilities Limited under Defense Advanced Research
 .\" Projects Agency (DARPA) Contract No. FA8750-24-C-B047 ("DEC").
 .\"
-.Dd December 9, 2025
+.Dd February 5, 2026
 .Dt ACE2_SYNCPOINT 4
 .Os
 .Sh NAME
@@ -96,7 +96,7 @@ id = ace2_syncpoint("example1", "example %d\n", 1);
 This will generate the following output:
 .Pp
 .Bd -literal -offset indent
-ACE2_SYNC_BARRIER example1:1 /usr/src/sys/dev/sift/ace2_syncpoint/ace2_syncpoint_test.c:35:syncpoint_example1 example 1
+ace2: ACE2_SYNC_BARRIER example1:1 /usr/src/sys/dev/sift/ace2_syncpoint/ace2_syncpoint_test.c:35:syncpoint_example1 example 1
 .Ed
 .Pp
 .Ss ace2_observe
@@ -128,7 +128,7 @@ ace2_observe(id, "example1", "%d", 1);
 This will generate the following output:
 .Pp
 .Bd -literal -offset indent
-ACE2_SYNC_PASSED example1:1 /usr/src/sys/dev/sift/ace2_syncpoint/ace2_syncpoint_test.c:35:syncpoint_example1 example 1
+ace2: ACE2_SYNC_PASSED example1:1 /usr/src/sys/dev/sift/ace2_syncpoint/ace2_syncpoint_test.c:35:syncpoint_example1 example 1
 .Ed
 .Sh DEVICE NODES
 When

--- a/sys/dev/sift/ace2/ace2.c
+++ b/sys/dev/sift/ace2/ace2.c
@@ -24,6 +24,13 @@
 #include <vm/vm_param.h>
 
 /*
+ * Offsets in device files are treated as a relative offset to this
+ * base address.  Since ACE2 should only access kernel addresses, use
+ * the start of the kernel's address space as the base.
+ */
+#define	ACE2_BASE		VM_MIN_KERNEL_ADDRESS
+
+/*
  * Wrapper for printf() that outputs an "ace2: " prefix for each
  * message.
  */
@@ -104,11 +111,13 @@ static int
 ace2_data_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 {
 	void *kva;
+	ptraddr_t addr;
 	int error;
 	bool read = uio->uio_rw == UIO_READ;
 	size_t len = uio->uio_resid;
 
-	error = validate_kva_range(uio->uio_offset, len, read ? VM_PROT_READ :
+	addr = ACE2_BASE + uio->uio_offset;
+	error = validate_kva_range(addr, len, read ? VM_PROT_READ :
 	    VM_PROT_WRITE);
 	if (error != 0)
 		return (error);
@@ -123,10 +132,10 @@ ace2_data_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 	 * and may end up overly-broad.
 	 */
 #ifdef __CHERI_PURE_CAPABILITY__
-	kva = cheri_setaddress(kernel_root_cap, uio->uio_offset);
+	kva = cheri_setaddress(kernel_root_cap, addr);
 	kva = cheri_setbounds(kva, len);
 #else
-	kva = (void *)(uintptr_t)uio->uio_offset;
+	kva = (void *)(uintptr_t)addr;
 #endif
 	error = uiomove(kva, uio->uio_resid, uio);
 	if (error != 0) {
@@ -143,6 +152,7 @@ static int
 ace2_capability_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 {
 	uintptr_t *kva;
+	ptraddr_t addr;
 	int error;
 	bool read = uio->uio_rw == UIO_READ;
 	size_t len = uio->uio_resid;
@@ -152,16 +162,17 @@ ace2_capability_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 	    !is_aligned(uio->uio_offset, sizeof(void *)))
 		return (EINVAL);
 
+	addr = ACE2_BASE + uio->uio_offset;
 	nptrs = len / sizeof(ptraddr_t);
 	len = nptrs * sizeof(void *);
-	error = validate_kva_range(uio->uio_offset, len, read ? VM_PROT_READ :
+	error = validate_kva_range(addr, len, read ? VM_PROT_READ :
 	    VM_PROT_WRITE);
 	if (error != 0)
 		return (error);
 
 	/* Comments in ace2_data_rdwr apply here as well. */
 #ifdef __CHERI_PURE_CAPABILITY__
-	kva = cheri_setaddress(kernel_root_cap, uio->uio_offset);
+	kva = cheri_setaddress(kernel_root_cap, addr);
 	kva = cheri_setbounds(kva, len);
 	for (size_t i = 0; i < nptrs; i++) {
 		ptraddr_t addr;
@@ -177,7 +188,7 @@ ace2_capability_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 			kva[i] = cheri_setaddress(kva[i], addr);
 	}
 #else
-	kva = (void *)(uintptr_t)uio->uio_offset;
+	kva = (void *)(uintptr_t)addr;
 	error = uiomove(kva, uio->uio_resid, uio);
 #endif
 	if (error != 0) {
@@ -203,16 +214,16 @@ ace2_copycap_write(struct cdev *dev, struct uio *uio, int ioflag)
 	    !is_aligned(uio->uio_offset, sizeof(void *)))
 		return (EINVAL);
 
-	error = validate_kva_range(uio->uio_offset, sizeof(void *),
-	    VM_PROT_WRITE);
+	addr = ACE2_BASE + uio->uio_offset;
+	error = validate_kva_range(addr, sizeof(void *), VM_PROT_WRITE);
 	if (error != 0)
 		return (error);
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	dst = cheri_setaddress(kernel_root_cap, uio->uio_offset);
+	dst = cheri_setaddress(kernel_root_cap, addr);
 	dst = cheri_setboundsexact(dst, sizeof(void *));
 #else
-	dst = (void *)(uintptr_t)uio->uio_offset;
+	dst = (void *)(uintptr_t)addr;
 #endif
 
 	error = uiomove(&addr, sizeof(addr), uio);
@@ -249,6 +260,8 @@ ace2_modevent(module_t mod, int type, void *data)
 		    UID_ROOT, GID_WHEEL, 0600, "ace2-ace-capability");
 		ace2_copycap = make_dev(&ace2_copycap_cdevsw, 0,
 		    UID_ROOT, GID_WHEEL, 0600, "ace2-ace-copycap");
+
+		pr_sift("ACE2_BASE %p\n", (void *)(uintptr_t)ACE2_BASE);
 		return (0);
 	case MOD_UNLOAD:
 		destroy_dev(ace2_data);

--- a/sys/dev/sift/ace2/ace2.c
+++ b/sys/dev/sift/ace2/ace2.c
@@ -23,6 +23,13 @@
 #include <vm/vm_extern.h>
 #include <vm/vm_param.h>
 
+/*
+ * Wrapper for printf() that outputs an "ace2: " prefix for each
+ * message.
+ */
+#define	pr_sift(fmt, ...)						\
+	printf("ace2: " fmt, ##__VA_ARGS__)
+
 static d_open_t ace2_open;
 static d_read_t ace2_data_rdwr;
 static d_read_t ace2_capability_rdwr;
@@ -123,10 +130,10 @@ ace2_data_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 #endif
 	error = uiomove(kva, uio->uio_resid, uio);
 	if (error != 0) {
-		printf("%s EFAULT %zu bytes at %p\n", read ? "ACE2_READ_DATA" :
+		pr_sift("%s EFAULT %zu bytes at %p\n", read ? "ACE2_READ_DATA" :
 		    "ACE2_WRITE_DATA", len, kva);
 	} else {
-		printf("%s %zu bytes at %p\n", read ? "ACE2_READ_DATA" :
+		pr_sift("%s %zu bytes at %p\n", read ? "ACE2_READ_DATA" :
 		    "ACE2_WRITE_DATA", len, kva);
 	}
 	return (error);
@@ -174,11 +181,11 @@ ace2_capability_rdwr(struct cdev *dev, struct uio *uio, int ioflag)
 	error = uiomove(kva, uio->uio_resid, uio);
 #endif
 	if (error != 0) {
-		printf("%s EFAULT %zu pointers at %p\n",
+		pr_sift("%s EFAULT %zu pointers at %p\n",
 		    read ? "ACE2_READ_CAPABILITY" : "ACE2_WRITE_CAPABILITY",
 		    nptrs, kva);
 	} else {
-		printf("%s %zu pointers at %p\n",
+		pr_sift("%s %zu pointers at %p\n",
 		    read ? "ACE2_READ_CAPABILITY" : "ACE2_WRITE_CAPABILITY",
 		    nptrs, kva);
 	}
@@ -223,7 +230,7 @@ ace2_copycap_write(struct cdev *dev, struct uio *uio, int ioflag)
 	src = (void *)(uintptr_t)addr;
 #endif
 	*dst = *src;
-	printf("ACE2_COPY_CAPABILITY from %p to %p\n", src, dst);
+	pr_sift("ACE2_COPY_CAPABILITY from %p to %p\n", src, dst);
 	return (0);
 }
 

--- a/sys/dev/sift/ace2_syncpoint/ace2_syncpoint.h
+++ b/sys/dev/sift/ace2_syncpoint/ace2_syncpoint.h
@@ -14,7 +14,7 @@
 
 #ifdef _KERNEL
 
-#define	pr_sift(fmt, ...)	printf((fmt), ##__VA_ARGS__)
+#define	pr_sift(fmt, ...)	printf("ace2: " fmt, ##__VA_ARGS__)
 
 #define	ace2_syncpoint(label, fmt, ...)					\
 	__ace2_syncpoint(label, __FILE__, __LINE__, __func__, (fmt),	\

--- a/tests/sys/ace2/ace2.c
+++ b/tests/sys/ace2/ace2.c
@@ -63,7 +63,8 @@ ATF_TC_BODY(read_version, tc)
 	    "sysctl(kern.version): %s", strerror(errno));
 
 	buf2 = malloc(len);
-	nread = pread(fd, buf2, len, symbol_address("version"));
+	nread = pread(fd, buf2, len, symbol_address("version") -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(nread != -1, "pread: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(len, nread);
 	ATF_REQUIRE_INTEQ(0, memcmp(buf1, buf2, len));
@@ -89,7 +90,8 @@ ATF_TC_BODY(toggle_bootverbose, tc)
 	ATF_REQUIRE_INTEQ(sizeof(old), len);
 
 	new = old ^ 1;
-	nwritten = pwrite(fd, &new, sizeof(new), symbol_address("bootverbose"));
+	nwritten = pwrite(fd, &new, sizeof(new), symbol_address("bootverbose") -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(nwritten != -1, "pwrite: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(new), nwritten);
 
@@ -150,7 +152,8 @@ ATF_TC_BODY(adjust_malloc_description, tc)
 	memstat_mtl_free(mtlp);
 
 	/* Read the current address of ks_shortdesc. */
-	rv = pread(fd[1], &desc_addr, sizeof(desc_addr), cap_addr);
+	rv = pread(fd[1], &desc_addr, sizeof(desc_addr), cap_addr -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "cap pread: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(desc_addr), rv);
 	printf("Original address: %p\n", (void *)(uintptr_t)desc_addr);
@@ -161,7 +164,7 @@ ATF_TC_BODY(adjust_malloc_description, tc)
 	 */
 	len = strlen(descr) + 1;
 	data_descr = malloc(len);
-	rv = pread(fd[0], data_descr, len, desc_addr);
+	rv = pread(fd[0], data_descr, len, desc_addr - VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "data pread: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(len, rv);
 
@@ -170,7 +173,8 @@ ATF_TC_BODY(adjust_malloc_description, tc)
 
 	/* Move the ks_shortdesc address one byte forward. */
 	desc_addr++;
-	rv = pwrite(fd[1], &desc_addr, sizeof(desc_addr), cap_addr);
+	rv = pwrite(fd[1], &desc_addr, sizeof(desc_addr), cap_addr -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "cap pwrite: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(desc_addr), rv);
 
@@ -184,7 +188,8 @@ ATF_TC_BODY(adjust_malloc_description, tc)
 
 	/* Restore the ks_shortdesc address. */
 	desc_addr--;
-	rv = pwrite(fd[1], &desc_addr, sizeof(desc_addr), cap_addr);
+	rv = pwrite(fd[1], &desc_addr, sizeof(desc_addr), cap_addr -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "cap pwrite: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(desc_addr), rv);
 }
@@ -234,12 +239,14 @@ ATF_TC_BODY(swap_malloc_description, tc)
 	memstat_mtl_free(mtlp);
 
 	/* Copy the current pointer to the kernel stack. */
-	rv = pwrite(fd, &cap_addr, sizeof(cap_addr), stack_addr);
+	rv = pwrite(fd, &cap_addr, sizeof(cap_addr), stack_addr -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "copycap to stack: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(cap_addr), rv);
 
 	/* Copy the Giant name to the M_LINKER description. */
-	rv = pwrite(fd, &giant_addr, sizeof(giant_addr), cap_addr);
+	rv = pwrite(fd, &giant_addr, sizeof(giant_addr), cap_addr -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "copycap from Giant: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(giant_addr), rv);
 
@@ -252,7 +259,8 @@ ATF_TC_BODY(swap_malloc_description, tc)
 	memstat_mtl_free(mtlp);
 
 	/* Restore the ks_shortdesc address. */
-	rv = pwrite(fd, &stack_addr, sizeof(stack_addr), cap_addr);
+	rv = pwrite(fd, &stack_addr, sizeof(stack_addr), cap_addr -
+	    VM_MIN_KERNEL_ADDRESS);
 	ATF_REQUIRE_MSG(rv != -1, "copycap from stack: %s", strerror(errno));
 	ATF_REQUIRE_INTEQ(sizeof(stack_addr), rv);
 }


### PR DESCRIPTION
This avoids having to use large, potentially signed values for the
seek offset with dd(1).
