### PR TITLE
Introduce support for tight bounds on the kernel stack.

### DIFF
--- a/sys/arm64/arm64/exception.S
+++ b/sys/arm64/arm64/exception.S
@@ -82,9 +82,22 @@
 	mrs	PTR(18), PTRN(tpidr_el1)
 .endm
 
+/*
+ * When CHERI_BOUNDED_KSTACK is enabled and saving user context,
+ * install the bounded kernel stack and leave a bounded pointer
+ * to td_frame in c20.
+ */
 .macro	save_registers el
 	add	PTR(29), PTRN(sp), #(TF_SIZE)
 .if \el == 0
+#ifdef CHERI_BOUNDED_KSTACK
+	ldr	PTR(20), [PTR(18), #(PC_CURTHREAD)]
+	ldr	PTRN(1), [PTR(20), #(TD_MD_KSTACK)]
+	mov	PTRN(sp), PTR(1)
+	ldr	PTR(20), [PTR(20), #(TD_FRAME)]
+	/* Note: fp is updated, but it is out of bounds. */
+	add	PTR(29), PTR(20), #(TF_SIZE)
+#endif
 #if defined(PERTHREAD_SSP)
 	/* Load the SSP canary to sp_el0 */
 	ldr	x1, [x18, #(PC_CURTHREAD)]
@@ -113,6 +126,7 @@
 
 	/* Unmask debug and SError exceptions */
 	msr	daifclr, #(DAIF_D | DAIF_A)
+
 .else
 	/*
 	 * Unmask debug and SError exceptions.
@@ -131,7 +145,11 @@
 	msr	daifset, #(DAIF_ALL)
 .if \el == 0
 	ldr	PTR(0), [PTR(18), #PC_CURTHREAD]
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	PTR(1), PTR(20)
+#else
 	mov	PTR(1), PTRN(sp)
+#endif
 	bl	dbg_monitor_exit
 
 #ifdef PAC
@@ -150,6 +168,17 @@
 #endif
 1:
 .endif
+
+#ifdef CHERI_BOUNDED_KSTACK
+.if \el == 0
+	/* Restore unbounded kstack to access trapframe from csp */
+	ldr	PTR(1), [PTR(18), #PC_CURTHREAD]
+	ldr	PTR(2), [PTR(1), #TD_FRAME]
+	ldr	PTR(1), [PTR(1), #TD_KSTACK]
+	scvalue	PTRN(sp), PTR(1), x2
+.endif
+#endif
+
 	ldp	CAP(18), CAPN(lr), [PTRN(sp), #(TF_SP)]
 #if __has_feature(capabilities)
 	ldr	w11, [PTRN(sp), #(TF_SPSR)]
@@ -233,7 +262,11 @@
 	msr	daif, x19
 
 	/* handle the ast */
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	PTR(0), PTR(20)
+#else
 	mov	PTR(0), PTRN(sp)
+#endif
 	bl	_C_LABEL(ast)
 
 	/* Re-check for new ast scheduled */
@@ -268,6 +301,10 @@ ENTRY(handle_el1h_sync)
 	KMSAN_ENTER
 	ldr	PTR(0), [PTR(18), #PC_CURTHREAD]
 	mov	PTR(1), PTRN(sp)
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	x2, #TF_SIZE
+	scbndse	PTR(1), PTR(1), x2
+#endif
 	bl	do_el1h_sync
 	KMSAN_LEAVE
 	restore_registers 1
@@ -278,6 +315,10 @@ ENTRY(handle_el1h_irq)
 	save_registers 1
 	KMSAN_ENTER
 	mov	PTR(0), PTRN(sp)
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	x1, #TF_SIZE
+	scbndse	PTR(0), PTR(0), x1
+#endif
 	mov	x1, #INTR_ROOT_IRQ
 	bl	intr_irq_handler
 	KMSAN_LEAVE
@@ -289,6 +330,10 @@ ENTRY(handle_el1h_fiq)
 	save_registers 1
 	KMSAN_ENTER
 	mov	PTR(0), PTRN(sp)
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	x1, #TF_SIZE
+	scbndse	PTR(0), PTR(0), x1
+#endif
 	mov	x1, #INTR_ROOT_FIQ
 	bl	intr_irq_handler
 	KMSAN_LEAVE
@@ -300,6 +345,10 @@ ENTRY(handle_el1h_serror)
 	save_registers 1
 	KMSAN_ENTER
 	mov	PTR(0), PTRN(sp)
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	x1, #TF_SIZE
+	scbndse	PTR(0), PTR(0), x1
+#endif
 1:	bl	do_serror
 	b	1b
 	KMSAN_LEAVE
@@ -309,12 +358,18 @@ ENTRY(handle_el0_sync)
 	save_registers 0
 	KMSAN_ENTER
 	ldr	PTR(0), [PTR(18), #PC_CURTHREAD]
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	PTR(1), PTR(20)
+#else
 	mov	PTR(1), PTRN(sp)
 	mov	PTR(22), PTR(0)
 	str	PTR(1), [PTR(0), #TD_FRAME]
+#endif
 	bl	do_el0_sync
 	do_ast
+#ifndef CHERI_BOUNDED_KSTACK
 	str	PTR(zr), [PTR(22), #TD_FRAME]
+#endif
 	KMSAN_LEAVE
 	restore_registers 0
 	ERET
@@ -323,7 +378,11 @@ END(handle_el0_sync)
 ENTRY(handle_el0_irq)
 	save_registers 0
 	KMSAN_ENTER
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	PTR(0), PTR(20)
+#else
 	mov	PTR(0), PTRN(sp)
+#endif
 	mov	x1, #INTR_ROOT_IRQ
 	bl	intr_irq_handler
 	do_ast
@@ -335,7 +394,11 @@ END(handle_el0_irq)
 ENTRY(handle_el0_fiq)
 	save_registers 0
 	KMSAN_ENTER
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	PTR(0), PTR(20)
+#else
 	mov	PTR(0), PTRN(sp)
+#endif
 	mov	x1, #INTR_ROOT_FIQ
 	bl	intr_irq_handler
 	do_ast
@@ -347,7 +410,11 @@ END(handle_el0_fiq)
 ENTRY(handle_el0_serror)
 	save_registers 0
 	KMSAN_ENTER
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	PTR(0), PTR(19)
+#else
 	mov	PTR(0), PTRN(sp)
+#endif
 1:	bl	do_serror
 	b	1b
 	KMSAN_LEAVE
@@ -357,6 +424,10 @@ ENTRY(handle_empty_exception)
 	save_registers 0
 	KMSAN_ENTER
 	mov	PTR(0), PTRN(sp)
+#ifdef CHERI_BOUNDED_KSTACK
+	mov	x1, #TF_SIZE
+	scbndse	PTR(0), PTR(0), x1
+#endif
 1:	bl	unhandled_exception
 	b	1b
 	KMSAN_LEAVE

--- a/sys/arm64/arm64/genassym.c
+++ b/sys/arm64/arm64/genassym.c
@@ -91,6 +91,10 @@ ASSYM(TD_FRAME, offsetof(struct thread, td_frame));
 ASSYM(TD_LOCK, offsetof(struct thread, td_lock));
 ASSYM(TD_MD_CANARY, offsetof(struct thread, td_md.md_canary));
 ASSYM(TD_MD_EFIRT_TMP, offsetof(struct thread, td_md.md_efirt_tmp));
+#ifdef CHERI_BOUNDED_KSTACK
+ASSYM(TD_KSTACK, offsetof(struct thread, td_kstack));
+ASSYM(TD_MD_KSTACK, offsetof(struct thread, td_md.md_kstack));
+#endif
 
 ASSYM(TF_SIZE, sizeof(struct trapframe));
 ASSYM(TF_SP, offsetof(struct trapframe, tf_sp));

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -73,11 +73,12 @@
  * Build kernel pointer for the given data symbol
  * assuming the kernel mmu mapping is enabled
  */
-.macro buildptr dregn, sym, size
+.macro buildptr dregn, sym, size, clrperm = xzr
 	ldr	x\dregn, =\sym
 #ifdef __CHERI_PURE_CAPABILITY__
 	cvtd	c\dregn, x\dregn
 	scbnds	c\dregn, c\dregn, \size
+	clrperm c\dregn, c\dregn, \clrperm
 #endif
 .endmacro
 
@@ -244,7 +245,8 @@ virtdone:
 
 	/* Set up the stack */
 	mov	x7, #(PAGE_SIZE * KSTACK_PAGES)
-	buildptr 25, initstack, x7
+	ldr	x6, =(~CHERI_PERMS_KERNEL_DATA)
+	buildptr 25, initstack, x7, x6
 	/* Preserve initstack in x/c25 for bootparams */
 	add	PTR(7), PTR(25), x7
 	/*
@@ -255,7 +257,7 @@ virtdone:
 	sub	PTRN(sp), PTR(7), #PCB_SIZE
 
 	/* Zero the BSS */
-	buildptr_range 15, 14, _bss_start, _end
+	buildptr_range 15, 14, _bss_start, _end, x6
 1:
 	stp	xzr, xzr, [PTR(15)], #16
 	cmp	PTR(15), PTR(14)

--- a/sys/arm64/arm64/swtch.S
+++ b/sys/arm64/arm64/swtch.S
@@ -278,7 +278,7 @@ END(cpu_switch)
 ENTRY(fork_trampoline)
 	mov	PTR(0), PTR(19)
 	mov	PTR(1), PTR(20)
-	mov	PTR(2), PTRN(sp)
+	mov	PTR(2), PTR(21)
 	mov	fp, #0	/* Stack traceback stops here. */
 	bl	_C_LABEL(fork_exit)
 
@@ -292,6 +292,14 @@ ENTRY(fork_trampoline)
 #ifdef PAC
 	ldr	x0, [x18, #PC_CURTHREAD]
 	bl	ptrauth_enter_el0
+#endif
+
+#ifdef CHERI_BOUNDED_KSTACK
+	/* Restore unbounded kstack to access trapframe from csp */
+	ldr	PTR(1), [PTR(18), #PC_CURTHREAD]
+	ldr	PTR(2), [PTR(1), #TD_FRAME]
+	ldr	PTR(1), [PTR(1), #TD_KSTACK]
+	scvalue	PTRN(sp), PTR(1), x2
 #endif
 
 	/* Restore sp, lr, elr, and spsr */
@@ -329,6 +337,7 @@ ENTRY(fork_trampoline)
 	ldp	CAP(26), CAP(27), [PTRN(sp), #TF_X + 26 * CAP_WIDTH]
 	ldp	CAP(28), CAP(29), [PTRN(sp), #TF_X + 28 * CAP_WIDTH]
 
+	add	PTRN(sp), PTRN(sp), #TF_SIZE
 	/*
 	 * No need for interrupts reenabling since PSR
 	 * will be set to the desired value anyway.

--- a/sys/arm64/arm64/trap.c
+++ b/sys/arm64/arm64/trap.c
@@ -785,6 +785,16 @@ do_el0_sync(struct thread *td, struct trapframe *frame)
 		cheri_stack_get(), td->td_pcb));
 	KASSERT(cheri_length_get(td->td_pcb) == sizeof(struct pcb),
 	    ("Unbounded PCB pointer %#p", td->td_pcb));
+	KASSERT(td->td_frame == frame, ("Invalid td_frame %#p != %#p",
+	    td->td_frame, frame));
+	KASSERT(cheri_length_get(frame) == sizeof(struct trapframe),
+	    ("Invalid trapframe bounds: %#p", frame));
+	KASSERT(cheri_base_get(cheri_stack_get()) == td->td_kstack,
+	    ("Invalid kernel stack base: %#p expect td_kstack %#p",
+		cheri_stack_get(), (void *)td->td_kstack));
+	KASSERT(cheri_top_get(cheri_stack_get()) <= (ptraddr_t)td->td_frame,
+	    ("Invalid kernel stack length: %#p overlaps frame %#p",
+		cheri_stack_get(), td->td_frame));
 #endif
 
 	kasan_mark(frame, sizeof(*frame), sizeof(*frame), 0);

--- a/sys/arm64/arm64/trap.c
+++ b/sys/arm64/arm64/trap.c
@@ -779,6 +779,13 @@ do_el0_sync(struct thread *td, struct trapframe *frame)
 	KASSERT((uintptr_t)get_pcpu() >= VM_MIN_KERNEL_ADDRESS,
 	    ("Invalid pcpu address from userland: %p (tpidr 0x%lx)",
 	     get_pcpu(), READ_SPECIALREG(tpidr_el1)));
+#ifdef CHERI_BOUNDED_KSTACK
+	KASSERT(cheri_base_get(td->td_pcb) >= cheri_top_get(cheri_stack_get()),
+	    ("Invalid kernel stack bounds: %#p overlaps pcb %#p",
+		cheri_stack_get(), td->td_pcb));
+	KASSERT(cheri_length_get(td->td_pcb) == sizeof(struct pcb),
+	    ("Unbounded PCB pointer %#p", td->td_pcb));
+#endif
 
 	kasan_mark(frame, sizeof(*frame), sizeof(*frame), 0);
 	kmsan_mark(frame, sizeof(*frame), KMSAN_STATE_INITED);

--- a/sys/arm64/arm64/vfp.c
+++ b/sys/arm64/arm64/vfp.c
@@ -547,6 +547,10 @@ vfp_save_state_common(struct thread *td, struct pcb *pcb, bool full_save)
 		 * heavy userspace code. This would require us to disable
 		 * SVE for all system calls and trap the next use of them.
 		 * As an optimisation only disable SVE on context switch.
+		 *
+		 * XXX-AM: It is unclear when td_frame would be NULL,
+		 * perhaps when handling an interrupt, but the EXCP_SVC64 check
+		 * should take care of this.
 		 */
 		if (td->td_frame == NULL ||
 		    (ESR_ELx_EXCEPTION(td->td_frame->tf_esr) != EXCP_SVC64 &&

--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -111,6 +111,9 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 
 	pcb2 = (struct pcb *)(td2->td_kstack +
 	    td2->td_kstack_pages * PAGE_SIZE) - 1;
+#ifdef CHERI_BOUNDED_KSTACK
+	pcb2 = cheri_bounds_set_exact(pcb2, sizeof(struct pcb));
+#endif
 
 	td2->td_pcb = pcb2;
 	bcopy(td1->td_pcb, pcb2, sizeof(*pcb2));
@@ -126,7 +129,18 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	ptrauth_fork(td2, td1);
 #endif
 
+#ifdef CHERI_BOUNDED_KSTACK
+	tf = (struct trapframe *)STACKALIGN(
+	    (struct trapframe *)cheri_address_set(td2->td_kstack,
+		(ptraddr_t)pcb2) - 1);
+	tf = cheri_bounds_set_exact(tf, sizeof(struct trapframe));
+	td2->td_md.md_kstack = (void *)cheri_address_set(
+	    cheri_bounds_set_exact(td2->td_kstack, (ptraddr_t)tf -
+		td2->td_kstack),
+	    (ptraddr_t)tf);
+#else
 	tf = (struct trapframe *)STACKALIGN((struct trapframe *)pcb2 - 1);
+#endif
 	bcopy(td1->td_frame, tf, sizeof(*tf));
 	tf->tf_x[0] = 0;
 	tf->tf_x[1] = 0;
@@ -141,8 +155,13 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	/* Set the return value registers for fork() */
 	td2->td_pcb->pcb_x[PCB_X19] = (uintptr_t)fork_return;
 	td2->td_pcb->pcb_x[PCB_X20] = (uintptr_t)td2;
+	td2->td_pcb->pcb_x[PCB_X21] = (uintptr_t)td2->td_frame;
 	td2->td_pcb->pcb_x[PCB_LR] = (uintptr_t)fork_trampoline;
+#ifdef CHERI_BOUNDED_KSTACK
+	td2->td_pcb->pcb_sp = (uintptr_t)td2->td_md.md_kstack;
+#else
 	td2->td_pcb->pcb_sp = (uintptr_t)td2->td_frame;
+#endif
 
 	vfp_new_thread(td2, td1, true);
 
@@ -209,8 +228,13 @@ cpu_copy_thread(struct thread *td, struct thread *td0)
 
 	td->td_pcb->pcb_x[PCB_X19] = (uintptr_t)fork_return;
 	td->td_pcb->pcb_x[PCB_X20] = (uintptr_t)td;
+	td->td_pcb->pcb_x[PCB_X21] = (uintptr_t)td->td_frame;
 	td->td_pcb->pcb_x[PCB_LR] = (uintptr_t)fork_trampoline;
+#ifdef CHERI_BOUNDED_KSTACK
+	td->td_pcb->pcb_sp = (uintptr_t)td->td_md.md_kstack;
+#else
 	td->td_pcb->pcb_sp = (uintptr_t)td->td_frame;
+#endif
 
 	/* Update VFP state for the new thread */
 	vfp_new_thread(td, td0, false);
@@ -317,6 +341,16 @@ cpu_thread_alloc(struct thread *td)
 	    td->td_kstack_pages * PAGE_SIZE) - 1;
 	td->td_frame = (struct trapframe *)STACKALIGN(
 	    (struct trapframe *)td->td_pcb - 1);
+#ifdef CHERI_BOUNDED_KSTACK
+	td->td_pcb = cheri_bounds_set_exact(td->td_pcb, sizeof(struct pcb));
+	td->td_frame = cheri_bounds_set_exact(td->td_frame,
+	    sizeof(struct trapframe));
+
+	td->td_md.md_kstack = (void *)cheri_address_set(
+	    cheri_bounds_set_exact(td->td_kstack,
+		(ptraddr_t)td->td_frame - td->td_kstack),
+	    (ptraddr_t)td->td_frame);
+#endif
 #ifdef PAC
 	ptrauth_thread_alloc(td);
 #endif
@@ -344,6 +378,7 @@ cpu_fork_kthread_handler(struct thread *td, void (*func)(void *), void *arg)
 
 	td->td_pcb->pcb_x[PCB_X19] = (uintptr_t)func;
 	td->td_pcb->pcb_x[PCB_X20] = (uintptr_t)arg;
+	td->td_pcb->pcb_x[PCB_X21] = (uintptr_t)td->td_frame;
 }
 
 void

--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -104,6 +104,11 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 #endif
 	}
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	KASSERT((cheri_perms_get(td2->td_kstack) & CHERI_PERM_EXECUTE) == 0,
+	    ("Executable td_kstack %#p", (void *)td2->td_kstack));
+#endif
+
 	pcb2 = (struct pcb *)(td2->td_kstack +
 	    td2->td_kstack_pages * PAGE_SIZE) - 1;
 

--- a/sys/arm64/conf/GENERIC-MORELLO-PURECAP
+++ b/sys/arm64/conf/GENERIC-MORELLO-PURECAP
@@ -27,6 +27,7 @@ machine 	arm64 aarch64c
 makeoptions	CHERI_SUBOBJECT_BOUNDS=subobject-safe
 
 options 	CHERI_PURECAP_KERNEL
+options		CHERI_BOUNDED_KSTACK
 
 nooptions 	PERTHREAD_SSP		# Not relevant in purecap
 

--- a/sys/arm64/include/pcb.h
+++ b/sys/arm64/include/pcb.h
@@ -43,6 +43,7 @@ struct trapframe;
 
 #define	PCB_X19		0
 #define	PCB_X20		1
+#define	PCB_X21		2
 #define	PCB_FP		10
 #define	PCB_LR		11
 

--- a/sys/arm64/include/proc.h
+++ b/sys/arm64/include/proc.h
@@ -44,6 +44,9 @@ struct mdthread {
 	int	md_spinlock_count;	/* (k) */
 	register_t md_saved_daif;	/* (k) */
 	uintptr_t md_canary;
+#ifdef CHERI_BOUNDED_KSTACK
+	void	*md_kstack;		/* (k) */
+#endif
 
 	/*
 	 * The pointer authentication keys. These are shared within a process,

--- a/sys/arm64/include/stack.h
+++ b/sys/arm64/include/stack.h
@@ -55,5 +55,4 @@ kstack_contains(struct thread *td, vm_offset_t va, size_t len)
 	    sizeof(struct pcb));
 }
 #endif	/* _SYS_PROC_H_ */
-
 #endif /* !_MACHINE_STACK_H_ */

--- a/sys/conf/options
+++ b/sys/conf/options
@@ -1020,6 +1020,7 @@ PRESERVE_EARLY_KENV	opt_global.h
 # CHERI
 CPU_CHERI	opt_global.h
 CHERI_PURECAP_KERNEL		opt_global.h
+CHERI_BOUNDED_KSTACK		opt_global.h
 
 #
 # Disable system-call authorisation for compartmentalised user code.

--- a/sys/riscv/conf/std.CHERI-PURECAP
+++ b/sys/riscv/conf/std.CHERI-PURECAP
@@ -5,3 +5,4 @@ machine		riscv	riscv64c
 makeoptions	CHERI_SUBOBJECT_BOUNDS=subobject-safe
 
 options 	CHERI_PURECAP_KERNEL
+options 	CHERI_BOUNDED_KSTACK

--- a/sys/riscv/include/proc.h
+++ b/sys/riscv/include/proc.h
@@ -35,6 +35,9 @@ struct mdthread {
 	int	md_spinlock_count;	/* (k) */
 	register_t md_saved_sstatus_ie;	/* (k) */
 	int	md_flags;		/* (k) */
+#ifdef CHERI_BOUNDED_KSTACK
+	void	*md_kstack;		/* (k) */
+#endif
 };
 
 /* md_flags */

--- a/sys/riscv/include/stack.h
+++ b/sys/riscv/include/stack.h
@@ -35,6 +35,8 @@
 #ifndef _MACHINE_STACK_H_
 #define	_MACHINE_STACK_H_
 
+#include <sys/proc.h>
+
 #define	INKERNEL(va)	((va) >= VM_MIN_KERNEL_ADDRESS && \
 			 (va) <= VM_MAX_KERNEL_ADDRESS)
 
@@ -65,5 +67,42 @@ kstack_contains(struct thread *td, vm_offset_t va, size_t len)
 	    sizeof(struct pcb));
 }
 #endif	/* _SYS_PROC_H_ */
+
+/*
+ * Get the thread kernel stack bottom.
+ * This is the space immediately after the reserved pcb and trapframe space.
+ * The returned stack pointer is precisely bounded.
+ *
+ * NB: This assumes that td_frame has been initialized.
+ */
+static __inline uintptr_t
+kstack_bottom(struct thread *td)
+{
+	uintptr_t ks = td->td_kstack;
+
+#ifdef CHERI_BOUNDED_KSTACK
+	size_t ks_size;
+
+	ks_size = (ptraddr_t)td->td_frame - (ptraddr_t)ks + TF_SIZE +
+	    sizeof(struct kernframe);
+	/*
+	 * Note: td_frame is placed so that td_kstack + ks_size is
+	 * representable.
+	 */
+	KASSERT(CHERI_REPRESENTABLE_LENGTH(ks_size),
+	    ("kstack size not representable: %#zx", ks_size));
+	KASSERT(is_aligned(ks, CHERI_REPRESENTABLE_ALIGNMENT(ks_size)),
+	    ("kstack not sufficiently aligned: %#p size %#zx", (void *)ks,
+		ks_size));
+
+	ks = cheri_bounds_set_exact(ks, ks_size);
+	KASSERT(cheri_tag_get(ks), ("Invalid kstack %#p", (void *)ks));
+	ks = cheri_address_set(ks, (ptraddr_t)td->td_frame);
+#else
+	ks = (uintptr_t)td->td_frame;
+#endif
+
+	return (ks);
+}
 
 #endif /* !_MACHINE_STACK_H_ */

--- a/sys/riscv/include/stack.h
+++ b/sys/riscv/include/stack.h
@@ -35,8 +35,6 @@
 #ifndef _MACHINE_STACK_H_
 #define	_MACHINE_STACK_H_
 
-#include <sys/proc.h>
-
 #define	INKERNEL(va)	((va) >= VM_MIN_KERNEL_ADDRESS && \
 			 (va) <= VM_MAX_KERNEL_ADDRESS)
 
@@ -67,42 +65,4 @@ kstack_contains(struct thread *td, vm_offset_t va, size_t len)
 	    sizeof(struct pcb));
 }
 #endif	/* _SYS_PROC_H_ */
-
-/*
- * Get the thread kernel stack bottom.
- * This is the space immediately after the reserved pcb and trapframe space.
- * The returned stack pointer is precisely bounded.
- *
- * NB: This assumes that td_frame has been initialized.
- */
-static __inline uintptr_t
-kstack_bottom(struct thread *td)
-{
-	uintptr_t ks = td->td_kstack;
-
-#ifdef CHERI_BOUNDED_KSTACK
-	size_t ks_size;
-
-	ks_size = (ptraddr_t)td->td_frame - (ptraddr_t)ks + TF_SIZE +
-	    sizeof(struct kernframe);
-	/*
-	 * Note: td_frame is placed so that td_kstack + ks_size is
-	 * representable.
-	 */
-	KASSERT(CHERI_REPRESENTABLE_LENGTH(ks_size),
-	    ("kstack size not representable: %#zx", ks_size));
-	KASSERT(is_aligned(ks, CHERI_REPRESENTABLE_ALIGNMENT(ks_size)),
-	    ("kstack not sufficiently aligned: %#p size %#zx", (void *)ks,
-		ks_size));
-
-	ks = cheri_bounds_set_exact(ks, ks_size);
-	KASSERT(cheri_tag_get(ks), ("Invalid kstack %#p", (void *)ks));
-	ks = cheri_address_set(ks, (ptraddr_t)td->td_frame);
-#else
-	ks = (uintptr_t)td->td_frame;
-#endif
-
-	return (ks);
-}
-
 #endif /* !_MACHINE_STACK_H_ */

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -224,6 +224,26 @@
 #ifdef __CHERI_PURE_CAPABILITY__
 	/* CHERI-RISC-V purecap doesn't currently use cgp. */
 	cmove	cgp, cnull
+#ifdef CHERI_BOUNDED_KSTACK
+	/* Prepare frame pointer in cs0 */
+	cmove	cs0, csp
+	li	t0, TF_SIZE
+	csetboundsexact	cs0, cs0, t0
+	/*
+	 * Narrow bounds on the kernel stack pointer.
+	 * Effectively this excludes trapframe and kernframe, the PCB should
+	 * already be out of bounds.
+	 * Note that we want exact bounds, so we will round the size to a
+	 * representable boundary.
+	 */
+	cgetbase	t0, csp
+	sub		t2, sp, t0
+	csetaddr	ct1, csp, t0
+	cram		t0, t2
+	and		t2, t2, t0
+	csetboundsexact	ct0, ct1, t2
+	cincoffset	csp, ct0, t2
+#endif
 #else
 .option push
 .option norelax
@@ -235,6 +255,28 @@
 .endm
 
 .macro load_registers mode
+#ifdef CHERI_BOUNDED_KSTACK
+.if \mode == 0
+	/*
+	 * Returning to userland, recover the full kstack bounds to access
+	 * trapframe and kernframe.
+	 * Compute larger bounds for the load_registers kstack:
+	 * expand the bounds to extend to the end of kernframe, which includes
+	 * the user trapframe. We use TD_FRAME here because save_registers may
+	 * have rounded the kstack bottom and the trapframe is no longer
+	 * guaranteed to be contiguous with the rest of the kernel stack in csp.
+	 */
+	clc	ct0, (PC_CURTHREAD)(ctp)
+	clc	ct1, (TD_KSTACK)(ct0)
+	clc	ct0, (TD_FRAME)(ct0)
+	addi	t0, t0, (TF_SIZE + KF_SIZE)
+	sub	t0, t0, t1
+	/* Note: guaranteed to be representable by td_frame construction */
+	csetboundsexact	ct0, ct1, t0
+	cgetaddr	t1, csp
+	csetaddr	csp, ct0, t1
+.endif
+#endif
 #ifdef __CHERI_PURE_CAPABILITY__
 	cld	t0, (TF_SSTATUS)(csp)
 #else
@@ -300,7 +342,6 @@
 	/* We go to userspace. Load user csp */
 	clc	ct0, (TF_SP)(csp)
 	cspecialw sscratchc, ct0
-
 	/* Store our pcpu */
 	csc	ctp, (TF_SIZE + KF_TP)(csp)
 	clc	ctp, (TF_TP)(csp)
@@ -418,7 +459,13 @@
 
 	/* Handle the ast */
 #ifdef __CHERI_PURE_CAPABILITY__
+
+#ifdef CHERI_BOUNDED_KSTACK
+	/* Note: save_registers leaves a bounded trapframe pointer in cs0 */
+	cmove	ca0, cs0
+#else
 	cmove	ca0, csp
+#endif
 	ccall	_C_LABEL(ast)
 #else
 	mv	a0, sp
@@ -453,6 +500,10 @@ ENTRY(cpu_exception_handler_supervisor)
 	save_registers 1
 #ifdef __CHERI_PURE_CAPABILITY__
 	cmove	ca0, csp
+#ifdef CHERI_BOUNDED_KSTACK
+	li	t1, TF_SIZE
+	csetboundsexact	ca0, ca0, t1
+#endif
 	ccall	_C_LABEL(do_trap_supervisor)
 #else
 	mv	a0, sp
@@ -465,7 +516,12 @@ END(cpu_exception_handler_supervisor)
 ENTRY(cpu_exception_handler_user)
 	save_registers 0
 #ifdef __CHERI_PURE_CAPABILITY__
+#ifdef CHERI_BOUNDED_KSTACK
+	/* Note: save_registers leaves trapframe pointer in cs0 */
+	cmove	ca0, cs0
+#else
 	cmove	ca0, csp
+#endif
 	ccall	_C_LABEL(do_trap_user)
 #else
 	mv	a0, sp

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -38,6 +38,13 @@
 #include <machine/trap.h>
 #include <machine/riscvreg.h>
 
+/*
+ * Save the registers to the kernel stack and enter the kernel context.
+ *
+ * When CHERI_BOUNDED_KSTACK is enabled, and saving userspace registers:
+ * 1. Return a bounded capability to td_frame in cs0.
+ * 2. Install a bounded kernel stack in csp.
+ */
 .macro save_registers mode
 #if __has_feature(capabilities)
 .option push
@@ -229,20 +236,10 @@
 	cmove	cs0, csp
 	li	t0, TF_SIZE
 	csetboundsexact	cs0, cs0, t0
-	/*
-	 * Narrow bounds on the kernel stack pointer.
-	 * Effectively this excludes trapframe and kernframe, the PCB should
-	 * already be out of bounds.
-	 * Note that we want exact bounds, so we will round the size to a
-	 * representable boundary.
-	 */
-	cgetbase	t0, csp
-	sub		t2, sp, t0
-	csetaddr	ct1, csp, t0
-	cram		t0, t2
-	and		t2, t2, t0
-	csetboundsexact	ct0, ct1, t2
-	cincoffset	csp, ct0, t2
+
+	/* Install bounded kstack */
+	clc	ct0, (PC_CURTHREAD)(ctp)
+	clc	csp, (TD_MDKSTACK)(ct0)
 #endif
 #else
 .option push
@@ -254,27 +251,22 @@
 .endif
 .endm
 
+/*
+ * Restore registers from the kernel stack and enter the user context.
+ *
+ * When CHERI_BOUNDED_KSTACK is enabled, and returning to userspace:
+ * 1. Recover the unbounded kstack pointer in csp, to be preserved in sscratch.
+ * 2. Ensure that the returned csp pointer points at the beginning of the
+ * td_frame structure.
+ */
 .macro load_registers mode
 #ifdef CHERI_BOUNDED_KSTACK
 .if \mode == 0
-	/*
-	 * Returning to userland, recover the full kstack bounds to access
-	 * trapframe and kernframe.
-	 * Compute larger bounds for the load_registers kstack:
-	 * expand the bounds to extend to the end of kernframe, which includes
-	 * the user trapframe. We use TD_FRAME here because save_registers may
-	 * have rounded the kstack bottom and the trapframe is no longer
-	 * guaranteed to be contiguous with the rest of the kernel stack in csp.
-	 */
+	/* Recover the full kstack bounds to access trapframe and kernframe. */
 	clc	ct0, (PC_CURTHREAD)(ctp)
 	clc	ct1, (TD_KSTACK)(ct0)
 	clc	ct0, (TD_FRAME)(ct0)
-	addi	t0, t0, (TF_SIZE + KF_SIZE)
-	sub	t0, t0, t1
-	/* Note: guaranteed to be representable by td_frame construction */
-	csetboundsexact	ct0, ct1, t0
-	cgetaddr	t1, csp
-	csetaddr	csp, ct0, t1
+	csetaddr	csp, ct1, t0
 .endif
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -461,7 +453,7 @@
 #ifdef __CHERI_PURE_CAPABILITY__
 
 #ifdef CHERI_BOUNDED_KSTACK
-	/* Note: save_registers leaves a bounded trapframe pointer in cs0 */
+	/* See save_registers */
 	cmove	ca0, cs0
 #else
 	cmove	ca0, csp
@@ -517,7 +509,6 @@ ENTRY(cpu_exception_handler_user)
 	save_registers 0
 #ifdef __CHERI_PURE_CAPABILITY__
 #ifdef CHERI_BOUNDED_KSTACK
-	/* Note: save_registers leaves trapframe pointer in cs0 */
 	cmove	ca0, cs0
 #else
 	cmove	ca0, csp

--- a/sys/riscv/riscv/genassym.c
+++ b/sys/riscv/riscv/genassym.c
@@ -88,6 +88,9 @@ ASSYM(TD_FRAME, offsetof(struct thread, td_frame));
 ASSYM(TD_MD, offsetof(struct thread, td_md));
 ASSYM(TD_LOCK, offsetof(struct thread, td_lock));
 ASSYM(TD_MDFLAGS, offsetof(struct thread, td_md.md_flags));
+#ifdef CHERI_BOUNDED_KSTACK
+ASSYM(TD_KSTACK, offsetof(struct thread, td_kstack));
+#endif
 
 ASSYM(TF_SIZE, TF_SIZE);
 ASSYM(TF_RA, offsetof(struct trapframe, tf_ra));
@@ -106,6 +109,9 @@ ASSYM(TF_SCAUSE, offsetof(struct trapframe, tf_scause));
 ASSYM(TF_SSTATUS, offsetof(struct trapframe, tf_sstatus));
 
 ASSYM(KF_TP, offsetof(struct kernframe, kf_tp));
+#ifdef CHERI_BOUNDED_KSTACK
+ASSYM(KF_SIZE, sizeof(struct kernframe));
+#endif
 #if __has_feature(capabilities) && !defined(__CHERI_PURE_CAPABILITY__)
 ASSYM(KF_DDC, offsetof(struct kernframe, kf_ddc));
 #endif

--- a/sys/riscv/riscv/genassym.c
+++ b/sys/riscv/riscv/genassym.c
@@ -90,6 +90,7 @@ ASSYM(TD_LOCK, offsetof(struct thread, td_lock));
 ASSYM(TD_MDFLAGS, offsetof(struct thread, td_md.md_flags));
 #ifdef CHERI_BOUNDED_KSTACK
 ASSYM(TD_KSTACK, offsetof(struct thread, td_kstack));
+ASSYM(TD_MDKSTACK, offsetof(struct thread, td_md.md_kstack));
 #endif
 
 ASSYM(TF_SIZE, TF_SIZE);

--- a/sys/riscv/riscv/machdep.c
+++ b/sys/riscv/riscv/machdep.c
@@ -349,6 +349,10 @@ init_proc0(vm_pointer_t kstack)
 	thread0.td_kstack_pages = KSTACK_PAGES;
 	thread0.td_pcb = (struct pcb *)(thread0.td_kstack +
 	    thread0.td_kstack_pages * PAGE_SIZE) - 1;
+#ifdef CHERI_BOUNDED_KSTACK
+	thread0.td_pcb = cheri_bounds_set_exact(thread0.td_pcb,
+	    sizeof(struct pcb));
+#endif
 	thread0.td_pcb->pcb_fpflags = 0;
 	thread0.td_frame = &proc0_tf;
 	pcpup->pc_curpcb = thread0.td_pcb;

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -625,6 +625,10 @@ ENTRY(fork_trampoline)
 	cmove	ca0, cs0
 	cmove	ca1, cs1
 	cmove	ca2, csp
+#ifdef CHERI_BOUNDED_KSTACK
+	li	t0, TF_SIZE
+	csetboundsexact	ca2, ca2, t0
+#endif
 	ccall	_C_LABEL(fork_exit)
 #else
 	mv	a0, s0

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -624,12 +624,16 @@ ENTRY(fork_trampoline)
 #ifdef __CHERI_PURE_CAPABILITY__
 	cmove	ca0, cs0
 	cmove	ca1, cs1
-	cmove	ca2, csp
-#ifdef CHERI_BOUNDED_KSTACK
-	li	t0, TF_SIZE
-	csetboundsexact	ca2, ca2, t0
-#endif
+	cmove	ca2, cs2
 	ccall	_C_LABEL(fork_exit)
+
+#ifdef CHERI_BOUNDED_KSTACK
+	/* Recover the full kstack bounds to access trapframe */
+	clc	ct0, (PC_CURTHREAD)(ctp)
+	clc	ct1, (TD_KSTACK)(ct0)
+	clc	ct0, (TD_FRAME)(ct0)
+	csetaddr	csp, ct1, t0
+#endif
 #else
 	mv	a0, s0
 	mv	a1, s1

--- a/sys/riscv/riscv/trap.c
+++ b/sys/riscv/riscv/trap.c
@@ -584,6 +584,22 @@ do_trap_user(struct trapframe *frame)
 	td = curthread;
 	pcb = td->td_pcb;
 
+#ifdef CHERI_BOUNDED_KSTACK
+	KASSERT(cheri_length_get(frame) == TF_SIZE,
+	    ("Invalid trapframe bounds: %#p", frame));
+	KASSERT(cheri_base_get(td->td_frame) >= cheri_top_get(cheri_stack_get()),
+	    ("Invalid kernel stack bounds: %#p overlaps frame %#p",
+		cheri_stack_get(), td->td_frame));
+	KASSERT(cheri_base_get(cheri_stack_get()) == td->td_kstack,
+	    ("Invalid kernel stack base: %#p expect td_kstack %#p",
+		cheri_stack_get(), (void *)td->td_kstack));
+	KASSERT(cheri_top_get(cheri_stack_get()) <= (ptraddr_t)td->td_frame,
+	    ("Invalid kernel stack length: %#p overlaps frame %#p",
+		cheri_stack_get(), td->td_frame));
+	KASSERT(cheri_length_get(pcb) == sizeof(struct pcb),
+	    ("Invalid PCB bounds %#p", pcb));
+#endif
+
 	KASSERT(td->td_frame == frame,
 	    ("%s: td_frame %p != frame %p", __func__, td->td_frame, frame));
 

--- a/sys/riscv/riscv/vm_machdep.c
+++ b/sys/riscv/riscv/vm_machdep.c
@@ -51,6 +51,7 @@
 #include <machine/cpu.h>
 #include <machine/cpufunc.h>
 #include <machine/pcb.h>
+#include <machine/stack.h>
 #include <machine/frame.h>
 #include <machine/sbi.h>
 
@@ -63,6 +64,11 @@
 static void
 cpu_set_pcb_frame(struct thread *td)
 {
+#ifdef CHERI_BOUNDED_KSTACK
+	ptraddr_t kstack_top;
+	ptraddr_t kstack_aligned_top;
+#endif
+
 	td->td_pcb = (struct pcb *)((char *)td->td_kstack +
 	    td->td_kstack_pages * PAGE_SIZE) - 1;
 
@@ -78,6 +84,26 @@ cpu_set_pcb_frame(struct thread *td)
 	 */
 	td->td_frame = (struct trapframe *)(STACKALIGN(
 	    (char *)td->td_pcb - sizeof(struct kernframe)) - TF_SIZE);
+
+#ifdef CHERI_BOUNDED_KSTACK
+	td->td_pcb = cheri_bounds_set_exact(td->td_pcb, sizeof(struct pcb));
+	/*
+	 * The placement is td_frame is more constrained here.
+	 * To ensure precise representability of the saved kernel stack,
+	 * top = td_frame + TF_SIZE + sizeof(struct kernframe) must fall at a
+	 * representable boundary for the region [td_kstack, top).
+	 * This means that we may insert additional padding between td_pcb
+	 * and the end of struct kernframe.
+	 */
+	kstack_top = (ptraddr_t)td->td_frame + TF_SIZE +
+	    sizeof(struct kernframe);
+	kstack_aligned_top = rounddown2(kstack_top,
+	    CHERI_REPRESENTABLE_ALIGNMENT(kstack_top - td->td_kstack));
+	td->td_frame -= kstack_top - kstack_aligned_top;
+	KASSERT(kstack_top - kstack_aligned_top < 64,
+	    ("Too much kernel stack wasted"));
+        td->td_frame = cheri_bounds_set_exact(td->td_frame, TF_SIZE);
+#endif
 }
 
 /*
@@ -125,7 +151,7 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	td2->td_pcb->pcb_s[0] = (uintptr_t)fork_return;
 	td2->td_pcb->pcb_s[1] = (uintptr_t)td2;
 	td2->td_pcb->pcb_ra = (uintptr_t)fork_trampoline;
-	td2->td_pcb->pcb_sp = (uintptr_t)td2->td_frame;
+	td2->td_pcb->pcb_sp = kstack_bottom(td2);
 
 	/* Setup to release spin count in fork_exit(). */
 	td2->td_md.md_spinlock_count = 1;
@@ -185,7 +211,7 @@ cpu_copy_thread(struct thread *td, struct thread *td0)
 	td->td_pcb->pcb_s[0] = (uintptr_t)fork_return;
 	td->td_pcb->pcb_s[1] = (uintptr_t)td;
 	td->td_pcb->pcb_ra = (uintptr_t)fork_trampoline;
-	td->td_pcb->pcb_sp = (uintptr_t)td->td_frame;
+	td->td_pcb->pcb_sp = kstack_bottom(td);
 
 	/* Setup to release spin count in fork_exit(). */
 	td->td_md.md_spinlock_count = 1;
@@ -272,7 +298,7 @@ cpu_fork_kthread_handler(struct thread *td, void (*func)(void *), void *arg)
 	td->td_pcb->pcb_s[0] = (uintptr_t)func;
 	td->td_pcb->pcb_s[1] = (uintptr_t)arg;
 	td->td_pcb->pcb_ra = (uintptr_t)fork_trampoline;
-	td->td_pcb->pcb_sp = (uintptr_t)td->td_frame;
+	td->td_pcb->pcb_sp = kstack_bottom(td);
 }
 
 void

--- a/sys/riscv/riscv/vm_machdep.c
+++ b/sys/riscv/riscv/vm_machdep.c
@@ -99,6 +99,10 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 #if __has_feature(capabilities)
 	p2->p_md.md_sigcode = td1->td_proc->p_md.md_sigcode;
 #endif
+#ifdef __CHERI_PURE_CAPABILITY__
+	KASSERT((cheri_perms_get(td2->td_kstack) & CHERI_PERM_EXECUTE) == 0,
+	    ("Executable td_kstack %#p", (void *)td2->td_kstack));
+#endif
 
 	cpu_set_pcb_frame(td2);
 

--- a/sys/riscv/riscv/vm_machdep.c
+++ b/sys/riscv/riscv/vm_machdep.c
@@ -51,7 +51,6 @@
 #include <machine/cpu.h>
 #include <machine/cpufunc.h>
 #include <machine/pcb.h>
-#include <machine/stack.h>
 #include <machine/frame.h>
 #include <machine/sbi.h>
 
@@ -66,7 +65,7 @@ cpu_set_pcb_frame(struct thread *td)
 {
 #ifdef CHERI_BOUNDED_KSTACK
 	ptraddr_t kstack_top;
-	ptraddr_t kstack_aligned_top;
+	ptraddr_t kstack_align;
 #endif
 
 	td->td_pcb = (struct pcb *)((char *)td->td_kstack +
@@ -87,22 +86,20 @@ cpu_set_pcb_frame(struct thread *td)
 
 #ifdef CHERI_BOUNDED_KSTACK
 	td->td_pcb = cheri_bounds_set_exact(td->td_pcb, sizeof(struct pcb));
-	/*
-	 * The placement is td_frame is more constrained here.
-	 * To ensure precise representability of the saved kernel stack,
-	 * top = td_frame + TF_SIZE + sizeof(struct kernframe) must fall at a
-	 * representable boundary for the region [td_kstack, top).
-	 * This means that we may insert additional padding between td_pcb
-	 * and the end of struct kernframe.
-	 */
-	kstack_top = (ptraddr_t)td->td_frame + TF_SIZE +
-	    sizeof(struct kernframe);
-	kstack_aligned_top = rounddown2(kstack_top,
-	    CHERI_REPRESENTABLE_ALIGNMENT(kstack_top - td->td_kstack));
-	td->td_frame -= kstack_top - kstack_aligned_top;
-	KASSERT(kstack_top - kstack_aligned_top < 64,
-	    ("Too much kernel stack wasted"));
         td->td_frame = cheri_bounds_set_exact(td->td_frame, TF_SIZE);
+
+	/*
+	 * Compute the bounded kernel stack pointer.
+	 * Note that we need to ensure representability and avoid giving
+	 * access to td_frame. This means that there may be a gap between
+	 * td_frame and the the kernel stack.
+	 */
+	kstack_align = CHERI_REPRESENTABLE_ALIGNMENT((ptraddr_t)td->td_frame -
+	    td->td_kstack);
+	kstack_top = rounddown2((ptraddr_t)td->td_frame, kstack_align);
+	td->td_md.md_kstack = (void *)cheri_address_set(
+	    cheri_bounds_set_exact(td->td_kstack, kstack_top - td->td_kstack),
+	    kstack_top);
 #endif
 }
 
@@ -150,8 +147,13 @@ cpu_fork(struct thread *td1, struct proc *p2, struct thread *td2, int flags)
 	/* Set the return value registers for fork() */
 	td2->td_pcb->pcb_s[0] = (uintptr_t)fork_return;
 	td2->td_pcb->pcb_s[1] = (uintptr_t)td2;
+	td2->td_pcb->pcb_s[2] = (uintptr_t)td2->td_frame;
 	td2->td_pcb->pcb_ra = (uintptr_t)fork_trampoline;
-	td2->td_pcb->pcb_sp = kstack_bottom(td2);
+#ifdef CHERI_BOUNDED_KSTACK
+	td2->td_pcb->pcb_sp = (uintptr_t)td2->td_md.md_kstack;
+#else
+	td2->td_pcb->pcb_sp = (uintptr_t)td2->td_frame;
+#endif
 
 	/* Setup to release spin count in fork_exit(). */
 	td2->td_md.md_spinlock_count = 1;
@@ -210,8 +212,13 @@ cpu_copy_thread(struct thread *td, struct thread *td0)
 
 	td->td_pcb->pcb_s[0] = (uintptr_t)fork_return;
 	td->td_pcb->pcb_s[1] = (uintptr_t)td;
+	td->td_pcb->pcb_s[2] = (uintptr_t)td->td_frame;
 	td->td_pcb->pcb_ra = (uintptr_t)fork_trampoline;
-	td->td_pcb->pcb_sp = kstack_bottom(td);
+#ifdef CHERI_BOUNDED_KSTACK
+	td->td_pcb->pcb_sp = (uintptr_t)td->td_md.md_kstack;
+#else
+	td->td_pcb->pcb_sp = (uintptr_t)td->td_frame;
+#endif
 
 	/* Setup to release spin count in fork_exit(). */
 	td->td_md.md_spinlock_count = 1;
@@ -297,8 +304,13 @@ cpu_fork_kthread_handler(struct thread *td, void (*func)(void *), void *arg)
 
 	td->td_pcb->pcb_s[0] = (uintptr_t)func;
 	td->td_pcb->pcb_s[1] = (uintptr_t)arg;
+	td->td_pcb->pcb_s[2] = (uintptr_t)td->td_frame;
 	td->td_pcb->pcb_ra = (uintptr_t)fork_trampoline;
-	td->td_pcb->pcb_sp = kstack_bottom(td);
+#ifdef CHERI_BOUNDED_KSTACK
+	td->td_pcb->pcb_sp = (uintptr_t)td->td_md.md_kstack;
+#else
+	td->td_pcb->pcb_sp = (uintptr_t)td->td_frame;
+#endif
 }
 
 void

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -346,6 +346,9 @@ vm_thread_alloc_kstack_kva(vm_size_t size, int domain)
 	    (kstack_pages + KSTACK_GUARD_PAGES) == 0,
 	    ("%s: allocated kstack KVA not aligned to multiple of kstack size",
 	    __func__));
+#ifdef __CHERI_PURE_CAPABILITY__
+	addr = cheri_perms_clear(addr, CHERI_PERM_EXECUTE);
+#endif
 
 	return (addr);
 #else


### PR DESCRIPTION
The implementation differs slightly depending on the architecture.

RISC-V uses kstack for the pcb, kernframe and trapframe structures.
These patches set tight bounds for the pcb, kernframe and remainder of the kernel stack.
The trapframe is left together with the kernel stack, given that it is part of the normal arithmetic on the kernel stack pointer in the trap handlers at the moment.
The `sscratchc` register is now used to hold a pointer to `struct kernframe` instead of the full `kstack` capability.
The kernframe is expanded to hold a bounded pointer to the kernel stack region and a scratch pointer.
The scratch pointer is used in the trap handler to swap register contents with constrained use of CPU registers.

Edit:
- Changed approach. Do not disrupt `sscratchc` or the existing stashed stack pointer. The following applies to all architectures:
  1. The stashed / banked stack pointer includes all kstack, except for `struct pcb` bounds. Representability is guaranteed.
  2. `struct pcb` has separate bounds that never overlap with the stack pointer.
  3. `td_kstack` is considered the root capability for all kernel stack sub-allocations.
  4. Upon entering the trap handler from userland, the trap handler accesses td_frame (and kernframe in RISC-V) from the csp pointer. It then proceeds to shrink csp to exclude the td_frame (and kernframe) regions. Again, representablity is guaranteed by construction of td_frame.
  5. Upon exiting the trap handler to userland, the trap handler recovers the csp bounds to include td_frame (and kernframe) prior to loading registers and returning to userland.
- Implemented Morello

Note that this is all gated by the CHERI_BOUNDED_KSTACK option, because I'd like to be able to measure the difference for dissertation purposes. Also, this is an intermediate patch for the use of local/global for kernel capability flow enforcement, which is currently WIP.