### PR TITLE
RVY Kernel permission bits and additional migration to HAS_PERM checks.

### DIFF
--- a/contrib/subrepo-snmalloc/src/snmalloc/mem/localalloc.h
+++ b/contrib/subrepo-snmalloc/src/snmalloc/mem/localalloc.h
@@ -502,8 +502,15 @@ namespace snmalloc
        * permissions checks are required in the non-SNMALLOC_CHECK_CLIENT case
        * to defend ourselves or other clients against a misbehaving client.
        */
+#if defined(__riscv_xcheri) || defined(__aarch64)
       static const size_t reqperm = CHERI_PERM_LOAD | CHERI_PERM_STORE |
         CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE_CAP;
+#elif defined(__riscv_zcheripurecap)
+      static const size_t reqperm = CHERI_PERM_LOAD | CHERI_PERM_STORE |
+        CHERI_PERM_CAP;
+#else
+#error "Missing LOAD/STORE CAP permission"
+#endif
       snmalloc_check_client(
         mitigations(cheri_checks),
         (__builtin_cheri_perms_get(p) & reqperm) == reqperm,

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -226,7 +226,10 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 
 		code_cap = cheri_pcc_get();
 		rodata_cap = cheri_perms_clear(data_cap,
-		    CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
+		    CHERI_PERM_STORE |
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+		    CHERI_PERM_STORE_CAP |
+#endif
 		    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
 
 		data_cap = cheri_address_set(data_cap, writable_start);

--- a/lib/libc/gen/dlfcn.c
+++ b/lib/libc/gen/dlfcn.c
@@ -224,8 +224,15 @@ dl_init_phdr_info(void)
 			phdr_info.dlpi_phdr =
 #ifdef __CHERI_PURE_CAPABILITY__
 			    /* XXXAR: currently needs load_cap for libunwind */
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 			    (const Elf_Phdr *)cheri_perms_and(auxp->a_un.a_ptr,
 			        CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP);
+#elif defined(HAS_CHERI_PERM_CAP)
+			    (const Elf_Phdr *)cheri_perms_and(auxp->a_un.a_ptr,
+				CHERI_PERM_LOAD | CHERI_PERM_CAP);
+#else
+#error "Missing LOAD_CAP permission"
+#endif
 #else
 			    (const Elf_Phdr *)auxp->a_un.a_ptr;
 #endif

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -5052,10 +5052,19 @@ static void
 rtld_fill_dl_phdr_info(const Obj_Entry *obj, struct dl_phdr_info *phdr_info)
 {
 #ifdef __CHERI_PURE_CAPABILITY__
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 	phdr_info->dlpi_addr = (uintptr_t)cheri_perms_and(obj->relocbase,
 	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP);
 	phdr_info->dlpi_phdr = cheri_perms_and(obj->phdr,
 	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP);
+#elif defined(HAS_CHERI_PERM_CAP)
+	phdr_info->dlpi_addr = (uintptr_t)cheri_perms_and(obj->relocbase,
+	    CHERI_PERM_LOAD | CHERI_PERM_CAP);
+	phdr_info->dlpi_phdr = cheri_perms_and(obj->phdr,
+	    CHERI_PERM_LOAD | CHERI_PERM_CAP);
+#else
+#error "Missing LOAD_CAP permission"
+#endif
 #else
 	phdr_info->dlpi_addr = (Elf_Addr)obj->relocbase;
 	phdr_info->dlpi_phdr = obj->phdr;

--- a/sys/arm64/include/cherireg.h
+++ b/sys/arm64/include/cherireg.h
@@ -80,6 +80,7 @@
 #define	HAS_CHERI_PERM_LOAD_STORE_CAP
 #define	HAS_CHERI_PERM_LOAD_MUTABLE
 #define	HAS_CHERI_PERM_EXECUTIVE
+#define	HAS_CHERI_PERM_SEAL
 
 /* Define alias for MUTABLE_LOAD permission bit to have consistent spelling */
 #define	CHERI_PERM_LOAD_MUTABLE CHERI_PERM_MUTABLE_LOAD

--- a/sys/cheri/cheri_otype.c
+++ b/sys/cheri/cheri_otype.c
@@ -42,6 +42,7 @@
 #include <vm/vm_cheri_revoke.h>
 #endif
 
+#ifdef HAS_CHERI_PERM_SEAL
 static struct mtx cheri_otype_lock;
 static struct unrhdr *cheri_otypes;
 /* Initialized in _start() */
@@ -103,6 +104,7 @@ cheri_otype_free(otype_t cap)
 	type = cheri_base_get(cap);
 	free_unr(cheri_otypes, type);
 }
+#endif /* HAS_CHERI_PERM_SEAL */
 
 #ifdef CHERI_CAPREVOKE
 #ifndef CHERI_CAPREVOKE_CLEARTAGS

--- a/sys/cheri/cheri_usercap.c
+++ b/sys/cheri/cheri_usercap.c
@@ -243,7 +243,9 @@ ptrace_derive_cap(struct proc *p, uintcap_t in, uintcap_t *out)
 {
 	struct thread *td;
 	void * __capability cap;
+#ifdef HAS_CHERI_PERM_SEAL
 	void * __capability sealcap;
+#endif
 
 	/*
 	 * Try to derive from existing user registers in this
@@ -263,8 +265,10 @@ ptrace_derive_cap(struct proc *p, uintcap_t in, uintcap_t *out)
 	if (cheri_ptrace_caps >= 2) {
 		/* If forging is allowed, derive from the userspace root. */
 		cap = cheri_cap_build(userspace_root_cap, in);
+#ifdef HAS_CHERI_PERM_SEAL
 		sealcap = cheri_type_copy(userspace_root_sealcap, in);
 		cap = cheri_seal_conditionally(cap, sealcap);
+#endif
 		if (cheri_tag_get(cap)) {
 			atomic_add_long(&cheri_forged_ptrace_caps, 1);
 			*out = (uintcap_t)cap;

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -609,8 +609,14 @@ __elfN(build_imgact_capability)(struct image_params *imgp,
     void * __capability *imgact_cap, const Elf_Ehdr *hdr, const Elf_Phdr *phdr,
     Elf_Addr *preferred_rbase)
 {
-	u_long perm = CHERI_PERM_STORE | CHERI_PERM_GLOBAL |
-	    CHERI_PERM_STORE_CAP;
+	u_long perm = CHERI_PERM_STORE |
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+	    CHERI_PERM_STORE_CAP |
+#endif
+#ifdef HAS_CHERI_PERM_CAP
+	    CHERI_PERM_CAP |
+#endif
+	    CHERI_PERM_GLOBAL;
 	vm_offset_t start = (vm_offset_t)-1;
 	vm_offset_t end = 0;
 	vm_offset_t seg_addr;

--- a/sys/kern/kern_cheri_revoke.c
+++ b/sys/kern/kern_cheri_revoke.c
@@ -816,6 +816,7 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 
 	case CHERI_REVOKE_SHADOW_OTYPE:
 	    {
+#ifdef HAS_CHERI_PERM_SEAL
 		int reqperms;
 
 		if (cheri_tag_get(arena) == 0)
@@ -833,6 +834,9 @@ kern_cheri_revoke_get_shadow(struct thread *td, int flags,
 
 		cres = vm_cheri_revoke_shadow_cap(curproc->p_sysent,
 			sel, base, size, 0);
+#else
+		return (EINVAL);
+#endif
 
 		break;
 	    }

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2665,7 +2665,11 @@ sysctl_kern_proc_c18n_compartments(SYSCTL_HANDLER_ARGS)
 	 * out.
 	 */
 	if (!cheri_can_access(info.comparts,
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
+#elif defined(HAS_CHERI_PERM_CAP)
+	    CHERI_PERM_LOAD | CHERI_PERM_CAP,
+#endif
 	    info.comparts_size * info.comparts_entry_size)) {
 		error = EPROT;
 		goto out;

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -886,6 +886,10 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				if (num & CHERI_PERM_CAP)
 					PCHAR('C');
 #endif
+#ifdef HAS_CHERI_PERM_LOAD_MUTABLE
+				if (num & CHERI_PERM_LOAD_MUTABLE)
+					PCHAR('M');
+#endif
 				PCHAR(',');
 
 				/* bounds */

--- a/sys/kern/subr_prf.c
+++ b/sys/kern/subr_prf.c
@@ -876,10 +876,16 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 					PCHAR('w');
 				if (num & CHERI_PERM_EXECUTE)
 					PCHAR('x');
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 				if (num & CHERI_PERM_LOAD_CAP)
 					PCHAR('R');
 				if (num & CHERI_PERM_STORE_CAP)
 					PCHAR('W');
+#endif
+#ifdef HAS_CHERI_PERM_CAP
+				if (num & CHERI_PERM_CAP)
+					PCHAR('C');
+#endif
 				PCHAR(',');
 
 				/* bounds */

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -579,7 +579,11 @@ kern_shmat_locked(struct thread *td, int shmid,
 		     attach_va), size);
 		/* Remove inappropriate permissions. */
 		shmaddr = cheri_perms_and(shmaddr, ~(CHERI_PERM_EXECUTE |
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 		    CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE_CAP |
+#elif defined(HAS_CHERI_PERM_CAP)
+		    CHERI_PERM_CAP |
+#endif
 		    ((shmflg & SHM_RDONLY) != 0 ? CHERI_PERM_STORE : 0)));
 		td->td_retval[0] = (uintcap_t)__DECONST_CAP(void * __capability,
 		    shmaddr);

--- a/sys/libkern/bcopy_c.c
+++ b/sys/libkern/bcopy_c.c
@@ -143,7 +143,14 @@ void * __capability
 memcpy_data_c(void * __capability dst, const void *  __capability src,
     size_t len)
 {
-	return (memcpy_c(dst, cheri_perms_and(src, ~CHERI_PERM_LOAD_CAP), len));
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+	src = cheri_perms_and(src, ~CHERI_PERM_LOAD_CAP);
+#endif
+#ifdef HAS_CHERI_PERM_CAP
+	src = cheri_perms_and(src, ~CHERI_PERM_CAP);
+#endif
+
+	return (memcpy_c(dst, src, len));
 }
 
 __strong_reference(memcpy_data_c, memmove_data_c);

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -53,10 +53,12 @@ cheri_init_capabilities(void * __capability kroot)
 {
 	void * __capability ctemp;
 
+#ifdef HAS_CHERI_PERM_SEAL
 	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_KERNEL_BASE);
 	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_KERNEL_LENGTH);
 	ctemp = cheri_perms_and(ctemp, CHERI_SEALCAP_KERNEL_PERMS);
 	kernel_root_sealcap = ctemp;
+#endif
 
 	ctemp = cheri_address_set(kroot, CHERI_CAP_USER_DATA_BASE);
 	ctemp = cheri_bounds_set(ctemp, CHERI_CAP_USER_DATA_LENGTH);
@@ -64,10 +66,12 @@ cheri_init_capabilities(void * __capability kroot)
 	    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
 	userspace_root_cap_init(ctemp);
 
+#ifdef HAS_CHERI_PERM_SEAL
 	ctemp = cheri_address_set(kroot, CHERI_SEALCAP_USERSPACE_BASE);
 	ctemp = cheri_bounds_set(ctemp, CHERI_SEALCAP_USERSPACE_LENGTH);
 	ctemp = cheri_perms_and(ctemp, CHERI_SEALCAP_USERSPACE_PERMS);
 	userspace_root_sealcap = ctemp;
+#endif
 
 	swap_restore_cap = kroot;
 
@@ -78,8 +82,12 @@ cheri_init_capabilities(void * __capability kroot)
 	ctemp = cheri_perms_and(ctemp, CHERI_PERMS_KERNEL_DATA);
 	devmap_init_capability(ctemp);
 
+#ifdef HAS_CHERI_PERM_SEAL
 	kernel_root_cap = cheri_perms_and(kroot,
 	    ~(CHERI_PERM_SEAL | CHERI_PERM_UNSEAL));
+#else
+	kernel_root_cap = kroot;
+#endif
 #endif
 }
 

--- a/sys/riscv/cheri/cheri_machdep.c
+++ b/sys/riscv/cheri/cheri_machdep.c
@@ -106,23 +106,31 @@ int
 vm_prot2perms(int base, vm_prot_t prot)
 {
 	int perms = 0;
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+	const int perm_load_cap = CHERI_PERM_LOAD_CAP;
+	const int perm_store_cap = CHERI_PERM_STORE_CAP |
+	    CHERI_PERM_STORE_LOCAL_CAP;
+#else
+	const int perm_load_cap = CHERI_PERM_CAP |
+	    CHERI_PERM_LOAD_MUTABLE;
+	const int perm_store_cap = CHERI_PERM_CAP |
+	    CHERI_PERM_STORE_LOCAL_CAP;
+#endif
 
 	if (prot & (VM_PROT_CAP | VM_PROT_NO_IMPLY_CAP)) {
 		if (prot & (VM_PROT_READ | VM_PROT_COPY))
 			perms |= CHERI_PERM_LOAD;
 		if (VM_PROT_HAS_READ_CAP(prot))
-			perms |= CHERI_PERM_LOAD_CAP;
+			perms |= perm_load_cap;
 		if (prot & VM_PROT_WRITE)
 			perms |= CHERI_PERM_STORE;
 		if (VM_PROT_HAS_WRITE_CAP(prot))
-			perms |= CHERI_PERM_STORE_CAP |
-			    CHERI_PERM_STORE_LOCAL_CAP;
+			perms |= perm_store_cap;
 	} else {
 		if (prot & (VM_PROT_READ | VM_PROT_COPY))
-			perms |= CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP;
+			perms |= CHERI_PERM_LOAD | perm_load_cap;
 		if (prot & VM_PROT_WRITE)
-			perms |= CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
-			    CHERI_PERM_STORE_LOCAL_CAP;
+			perms |= CHERI_PERM_STORE | perm_store_cap;
 	}
 	if (prot & VM_PROT_EXECUTE)
 		perms |= CHERI_PERM_EXECUTE | CHERI_PERM_LOAD |

--- a/sys/riscv/include/cherireg.h
+++ b/sys/riscv/include/cherireg.h
@@ -281,6 +281,7 @@
  * User and kernel software should be written so as to not place assumptions
  * about the specific values used here, as they may change.
  */
+#ifdef __riscv_xcheri
 #define	CHERI_OTYPE_BITS	(18)
 #define	CHERI_OTYPE_USER_MIN	(0)
 #define	CHERI_OTYPE_USER_MAX	((1 << (CHERI_OTYPE_BITS - 1)) - 1)
@@ -295,6 +296,14 @@
 #define	CHERI_OTYPE_UNSEALED	(-1l)
 #define	CHERI_OTYPE_SENTRY	(-2l)
 #endif
+#else /* !defined(__riscv_xcheri) */
+#define	CHERI_OTYPE_BITS	(1)
+
+#ifdef _KERNEL
+#define	CHERI_OTYPE_UNSEALED	(0l)
+#define	CHERI_OTYPE_SENTRY	(1l)
+#endif
+#endif /* !defined(__riscv_xcheri) */
 
 /*
  * List of CHERI capability cause code constants.

--- a/sys/riscv/include/cherireg.h
+++ b/sys/riscv/include/cherireg.h
@@ -120,6 +120,7 @@
 /* Supported architecture permission bits feature flags */
 #ifdef __riscv_xcheri
 #define	HAS_CHERI_PERM_LOAD_STORE_CAP
+#define	HAS_CHERI_PERM_SEAL
 #else
 #define	HAS_CHERI_PERM_CAP
 #define	HAS_CHERI_PERM_LOAD_MUTABLE

--- a/sys/riscv/include/cherireg.h
+++ b/sys/riscv/include/cherireg.h
@@ -51,6 +51,7 @@
  * XXXRW: CHERI_UNSEALED is not currently considered part of the perms word,
  * but perhaps it should be.
  */
+#ifdef __riscv_xcheri
 #define	CHERI_PERM_GLOBAL			(1 << 0)	/* 0x00000001 */
 #define	CHERI_PERM_EXECUTE			(1 << 1)	/* 0x00000002 */
 #define	CHERI_PERM_LOAD				(1 << 2)	/* 0x00000004 */
@@ -69,16 +70,52 @@
 #define	CHERI_PERM_SW1			(1 << 16)	/* 0x00010000 */
 #define	CHERI_PERM_SW2			(1 << 17)	/* 0x00020000 */
 #define	CHERI_PERM_SW3			(1 << 18)	/* 0x00040000 */
+#else /* !defined(__riscv_xcheri) */
+#define	CHERI_PERM_WRITE		(1 << 0)	/* 0x00000001 */
+#define	CHERI_PERM_LOAD_MUTABLE		(1 << 1)	/* 0x00000002 */
+#define	CHERI_PERM_ELEVATE_LEVEL	(1 << 2)	/* 0x00000004 */
+#define	CHERI_PERM_STORE_LEVEL		(1 << 3)	/* 0x00000008 */
+#define	CHERI_PERM_CAPABILITY_LEVEL	(1 << 4)	/* 0x00000010 */
+#define	CHERI_PERM_CAP			(1 << 5)	/* 0x00000020 */
+#define	CHERI_PERM_SYSTEM_REGS		(1 << 16)	/* 0x00010000 */
+#define	CHERI_PERM_EXECUTE		(1 << 17)	/* 0x00020000 */
+#define	CHERI_PERM_READ			(1 << 18)	/* 0x00040000 */
+
+/* User-defined permission bits. */
+#define	CHERI_PERM_SW0			(1 << 6)	/* 0x00000040 */
+#define	CHERI_PERM_SW1			(1 << 7)	/* 0x00000080 */
+#define	CHERI_PERM_SW2			(1 << 8)	/* 0x00000100 */
+#define	CHERI_PERM_SW3			(1 << 9)	/* 0x00000200 */
+#endif /* !defined(__riscv_xcheri) */
+
 #else /* !_KERNEL */
 /*
  * These should be defined in cheriintrin.h, but aren't yet.
  */
+#ifdef __riscv_xcheri
 #define	CHERI_PERM_SET_CID		(1 << 11)	/* 0x00000800 */
 #define	CHERI_PERM_SW0			(1 << 15)	/* 0x00008000 */
 #define	CHERI_PERM_SW1			(1 << 16)	/* 0x00010000 */
 #define	CHERI_PERM_SW2			(1 << 17)	/* 0x00020000 */
 #define	CHERI_PERM_SW3			(1 << 18)	/* 0x00040000 */
+#else
+#define	CHERI_PERM_SW0			(1 << 6)	/* 0x00000040 */
+#define	CHERI_PERM_SW1			(1 << 7)	/* 0x00000080 */
+#define	CHERI_PERM_SW2			(1 << 8)	/* 0x00000100 */
+#define	CHERI_PERM_SW3			(1 << 9)	/* 0x00000200 */
+#endif
 #endif /* !_KERNEL */
+
+#ifdef __riscv_zcheripurecap
+/*
+ * Re-define these because RVY cheriintrin.h uses different names.
+ * XXX-AM: Ideally we unify on a single naming convention.
+ */
+#define	CHERI_PERM_STORE		CHERI_PERM_WRITE
+#define	CHERI_PERM_LOAD			CHERI_PERM_READ
+#define	CHERI_PERM_GLOBAL		CHERI_PERM_CAPABILITY_LEVEL
+#define	CHERI_PERM_STORE_LOCAL_CAP	CHERI_PERM_STORE_LEVEL
+#endif
 
 /* Supported architecture permission bits feature flags */
 #ifdef __riscv_xcheri
@@ -96,12 +133,20 @@
 	(CHERI_PERM_SW0 | CHERI_PERM_SW1 | CHERI_PERM_SW2 |		\
 	CHERI_PERM_SW3)
 
-#define	CHERI_PERMS_HWALL						\
+#define	_CHERI_PERMS_HWALL_COMMON					\
 	(CHERI_PERM_GLOBAL | CHERI_PERM_EXECUTE |			\
-	CHERI_PERM_LOAD | CHERI_PERM_STORE | CHERI_PERM_LOAD_CAP |	\
-	CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP |		\
-	CHERI_PERM_SEAL | CHERI_PERM_INVOKE | CHERI_PERM_UNSEAL |	\
-	CHERI_PERM_SYSTEM_REGS | CHERI_PERM_SET_CID)
+	CHERI_PERM_LOAD | CHERI_PERM_STORE |				\
+	CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SYSTEM_REGS)
+#ifdef __riscv_xcheri
+#define	CHERI_PERMS_HWALL						\
+	(CHERI_PERM_SEAL | CHERI_PERM_INVOKE | CHERI_PERM_UNSEAL |	\
+	CHERI_PERM_SET_CID | CHERI_PERM_LOAD_CAP |			\
+	CHERI_PERM_STORE_CAP | _CHERI_PERMS_HWALL_COMMON)
+#else /* !defined(__riscv_xcheri) */
+#define	CHERI_PERMS_HWALL						\
+	(CHERI_PERM_CAP | CHERI_PERM_ELEVATE_LEVEL |			\
+	CHERI_PERM_LOAD_MUTABLE | _CHERI_PERMS_HWALL_COMMON)
+#endif /* !defined(__riscv_xcheri) */
 
 /*
  * Hardware defines a kind of tripartite taxonomy: memory, type, and CID.
@@ -109,13 +154,22 @@
  * that give us a kind of "kind" for capabilities.  A capability may belong
  * to zero, one, or more than one of these.
  */
-
-#define CHERI_PERMS_HWALL_MEMORY                                        \
-	(CHERI_PERM_EXECUTE | CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP |   \
-		CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |               \
-		CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_INVOKE)
+#define _CHERI_PERMS_HWALL_MEMORY_COMMON				\
+	(CHERI_PERM_EXECUTE | CHERI_PERM_LOAD | CHERI_PERM_STORE |	\
+	CHERI_PERM_STORE_LOCAL_CAP)
+#ifdef __riscv_xcheri
+#define CHERI_PERMS_HWALL_MEMORY					\
+	(CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE_CAP |			\
+	CHERI_PERM_INVOKE | _CHERI_PERMS_HWALL_MEMORY_COMMON)
 
 #define CHERI_PERMS_HWALL_OTYPE	(CHERI_PERM_SEAL | CHERI_PERM_UNSEAL)
+#else /* !defined(__riscv_xcheri) */
+#define CHERI_PERMS_HWALL_MEMORY					\
+	(CHERI_PERM_CAP | CHERI_PERM_LOAD_MUTABLE |			\
+	CHERI_PERM_ELEVATE_LEVEL | _CHERI_PERMS_HWALL_MEMORY_COMMON)
+
+#define CHERI_PERMS_HWALL_OTYPE
+#endif /* !defined(__riscv_xcheri) */
 
 /*
  * Basic userspace permission mask; CHERI_PERM_EXECUTE will be added for
@@ -126,13 +180,13 @@
  * CHERI_PERM_SYSCALL.  CHERI_PERM_SW_VMEM will be added for
  * permissions returned from mmap().
  */
-#define	CHERI_PERMS_USERSPACE						\
-	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP |	\
-	CHERI_PERM_INVOKE |						\
+#define	_CHERI_PERMS_USERSPACE_COMMON					\
+	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD  |				\
 	(CHERI_PERMS_SWALL & ~(CHERI_PERM_SW_VMEM | CHERI_PERM_SYSCALL)))
-
-#define	CHERI_PERMS_USERSPACE_CODE					\
-	(CHERI_PERMS_USERSPACE | CHERI_PERM_EXECUTE | CHERI_PERM_SYSCALL)
+#ifdef __riscv_xcheri
+#define	CHERI_PERMS_USERSPACE						\
+	(CHERI_PERM_LOAD_CAP | CHERI_PERM_INVOKE |			\
+	_CHERI_PERMS_USERSPACE_COMMON)
 
 #define	CHERI_PERMS_USERSPACE_SEALCAP					\
 	(CHERI_PERM_GLOBAL | CHERI_PERM_SEAL | CHERI_PERM_UNSEAL)
@@ -140,6 +194,18 @@
 #define	CHERI_PERMS_USERSPACE_DATA					\
 	(CHERI_PERMS_USERSPACE | CHERI_PERM_STORE |			\
 	CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP)
+#else /* !defined(__riscv_xcheri) */
+#define	CHERI_PERMS_USERSPACE						\
+	(CHERI_PERM_CAP | CHERI_PERM_LOAD_MUTABLE |			\
+	CHERI_PERM_ELEVATE_LEVEL | _CHERI_PERMS_USERSPACE_COMMON)
+
+#define	CHERI_PERMS_USERSPACE_DATA					\
+	(CHERI_PERMS_USERSPACE | CHERI_PERM_STORE |			\
+	CHERI_PERM_STORE_LOCAL_CAP)
+#endif /* !defined(__riscv_xcheri) */
+
+#define	CHERI_PERMS_USERSPACE_CODE					\
+	(CHERI_PERMS_USERSPACE | CHERI_PERM_EXECUTE | CHERI_PERM_SYSCALL)
 
 #define	CHERI_PERMS_USERSPACE_RODATA					\
 	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD)
@@ -149,21 +215,35 @@
  * currently a bit broad, and should be narrowed over time as the kernel
  * becomes more capability-aware.
  */
+#ifdef __riscv_xcheri
 #define	CHERI_PERMS_KERNEL						\
-	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)	\
-
-#define	CHERI_PERMS_KERNEL_CODE						\
-	(CHERI_PERMS_KERNEL | CHERI_PERM_EXECUTE | CHERI_PERM_SYSTEM_REGS)
+	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP)
 
 #define	CHERI_PERMS_KERNEL_DATA				       		\
 	(CHERI_PERMS_KERNEL | CHERI_PERM_STORE | CHERI_PERM_STORE_CAP | \
 	CHERI_PERM_STORE_LOCAL_CAP)
 
