### PR TITLE
libc/csu: Use tight PCC bounds for static binaries when PT_CHERI_PCC is present

### DIFF
--- a/lib/libc/csu/aarch64/reloc.c
+++ b/lib/libc/csu/aarch64/reloc.c
@@ -27,9 +27,37 @@
 
 #include <sys/cdefs.h>
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#include <stdbool.h>
+
+static bool use_code_bounds;
+#endif
+
 static void
 ifunc_init(const Elf_Auxinfo *aux __unused)
 {
+#ifdef __CHERI_PURE_CAPABILITY__
+	const Elf_Phdr *phdr;
+	long phnum;
+
+	/* Digest the auxiliary vector. */
+	for (; aux->a_type != AT_NULL; aux++) {
+		switch (aux->a_type) {
+		case AT_PHDR:
+			phdr = aux->a_un.a_ptr;
+			break;
+		case AT_PHNUM:
+			phnum = aux->a_un.a_val;
+			break;
+		}
+	}
+	for (const Elf_Phdr *ph = phdr; ph < phdr + phnum; ph++) {
+		if (ph->p_type == PT_CHERI_PCC) {
+			use_code_bounds = true;
+			break;
+		}
+	}
+#endif
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -45,7 +73,7 @@ ifunc_init(const Elf_Auxinfo *aux __unused)
 static uintcap_t
 init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
     const void * __capability text_rodata_cap, Elf_Addr base_addr,
-    Elf_Size addend)
+    Elf_Size addend, bool use_code_bounds)
 {
 	uintcap_t cap;
 	Elf_Addr address, len;
@@ -58,6 +86,8 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)text_rodata_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, base_addr + address);
+	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
+		cap = cheri_bounds_set(cap, len);
 	cap = cheri_perms_clear(cap, CHERI_PERM_SW_VMEM);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
@@ -68,16 +98,11 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	if (perms == MORELLO_FRAG_RWDATA || perms == MORELLO_FRAG_RODATA) {
 		cap = cheri_perms_clear(cap, CHERI_PERM_SEAL |
 		    CHERI_PERM_EXECUTE);
-		cap = cheri_bounds_set(cap, len);
 	}
 
 	cap += addend;
 
 	if (perms == MORELLO_FRAG_EXECUTABLE) {
-		/*
-		 * TODO tight bounds: lower bound and len should be set
-		 * with LSB == 0 for C64 code.
-		 */
 		cap = cheri_sentry_create(cap);
 	}
 
@@ -107,7 +132,7 @@ crt1_handle_rela(const Elf_Rela *r, void *data_cap, const void *code_cap)
 			    (r->r_addend - (ptraddr_t)code_cap);
 		else
 			ptr = init_cap_from_fragment(fragment, data_cap,
-			    code_cap, 0, r->r_addend);
+			    code_cap, 0, r->r_addend, use_code_bounds);
 		target = ((ifunc_resolver_t)ptr)(0, 0, 0, 0, 0, 0, 0, 0);
 		*where = target;
 		break;
@@ -126,7 +151,7 @@ crt1_handle_tgot_rela(const Elf_Rela *r, void *tgot, Elf_Addr init, void *tls)
 		    (r->r_offset - init));
 		fragment = (Elf_Addr *)where;
 		*where = init_cap_from_fragment(fragment, tls,
-		    NULL, (ptraddr_t)tls, 0);
+		    NULL, (ptraddr_t)tls, 0, true);
 		break;
 	}
 }

--- a/lib/libc/csu/riscv/reloc.c
+++ b/lib/libc/csu/riscv/reloc.c
@@ -23,17 +23,45 @@
 
 static unsigned long elf_hwcap;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#include <stdbool.h>
+
+static bool use_code_bounds;
+#endif
+
 static void
 ifunc_init(const Elf_Auxinfo *aux)
 {
+#ifdef __CHERI_PURE_CAPABILITY__
+	const Elf_Phdr *phdr;
+	long phnum;
+#endif
+
 	/* Digest the auxiliary vector. */
 	for (; aux->a_type != AT_NULL; aux++) {
 		switch (aux->a_type) {
 		case AT_HWCAP:
 			elf_hwcap = (uint32_t)aux->a_un.a_val;
 			break;
+#ifdef __CHERI_PURE_CAPABILITY__
+		case AT_PHDR:
+			phdr = aux->a_un.a_ptr;
+			break;
+		case AT_PHNUM:
+			phnum = aux->a_un.a_val;
+			break;
+#endif
 		}
 	}
+
+#ifdef __CHERI_PURE_CAPABILITY__
+	for (const Elf_Phdr *ph = phdr; ph < phdr + phnum; ph++) {
+		if (ph->p_type == PT_CHERI_PCC) {
+			use_code_bounds = true;
+			break;
+		}
+	}
+#endif
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -61,7 +89,8 @@ crt1_handle_capreloc(const struct capreloc *r, void *data_cap,
 		ptr = (uintptr_t)cheri_perms_and(code_cap,
 		    function_pointer_permissions_mask);
 		ptr = cheri_address_set(ptr, r->object);
-		/* TODO: tight bounds */
+		if (use_code_bounds && r->size != 0)
+			ptr = cheri_bounds_set(ptr, r->size);
 		ptr += r->offset;
 		ptr = cheri_sentry_create(ptr);
 		target = ((ifunc_resolver_t)ptr)(elf_hwcap,


### PR DESCRIPTION
Normal relative relocations and caprelocs are handled in csu itself
rather than libc/csu, but IFUNC resolvers are handled here later and
were missed in a581a08d5776 ("csu: Use tight PCC bounds for static
binaries when PT_CHERI_PCC is present").

This trusts the bounds from both cap relocs and relative ELF relocations
if PT_CHERI_PCC bounds program headers are present.
