### PR TITLE
Harden proc strings

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -89,16 +89,16 @@ static const struct cheri_test *running_test;
 static int tests_run, tests_skipped;
 static int tests_failed, tests_passed, tests_xfailed, tests_xpassed;
 static int expected_failures;
-static int is_execed_child;
-static int execed_child_has_extra_argv;
-static int list;
-static int run_all;
-static int fast_tests_only;
-static int qtrace;
-static int qtrace_user_mode_only;
-static int sleep_after_test;
-static int coredump_enabled;
-static int debugger_enabled;
+static bool is_execed_child;
+static bool execed_child_has_extra_argv;
+static bool list;
+static bool run_all;
+static bool fast_tests_only;
+static bool qtrace;
+static bool qtrace_user_mode_only;
+static bool sleep_after_test;
+static bool coredump_enabled;
+static bool debugger_enabled;
 
 int verbose;
 struct cheribsdtest_entrystate entrystate;
@@ -836,31 +836,31 @@ main(int argc, char *argv[])
 	while ((opt = getopt(argc, argv, "acdEfgKlQqsuvx")) != -1) {
 		switch (opt) {
 		case 'a':
-			run_all = 1;
+			run_all = true;
 			break;
 		case 'c':
-			coredump_enabled = 1;
+			coredump_enabled = true;
 			break;
 		case 'd':
-			debugger_enabled = 1;
+			debugger_enabled = true;
 			break;
 		case 'E':
-			is_execed_child = 1;
+			is_execed_child = true;
 			break;
 		case 'f':
-			fast_tests_only = 1;
+			fast_tests_only = true;
 			break;
 		case 'g':
-			glob = 1;
+			glob = true;
 			break;
 		case 'K':
-			execed_child_has_extra_argv = 1;
+			execed_child_has_extra_argv = true;
 			break;
 		case 'l':
-			list = 1;
+			list = true;
 			break;
 		case 'Q':
-			qtrace_user_mode_only = 1;
+			qtrace_user_mode_only = true;
 			/* FALLTHROUGH */
 		case 'q':
 			len = sizeof(qemu_trace_perthread);
@@ -872,10 +872,10 @@ main(int argc, char *argv[])
 			if (!qemu_trace_perthread)
 				errx(EX_USAGE, "-%c requires sysctl "
 				    "hw.qemu_trace_perthread=1", opt);
-			qtrace = 1;
+			qtrace = true;
 			break;
 		case 's':
-			sleep_after_test = 1;
+			sleep_after_test = true;
 			break;
 		case 'v':
 			verbose++;

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -100,6 +100,7 @@ static int coredump_enabled;
 static int debugger_enabled;
 
 int verbose;
+struct cheribsdtest_entrystate entrystate;
 
 extern char **environ;
 
@@ -216,6 +217,14 @@ set_thread_tracing(void)
 #else
 	err(EX_OSERR, "%s", __func__);
 #endif
+}
+
+static void
+cheribsdtest_entrystate_snapshot(struct cheribsdtest_entrystate *state,
+    int argc, char *argv[])
+{
+	state->es_argc = argc;
+	state->es_argv = argv;
 }
 
 /* Maximum size of stdout data we will check if called for by a test. */
@@ -795,6 +804,8 @@ main(int argc, char *argv[])
 	size_t len;
 	const char *sep;
 	struct cheri_test **ctp, *ct;
+
+	cheribsdtest_entrystate_snapshot(&entrystate, argc, argv);
 
 	argc = xo_parse_args(argc, argv);
 	if (argc < 0)

--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -90,6 +90,7 @@ static int tests_run, tests_skipped;
 static int tests_failed, tests_passed, tests_xfailed, tests_xpassed;
 static int expected_failures;
 static int is_execed_child;
+static int execed_child_has_extra_argv;
 static int list;
 static int run_all;
 static int fast_tests_only;
@@ -667,16 +668,23 @@ cheribsdtest_run_child_name(const char *name)
 }
 
 static char **
