### PR TITLE
Hide userspace_root_cap

### DIFF
--- a/sys/arm64/cheri/cheri_machdep.c
+++ b/sys/arm64/cheri/cheri_machdep.c
@@ -66,7 +66,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_bounds_set(ctemp, CHERI_CAP_USER_DATA_LENGTH);
 	ctemp = cheri_perms_and(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
-	userspace_root_cap = ctemp;
+	userspace_root_cap_init(ctemp);
 
 	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_USERSPACE_BASE);
 	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -109,6 +109,11 @@ extern void * __capability vmm_el2_root_cap;
 #endif
 
 /*
+ * Initialize root caps.
+ */
+void userspace_root_cap_init(void * __capability);
+
+/*
  * Construct capabilities in the sysvec.
  */
 struct sysentvec;

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -75,9 +75,6 @@ void * __capability	_cheri_capability_build_user_rwx_unchecked(
  * Global capabilities used to construct other capabilities.
  */
 
-/* Root of all unsealed userspace capabilities. */
-extern void * __capability userspace_root_cap;
-
 /* Root of all sealed userspace capabilities. */
 extern void * __capability userspace_root_sealcap;
 

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -109,6 +109,12 @@ extern void * __capability vmm_el2_root_cap;
 #endif
 
 /*
+ * Construct capabilities in the sysvec.
+ */
+struct sysentvec;
+void cheri_sysvec_init(struct sysentvec *sv);
+
+/*
  * Functions to create capabilities used in exec.
  */
 struct image_params;

--- a/sys/cheri/cheri_tags.c
+++ b/sys/cheri/cheri_tags.c
@@ -90,6 +90,7 @@ static void
 measure_cloadtags_stride(void *dummy __unused)
 {
 	void * __capability *buf;
+	void * __capability cap;
 	uint64_t tags;
 	u_int i;
 
@@ -103,6 +104,7 @@ measure_cloadtags_stride(void *dummy __unused)
 	 */
 	buf = malloc_aligned(sizeof(*buf) * 64, sizeof(*buf) * 64,
 	    M_TEMP, M_WAITOK | M_ZERO);
+	cap = (__cheri_tocap void * __capability)&tags;
 
 #ifdef INVARIANTS
 	tags = cheri_loadtags(buf);
@@ -112,7 +114,7 @@ measure_cloadtags_stride(void *dummy __unused)
 
 	/* CLoadTags can't return more than 64 bits. */
 	for (i = 0; i < 64; i++)
-		buf[i] = userspace_root_cap;
+		buf[i] = cap;
 
 	tags = cheri_loadtags(buf);
 

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -181,6 +181,51 @@ _cheri_capability_build_user_rwx_unchecked(uint32_t perms, ptraddr_t basep,
 	    cheri_offset_set(userspace_root_cap, basep), length), perms), off));
 }
 
+void
+cheri_sysvec_init(struct sysentvec *sv)
+{
+	ptraddr_t minuser, maxuser, padded_minuser;
+	size_t user_length;
+
+	KASSERT(sv->sv_vmspace_cap == 0, ("sv_vmspace_cap already set"));
+
+	minuser = sv->sv_minuser;
+	maxuser = sv->sv_maxuser;
+
+	KASSERT(minuser >= VM_MINUSER_ADDRESS,
+	    ("sv_minuser < VM_MINUSER_ADDRESS"));
+	KASSERT(maxuser <= VM_MAXUSER_ADDRESS,
+	    ("sv_maxuser > VM_MAXUSER_ADDRESS"));
+	KASSERT("maxuser > minuser", ("sv_maxuser <= sv_minuser"));
+
+	/*
+	 * Create a userspace capability for maps created for this
+	 * sysvec, nominally bounded by sv_minuser and sv_maxuser.
+	 * Allow the lower bound to be imprecise if sv_minuser excludes
+	 * the first page.
+	 */
+	user_length = maxuser - minuser;
+	padded_minuser = CHERI_REPRESENTABLE_ALIGN_DOWN(minuser,
+	    user_length);
+	KASSERT(padded_minuser == minuser ||
+	    minuser <= PAGE_SIZE, ("Unrepresentable base"));
+	user_length = CHERI_REPRESENTABLE_LENGTH(user_length);
+	KASSERT(maxuser - padded_minuser == user_length,
+	    ("Unrepresentable length"));
+	/*
+	 * Use the unchecked version here because we're not in a syscall
+	 * and the associated map is probably the kernel map.
+	 */
+	sv->sv_vmspace_cap = (uintcap_t)
+	    cheri_capability_build_user_rwx_unchecked(
+	    CHERI_CAP_USER_CODE_PERMS | CHERI_CAP_USER_DATA_PERMS |
+	    CHERI_PERMS_SWALL, padded_minuser, user_length,
+	    minuser - padded_minuser);
+	KASSERT(cheri_tag_get(sv->sv_vmspace_cap),
+	    ("sv_vmspace_cap untagged %#lp",
+	     (void * __capability)sv->sv_vmspace_cap));
+}
+
 /*
  * Try to store a tagged capability in *out, derived from an untagged
  * "bag of bits" in in.  If a tagged capability cannot be derived,

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -42,7 +42,8 @@
 #include <cheri/cheric.h>
 
 /* Set to -1 to prevent it from being zeroed with the rest of BSS */
