### PR TITLE
mmap: limit PROT_CAP and PROT_NO_CAP to CHERI ABIs

### DIFF
--- a/lib/libsys/mmap.2
+++ b/lib/libsys/mmap.2
@@ -30,7 +30,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 14, 2023
+.Dd February 19, 2026
 .Dt MMAP 2
 .Os
 .Sh NAME
@@ -113,6 +113,11 @@ Pages may be read.
 Pages may be written.
 .It Dv PROT_EXEC
 Pages may be executed.
+.El
+.Pp
+For CHERI ABIs, two additional values are defined:
+.Pp
+.Bl -tag -width PROT_NO_CAP -compact
 .It Dv PROT_CAP
 CHERI capabilities may be read or written as dictated by
 .Dv PROT_READ
@@ -123,20 +128,20 @@ Respect the absence of
 .Dv PROT_CAP .
 .El
 .Pp
-On CHERI platforms, compatability is retained with unmodified POSIX
+Compatibility with non-CHERI ABIs is retained in unmodified POSIX
 programs by implying
 .Dv PROT_CAP
 if either of
 .Dv PROT_READ
 and
 .Dv PROT_WRITE
-is set unless the underlying backing store can not safety support
+is set unless the underlying backing store cannot safety support
 capabilities (e.g., a
 .Dv MAP_SHARED
 mapping of a file).
-If either of
+If
 .Dv PROT_NO_CAP
-are set, then capability permissions will not be implied.
+is set, then capability permissions will not be implied.
 When
 .Dv PROT_CAP
 is passed, at least one of
@@ -144,11 +149,11 @@ is passed, at least one of
 and
 .Dv PROT_WRITE
 is required.
-On non-CHERI platforms the
+On non-CHERI ABIs the
 .Dv PROT_CAP
 and
 .Dv PROT_NO_CAP
-flags have no effect.
+flags are not defined.
 .Pp
 In addition to these protection flags,
 .Fx
@@ -265,7 +270,7 @@ Under CheriABI
 may be used with a NULL-derived capability, in which case
 .Dv MAP_EXCL
 is implied, or with a valid capability to an existing mapping.
-The former is allowed for compatability purposes and should be avoided
+The former is allowed for compatibility purposes and should be avoided
 in new code.
 .It Dv MAP_GUARD
 Instead of a mapping, create a guard of the specified size.

--- a/lib/libsysdecode/mktables
+++ b/lib/libsysdecode/mktables
@@ -106,7 +106,14 @@ gen_table "lio_listiomodes" "LIO_(NO)?WAIT[[:space:]]+[0-9]+"              "aio.
 gen_table "madvisebehav"    "_?MADV_[A-Z]+[[:space:]]+[0-9]+"              "sys/mman.h"
 gen_table "minheritflags"   "INHERIT_[A-Z]+[[:space:]]+[0-9]+"             "sys/mman.h"
 gen_table "mlockallflags"   "MCL_[A-Z]+[[:space:]]+0x[0-9]+"               "sys/mman.h"
-gen_table "mmapprot"        "PROT_[A-Z]+[[:space:]]+0x[0-9A-Fa-f]+"        "sys/mman.h"
+case $MACHINE_ARCH in
+aarch64c|aarch64cb|riscv64c)
+	gen_table "mmapprot"        "PROT_[A-Z]+[[:space:]]+0x[0-9A-Fa-f]+"        "sys/mman.h"
+	;;
+*)
+	gen_table "mmapprot"        "PROT_[A-Z]+[[:space:]]+0x[0-9A-Fa-f]+"        "sys/mman.h" "_CAP"
+	;;
+esac
 gen_table "ngbtsolevel"     "SOL_[A-Z0-9]+[[:space:]]+0x[0-9A-Fa-f]+"      "netgraph/bluetooth/include/ng_btsocket.h"
 gen_table "fileflags"       "[SU]F_[A-Z]+[[:space:]]+0x[0-9A-Fa-f]+"       "sys/stat.h"		"UF_COMPRESSED|UF_TRACKED|UF_SETTABLE|SF_SETTABLE"
 gen_table "filemode"        "S_[A-Z]+[[:space:]]+[0-6]{7}"                 "sys/stat.h"

--- a/sys/sys/mman.h
+++ b/sys/sys/mman.h
@@ -52,11 +52,17 @@
 #define	PROT_READ	0x01	/* pages can be read */
 #define	PROT_WRITE	0x02	/* pages can be written */
 #define	PROT_EXEC	0x04	/* pages can be executed */
