### PR TITLE
kernel-c18n: Don't force capmode for all trampoline targets

### DIFF
--- a/sys/arm64/arm64/mp_machdep.c
+++ b/sys/arm64/arm64/mp_machdep.c
@@ -530,8 +530,7 @@ start_cpu(u_int cpuid, uint64_t target_cpu, int domain, vm_paddr_t release_addr)
 	} else {
 		pa = pmap_extract(kernel_pmap,
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
-		    (vm_offset_t)executive_get_function(
-		    (uintptr_t)mpentry_psci) - 1
+		    (vm_offset_t)executive_get_function((uintptr_t)mpentry_psci)
 #else
 		    (vm_offset_t)mpentry_psci
 #endif

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -2271,7 +2271,8 @@ elf_compartment_entry(linker_file_t lf, uintcap_t ptr, u_long *idp,
 	*idp = ec->id;
 	cap = cheri_setaddress((uintcap_t)ec->pcc->pcc, ptr);
 	cap = cheri_andperm(cap, cheri_getperm(ptr));
-	cap = cheri_sealentry(cheri_capmode(cap));
+	cap = cheri_flags_set(cap, cheri_flags_get(ptr));
+	cap = cheri_sealentry(cap);
 	*ptrp = (uintptr_t)cap;
 }
 #endif


### PR DESCRIPTION
On Morello we have both A64 and C64 symbols, and the address already
encodes that in the capability, so we don't need to do anything extra.
On CHERI-RISC-V, the flags of the input should encode capmode, and so
they should just be propagated, rather than forcing to true. Since
setting the flags is a no-op on Morello we can just copy the flags
unconditionally.
