### PR TITLE
Stop creating compat/cheriabi include directories

### DIFF
--- a/ObsoleteFiles.inc
+++ b/ObsoleteFiles.inc
@@ -51,6 +51,10 @@
 #   xargs -n1 | sort | uniq -d;
 # done
 
+# 20260516: Stop creating compat/cheriabi include directories
+OLD_DIRS+=usr/include/compat/cheriabi
+OLD_DIRS+=usr/include/compat
+
 # 20250409: removal of iwlwifi firmware files
 OLD_FILES+=usr/share/doc/legal/intel_iwlwifi_firmware.LICENCE
 

--- a/etc/mtree/BSD.include.dist
+++ b/etc/mtree/BSD.include.dist
@@ -114,10 +114,6 @@
     ..
     cheri
     ..
-    compat
-        cheriabi
-	..
-    ..
     casper
     ..
     crypto


### PR DESCRIPTION
We stopped installing things in them in 2020 (commit 04e80a58ee8e), but missed the mtree entries.

I suppose we could add ObsoleteFiles.inc entries, but we've mostly not in the past and these directories are harmless in practice since little or nothing ever included files from them.