### PR TITLE
Pass cheri_build_user_* an address not an offset

### DIFF
--- a/sys/arm64/cheri/cheri_machdep.c
+++ b/sys/arm64/cheri/cheri_machdep.c
@@ -121,12 +121,13 @@ hybridabi_thread_setregs(struct thread *td, unsigned long entry_addr)
 	tf->tf_ddc = (uintcap_t)cheri_capability_build_user_rwx(
 	    CHERI_CAP_USER_DATA_PERMS | CHERI_PERMS_SWALL,
 	    CHERI_CAP_USER_DATA_BASE, CHERI_CAP_USER_DATA_LENGTH,
-	    CHERI_CAP_USER_DATA_OFFSET);
+	    CHERI_CAP_USER_DATA_BASE);
 
 	/* Use 'entry_addr' as offset of PCC. */
 	trapframe_set_elr(tf, (uintcap_t)cheri_capability_build_user_code(
 	    td, CHERI_CAP_USER_CODE_PERMS, CHERI_CAP_USER_CODE_BASE,
-	    CHERI_CAP_USER_CODE_LENGTH, entry_addr));
+	    CHERI_CAP_USER_CODE_LENGTH,
+	    CHERI_CAP_USER_CODE_BASE + entry_addr));
 }
 
 int

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -45,30 +45,31 @@
  */
 void * __capability	_cheri_capability_build_user_code(struct thread *td,
 			    uint32_t perms, ptraddr_t basep, size_t length,
-			    off_t off, const char* func, int line);
+			    ptraddr_t addr, const char* func, int line);
 void * __capability	_cheri_capability_build_user_data(uint32_t perms,
-			    ptraddr_t basep, size_t length, off_t off,
+			    ptraddr_t basep, size_t length, ptraddr_t addr,
 			    const char* func, int line, bool exact);
 void * __capability	_cheri_capability_build_user_rwx(uint32_t perms,
-			    ptraddr_t basep, size_t length, off_t off,
+			    ptraddr_t basep, size_t length, ptraddr_t addr,
 			    const char* func, int line, bool exact);
 void * __capability	_cheri_capability_build_user_rwx_unchecked(
 			    uint32_t perms, ptraddr_t basep, size_t length,
-			    off_t off, const char* func, int line, bool exact);
-#define cheri_capability_build_user_code(td, perms, basep, length, off)	\
-	_cheri_capability_build_user_code(td, perms, basep, length, off,\
+			    ptraddr_t addr, const char* func, int line,
+			    bool exact);
+#define cheri_capability_build_user_code(td, perms, basep, length, addr) \
+	_cheri_capability_build_user_code(td, perms, basep, length, addr, \
 	    __func__, __LINE__)
