### PR TITLE
Initial build system integration for cheri-rv64y support.

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -116,8 +116,13 @@ HAS_COMPAT+=	64
 LIB64_RISCV_ABI=	lp64d
 LIB64_MACHINE=	riscv
 LIB64_MACHINE_ARCH=riscv64
-LIB64WMAKEENV=	MACHINE_CPU="riscv cheri"
-LIB64WMAKEFLAGS= LD="${XLD}" CPUTYPE=cheri
+.  if ${TARGET_CPUTYPE} == "cheri"
+.    warning "CPUTYPE=cheri is deprecated, please use xcheri or rvy"
+LIB64WMAKEENV=	MACHINE_CPU="riscv xcheri"
+.  else
+LIB64WMAKEENV=	MACHINE_CPU="riscv ${TARGET_CPUTYPE}"
+.  endif
+LIB64WMAKEFLAGS= LD="${XLD}" CPUTYPE=${TARGET_CPUTYPE}
 # XXX: clang specific
 LIB64CPUFLAGS=	-target riscv64-unknown-freebsd${OS_REVISION}
 LIB64CPUFLAGS+=	-march=${LIB64_RISCV_MARCH} -mabi=${LIB64_RISCV_ABI}
@@ -142,7 +147,7 @@ LIB64CCPUFLAGS+=	-march=morello -mabi=purecap
 HAS_COMPAT+=	64C
 LIB64C_MACHINE=	riscv
 LIB64C_MACHINE_ARCH=	${COMPAT_ARCH}c
-LIB64CWMAKEFLAGS=	CPUTYPE=cheri
+LIB64CWMAKEFLAGS=	CPUTYPE=${TARGET_CPUTYPE}
 LIB64CCPUFLAGS=	-target riscv64-unknown-freebsd${OS_REVISION}
 LIB64C_RISCV_ABI=	l64pc128d
 LIB64CCPUFLAGS+=	-march=${LIB64C_RISCV_MARCH} -mabi=${LIB64C_RISCV_ABI}
@@ -154,7 +159,13 @@ LIB64CCPUFLAGS+=	-march=${LIB64C_RISCV_MARCH} -mabi=${LIB64C_RISCV_ABI}
 # See bsd.cpu.mk
 LIB${_LIBCOMPAT}_RISCV_MARCH=	rv64imafdc
 .if ${COMPAT_ARCH:Mriscv*c*} || ${_LIBCOMPAT:M64C}
+.  if ${__C:Mxcheri} || ${__C} == "cheri"
 LIB${_LIBCOMPAT}_RISCV_MARCH:=	${LIB${_LIBCOMPAT}_RISCV_MARCH}xcheri
+.  elif ${__C:Mrvy}
+LIB${_LIBCOMPAT}_RISCV_MARCH:=	${LIB${_LIBCOMPAT}_RISCV_MARCH}zcherihybrid_zcherilevels
+.  else
+.    error "Invalid CHERI variant ${__C}"
+.  endif
 .endif
 .endfor
 .endif

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -322,7 +322,12 @@ MACHINE_CPU += vsx3
 ########## riscv
 . elif ${MACHINE_CPUARCH} == "riscv"
 .  if ${CPUTYPE} == "cheri"
-MACHINE_CPU = cheri
+.warning "CPUTYPE=cheri is deprecated, please use xcheri or rvy"
+MACHINE_CPU = cheri xcheri
+.  elif ${CPUTYPE} == "xcheri"
+MACHINE_CPU = cheri xcheri
+.  elif ${CPUTYPE} == "rvy"
+MACHINE_CPU = cheri rvy
 .  endif
 MACHINE_CPU += riscv
 . endif
@@ -382,8 +387,10 @@ CFLAGS.gcc+= -mabi=spe -mfloat-gprs=double -Wa,-me500
 
 .if ${MACHINE_CPUARCH} == "riscv"
 RISCV_MARCH=	rv64imafdc
-.if ${MACHINE_CPU:Mcheri}
+.if ${MACHINE_CPU:Mxcheri}
 RISCV_MARCH:=	${RISCV_MARCH}xcheri
+.elif ${MACHINE_CPU:Mrvy}
+RISCV_MARCH:=	${RISCV_MARCH}zcherihybrid_zcherilevels
 .endif
 
 .if ${MACHINE_ARCH:Mriscv*c*}

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -397,7 +397,7 @@ BROKEN_OPTIONS+=CXGBETOOL
 BROKEN_OPTIONS+=MLX5TOOL
 .endif
 
-.if (${__C} != "cheri" && ${__C} != "morello" && \
+.if (${__C} != "cheri" && ${__C} != "rvy" && ${__C} != "morello" && \
     !${__T:Maarch64*c*} && !${__T:Mriscv64*c*})
 BROKEN_OPTIONS+=CHERI_CAPREVOKE
 .endif
@@ -409,7 +409,7 @@ BROKEN_OPTIONS+=MALLOC_REVOCATION_SHIM
 # We'd really like this to be:
 #    !${MACHINE_CPU:Mcheri} || ${MACHINE_ABI:Mpurecap}
 # but that logic doesn't work in Makefile.inc1...
-.if (${__C} != "cheri" && ${__C} != "morello") || \
+.if (${__C} != "cheri" && ${__C} != "rvy" && ${__C} != "morello") || \
     (${__T:Maarch64*c*} || ${__T:Mriscv64*c*})
 BROKEN_OPTIONS+=LIB64C
 .endif

--- a/sys/conf/kern.mk
+++ b/sys/conf/kern.mk
@@ -192,8 +192,10 @@ CFLAGS+=	-no-cheri-tgot-tls
 #
 .if ${MACHINE_CPUARCH} == "riscv"
 RISCV_MARCH=	rv64imafdch
-.if ${MACHINE_CPU:Mcheri}
+.if ${MACHINE_CPU:Mxcheri}
 RISCV_MARCH:=	${RISCV_MARCH}xcheri
+.elif ${MACHINE_CPU:Mrvy}
+RISCV_MARCH:=	${RISCV_MARCH}zcherihybrid_zcherilevels
 .endif
 
 RISCV_ABI=	lp64

--- a/sys/riscv/conf/std.CHERI
+++ b/sys/riscv/conf/std.CHERI
@@ -1,4 +1,6 @@
-makeoptions	CPUTYPE=cheri
+
+makeoptions 	CPUTYPE=xcheri
+
 options 	CPU_CHERI
 options 	COMPAT_FREEBSD64
 


### PR DESCRIPTION
This introduces a new CPUTYPE=rvy for the standard CHERI RISC-V.

Currently, the RVY CPUTYPE remains unused and the default value remains cheri / xcheri.
The value CPUTYPE=cheri is deprecated in favor of "xcheri".