### PR TITLE
Small fixes for p9fs

### DIFF
--- a/sys/dev/virtio/p9fs/virtio_p9fs.c
+++ b/sys/dev/virtio/p9fs/virtio_p9fs.c
@@ -110,7 +110,7 @@ SYSCTL_UINT(_vfs_9p, OID_AUTO, ackmaxidle, CTLFLAG_RW, &vt9p_ackmaxidle, 0,
 static int
 vt9p_req_wait(struct vt9p_softc *chan, struct p9_req_t *req)
 {
-	KASSERT(req->tc->tag != req->rc->tag,
+	KASSERT(req->tc.tag != req->rc.tag,
 	    ("%s: request %p already completed", __func__, req));
 
 	if (msleep(req, VT9P_MTX(chan), 0, "chan lock", vt9p_ackmaxidle * hz)) {
@@ -122,7 +122,7 @@ vt9p_req_wait(struct vt9p_softc *chan, struct p9_req_t *req)
 		    "for an ack from host\n", vt9p_ackmaxidle);
 		return (EIO);
 	}
-	KASSERT(req->tc->tag == req->rc->tag,
+	KASSERT(req->tc.tag == req->rc.tag,
 	    ("%s spurious event on request %p", __func__, req));
 	return (0);
 }
@@ -155,7 +155,7 @@ vt9p_request(void *handle, struct p9_req_t *req)
 req_retry:
 	sglist_reset(sg);
 	/* Handle out VirtIO ring buffers */
-	error = sglist_append(sg, req->tc->sdata, req->tc->size);
+	error = sglist_append(sg, req->tc.sdata, req->tc.size);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: sglist append failed\n", __func__);
 		VT9P_UNLOCK(chan);
@@ -163,7 +163,7 @@ req_retry:
 	}
 	readable = sg->sg_nseg;
 
-	error = sglist_append(sg, req->rc->sdata, req->rc->capacity);
+	error = sglist_append(sg, req->rc.sdata, req->rc.capacity);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: sglist append failed\n", __func__);
 		VT9P_UNLOCK(chan);
@@ -224,7 +224,7 @@ vt9p_intr_complete(void *xsc)
 	VT9P_LOCK(chan);
 again:
 	while ((curreq = virtqueue_dequeue(vq, NULL)) != NULL) {
-		curreq->rc->tag = curreq->tc->tag;
+		curreq->rc.tag = curreq->tc.tag;
 		wakeup_one(curreq);
 	}
 	if (virtqueue_enable_intr(vq) != 0) {

--- a/sys/dev/virtio/p9fs/virtio_p9fs.c
+++ b/sys/dev/virtio/p9fs/virtio_p9fs.c
@@ -468,16 +468,22 @@ static int
 vt9p_modevent(module_t mod, int type, void *unused)
 {
 	int error;
+	static int loaded = 0;
 
 	error = 0;
 
 	switch (type) {
 	case MOD_LOAD:
-		p9_init_zones();
-		p9_register_trans(&vt9p_trans);
+		if (loaded++ == 0) {
+			p9_init_zones();
+			p9_register_trans(&vt9p_trans);
+		}
 		break;
 	case MOD_UNLOAD:
-		p9_destroy_zones();
+		if (--loaded == 0) {
+			p9_unregister_trans(&vt9p_trans);
+			p9_destroy_zones();
+		}
 		break;
 	case MOD_SHUTDOWN:
 		break;

--- a/sys/dev/virtio/p9fs/virtio_p9fs.c
+++ b/sys/dev/virtio/p9fs/virtio_p9fs.c
@@ -475,14 +475,12 @@ vt9p_modevent(module_t mod, int type, void *unused)
 	switch (type) {
 	case MOD_LOAD:
 		if (loaded++ == 0) {
-			p9_init_zones();
 			p9_register_trans(&vt9p_trans);
 		}
 		break;
 	case MOD_UNLOAD:
 		if (--loaded == 0) {
 			p9_unregister_trans(&vt9p_trans);
-			p9_destroy_zones();
 		}
 		break;
 	case MOD_SHUTDOWN:
@@ -491,6 +489,7 @@ vt9p_modevent(module_t mod, int type, void *unused)
 		error = EOPNOTSUPP;
 		break;
 	}
+
 	return (error);
 }
 

--- a/sys/fs/p9fs/p9_client.c
+++ b/sys/fs/p9fs/p9_client.c
@@ -95,7 +95,14 @@ p9_parse_opts(struct mount  *mp, struct p9_client *clnt)
 
 	/* These are defaults for now */
 	clnt->proto_version = p9_proto_2000L;
-	clnt->msize = 8192;
+	clnt->msize = P9FS_MTU;
+
+	vfs_scanopt(mp->mnt_optnew, "msize", "%u", &clnt->msize);
+	if (clnt->msize > P9FS_MTU) {
+		vfs_mount_error(mp, "msize %u is greater than max allowed %u",
+		    clnt->msize, P9FS_MTU);
+		return (EINVAL);
+	}
 
 	/* Get the default trans callback */
 	clnt->ops = p9_get_trans_by_name(trans);

--- a/sys/fs/p9fs/p9_client.c
+++ b/sys/fs/p9fs/p9_client.c
@@ -104,43 +104,33 @@ p9_parse_opts(struct mount  *mp, struct p9_client *clnt)
 }
 
 /* Allocate buffer for sending request and getting responses */
-static struct p9_buffer *
-p9_buffer_alloc(int alloc_msize)
+static void
+p9_buffer_alloc(struct p9_buffer *fc, int alloc_msize)
 {
-	struct p9_buffer *fc;
-
-	fc = uma_zalloc(p9fs_buf_zone, M_WAITOK | M_ZERO);
+	bzero(fc, sizeof(*fc));
 	fc->capacity = alloc_msize;
-	fc->offset = 0;
-	fc->size = 0;
-	fc->sdata = (char *)fc + sizeof(struct p9_buffer);
-
-	return (fc);
+	fc->sdata = uma_zalloc(p9fs_buf_zone, M_WAITOK);
 }
 
 /* Free memory used by request and response buffers */
 static void
-p9_buffer_free(struct p9_buffer **buf)
+p9_buffer_free(struct p9_buffer *buf)
 {
-
-	/* Free the sdata buffers first, then the whole structure*/
-	uma_zfree(p9fs_buf_zone, *buf);
-	*buf = NULL;
+	uma_zfree(p9fs_buf_zone, buf->sdata);
+	buf->sdata = NULL;
 }
 
 /* Free the request */
 static void
 p9_free_req(struct p9_client *clnt, struct p9_req_t *req)
 {
+	if (req == NULL)
+		return;
 
-	if (req->tc != NULL) {
-		if (req->tc->tag != P9_NOTAG)
-			p9_tag_destroy(clnt, req->tc->tag);
-		p9_buffer_free(&req->tc);
-	}
-
-	if (req->rc != NULL)
-		p9_buffer_free(&req->rc);
+	if (req->tc.tag != P9_NOTAG)
+		p9_tag_destroy(clnt, req->tc.tag);
+	p9_buffer_free(&req->tc);
+	p9_buffer_free(&req->rc);
 
 	uma_zfree(p9fs_req_zone, req);
 }
@@ -156,17 +146,17 @@ p9_get_request(struct p9_client *clnt, int *error)
 	alloc_msize = P9FS_MTU;
 
 	req = uma_zalloc(p9fs_req_zone, M_WAITOK | M_ZERO);
-	req->tc = p9_buffer_alloc(alloc_msize);
-	req->rc = p9_buffer_alloc(alloc_msize);
+	p9_buffer_alloc(&req->tc, alloc_msize);
+	p9_buffer_alloc(&req->rc, alloc_msize);
 
 	tag = p9_tag_create(clnt);
 	if (tag == P9_NOTAG) {
 		*error = EAGAIN;
-		req->tc->tag = P9_NOTAG;
+		req->tc.tag = P9_NOTAG;
 		p9_free_req(clnt, req);
 		return (NULL);
 	}
-	req->tc->tag = tag;
+	req->tc.tag = tag;
 	return (req);
 }
 
@@ -208,7 +198,7 @@ p9_client_check_return(struct p9_client *c, struct p9_req_t *req)
 	char *ename;
 
 	/* Check what we have in the receive bufer .*/
-	error = p9_parse_receive(req->rc, c);
+	error = p9_parse_receive(&req->rc, c);
 	if (error != 0)
 		goto out;
 
@@ -216,17 +206,17 @@ p9_client_check_return(struct p9_client *c, struct p9_req_t *req)
 	 * No error, We are done with the preprocessing. Return to the caller
 	 * and process the actual data.
 	 */
-	if (req->rc->id != P9PROTO_RERROR && req->rc->id != P9PROTO_RLERROR)
+	if (req->rc.id != P9PROTO_RERROR && req->rc.id != P9PROTO_RLERROR)
 		return (0);
 
 	/*
 	 * Interpreting the error is done in different ways for Linux and
 	 * Unix version. Make sure you interpret it right.
 	 */
-	if (req->rc->id == P9PROTO_RERROR) {
-	        error = p9_buf_readf(req->rc, c->proto_version, "s?d", &ename, &ecode);
-	} else if (req->rc->id == P9PROTO_RLERROR) {
-	        error = p9_buf_readf(req->rc, c->proto_version, "d", &ecode);
+	if (req->rc.id == P9PROTO_RERROR) {
+	        error = p9_buf_readf(&req->rc, c->proto_version, "s?d", &ename, &ecode);
+	} else if (req->rc.id == P9PROTO_RLERROR) {
+	        error = p9_buf_readf(&req->rc, c->proto_version, "d", &ecode);
 	} else {
 		goto out;
 	}
@@ -241,15 +231,15 @@ p9_client_check_return(struct p9_client *c, struct p9_req_t *req)
 	 * not present can hit this and return. Hence it is made a debug print.
 	 */
 	if (error != 0) {
-	        if (req->rc->id == P9PROTO_RERROR) {
+	        if (req->rc.id == P9PROTO_RERROR) {
 		        P9_DEBUG(PROTO, "RERROR error %d ename %s\n",
 			    error, ename);
-	        } else if (req->rc->id == P9PROTO_RLERROR) {
+	        } else if (req->rc.id == P9PROTO_RLERROR) {
 		        P9_DEBUG(PROTO, "RLERROR error %d\n", error);
 		}
 	}
 
-	if (req->rc->id == P9PROTO_RERROR) {
+	if (req->rc.id == P9PROTO_RERROR) {
 	        free(ename, M_TEMP);
 	}
 	return (error);
@@ -308,21 +298,21 @@ p9_client_prepare_req(struct p9_client *c, int8_t type,
 	}
 
 	/* Marshall the data according to QEMU standards */
-	*error = p9_buf_prepare(req->tc, type);
+	*error = p9_buf_prepare(&req->tc, type);
 	if (*error != 0) {
 		P9_DEBUG(ERROR, "%s: p9_buf_prepare failed: %d\n",
 		    __func__, *error);
 		goto out;
 	}
 
-	*error = p9_buf_vwritef(req->tc, c->proto_version, fmt, ap);
+	*error = p9_buf_vwritef(&req->tc, c->proto_version, fmt, ap);
 	if (*error != 0) {
 		P9_DEBUG(ERROR, "%s: p9_buf_vwrite failed: %d\n",
 		    __func__, *error);
 		goto out;
 	}
 
-	*error = p9_buf_finalize(c, req->tc);
+	*error = p9_buf_finalize(c, &req->tc);
 	if (*error != 0) {
 		P9_DEBUG(ERROR, "%s: p9_buf_finalize failed: %d \n",
 		    __func__, *error);
@@ -474,7 +464,7 @@ p9_client_version(struct p9_client *c)
 	if (error != 0)
 		return (error);
 
-	error = p9_buf_readf(req->rc, c->proto_version, "ds", &msize, &version);
+	error = p9_buf_readf(&req->rc, c->proto_version, "ds", &msize, &version);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: version error: %d\n", __func__, error);
 		goto out;
@@ -519,8 +509,7 @@ p9_init_zones(void)
 
 	/* Create the buffer zone */
 	p9fs_buf_zone = uma_zcreate("p9fs buf zone",
-	    sizeof(struct p9_buffer) + P9FS_MTU, NULL, NULL,
-	    NULL, NULL, UMA_ALIGN_PTR, 0);
+	    P9FS_MTU, NULL, NULL, NULL, NULL, UMA_ALIGN_PTR, 0);
 }
 
 void
@@ -623,7 +612,7 @@ p9_client_attach(struct p9_client *clnt, struct p9_fid *afid,
 	if (*error != 0)
 		goto out;
 
-	*error = p9_buf_readf(req->rc, clnt->proto_version, "Q", &qid);
+	*error = p9_buf_readf(&req->rc, clnt->proto_version, "Q", &qid);
 	if (*error != 0) {
 		P9_DEBUG(ERROR, "%s: p9_buf_readf failed: %d \n",
 		    __func__, *error);
@@ -777,7 +766,7 @@ p9_client_walk(struct p9_fid *oldfid, uint16_t nwnames, char **wnames,
 		return (NULL);
 	}
 
-	*error = p9_buf_readf(req->rc, clnt->proto_version, "R", &nwqids,
+	*error = p9_buf_readf(&req->rc, clnt->proto_version, "R", &nwqids,
 	    &wqids);
 	if (*error != 0)
 		goto out;
@@ -842,7 +831,7 @@ p9_client_open(struct p9_fid *fid, int mode)
 	if (error != 0)
 		return (error);
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "Qd", &fid->qid,
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "Qd", &fid->qid,
 	    &mtu);
 	if (error != 0)
 		goto out;
@@ -892,7 +881,7 @@ p9_client_readdir(struct p9_fid *fid, char *data, uint64_t offset,
 		return (-error);
 	}
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "D", &count,
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "D", &count,
 	    &dataptr);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: p0_buf_readf failed: %d\n",
@@ -945,7 +934,7 @@ p9_client_read(struct p9_fid *fid, uint64_t offset, uint32_t count, char *data)
 		return (-error);
 	}
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "D", &count,
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "D", &count,
 	    &dataptr);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: p9_buf_readf failed: %d\n",
@@ -1017,7 +1006,7 @@ p9_client_write(struct p9_fid *fid, uint64_t offset, uint32_t count, char *data)
 		return (-error);
 	}
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "d", &ret);
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "d", &ret);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: p9_buf_readf error: %d\n",
 		    __func__, error);