+#else /* !defined(__riscv_xcheri) */
+#define	CHERI_PERMS_KERNEL						\
+	(CHERI_PERM_GLOBAL | CHERI_PERM_LOAD | CHERI_PERM_CAP |		\
+	CHERI_PERM_LOAD_MUTABLE | CHERI_PERM_ELEVATE_LEVEL)
+
+#define	CHERI_PERMS_KERNEL_DATA				       		\
+	(CHERI_PERMS_KERNEL | CHERI_PERM_STORE |			\
+	CHERI_PERM_STORE_LOCAL_CAP)
+
+#endif /* !defined(__riscv_xcheri) */
+
+#define	CHERI_PERMS_KERNEL_CODE						\
+	(CHERI_PERMS_KERNEL | CHERI_PERM_EXECUTE | CHERI_PERM_SYSTEM_REGS)
+
 #define	CHERI_PERMS_KERNEL_RODATA			       		\
 	(CHERI_PERMS_KERNEL)
 
+#ifdef __riscv_xcheri
 #define	CHERI_PERMS_KERNEL_SEALCAP					\
 	(CHERI_PERM_GLOBAL | CHERI_PERM_SEAL | CHERI_PERM_UNSEAL)
+#endif
 
 /*
  * Permission mask that encodes the permission bits associated to
@@ -171,10 +251,17 @@
  * These are separate from the permission bits that encode other
  * properties of capabilities (e.g. sealing or ASR).
  */