-void * __capability userspace_root_cap = (void * __capability)(intcap_t)-1;
+static void * __capability userspace_root_cap =
+    (void * __capability)(intcap_t)-1;
 
 static u_int cheri_ptrace_caps;
 SYSCTL_UINT(_security_cheri, OID_AUTO, ptrace_caps, CTLFLAG_RWTUN,

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -59,6 +59,12 @@ SYSCTL_ULONG(_security_cheri_stats, OID_AUTO, untagged_ptrace_caps, CTLFLAG_RD,
     &cheri_untagged_ptrace_caps, 0,
     "Number of capabilities injected via ptrace that failed to tag");
 
+void
+userspace_root_cap_init(void * __capability cap)
+{
+	userspace_root_cap = cap;
+}
+
 /*
  * Build a new userspace capability derived from userspace_root_cap.
  * The resulting capability may include both read and execute permissions,

--- a/sys/compat/freebsd64/freebsd64_mmap.c
+++ b/sys/compat/freebsd64/freebsd64_mmap.c
@@ -95,10 +95,6 @@ freebsd64_mmap(struct thread *td, struct freebsd64_mmap_args *uap)
 		.mr_flags = uap->flags,
 		.mr_fd = uap->fd,
 		.mr_pos = uap->pos,
-#ifdef __CHERI_PURE_CAPABILITY__
-		/* Needed for fixed mappings */
-		.mr_source_cap = userspace_root_cap
-#endif
 	    }));
 }
 
@@ -114,10 +110,6 @@ freebsd6_freebsd64_mmap(struct thread *td,
 		.mr_flags = uap->flags,
 		.mr_fd = uap->fd,
 		.mr_pos = uap->pos,
-#ifdef __CHERI_PURE_CAPABILITY__
-		/* Needed for fixed mappings */
-		.mr_source_cap = userspace_root_cap
-#endif
 	    }));
 }
 #endif

--- a/sys/i386/linux/imgact_linux.c
+++ b/sys/i386/linux/imgact_linux.c
@@ -218,8 +218,6 @@ exec_linux_imgact(struct image_params *imgp)
 	imgp->interpreted = 0;
 	imgp->entry_addr = a_out->a_entry;
 
-	imgp->proc->p_sysent = &linux_sysvec;
-
 fail:
 	vn_lock(imgp->vp, LK_EXCLUSIVE | LK_RETRY);
 	return (error);

--- a/sys/kern/imgact_aout.c
+++ b/sys/kern/imgact_aout.c
@@ -368,8 +368,6 @@ exec_aout_imgact(struct image_params *imgp)
 	imgp->interpreted = 0;
 	imgp->entry_addr = a_out->a_entry;
 
-	imgp->proc->p_sysent = &aout_sysvec;
-
 	return (0);
 }
 

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -667,8 +667,8 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
 #ifdef __CHERI_PURE_CAPABILITY__
 	reservation_cap = (void *)reservation;
 #else
