### PR TITLE
COMPAT_FREEBSD64 support for kinfo_knote

### DIFF
--- a/sys/compat/freebsd64/freebsd64.h
+++ b/sys/compat/freebsd64/freebsd64.h
@@ -173,6 +173,26 @@ struct kinfo_sigtramp64 {
 	uint64_t ksigtramp_spare[4];
 };
 
+#if defined(_WANT_KEVENT64) || (defined(_KERNEL) && __has_feature(capabilities))
+struct kinfo_knote64 {
+	int		knt_kq_fd;
+	struct kevent64	knt_event;
+	int		knt_status;
+	int		knt_extdata;
+	uint64_t	knt_spare0[4];
+	union {
+		struct {
+			int		knt_vnode_type;
+			uint64_t	knt_vnode_fsid;
+			uint64_t	knt_vnode_fileid;
+			char		knt_vnode_fullpath[PATH_MAX];
+		} knt_vnode;
+		struct {
+			ino_t		knt_pipe_ino;
+		} knt_pipe;
+	};
+};
+#endif
 
 struct kld_file_stat64 {
     int		version;	/* set to sizeof(struct kld_file_stat64) */

--- a/sys/compat/freebsd64/freebsd64_misc.c
+++ b/sys/compat/freebsd64/freebsd64_misc.c
@@ -208,6 +208,43 @@ freebsd64_fexecve(struct thread *td, struct freebsd64_fexecve_args *uap)
 	return (error);
 }
 
+static void
+freebsd64_kevent_to_kevent64(const struct kevent *kevp, struct kevent64 *ks64)
+{
+	CP(*kevp, *ks64, ident);
+	CP(*kevp, *ks64, filter);
+	CP(*kevp, *ks64, flags);
+	CP(*kevp, *ks64, fflags);
+	CP(*kevp, *ks64, data);
+	ks64->udata = (__cheri_addr uint64_t)kevp->udata;
+	memcpy(&ks64->ext[0], &kevp->ext[0], sizeof(kevp->ext));
+}
+
+void
+freebsd64_kinfo_knote_to_64(const struct kinfo_knote *kin,
+    struct kinfo_knote64 *kin64)
+{
+	memset(kin64, 0, sizeof(*kin64));
+	CP(*kin, *kin64, knt_kq_fd);
+	freebsd64_kevent_to_kevent64(&kin->knt_event, &kin64->knt_event);
+	CP(*kin, *kin64, knt_status);
+	CP(*kin, *kin64, knt_extdata);
+	switch (kin->knt_extdata) {
+	case KNOTE_EXTDATA_NONE:
+		break;
+	case KNOTE_EXTDATA_VNODE:
+		CP(*kin, *kin64, knt_vnode.knt_vnode_type);
+		CP(*kin, *kin64, knt_vnode.knt_vnode_fsid);
+		CP(*kin, *kin64, knt_vnode.knt_vnode_fileid);
+		memcpy(kin64->knt_vnode.knt_vnode_fullpath,
+		    kin->knt_vnode.knt_vnode_fullpath, PATH_MAX);
+		break;
+	case KNOTE_EXTDATA_PIPE:
+		CP(*kin, *kin64, knt_pipe.knt_pipe_ino);
+		break;
+	}
+}
+
 /*
  * Copy 'count' items into the destination list pointed to by uap->eventlist.
  */

