### PR TITLE
Fix building out-of-tree kernel modules

### DIFF
--- a/sys/conf/config.mk
+++ b/sys/conf/config.mk
@@ -80,6 +80,9 @@ KERN_OPTS+= IPSEC_SUPPORT
 .if ${MK_SCTP_SUPPORT} != "no"
 KERN_OPTS+= SCTP_SUPPORT
 .endif
+
+# Default pure-capability kernels use sub-object bounds.
+CHERI_SUBOBJECT_BOUNDS?=	subobject-safe
 .elif !defined(KERN_OPTS)
 # Add all the options that are mentioned in any opt_*.h file when we
 # have a kernel build directory to pull them from.

--- a/sys/conf/kmod.mk
+++ b/sys/conf/kmod.mk
@@ -548,10 +548,11 @@ OBJS_DEPEND_GUESS+= ${SRCS:M*.h}
 OBJS_DEPEND_GUESS+= opt_global.h
 .endif
 
+.if defined(ZFSTOP)
+# Define include search paths of in-tree ZFS for use by ZFS/DTrace-related
+# modules if a build uses in-tree ZFS by virtue of defining ZFSTOP. For example,
+# in-tree kernel modules use ZFSTOP but out-of-tree kernel modules not.
 ZINCDIR=${ZFSTOP}/include
-.if !exists(${ZINCDIR})
-.error is ZFSTOP set?
-.endif
 OPENZFS_CFLAGS=     \
 	-D_SYS_VMEM_H_  \
 	-D__KERNEL__ \
@@ -564,6 +565,7 @@ OPENZFS_CFLAGS=     \
 	-I${SYSDIR}/cddl/compat/opensolaris \
 	-I${SYSDIR}/cddl/contrib/opensolaris/uts/common \
 	-include ${ZINCDIR}/os/freebsd/spl/sys/ccompile.h
+.endif
 
 .include <bsd.dep.mk>
 .include <bsd.clang-analyze.mk>

--- a/sys/modules/zfs/Makefile
+++ b/sys/modules/zfs/Makefile
@@ -379,6 +379,8 @@ SRCS+=	zfs_zstd.c \
 	zstd_ldm.c \
 	zstd_opt.c
 
+CHERI_SUBOBJECT_BOUNDS=	conservative
+
 .include <bsd.kmod.mk>
 
 CFLAGS+= -include ${SRCTOP}/sys/cddl/compat/opensolaris/sys/debug_compat.h
@@ -530,8 +532,4 @@ zfs-sha512-x86_64.o: sha512-x86_64.S
 	    ${SRCDIR}/icp/asm-x86_64/sha2/sha512-x86_64.S \
 	    -o ${.TARGET}
 	${CTFCONVERT_CMD}
-.endif
-
-.if ${MACHINE_ABI:Mpurecap}
-CFLAGS+=-Xclang -cheri-bounds=conservative
 .endif


### PR DESCRIPTION
These two changes are required to build out-of-tree kernel modules, e.g. from CheriBSD ports.