### PR TITLE
libsys: fix c18n wrappers

### DIFF
--- a/lib/libmalloc_simple/heap.c
+++ b/lib/libmalloc_simple/heap.c
@@ -73,6 +73,10 @@ static char *rcsid = "$FreeBSD$";
 #define	error_printf(...)	fprintf(stderr, __VA_ARGS__)
 #endif
 
+#ifdef IN_RTLD
+#include "rtld_libc.h"
+#endif
+
 struct pagepool_header {
 	size_t			ph_size;
 #ifdef __CHERI_PURE_CAPABILITY__

--- a/lib/libsys/Makefile.sys
+++ b/lib/libsys/Makefile.sys
@@ -118,12 +118,13 @@ NO_UNDERSCORE+= \
 .if ${MACHINE_ABI:Mpurecap}
 # Var-args calling convention different for purecap
 NO_UNDERSCORE=	fcntl ioctl open openat
+
 .for _nu in ${NO_UNDERSCORE}
 INTERPOSED:=	${INTERPOSED:N${_nu}}
 .endfor
 S_NU+=		${NO_UNDERSCORE:C/^.*$/_&.S/}
 SRCS+=		${NO_UNDERSCORE:S/$/.c/} ${S_NU}
-NOASM+=		${NO_UNDERSCORE:S/$/.o/}
+NOASM+=		${NO_UNDERSCORE}
 .endif
 
 PSEUDO+=	${INTERPOSED}

--- a/lib/libsys/Makefile.sys
+++ b/lib/libsys/Makefile.sys
@@ -102,17 +102,14 @@ INTERPOSED = \
 
 .ifdef CHERI_LIB_C18N
 # Pseudo implementations of system calls with special behavior under c18n
-SRCS+= \
-	mmap_c18n.c \
-	rfork_c18n.c \
-	thr_exit_c18n.c \
-	vfork_c18n.c
-
-NO_UNDERSCORE+= \
+C18N_WRAPPED=	\
 	mmap \
 	rfork \
 	thr_exit \
 	vfork
+
+SRCS+=		${C18N_WRAPPED:S/$/_c18n.c/}
+PSEUDO+=	${C18N_WRAPPED}
 .endif
 
 .if ${MACHINE_ABI:Mpurecap}

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -51,6 +51,7 @@
 
 #include "debug.h"
 #include "rtld.h"
+#include "rtld_libc.h"
 #ifdef CHERI_LIB_C18N
 #include "rtld_c18n.h"
 #endif

--- a/libexec/rtld-elf/rtld-libc/Makefile.inc
+++ b/libexec/rtld-elf/rtld-libc/Makefile.inc
@@ -62,13 +62,15 @@ CFLAGS.memset.c+=-I${LIBC_SRCTOP}/include
 _libsys_other_objects= fstat fstatat fstatfs syscall \
     cerror geteuid getegid sigfastblock munmap mprotect \
     sysarch __sysctl issetugid __getcwd utrace getpid \
-    thr_self thr_kill pread mmap lseek _exit \
+    thr_self thr_kill pread lseek _exit \
     getdirentries _close _fcntl _open _openat _read \
     __sysctlbyname \
     _sigprocmask _write readlink ___realpathat
 
 .ifdef CHERI_LIB_C18N
-_libsys_other_objects+=thr_exit _sigaction ftruncate
+_libsys_other_objects+=_mmap _thr_exit _sigaction ftruncate
+.else
+_libsys_other_objects+=mmap
 .endif
 
 # A few other bits from libc_nossp_pic:

--- a/libexec/rtld-elf/rtld-libc/rtld_libc.h
+++ b/libexec/rtld-elf/rtld-libc/rtld_libc.h
@@ -48,6 +48,7 @@ void	__sys_exit(int) __dead2;
 int	__sys_fstat(int fd, struct stat *);
 int	__sys_fstatat(int, const char *, struct stat *, int);
 int	__sys___getcwd(char *, size_t);
+void	*__sys_mmap(void *, size_t, int, int, int, off_t);
 int	__sys_sigprocmask(int, const sigset_t *, sigset_t *);
 int	__sys_thr_kill(long, int);
 int	__sys_thr_self(long *);
@@ -75,6 +76,8 @@ int __getosreldate(void);
 #define exit(status)	__sys_exit(status)
 #define _exit(status)	__sys_exit(status)
 #define _fstat(fd, sb)	__sys_fstat(fd, sb)
+#define mmap(addr, len, prot, flags, fd, pos) \
+	__sys_mmap((addr), (len), (prot),(flags), (fd), (pos))
 #define pread(fd, buf, nbytes, offset)	__sys_pread(fd, buf, nbytes, offset)
 #define read(fd, buf, nbytes)	__sys_read(fd, buf, nbytes)
 #define sigprocmask(how, set, oset)	__sys_sigprocmask(how, set, oset)


### PR DESCRIPTION
Adding the syscalls wrapped for c18n to NO_UNDERSCORE didn't work because the entries were removed and didn't compiled once that was fixed. PSEUDO should have been used.