-#define cheri_capability_build_user_data(perms, basep, length, off)	\
-	_cheri_capability_build_user_data(perms, basep, length, off,	\
+#define cheri_capability_build_user_data(perms, basep, length, addr)	\
+	_cheri_capability_build_user_data(perms, basep, length, addr,	\
 	    __func__, __LINE__, true)
-#define cheri_capability_build_inexact_user_data(perms, basep, length, off) \
-	_cheri_capability_build_user_data(perms, basep, length, off,	\
+#define cheri_capability_build_inexact_user_data(perms, basep, length, addr) \
+	_cheri_capability_build_user_data(perms, basep, length, addr,	\
 	    __func__, __LINE__, false)
-#define cheri_capability_build_user_rwx(perms, basep, length, off)	\
-	_cheri_capability_build_user_rwx(perms, basep, length, off,	\
+#define cheri_capability_build_user_rwx(perms, basep, length, addr)	\
+	_cheri_capability_build_user_rwx(perms, basep, length, addr,	\
 	    __func__, __LINE__, true)
-#define cheri_capability_build_user_rwx_unchecked(perms, basep, length, off) \
-	_cheri_capability_build_user_rwx_unchecked(perms, basep, length, off, \
+#define cheri_capability_build_user_rwx_unchecked(perms, basep, length, addr) \
+	_cheri_capability_build_user_rwx_unchecked(perms, basep, length, addr, \
 	    __func__, __LINE__, true)
 
 /*

--- a/sys/cheri/cheri_exec.c
+++ b/sys/cheri/cheri_exec.c
@@ -82,7 +82,7 @@ cheri_exec_pcc(struct thread *td, struct image_params *imgp)
 	MPASS(code_length == CHERI_REPRESENTABLE_LENGTH(code_length));
 	KASSERT(code_start < code_end, ("%s: truncated PCC", __func__));
 	return (cheri_capability_build_user_code(td, CHERI_CAP_USER_CODE_PERMS,
-	    code_start, code_length, imgp->entry_addr - code_start));
+	    code_start, code_length, imgp->entry_addr));
 }
 
 void * __capability
@@ -100,7 +100,7 @@ cheri_sigcode_capability(struct thread *td)
 		return (cheri_capability_build_user_code(td,
 		    CHERI_CAP_USER_CODE_PERMS, CHERI_CAP_USER_CODE_BASE,
 		    CHERI_CAP_USER_CODE_LENGTH,
-		    PROC_SIGCODE(p) - CHERI_CAP_USER_CODE_BASE));
+		    PROC_SIGCODE(p)));
 
 	tmpcap = (void * __capability)cheri_bounds_set_exact(
 	    cheri_perms_and(PROC_SIGCODE(p), CHERI_CAP_USER_CODE_PERMS),

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -75,7 +75,7 @@ userspace_root_cap_init(void * __capability cap)
  */
 void * __capability
 _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
-    ptraddr_t basep, size_t length, off_t off, const char* func, int line)
+    ptraddr_t basep, size_t length, ptraddr_t addr, const char* func, int line)
 {
 	void * __capability tmpcap;
 
@@ -84,7 +84,7 @@ _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
 	    func, line, perms, CHERI_CAP_USER_CODE_PERMS));
 
 	tmpcap = _cheri_capability_build_user_rwx(
-	    perms & CHERI_CAP_USER_CODE_PERMS, basep, length, off, func, line,
+	    perms & CHERI_CAP_USER_CODE_PERMS, basep, length, addr, func, line,
 	    true);
 
 	if (SV_PROC_FLAG(td->td_proc, SV_CHERI))
@@ -100,7 +100,7 @@ _cheri_capability_build_user_code(struct thread *td, uint32_t perms,
  */
 void * __capability
 _cheri_capability_build_user_data(uint32_t perms, ptraddr_t basep,
-    size_t length, off_t off, const char* func, int line, bool exact)
+    size_t length, ptraddr_t addr, const char* func, int line, bool exact)
 {
 
 	KASSERT((perms & ~CHERI_CAP_USER_DATA_PERMS) == 0,
@@ -108,7 +108,7 @@ _cheri_capability_build_user_data(uint32_t perms, ptraddr_t basep,
 	    func, line, perms, CHERI_CAP_USER_DATA_PERMS));
 
 	return (_cheri_capability_build_user_rwx(
-	    perms & CHERI_CAP_USER_DATA_PERMS, basep, length, off, func, line,
+	    perms & CHERI_CAP_USER_DATA_PERMS, basep, length, addr, func, line,
 	    exact));
 }
 
@@ -121,7 +121,7 @@ _cheri_capability_build_user_data(uint32_t perms, ptraddr_t basep,
  */
 void * __capability
 _cheri_capability_build_user_rwx(uint32_t perms, ptraddr_t basep, size_t length,
-    off_t off, const char* func __unused, int line __unused, bool exact)
+    ptraddr_t addr, const char* func __unused, int line __unused, bool exact)
 {
 	void * __capability tmpcap;
 #ifdef INVARIANTS
@@ -143,8 +143,8 @@ _cheri_capability_build_user_rwx(uint32_t perms, ptraddr_t basep, size_t length,
 		vm_map_lock_read(map);
 		KASSERT(vm_map_lookup_entry(map, basep, &entry),
 		    ("%s:%d: vm_map does not contain basep 0x%zx "
-		    "(length 0x%zu, offset 0x%ju)", func, line,
-		    (size_t)basep, length, (uintmax_t)off));
+		    "(length 0x%zu, address 0x%ju)", func, line,
+		    (size_t)basep, length, (uintmax_t)addr));
 		reservation = entry->reservation;
 		for( ; basep + length > entry->end;
 		    entry = vm_map_entry_succ(entry)) {
@@ -170,7 +170,7 @@ _cheri_capability_build_user_rwx(uint32_t perms, ptraddr_t basep, size_t length,
 #endif
 
 	tmpcap = _cheri_capability_build_user_rwx_unchecked(perms, basep,
-	    length, off, func, line, exact);
+	    length, addr, func, line, exact);
 
 	KASSERT(!exact || cheri_length_get(tmpcap) == length,
 	    ("%s:%d: Constructed capability has wrong length 0x%zx != 0x%zx: "
@@ -181,11 +181,11 @@ _cheri_capability_build_user_rwx(uint32_t perms, ptraddr_t basep, size_t length,
 
 void * __capability
 _cheri_capability_build_user_rwx_unchecked(uint32_t perms, ptraddr_t basep,
-    size_t length, off_t off, const char* func __unused, int line __unused,
+    size_t length, ptraddr_t addr, const char* func __unused, int line __unused,
     bool exact)
 {
-	return (cheri_offset_set(cheri_perms_and(cheri_bounds_set(
-	    cheri_offset_set(userspace_root_cap, basep), length), perms), off));
+	return (cheri_address_set(cheri_perms_and(cheri_bounds_set(
+	    cheri_address_set(userspace_root_cap, basep), length), perms), addr));
 }
 
 void

--- a/sys/dev/pci/pci_user.c
+++ b/sys/dev/pci/pci_user.c
@@ -1022,7 +1022,7 @@ pci_bar_mmap(device_t pcidev, struct pci_bar_mmap *pbm)
 	}
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 	pbm->pbm_map_base = cheri_capability_build_user_data(
-	    vm_prot2perms(0, prot), addr, plen, 0);
+	    vm_prot2perms(0, prot), addr, plen, addr);
 #else
 	pbm->pbm_map_base = (void *)addr;
 #endif

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1736,7 +1736,7 @@ prog_cap(struct image_params *imgp, uint64_t perms)
 	    (uintmax_t)prog_base, (uintmax_t)imgp->end_addr, prog_len));
 
 	return (cheri_capability_build_user_rwx(perms, prog_base, prog_len,
-	    imgp->start_addr - prog_base));
+	    imgp->start_addr));
 }
 
 static void * __capability
