### PR TITLE
cheri: Turn off caprevoke statistics for NODEBUG kernels.

### DIFF
--- a/sys/conf/std.nodebug
+++ b/sys/conf/std.nodebug
@@ -27,3 +27,7 @@ nooptions	HID_DEBUG
 # CAM debugging
 nooptions	CAMDEBUG
 nooptions	CAM_DEBUG_FLAGS
+
+# CHERI revocation profiling
+# This introduces significant performance overhead
+nooptions 	CHERI_CAPREVOKE_STATS


### PR DESCRIPTION
This has been reported by @markjdb.