### PR TITLE
stand: allow program headers beyond one page

### DIFF
--- a/stand/common/load_elf.c
+++ b/stand/common/load_elf.c
@@ -634,12 +634,13 @@ __elfN(loadimage)(struct preloaded_file *fp, elf_file_t ef, uint64_t off)
 	if (ef->kernel)
 		__elfN(relocation_offset) = off;
 
-	if ((ehdr->e_phoff + ehdr->e_phnum * sizeof(*phdr)) > ef->firstlen) {
-		printf("elf" __XSTRING(__ELF_WORD_SIZE)
-		    "_loadimage: program header not within first page\n");
+	phdr = alloc_pread(VECTX_HANDLE(ef), ehdr->e_phoff, ehdr->e_phnum *
+	    sizeof(*phdr));
+	if (phdr == NULL) {
+		printf("\nelf" __XSTRING(__ELF_WORD_SIZE)
+		    "_loadimage: failed to read program headers");
 		goto out;
 	}
-	phdr = (Elf_Phdr *)(ef->firstpage + ehdr->e_phoff);
 
 	for (i = 0; i < ehdr->e_phnum; i++) {
 		if (elf_program_header_convert(ehdr, phdr))
@@ -944,6 +945,8 @@ out:
 		free(dp);
 	if (shdr)
 		free(shdr);
+	if (phdr)
+		free(phdr);
 	return ret;
 }
 


### PR DESCRIPTION
Depends on https://github.com/CTSRD-CHERI/cheribsd/pull/2672.

I've tested this under bhyve and on hardware using GENERIC-MORELLO-PURECAP from dev, GENERIC-MORELLO-PURECAP-COMPARTMENTS from kernel-c18n and GENERIC-MORELLO-PURECAP-COMPARTMENTS-ARC from cpm-kernel-c18n-2026h1 using 250 compartments (the only case with multi-page program headers).

Everything works fine except for one case: GENERIC-MORELLO-PURECAP-COMPARTMENTS-ARC on hardware. When loading the kernel the boot loader prints out the following and then the host boots and runs without any issues:
```
text=0x89bdf0 text=0x81aa38 data=0x492000 data=0x0+0x27be110 text=0x11a510 text=
0x1580 data=0x230 data=0x540 text=0x11a510 text=0x140 data=0x50 data=0x160 text=
0x11a510 ConvertPages: Incompatible memory types, the pages to allocate have been allocated
text=0x60 data=0x10 data=0x80 text=0x11a510 text=0x50 data=0xa0 text=0x
11a510 ConvertPages: Incompatible memory types, the pages to allocate have been allocated
(...)
text=0x32
0 data=0x100 data=0xd0 text=0x234b10 ConvertPages: Incompatible memory types, the pages to allocate have been allocated
text=0x24 data=0xc0 text=0x9ecf30 ConvertPages: range E0000000 - E0843FFF covers multiple entries
text=0xf0
 data=0x20 data=0x1c0 0x8+0x169170+0x8+0x13e9b1ConvertPages: Incompatible memory types, the pages to allocate have been allocated
```
@jrtc27 tells me that the Morello firmware uses a debug version of EDK2. The messages printed out most likely relate to the allocations made by the boot loader for the kernel itself that overlap with each other as more are parsed. This should not be a concern but given the boot loader prints out these false negatives the Getting Started with CheriBSD guide should document this behaviour.

Fixes: https://github.com/CTSRD-CHERI/cheribsd/issues/2646