@@ -1761,7 +1761,7 @@ interp_cap(struct image_params *imgp, Elf_Auxargs *args, uint64_t perms)
 	MPASS(args->base >= interp_base);
 
 	return (cheri_capability_build_user_rwx(perms, interp_base, interp_len,
-	    args->base - interp_base));
+	    args->base));
 }
 
 static void * __capability
@@ -2159,11 +2159,13 @@ __elfN(coredump)(struct thread *td, struct vnode *vp, off_t limit, int flags)
 		php = (Elf_Phdr *)((char *)hdr + sizeof(Elf_Ehdr)) + 1;
 		for (i = 0; i < seginfo.count; i++) {
 #if __has_feature(capabilities)
-			section_cap = cheri_capability_build_user_data(
-			    CHERI_PERM_LOAD,
+			ptraddr_t section_addr =
 			    CHERI_REPRESENTABLE_ALIGN_DOWN(php->p_vaddr,
-			    php->p_filesz),
-			    CHERI_REPRESENTABLE_LENGTH(php->p_filesz), 0);
+			    php->p_filesz);
+			section_cap = cheri_capability_build_user_data(
+			    CHERI_PERM_LOAD, section_addr,
+			    CHERI_REPRESENTABLE_LENGTH(php->p_filesz),
+			    section_addr);
 #else
 			section_cap = (char *)(uintptr_t)php->p_vaddr;
 #endif

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -655,7 +655,8 @@ proc0_init(void *dummy __unused)
 	uintcap_t minuser_cap =
 	    (uintcap_t)cheri_capability_build_user_rwx_unchecked(
 	    0, p->p_sysent->sv_minuser,
-	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser, 0);
+	    p->p_sysent->sv_maxuser - p->p_sysent->sv_minuser,
+	    p->p_sysent->sv_minuser);
 
 	vm_map_init(&vmspace0.vm_map, vmspace_pmap(&vmspace0),
 	    minuser_cap,

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1317,10 +1317,10 @@ exec_map_stack(struct image_params *imgp)
 #else
 	if (sv->sv_flags & SV_CHERI)
 		imgp->stack = cheri_capability_build_user_data(perms,
-		    stack_addr, ssiz, ssiz);
+		    stack_addr, ssiz, stack_top);
 	else
 		imgp->stack = cheri_capability_build_inexact_user_data(perms,
-		    stack_addr, ssiz, stack_top - stack_addr);
+		    stack_addr, ssiz, stack_top);
 #endif
 
 	if (sv->sv_flags & SV_CHERI) {
@@ -1348,7 +1348,8 @@ exec_map_stack(struct image_params *imgp)
 		imgp->strings = (void *)strings_addr;
 #else
 		imgp->strings = cheri_capability_build_user_data(
-		    CHERI_CAP_USER_DATA_PERMS, strings_addr, strings_size, 0);
+		    CHERI_CAP_USER_DATA_PERMS, strings_addr, strings_size,
+		    strings_addr);
 #endif
 	} else
 		imgp->strings = imgp->stack;