-	reservation_cap = cheri_bounds_set(
-	    cheri_address_set(userspace_root_cap, reservation), end - start);
+	reservation_cap = (void * __capability)vm_map_buildcap(map, reservation,
+	    end - start, VM_PROT_ALL);
 #endif
 	*imgact_cap = cheri_perms_and(reservation_cap, perm);
 

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1575,7 +1575,6 @@ __CONCAT(exec_, __elfN(imgact))(struct image_params *imgp)
 
 	error = exec_new_vmspace(imgp, sv);
 
-	imgp->proc->p_sysent = sv;
 	imgp->proc->p_elf_brandinfo = brand_info;
 
 	vmspace = imgp->proc->p_vmspace;

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -652,11 +652,10 @@ proc0_init(void *dummy __unused)
 	 * we strip all access permission because proc0 is not
 	 * expected to enter usermode.
 	 */
-	uintcap_t minuser_cap = (uintcap_t)cheri_address_set(userspace_root_cap,
-	    p->p_sysent->sv_minuser);
-	minuser_cap = cheri_bounds_set(minuser_cap,
-	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser);
-	minuser_cap = cheri_perms_and(minuser_cap, 0);
+	uintcap_t minuser_cap =
+	    (uintcap_t)cheri_capability_build_user_rwx_unchecked(
+	    0, p->p_sysent->sv_minuser,
+	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser, 0);
 
 	vm_map_init(&vmspace0.vm_map, vmspace_pmap(&vmspace0),
 	    minuser_cap,

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -643,7 +643,7 @@ proc0_init(void *dummy __unused)
 	 * proc0 is not expected to enter usermode, so there is no special
 	 * handling for sv_minuser here, like is done for exec_new_vmspace().
 	 */
-#ifndef __CHERI_PURE_CAPABILITY__
+#if !__has_feature(capabilities)
 	vm_map_init(&vmspace0.vm_map, vmspace_pmap(&vmspace0),
 	    p->p_sysent->sv_minuser, p->p_sysent->sv_maxuser);
 #else
@@ -652,15 +652,15 @@ proc0_init(void *dummy __unused)
 	 * we strip all access permission because proc0 is not
 	 * expected to enter usermode.
 	 */
-	caddr_t minuser_cap = cheri_address_set(userspace_root_cap,
+	uintcap_t minuser_cap = (uintcap_t)cheri_address_set(userspace_root_cap,
 	    p->p_sysent->sv_minuser);
 	minuser_cap = cheri_bounds_set(minuser_cap,
 	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser);
 	minuser_cap = cheri_perms_and(minuser_cap, 0);
 
 	vm_map_init(&vmspace0.vm_map, vmspace_pmap(&vmspace0),
-	    (vm_pointer_t)minuser_cap,
-	    (vm_pointer_t)minuser_cap + cheri_length_get(minuser_cap));
+	    minuser_cap,
+	    minuser_cap + cheri_length_get(minuser_cap));
 	vmspace0.vm_map.flags |= MAP_RESERVATIONS;
 #endif
 

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1169,6 +1169,8 @@ exec_new_vmspace(struct image_params *imgp, struct sysentvec *sv)
 
 	EVENTHANDLER_DIRECT_INVOKE(process_exec, p, imgp);
 
+	p->p_sysent = sv;
+
 	/*
 	 * Blow away entire process VM, if address space not shared,
 	 * otherwise, create a new VM space so that other threads are

--- a/sys/kern/kern_sharedpage.c
+++ b/sys/kern/kern_sharedpage.c
@@ -368,6 +368,10 @@ exec_sysvec_init(void *param)
 		    (char *)fxrng_shpage_mapping - shared_page_mapping;
 	}
 #endif
+
+#if __has_feature(capabilities)
+	cheri_sysvec_init(sv);
+#endif
 }
 
 void
@@ -383,6 +387,10 @@ exec_sysvec_init_secondary(struct sysentvec *sv, struct sysentvec *sv2)
 	sv2->sv_shared_page_obj = sv->sv_shared_page_obj;
 	sv2->sv_sigcode_offset = sv->sv_sigcode_offset;
 	sv2->sv_vdso_offset = sv->sv_vdso_offset;
+#if __has_feature(capabilities)
+	/* Need to compute a new sv_vmspace_cap */
+	cheri_sysvec_init(sv2);
+#endif
 	if ((sv2->sv_flags & SV_ABI_MASK) != SV_ABI_FREEBSD)
 		return;
 	sv2->sv_timekeep_offset = sv->sv_timekeep_offset;

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -509,7 +509,8 @@ kern_shmat_locked(struct thread *td, int shmid,
 			/* As with mmap, untagged implies exclusive. */
 			if ((shmflg & SHM_REMAP) != 0)
 				return (EINVAL);
-			shmaddr = cheri_address_set(userspace_root_cap,
+			shmaddr = (void * __capability)cheri_address_set(
+			    vm_map_rootcap(&td->td_proc->p_vmspace->vm_map),
 			    attach_va);
 		}
 #endif
@@ -536,7 +537,9 @@ kern_shmat_locked(struct thread *td, int shmid,
 			    CHERI_REPRESENTABLE_ALIGNMENT(size) < (1UL << 12) ?
 			    VMFS_OPTIMAL_SPACE :
 			    VMFS_ALIGNED_SPACE(CHERI_ALIGN_SHIFT(size));
-			shmaddr = cheri_address_set(userspace_root_cap, attach_va);
+			shmaddr = (void * __capability)cheri_address_set(
+			    vm_map_rootcap(&td->td_proc->p_vmspace->vm_map),
+			    attach_va);
 		} else
 #endif
 			find_space = VMFS_OPTIMAL_SPACE;

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -61,7 +61,7 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_bounds_set(ctemp, CHERI_CAP_USER_DATA_LENGTH);
 	ctemp = cheri_perms_and(ctemp, CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
-	userspace_root_cap = ctemp;
+	userspace_root_cap_init(ctemp);
 
 	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_USERSPACE_BASE);
 	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);

--- a/sys/riscv/riscv/cheri_revoke_machdep.c
+++ b/sys/riscv/riscv/cheri_revoke_machdep.c
@@ -210,47 +210,6 @@ disable_user_memory_access(void)
 	);
 }
 
