### PR TITLE
fix: exploit-localbase

### DIFF
--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -135,6 +135,20 @@ int	bootverbose = BOOTVERBOSE;
 SYSCTL_INT(_debug, OID_AUTO, bootverbose, CTLFLAG_RW, &bootverbose, 0,
 	"Control the output of verbose kernel messages");
 
+static void
+sift_print_debug_bootverbose_ptr(void *arg __unused)
+{
+	printf("SIFT_ACE2 DEBUG_BOOTVERBOSE_ADDRESS=%p\n",
+	&sysctl___debug_bootverbose.oid_arg1
+	);
+	printf("SIFT_ACE2 DEBUG_BOOTVERBOSE_CAPABILITY=%#p\n",
+	&sysctl___debug_bootverbose.oid_arg1
+	);
+}
+
+SYSINIT(bootverbose_sysctl_ptr, SI_SUB_TUNABLES, SI_ORDER_ANY,
+sift_print_debug_bootverbose_ptr, NULL);
+
 #ifdef VERBOSE_SYSINIT
 /*
  * We'll use the defined value of VERBOSE_SYSINIT from the kernel config to

--- a/sys/kern/kern_mib.c
+++ b/sys/kern/kern_mib.c
@@ -749,6 +749,18 @@ static char localbase[MAXPATHLEN] = "";
 SYSCTL_STRING(_user, USER_LOCALBASE, localbase, CTLFLAG_RWTUN,
     localbase, sizeof(localbase), "Prefix used to install and locate add-on packages");
 
+static void
+sift_print_localbase_sysctl_ptr(void *arg __unused)
+{
+	printf("SIFT_ACE2 USER_LOCALBASE_ADDRESS=%p\n",
+	    &sysctl___user_localbase.oid_arg1);
+	printf("SIFT_ACE2 USER_LOCALBASE_CAPABILITY=%#p\n",
+	    &sysctl___user_localbase.oid_arg1);
+}
+
+SYSINIT(localbase_sysctl_ptr, SI_SUB_TUNABLES, SI_ORDER_ANY,
+    sift_print_localbase_sysctl_ptr, NULL);
+
 #include <sys/vnode.h>
 SYSCTL_INT(_debug_sizeof, OID_AUTO, vnode, CTLFLAG_RD,
     SYSCTL_NULL_INT_PTR, sizeof(struct vnode), "sizeof(struct vnode)");


### PR DESCRIPTION
This adds back the kernel prints on boot that make the localbase exploit function.