### PR TITLE
openssl: Fix various issues with purecap vpaes-armv8.pl

### DIFF
--- a/crypto/openssl/crypto/aes/asm/vpaes-armv8.pl
+++ b/crypto/openssl/crypto/aes/asm/vpaes-armv8.pl
@@ -710,7 +710,12 @@ _vpaes_schedule_core:
 	ld1	{v1.2d}, [PTR(8)]		// vmovdqa	(%r8,%r10),	%xmm1
 	tbl	v3.16b, {v3.16b}, v1.16b	// vpshufb  %xmm1,	%xmm3,	%xmm3
 	st1	{v3.2d}, [$out]			// vmovdqu	%xmm3,	(%rdx)
+#ifdef __CHERI_PURE_CAPABILITY__
+	eor	x9, x8, #0x30			// xor	\$0x30, %r8
+	scvalue	c8, c8, x9
+#else
 	eor	x8, x8, #0x30			// xor	\$0x30, %r8
+#endif
 
 .Lschedule_go:
 	cmp	$bits, #192			// cmp	\$192,	%esi

--- a/crypto/openssl/crypto/aes/asm/vpaes-armv8.pl
+++ b/crypto/openssl/crypto/aes/asm/vpaes-armv8.pl
@@ -225,7 +225,7 @@ _vpaes_encrypt_core:
 	eor	v0.16b, v0.16b, v3.16b		// vpxor	%xmm3,	%xmm0,	%xmm0	# 3 = 2A+B+D
 #ifdef __CHERI_PURE_CAPABILITY__
 	alignd	c11, c11, #6			// and		\$0x30,	%r11		# ... mod 4
-#else		     
+#else
 	and	x11, x11, #~(1<<6)		// and		\$0x30,	%r11		# ... mod 4
 #endif
 	eor	v0.16b, v0.16b, v4.16b		// vpxor	%xmm4,	%xmm0, %xmm0	# 0 = 2A+3B+C+D
@@ -334,7 +334,7 @@ _vpaes_encrypt_2x:
 	 eor	v8.16b,  v8.16b,  v11.16b
 #ifdef __CHERI_PURE_CAPABILITY__
 	alignd	c11, c11, #6			// and		\$0x30,	%r11		# ... mod 4
-#else		     
+#else
 	and	x11, x11, #~(1<<6)		// and		\$0x30,	%r11		# ... mod 4
 #endif
 	eor	v0.16b,  v0.16b,  v4.16b	// vpxor	%xmm4,	%xmm0, %xmm0	# 0 = 2A+3B+C+D