+#ifdef __riscv_xcheri
 #define	CHERI_PERMS_RWX_MASK						\
 	(CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE |	\
 	CHERI_PERM_STORE_CAP | CHERI_PERM_STORE_LOCAL_CAP |		\
 	CHERI_PERM_EXECUTE | CHERI_PERM_SYSCALL)
+#else
+#define	CHERI_PERMS_RWX_MASK						\
+	(CHERI_PERM_LOAD | CHERI_PERM_STORE | CHERI_PERM_CAP |		\
+	CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_LOAD_MUTABLE |		\
+	CHERI_PERM_EXECUTE | CHERI_PERM_SYSCALL)
+#endif
 
 #ifdef __riscv_xcheri
 #define	CHERI_FLAGS_CAP_MODE	0x1

--- a/sys/riscv/riscv/db_trace.c
+++ b/sys/riscv/riscv/db_trace.c
@@ -85,7 +85,13 @@ db_stack_trace_cmd(struct thread *td, struct unwind_state *frame)
 			tf = (struct trapframe *)(uintptr_t)frame->sp;
 #ifdef __CHERI_PURE_CAPABILITY__
 			if (!cheri_can_access(tf,
+#if defined(HAS_CHERI_PERM_LOAD_STORE_CAP)
 			    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
+#elif defined(HAS_CHERI_PERM_CAP)
+			    CHERI_PERM_LOAD | CHERI_PERM_CAP,
+#else
+#error "Missing LOAD_CAP permission"
+#endif
 			    sizeof(*tf))) {
 				db_printf("--- invalid trapframe %#p\n", tf);
 				break;

--- a/sys/riscv/riscv/unwind.c
+++ b/sys/riscv/riscv/unwind.c
@@ -47,7 +47,14 @@ unwind_frame(struct thread *td, struct unwind_state *frame)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (!cheri_can_access((void *)(fp - sizeof(fp) * 2),
-	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP, sizeof(fp) * 2))
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+	    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP,
+#elif defined(HAS_CHERI_PERM_CAP)
+	    CHERI_PERM_LOAD | CHERI_PERM_CAP,
+#else
+#error "Missing LOAD/STORE CAP permission"
+#endif
+	    sizeof(fp) * 2))
 		return (false);
 #endif
 

