### PR TITLE
Clean up old ISAv8 compat code

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_fault.c
+++ b/bin/cheribsdtest/cheribsdtest_fault.c
@@ -226,20 +226,7 @@ CHERIBSDTEST(nofault_cfromptr, "Exercise CFromPtr success")
 	char * __capability cd; /* stored into here */
 
 	cb = cheri_ptr(buf, 256);
-#if defined(__aarch64__) || defined(__riscv_xcheri_no_relocation) || defined(__riscv_zcheripurecap)
-	/*
-	 * morello-llvm emits cvtz for this intrinsic, which has an
-	 * address interpretation by default (unlike CFromPtr, which
-	 * has an offset interpretation).
-	 * https://git.morello-project.org/morello/llvm-project/-/issues/16
-	 *
-	 * Similarly, CHERI-RISC-V with ISAv9 always uses address
-	 * interpretation instead of offsetting from the base.
-	 */
 	cd = __builtin_cheri_cap_from_pointer(cb, (ptraddr_t)buf + 10);
-#else
-	cd = __builtin_cheri_cap_from_pointer(cb, 10);
-#endif
 	*cd = '\0';
 	cheribsdtest_success();
 }

--- a/lib/libc/riscv/gen/_setjmp.S
+++ b/lib/libc/riscv/gen/_setjmp.S
@@ -237,10 +237,8 @@ botch:
 #ifdef _STANDALONE
 	j	botch
 #elif defined(__CHERI_PURE_CAPABILITY__)
-	clgc	ct0, _C_LABEL(longjmperror)
-	cjalr	ct0
-	clgc	ct0, _C_LABEL(abort)
-	cjalr	ct0
+	ccall	_C_LABEL(longjmperror)
+	ccall	_C_LABEL(abort)
 #else
 	call	_C_LABEL(longjmperror)
 	call	_C_LABEL(abort)

--- a/lib/libc/riscv/gen/_setjmp.S
+++ b/lib/libc/riscv/gen/_setjmp.S
@@ -180,6 +180,9 @@ ENTRY(_longjmp)
 
 	/* Load the return value */
 	mv	a0, a1
+	bnez	a1, 1f
+	li	a0, 1
+1:
 	cret
 #else
 	/* Check the magic value */

--- a/lib/libc/riscv/gen/setjmp.S
+++ b/lib/libc/riscv/gen/setjmp.S
@@ -224,6 +224,9 @@ ENTRY(longjmp)
 
 	/* Load the return value */
 	mv	a0, a1
+	bnez	a1, 1f
+	li	a0, 1
+1:
 	cret
 
 botch:

--- a/lib/libc/riscv/gen/setjmp.S
+++ b/lib/libc/riscv/gen/setjmp.S
@@ -45,8 +45,7 @@ ENTRY(setjmp)
 	cincoffset ca2, ca0, (_JB_SIGMASK * 16)	/* oset */
 	li	a1, 0				/* set */
 	li	a0, 1				/* SIG_BLOCK */
-	clgc	ct0, _C_LABEL(sigprocmask)
-	cjalr	ct0
+	ccall	_C_LABEL(sigprocmask)
 
 	clc	ca0, 0(csp)
 	clc	cra, 16(csp)
@@ -177,8 +176,7 @@ ENTRY(longjmp)
 	li	a2, 0				/* oset */
 	cincoffset ca1, ca0, (_JB_SIGMASK * 16)	/* set */
 	li	a0, 3				/* SIG_BLOCK */
-	clgc	ct0, _C_LABEL(sigprocmask)
-	cjalr	ct0
+	ccall	_C_LABEL(sigprocmask)
 
 	clc	ca1, (2 * 16)(csp)
 	clc	cra, (1 * 16)(csp)
@@ -229,10 +227,8 @@ ENTRY(longjmp)
 	cret
 
 botch:
-	clgc	ct0, _C_LABEL(longjmperror)
-	cjalr	ct0
-	clgc	ct0, _C_LABEL(abort)
-	cjalr	ct0
+	ccall	_C_LABEL(longjmperror)
+	ccall	_C_LABEL(abort)
 #else
 	/* Check the magic value */
 	ld	t0, 0(a0)