-#ifdef CHERI_CAPREVOKE_CLOADTAGS
-uint8_t cloadtags_stride;
-SYSCTL_U8(_vm, OID_AUTO, cloadtags_stride, 0, &cloadtags_stride, 0, "XXX");
-
-static void
-measure_cloadtags_stride(void *ignored __unused)
-{
-	/* A 256-byte cache-line is probably beyond the pale, so use that */
-	void * __capability buf[16] __attribute__((aligned(256)));
-	int i;
-
-	/* Fill with capabilities */
-	for (i = 0; i < sizeof(buf)/sizeof(buf[0]); i++) {
-		buf[i] = userspace_root_cap;
-	}
-
-	uint64_t tags = __builtin_cheri_cap_load_tags(buf);
-	switch (tags) {
-	case 0x0001:
-		cloadtags_stride = 1;
-		break;
-	case 0x0003:
-		cloadtags_stride = 2;
-		break;
-	case 0x000F:
-		cloadtags_stride = 4;
-		break;
-	case 0x00FF:
-		cloadtags_stride = 8;
-		break;
-	case 0xFFFF:
-		cloadtags_stride = 16;
-		break;
-	default:
-		panic("Bad cloadtags result 0x%" PRIx64, tags);
-	}
-}
-SYSINIT(
-    cloadtags_stride, SI_SUB_VM, SI_ORDER_ANY, measure_cloadtags_stride, NULL);
-#endif
-
 // TODO: CPREFETCH()
 
 static inline int