@@ -1446,7 +1447,7 @@ out:
 	 */
 	vmspace->vm_shp_base = (uintcap_t)cheri_capability_build_user_rwx(
 	    CHERI_CAP_USER_CODE_PERMS, sharedpage_addr,
-	    sv->sv_shared_page_len, 0);
+	    sv->sv_shared_page_len, sharedpage_addr);
 #endif
 
 	return (0);

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -94,7 +94,7 @@ hybridabi_thread_setregs(struct thread *td, unsigned long entry_addr)
 	tf->tf_ddc = (uintcap_t)cheri_capability_build_user_rwx(
 	    CHERI_CAP_USER_DATA_PERMS | CHERI_PERMS_SWALL,
 	    CHERI_CAP_USER_DATA_BASE, CHERI_CAP_USER_DATA_LENGTH,
-	    CHERI_CAP_USER_DATA_OFFSET);
+	    CHERI_CAP_USER_DATA_BASE);
 
 	/* Use 'entry_addr' as offset of PCC. */
 	tf->tf_sepc = (uintcap_t)cheri_capability_build_user_code(

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -1235,6 +1235,7 @@ vm_cheri_revoke_cookie_init(vm_map_t map, struct vm_cheri_revoke_cookie *crc)
 	    CHERI_PERM_LOAD | CHERI_PERM_GLOBAL,
 	    curproc->p_sysent->sv_cheri_revoke_shadow_base,
 	    curproc->p_sysent->sv_cheri_revoke_shadow_length,
+	    curproc->p_sysent->sv_cheri_revoke_shadow_base +
 	    curproc->p_sysent->sv_cheri_revoke_shadow_offset);
 
 	return (KERN_SUCCESS);
@@ -1410,7 +1411,7 @@ vm_cheri_revoke_shadow_cap(struct sysentvec *sv, int sel, vm_offset_t base,
 		return (cheri_capability_build_user_data(
 		    (pmask & (CHERI_PERM_LOAD | CHERI_PERM_STORE)) |
 		    CHERI_PERM_GLOBAL,
-		    shadow_base, shadow_size, 0));
+		    shadow_base, shadow_size, shadow_base));
 	}
 	case CHERI_REVOKE_SHADOW_OTYPE: {
 		vm_offset_t shadow_base, shadow_size;
@@ -1429,13 +1430,14 @@ vm_cheri_revoke_shadow_cap(struct sysentvec *sv, int sel, vm_offset_t base,
 
 		return (cheri_capability_build_user_data(
 		    CHERI_PERM_LOAD | CHERI_PERM_STORE | CHERI_PERM_GLOBAL,
-		    shadow_base, shadow_size, 0));
+		    shadow_base, shadow_size, shadow_base));
 	}
 	case CHERI_REVOKE_SHADOW_INFO_STRUCT: {
 		return (cheri_capability_build_user_data(
 		    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP | CHERI_PERM_GLOBAL,
 		    sv->sv_cheri_revoke_info_page,
-		    sizeof(struct cheri_revoke_info), 0));
+		    sizeof(struct cheri_revoke_info),
+		    sv->sv_cheri_revoke_info_page));
 	}
 	case CHERI_REVOKE_SHADOW_NOVMEM_ENTIRE: {
 		vm_offset_t shadow_base, shadow_size;
@@ -1447,7 +1449,7 @@ vm_cheri_revoke_shadow_cap(struct sysentvec *sv, int sel, vm_offset_t base,
 
 		return (cheri_capability_build_user_data(
 		    CHERI_PERM_LOAD | CHERI_PERM_STORE | CHERI_PERM_GLOBAL,
-		    shadow_base, shadow_size, 0));
+		    shadow_base, shadow_size, shadow_base));
 	}
 	default:
 		return ((void * __capability)(uintptr_t)EINVAL);
@@ -1464,7 +1466,8 @@ vm_cheri_revoke_info_page(struct vm_map *map, struct sysentvec *sv,
 	*ifp = cheri_capability_build_user_data(CHERI_PERM_LOAD |
 	    CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
 	    CHERI_PERM_GLOBAL,
-	    sv->sv_cheri_revoke_info_page, PAGE_SIZE, 0);
+	    sv->sv_cheri_revoke_info_page, PAGE_SIZE,
+	    sv->sv_cheri_revoke_info_page);
 }
 
 void


### PR DESCRIPTION
It doesn't generally make sense to think about offsets and many cases we were doing math to compute the offset from the desired address.  The case for this change isn't enterly clear cut, but the bulk of consumsers do create capabilities with no offset.

The actual implementation was a bit questionable as it required userspace_root_cap to be based at 0 (true, but implicit and potentially confusing).

This follows from a suggestion from @bsdjhb in #2554 