-mk_exec_args(const struct cheri_test *ctp)
+mk_exec_args(const struct cheri_test *ctp, char **extra_args)
 {
 	char *execpath;
 	char const **exec_args;
-	int argc = 0, error;
+	int argc = 0;
+	int extra_argc = 0;
+	int error;
+
+	if (extra_args) {
+		while (extra_args[extra_argc] != NULL)
+			extra_argc++;
+	}
 
 	execpath = malloc(PATH_MAX);
 	if (execpath == NULL)
 		err(EX_OSERR, "malloc");
-	exec_args = calloc(5, sizeof(*exec_args));
+	exec_args = calloc(6 + extra_argc, sizeof(*exec_args));
 	if (exec_args == NULL)
 		err(EX_OSERR, "calloc");
 
@@ -692,29 +700,38 @@ mk_exec_args(const struct cheri_test *ctp)
 		errx(EX_OSERR, "elf_aux_info: %s", strerror(error));
 	exec_args[argc++] = execpath;
 	exec_args[argc++] = "-E";
+	if (extra_argc > 0)
+		exec_args[argc++] = "-K";
 	if (coredump_enabled)
 		exec_args[argc++] = "-c";
 	if (verbose)
 		exec_args[argc++] = "-v";
 	exec_args[argc++] = ctp->ct_name;
+	while (extra_argc > 0) {
+		exec_args[argc++] = *(extra_args++);
+		extra_argc--;
+	}
 	exec_args[argc++] = NULL;
 
 	return (__DECONST(char **, exec_args));
 }
 
 pid_t
