### PR TITLE
caprevoke: Unbreak revoker without CHERI_CAPREVOKE_CLEARTAGS.

### DIFF
--- a/sys/cheri/revoke.h
+++ b/sys/cheri/revoke.h
@@ -38,6 +38,9 @@
 
 #if __has_feature(capabilities)
 #include <cheri/cherireg.h> /* For CHERI_OTYPE_BITS */
+#ifndef _KERNEL
+#include <cheriintrin.h>
+#endif
 #endif
 
 typedef	uint64_t	cheri_revoke_epoch_t;
@@ -87,11 +90,13 @@ cheri_revoke_epoch_clears(cheri_revoke_epoch_t now, cheri_revoke_epoch_t then)
 static inline int
 cheri_revoke_is_revoked(const void * __capability cap)
 {
+	int is_revoked;
+
+	is_revoked = (cheri_tag_get(cap) == 0);
 #ifndef CHERI_CAPREVOKE_CLEARTAGS
-	return (__builtin_cheri_perms_get(cap) == 0);
-#else
-	return (__builtin_cheri_tag_get(cap) == 0);
+	is_revoked |= (cheri_perms_get(cap) == 0);
 #endif
+	return (is_revoked);
 }
 
 /*************************** SHADOW BITMAP LAYOUT ***************************/


### PR DESCRIPTION
When the CHERI_CAPREVOKE_CLEARTAGS is not defined, the cheri_revoke_is_revoked function must detect a capability as revoked if it is untagged or has 0 permissions.

While at it, I also removed the direct use of compiler builtins in favor of cheriintrin.h.