--- a/lib/libc/riscv/gen/sigsetjmp.S
+++ b/lib/libc/riscv/gen/sigsetjmp.S
@@ -38,11 +38,9 @@
 ENTRY(sigsetjmp)
 #ifdef __CHERI_PURE_CAPABILITY__
 	beqz	a1, 1f
-	clgc	ct0, _C_LABEL(setjmp)
-	cjr	ct0
+	ctail	_C_LABEL(setjmp)
 1:
-	clgc	ct0, _C_LABEL(_setjmp)
-	cjr	ct0
+	ctail	_C_LABEL(_setjmp)
 #else
 	beqz	a1, 1f
 	tail	_C_LABEL(setjmp)
@@ -60,11 +58,9 @@ ENTRY(siglongjmp)
 
 	/* Check the magic */
 	beq	a2, a3, 1f
-	clgc	ct0, _C_LABEL(longjmp)
-	cjr	ct0
+	ctail	_C_LABEL(longjmp)
 1:
-	clgc	ct0, _C_LABEL(_longjmp)
-	cjr	ct0
+	ctail	_C_LABEL(_longjmp)
 #else
 	/* Load the _setjmp magic */
 	ld	a2, .Lmagic

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -419,8 +419,7 @@
 	/* Handle the ast */
 #ifdef __CHERI_PURE_CAPABILITY__
 	cmove	ca0, csp
-	clgc	cra, _C_LABEL(ast)
-	cjalr	cra
+	ccall	_C_LABEL(ast)
 #else
 	mv	a0, sp
 	call	_C_LABEL(ast)

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -264,11 +264,7 @@
 	csetaddr ct1, ct1, t0
 	li	t0, 1
 	csetflags ct1, ct1, t0
-#ifdef __riscv_xcheri_mode_dependent_jumps
 	jr.cap	ct1
-#else
-	cjr	ct1
-#endif
 .option capmode
 1:
 	/*

--- a/sys/riscv/riscv/exception.S
+++ b/sys/riscv/riscv/exception.S
@@ -453,8 +453,7 @@ ENTRY(cpu_exception_handler_supervisor)
 	save_registers 1
 #ifdef __CHERI_PURE_CAPABILITY__
 	cmove	ca0, csp
-	clgc	cra, _C_LABEL(do_trap_supervisor)
-	cjalr	cra
+	ccall	_C_LABEL(do_trap_supervisor)
 #else
 	mv	a0, sp
 	call	_C_LABEL(do_trap_supervisor)
@@ -467,8 +466,7 @@ ENTRY(cpu_exception_handler_user)
 	save_registers 0
 #ifdef __CHERI_PURE_CAPABILITY__
 	cmove	ca0, csp
-	clgc	cra, _C_LABEL(do_trap_user)
-	cjalr	cra
+	ccall	_C_LABEL(do_trap_user)
 #else
 	mv	a0, sp
 	call	_C_LABEL(do_trap_user)

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -90,11 +90,7 @@ _alt_start:
 	csetaddr ct1, ct1, t0
 	li	t0, 1
 	csetflags ct1, ct1, t0
-#ifdef __riscv_xcheri_mode_dependent_jumps
 	jr.cap	ct1
-#else
-	cjr	ct1
-#endif
 1:
 .option pop
 #endif

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -186,16 +186,14 @@ _start:
 pagetables:
 	/* Get the kernel's load address (kernstart) in s9 */
 #ifdef __CHERI_PURE_CAPABILITY__
-	cllc	cra, get_physmem
-	cjalr	cra
+	cjal	get_physmem
 #else
 	jal	get_physmem
 #endif
 
 	/* Get PTE attribute bits in s8 */
 #ifdef __CHERI_PURE_CAPABILITY__
-	cllc	cra, get_pte_fixup_bits
-	cjalr	cra
+	cjal	get_pte_fixup_bits
 #else
 	jal	get_pte_fixup_bits
 #endif