--- a/sys/compat/freebsd64/freebsd64_util.h
+++ b/sys/compat/freebsd64/freebsd64_util.h
@@ -108,6 +108,11 @@ int	freebsd64_copyiniov(const struct iovec * __capability cb_arg,
 int	freebsd64_copyinuio(const struct iovec * __capability cb_arg,
 	    u_int iovcnt, struct uio **uiop);
 
+struct kinfo_knote;
+struct kinfo_knote64;
+void	freebsd64_kinfo_knote_to_64(const struct kinfo_knote *kin,
+	    struct kinfo_knote64 *kin64);
+
 int	freebsd64_get_mcontext(struct thread *td, mcontext64_t *mcp, int flags);
 int	freebsd64_set_mcontext(struct thread *td, mcontext64_t *mcp);
 

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -3324,13 +3324,10 @@ __elfN(note_procstat_kqueues)(void *arg, struct sbuf *sb, size_t *sizep)
 	size_t size, sect_sz, i;
 	ssize_t start_len, sect_len;
 	int structsize;
-	bool compat32;
 
 #if defined(COMPAT_FREEBSD32) && __ELF_WORD_SIZE == 32
-	compat32 = true;
 	structsize = sizeof(struct kinfo_knote32);
 #else
-	compat32 = false;
 	structsize = sizeof(struct kinfo_knote);
 #endif
 	p = arg;
@@ -3339,7 +3336,7 @@ __elfN(note_procstat_kqueues)(void *arg, struct sbuf *sb, size_t *sizep)
 		sb = sbuf_new(NULL, NULL, 128, SBUF_FIXEDLEN);
 		sbuf_set_drain(sb, sbuf_count_drain, &size);
 		sbuf_bcat(sb, &structsize, sizeof(structsize));
-		kern_proc_kqueues_out(p, sb, -1, compat32);
+		kern_proc_kqueues_out(p, sb, -1, p->p_sysent->sv_flags);
 		sbuf_finish(sb);
 		sbuf_delete(sb);
 		*sizep = size;
@@ -3348,7 +3345,7 @@ __elfN(note_procstat_kqueues)(void *arg, struct sbuf *sb, size_t *sizep)
 
 		sbuf_bcat(sb, &structsize, sizeof(structsize));
 		kern_proc_kqueues_out(p, sb, *sizep - sizeof(structsize),
-		    compat32);
+		    p->p_sysent->sv_flags);
 
 		sect_len = sbuf_end_section(sb, start_len, 0, 0);
 		if (sect_len < 0)

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -3327,6 +3327,8 @@ __elfN(note_procstat_kqueues)(void *arg, struct sbuf *sb, size_t *sizep)
 
 #if defined(COMPAT_FREEBSD32) && __ELF_WORD_SIZE == 32
 	structsize = sizeof(struct kinfo_knote32);