-cheribsdtest_spawn_child(enum spawn_child_mode mode)
+cheribsdtest_spawn_child_args(enum spawn_child_mode mode, char **argv,
+    char **envv)
 {
 	char **exec_args;
 	int error;
 	pid_t pid;
 
-	exec_args = mk_exec_args(running_test);
+	exec_args = mk_exec_args(running_test, argv);
 
 	switch (mode) {
 	case SC_MODE_POSIX_SPAWN:
+		if (envv == NULL)
+			envv = environ;
 		error = posix_spawn(&pid, exec_args[0], NULL, NULL, exec_args,
-		    environ);
+		    envv);
 		if (error != 0) {
 			errno = error;
 			pid = -1;
@@ -738,8 +755,14 @@ cheribsdtest_spawn_child(enum spawn_child_mode mode)
 	if (pid == -1)
 		err(EX_OSERR, "%s: fork/spawn error (mode = %d)", __func__, mode);
 	if (mode != SC_MODE_POSIX_SPAWN && pid == 0)
-		execve(exec_args[0], exec_args, NULL);
+		execve(exec_args[0], exec_args, envv);
 	return (pid);
+}
+
+pid_t
+cheribsdtest_spawn_child(enum spawn_child_mode mode)
+{
+	return (cheribsdtest_spawn_child_args(mode, NULL, NULL));
 }
 
 static const char *
@@ -810,7 +833,7 @@ main(int argc, char *argv[])
 	argc = xo_parse_args(argc, argv);
 	if (argc < 0)
 		errx(1, "xo_parse_args failed\n");
-	while ((opt = getopt(argc, argv, "acdEfglQqsuvx")) != -1) {
+	while ((opt = getopt(argc, argv, "acdEfgKlQqsuvx")) != -1) {
 		switch (opt) {
 		case 'a':
 			run_all = 1;
@@ -829,6 +852,9 @@ main(int argc, char *argv[])
 			break;
 		case 'g':
 			glob = 1;
+			break;
+		case 'K':
+			execed_child_has_extra_argv = 1;
 			break;
 		case 'l':
 			list = 1;
@@ -866,12 +892,16 @@ main(int argc, char *argv[])
 	}
 	argc -= optind;
 	argv += optind;
+	if (execed_child_has_extra_argv && !is_execed_child) {
+		warnx("-K requires -E");
+		usage();
+	}
 	if (is_execed_child) {
 		if (run_all || glob || list) {
 			warnx("-E is incompatible with -a, -g, and -l");
 			usage();
 		}
-		if (argc != 1) {
+		if (argc != 1 && !execed_child_has_extra_argv) {
 			warnx("-E requires exactly one test argument");
 			usage();
 		}

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -386,6 +386,8 @@ extern ptraddr_t find_address_space_gap(size_t len, size_t align);
  * function.
  */
 extern pid_t cheribsdtest_spawn_child(enum spawn_child_mode mode);
+extern pid_t cheribsdtest_spawn_child_args(enum spawn_child_mode mode,
+    char **argv, char **envv);
 
 const char *skip_need_cheri_revoke(const struct cheri_test *ctp);
 const char *skip_need_default_cheri_revoke(const struct cheri_test *ctp);

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -363,6 +363,17 @@ cheri_ptr_equal_exact(void *x, void *y)
 #endif
 }
 
+/*
+ * Snapshot of the startup state upon entry to main().
+ * This is used by tests that need to verify properties that may
+ * be tampered with by the cheribsdtest runtime environment.
+ */
+struct cheribsdtest_entrystate {
+	int es_argc;
+	char **es_argv;
+};
+
+extern struct cheribsdtest_entrystate entrystate;
 
 /* For libc_memcpy and libc_memset tests and the unaligned copy tests: */
 extern void *cheribsdtest_memcpy(void *dst, const void *src, size_t n);

--- a/bin/cheribsdtest/cheribsdtest_cheriabi.c
+++ b/bin/cheribsdtest/cheribsdtest_cheriabi.c
@@ -42,7 +42,9 @@
 #include <sys/signal.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 
+#include <assert.h>
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -53,9 +55,13 @@
 #include <sysexits.h>
 #include <unistd.h>
 
+#include <cheri/cheric.h>
+
 #include "cheribsdtest.h"
 
 #define	MINCORE_PAGES	3
+
+extern char **environ;
 
 CHERIBSDTEST(cheriabi_mincore,
     "Test CheriABI mincore() with various permissions and bounds")
@@ -779,5 +785,176 @@ CHERIBSDTEST(cheriabi_shmdt_invalid_ptr,
 
 	/* Unmapping the original capabilities should succeed. */
 	free_adjacent_mappings_shm(&mappings);
+	cheribsdtest_success();
+}
+
+/*
+ * Verify that the argv/envv array elements are precisely bounded and
+ * do not have overlapping bounds.
+ */
+static void
+check_string_array_bounds(char **argp)
+{
+	int i;
+
+	for (i = 0; argp[i] != NULL; i++) {
+		char *arg = argp[i];
+
+		CHERIBSDTEST_VERIFY2(
+			cheri_base_get(arg) == cheri_address_get(arg),
+			"unexpected argp[%d] addr and base %#p", i, arg);
+		if (argp[i + 1] != NULL) {
+			char *next = argp[i + 1];
+			CHERIBSDTEST_VERIFY2(cheri_base_get(arg) <
+			    cheri_base_get(next),
+			    "Invalid argp[%d] base: expect %#p < %#p",
+			    i, arg, next);
+			CHERIBSDTEST_VERIFY2(cheri_top_get(arg) <=
+			    cheri_base_get(next),
+			    "Invalid argp[%d] top: %#p overlaps %#p",
+			    i, arg, next);
+		}
+	}
+}
+
+/*
+ * Verify that the argv and envv vectors are precisely bounded.
+ * Verify that each individual string in argv and envv is precisely
+ * bounded and bounds do not overlap.
+ * This assumes that the kernel lays out the argv and envv arrays in-order,
+ * meaning that if the string index i < j, then base(argv[i]) < base(argv[j]).
+ */
+static void
+cheriabi_check_argv_envv_bounds(void)
+{
+	char **argv = entrystate.es_argv;
+	ptraddr_t argv_top = cheri_top_get(argv) - 1;
+	ptraddr_t envv_top = cheri_top_get(environ) - 1;
+
+	if (verbose)
+		fprintf(stderr, "argv=%#p\n", argv);
+
+	/*
+	 * Verify that the argv array is precisely bounded and
+	 * does not overlap envv.
+	 */
+	CHERIBSDTEST_VERIFY2(cheri_base_get(argv) ==
+	    cheri_address_get(argv),
+	    "invalid argv base %#p", argv);
+	CHERIBSDTEST_VERIFY2(cheri_base_get(environ) ==
+	    cheri_address_get(environ),
+	    "invalid envv base %#p", environ);
+	CHERIBSDTEST_VERIFY2(!cheri_is_address_inbounds(environ, argv_top) &&
+	    !cheri_is_address_inbounds(argv, envv_top),
+	    "invalid argv bounds %#p overlaps envv %#p",
+	    argv, environ);
+
+	check_string_array_bounds(argv);
+	check_string_array_bounds(environ);
+
+	exit(0);
+}
+
+CHERIBSDTEST(cheriabi_argv_bounds,
+    "Check that argv strings are aligned for representability",
+    .ct_child_func = cheriabi_check_argv_envv_bounds)
+{
+	char *argv[2];
+	char *envv[1];
+	char *large_entry;
+	pid_t pid;
+	int res;
+	/*
+	 * Note: the child process is run with <execpath> -E -K <testname> which
+	 * means that we don't have full control over the argv data.
+	 *
+	 * The large_entry_size of 50000 bytes string should be unrepresentable
+	 * everywhere and allows some slack on alignment of the kernel string
+	 * buffer.
+	 * On RISC-V expect CRAM(large_entry_size) = 0xffffffffffffffc0.
+	 */
+	const size_t large_entry_size = 50000;
+
+	large_entry = malloc(large_entry_size);
+	memset(large_entry, 'A', large_entry_size - 1);
+	large_entry[large_entry_size - 1] = '\0';
+
+	argv[0] = large_entry;
+	argv[1] = NULL;
+	envv[0] = NULL;
+
+	pid = cheribsdtest_spawn_child_args(SC_MODE_FORK, argv, envv);
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	free(large_entry);
+
+	if (res != 0)
+		cheribsdtest_failure_errx("argv bounds check failed: %d", res);
+
+	cheribsdtest_success();
+}
+
+CHERIBSDTEST(cheriabi_envv_bounds,
+    "Check that envv strings are aligned for representability",
+    .ct_child_func = cheriabi_check_argv_envv_bounds)
+{
+	char *envv[3];
+	char small_entry[] = "XX";
+	char *large_entry;
+	pid_t pid;
+	int res;
+	/* See cheriabi_argv_bounds */
+	const size_t large_entry_size = 50000;
+
+	large_entry = malloc(large_entry_size);
+	memset(large_entry, 'A', large_entry_size - 1);
+	envv[0] = small_entry;
+	envv[1] = large_entry;
+	envv[2] = NULL;
+
+	pid = cheribsdtest_spawn_child_args(SC_MODE_FORK, NULL, envv);
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	free(large_entry);
+
+	if (res != 0)
+		cheribsdtest_failure_errx("envv bounds check failed");
+
+	cheribsdtest_success();
+}
+
+/*
+ * To verify argv and envv arrays representability, generate a 5000 entry
+ * argv vector and check that the envv vector sub-allocation is padded.
+ * This assumes that the argv vector begins at a pointer-aligned boundary, but
+ * not necessarily a representable boundary.
+ */
+CHERIBSDTEST(cheriabi_argv_array_bounds,
+    "Check that the argv capability is precisely bounded",
+    .ct_child_func = cheriabi_check_argv_envv_bounds)
+{
+	char **argv;
+	char empty_arg[] = "";
+	char *envv[2]= { empty_arg, NULL };
+	const size_t large_argv_size = 5000;
+	size_t i;
+	pid_t pid;
+	int res;
+
+	/* Note: expect extra argv -E -K <testname> */
+	argv = malloc((large_argv_size + 1) * sizeof(char *));
+	for (i = 0; i < large_argv_size; i++) {
+		argv[i] = empty_arg;
+	}
+	argv[large_argv_size] = NULL;
+
+	pid = cheribsdtest_spawn_child_args(SC_MODE_FORK, argv, envv);
+	CHERIBSDTEST_VERIFY2(pid > 0, "spawning child process failed");
+	waitpid(pid, &res, 0);
+	free(argv);
+
+	if (res != 0)
+		cheribsdtest_failure_errx("argv array bounds check failed");
+
 	cheribsdtest_success();
 }

--- a/bin/cheribsdtest/cheribsdtest_util.c
+++ b/bin/cheribsdtest/cheribsdtest_util.c
@@ -59,7 +59,11 @@
 static void
 vcheribsdtest_failure_errx(const char *msg, va_list ap)
 {
-
+	if (ccsp == NULL) {
+		vfprintf(stderr, msg, ap);
+		fprintf(stderr, "\n");
+		return;
+	}
 	ccsp->ccs_testresult = TESTRESULT_FAILURE;
 	vsnprintf(ccsp->ccs_testresult_str, sizeof(ccsp->ccs_testresult_str),
 	    msg, ap);
@@ -71,6 +75,11 @@ vcheribsdtest_failure_errc(int code, const char *msg, va_list ap)
 	size_t buflen;
 	int len;
 
+	if (ccsp == NULL) {
+		vfprintf(stderr, msg, ap);
+		fprintf(stderr, "\n");
+		return;
+	}
 	ccsp->ccs_testresult = TESTRESULT_FAILURE;
 	buflen = sizeof(ccsp->ccs_testresult_str);
 	len = vsnprintf(ccsp->ccs_testresult_str, buflen, msg, ap);

--- a/sys/cheri/cheric.h
+++ b/sys/cheri/cheric.h
@@ -242,13 +242,13 @@ cheri_can_access(const void * __capability cap, ptraddr_t perms,
 #endif /* !__has_feature(capabilities) */
 
 /* Provide macros to make it easier to work with the raw CRAM/CRRL results: */
-#define	CHERI_REPRESENTABLE_ALIGNMENT(len) \
+#define	CHERI_REPRESENTABLE_ALIGNMENT(len)		\
 	(~CHERI_REPRESENTABLE_ALIGNMENT_MASK(len) + 1)
-#define	CHERI_REPRESENTABLE_ALIGN_DOWN(base, len) \
-	((base) & CHERI_REPRESENTABLE_ALIGNMENT_MASK(len))
+#define	CHERI_REPRESENTABLE_ALIGN_DOWN(base, len)		\
+	__align_down((base), CHERI_REPRESENTABLE_ALIGNMENT(len))
 
 #if __has_feature(capabilities)
-#define	CHERI_REPRESENTABLE_ALIGN_UP(base, len) \
+#define	CHERI_REPRESENTABLE_ALIGN_UP(base, len)			\
 	__align_up((base), CHERI_REPRESENTABLE_ALIGNMENT(len))
 #else
 #define	CHERI_REPRESENTABLE_ALIGN_UP(base, len) (base)

--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1753,6 +1753,10 @@ exec_args_add_str(struct image_args *args, const char * __capability str,
 {
 	int error;
 	size_t length;
+#if __has_feature(capabilities)
+	size_t rounded_length;
+	size_t base_pad;
+#endif
 
 	KASSERT(args->endp != NULL, ("endp not initialized"));
 	KASSERT(args->begin_argv != NULL, ("begin_argp not initialized"));
@@ -1765,7 +1769,16 @@ exec_args_add_str(struct image_args *args, const char * __capability str,
 		    &length);
 	if (error != 0)
 		return (error == ENAMETOOLONG ? E2BIG : error);
+#if __has_feature(capabilities)
+	rounded_length = CHERI_REPRESENTABLE_LENGTH(length);
+	base_pad = CHERI_REPRESENTABLE_ALIGN_UP(args->endp, rounded_length) -
+	    args->endp;
+	if (rounded_length + base_pad > args->stringspace)
+		return (E2BIG);
+	args->stringspace -= base_pad + rounded_length;
+#else
 	args->stringspace -= length;
+#endif
 	args->endp += length;
 	(*countp)++;
 
@@ -1828,9 +1841,6 @@ exec_args_get_begin_envv(struct image_args *args)
  * Copy strings out to the new process address space, constructing new arg
  * and env vector tables. Return a pointer to the base so that it can be used
  * as the initial stack pointer.
- *
- * XXX: We may want a wrapper of cheri_bounds_set() that warns about
- * capabilities that are overly broad.
  */
 int
 exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
@@ -1843,9 +1853,15 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	struct proc *p;
 	struct sysentvec *sysent;
 	size_t execpath_len, len;
+	size_t strings_len;
 	int error, szsigcode;
 	char canary[sizeof(long) * 8];
 	bool strings_on_stack;
+#if __has_feature(capabilities)
+	size_t rounded_len;
+	size_t argv_space, envv_space;
+	uintcap_t vecstr_cap;
+#endif
 
 	p = imgp->proc;
 	sysent = p->p_sysent;
@@ -1929,11 +1945,16 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 
 	/*
 	 * Allocate room for the argument and environment strings.
+	 * On CHERI, ensure that the entire stringspace sub-allocation is
+	 * representable.
 	 */
-	destp -= ARG_MAX - imgp->args->stringspace;
+	strings_len = ARG_MAX - imgp->args->stringspace;
+	destp -= strings_len;
 	destp = rounddown2(destp, sizeof(void * __capability));
 #if __has_feature(capabilities)
-	ustringp = cheri_bounds_set(destp, ARG_MAX - imgp->args->stringspace);
+	strings_len = CHERI_REPRESENTABLE_LENGTH(strings_len);
+	destp = CHERI_REPRESENTABLE_ALIGN_DOWN(destp, strings_len);
+	ustringp = cheri_bounds_set_exact(destp, strings_len);
 #else
 	ustringp = destp;
 #endif
@@ -1965,7 +1986,18 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	 * Allocate room for the argv[] and env vectors including the
 	 * terminating NULL pointers.
 	 */
+#if __has_feature(capabilities)
+	argv_space = (imgp->args->argc + 1) * sizeof(*vectp);
+	envv_space = (imgp->args->envc + 1) * sizeof(*vectp);
+	envv_space = CHERI_REPRESENTABLE_LENGTH(envv_space);
+	vectp -= imgp->args->envc + 1;
+	vectp = CHERI_REPRESENTABLE_ALIGN_DOWN(vectp, envv_space);
+	argv_space = CHERI_REPRESENTABLE_LENGTH(argv_space);
+	vectp -= imgp->args->argc + 1;
+	vectp = CHERI_REPRESENTABLE_ALIGN_DOWN(vectp, argv_space);
+#else
 	vectp -= imgp->args->argc + 1 + imgp->args->envc + 1;
+#endif
 
 	if (!strings_on_stack) {
 		*stack_base = (uintcap_t)imgp->stack;
@@ -1982,17 +2014,23 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 
 	/*
 	 * Copy out strings - arguments and environment.
+	 *
+	 * For CHERI, strings are copied out individually when populating the
+	 * string vectors to account for padding. For non-CHERI, the buffer is
+	 * packed and copied out as one buffer.
 	 */
+#if !__has_feature(capabilities)
 	error = copyout(stringp, (void * __capability)ustringp,
 	    ARG_MAX - imgp->args->stringspace);
 	if (error != 0)
 		return (error);
+#endif
 
 	/*
 	 * Fill in "ps_strings" struct for ps, w, etc.
 	 */
 #if __has_feature(capabilities)
-	imgp->argv = cheri_bounds_set(vectp, (argc + 1) * sizeof(*vectp));
+	imgp->argv = cheri_bounds_set_exact(vectp, argv_space);
 #else
 	imgp->argv = vectp;
 #endif
@@ -2006,14 +2044,21 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	for (; argc > 0; --argc) {
 		len = strlen(stringp) + 1;
 #if __has_feature(capabilities)
-		if (sucap(vectp++, cheri_bounds_set(ustringp, len)) != 0)
+		rounded_len = CHERI_REPRESENTABLE_LENGTH(len);
+		ustringp = CHERI_REPRESENTABLE_ALIGN_UP(ustringp, rounded_len);
+		error = copyout(stringp, (void * __capability)ustringp, len);
+		if (error != 0)
+			return (error);
+		vecstr_cap = cheri_bounds_set_exact(ustringp, rounded_len);
+		if (sucap(vectp++, vecstr_cap) != 0)
 			return (EFAULT);
+		ustringp += rounded_len;
 #else
 		if (suptr(vectp++, ustringp) != 0)
 			return (EFAULT);
+		ustringp += len;
 #endif
 		stringp += len;
-		ustringp += len;
 	}
 
 	/* a null vector table pointer separates the argp's from the envp's */
@@ -2021,7 +2066,8 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 		return (EFAULT);
 
 #if __has_feature(capabilities)
-	imgp->envv = cheri_bounds_set(vectp, (envc + 1) * sizeof(*vectp));
+	vectp = CHERI_REPRESENTABLE_ALIGN_UP(vectp, argv_space);
+	imgp->envv = cheri_bounds_set_exact(vectp, envv_space);
 #else
 	imgp->envv = vectp;
 #endif
@@ -2035,14 +2081,22 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	for (; envc > 0; --envc) {
 		len = strlen(stringp) + 1;
 #if __has_feature(capabilities)
-		if (sucap(vectp++, cheri_bounds_set(ustringp, len)) != 0)
+		rounded_len = CHERI_REPRESENTABLE_LENGTH(len);
+		ustringp = CHERI_REPRESENTABLE_ALIGN_UP(ustringp, rounded_len);
+		error = copyout(stringp, (void * __capability)ustringp,
+		    rounded_len);
+		if (error != 0)
+			return (error);
+		vecstr_cap = cheri_bounds_set_exact(ustringp, rounded_len);
+		if (sucap(vectp++, vecstr_cap) != 0)
 			return (EFAULT);
+		ustringp += rounded_len;
 #else
 		if (suptr(vectp++, ustringp) != 0)
 			return (EFAULT);
+		ustringp += len;
 #endif
 		stringp += len;
-		ustringp += len;
 	}
 
 	/* end of vector table is a null pointer */
@@ -2052,7 +2106,7 @@ exec_copyout_strings(struct image_params *imgp, uintcap_t *stack_base)
 	if (imgp->auxargs) {
 		vectp++;
 #if __has_feature(capabilities)
-		imgp->auxv = cheri_bounds_set(vectp,
+		imgp->auxv = cheri_bounds_set_exact(vectp,
 		    AT_COUNT * sizeof(Elf_Auxinfo));
 #else
 		imgp->auxv = vectp;


### PR DESCRIPTION
Ensure representability of argv, envv vectors and the respective string pointers.

Currently this introduces additional padding and does not attempt to optimize it, still it should be POSIX-compliant.
The current code does not attempt to initialize the padding in memory, perhaps we should be mapping the strings region with MAP_ZERO?