@@ -1069,7 +1058,7 @@ p9_client_file_create(struct p9_fid *fid, char *name, uint32_t perm, int mode,
 	if (error != 0)
 		return (error);
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "Qd", &qid, &mtu);
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "Qd", &qid, &mtu);
 	if (error != 0)
 		goto out;
 
@@ -1101,7 +1090,7 @@ p9_client_statfs(struct p9_fid *fid, struct p9_statfs *stat)
 		return (error);
 	}
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "ddqqqqqqd",
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "ddqqqqqqd",
 	    &stat->type, &stat->bsize, &stat->blocks, &stat->bfree,
 	    &stat->bavail, &stat->files, &stat->ffree, &stat->fsid,
 	    &stat->namelen);
@@ -1173,7 +1162,7 @@ p9_create_symlink(struct p9_fid *fid, char *name, char *symtgt, gid_t gid)
 	if (error != 0)
 		return (error);
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "Q", &qid);
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "Q", &qid);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: buf_readf failed %d\n", __func__, error);
 		return (error);
@@ -1226,7 +1215,7 @@ p9_readlink(struct p9_fid *fid, char **target)
 	if (error != 0)
 		return (error);
 
-	error = p9_buf_readf(req->rc, clnt->proto_version, "s", target);
+	error = p9_buf_readf(&req->rc, clnt->proto_version, "s", target);
 	if (error != 0) {
 		P9_DEBUG(ERROR, "%s: buf_readf failed %d\n", __func__, error);
 		return (error);
@@ -1260,7 +1249,7 @@ p9_client_getattr(struct p9_fid *fid, struct p9_stat_dotl *stat_dotl,
 		goto error;
 	}
 
-	err = p9_buf_readf(req->rc, clnt->proto_version, "A", stat_dotl);
+	err = p9_buf_readf(&req->rc, clnt->proto_version, "A", stat_dotl);
 	if (err != 0) {
 		P9_DEBUG(ERROR, "%s: buf_readf failed %d\n", __func__, err);
 		goto error;

--- a/sys/fs/p9fs/p9_client.h
+++ b/sys/fs/p9fs/p9_client.h
@@ -54,8 +54,8 @@ enum p9_proto_versions {
 
 /* P9 Request exchanged between Host and Guest */
 struct p9_req_t {
-	struct p9_buffer *tc;	/* request buffer */
-	struct p9_buffer *rc;	/* response buffer */
+	struct p9_buffer tc;	/* request buffer */
+	struct p9_buffer rc;	/* response buffer */
 };
 
 /* 9P transport status */

--- a/sys/fs/p9fs/p9_client.h
+++ b/sys/fs/p9fs/p9_client.h
@@ -65,8 +65,11 @@ enum transport_status {
 	P9FS_DISCONNECT,	/* transport has been dosconnected */
 };
 
-/* This is set by QEMU so we will oblige */
-#define P9FS_MTU 8192
+/*
+ * This matches the Linux 5.15 and newer default.
+ * Note: Linux allows larger msize values than this.
+ */
+#define P9FS_MTU 131072
 
 /*
  * Even though we have a 8k buffer, Qemu is typically doing 8168

--- a/sys/fs/p9fs/p9fs.h
+++ b/sys/fs/p9fs/p9fs.h
@@ -151,6 +151,7 @@ struct p9fs_session {
 	struct mtx p9fs_mtx;				/* mutex used for guarding the chain.*/
 	STAILQ_HEAD( ,p9fs_node) virt_node_list;	/* list of p9fs nodes in this session*/
 	struct p9_fid *mnt_fid;				/* to save nobody 's fid for unmounting as root user */
+	unsigned int name_max;				/* cached max filename length */
 };
 
 struct p9fs_mount {

--- a/sys/fs/p9fs/p9fs_subr.c
+++ b/sys/fs/p9fs/p9fs_subr.c
@@ -275,16 +275,20 @@ p9fs_compatible_mode(struct p9_fid *fid, int mode)
 {
 	/*
 	 * Return TRUE for an exact match. For OREAD and OWRITE, allow
-	 * existing ORDWR fids to match. Only check the low two bits
-	 * of mode.
+	 * existing ORDWR fids to match.
 	 *
-	 * TODO: figure out if this is correct for O_APPEND
+	 * We mask both the requested mode and the existing fid's mode
+	 * with 3 (0b11) to isolate the base access intent (O_RDONLY,
+	 * O_WRONLY, or O_RDWR). This prevents extended open flags like
+	 * O_EXCL or O_APPEND from causing a mismatch when we are merely
+	 * looking for an appropriately privileged open descriptor.
 	 */
 	int fid_mode = fid->mode & 3;
-	if (fid_mode == mode)
+	int req_mode = mode & 3;
+	if (fid_mode == req_mode)
 		return (TRUE);
 	if (fid_mode == P9PROTO_ORDWR)
-		return (mode == P9PROTO_OREAD || mode == P9PROTO_OWRITE);
+		return (req_mode == P9PROTO_OREAD || req_mode == P9PROTO_OWRITE);
 	return (FALSE);
 }
 

--- a/sys/fs/p9fs/p9fs_vfsops.c
+++ b/sys/fs/p9fs/p9fs_vfsops.c
@@ -119,6 +119,8 @@ p9fs_init(struct vfsconf *vfsp)
 	p9fs_io_buffer_zone = uma_zcreate("p9fs io_buffer zone",
 	    P9FS_MTU, NULL, NULL, NULL, NULL, UMA_ALIGN_PTR, 0);
 
+	p9_init_zones();
+
 	return (0);
 }
 
@@ -126,6 +128,8 @@ p9fs_init(struct vfsconf *vfsp)
 static int
 p9fs_uninit(struct vfsconf *vfsp)
 {
+
+	p9_destroy_zones();
 
 	uma_zdestroy(p9fs_node_zone);
 	uma_zdestroy(p9fs_io_buffer_zone);

--- a/sys/fs/p9fs/p9fs_vfsops.c
+++ b/sys/fs/p9fs/p9fs_vfsops.c
@@ -59,7 +59,7 @@ extern struct vop_vector p9fs_vnops;
 
 /* option parsing */
 static const char *p9fs_opts[] = {
-        "from", "trans", "access", NULL
+        "from", "trans", "access", "msize", NULL
 };
 
 /* Dispose p9fs node, freeing it to the UMA zone */

--- a/sys/fs/p9fs/p9fs_vnops.c
+++ b/sys/fs/p9fs/p9fs_vnops.c
@@ -419,7 +419,7 @@ out:
  * the name and perm specified under the parent dir. If this succeeds (an entry
  * is created for the new file on the server), we create our metadata for this
  * file (vnode, p9fs node calling vget). Once we are done, we clunk the open
- * fid of the parent directory.
+ * fid of the parent directory if it was not retained.
  */
 static int
 create_common(struct p9fs_node *dnp, struct componentname *cnp,
@@ -473,6 +473,28 @@ create_common(struct p9fs_node *dnp, struct componentname *cnp,
 			    dnp, newfid, vpp, cnp->cn_nameptr);
 			if (error != 0)
 				goto out;
+
+			if (ofid != NULL) {
+				struct p9fs_node *np = P9FS_VTON(*vpp);
+				ofid->v_opens = 0;
+				/*
+				 * The 9P file creation request natively opens
+				 * the file as part of the create operation and
+				 * gives us a writable file handle (ofid).
+				 * We retain this open descriptor by adding it
+				 * to the VOFID list of the new vnode. This
+				 * guarantees that a subsequent VOP_OPEN call
+				 * does not need to send a redundant TOPEN
+				 * request. This is particularly important
+				 * because if a file was requested to be created
+				 * with 000 permissions, the host will reject
+				 * subsequent TOPEN requests due to insufficient
+				 * permissions, which would cause an overall
+				 * open() failure.
+				 */
+				p9fs_fid_add(np, ofid, VOFID);
+				ofid = NULL; /* prevent closing handle below */
+			}
 		} else {
 			/* Not found return NOENTRY.*/
 			goto out;

--- a/sys/fs/p9fs/p9fs_vnops.c
+++ b/sys/fs/p9fs/p9fs_vnops.c
@@ -37,10 +37,12 @@
 #include <sys/fcntl.h>
 #include <sys/namei.h>
 #include <sys/priv.h>
-#include <sys/stat.h>
-#include <sys/vnode.h>
 #include <sys/rwlock.h>
+#include <sys/stat.h>
+#include <sys/syslimits.h>
+#include <sys/unistd.h>
 #include <sys/vmmeter.h>
+#include <sys/vnode.h>
 
 #include <vm/vm.h>
 #include <vm/vm_extern.h>
@@ -2202,6 +2204,72 @@ p9fs_putpages(struct vop_putpages_args *ap)
 	return (rtvals[0]);
 }
 
+static unsigned int
+p9fs_get_name_max(struct p9fs_node *np)
+{
+	struct p9fs_session *vses = np->p9fs_ses;
+	struct p9_statfs statfs;
+	struct p9_fid *vfid;
+	unsigned int name_max;
+	int error = 0;
+
+	name_max = atomic_load_int(&vses->name_max);
+	if (name_max != 0)
+		return (name_max);
+
+	P9_DEBUG(VOPS, "%s: querying _PC_NAME_MAX\n", __func__);
+	vfid = p9fs_get_fid(vses->clnt, np, NULL, VFID, -1, &error);
+	if (vfid != NULL) {
+		error = p9_client_statfs(vfid, &statfs);
+		if (error == 0) {
+			/*
+			 * Note that this is not strictly correct if you have
+			 * nested mounts on the host (e.g. when using qemu with
+			 * multidevs=remap), but is a better estimate than just
+			 * returning 255.
+			 */
+			name_max = statfs.namelen;
+		}
+	}
+	P9_DEBUG(VOPS, "%s: max_name=%u error=%d\n", __func__, name_max, error);
+	if (error != 0 || name_max == 0) {
+		printf("p9fs: warning: failed to query name_max (error %d), "
+		    "using fallback %d\n", error, NAME_MAX);
+		name_max = NAME_MAX; /* fallback and prevent retrying */
+	}
+	atomic_store_int(&vses->name_max, name_max);
+	return (name_max);
+}
+
+/*
+ * Return POSIX pathconf information applicable to p9fs filesystems.
+ */
+static int
+p9fs_pathconf(struct vop_pathconf_args *ap)
+{
+	int error = 0;
+	struct vnode *vp = ap->a_vp;
+	struct p9fs_node *np = P9FS_VTON(vp);
+
+	switch (ap->a_name) {
+	case _PC_NAME_MAX:
+		*ap->a_retval = p9fs_get_name_max(np);
+		break;
+	case _PC_SYMLINK_MAX:
+	case _PC_PATH_MAX:
+		/*
+		 * These are conservative estimates, the real value depends on
+		 * the host file system.
+		 */
+		*ap->a_retval = MAXPATHLEN;
+		break;
+	default:
+		error = vop_stdpathconf(ap);
+		break;
+	}
+	return (error);
+}
+
 struct vop_vector p9fs_vnops = {
 	.vop_default =		&default_vnodeops,
 	.vop_lookup =		p9fs_lookup,
@@ -2210,6 +2278,7 @@ struct vop_vector p9fs_vnops = {
 	.vop_access =		p9fs_access,
 	.vop_getattr =		p9fs_getattr_dotl,
 	.vop_setattr =		p9fs_setattr_dotl,
+	.vop_pathconf =		p9fs_pathconf,
 	.vop_reclaim =		p9fs_reclaim,
 	.vop_inactive =		p9fs_inactive,
 	.vop_readdir =		p9fs_readdir,


### PR DESCRIPTION
This was triggered by https://github.com/CTSRD-CHERI/cheribsd/issues/2617.

I'm not 100% convinced that the fix for open() is correct, but it does make most of the pjdfstest open() tests pass.