### PR TITLE
Expose struct capreg for non-CHERI compilers

### DIFF
--- a/sys/arm64/include/reg.h
+++ b/sys/arm64/include/reg.h
@@ -103,7 +103,15 @@ struct arm64_addr_mask {
 	__uint64_t	data;
 };
 
-#if __has_feature(capabilities)
+#if !__has_feature(capabilities)
+struct __chericap {
+	__uint64_t	addr;
+	__uint64_t	meta;
+} __aligned(16);
+
+#define	__uintcap_t	struct __chericap
+#endif
+
 struct capreg {
 	__uintcap_t c[30];
 	__uintcap_t clr;
@@ -119,9 +127,13 @@ struct capreg {
 	__uint64_t tagmask;
 	__uint64_t pad;
 };
+
+#if !__has_feature(capabilities)
+#undef	__uintcap_t
 #endif
 
 #define	__HAVE_REG32
+#define	__HAVE_CAPREG
 
 #endif /* !_MACHINE_REG_H_ */
 

--- a/sys/riscv/include/reg.h
+++ b/sys/riscv/include/reg.h
@@ -58,7 +58,15 @@ struct dbreg {
 	int dummy;
 };
 
-#if __has_feature(capabilities)
+#if !__has_feature(capabilities)
+struct __chericap {
+	__uint64_t	addr;
+	__uint64_t	meta;
+} __aligned(16);
+
+#define	__uintcap_t	struct __chericap
+#endif
+
 struct capreg {
 	__uintcap_t cra;		/* return address */
 	__uintcap_t csp;		/* stack pointer */
@@ -72,6 +80,11 @@ struct capreg {
 	__uint64_t tagmask;
 	__uint64_t pad;
 };
+
+#if !__has_feature(capabilities)
+#undef	__uintcap_t
 #endif
+
+#define	__HAVE_CAPREG
 
 #endif /* !_MACHINE_REG_H_ */


### PR DESCRIPTION
Define a struct __chericap with two words that requires 16-byte
alignment and use it in place of __uintcap_t for struct capreg when
compiling without CHERI support.

While here, add a __HAVE_CAPREG helper macro that can be used to
detect this at compile time.

In particular, this should permit compiling GDB as a plain 64-bit
binary rather than hybrid.
