### PR TITLE
compartmentalization.7: Add elf_aux_info(3) to the dangerous list

### DIFF
--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -23,7 +23,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd February 3 2026
+.Dd February 25, 2026
 .Dt COMPARTMENTALIZATION 7
 .Os
 .Sh NAME
@@ -206,6 +206,9 @@ than the calling compartment.
 .It
 .Xr dl_iterate_phdr 3
 can access the program headers of all loaded libraries.
+.It
+.Xr elf_aux_info 3
+can return highly privileged pointers.
 .El
 .Sh AUTHORS
 .An Dapeng Gao Aq Mt dapeng.gao@cl.cam.ac.uk


### PR DESCRIPTION
Not all auxv entries are privileged (e.g. it probably is fine to
permit reading scalar values like AT_HWCAP), so it might be nice to
have separate functions for scalar vs pointer values (e.g. Linux-style
getauxval() for scalars, and a getauxptr() for pointers).  For the
FreeBSD API, perhaps elf_aux_info(3) could only return scalar values,
and a new elf_aux_info_tcb(3) or the like could return privileged
values.