@@ -654,7 +654,7 @@ ___
 }
 {
 my ($inp,$bits,$out,$dir)=("PTR(0)","w1","PTR(2)","w3");
-my ($inpx)=("x0");    
+my ($inpx)=("x0");
 my ($invlo,$invhi,$iptlo,$ipthi,$rcon) = map("v$_.16b",(18..21,8));
 
 $code.=<<___;
@@ -1055,7 +1055,7 @@ _vpaes_schedule_mangle:
 	add	PTR(8), PTR(8), #64-16		// add	\$-16,	%r8
 #ifdef __CHERI_PURE_CAPABILITY__
 	alignd	c8, c8, #6			// and	\$0x30,	%r8
-#else		     
+#else
 	and	x8, x8, #~(1<<6)		// and	\$0x30,	%r8
 #endif
 	st1	{v3.2d}, [$out]			// vmovdqu	%xmm3,	(%rdx)

--- a/crypto/openssl/crypto/aes/asm/vpaes-armv8.pl
+++ b/crypto/openssl/crypto/aes/asm/vpaes-armv8.pl
@@ -224,7 +224,8 @@ _vpaes_encrypt_core:
 	tbl	v4.16b, {v3.16b}, v1.16b	// vpshufb	%xmm1,	%xmm3,	%xmm4	# 0 = 2B+C
 	eor	v0.16b, v0.16b, v3.16b		// vpxor	%xmm3,	%xmm0,	%xmm0	# 3 = 2A+B+D
 #ifdef __CHERI_PURE_CAPABILITY__
-	alignd	c11, c11, #6			// and		\$0x30,	%r11		# ... mod 4
+	and	x12, x11, #~(1<<6)		// and		\$0x30,	%r11		# ... mod 4
+	scvalue	c11, c11, x12
 #else
 	and	x11, x11, #~(1<<6)		// and		\$0x30,	%r11		# ... mod 4
 #endif
@@ -333,7 +334,8 @@ _vpaes_encrypt_2x:
 	eor	v0.16b,  v0.16b,  v3.16b	// vpxor	%xmm3,	%xmm0,	%xmm0	# 3 = 2A+B+D
 	 eor	v8.16b,  v8.16b,  v11.16b
 #ifdef __CHERI_PURE_CAPABILITY__
-	alignd	c11, c11, #6			// and		\$0x30,	%r11		# ... mod 4
+	and	x12, x11, #~(1<<6)		// and		\$0x30,	%r11		# ... mod 4
+	scvalue	c11, c11, x12
 #else
 	and	x11, x11, #~(1<<6)		// and		\$0x30,	%r11		# ... mod 4
 #endif
@@ -1059,7 +1061,8 @@ _vpaes_schedule_mangle:
 	tbl	v3.16b, {v3.16b}, v1.16b	// vpshufb	%xmm1,	%xmm3,	%xmm3
 	add	PTR(8), PTR(8), #64-16		// add	\$-16,	%r8
 #ifdef __CHERI_PURE_CAPABILITY__
-	alignd	c8, c8, #6			// and	\$0x30,	%r8
+	and	x9, x8, #~(1<<6)		// and	\$0x30,	%r8
+	scvalue	c8, c8, x9
 #else
 	and	x8, x8, #~(1<<6)		// and	\$0x30,	%r8
 #endif

--- a/sys/crypto/openssl/aarch64/vpaes-armv8.S
+++ b/sys/crypto/openssl/aarch64/vpaes-armv8.S
@@ -162,7 +162,7 @@ _vpaes_encrypt_core:
 	eor	v0.16b, v0.16b, v3.16b		// vpxor	%xmm3,	%xmm0,	%xmm0	# 3 = 2A+B+D
 #ifdef __CHERI_PURE_CAPABILITY__
 	alignd	c11, c11, #6			// and		$0x30,	%r11		# ... mod 4
-#else		     
+#else
 	and	x11, x11, #~(1<<6)		// and		$0x30,	%r11		# ... mod 4
 #endif
 	eor	v0.16b, v0.16b, v4.16b		// vpxor	%xmm4,	%xmm0, %xmm0	# 0 = 2A+3B+C+D
@@ -271,7 +271,7 @@ _vpaes_encrypt_2x:
 	eor	v8.16b,  v8.16b,  v11.16b
 #ifdef __CHERI_PURE_CAPABILITY__
 	alignd	c11, c11, #6			// and		$0x30,	%r11		# ... mod 4
-#else		     
+#else
 	and	x11, x11, #~(1<<6)		// and		$0x30,	%r11		# ... mod 4
 #endif
 	eor	v0.16b,  v0.16b,  v4.16b	// vpxor	%xmm4,	%xmm0, %xmm0	# 0 = 2A+3B+C+D
@@ -984,7 +984,7 @@ _vpaes_schedule_mangle:
 	add	PTR(8), PTR(8), #64-16		// add	$-16,	%r8
 #ifdef __CHERI_PURE_CAPABILITY__
 	alignd	c8, c8, #6			// and	$0x30,	%r8
-#else		     
+#else
 	and	x8, x8, #~(1<<6)		// and	$0x30,	%r8
 #endif
 	st1	{v3.2d}, [PTR(2)]			// vmovdqu	%xmm3,	(%rdx)

--- a/sys/crypto/openssl/aarch64/vpaes-armv8.S
+++ b/sys/crypto/openssl/aarch64/vpaes-armv8.S
@@ -639,7 +639,12 @@ _vpaes_schedule_core:
 	ld1	{v1.2d}, [PTR(8)]		// vmovdqa	(%r8,%r10),	%xmm1
 	tbl	v3.16b, {v3.16b}, v1.16b	// vpshufb  %xmm1,	%xmm3,	%xmm3
 	st1	{v3.2d}, [PTR(2)]			// vmovdqu	%xmm3,	(%rdx)
+#ifdef __CHERI_PURE_CAPABILITY__
+	eor	x9, x8, #0x30			// xor	$0x30, %r8
+	scvalue	c8, c8, x9
+#else
 	eor	x8, x8, #0x30			// xor	$0x30, %r8
+#endif
 
 .Lschedule_go:
 	cmp	w1, #192			// cmp	$192,	%esi

--- a/sys/crypto/openssl/aarch64/vpaes-armv8.S
+++ b/sys/crypto/openssl/aarch64/vpaes-armv8.S
@@ -161,7 +161,8 @@ _vpaes_encrypt_core:
 	tbl	v4.16b, {v3.16b}, v1.16b	// vpshufb	%xmm1,	%xmm3,	%xmm4	# 0 = 2B+C
 	eor	v0.16b, v0.16b, v3.16b		// vpxor	%xmm3,	%xmm0,	%xmm0	# 3 = 2A+B+D
 #ifdef __CHERI_PURE_CAPABILITY__
-	alignd	c11, c11, #6			// and		$0x30,	%r11		# ... mod 4
+	and	x12, x11, #~(1<<6)		// and		$0x30,	%r11		# ... mod 4
+	scvalue	c11, c11, x12
 #else
 	and	x11, x11, #~(1<<6)		// and		$0x30,	%r11		# ... mod 4
 #endif
@@ -270,7 +271,8 @@ _vpaes_encrypt_2x:
 	eor	v0.16b,  v0.16b,  v3.16b	// vpxor	%xmm3,	%xmm0,	%xmm0	# 3 = 2A+B+D
 	eor	v8.16b,  v8.16b,  v11.16b
 #ifdef __CHERI_PURE_CAPABILITY__
-	alignd	c11, c11, #6			// and		$0x30,	%r11		# ... mod 4
+	and	x12, x11, #~(1<<6)		// and		$0x30,	%r11		# ... mod 4
+	scvalue	c11, c11, x12
 #else
 	and	x11, x11, #~(1<<6)		// and		$0x30,	%r11		# ... mod 4
 #endif
@@ -988,7 +990,8 @@ _vpaes_schedule_mangle:
 	tbl	v3.16b, {v3.16b}, v1.16b	// vpshufb	%xmm1,	%xmm3,	%xmm3
 	add	PTR(8), PTR(8), #64-16		// add	$-16,	%r8
 #ifdef __CHERI_PURE_CAPABILITY__
-	alignd	c8, c8, #6			// and	$0x30,	%r8
+	and	x9, x8, #~(1<<6)		// and	$0x30,	%r8
+	scvalue	c8, c8, x9
 #else
 	and	x8, x8, #~(1<<6)		// and	$0x30,	%r8
 #endif


### PR DESCRIPTION
CheriBSD on Morello and qemu-system-morello will advertise hardware AES support
so these code paths are not hit. However, qemu-user presents a rather limited
AT_HWCAP that excludes it, and so we fall back on the plain NEON version, which
does not quite work.