@@ -403,13 +401,11 @@ va:
 	mv	a4, zero		/* TODO: true for PT_CHERI_PCC */
 	cllc	ca5, _C_LABEL(kernel_cap_relocs_cb)
 	csetflags ca6, ca5, zero
-	cllc	cra, _C_LABEL(init_linker_file_cap_relocs)
-	cjalr	cra
+	ccall	_C_LABEL(init_linker_file_cap_relocs)
 
 	/* Initialize capabilities. */
 	cmove	ca0, cs0
-	clgc	cra, _C_LABEL(cheri_init_capabilities)
-	cjalr	cra
+	ccall	_C_LABEL(cheri_init_capabilities)
 
 	/* Fill riscv_bootparams */
 	csd	s9, RISCV_BOOTPARAMS_KERN_PHYS(csp)
@@ -427,10 +423,8 @@ va:
 	cmove	cs3, cnull
 
 	csetbounds ca0, csp, RISCV_BOOTPARAMS_SIZE
-	clgc	cra, _C_LABEL(initriscv)
-	cjalr	cra			/* Off we go */
-	clgc	cra, _C_LABEL(mi_startup)
-	cjalr	cra
+	ccall	_C_LABEL(initriscv)
+	ccall	_C_LABEL(mi_startup)
 #else
 	/* Initialize stack pointer */
 	la	sp, initstack_end
@@ -570,8 +564,7 @@ ENTRY(mpentry)
 	clc	csp, 0(ct0)
 
 	/* Get the kernel's load address */
-	cllc	cra, get_physmem
-	cjalr	cra
+	cjal	get_physmem
 
 	/* Setup supervisor trap vector */
 	cllc	ct0, mpva
@@ -673,8 +666,7 @@ mpva:
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	clgc	cra, init_secondary
-	cjalr	cra
+	ccall	init_secondary
 #else
 	call	init_secondary
 #endif

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -291,8 +291,7 @@ ENTRY(cpu_throw)
 	/* Activate the new thread's pmap. */
 	cmove	cs0, ca1
 	cmove	ca0, ca1
-	clgc	cra, _C_LABEL(pmap_activate_sw)
-	cjalr	cra
+	ccall	_C_LABEL(pmap_activate_sw)
 	cmove	ca0, cs0
 
 	/* Store the new curthread */
@@ -481,8 +480,7 @@ ENTRY(cpu_switch)
 	cmove	cs1, ca1
 	cmove	cs2, ca2
 	cmove	ca0, ca1
-	clgc	cra, _C_LABEL(pmap_activate_sw)
-	cjalr	cra
+	ccall	_C_LABEL(pmap_activate_sw)
 	cmove	ca1, cs1
 #else
 	mv	s0, a0
@@ -627,8 +625,7 @@ ENTRY(fork_trampoline)
 	cmove	ca0, cs0
 	cmove	ca1, cs1
 	cmove	ca2, csp
-	clgc	cra, _C_LABEL(fork_exit)
-	cjalr	cra
+	ccall	_C_LABEL(fork_exit)
 #else
 	mv	a0, s0
 	mv	a1, s1

--- a/sys/riscv/riscv/swtch.S
+++ b/sys/riscv/riscv/swtch.S
@@ -655,11 +655,7 @@ ENTRY(fork_trampoline)
 	csetaddr ct1, ct1, t0
 	li	t0, 1
 	csetflags ct1, ct1, t0
-#ifdef __riscv_xcheri_mode_dependent_jumps
 	jr.cap	ct1
-#else
-	cjr	ct1
-#endif
 .option push
 .option capmode
 1:


### PR DESCRIPTION
- riscv: Drop support for pre-mode-dependent jumps CHERI-RISC-V
- cheribsdtest: Assume address not offset semantics
- libc: Use ccall/ctail/cjal rather than clgc+cjalr
- riscv: Use ccall/ctail/cjal rather than clgc+cjalr
- libc: Fix longjmp/_longjmp(buf, 0) for CHERI-RISC-V
