### PR TITLE
Pass user pointers down into Linux read/write file operations

### DIFF
--- a/sys/compat/lindebugfs/lindebugfs.c
+++ b/sys/compat/lindebugfs/lindebugfs.c
@@ -663,7 +663,7 @@ fops_str_open(struct inode *inode, struct file *filp)
 }
 
 static ssize_t
-fops_str_read(struct file *filp, char __user *ubuf, size_t read_size,
+fops_str_read(struct file *filp, char __user * __capability ubuf, size_t read_size,
     loff_t *ppos)
 {
 	ssize_t ret;
@@ -697,7 +697,7 @@ fops_str_read(struct file *filp, char __user *ubuf, size_t read_size,
 }
 
 static ssize_t
-fops_str_write(struct file *filp, const char __user *buf, size_t write_size,
+fops_str_write(struct file *filp, const char __user * __capability buf, size_t write_size,
     loff_t *ppos)
 {
 	char *old, *new;
@@ -771,7 +771,7 @@ debugfs_create_str(const char *name, umode_t mode, struct dentry *parent,
 
 
 static ssize_t
-fops_blob_read(struct file *filp, char __user *ubuf, size_t read_size, loff_t *ppos)
+fops_blob_read(struct file *filp, char __user * __capability ubuf, size_t read_size, loff_t *ppos)
 {
 	struct debugfs_blob_wrapper *blob;
 

--- a/sys/compat/lindebugfs/lindebugfs.c
+++ b/sys/compat/lindebugfs/lindebugfs.c
@@ -117,9 +117,14 @@ debugfs_fill(PFS_FILL_ARGS)
 	struct dentry_meta *d;
 	struct linux_file lf = {};
 	struct vnode vn;
-	char *buf;
-	int rc;
-	off_t off = 0;
+	struct iovec *iov;
+	size_t cnt, orig_resid;
+	ssize_t rc;
+	off_t off;
+
+	/* Linux file operations assume a pointer to a user buffer. */
+	if (uio->uio_segflg != UIO_USERSPACE)
+		return (EOPNOTSUPP);
 
 	if ((rc = linux_set_current_flags(curthread, M_NOWAIT)))
 		return (rc);
@@ -130,47 +135,68 @@ debugfs_fill(PFS_FILL_ARGS)
 	rc = d->dm_fops->open(&vn, &lf);
 	if (rc < 0) {
 #ifdef INVARIANTS
-		printf("%s:%d open failed with %d\n", __func__, __LINE__, rc);
+		printf("%s:%d open failed with %zd\n", __func__, __LINE__, rc);
 #endif
 		return (-rc);
 	}
 
-	rc = -ENODEV;
-	switch (uio->uio_rw) {
-	case UIO_READ:
-		if (d->dm_fops->read != NULL) {
-			rc = -ENOMEM;
-			buf = malloc(sb->s_size, M_DFSINT, M_ZERO | M_NOWAIT);
-			if (buf != NULL) {
-				rc = d->dm_fops->read(&lf, buf, sb->s_size,
-				    &off);
-				if (rc > 0)
-					sbuf_bcpy(sb, buf, strlen(buf));
+	off = uio->uio_offset;
+	orig_resid = uio->uio_resid;
+	while (uio->uio_resid > 0) {
+		KASSERT(uio->uio_iovcnt > 0,
+		    ("%s: uio %p iovcnt underflow", __func__, uio));
 
-				free(buf, M_DFSINT);
-			}
+		iov = uio->uio_iov;
+		cnt = iov->iov_len;
+		if (cnt == 0) {
+			uio->uio_iov++;
+			uio->uio_iovcnt--;
+			continue;
 		}
-		break;
-	case UIO_WRITE:
-		if (d->dm_fops->write != NULL) {
-			sbuf_finish(sb);
-			rc = d->dm_fops->write(&lf, sbuf_data(sb), sbuf_len(sb),
-			    &off);
-		}
-		break;
+		if (cnt > uio->uio_resid)
+			cnt = uio->uio_resid;
+
+		switch (uio->uio_rw) {
+		case UIO_READ:
+			if (d->dm_fops->read != NULL)
+				rc = d->dm_fops->read(&lf, iov->iov_base, cnt,
+				    &off);
+			else
+				rc = -ENODEV;
+			break;
+		case UIO_WRITE:
+			if (d->dm_fops->write != NULL)
+				rc = d->dm_fops->write(&lf, iov->iov_base, cnt,
+				    &off);
+			else
+				rc = -ENODEV;
+			break;
 #if __has_feature(capabilities)
-	case UIO_READ_CAP:
-	case UIO_WRITE_CAP:
-		__assert_unreachable();
+		case UIO_READ_CAP:
+		case UIO_WRITE_CAP:
+			__assert_unreachable();
 #endif
+		}
+
+		if (rc <= 0)
+			break;
+
+		IOVEC_ADVANCE(iov, rc);
+		uio->uio_resid -= rc;
+		uio->uio_offset = off;
 	}
 
 	if (d->dm_fops->release)
 		d->dm_fops->release(&vn, &lf);
 
+	/* Return success for short operations. */
+	if (orig_resid != uio->uio_resid)
+		rc = 0;
+
 	if (rc < 0) {
 #ifdef INVARIANTS
-		printf("%s:%d read/write failed with %d\n", __func__, __LINE__, rc);
+		printf("%s:%d read/write failed with %zd\n", __func__, __LINE__,
+		    rc);
 #endif
 		return (-rc);
 	}
@@ -212,7 +238,7 @@ debugfs_create_file(const char *name, umode_t mode,
 
 	flags = fops->write ? PFS_RDWR : PFS_RD;
 	dnode->d_pfs_node = pfs_create_file(pnode, name, debugfs_fill,
-	    debugfs_attr, NULL, debugfs_destroy, flags | PFS_NOWAIT);
+	    debugfs_attr, NULL, debugfs_destroy, flags | PFS_RAW | PFS_NOWAIT);
 	if (dnode->d_pfs_node == NULL) {
 		free(dm, M_DFSINT);
 		return (NULL);
@@ -671,7 +697,7 @@ fops_str_read(struct file *filp, char __user *ubuf, size_t read_size,
 }
 
 static ssize_t
-fops_str_write(struct file *filp, const char *buf, size_t write_size,
+fops_str_write(struct file *filp, const char __user *buf, size_t write_size,
     loff_t *ppos)
 {
 	char *old, *new;

--- a/sys/compat/lindebugfs/lindebugfs.c
+++ b/sys/compat/lindebugfs/lindebugfs.c
@@ -700,12 +700,10 @@ fops_str_write(struct file *filp, const char *buf, size_t write_size,
 		return (-ENOMEM);
 
 	memcpy(new, old, old_len);
-
-	/*
-	 * In Linux this would use copy_from_user, but pseudofs passes
-	 * a pointer to a kernel buffer in *buf, not a user pointer.
-	 */
-	memcpy(new + old_len, buf, write_size);
+	if (copy_from_user(new + old_len, buf, write_size) != 0) {
+		kfree(new);
+		return (-EFAULT);
+	}
 
 	new[new_len] = '\0';
 	strim(new);

--- a/sys/compat/linuxkpi/common/include/linux/fs.h
+++ b/sys/compat/linuxkpi/common/include/linux/fs.h
@@ -134,8 +134,8 @@ typedef int (*filldir_t)(void *, const char *, int, off_t, u64, unsigned);
 
 struct file_operations {
 	struct module *owner;
-	ssize_t (*read)(struct linux_file *, char __user *, size_t, off_t *);
-	ssize_t (*write)(struct linux_file *, const char __user *, size_t, off_t *);
+	ssize_t (*read)(struct linux_file *, char __user * __capability, size_t, off_t *);
+	ssize_t (*write)(struct linux_file *, const char __user * __capability, size_t, off_t *);
 	unsigned int (*poll) (struct linux_file *, struct poll_table_struct *);
 	long (*unlocked_ioctl)(struct linux_file *, unsigned int, uintcap_t);
 	long (*compat_ioctl)(struct linux_file *, unsigned int, uintcap_t);
@@ -360,7 +360,7 @@ i_size_write(struct inode *inode, loff_t i_size)
  * On failure, negative value.
  */
 static inline ssize_t
-simple_read_from_buffer(void __user *dest, size_t read_size, loff_t *ppos,
+simple_read_from_buffer(void __user * __capability dest, size_t read_size, loff_t *ppos,
     void *orig, size_t buf_size)
 {
 	void *read_pos = ((char *) orig) + *ppos;
@@ -410,13 +410,13 @@ int simple_attr_open(struct inode *inode, struct file *filp,
 
 int simple_attr_release(struct inode *inode, struct file *filp);
 
-ssize_t simple_attr_read(struct file *filp, char __user *buf, size_t read_size,
+ssize_t simple_attr_read(struct file *filp, char __user * __capability buf, size_t read_size,
     loff_t *ppos);
 
-ssize_t simple_attr_write(struct file *filp, const char __user *buf,
+ssize_t simple_attr_write(struct file *filp, const char __user * __capability buf,
     size_t write_size, loff_t *ppos);
 
-ssize_t simple_attr_write_signed(struct file *filp, const char __user *buf,
+ssize_t simple_attr_write_signed(struct file *filp, const char __user * __capability buf,
 	    size_t write_size, loff_t *ppos);
 
 #endif /* _LINUXKPI_LINUX_FS_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/fs.h
+++ b/sys/compat/linuxkpi/common/include/linux/fs.h
@@ -367,8 +367,8 @@ simple_read_from_buffer(void __user *dest, size_t read_size, loff_t *ppos,
 	size_t buf_remain = buf_size - *ppos;
 	ssize_t num_read;
 
-	if (buf_remain < 0 || buf_remain > buf_size)
-		return -EINVAL;
+	if (*ppos >= buf_size || read_size == 0)
+		return (0);
 
 	if (read_size > buf_remain)
 		read_size = buf_remain;

--- a/sys/compat/linuxkpi/common/include/linux/fs.h
+++ b/sys/compat/linuxkpi/common/include/linux/fs.h
@@ -363,8 +363,9 @@ static inline ssize_t
 simple_read_from_buffer(void __user *dest, size_t read_size, loff_t *ppos,
     void *orig, size_t buf_size)
 {
-	void *p, *read_pos = ((char *) orig) + *ppos;
+	void *read_pos = ((char *) orig) + *ppos;
 	size_t buf_remain = buf_size - *ppos;
+	ssize_t num_read;
 
 	if (buf_remain < 0 || buf_remain > buf_size)
 		return -EINVAL;
@@ -372,18 +373,13 @@ simple_read_from_buffer(void __user *dest, size_t read_size, loff_t *ppos,
 	if (read_size > buf_remain)
 		read_size = buf_remain;
 
-	/*
-	 * XXX At time of commit only debugfs consumers could be
-	 * identified.  If others will use this function we may
-	 * have to revise this: normally we would call copy_to_user()
-	 * here but lindebugfs will return the result and the
-	 * copyout is done elsewhere for us.
-	 */
-	p = memcpy(dest, read_pos, read_size);
-	if (p != NULL)
-		*ppos += read_size;
+	/* copy_to_user returns number of bytes NOT read */
+	num_read = read_size - copy_to_user(dest, read_pos, read_size);
+	if (num_read == 0)
+		return -EFAULT;
+	*ppos += num_read;
 
-	return (read_size);
+	return (num_read);
 }
 
 MALLOC_DECLARE(M_LSATTR);
@@ -414,11 +410,13 @@ int simple_attr_open(struct inode *inode, struct file *filp,
 
 int simple_attr_release(struct inode *inode, struct file *filp);
 
-ssize_t simple_attr_read(struct file *filp, char *buf, size_t read_size, loff_t *ppos);
+ssize_t simple_attr_read(struct file *filp, char __user *buf, size_t read_size,
+    loff_t *ppos);
 
-ssize_t simple_attr_write(struct file *filp, const char *buf, size_t write_size, loff_t *ppos);
+ssize_t simple_attr_write(struct file *filp, const char __user *buf,
+    size_t write_size, loff_t *ppos);
 
-ssize_t simple_attr_write_signed(struct file *filp, const char *buf,
+ssize_t simple_attr_write_signed(struct file *filp, const char __user *buf,
 	    size_t write_size, loff_t *ppos);
 
 #endif /* _LINUXKPI_LINUX_FS_H_ */

--- a/sys/compat/linuxkpi/common/include/linux/seq_file.h
+++ b/sys/compat/linuxkpi/common/include/linux/seq_file.h
@@ -70,7 +70,7 @@ struct seq_operations {
 	int (*show) (struct seq_file *m, void *v);
 };
 
-ssize_t seq_read(struct linux_file *, char *, size_t, off_t *);
+ssize_t seq_read(struct linux_file *, char __user *, size_t, off_t *);
 int seq_write(struct seq_file *seq, const void *data, size_t len);
 void seq_putc(struct seq_file *m, char c);
 void seq_puts(struct seq_file *m, const char *str);

--- a/sys/compat/linuxkpi/common/include/linux/seq_file.h
+++ b/sys/compat/linuxkpi/common/include/linux/seq_file.h
@@ -70,7 +70,7 @@ struct seq_operations {
 	int (*show) (struct seq_file *m, void *v);
 };
 
-ssize_t seq_read(struct linux_file *, char __user *, size_t, off_t *);
+ssize_t seq_read(struct linux_file *, char __user * __capability, size_t, off_t *);
 int seq_write(struct seq_file *seq, const void *data, size_t len);
 void seq_putc(struct seq_file *m, char c);
 void seq_puts(struct seq_file *m, const char *str);

--- a/sys/compat/linuxkpi/common/src/linux_compat.c
+++ b/sys/compat/linuxkpi/common/src/linux_compat.c
@@ -1441,7 +1441,7 @@ linux_file_read(struct file *file, struct uio *uio, struct ucred *active_cred,
 	linux_get_fop(filp, &fop, &ldev);
 	if (fop->read != NULL) {
 		bytes = OPW(file, td, fop->read(filp,
-		    (__cheri_fromcap void *)uio->uio_iov->iov_base,
+		    uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset));
 		if (bytes >= 0) {
 			IOVEC_ADVANCE(uio->uio_iov, bytes);
@@ -1480,7 +1480,7 @@ linux_file_write(struct file *file, struct uio *uio, struct ucred *active_cred,
 	linux_get_fop(filp, &fop, &ldev);
 	if (fop->write != NULL) {
 		bytes = OPW(file, td, fop->write(filp,
-		    (__cheri_fromcap void *)uio->uio_iov->iov_base,
+		    uio->uio_iov->iov_base,
 		    uio->uio_iov->iov_len, &uio->uio_offset));
 		if (bytes >= 0) {
 			IOVEC_ADVANCE(uio->uio_iov, bytes);

--- a/sys/compat/linuxkpi/common/src/linux_seq_file.c
+++ b/sys/compat/linuxkpi/common/src/linux_seq_file.c
@@ -64,13 +64,10 @@ seq_read(struct linux_file *f, char *ubuf, size_t size, off_t *ppos)
 		return (-EINVAL);
 
 	size = min(rc - *ppos, size);
-	rc = strscpy(ubuf, sbuf_data(sbuf) + *ppos, size + 1);
+	memcpy(ubuf, sbuf_data(sbuf) + *ppos, size);
+	*ppos += size;
 
-	/* add 1 for null terminator */
-	if (rc > 0)
-		rc += 1;
-
-	return (rc);
+	return (size);
 }
 
 int

--- a/sys/compat/linuxkpi/common/src/linux_seq_file.c
+++ b/sys/compat/linuxkpi/common/src/linux_seq_file.c
@@ -49,6 +49,7 @@ seq_read(struct linux_file *f, char *ubuf, size_t size, off_t *ppos)
 
 	m = f->private_data;
 	sbuf = m->buf;
+	sbuf_clear(sbuf);
 
 	p = m->op->start(m, ppos);
 	rc = m->op->show(m, p);

--- a/sys/compat/linuxkpi/common/src/linux_seq_file.c
+++ b/sys/compat/linuxkpi/common/src/linux_seq_file.c
@@ -60,15 +60,8 @@ seq_read(struct linux_file *f, char *ubuf, size_t size, off_t *ppos)
 	if (rc)
 		return (rc);
 
-	rc = sbuf_len(sbuf);
-	if (*ppos >= rc || size < 1)
-		return (-EINVAL);
-
-	size = min(rc - *ppos, size);
-	memcpy(ubuf, sbuf_data(sbuf) + *ppos, size);
-	*ppos += size;
-
-	return (size);
+	return (simple_read_from_buffer(ubuf, size, ppos, sbuf_data(sbuf),
+	    sbuf_len(sbuf)));
 }
 
 int

--- a/sys/compat/linuxkpi/common/src/linux_seq_file.c
+++ b/sys/compat/linuxkpi/common/src/linux_seq_file.c
@@ -40,7 +40,7 @@
 MALLOC_DEFINE(M_LSEQ, "seq_file", "seq_file");
 
 ssize_t
-seq_read(struct linux_file *f, char *ubuf, size_t size, off_t *ppos)
+seq_read(struct linux_file *f, char __user *ubuf, size_t size, off_t *ppos)
 {
 	struct seq_file *m;
 	struct sbuf *sbuf;

--- a/sys/compat/linuxkpi/common/src/linux_seq_file.c
+++ b/sys/compat/linuxkpi/common/src/linux_seq_file.c
@@ -40,7 +40,7 @@
 MALLOC_DEFINE(M_LSEQ, "seq_file", "seq_file");
 
 ssize_t
-seq_read(struct linux_file *f, char __user *ubuf, size_t size, off_t *ppos)
+seq_read(struct linux_file *f, char __user * __capability ubuf, size_t size, off_t *ppos)
 {
 	struct seq_file *m;
 	struct sbuf *sbuf;

--- a/sys/compat/linuxkpi/common/src/linux_simple_attr.c
+++ b/sys/compat/linuxkpi/common/src/linux_simple_attr.c
@@ -99,7 +99,8 @@ simple_attr_release(struct inode *inode, struct file *filp)
  * On failure, negative signed ERRNO
  */
 ssize_t
-simple_attr_read(struct file *filp, char *buf, size_t read_size, loff_t *ppos)
+simple_attr_read(struct file *filp, char __user *buf, size_t read_size,
+    loff_t *ppos)
 {
 	struct simple_attr *sattr;
 	uint64_t data;
@@ -146,29 +147,38 @@ unlock:
  * On failure, negative signed ERRNO
  */
 static ssize_t
-simple_attr_write_common(struct file *filp, const char *buf, size_t write_size,
-    loff_t *ppos, bool is_signed)
+simple_attr_write_common(struct file *filp, const char __user *ubuf,
+    size_t write_size, loff_t *ppos, bool is_signed)
 {
 	struct simple_attr *sattr;
 	unsigned long long data;
-	size_t bufsize;
+	char *buf;
 	ssize_t ret;
 
 	sattr = filp->private_data;
-	bufsize = strlen(buf) + 1;
 
 	if (sattr->set == NULL)
 		return (-EFAULT);
 
-	if (*ppos >= bufsize || write_size < 1)
+	if (*ppos != 0 || write_size < 1)
 		return (-EINVAL);
+
+	buf = malloc(write_size, M_LSATTR, M_WAITOK);
+	if (copy_from_user(buf, ubuf, write_size) != 0) {
+		free(buf, M_LSATTR);
+		return (-EFAULT);
+	}
+	if (strnlen(buf, write_size) == write_size) {
+		free(buf, M_LSATTR);
+		return (-EINVAL);
+	}
 
 	mutex_lock(&sattr->mutex);
 
 	if (is_signed)
-		ret = kstrtoll(buf + *ppos, 0, &data);
+		ret = kstrtoll(buf, 0, &data);
 	else
-		ret = kstrtoull(buf + *ppos, 0, &data);
+		ret = kstrtoull(buf, 0, &data);
 	if (ret)
 		goto unlock;
 
@@ -176,23 +186,24 @@ simple_attr_write_common(struct file *filp, const char *buf, size_t write_size,
 	if (ret)
 		goto unlock;
 
-	ret = bufsize - *ppos;
+	ret = write_size;
 
 unlock:
 	mutex_unlock(&sattr->mutex);
+	free(buf, M_LSATTR);
 	return (ret);
 }
 
 ssize_t
-simple_attr_write(struct file *filp, const char *buf, size_t write_size,
+simple_attr_write(struct file *filp, const char __user *buf, size_t write_size,
     loff_t *ppos)
 {
 	return (simple_attr_write_common(filp, buf,  write_size, ppos, false));
 }
 
 ssize_t
-simple_attr_write_signed(struct file *filp, const char *buf, size_t write_size,
-    loff_t *ppos)
+simple_attr_write_signed(struct file *filp, const char __user *buf,
+    size_t write_size, loff_t *ppos)
 {
 	return (simple_attr_write_common(filp, buf,  write_size, ppos, true));
 }

--- a/sys/compat/linuxkpi/common/src/linux_simple_attr.c
+++ b/sys/compat/linuxkpi/common/src/linux_simple_attr.c
@@ -119,18 +119,9 @@ simple_attr_read(struct file *filp, char *buf, size_t read_size, loff_t *ppos)
 
 	scnprintf(prebuf, sizeof(prebuf), sattr->fmt, data);
 
-	ret = strlen(prebuf) + 1;
-	if (*ppos >= ret || read_size < 1) {
-		ret = -EINVAL;
-		goto unlock;
-	}
-
-	read_size = min(ret - *ppos, read_size);
-	ret = strscpy(buf, prebuf + *ppos, read_size);
-
 	/* add 1 for null terminator */
-	if (ret > 0)
-		ret += 1;
+	ret = simple_read_from_buffer(buf, read_size, ppos, prebuf,
+	    strlen(prebuf) + 1);
 
 unlock:
 	mutex_unlock(&sattr->mutex);

--- a/sys/compat/linuxkpi/common/src/linux_simple_attr.c
+++ b/sys/compat/linuxkpi/common/src/linux_simple_attr.c
@@ -99,7 +99,7 @@ simple_attr_release(struct inode *inode, struct file *filp)
  * On failure, negative signed ERRNO
  */
 ssize_t
-simple_attr_read(struct file *filp, char __user *buf, size_t read_size,
+simple_attr_read(struct file *filp, char __user * __capability buf, size_t read_size,
     loff_t *ppos)
 {
 	struct simple_attr *sattr;
@@ -147,7 +147,7 @@ unlock:
  * On failure, negative signed ERRNO
  */
 static ssize_t
-simple_attr_write_common(struct file *filp, const char __user *ubuf,
+simple_attr_write_common(struct file *filp, const char __user * __capability ubuf,
     size_t write_size, loff_t *ppos, bool is_signed)
 {
 	struct simple_attr *sattr;
@@ -195,14 +195,14 @@ unlock:
 }
 
 ssize_t
-simple_attr_write(struct file *filp, const char __user *buf, size_t write_size,
+simple_attr_write(struct file *filp, const char __user * __capability buf, size_t write_size,
     loff_t *ppos)
 {
 	return (simple_attr_write_common(filp, buf,  write_size, ppos, false));
 }
 
 ssize_t
-simple_attr_write_signed(struct file *filp, const char __user *buf,
+simple_attr_write_signed(struct file *filp, const char __user * __capability buf,
     size_t write_size, loff_t *ppos)
 {
 	return (simple_attr_write_common(filp, buf,  write_size, ppos, true));

--- a/sys/contrib/dev/iwlwifi/fw/debugfs.c
+++ b/sys/contrib/dev/iwlwifi/fw/debugfs.c
@@ -34,7 +34,7 @@ static int _iwl_dbgfs_##name##_open(struct inode *inode,		\
 
 #define FWRT_DEBUGFS_READ_WRAPPER(name)					\
 static ssize_t _iwl_dbgfs_##name##_read(struct file *file,		\
-					char __user *user_buf,		\
+					char __user * __capability user_buf,		\
 					size_t count, loff_t *ppos)	\
 {									\
 	struct dbgfs_##name##_data *data = file->private_data;		\
@@ -71,7 +71,7 @@ static const struct file_operations iwl_dbgfs_##name##_ops = {		\
 
 #define FWRT_DEBUGFS_WRITE_WRAPPER(name, buflen, argtype)		\
 static ssize_t _iwl_dbgfs_##name##_write(struct file *file,		\
-					 const char __user *user_buf,	\
+					 const char __user * __capability user_buf,	\
 					 size_t count, loff_t *ppos)	\
 {									\
 	argtype *arg =							\

--- a/sys/contrib/dev/iwlwifi/mvm/debugfs-vif.c
+++ b/sys/contrib/dev/iwlwifi/mvm/debugfs-vif.c
@@ -136,7 +136,7 @@ static ssize_t iwl_dbgfs_pm_params_write(struct ieee80211_vif *vif, char *buf,
 }
 
 static ssize_t iwl_dbgfs_tx_pwr_lmt_read(struct file *file,
-					 char __user *user_buf,
+					 char __user * __capability user_buf,
 					 size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -151,7 +151,7 @@ static ssize_t iwl_dbgfs_tx_pwr_lmt_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_pm_params_read(struct file *file,
-					char __user *user_buf,
+					char __user * __capability user_buf,
 					size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -167,7 +167,7 @@ static ssize_t iwl_dbgfs_pm_params_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_mac_params_read(struct file *file,
-					 char __user *user_buf,
+					 char __user * __capability user_buf,
 					 size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -393,7 +393,7 @@ static ssize_t iwl_dbgfs_bf_params_write(struct ieee80211_vif *vif, char *buf,
 }
 
 static ssize_t iwl_dbgfs_bf_params_read(struct file *file,
-					char __user *user_buf,
+					char __user * __capability user_buf,
 					size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -442,7 +442,7 @@ static ssize_t iwl_dbgfs_bf_params_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_os_device_timediff_read(struct file *file,
-						 char __user *user_buf,
+						 char __user * __capability user_buf,
 						 size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -521,7 +521,7 @@ iwl_dbgfs_low_latency_force_write(struct ieee80211_vif *vif, char *buf,
 }
 
 static ssize_t iwl_dbgfs_low_latency_read(struct file *file,
-					  char __user *user_buf,
+					  char __user * __capability user_buf,
 					  size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -549,7 +549,7 @@ static ssize_t iwl_dbgfs_low_latency_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_uapsd_misbehaving_read(struct file *file,
-						char __user *user_buf,
+						char __user * __capability user_buf,
 						size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -632,7 +632,7 @@ static ssize_t iwl_dbgfs_rx_phyinfo_write(struct ieee80211_vif *vif, char *buf,
 }
 
 static ssize_t iwl_dbgfs_rx_phyinfo_read(struct file *file,
-					 char __user *user_buf,
+					 char __user * __capability user_buf,
 					 size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -686,7 +686,7 @@ static ssize_t iwl_dbgfs_quota_min_write(struct ieee80211_vif *vif, char *buf,
 }
 
 static ssize_t iwl_dbgfs_quota_min_read(struct file *file,
-					char __user *user_buf,
+					char __user * __capability user_buf,
 					size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -719,7 +719,7 @@ static ssize_t iwl_dbgfs_max_tx_op_write(struct ieee80211_vif *vif, char *buf,
 }
 
 static ssize_t iwl_dbgfs_max_tx_op_read(struct file *file,
-					char __user *user_buf,
+					char __user * __capability user_buf,
 					size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;
@@ -766,7 +766,7 @@ static ssize_t iwl_dbgfs_int_mlo_scan_write(struct ieee80211_vif *vif,
 }
 
 static ssize_t iwl_dbgfs_esr_disable_reason_read(struct file *file,
-						 char __user *user_buf,
+						 char __user * __capability user_buf,
 						 size_t count, loff_t *ppos)
 {
 	struct ieee80211_vif *vif = file->private_data;

--- a/sys/contrib/dev/iwlwifi/mvm/debugfs.c
+++ b/sys/contrib/dev/iwlwifi/mvm/debugfs.c
@@ -20,7 +20,7 @@
 #include "fw/api/phy-ctxt.h"
 
 static ssize_t iwl_dbgfs_ctdp_budget_read(struct file *file,
-					  char __user *user_buf,
+					  char __user * __capability user_buf,
 					  size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -151,7 +151,7 @@ static ssize_t iwl_dbgfs_tx_flush_write(struct iwl_mvm *mvm, char *buf,
 	return ret;
 }
 
-static ssize_t iwl_dbgfs_sram_read(struct file *file, char __user *user_buf,
+static ssize_t iwl_dbgfs_sram_read(struct file *file, char __user * __capability user_buf,
 				   size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -218,7 +218,7 @@ static ssize_t iwl_dbgfs_sram_write(struct iwl_mvm *mvm, char *buf,
 }
 
 static ssize_t iwl_dbgfs_set_nic_temperature_read(struct file *file,
-						  char __user *user_buf,
+						  char __user * __capability user_buf,
 						  size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -285,7 +285,7 @@ out:
 }
 
 static ssize_t iwl_dbgfs_nic_temp_read(struct file *file,
-				       char __user *user_buf,
+				       char __user * __capability user_buf,
 				       size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -310,7 +310,7 @@ static ssize_t iwl_dbgfs_nic_temp_read(struct file *file,
 
 #ifdef CONFIG_ACPI
 static ssize_t iwl_dbgfs_sar_geo_profile_read(struct file *file,
-					      char __user *user_buf,
+					      char __user * __capability user_buf,
 					      size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -352,7 +352,7 @@ static ssize_t iwl_dbgfs_sar_geo_profile_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_wifi_6e_enable_read(struct file *file,
-					     char __user *user_buf,
+					     char __user * __capability user_buf,
 					     size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -370,7 +370,7 @@ static ssize_t iwl_dbgfs_wifi_6e_enable_read(struct file *file,
 }
 #endif
 
-static ssize_t iwl_dbgfs_stations_read(struct file *file, char __user *user_buf,
+static ssize_t iwl_dbgfs_stations_read(struct file *file, char __user * __capability user_buf,
 				       size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -403,7 +403,7 @@ static ssize_t iwl_dbgfs_rs_data_read(struct ieee80211_link_sta *link_sta,
 				      struct iwl_mvm_sta *mvmsta,
 				      struct iwl_mvm *mvm,
 				      struct iwl_mvm_link_sta *mvm_link_sta,
-				      char __user *user_buf,
+				      char __user * __capability user_buf,
 				      size_t count, loff_t *ppos)
 {
 	struct iwl_lq_sta_rs_fw *lq_sta = &mvm_link_sta->lq_sta.rs_fw;
@@ -479,7 +479,7 @@ static ssize_t iwl_dbgfs_amsdu_len_read(struct ieee80211_link_sta *link_sta,
 					struct iwl_mvm_sta *mvmsta,
 					struct iwl_mvm *mvm,
 					struct iwl_mvm_link_sta *mvm_link_sta,
-					char __user *user_buf,
+					char __user * __capability user_buf,
 					size_t count, loff_t *ppos)
 {
 	char buf[32];
@@ -494,7 +494,7 @@ static ssize_t iwl_dbgfs_amsdu_len_read(struct ieee80211_link_sta *link_sta,
 }
 
 static ssize_t iwl_dbgfs_disable_power_off_read(struct file *file,
-						char __user *user_buf,
+						char __user * __capability user_buf,
 						size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -537,7 +537,7 @@ static ssize_t iwl_dbgfs_disable_power_off_write(struct iwl_mvm *mvm, char *buf,
 	return ret ?: count;
 }
 
-static ssize_t iwl_dbgfs_fw_ver_read(struct file *file, char __user *user_buf,
+static ssize_t iwl_dbgfs_fw_ver_read(struct file *file, char __user * __capability user_buf,
 				     size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -572,7 +572,7 @@ static ssize_t iwl_dbgfs_fw_ver_read(struct file *file, char __user *user_buf,
 }
 
 static ssize_t iwl_dbgfs_tas_get_status_read(struct file *file,
-					     char __user *user_buf,
+					     char __user * __capability user_buf,
 					     size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -756,7 +756,7 @@ out:
 }
 
 static ssize_t iwl_dbgfs_phy_integration_ver_read(struct file *file,
-						  char __user *user_buf,
+						  char __user * __capability user_buf,
 						  size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -785,7 +785,7 @@ static ssize_t iwl_dbgfs_phy_integration_ver_read(struct file *file,
 					  le32_to_cpu(_struct->_memb))
 
 static ssize_t iwl_dbgfs_fw_rx_stats_read(struct file *file,
-					  char __user *user_buf, size_t count,
+					  char __user * __capability user_buf, size_t count,
 					  loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -982,7 +982,7 @@ static ssize_t iwl_dbgfs_fw_rx_stats_read(struct file *file,
 #undef PRINT_STAT_LE32
 
 static ssize_t iwl_dbgfs_fw_system_stats_read(struct file *file,
-					      char __user *user_buf,
+					      char __user * __capability user_buf,
 					      size_t count, loff_t *ppos)
 {
 	char *buff, *pos, *endpos;
@@ -1077,7 +1077,7 @@ send_out:
 }
 
 static ssize_t iwl_dbgfs_frame_stats_read(struct iwl_mvm *mvm,
-					  char __user *user_buf, size_t count,
+					  char __user * __capability user_buf, size_t count,
 					  loff_t *ppos,
 					  struct iwl_mvm_frame_stats *stats)
 {
@@ -1144,7 +1144,7 @@ static ssize_t iwl_dbgfs_frame_stats_read(struct iwl_mvm *mvm,
 }
 
 static ssize_t iwl_dbgfs_drv_rx_stats_read(struct file *file,
-					   char __user *user_buf, size_t count,
+					   char __user * __capability user_buf, size_t count,
 					   loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1200,7 +1200,7 @@ static ssize_t iwl_dbgfs_fw_nmi_write(struct iwl_mvm *mvm, char *buf,
 
 static ssize_t
 iwl_dbgfs_scan_ant_rxchain_read(struct file *file,
-				char __user *user_buf,
+				char __user * __capability user_buf,
 				size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1457,7 +1457,7 @@ static ssize_t iwl_dbgfs_inject_beacon_ie_restore_write(struct iwl_mvm *mvm,
 }
 
 static ssize_t iwl_dbgfs_fw_dbg_conf_read(struct file *file,
-					  char __user *user_buf,
+					  char __user * __capability user_buf,
 					  size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1595,10 +1595,10 @@ _iwl_dbgfs_link_sta_wrap_read(ssize_t (*real)(struct ieee80211_link_sta *,
 					      struct iwl_mvm_sta *,
 					      struct iwl_mvm *,
 					      struct iwl_mvm_link_sta *,
-					      char __user *,
+					      char __user * __capability,
 					      size_t, loff_t *),
 			   struct file *file,
-			   char __user *user_buf, size_t count, loff_t *ppos)
+			   char __user * __capability user_buf, size_t count, loff_t *ppos)
 {
 	struct ieee80211_link_sta *link_sta = file->private_data;
 	struct iwl_mvm_sta *mvmsta = iwl_mvm_sta_from_mac80211(link_sta->sta);
@@ -1624,7 +1624,7 @@ _iwl_dbgfs_link_sta_wrap_read(ssize_t (*real)(struct ieee80211_link_sta *,
 
 #define MVM_DEBUGFS_LINK_STA_WRITE_WRAPPER(name, buflen)		\
 static ssize_t _iwl_dbgfs_link_sta_##name##_write(struct file *file,	\
-					 const char __user *user_buf,	\
+					 const char __user * __capability user_buf,	\
 					 size_t count, loff_t *ppos)	\
 {									\
 	char buf[buflen] = {};						\
@@ -1640,7 +1640,7 @@ static ssize_t _iwl_dbgfs_link_sta_##name##_write(struct file *file,	\
 
 #define MVM_DEBUGFS_LINK_STA_READ_WRAPPER(name)		\
 static ssize_t _iwl_dbgfs_link_sta_##name##_read(struct file *file,	\
-					 char __user *user_buf,		\
+					 char __user * __capability user_buf,		\
 					 size_t count, loff_t *ppos)	\
 {									\
 	return _iwl_dbgfs_link_sta_wrap_read(iwl_dbgfs_##name##_read,	\
@@ -1682,7 +1682,7 @@ static const struct file_operations iwl_dbgfs_link_sta_##name##_ops = {	\
 
 static ssize_t
 iwl_dbgfs_prph_reg_read(struct file *file,
-			char __user *user_buf,
+			char __user * __capability user_buf,
 			size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1815,7 +1815,7 @@ iwl_dbgfs_he_sniffer_params_write(struct iwl_mvm *mvm, char *buf,
 }
 
 static ssize_t
-iwl_dbgfs_he_sniffer_params_read(struct file *file, char __user *user_buf,
+iwl_dbgfs_he_sniffer_params_read(struct file *file, char __user * __capability user_buf,
 				 size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1832,7 +1832,7 @@ iwl_dbgfs_he_sniffer_params_read(struct file *file, char __user *user_buf,
 }
 
 static ssize_t
-iwl_dbgfs_uapsd_noagg_bssids_read(struct file *file, char __user *user_buf,
+iwl_dbgfs_uapsd_noagg_bssids_read(struct file *file, char __user * __capability user_buf,
 				  size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1914,7 +1914,7 @@ static ssize_t iwl_dbgfs_rfi_freq_table_write(struct iwl_mvm *mvm, char *buf,
 				(5 + IWL_RFI_LUT_ENTRY_CHANNELS_NUM * (6 + 5)))
 
 static ssize_t iwl_dbgfs_rfi_freq_table_read(struct file *file,
-					     char __user *user_buf,
+					     char __user * __capability user_buf,
 					     size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -1998,7 +1998,7 @@ MVM_DEBUGFS_READ_WRITE_FILE_OPS(he_sniffer_params, 32);
 MVM_DEBUGFS_WRITE_FILE_OPS(ltr_config, 512);
 MVM_DEBUGFS_READ_WRITE_FILE_OPS(rfi_freq_table, 16);
 
-static ssize_t iwl_dbgfs_mem_read(struct file *file, char __user *user_buf,
+static ssize_t iwl_dbgfs_mem_read(struct file *file, char __user * __capability user_buf,
 				  size_t count, loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;
@@ -2059,7 +2059,7 @@ out:
 }
 
 static ssize_t iwl_dbgfs_mem_write(struct file *file,
-				   const char __user *user_buf, size_t count,
+				   const char __user * __capability user_buf, size_t count,
 				   loff_t *ppos)
 {
 	struct iwl_mvm *mvm = file->private_data;

--- a/sys/contrib/dev/iwlwifi/mvm/debugfs.h
+++ b/sys/contrib/dev/iwlwifi/mvm/debugfs.h
@@ -13,7 +13,7 @@ static const struct file_operations iwl_dbgfs_##name##_ops = {		\
 
 #define MVM_DEBUGFS_WRITE_WRAPPER(name, buflen, argtype)		\
 static ssize_t _iwl_dbgfs_##name##_write(struct file *file,		\
-					 const char __user *user_buf,	\
+					 const char __user * __capability user_buf,	\
 					 size_t count, loff_t *ppos)	\
 {									\
 	argtype *arg = file->private_data;				\

--- a/sys/contrib/dev/iwlwifi/pcie/trans.c
+++ b/sys/contrib/dev/iwlwifi/pcie/trans.c
@@ -2754,7 +2754,7 @@ static int iwl_dbgfs_tx_queue_open(struct inode *inode, struct file *filp)
 }
 
 static ssize_t iwl_dbgfs_rx_queue_read(struct file *file,
-				       char __user *user_buf,
+				       char __user * __capability user_buf,
 				       size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2803,7 +2803,7 @@ static ssize_t iwl_dbgfs_rx_queue_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_interrupt_read(struct file *file,
-					char __user *user_buf,
+					char __user * __capability user_buf,
 					size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2861,7 +2861,7 @@ static ssize_t iwl_dbgfs_interrupt_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_interrupt_write(struct file *file,
-					 const char __user *user_buf,
+					 const char __user * __capability user_buf,
 					 size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2880,7 +2880,7 @@ static ssize_t iwl_dbgfs_interrupt_write(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_csr_write(struct file *file,
-				   const char __user *user_buf,
+				   const char __user * __capability user_buf,
 				   size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2891,7 +2891,7 @@ static ssize_t iwl_dbgfs_csr_write(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_fh_reg_read(struct file *file,
-				     char __user *user_buf,
+				     char __user * __capability user_buf,
 				     size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2909,7 +2909,7 @@ static ssize_t iwl_dbgfs_fh_reg_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_rfkill_read(struct file *file,
-				     char __user *user_buf,
+				     char __user * __capability user_buf,
 				     size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2926,7 +2926,7 @@ static ssize_t iwl_dbgfs_rfkill_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_rfkill_write(struct file *file,
-				      const char __user *user_buf,
+				      const char __user * __capability user_buf,
 				      size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -2977,7 +2977,7 @@ static int iwl_dbgfs_monitor_data_release(struct inode *inode,
 	return 0;
 }
 
-static bool iwl_write_to_user_buf(char __user *user_buf, ssize_t count,
+static bool iwl_write_to_user_buf(char __user * __capability user_buf, ssize_t count,
 				  void *buf, ssize_t *size,
 				  ssize_t *bytes_copied)
 {
@@ -2996,7 +2996,7 @@ static bool iwl_write_to_user_buf(char __user *user_buf, ssize_t count,
 }
 
 static ssize_t iwl_dbgfs_monitor_data_read(struct file *file,
-					   char __user *user_buf,
+					   char __user * __capability user_buf,
 					   size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;
@@ -3079,7 +3079,7 @@ static ssize_t iwl_dbgfs_monitor_data_read(struct file *file,
 }
 
 static ssize_t iwl_dbgfs_rf_read(struct file *file,
-				 char __user *user_buf,
+				 char __user * __capability user_buf,
 				 size_t count, loff_t *ppos)
 {
 	struct iwl_trans *trans = file->private_data;

--- a/sys/contrib/dev/rtw88/debug.c
+++ b/sys/contrib/dev/rtw88/debug.c
@@ -19,7 +19,7 @@
 struct rtw_debugfs_priv {
 	struct rtw_dev *rtwdev;
 	int (*cb_read)(struct seq_file *m, void *v);
-	ssize_t (*cb_write)(struct file *filp, const char __user *buffer,
+	ssize_t (*cb_write)(struct file *filp, const char __user * __capability buffer,
 			    size_t count, loff_t *loff);
 	union {
 		u32 cb_data;
@@ -112,7 +112,7 @@ static int rtw_debugfs_single_show(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_common_write(struct file *filp,
-					const char __user *buffer,
+					const char __user * __capability buffer,
 					size_t count, loff_t *loff)
 {
 	struct rtw_debugfs_priv *debugfs_priv = filp->private_data;
@@ -121,7 +121,7 @@ static ssize_t rtw_debugfs_common_write(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_single_write(struct file *filp,
-					const char __user *buffer,
+					const char __user * __capability buffer,
 					size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -227,7 +227,7 @@ static int rtw_debugfs_get_fix_rate(struct seq_file *m, void *v)
 }
 
 static int rtw_debugfs_copy_from_user(char tmp[], int size,
-				      const char __user *buffer, size_t count,
+				      const char __user * __capability buffer, size_t count,
 				      int num)
 {
 	int tmp_len;
@@ -248,7 +248,7 @@ static int rtw_debugfs_copy_from_user(char tmp[], int size,
 }
 
 static ssize_t rtw_debugfs_set_read_reg(struct file *filp,
-					const char __user *buffer,
+					const char __user * __capability buffer,
 					size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -338,7 +338,7 @@ static int rtw_debugfs_get_rsvd_page(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_set_rsvd_page(struct file *filp,
-					 const char __user *buffer,
+					 const char __user * __capability buffer,
 					 size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -367,7 +367,7 @@ static ssize_t rtw_debugfs_set_rsvd_page(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_set_single_input(struct file *filp,
-					    const char __user *buffer,
+					    const char __user * __capability buffer,
 					    size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -385,7 +385,7 @@ static ssize_t rtw_debugfs_set_single_input(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_set_write_reg(struct file *filp,
-					 const char __user *buffer,
+					 const char __user * __capability buffer,
 					 size_t count, loff_t *loff)
 {
 	struct rtw_debugfs_priv *debugfs_priv = filp->private_data;
@@ -431,7 +431,7 @@ static ssize_t rtw_debugfs_set_write_reg(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_set_h2c(struct file *filp,
-				   const char __user *buffer,
+				   const char __user * __capability buffer,
 				   size_t count, loff_t *loff)
 {
 	struct rtw_debugfs_priv *debugfs_priv = filp->private_data;
@@ -461,7 +461,7 @@ static ssize_t rtw_debugfs_set_h2c(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_set_rf_write(struct file *filp,
-					const char __user *buffer,
+					const char __user * __capability buffer,
 					size_t count, loff_t *loff)
 {
 	struct rtw_debugfs_priv *debugfs_priv = filp->private_data;
@@ -493,7 +493,7 @@ static ssize_t rtw_debugfs_set_rf_write(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_set_rf_read(struct file *filp,
-				       const char __user *buffer,
+				       const char __user * __capability buffer,
 				       size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -523,7 +523,7 @@ static ssize_t rtw_debugfs_set_rf_read(struct file *filp,
 }
 
 static ssize_t rtw_debugfs_set_fix_rate(struct file *filp,
-					const char __user *buffer,
+					const char __user * __capability buffer,
 					size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -911,7 +911,7 @@ static int rtw_debugfs_get_coex_info(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_set_coex_enable(struct file *filp,
-					   const char __user *buffer,
+					   const char __user * __capability buffer,
 					   size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -945,7 +945,7 @@ static int rtw_debugfs_get_coex_enable(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_set_edcca_enable(struct file *filp,
-					    const char __user *buffer,
+					    const char __user * __capability buffer,
 					    size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -977,7 +977,7 @@ static int rtw_debugfs_get_edcca_enable(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_set_fw_crash(struct file *filp,
-					const char __user *buffer,
+					const char __user * __capability buffer,
 					size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -1017,7 +1017,7 @@ static int rtw_debugfs_get_fw_crash(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_set_force_lowest_basic_rate(struct file *filp,
-						       const char __user *buffer,
+						       const char __user * __capability buffer,
 						       size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
@@ -1050,7 +1050,7 @@ static int rtw_debugfs_get_force_lowest_basic_rate(struct seq_file *m, void *v)
 }
 
 static ssize_t rtw_debugfs_set_dm_cap(struct file *filp,
-				      const char __user *buffer,
+				      const char __user * __capability buffer,
 				      size_t count, loff_t *loff)
 {
 	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;

--- a/sys/modules/iwlwifi/Makefile
+++ b/sys/modules/iwlwifi/Makefile
@@ -1,15 +1,9 @@
 DEVIWLWIFIDIR=	${SRCTOP}/sys/contrib/dev/iwlwifi
 
-.include <kmod.opts.mk>
-
 .PATH: ${DEVIWLWIFIDIR}
 
 WITH_CONFIG_PM=	0
-.if ${MACHINE_CPU:Mcheri} && !${MACHINE_ABI:Mpurecap}
-WITH_DEBUGFS=	0
-.else
 WITH_DEBUGFS=	1
-.endif
 
 KMOD=	if_iwlwifi
 

--- a/sys/modules/rtw88/Makefile
+++ b/sys/modules/rtw88/Makefile
@@ -1,15 +1,9 @@
 DEVRTW88DIR=	${SRCTOP}/sys/contrib/dev/rtw88
 
-.include <kmod.opts.mk>
-
 .PATH: ${DEVRTW88DIR}
 
 WITH_CONFIG_PM=	0
-.if ${MACHINE_CPU:Mcheri} && !${MACHINE_ABI:Mpurecap}
-WITH_DEBUGFS=	0
-.else
 WITH_DEBUGFS=	1
-.endif
 WITH_LEDS=	0
 
 KMOD=	if_rtw88


### PR DESCRIPTION
- **Revert "lindebugfs: Don't pass a kernel pointer to copy_from_user"**
- **lindebugfs: Pass user buffer pointers to the read/write file operations**
- **LinuxKPI: Better handling of zero-size and off-the-end reads**
- **LinuxKPI: Mark file_operations read/write user pointers as capabilities**
