### PR TITLE
cherry-pick: pkg: suppress error on unknown options

### DIFF
--- a/usr.sbin/pkg/pkg.c
+++ b/usr.sbin/pkg/pkg.c
@@ -1164,7 +1164,7 @@ main(int argc, char *argv[])
 				{ "yes",	no_argument,	NULL,	'y' },
 				{ NULL,		0,		NULL,	0   },
 			};
-			while ((ch = getopt_long(argc, argv, "+y",
+			while ((ch = getopt_long(argc, argv, "+:y",
 			    sub_longopts, NULL)) != -1) {
 				switch (ch) {
 				case 'y':


### PR DESCRIPTION
Without this change, any use of `pkg64{,c,cb}` with a single-letter flag results in:
```
kw543@stevnsbaer:~ $ sudo pkg64c update -f
pkg64c: invalid option -- f
```

The cherry-picked change is:
```
pkg(7) does not understand all the options that pkg(8) understands and should never log errors about unknown options that it will pass on to pkg(8) without touching.

PR:		286510
Reviewed by:	bapt
Fixes:		be61deae0aa2 ("pkg: clarify argument parsing")
Sponsored by:	The FreeBSD Foundation
Differential Revision: https://reviews.freebsd.org/D50163

(cherry picked from commit 73ba568b1c35aabc1682540b5b4d5d77220c5468)
```