### PR TITLE
Retire a few more helpers from cheric.h

### DIFF
--- a/ObsoleteFiles.inc
+++ b/ObsoleteFiles.inc
@@ -51,6 +51,9 @@
 #   xargs -n1 | sort | uniq -d;
 # done
 
+# 20260302: Removed cheri_fromint
+OLD_FILES+=usr/share/man/man9/cheri_fromint.9.gz
+
 # 20260211: Removed cheri_*_ptr_bits
 OLD_FILES+=usr/share/man/man9/cheri_clear_low_ptr_bits.9.gz
 OLD_FILES+=usr/share/man/man9/cheri_get_low_ptr_bits.9.gz

--- a/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
@@ -71,7 +71,7 @@ make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 	 * Note: The addend is required for C++ exceptions since capabilities
 	 * for catch blocks point to the middle of a function.
 	 */
-	ret = cheri_offset_inc(ret, addend);
+	ret = (const char * __capability)ret + addend;
 	/* All code pointers should be sentries: */
 	ret = __builtin_cheri_seal_entry(ret);
 	return __DECONST_CAP(dlfunc_t __capability, ret);

--- a/libexec/rtld-elf/cheri/cheri_reloc.h
+++ b/libexec/rtld-elf/cheri/cheri_reloc.h
@@ -148,7 +148,8 @@ process_r_cheri_capability(Obj_Entry *obj, Elf_Word r_symndx,
 #endif
 	} else {
 		/* Remove execute permissions and set bounds */
-		symval = cheri_offset_inc(make_data_cap(def, defobj), addend);
+		symval = (const char * __capability)make_data_cap(def, defobj) +
+		    addend;
 	}
 #ifdef DEBUG
 	// FIXME: this warning breaks some tests that expect clean stdout/stderr

--- a/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
@@ -70,7 +70,7 @@ make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
 	 * Note: The addend is required for C++ exceptions since capabilities
 	 * for catch blocks point to the middle of a function.
 	 */
-	ret = cheri_offset_inc(ret, addend);
+	ret = (const char * __capability)ret + addend;
 	/* All code pointers should be sentries: */
 	ret = __builtin_cheri_seal_entry(ret);
 	return __DECONST_CAP(dlfunc_t __capability, ret);

--- a/share/man/man9/Makefile
+++ b/share/man/man9/Makefile
@@ -849,7 +849,6 @@ MLINKS+=cheric.9 cheri_address_get.9 \
 	cheric.9 cheri_base_get.9 \
 	cheric.9 cheri_bounds_set.9 \
 	cheric.9 cheri_ddc_get.9 \
-	cheric.9 cheri_fromint.9 \
 	cheric.9 cheri_is_sealed.9 \
 	cheric.9 cheri_length_get.9 \
 	cheric.9 cheri_offset_get.9 \

--- a/share/man/man9/cheric.9
+++ b/share/man/man9/cheric.9
@@ -29,7 +29,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 11, 2026
+.Dd March 2, 2026
 .Dt CHERIC 9
 .Os
 .Sh NAME
@@ -38,7 +38,6 @@
 .Nm cheri_base_get
 .Nm cheri_bounds_set
 .Nm cheri_ddc_get
-.Nm cheri_fromint
 .Nm cheri_is_sealed
 .Nm cheri_length_get
 .Nm cheri_offset_get
@@ -68,8 +67,6 @@
 .Fn cheri_bounds_set "void * __capability c" "size_t length"
 .Ft void * __capability
 .Fn cheri_ddc_get "void"
-.Ft void * __capability
-.Fn cheri_fromint "ptraddr_t"
 .Ft bool
 .Fn cheri_is_sealed "void * __capability c"
 .Ft size_t

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -168,8 +168,6 @@
 #define cheri_address_copy(dst, src)					\
 	(cheri_address_set(dst, cheri_address_get(src)))
 
-#define	cheri_offset_inc(x, y)	__builtin_cheri_offset_increment((x), (y))
-
 /* Get the top of a capability (i.e. one byte past the last accessible one) */
 #define	cheri_top_get(cap)	__extension__({			\
 	__typeof__(cap) c = (cap);				\

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -164,9 +164,6 @@
 #define	cheri_is_null_derived(x)					\
 	cheri_is_equal_exact((uintcap_t)cheri_address_get(x), x)
 
-/* Create an untagged capability from an integer */
-#define cheri_fromint(x)	cheri_offset_set(NULL, x)
-
 /* Increment @p dst to have the address of @p src */
 #define cheri_address_copy(dst, src)					\
 	(cheri_address_set(dst, cheri_address_get(src)))

--- a/sys/compat/freebsd64/freebsd64_signal.c
+++ b/sys/compat/freebsd64/freebsd64_signal.c
@@ -66,14 +66,14 @@ convert_sigevent64(const struct sigevent64 *sig64, struct sigevent *sig)
 		CP(*sig64, *sig, sigev_signo);
 		memset(&sig->sigev_value, 0, sizeof(sig->sigev_value));
 		sig->sigev_value.sival_ptr =
-		    cheri_fromint(sig64->sigev_value.sival_ptr);
+		    (void * __capability)(uintcap_t)sig64->sigev_value.sival_ptr;
 		break;
 	case SIGEV_KEVENT:
 		CP(*sig64, *sig, sigev_notify_kqueue);
 		CP(*sig64, *sig, sigev_notify_kevent_flags);
 		memset(&sig->sigev_value, 0, sizeof(sig->sigev_value));
 		sig->sigev_value.sival_ptr =
-		    cheri_fromint(sig64->sigev_value.sival_ptr);
+		    (void * __capability)(uintcap_t)sig64->sigev_value.sival_ptr;
 		break;
 	default:
 		return (EINVAL);
@@ -108,7 +108,8 @@ freebsd64_sigaction(struct thread *td, struct freebsd64_sigaction_args *uap)
 		if (error)
 			return (error);
 		if (is_magic_sighandler_constant(act64.sa_u))
-			actp->sa_handler = cheri_fromint(act64.sa_u);
+			actp->sa_handler =
+			    (void * __capability)(uintcap_t)act64.sa_u;
 		else
 			actp->sa_handler = USER_CODE_PTR(act64.sa_u);
 		actp->sa_flags = act64.sa_flags;
@@ -235,7 +236,7 @@ freebsd64_sigqueue(struct thread *td, struct freebsd64_sigqueue_args *uap)
 	 * capability's address.
 	 */
 	memset(&sv, 0, sizeof(sv));
-	sv.sival_ptr = cheri_fromint((uintptr_t)uap->value);
+	sv.sival_ptr = (void * __capability)(uintcap_t)uap->value;
 
 	return (kern_sigqueue(td, uap->pid, uap->signum, &sv));
 }

--- a/sys/kern/kern_proc.c
+++ b/sys/kern/kern_proc.c
@@ -2155,7 +2155,8 @@ get_proc_vector64(struct thread *td, struct proc *p,
 	proc_vector = malloc(vsize * sizeof(char * __capability), M_TEMP,
 	    M_WAITOK);
 	for (i = 0; i < (int)vsize; i++)
-		proc_vector[i] = cheri_fromint(proc_vector64[i]);
+		proc_vector[i] =
+		    (char * __capability)(uintcap_t)proc_vector64[i];
 	*proc_vectorp = proc_vector;
 	*vsizep = vsize;
 done:


### PR DESCRIPTION
- **freebsd64: Use casts to convert uint64_t values to untagged capabilities**
- **cheric: Retire cheri_fromint**
- **cheric: Retire cheri_offset_inc**
