### PR TITLE
Various fixes for malloc_early_constructor Makefile.inc

### DIFF
--- a/libexec/malloc_early_constructor/Makefile.inc
+++ b/libexec/malloc_early_constructor/Makefile.inc
@@ -2,7 +2,10 @@
 
 BINDIR=	/usr/libexec
 
-.if ${.CURDIR:T:M*benchmark*}
+VARIANT=		${.CURDIR:T}
+VARIANT_SUFFICES=	${VARIANT:S/-/ /g}
+
+.if ${VARIANT_SUFFICES:Mbenchmark}
 .if !${MACHINE_ABI:Mbenchmark}
 NEED_COMPAT=	64CB
 .include <bsd.compat.mk>
@@ -14,15 +17,15 @@ NEED_COMPAT=    64C
 .endif
 .endif
 
-PROG:=	${.PARSEDIR:tA:T}-${.CURDIR:T}
+PROG:=	${.PARSEDIR:tA:T}-${VARIANT}
 .PATH: ${.PARSEDIR}
 SRCS:=	${.PARSEDIR:tA:T}.c
 MAN=
 
-.if ${.CURDIR:T:M*mt*}
+.if ${VARIANT_SUFFICES:Mmt}
 LIBADD+=	pthread
 .endif
 
-.if !${.CURDIR:T:M*dynamic*} && !${.CURDIR:T:M*-c18n*}
+.if !${VARIANT_SUFFICES:Mdynamic} && !${VARIANT_SUFFICES:Mc18n}
 NO_SHARED=t
 .endif

--- a/libexec/malloc_early_constructor/Makefile.inc
+++ b/libexec/malloc_early_constructor/Makefile.inc
@@ -2,7 +2,7 @@
 
 BINDIR=	/usr/libexec
 
-.if ${.CURDIR:M*benchmark*}
+.if ${.CURDIR:T:M*benchmark*}
 .if !${MACHINE_ABI:Mbenchmark}
 NEED_COMPAT=	64CB
 .include <bsd.compat.mk>
@@ -19,10 +19,10 @@ PROG:=	${.PARSEDIR:tA:T}-${.CURDIR:T}
 SRCS:=	${.PARSEDIR:tA:T}.c
 MAN=
 
-.if ${.CURDIR:M*-mt*}
+.if ${.CURDIR:T:M*-mt*}
 LIBADD+=	pthread
 .endif
 
-.if ${.CURDIR:M*static*}
+.if ${.CURDIR:T:M*static*}
 NO_SHARED=t
 .endif

--- a/libexec/malloc_early_constructor/Makefile.inc
+++ b/libexec/malloc_early_constructor/Makefile.inc
@@ -19,10 +19,10 @@ PROG:=	${.PARSEDIR:tA:T}-${.CURDIR:T}
 SRCS:=	${.PARSEDIR:tA:T}.c
 MAN=
 
-.if ${.CURDIR:T:M*-mt*}
+.if ${.CURDIR:T:M*mt*}
 LIBADD+=	pthread
 .endif
 
-.if ${.CURDIR:T:M*static*}
+.if !${.CURDIR:T:M*dynamic*} && !${.CURDIR:T:M*-c18n*}
 NO_SHARED=t
 .endif


### PR DESCRIPTION
- malloc_early_constructor: Only look at dirname not full path
- malloc_early_constructor: Fix static vs dynamic and mt checks
- malloc_early_constructor: Make more robust