--- a/sys/vm/swap_pager.c
+++ b/sys/vm/swap_pager.c
@@ -2328,13 +2328,17 @@ cheri_restore_tag(void * __capability *cp)
 {
 	uintcap_t cap;
 	void * __capability newcap;
+#ifdef HAS_CHERI_PERM_SEAL
 	void * __capability sealcap;
+#endif
 
 	cap = (uintcap_t)*cp;
 
 	newcap = cheri_cap_build(swap_restore_cap, cap);
+#ifdef HAS_CHERI_PERM_SEAL
 	sealcap = cheri_type_copy(swap_restore_cap, cap);
 	newcap = cheri_seal_conditionally(newcap, sealcap);
+#endif
 
 	*cp = newcap;
 }

--- a/sys/vm/vm_cheri_revoke.c
+++ b/sys/vm/vm_cheri_revoke.c
@@ -1434,7 +1434,13 @@ vm_cheri_revoke_shadow_cap(struct sysentvec *sv, int sel, vm_offset_t base,
 	}
 	case CHERI_REVOKE_SHADOW_INFO_STRUCT: {
 		return (cheri_capability_build_user_data(
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 		    CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP | CHERI_PERM_GLOBAL,
+#elif defined(HAS_CHERI_PERM_CAP)
+		    CHERI_PERM_LOAD | CHERI_PERM_CAP | CHERI_PERM_GLOBAL,
+#else
+#error "Missing LOAD_CAP permission"
+#endif
 		    sv->sv_cheri_revoke_info_page,
 		    sizeof(struct cheri_revoke_info),
 		    sv->sv_cheri_revoke_info_page));
@@ -1464,7 +1470,14 @@ vm_cheri_revoke_info_page(struct vm_map *map, struct sysentvec *sv,
 	    ("vm_cheri_revoke_page_info req. intraprocess work right now"));
 
 	*ifp = cheri_capability_build_user_data(CHERI_PERM_LOAD |
-	    CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
+	    CHERI_PERM_STORE |
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+	    CHERI_PERM_LOAD_CAP | CHERI_PERM_STORE_CAP |
+#elif defined(HAS_CHERI_PERM_CAP)
+	    CHERI_PERM_CAP |
+#else
+#error "Missing LOAD/STORE CAP permission"
+#endif
 	    CHERI_PERM_GLOBAL,
 	    sv->sv_cheri_revoke_info_page, PAGE_SIZE,
 	    sv->sv_cheri_revoke_info_page);

--- a/sys/vm/vm_glue.c
+++ b/sys/vm/vm_glue.c
@@ -868,12 +868,24 @@ vm_cap_allows_prot(const void * __capability cap, vm_prot_t prot)
 	if (prot & VM_PROT_READ) {
 		reqperm |= CHERI_PERM_LOAD;
 		if (prot & VM_PROT_CAP)
+#if defined(HAS_CHERI_PERM_LOAD_STORE_CAP)
 			reqperm |= CHERI_PERM_LOAD_CAP;
+#elif defined(HAS_CHERI_PERM_CAP)
+			reqperm |= CHERI_PERM_CAP;
+#else
+#error "Missing LOAD_CAP permission"
+#endif
 	}
 	if (prot & VM_PROT_WRITE) {
 		reqperm |= CHERI_PERM_STORE;
 		if (prot & VM_PROT_CAP)
+#if defined(HAS_CHERI_PERM_LOAD_STORE_CAP)
 			reqperm |= CHERI_PERM_STORE_CAP;
+#elif defined(HAS_CHERI_PERM_CAP)
+		reqperm |= CHERI_PERM_CAP;
+#else
+#error "Missing STORE_CAP permission"
+#endif
 	}
 	if (prot & VM_PROT_EXECUTE)
 		reqperm |= CHERI_PERM_EXECUTE;


### PR DESCRIPTION
This patch updates the kernel permission bits definitions for RVY and makes additional use of the HAS_CHERI_PERM_* macros across kernel and userspace.

Possible points of contention:
 - The snmalloc changes should probably be upstreamed to snmalloc and pulled in later. I'm not sure if having changes in the subtree is problematic.

Edit:
 - Added HAS_CHERI_PERM_SEAL to signal presence of SEAL/UNSEAL perms and otypes.
 - Consistently `#error` when neither HAS_CHERI_PERM_LOAD_STORE_CAP or HAS_CHERI_PERM_CAP are defined. This may be going away if we move to having only HAS_CHERI_PERM_CAP and implying that the `#else` branch means separate LOAD/STORE CAP permissions. 