### PR TITLE
c18n: Make dl_c18n_get_trampoline_target return an untagged uintptr_t

### DIFF
--- a/lib/libc/gen/elf_utils.c
+++ b/lib/libc/gen/elf_utils.c
@@ -50,11 +50,11 @@ __elf_phdr_match_addr(struct dl_phdr_info *phdr_info, void *addr)
 	const Elf_Phdr *ph;
 	int i;
 #ifdef CHERI_LIB_C18N
-	ptraddr_t target;
+	uintptr_t target;
 
 	target = dl_c18n_get_trampoline_target(addr);
 	if (target != 0)
-		addr = (void *)(uintptr_t)target;
+		addr = (void *)target;
 #endif
 
 	for (i = 0; i < phdr_info->dlpi_phnum; i++) {

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1701,7 +1701,8 @@ dl_c18n_get_trampoline_target(const void *addr)
 	if (header == NULL)
 		return (0);
 
-	return ((ptraddr_t)header->target);
+	return ((ptraddr_t)atomic_load_explicit(&header->target,
+	    memory_order_relaxed));
 }
 
 /*
@@ -2314,7 +2315,8 @@ _rtld_siginvoke(int sig, siginfo_t *info, ucontext_t *ucp,
 	 * in one.
 	 */
 	callee = compart_id_for_address(header->defobj,
-	    (ptraddr_t)header->target);
+	    (ptraddr_t)atomic_load_explicit(&header->target,
+		memory_order_relaxed));
 	callee_idx = cid_to_index(callee);
 
 	/*

--- a/libexec/rtld-elf/rtld_c18n.c
+++ b/libexec/rtld-elf/rtld_c18n.c
@@ -1687,9 +1687,9 @@ tramp_get_header(const void *data)
 	return (NULL);
 }
 
-ptraddr_t dl_c18n_get_trampoline_target(const void *);
+uintptr_t dl_c18n_get_trampoline_target(const void *);
 
-ptraddr_t
+uintptr_t
 dl_c18n_get_trampoline_target(const void *addr)
 {
 	struct tramp_header *header;
@@ -1701,8 +1701,8 @@ dl_c18n_get_trampoline_target(const void *addr)
 	if (header == NULL)
 		return (0);
 
-	return ((ptraddr_t)atomic_load_explicit(&header->target,
-	    memory_order_relaxed));
+	return ((uintptr_t)cheri_tag_clear(
+	    atomic_load_explicit(&header->target, memory_order_relaxed)));
 }
 
 /*

--- a/sys/sys/link_elf.h
+++ b/sys/sys/link_elf.h
@@ -123,7 +123,7 @@ void *dl_c18n_get_trusted_stack(uintptr_t);
 void dl_c18n_unwind_trusted_stack(void *, void *);
 int dl_c18n_is_trampoline(uintptr_t, void *);
 void *dl_c18n_pop_trusted_stack(struct dl_c18n_compart_state *, void *);
-ptraddr_t dl_c18n_get_trampoline_target(const void *);
+uintptr_t dl_c18n_get_trampoline_target(const void *);
 #endif
 
 #ifdef __ARM_EABI__


### PR DESCRIPTION
Previously the function only returned an integer address, but certain callers (e.g., cheritree) need the capability metadata as well. Thus, we return a full capability with tagged removed.

This change only widens the return type from ptraddr_t to uintptr_t and so should not break the ABI.