### PR TITLE
share/mk: Disable CPUTYPE=cheri deprecation warnings

### DIFF
--- a/share/mk/bsd.compat.mk
+++ b/share/mk/bsd.compat.mk
@@ -122,7 +122,9 @@ LIB64_RISCV_ABI=	lp64d
 LIB64_MACHINE=	riscv
 LIB64_MACHINE_ARCH=riscv64
 .if ${LIB64CPUTYPE} == "cheri"
+.if 0
 .warning "CPUTYPE=cheri is deprecated, please use xcheri or rvy"
+.endif
 LIB64_RISCV_CHERI_TYPE=	xcheri
 .elif empty(LIB64CPUTYPE)
 LIB64_RISCV_CHERI_TYPE=	xcheri
@@ -158,7 +160,9 @@ HAS_COMPAT+=	64C
 LIB64C_MACHINE=	riscv
 LIB64C_MACHINE_ARCH=	${COMPAT_ARCH}c
 .if ${LIB64CCPUTYPE} == "cheri"
+.if 0
 .warning "CPUTYPE=cheri is deprecated, please use xcheri or rvy"
+.endif
 LIB64CWMAKEFLAGS=	CPUTYPE=xcheri
 .elif empty(LIB64CCPUTYPE)
 LIB64CWMAKEFLAGS=	CPUTYPE=xcheri

--- a/share/mk/bsd.cpu.mk
+++ b/share/mk/bsd.cpu.mk
@@ -322,7 +322,9 @@ MACHINE_CPU += vsx3
 ########## riscv
 . elif ${MACHINE_CPUARCH} == "riscv"
 .  if ${CPUTYPE} == "cheri"
+.   if 0
 .warning "CPUTYPE=cheri is deprecated, please use xcheri or rvy"
+.   endif
 MACHINE_CPU = cheri xcheri
 .  elif ${CPUTYPE} == "xcheri"
 MACHINE_CPU = cheri xcheri


### PR DESCRIPTION
We can't switch cheribuild to CPUTYPE=xcheri until all supported
CheriBSD branches recognise it, and 25.03 is still supported. Until that
point this is going to be a very obnoxious, noisy warning, so disable it
until a new release is out the door.
