### PR TITLE
riscv cheri: Disable Zicbom for purecap kernels.

### DIFF
--- a/sys/conf/files.riscv
+++ b/sys/conf/files.riscv
@@ -54,7 +54,7 @@ riscv/riscv/bus_space_asm.S	standard
 riscv/riscv/busdma_bounce.c	standard
 riscv/riscv/busdma_machdep.c	standard
 riscv/riscv/cache.c		standard
-riscv/riscv/cbo.c		standard
+riscv/riscv/cbo.c		optional	!cheri_purecap_kernel
 riscv/riscv/clock.c		standard
 riscv/riscv/copyinout.S		standard
 riscv/riscv/cpufunc_asm.S	standard

--- a/sys/riscv/riscv/identcpu.c
+++ b/sys/riscv/riscv/identcpu.c
@@ -557,8 +557,10 @@ identify_cpu(u_int cpu)
 	update_global_capabilities(cpu, desc);
 	handle_cpu_quirks(cpu, desc);
 
+#ifndef __CHERI_PURE_CAPABILITY__
 	if (has_zicbom && cpu == 0)
 		cbo_zicbom_setup_cache(desc->cbom_block_size);
+#endif
 }
 
 void


### PR DESCRIPTION
This is not yet supported by the CHERI ISAv9.

Interface changes are necessary to work with cheri, specifically `vm_offset_t` is not correct here.