+#elif defined(COMPAT_FREEBSD64) && __ELF_WORD_SIZE == 64 && !defined(__ELF_CHERI)
+	structsize = sizeof(struct kinfo_knote64);
 #else
 	structsize = sizeof(struct kinfo_knote);
 #endif

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -2891,7 +2891,7 @@ knote_status_export(int kn_status)
 
 static int
 kern_proc_kqueue_report_one(struct sbuf *s, struct proc *p,
-    int kq_fd, struct kqueue *kq, struct knote *kn, bool compat32 __unused)
+    int kq_fd, struct kqueue *kq, struct knote *kn, u_int sv_flags __unused)
 {
 	struct kinfo_knote kin;
 #ifdef COMPAT_FREEBSD32
@@ -2911,7 +2911,7 @@ kern_proc_kqueue_report_one(struct sbuf *s, struct proc *p,
 	if (kn->kn_fop->f_userdump != NULL)
 		(void)kn->kn_fop->f_userdump(p, kn, &kin);
 #ifdef COMPAT_FREEBSD32
-	if (compat32) {
+	if ((sv_flags & SV_ILP32) != 0) {
 		freebsd32_kinfo_knote_to_32(&kin, &kin32);
 		error = sbuf_bcat(s, &kin32, sizeof(kin32));
 	} else
@@ -2924,7 +2924,7 @@ kern_proc_kqueue_report_one(struct sbuf *s, struct proc *p,
 
 static int
 kern_proc_kqueue_report(struct sbuf *s, struct proc *p, int kq_fd,
-    struct kqueue *kq, bool compat32)
+    struct kqueue *kq, u_int sv_flags)
 {
 	struct knote *kn;
 	int error, i;
@@ -2934,7 +2934,7 @@ kern_proc_kqueue_report(struct sbuf *s, struct proc *p, int kq_fd,
 	for (i = 0; i < kq->kq_knlistsize; i++) {
 		SLIST_FOREACH(kn, &kq->kq_knlist[i], kn_link) {
 			error = kern_proc_kqueue_report_one(s, p, kq_fd,
-			    kq, kn, compat32);
+			    kq, kn, sv_flags);
 			if (error != 0)
 				goto out;
 		}
@@ -2944,7 +2944,7 @@ kern_proc_kqueue_report(struct sbuf *s, struct proc *p, int kq_fd,
 	for (i = 0; i <= kq->kq_knhashmask; i++) {
 		SLIST_FOREACH(kn, &kq->kq_knhash[i], kn_link) {
 			error = kern_proc_kqueue_report_one(s, p, kq_fd,
-			    kq, kn, compat32);
+			    kq, kn, sv_flags);
 			if (error != 0)
 				goto out;
 		}
@@ -2956,7 +2956,7 @@ out:
 
 struct kern_proc_kqueues_out1_cb_args {
 	struct sbuf *s;
-	bool compat32;
+	u_int sv_flags;
 };
 
 static int
@@ -2969,23 +2969,23 @@ kern_proc_kqueues_out1_cb(struct proc *p, int fd, struct file *fp, void *arg)
 		return (0);
 	a = arg;
 	kq = fp->f_data;
-	return (kern_proc_kqueue_report(a->s, p, fd, kq, a->compat32));
+	return (kern_proc_kqueue_report(a->s, p, fd, kq, a->sv_flags));
 }
 
 static int
 kern_proc_kqueues_out1(struct thread *td, struct proc *p, struct sbuf *s,
-    bool compat32)
+    u_int sv_flags)
 {
 	struct kern_proc_kqueues_out1_cb_args a;
 
 	a.s = s;
-	a.compat32 = compat32;
+	a.sv_flags = sv_flags;
 	return (fget_remote_foreach(td, p, kern_proc_kqueues_out1_cb, &a));
 }
 
 int
 kern_proc_kqueues_out(struct proc *p, struct sbuf *sb, size_t maxlen,
-    bool compat32)
+    u_int sv_flags)
 {
 	struct sbuf *s, sm;
 	size_t sb_len;
@@ -2997,7 +2997,7 @@ kern_proc_kqueues_out(struct proc *p, struct sbuf *sb, size_t maxlen,
 		sb_len = maxlen;
 	s = sbuf_new(&sm, NULL, sb_len, maxlen == -1 ? SBUF_AUTOEXTEND :
 	    SBUF_FIXEDLEN);
-	error = kern_proc_kqueues_out1(curthread, p, s, compat32);
+	error = kern_proc_kqueues_out1(curthread, p, s, sv_flags);
 	sbuf_finish(s);
 	if (error == 0) {
 		sbuf_bcat(sb, sbuf_data(s), MIN(sbuf_len(s), maxlen == -1 ?
@@ -3009,7 +3009,7 @@ kern_proc_kqueues_out(struct proc *p, struct sbuf *sb, size_t maxlen,
 
 static int
 sysctl_kern_proc_kqueue_one(struct thread *td, struct sbuf *s, struct proc *p,
-    int kq_fd, bool compat32)
+    int kq_fd, u_int sv_flags)
 {
 	struct file *fp;
 	struct kqueue *kq;
@@ -3022,7 +3022,7 @@ sysctl_kern_proc_kqueue_one(struct thread *td, struct sbuf *s, struct proc *p,
 		} else {
 			kq = fp->f_data;
 			error = kern_proc_kqueue_report(s, p, kq_fd, kq,
-			    compat32);
+			    sv_flags);
 		}
 		fdrop(fp, td);
 	}
@@ -3035,8 +3035,8 @@ sysctl_kern_proc_kqueue(SYSCTL_HANDLER_ARGS)
 	struct thread *td;
 	struct proc *p;
 	struct sbuf *s, sm;
+	u_int sv_flags;
 	int error, error1, *name;
-	bool compat32;
 
 	name = (int *)arg1;
 	if ((u_int)arg2 > 2 || (u_int)arg2 == 0)
@@ -3047,11 +3047,6 @@ sysctl_kern_proc_kqueue(SYSCTL_HANDLER_ARGS)
 		return (error);
 
 	td = curthread;
-#ifdef FREEBSD_COMPAT32
-	compat32 = SV_CURPROC_FLAG(SV_ILP32);
-#else
-	compat32 = false;
-#endif
 
 	s = sbuf_new_for_sysctl(&sm, NULL, 0, req);
 	if (s == NULL) {
@@ -3060,11 +3055,12 @@ sysctl_kern_proc_kqueue(SYSCTL_HANDLER_ARGS)
 	}
 	sbuf_clear_flags(s, SBUF_INCLUDENUL);
 
+	sv_flags = curproc->p_sysent->sv_flags;
 	if ((u_int)arg2 == 1) {
-		error = kern_proc_kqueues_out1(td, p, s, compat32);
+		error = kern_proc_kqueues_out1(td, p, s, sv_flags);
 	} else {
 		error = sysctl_kern_proc_kqueue_one(td, s, p,
-		    name[1] /* kq_fd */, compat32);
+		    name[1] /* kq_fd */, sv_flags);
 	}
 
 	error1 = sbuf_finish(s);

--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -75,6 +75,10 @@
 #include <sys/ktrace.h>
 #endif
 #include <machine/atomic.h>
+#ifdef COMPAT_FREEBSD64
+#include <compat/freebsd64/freebsd64.h>
+#include <compat/freebsd64/freebsd64_util.h>
+#endif
 #ifdef COMPAT_FREEBSD32
 #include <compat/freebsd32/freebsd32.h>
 #include <compat/freebsd32/freebsd32_util.h>
@@ -2894,6 +2898,9 @@ kern_proc_kqueue_report_one(struct sbuf *s, struct proc *p,
     int kq_fd, struct kqueue *kq, struct knote *kn, u_int sv_flags __unused)
 {
 	struct kinfo_knote kin;
+#ifdef COMPAT_FREEBSD64
+	struct kinfo_knote64 kin64;
+#endif
 #ifdef COMPAT_FREEBSD32
 	struct kinfo_knote32 kin32;
 #endif
@@ -2910,6 +2917,12 @@ kern_proc_kqueue_report_one(struct sbuf *s, struct proc *p,
 	KQ_UNLOCK_FLUX(kq);
 	if (kn->kn_fop->f_userdump != NULL)
 		(void)kn->kn_fop->f_userdump(p, kn, &kin);
+#ifdef COMPAT_FREEBSD64
+	if ((sv_flags & (SV_LP64 | SV_CHERI)) == SV_LP64) {
+		freebsd64_kinfo_knote_to_64(&kin, &kin64);
+		error = sbuf_bcat(s, &kin64, sizeof(kin64));
+	} else
+#endif
 #ifdef COMPAT_FREEBSD32
 	if ((sv_flags & SV_ILP32) != 0) {
 		freebsd32_kinfo_knote_to_32(&kin, &kin32);

--- a/sys/sys/user.h
+++ b/sys/sys/user.h
@@ -732,7 +732,7 @@ int	kern_proc_out(struct proc *p, struct sbuf *sb, int flags);
 int	kern_proc_vmmap_out(struct proc *p, struct sbuf *sb, ssize_t maxlen,
 	int flags);
 int	kern_proc_kqueues_out(struct proc *p, struct sbuf *s, size_t maxlen,
-	bool compat32);
+	    u_int sv_flags);
 
 int	vntype_to_kinfo(int vtype);
 void	pack_kinfo(struct kinfo_file *kif);


### PR DESCRIPTION
- **kinfo_knote: Pass down the full sysentvec flags instead of a bool compat32**
- **kinfo_knote: Add COMPAT_FREEBSD64 support**
