### PR TITLE
Improve handling of multiple slirp backends

### DIFF
--- a/usr.sbin/bhyve/bhyve.8
+++ b/usr.sbin/bhyve/bhyve.8
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd August 21, 2024
+.Dd January 5, 2026
 .Dt BHYVE 8
 .Os
 .Sh NAME
@@ -482,6 +482,8 @@ considered unconnected.
 .Cm slirp
 .Op Cm \&,open
 .Op Cm \&,hostfwd= Ar proto : Ar hostaddr : Ar hostport - Ar guestaddr : Ar guestport
+.Op Cm \&,mac= Ar xx:xx:xx:xx:xx:xx
+.Op Cm \&,mtu= Ar N
 .Xc
 .El
 .Sm on

--- a/usr.sbin/bhyve/net_backend_slirp.c
+++ b/usr.sbin/bhyve/net_backend_slirp.c
@@ -83,6 +83,7 @@ static int
 slirp_init(struct net_backend *be, const char *devname __unused,
     nvlist_t *nvl, net_be_rxeof_t cb, void *param)
 {
+	static unsigned int slirp_index = 0;
 	struct slirp_priv *priv = NET_BE_PRIV(be);
 	nvlist_t *config;
 	posix_spawn_file_actions_t fa;
@@ -148,6 +149,7 @@ slirp_init(struct net_backend *be, const char *devname __unused,
 		mtu = DEFAULT_MTU;
 	}
 	nvlist_add_number(config, "mtui", mtu);
+	nvlist_add_number(config, "index", slirp_index);
 
 	priv->mtu = mtu;
 	priv->buf = malloc(mtu);
@@ -176,6 +178,8 @@ slirp_init(struct net_backend *be, const char *devname __unused,
 	(void)close(p[1]);
 	priv->s = s[0];
 	(void)close(s[1]);
+
+	slirp_index++;
 
 	return (0);
 

--- a/usr.sbin/bhyve/net_backend_slirp.c
+++ b/usr.sbin/bhyve/net_backend_slirp.c
@@ -62,16 +62,19 @@
 #include "config.h"
 #include "debug.h"
 #include "mevent.h"
+#include "net_utils.h"
 #include "net_backends.h"
 #include "net_backends_priv.h"
 
-#define	SLIRP_MTU	2048
+#define	DEFAULT_MTU	2048
 
 struct slirp_priv {
 	int p;
 	int s;
 	pid_t helper;
 	struct mevent *mevp;
+	size_t mtu;
+	uint8_t *buf;
 };
 
 extern char **environ;
@@ -87,6 +90,8 @@ slirp_init(struct net_backend *be, const char *devname __unused,
 	const char **argv;
 	char pipename[32], sockname[32];
 	int error, p[2], s[2];
+	const char *mtu_value;
+	size_t mtu;
 
 	if (socketpair(PF_LOCAL, SOCK_DGRAM | SOCK_NONBLOCK, 0, s) != 0) {
 		EPRINTLN("socketpair");
@@ -132,6 +137,25 @@ slirp_init(struct net_backend *be, const char *devname __unused,
 		EPRINTLN("nvlist_clone");
 		goto err;
 	}
+
+	mtu_value = get_config_value_node(config, "mtu");
+	if (mtu_value != NULL) {
+		if (net_parsemtu(mtu_value, &mtu)) {
+		    	EPRINTLN("Could not parse MTU");
+		    	goto err;
+		}
+	} else {
+		mtu = DEFAULT_MTU;
+	}
+	nvlist_add_number(config, "mtui", mtu);
+
+	priv->mtu = mtu;
+	priv->buf = malloc(mtu);
+	if (priv->buf == NULL) {
+		EPRINTLN("Could not allocate buffer");
+		goto err;
+	}
+
 	nvlist_add_string(config, "vmname", get_config_value("name"));
 	error = nvlist_send(s[0], config);
 	nvlist_destroy(config);
@@ -156,6 +180,7 @@ slirp_init(struct net_backend *be, const char *devname __unused,
 	return (0);
 
 err:
+	free(priv->buf);
 	(void)close(p[0]);
 	(void)close(p[1]);
 	(void)close(s[0]);
@@ -180,6 +205,8 @@ slirp_cleanup(struct net_backend *be)
 {
 	struct slirp_priv *priv = NET_BE_PRIV(be);
 
+	free(priv->buf);
+
 	if (priv->helper > 0) {
 		int status;
 
@@ -196,17 +223,15 @@ static ssize_t
 slirp_peek_recvlen(struct net_backend *be)
 {
 	struct slirp_priv *priv = NET_BE_PRIV(be);
-	uint8_t buf[SLIRP_MTU];
 	ssize_t n;
 
 	/*
 	 * Copying into the buffer is totally unnecessary, but we don't
 	 * implement MSG_TRUNC for SEQPACKET sockets.
 	 */
-	n = recv(priv->s, buf, sizeof(buf), MSG_PEEK | MSG_DONTWAIT);
+	n = recv(priv->s, priv->buf, priv->mtu, MSG_PEEK | MSG_DONTWAIT);
 	if (n < 0)
 		return (errno == EWOULDBLOCK ? 0 : -1);
-	assert((size_t)n <= SLIRP_MTU);
 	return (n);
 }
 
@@ -230,7 +255,7 @@ slirp_recv(struct net_backend *be, const struct iovec *iov, int iovcnt)
 			return (0);
 		return (-1);
 	}
-	assert(n <= SLIRP_MTU);
+	assert((size_t)n <= priv->mtu);
 	return (n);
 }
 

--- a/usr.sbin/bhyve/slirp/slirp-helper.c
+++ b/usr.sbin/bhyve/slirp/slirp-helper.c
@@ -516,6 +516,8 @@ main(int argc, char **argv)
 	memset(&priv, 0, sizeof(priv));
 	priv.sock = sd;
 	priv.pipe = pipe;
+	if (ioctl(priv.sock, FIONBIO, &(int){0}) == -1)
+		err(1, "ioctl(FIONBIO)");
 	if (pipe2(priv.wakeup, O_CLOEXEC | O_NONBLOCK) != 0)
 		err(1, "pipe2");
 

--- a/usr.sbin/bhyve/slirp/slirp-helper.c
+++ b/usr.sbin/bhyve/slirp/slirp-helper.c
@@ -38,8 +38,6 @@
 #include "config.h"
 #include "libslirp.h"
 
-#define	SLIRP_MTU	2048
-
 struct slirp_priv {
 	Slirp *slirp;		/* libslirp handle */
 	int sock;		/* data and control socket */
@@ -48,6 +46,8 @@ struct slirp_priv {
 	struct pollfd *pollfds;
 	size_t npollfds;
 	size_t lastpollfd;
+	size_t mtu;
+	uint8_t *buf;
 };
 
 typedef int (*slirp_add_hostxfwd_p_t)(Slirp *,
@@ -105,7 +105,7 @@ slirp_cb_send_packet(const void *buf, size_t len, void *param)
 
 	priv = param;
 
-	assert(len <= SLIRP_MTU);
+	assert(len <= priv->mtu);
 	n = send(priv->sock, buf, len, MSG_EOR);
 	if (n < 0) {
 		warn("slirp_cb_send_packet: send");
@@ -293,16 +293,14 @@ slirp_pollfd_loop(struct slirp_priv *priv)
 			ssize_t n;
 
 			do {
-				uint8_t buf[SLIRP_MTU];
-
-				n = recv(priv->sock, buf, sizeof(buf),
+				n = recv(priv->sock, priv->buf, priv->mtu,
 				    MSG_DONTWAIT);
 				if (n < 0) {
 					if (errno == EWOULDBLOCK)
 						break;
 					err(1, "recv");
 				}
-				slirp_input_p(priv->slirp, buf, (int)n);
+				slirp_input_p(priv->slirp, priv->buf, (int)n);
 			} while (n >= 0);
 		}
 	}
@@ -468,6 +466,7 @@ main(int argc, char **argv)
 	const char *hostfwd, *vmname;
 	int ch, fd, pipe, sd;
 	bool restricted;
+	size_t mtu;
 
 	sd = -1;
 	while ((ch = getopt(argc, argv, "P:S:")) != -1) {
@@ -527,6 +526,13 @@ main(int argc, char **argv)
 	config = nvlist_recv(sd, 0);
 	if (config == NULL)
 		err(1, "nvlist_recv");
+
+	mtu = nvlist_get_number(config, "mtui");
+	priv.mtu = mtu;
+	priv.buf = malloc(mtu);
+	if (priv.buf == NULL)
+		err(1, "malloc");
+
 	vmname = get_config_value_node(config, "vmname");
 	if (vmname != NULL)
 		setproctitle("%s", vmname);
@@ -534,7 +540,7 @@ main(int argc, char **argv)
 
 	slirpconfig = (SlirpConfig){
 		.version = 4,
-		.if_mtu = SLIRP_MTU,
+		.if_mtu = mtu,
 		.restricted = restricted,
 		.in_enabled = true,
 		.vnetwork.s_addr = htonl(0x0a000200),	/* 10.0.2.0/24 */

--- a/usr.sbin/bhyve/slirp/slirp-helper.c
+++ b/usr.sbin/bhyve/slirp/slirp-helper.c
@@ -464,6 +464,7 @@ main(int argc, char **argv)
 	Slirp *slirp;
 	nvlist_t *config;
 	const char *hostfwd, *vmname;
+	unsigned int index;
 	int ch, fd, pipe, sd;
 	bool restricted;
 	size_t mtu;
@@ -527,6 +528,10 @@ main(int argc, char **argv)
 	if (config == NULL)
 		err(1, "nvlist_recv");
 
+	index = nvlist_get_number(config, "index") + 2;
+	if (index > 0xff)
+		errx(1, "index %u out of range", index);
+
 	mtu = nvlist_get_number(config, "mtui");
 	priv.mtu = mtu;
 	priv.buf = malloc(mtu);
@@ -538,16 +543,17 @@ main(int argc, char **argv)
 		setproctitle("%s", vmname);
 	restricted = !get_config_bool_node_default(config, "open", false);
 
+	index <<= 8;
 	slirpconfig = (SlirpConfig){
 		.version = 4,
 		.if_mtu = mtu,
 		.restricted = restricted,
 		.in_enabled = true,
-		.vnetwork.s_addr = htonl(0x0a000200),	/* 10.0.2.0/24 */
+		.vnetwork.s_addr = htonl(0x0a000000 | index), /* 10.0.n.0/24 */
 		.vnetmask.s_addr = htonl(0xffffff00),	/* 255.255.255.0 */
-		.vdhcp_start.s_addr = htonl(0x0a00020f),/* 10.0.2.15 */
-		.vhost.s_addr = htonl(0x0a000202),	/* 10.0.2.2 */
-		.vnameserver.s_addr = htonl(0x0a000203),/* 10.0.2.3 */
+		.vdhcp_start.s_addr = htonl(0x0a00000f | index), /* 10.0.2.15 */
+		.vhost.s_addr = htonl(0x0a000002 | index), /* 10.0.2.2 */
+		.vnameserver.s_addr = htonl(0x0a000003 | index), /* 10.0.2.3 */
 		.enable_emu = false,
 	};
 	libslirp_init();


### PR DESCRIPTION
Add a global index, used to select a private subnet for each backend. Otherwise, each backend gets an identical slirp configuration.