### PR TITLE
Fixes for loader.efi motivated by kernel-c18n's zfs.ko

### DIFF
--- a/stand/common/load_elf.c
+++ b/stand/common/load_elf.c
@@ -313,6 +313,18 @@ __elfN(load_elf_header)(char *filename, elf_file_t ef)
 		goto error;
 	}
 
+#if defined(__ELF_CHERI)
+	if (!ELF_IS_CHERI(ehdr)) {
+		err = EFTYPE;
+		goto error;
+	}
+#elif defined(ELF_IS_CHERI)
+	if (ELF_IS_CHERI(ehdr)) {
+		err = EFTYPE;
+		goto error;
+	}
+#endif
+
 	err = elf_header_convert(ehdr);
 	if (err)
 		goto error;
@@ -965,6 +977,20 @@ fake_modname(const char *name)
 	return fp;
 }
 
+#if defined(__ELF_CHERI)
+typedef struct { Elf_Addr words[2]; } __aligned(2 * sizeof(Elf_Addr)) Elf_Ptr;
+#else
+typedef Elf_Addr Elf_Ptr;
+#endif
+
+#if defined(__ELF_CHERI)
+struct mod_metadata64c {
+	int		md_version;	/* structure version MDTV_* */
+	int		md_type;	/* type of entry MDT_* */
+	Elf_Ptr		md_data;	/* specific data */
+	Elf_Ptr		md_cval;	/* common string label */
+};
+#endif
 #if (defined(__i386__) || defined(__powerpc__)) && __ELF_WORD_SIZE == 64
 struct mod_metadata64 {
 	int		md_version;	/* structure version MDTV_* */
@@ -1114,7 +1140,9 @@ __elfN(parse_modmetadata)(struct preloaded_file *fp, elf_file_t ef,
     Elf_Addr p_start, Elf_Addr p_end)
 {
 	struct mod_metadata md;
-#if (defined(__i386__) || defined(__powerpc__)) && __ELF_WORD_SIZE == 64
+#if defined(__ELF_CHERI)
+	struct mod_metadata64c md64c;
+#elif (defined(__i386__) || defined(__powerpc__)) && __ELF_WORD_SIZE == 64
 	struct mod_metadata64 md64;
 #elif defined(__amd64__) && __ELF_WORD_SIZE == 32
 	struct mod_metadata32 md32;
@@ -1123,20 +1151,38 @@ __elfN(parse_modmetadata)(struct preloaded_file *fp, elf_file_t ef,
 	struct mod_version mver;
 	char *s;
 	int error, modcnt, minfolen;
-	Elf_Addr v, p;
+	Elf_Addr va, p;
+	Elf_Ptr vp;
 
 	modcnt = 0;
 	p = p_start;
 	while (p < p_end) {
-		COPYOUT(p, &v, sizeof(v));
-		error = __elfN(reloc_ptr)(fp, ef, p, &v, sizeof(v));
+		COPYOUT(p, &vp, sizeof(vp));
+		error = __elfN(reloc_ptr)(fp, ef, p, &vp, sizeof(vp));
+#if defined(__ELF_CHERI)
+		va = vp.words[0];
+#else
+		va = vp;
+#endif
 		if (error == EOPNOTSUPP)
-			v += ef->off;
+			va += ef->off;
 		else if (error != 0)
 			return (error);
-#if (defined(__i386__) || defined(__powerpc__)) && __ELF_WORD_SIZE == 64
-		COPYOUT(v, &md64, sizeof(md64));
-		error = __elfN(reloc_ptr)(fp, ef, v, &md64, sizeof(md64));
+#if defined(__ELF_CHERI)
+		COPYOUT(va, &md64c, sizeof(md64c));
+		error = __elfN(reloc_ptr)(fp, ef, va, &md64c, sizeof(md64c));
+		if (error == EOPNOTSUPP) {
+			md64c.md_cval.words[0] += ef->off;
+			md64c.md_data.words[0] += ef->off;
+		} else if (error != 0)
+			return (error);
+		md.md_version = md64c.md_version;
+		md.md_type = md64c.md_type;
+		md.md_cval = (const char *)(uintptr_t)md64c.md_cval.words[0];
+		md.md_data = (void *)(uintptr_t)md64c.md_data.words[0];
+#elif (defined(__i386__) || defined(__powerpc__)) && __ELF_WORD_SIZE == 64
+		COPYOUT(va, &md64, sizeof(md64));
+		error = __elfN(reloc_ptr)(fp, ef, va, &md64, sizeof(md64));
 		if (error == EOPNOTSUPP) {
 			md64.md_cval += ef->off;
 			md64.md_data += ef->off;
@@ -1147,8 +1193,8 @@ __elfN(parse_modmetadata)(struct preloaded_file *fp, elf_file_t ef,
 		md.md_cval = (const char *)(uintptr_t)md64.md_cval;
 		md.md_data = (void *)(uintptr_t)md64.md_data;
 #elif defined(__amd64__) && __ELF_WORD_SIZE == 32
-		COPYOUT(v, &md32, sizeof(md32));
-		error = __elfN(reloc_ptr)(fp, ef, v, &md32, sizeof(md32));
+		COPYOUT(va, &md32, sizeof(md32));
+		error = __elfN(reloc_ptr)(fp, ef, va, &md32, sizeof(md32));
 		if (error == EOPNOTSUPP) {
 			md32.md_cval += ef->off;
 			md32.md_data += ef->off;
@@ -1159,8 +1205,8 @@ __elfN(parse_modmetadata)(struct preloaded_file *fp, elf_file_t ef,
 		md.md_cval = (const char *)(uintptr_t)md32.md_cval;
 		md.md_data = (void *)(uintptr_t)md32.md_data;
 #else
-		COPYOUT(v, &md, sizeof(md));
-		error = __elfN(reloc_ptr)(fp, ef, v, &md, sizeof(md));
+		COPYOUT(va, &md, sizeof(md));
+		error = __elfN(reloc_ptr)(fp, ef, va, &md, sizeof(md));
 		if (error == EOPNOTSUPP) {
 			md.md_cval += ef->off;
 			md.md_data = (void *)((uintptr_t)md.md_data +
@@ -1168,7 +1214,7 @@ __elfN(parse_modmetadata)(struct preloaded_file *fp, elf_file_t ef,
 		} else if (error != 0)
 			return (error);
 #endif
-		p += sizeof(Elf_Addr);
+		p += sizeof(vp);
 		switch(md.md_type) {
 		case MDT_DEPEND:
 			if (ef->kernel) /* kernel must not depend on anything */
@@ -1305,6 +1351,9 @@ __elfN(reloc_ptr)(struct preloaded_file *mp, elf_file_t ef,
 		if (error != 0)
 			return (error);
 	}
+#ifdef __ELF_CHERI
+	/* TODO: __cap_relocs */
+#endif
 
 	return (0);
 }

--- a/stand/common/load_elf64c.c
+++ b/stand/common/load_elf64c.c
@@ -1,0 +1,5 @@
+/* This file is in the public domain */
+
+#define __ELF_WORD_SIZE 64
+#define __ELF_CHERI
+#include "load_elf.c"

--- a/stand/common/reloc_elf.c
+++ b/stand/common/reloc_elf.c
@@ -48,8 +48,71 @@ int
 __elfN(reloc)(struct elf_file *ef, symaddr_fn *symaddr, const void *reldata,
     int reltype, Elf_Addr relbase, Elf_Addr dataaddr, void *data, size_t len)
 {
-#if (defined(__aarch64__) || defined(__amd64__) || defined(__i386__)) && \
-    __ELF_WORD_SIZE == 64
+#if defined(__aarch64__) && __ELF_WORD_SIZE == 64 && defined(__ELF_CHERI)
+	Elf64_Addr *where, val;
+	Elf_Addr addend, addr;
+	Elf_Size rtype;
+	const Elf_Rel *rel;
+	const Elf_Rela *rela;
+
+	switch (reltype) {
+	case ELF_RELOC_REL:
+		rel = (const Elf_Rel *)reldata;
+		where = (Elf_Addr *)((char *)data + relbase + rel->r_offset -
+		    dataaddr);
+		addend = 0;
+		rtype = ELF_R_TYPE(rel->r_info);
+		addend = 0;
+		break;
+	case ELF_RELOC_RELA:
+		rela = (const Elf_Rela *)reldata;
+		where = (Elf_Addr *)((char *)data + relbase + rela->r_offset -
+		    dataaddr);
+		addend = rela->r_addend;
+		rtype = ELF_R_TYPE(rela->r_info);
+		break;
+	default:
+		return (EINVAL);
+	}
+
+	if ((char *)where < (char *)data || (char *)where >= (char *)data + len)
+		return (0);
+
+#if defined(__aarch64__)
+#define	RELOC_RELATIVE		R_AARCH64_RELATIVE
+#define	RELOC_RELATIVE_CAP	R_MORELLO_RELATIVE
+#endif
+
+	switch (rtype) {
+	case RELOC_RELATIVE:
+		addr = (Elf_Addr)addend + relbase;
+		val = addr;
+		memcpy(where, &val, sizeof(val));
+		break;
+	case RELOC_RELATIVE_CAP:
+		if (reltype == ELF_RELOC_REL) {
+			printf("\ninvalid Elf_Rel for relocation type %u\n",
+			    (u_int)rtype);
+			return (EINVAL);
+		}
+		/*
+		 * We currently can't use capabilities in loader, but also only
+		 * need the address anyway so just fake a null-derived one.
+		 */
+		addr = (Elf_Addr)addend + relbase + *where;
+		val = 0;
+		memcpy(where + 1, &val, sizeof(val));
+		val = addr;
+		memcpy(where, &val, sizeof(val));
+		break;
+	default:
+		printf("\nunhandled relocation type %u\n", (u_int)rtype);
+		return (EFTYPE);
+	}
+
+	return (0);
+#elif (defined(__aarch64__) || defined(__amd64__) || defined(__i386__)) && \
+    __ELF_WORD_SIZE == 64 && !defined(__ELF_CHERI)
 	Elf64_Addr *where, val;
 	Elf_Addr addend, addr;
 	Elf_Size rtype;
@@ -128,7 +191,7 @@ __elfN(reloc)(struct elf_file *ef, symaddr_fn *symaddr, const void *reldata,
 	}
 
 	return (0);
-#elif defined(__i386__) && __ELF_WORD_SIZE == 32
+#elif defined(__i386__) && __ELF_WORD_SIZE == 32 && !defined(__ELF_CHERI)
 	Elf_Addr addend, addr, *where, val;
 	Elf_Size rtype, symidx;
 	const Elf_Rel *rel;

--- a/stand/common/reloc_elf64c.c
+++ b/stand/common/reloc_elf64c.c
@@ -1,0 +1,3 @@
+#define __ELF_WORD_SIZE 64
+#define __ELF_CHERI
+#include "reloc_elf.c"

--- a/stand/efi/loader/arch/arm/exec.c
+++ b/stand/efi/loader/arch/arm/exec.c
@@ -69,9 +69,6 @@ __elfN(arm_exec)(struct preloaded_file *fp)
 
 	efi_time_fini();
 
-	entry = efi_translate(e->e_entry);
-
-	printf("Kernel entry at %p...\n", entry);
 	printf("Kernel args: %s\n", fp->f_args);
 
 	if ((error = bi_load(fp->f_args, &modulep, &kernend, true)) != 0) {
@@ -83,6 +80,8 @@ __elfN(arm_exec)(struct preloaded_file *fp)
 	 * printf or any other function that uses Boot Services */
 
 	dev_cleanup();
+
+	entry = efi_translate(e->e_entry);
 
 	(*entry)((void *)modulep);
 	panic("exec returned");

--- a/stand/efi/loader/arch/arm64/Makefile.inc
+++ b/stand/efi/loader/arch/arm64/Makefile.inc
@@ -1,6 +1,8 @@
 HAVE_FDT=yes
 
 SRCS+=	exec.c \
+	exec_elf64.c \
+	exec_elf64c.c \
 	start.S
 
 .PATH:	${BOOTSRC}/arm64/libarm64

--- a/stand/efi/loader/arch/arm64/exec.c
+++ b/stand/efi/loader/arch/arm64/exec.c
@@ -67,7 +67,6 @@ elf64_exec(struct preloaded_file *fp)
         	return(EFTYPE);
 
 	ehdr = (Elf_Ehdr *)&(md->md_data);
-	entry = efi_translate(ehdr->e_entry);
 
 	efi_time_fini();
 	err = bi_load(fp->f_args, &modulep, &kernendp, true);
@@ -77,6 +76,8 @@ elf64_exec(struct preloaded_file *fp)
 	}
 
 	dev_cleanup();
+
+	entry = efi_translate(ehdr->e_entry);
 
 	/* Clean D-cache under kernel area and invalidate whole I-cache */
 	clean_addr = (vm_offset_t)efi_translate(fp->f_addr);

--- a/stand/efi/loader/arch/arm64/exec.c
+++ b/stand/efi/loader/arch/arm64/exec.c
@@ -24,78 +24,13 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stand.h>
-#include <string.h>
-
-#include <sys/param.h>
-#include <sys/linker.h>
-#include <machine/elf.h>
-
 #include <bootstrap.h>
 
-#include <efi.h>
-#include <efilib.h>
-
-#include "loader_efi.h"
-#include "cache.h"
-
-static int elf64_exec(struct preloaded_file *amp);
-static int elf64_obj_exec(struct preloaded_file *amp);
-
-static struct file_format arm64_elf = {
-	elf64_loadfile,
-	elf64_exec
-};
+extern struct file_format elf64_arm64;
+extern struct file_format elf64c_arm64;
 
 struct file_format *file_formats[] = {
-	&arm64_elf,
+	&elf64_arm64,
+	&elf64c_arm64,
 	NULL
 };
-
-static int
-elf64_exec(struct preloaded_file *fp)
-{
-	vm_offset_t modulep, kernendp;
-	vm_offset_t clean_addr;
-	size_t clean_size;
-	struct file_metadata *md;
-	Elf_Ehdr *ehdr;
-	int err;
-	void (*entry)(vm_offset_t);
-
-	if ((md = file_findmetadata(fp, MODINFOMD_ELFHDR)) == NULL)
-        	return(EFTYPE);
-
-	ehdr = (Elf_Ehdr *)&(md->md_data);
-
-	efi_time_fini();
-	err = bi_load(fp->f_args, &modulep, &kernendp, true);
-	if (err != 0) {
-		efi_time_init();
-		return (err);
-	}
-
-	dev_cleanup();
-
-	entry = efi_translate(ehdr->e_entry);
-
-	/* Clean D-cache under kernel area and invalidate whole I-cache */
-	clean_addr = (vm_offset_t)efi_translate(fp->f_addr);
-	clean_size = (vm_offset_t)efi_translate(kernendp) - clean_addr;
-
-	cpu_flush_dcache((void *)clean_addr, clean_size);
-	cpu_inval_icache();
-
-	(*entry)(modulep);
-	panic("exec returned");
-}
-
-static int
-elf64_obj_exec(struct preloaded_file *fp)
-{
-
-	printf("%s called for preloaded file %p (=%s):\n", __func__, fp,
-	    fp->f_name);
-	return (ENOSYS);
-}
-

--- a/stand/efi/loader/arch/arm64/exec_elf.c
+++ b/stand/efi/loader/arch/arm64/exec_elf.c
@@ -1,0 +1,96 @@
+/*-
+ * Copyright (c) 2006 Marcel Moolenaar
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stand.h>
+#include <string.h>
+
+#include <sys/param.h>
+#include <sys/linker.h>
+#include <machine/elf.h>
+
+#include <bootstrap.h>
+
+#include <efi.h>
+#include <efilib.h>
+
+#include "loader_efi.h"
+#include "cache.h"
+
+static int __elfN(exec)(struct preloaded_file *amp);
+static int __elfN(obj_exec)(struct preloaded_file *amp);
+
+struct file_format __elfN(arm64) = {
+	__elfN(loadfile),
+	__elfN(exec)
+};
+
+static int
+__elfN(exec)(struct preloaded_file *fp)
+{
+	vm_offset_t modulep, kernendp;
+	vm_offset_t clean_addr;
+	size_t clean_size;
+	struct file_metadata *md;
+	Elf_Ehdr *ehdr;
+	int err;
+	void (*entry)(vm_offset_t);
+
+	if ((md = file_findmetadata(fp, MODINFOMD_ELFHDR)) == NULL)
+        	return(EFTYPE);
+
+	ehdr = (Elf_Ehdr *)&(md->md_data);
+
+	efi_time_fini();
+	err = bi_load(fp->f_args, &modulep, &kernendp, true);
+	if (err != 0) {
+		efi_time_init();
+		return (err);
+	}
+
+	dev_cleanup();
+
+	entry = efi_translate(ehdr->e_entry);
+
+	/* Clean D-cache under kernel area and invalidate whole I-cache */
+	clean_addr = (vm_offset_t)efi_translate(fp->f_addr);
+	clean_size = (vm_offset_t)efi_translate(kernendp) - clean_addr;
+
+	cpu_flush_dcache((void *)clean_addr, clean_size);
+	cpu_inval_icache();
+
+	(*entry)(modulep);
+	panic("exec returned");
+}
+
+static int
+__elfN(obj_exec)(struct preloaded_file *fp)
+{
+
+	printf("%s called for preloaded file %p (=%s):\n", __func__, fp,
+	    fp->f_name);
+	return (ENOSYS);
+}
+

--- a/stand/efi/loader/arch/arm64/exec_elf64.c
+++ b/stand/efi/loader/arch/arm64/exec_elf64.c
@@ -1,0 +1,2 @@
+#define	__ELF_WORD_SIZE	64
+#include "exec_elf.c"

--- a/stand/efi/loader/arch/arm64/exec_elf64c.c
+++ b/stand/efi/loader/arch/arm64/exec_elf64c.c
@@ -1,0 +1,3 @@
+#define	__ELF_WORD_SIZE	64
+#define	__ELF_CHERI
+#include "exec_elf.c"

--- a/stand/efi/loader/arch/riscv/exec.c
+++ b/stand/efi/loader/arch/riscv/exec.c
@@ -81,9 +81,6 @@ __elfN(exec)(struct preloaded_file *fp)
 
 	efi_time_fini();
 
-	entry = efi_translate(e->e_entry);
-
-	printf("Kernel entry at %p...\n", entry);
 	printf("Kernel args: %s\n", fp->f_args);
 
 	if ((error = bi_load(fp->f_args, &modulep, &kernend, true)) != 0) {
@@ -96,6 +93,8 @@ __elfN(exec)(struct preloaded_file *fp)
 	 * printf or any other function that uses Boot Services
 	 */
 	dev_cleanup();
+
+	entry = efi_translate(e->e_entry);
 
 	(*entry)((void *)modulep);
 	panic("exec returned");

--- a/stand/loader.mk
+++ b/stand/loader.mk
@@ -18,6 +18,7 @@ SRCS+=	load_elf32.c load_elf32_obj.c reloc_elf32.c
 SRCS+=	load_elf64.c load_elf64_obj.c reloc_elf64.c
 .elif ${MACHINE_CPUARCH} == "aarch64"
 SRCS+=	load_elf64.c reloc_elf64.c
+SRCS+=	load_elf64c.c reloc_elf64c.c
 .elif ${MACHINE_CPUARCH} == "arm"
 SRCS+=	load_elf32.c reloc_elf32.c
 .elif ${MACHINE_CPUARCH} == "powerpc"

--- a/sys/arm64/include/elf.h
+++ b/sys/arm64/include/elf.h
@@ -82,7 +82,15 @@ typedef struct {	/* Auxiliary vector entry on initial stack */
 #endif
 
 #ifdef __ELF_CHERI
+/*
+ * We need __ELF_CHERI for stand, but currently don't built with capabilities,
+ * so can't provide a proper Elf_Auxinfo. We could use fake int128-ish types
+ * but don't actually need Elf_Auxinfo at all in stand, so just don't provide
+ * it at all.
+ */
+#if __has_feature(capabilities) || !defined(_STANDALONE)
 typedef Elf64C_Auxinfo Elf_Auxinfo;
+#endif
 #else
 __ElfType(Auxinfo);
 #endif


### PR DESCRIPTION
- loader.efi: Defer efi_translate(e_entry) until after bi_load
- arm64: Allow non-CHERI stand code to define __ELF_CHERI
- loader.efi: Support metadata in pure-capability Morello kernels