+#if __has_feature(capabilities)
 #define	PROT_CAP	0x08	/* capabilities can be read/written */
 #define	PROT_NO_CAP	0x10	/* honor PROT_CAP absense */
+#endif
 #if __BSD_VISIBLE
+#if __has_feature(capabilities)
 #define	_PROT_CAP	(PROT_CAP | PROT_NO_CAP)
 #define	_PROT_ALL	(PROT_READ | PROT_WRITE | PROT_EXEC | _PROT_CAP)
+#else
+#define	_PROT_ALL	(PROT_READ | PROT_WRITE | PROT_EXEC)
+#endif
 #define	PROT_EXTRACT(prot)	((prot) & _PROT_ALL)
 
 #define	_PROT_MAX_SHIFT	16

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -238,6 +238,7 @@ vm_wxcheck(struct proc *p, char *call)
 static inline int
 vm_prot2vmprot(vm_prot_t *prot, const char *func, const char *protname)
 {
+#if __has_feature(capabilities)
 	vm_prot_t vm_prot;
 
 	KASSERT((*prot & ~_PROT_ALL) == 0, ("invalid bits in %s", protname));
@@ -258,6 +259,7 @@ vm_prot2vmprot(vm_prot_t *prot, const char *func, const char *protname)
 		vm_prot |= VM_PROT_NO_IMPLY_CAP;
 
 	*prot = vm_prot;
+#endif
 	return (0);
 }
 
@@ -463,6 +465,7 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 	prot = PROT_EXTRACT(mrp->mr_prot);
 	/* Ensure max_prot is a superset of prot if non-zero */
 	if (max_prot != 0) {
+#if __has_feature(capabilities)
 		/*
 		 * If prot contains explicit capability permissions then
 		 * max_prot must as well.  Add PROT_NO_CAP to both to allow
@@ -476,6 +479,7 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 			prot |= PROT_NO_CAP;
 			max_prot |= PROT_NO_CAP;
 		}
+#endif
 		if ((max_prot & prot) != prot) {
 			SYSERRCAUSE("%s: requested page permissions exceed "
 			    "requested maximum", __func__);
@@ -566,7 +570,11 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 		return (EINVAL);
 	}
 	if ((flags & MAP_GUARD) != 0 &&
-	    ((prot != PROT_NONE && prot != PROT_NO_CAP) || fd != -1 ||
+	    ((prot != PROT_NONE
+#if __has_feature(capabilities)
+	      && prot != PROT_NO_CAP
+#endif
+	     ) || fd != -1 ||
 	    pos != 0 || (flags & ~(MAP_FIXED | MAP_GUARD | MAP_EXCL |
 	    MAP_RESERVATION_CREATE |
 	    MAP_32BIT | MAP_ALIGNMENT_MASK)) != 0)) {
@@ -724,8 +732,10 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 			error = EINVAL;
 			goto done;
 		}
+#if __has_feature(capabilities)
 		if ((cap_prot & VM_PROT_CAP) != 0)
 			cap_maxprot = VM_PROT_ADD_CAP(cap_maxprot);
+#endif
 		if ((cap_prot & cap_maxprot) != cap_prot) {
 			SYSERRCAUSE("%s: unable to map file with "
 			    "requested permissions", __func__);
@@ -1056,11 +1066,13 @@ kern_mprotect(struct thread *td, uintptr_t addr0, size_t size, int userprot,
 
 	flags |= VM_MAP_PROTECT_SET_PROT | VM_MAP_PROTECT_KEEP_CAP;
 	if (max_prot != 0) {
+#if __has_feature(capabilities)
 		/* see comment in kern_mmap() */
 		if ((prot & _PROT_CAP) != 0 || (max_prot & _PROT_CAP) != 0) {
 			prot |= PROT_NO_CAP;
 			max_prot |= PROT_NO_CAP;
 		}
+#endif
 		if ((max_prot & prot) != prot)
 			return (ENOTSUP);
 		flags |= VM_MAP_PROTECT_SET_MAXPROT;


### PR DESCRIPTION
Declaring them and using them in _PROT_ALL mean mmap would fail in rtld and risked in correct autoconf style checks for PROT_CAP on systems that otherwise don't support it.

This will conflict with @qwattash's proposed change to make vm_prot2vmprot MD, but it's easy to resolve.