### PR TITLE
arm64: Fix ct_entry_type load in kernel-c18n trampoline

### DIFF
--- a/sys/arm64/arm64/compartment.S
+++ b/sys/arm64/arm64/compartment.S
@@ -60,7 +60,7 @@ compartment_entries_length:
 
 .macro template_entry_trampoline type
 \type\()_entry_id:
-	.long		0
+	.quad		0
 \type\()_entry_type:
 	.word		0
 	.p2align 4
@@ -113,7 +113,7 @@ compartment_entries_length:
 
 	/* Get or allocate a callee stack. */
 	ldr	x0, \type\()_entry_id
-	ldr	x1, \type\()_entry_type
+	ldr	w1, \type\()_entry_type
 	ldr	c16, \type\()_entry_stackptr_func
 	blr	c16
 


### PR DESCRIPTION
Firstly, the type is a 32-bit integer so we should only be loading a
32-bit value not a 64-bit one.

Secondly, despite the name, .long gives a 32-bit value not a 64-bit one
on arm64, so the label corresponding to ct_type was in the wrong place
(but thankfully the capability alignment for the next field meant
everything else was still correct). As a result, the trampoline read the
upper bits of ct_compartment_id, which are always going to be 0 in any
sensible system (i.e. one with fewer than 2^32 compartments). As it
happens, this code is only used for the restricted target version, whose
corresponding type is always 0, so this is the right value, and even
were that not to be the case, in practice the argument here is only used
to increment the corresponding counter sysctl.