@@ -276,7 +235,7 @@ vm_cheri_revoke_page_iter(const struct vm_cheri_revoke_cookie *crc,
 	vm_cheri_revoke_test_fn ctp = crc->map->vm_cheri_revoke_test;
 	const uint8_t * __capability crshadow = crc->crshadow;
 #ifdef CHERI_CAPREVOKE_CLOADTAGS
-	uint8_t _cloadtags_stride = cloadtags_stride;
+	uint8_t _cloadtags_stride = cheri_cloadtags_stride;
 	uint64_t tags, nexttags;
 #endif
 

--- a/sys/sys/sysent.h
+++ b/sys/sys/sysent.h
@@ -120,6 +120,9 @@ struct sysentvec {
 	int		sv_minsigstksz;	/* minimum signal stack size */
 	vm_offset_t	sv_minuser;	/* VM_MIN_ADDRESS */
 	vm_offset_t	sv_maxuser;	/* VM_MAXUSER_ADDRESS */
+#if __has_feature(capabilities)
+	uintcap_t	sv_vmspace_cap;
+#endif
 	vm_offset_t	sv_usrstack;	/* USRSTACK */
 #ifdef CHERI_CAPREVOKE
 	vm_offset_t	sv_cheri_revoke_shadow_base;

--- a/sys/vm/vm_extern.h
+++ b/sys/vm/vm_extern.h
@@ -114,7 +114,7 @@ int vm_mmap_vnode(struct thread *, vm_size_t, vm_prot_t, vm_prot_t *, int *,
 void vm_set_page_size(void);
 void vm_sync_icache(vm_map_t, vm_offset_t, vm_size_t);
 typedef int (*pmap_pinit_t)(struct pmap *pmap);
-struct vmspace *vmspace_alloc(vm_pointer_t, vm_pointer_t, pmap_pinit_t);
+struct vmspace *vmspace_alloc(uintcap_t, uintcap_t, pmap_pinit_t);
 struct vmspace *vmspace_fork(struct vmspace *, vm_ooffset_t *);
 int vmspace_exec(struct proc *, vm_offset_t, vm_offset_t);
 int vmspace_unshare(struct proc *);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -6473,15 +6473,8 @@ vm_map_reservation_cap(vm_map_t map, vm_offset_t va)
 		max_prot = entry->max_protection;
 	}
 
-#ifdef __CHERI_PURE_CAPABILITY__
 	cap = (void * __capability)vm_map_buildcap(map, reservation,
 	    end - reservation, max_prot);
-#else
-	cap = cheri_address_set(userspace_root_cap, reservation);
-	cap = cheri_bounds_set(cap, end - reservation);
-	cap = cheri_perms_and(cap, ~CHERI_PROT2PERM_MASK |
-	    vm_map_prot2perms(max_prot));
-#endif
 out:
 	vm_map_unlock_read(map);
 	return (cap);

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -5755,39 +5755,19 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	struct vmspace *oldvmspace = p->p_vmspace;
 	struct vmspace *newvmspace;
 #if __has_feature(capabilities)
-	vm_offset_t padded_minuser;
 	uintcap_t minuser_cap;
 	uintcap_t maxuser_cap;
-	vm_offset_t user_length;
 #endif
 
 	KASSERT((curthread->td_pflags & TDP_EXECVMSPC) == 0,
 	    ("vmspace_exec recursed"));
 #if __has_feature(capabilities)
-	/*
-	 * We create a new userspace capability for this map
-	 * Only allow non-representable map capability if the minuser
-	 * excludes the first page.
-	 */
-	user_length = MIN(maxuser - minuser,
-	    VM_MAXUSER_ADDRESS - VM_MINUSER_ADDRESS);
-	padded_minuser = CHERI_REPRESENTABLE_ALIGN_DOWN(minuser, user_length);
-	KASSERT(padded_minuser == minuser || minuser <= PAGE_SIZE,
-	    ("Unrepresentable base for new vmspace"));
-	KASSERT(maxuser - padded_minuser ==
-	    CHERI_REPRESENTABLE_LENGTH(user_length),
-	    ("Unrepresentable length for new vmspace"));
-
-	user_length = CHERI_REPRESENTABLE_LENGTH(user_length);
-	/*
-	 * XXX: Use the unchecked version here because the map is empty
-	 * at this point.
-	 *
-	 * XXX: It seems like this should be an sv_* member.
-	 */
-	minuser_cap = (uintcap_t)cheri_capability_build_user_rwx_unchecked(
-	    CHERI_CAP_USER_CODE_PERMS | CHERI_CAP_USER_DATA_PERMS |
-	    CHERI_PERMS_SWALL, padded_minuser, user_length, minuser);
+	KASSERT(cheri_tag_get(p->p_sysent->sv_vmspace_cap),
+	    ("expected valid vmspace cap in sysvec %s, got %#lp",
+	     p->p_sysent->sv_name,
+	     (void * __capability)p->p_sysent->sv_vmspace_cap));
+	minuser_cap = cheri_address_set(p->p_sysent->sv_vmspace_cap,
+	    minuser);
 	maxuser_cap = cheri_address_set(minuser_cap, maxuser);
 	newvmspace = vmspace_alloc(minuser_cap, maxuser_cap, pmap_pinit);
 #else

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -136,8 +136,8 @@ static uma_zone_t mapentzone;
 static uma_zone_t kmapentzone;
 static uma_zone_t vmspace_zone;
 static int vmspace_zinit(void *mem, int size, int flags);
-static void _vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min,
-    vm_pointer_t max);
+static void _vm_map_init(vm_map_t map, pmap_t pmap, uintcap_t min,
+    uintcap_t max);
 static void vm_map_entry_deallocate(vm_map_entry_t entry, boolean_t system_map);
 static void vm_map_entry_delete(vm_map_t map, vm_map_entry_t entry);
 static void vm_map_entry_dispose(vm_map_t map, vm_map_entry_t entry);
@@ -391,7 +391,7 @@ vmspace_zdtor(void *mem, int size, void *arg)
  * and initialize those structures.  The refcnt is set to 1.
  */
 struct vmspace *
-vmspace_alloc(vm_pointer_t min, vm_pointer_t max, pmap_pinit_t pinit)
+vmspace_alloc(uintcap_t min, uintcap_t max, pmap_pinit_t pinit)
 {
 	struct vmspace *vm;
 
@@ -987,7 +987,7 @@ vmspace_resident_count(struct vmspace *vmspace)
  * such as that in the vmspace structure.
  */
 static void
-_vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
+_vm_map_init(vm_map_t map, pmap_t pmap, uintcap_t min, uintcap_t max)
 {
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -1005,7 +1005,7 @@ _vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
 	map->timestamp = 0;
 	map->busy = 0;
 	map->anon_loc = 0;
-#ifdef __CHERI_PURE_CAPABILITY__
+#if __has_feature(capabilities)
 	/*
 	 * Do not enforce exact bounds here. The kernel map
 	 * can not be made representable without dropping some
@@ -1028,7 +1028,7 @@ _vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
 }
 
 void
-vm_map_init(vm_map_t map, pmap_t pmap, vm_pointer_t min, vm_pointer_t max)
+vm_map_init(vm_map_t map, pmap_t pmap, uintcap_t min, uintcap_t max)
 {
 	_vm_map_init(map, pmap, min, max);
 	sx_init(&map->lock, "vm map (user)");
@@ -5117,7 +5117,7 @@ vmspace_fork(struct vmspace *vm1, vm_ooffset_t *fork_charge)
 
 	old_map = &vm1->vm_map;
 	/* Copy immutable fields of vm1 to vm2. */
-#ifndef __CHERI_PURE_CAPABILITY__
+#if !__has_feature(capabilities)
 	vm2 = vmspace_alloc(vm_map_min(old_map), vm_map_max(old_map),
 	    pmap_pinit);
 #else
@@ -5754,16 +5754,16 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 {
 	struct vmspace *oldvmspace = p->p_vmspace;
 	struct vmspace *newvmspace;
-#ifdef __CHERI_PURE_CAPABILITY__
+#if __has_feature(capabilities)
 	vm_offset_t padded_minuser;
-	vm_pointer_t minuser_cap;
-	vm_pointer_t maxuser_cap;
+	uintcap_t minuser_cap;
+	uintcap_t maxuser_cap;
 	vm_offset_t user_length;
 #endif
 
 	KASSERT((curthread->td_pflags & TDP_EXECVMSPC) == 0,
 	    ("vmspace_exec recursed"));
-#ifdef __CHERI_PURE_CAPABILITY__
+#if __has_feature(capabilities)
 	/*
 	 * We create a new userspace capability for this map
 	 * Only allow non-representable map capability if the minuser
@@ -5785,7 +5785,7 @@ vmspace_exec(struct proc *p, vm_offset_t minuser, vm_offset_t maxuser)
 	 *
 	 * XXX: It seems like this should be an sv_* member.
 	 */
-	minuser_cap = (vm_pointer_t)cheri_capability_build_user_rwx_unchecked(
+	minuser_cap = (uintcap_t)cheri_capability_build_user_rwx_unchecked(
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_CAP_USER_DATA_PERMS |
 	    CHERI_PERMS_SWALL, padded_minuser, user_length, minuser);
 	maxuser_cap = cheri_address_set(minuser_cap, maxuser);
@@ -6209,16 +6209,15 @@ vm_map_prot2perms(vm_prot_t prot)
 	return (perms);
 }
 
-#ifdef __CHERI_PURE_CAPABILITY__
 /*
  * Create a capability for the given map, derived from the map root
  * capability.
  */
-vm_pointer_t
+uintcap_t
 _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
     vm_prot_t prot)
 {
-	vm_pointer_t retcap;
+	uintcap_t retcap;
 	int perms = ~CHERI_PROT2PERM_MASK | vm_map_prot2perms(prot);
 
 	retcap = cheri_bounds_set(
@@ -6226,7 +6225,6 @@ _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
 
 	return (cheri_perms_and(retcap, perms));
 }
-#endif /* __CHERI_PURE_CAPABILITY__ */
 #endif /* has_feature(capabilities) */
 
 /*

--- a/sys/vm/vm_map.h
+++ b/sys/vm/vm_map.h
@@ -280,8 +280,8 @@ struct vm_map {
 	pmap_t pmap;			/* (c) Physical map */
 	vm_offset_t anon_loc;
 	int busy;
-#ifdef __CHERI_PURE_CAPABILITY__
-	vm_pointer_t map_capability;	/* Capability spanning the whole map */
+#if __has_feature(capabilities)
+	intcap_t map_capability;	/* Capability spanning the whole map */
 #endif
 #ifdef DIAGNOSTIC
 	int nupdates;
@@ -357,8 +357,8 @@ vm_map_is_system(vm_map_t map)
 }
 
 #endif	/* KLD_MODULE */
-#ifdef __CHERI_PURE_CAPABILITY__
-static __inline vm_pointer_t
+#if __has_feature(capabilities)
+static __inline uintcap_t
 vm_map_rootcap(vm_map_t map)
 {
 	return (map->map_capability);
@@ -580,7 +580,7 @@ vm_offset_t vm_map_findspace(vm_map_t, vm_offset_t, vm_size_t);
 int vm_map_alignspace(vm_map_t, vm_object_t, vm_ooffset_t,
     vm_offset_t *, vm_size_t, vm_offset_t, vm_offset_t);
 int vm_map_inherit (vm_map_t, vm_offset_t, vm_offset_t, vm_inherit_t);
-void vm_map_init(vm_map_t, pmap_t, vm_pointer_t, vm_pointer_t);
+void vm_map_init(vm_map_t, pmap_t, uintcap_t, uintcap_t);
 void vm_map_init_system(vm_map_t, pmap_t, vm_pointer_t, vm_pointer_t);
 int vm_map_insert (vm_map_t, vm_object_t, vm_ooffset_t, vm_pointer_t,
     vm_pointer_t, vm_prot_t, vm_prot_t, int, vm_offset_t);
@@ -602,8 +602,8 @@ int vm_map_reservation_get(vm_map_t, vm_offset_t, vm_size_t, vm_offset_t *);
 int vm_map_prot2perms(vm_prot_t prot);
 void * __capability vm_map_reservation_cap(vm_map_t, vm_offset_t);
 #endif
-#ifdef __CHERI_PURE_CAPABILITY__
-vm_pointer_t _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
+#if __has_feature(capabilities)
+uintcap_t _vm_map_buildcap(vm_map_t map, vm_offset_t addr, vm_size_t length,
     vm_prot_t prot);
 #define	vm_map_buildcap(map, addr, length, prot)	\
     _vm_map_buildcap(map, addr, length, prot)

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -354,7 +354,8 @@ sys_mmap(struct thread *td, struct mmap_args *uap)
 		if (flags & MAP_FIXED)
 			flags |= MAP_EXCL;
 
-		source_cap = userspace_root_cap;
+		source_cap = (void * __capability)vm_map_rootcap(
+		    &td->td_proc->p_vmspace->vm_map);
 	}
 	KASSERT(cheri_tag_get(source_cap),
 	    ("td->td_cheri_mmap_cap is untagged!"));


### PR DESCRIPTION
A collection of changes inspired by observations moving per-ABI vmspace capabilities into sysents.  This generally (at least on pure cap kernels) improves the intentionality of various cases where we used the generic userspace root capability. There should be no change in the values of capabilities used today.