### PR TITLE
vn_mmap: reject prot that maxprot can't satisfy

### DIFF
--- a/bin/cheribsdtest/cheribsdtest_vm.c
+++ b/bin/cheribsdtest/cheribsdtest_vm.c
@@ -83,6 +83,17 @@
 static const char *skip_need_writable_tmp(
     const struct cheri_test *ctp __unused);
 
+static int
+create_tempfile(void)
+{
+	char template[] = "/tmp/cheribsdtest.XXXXXXXX";
+	int fd = CHERIBSDTEST_CHECK_SYSCALL2(mkstemp(template),
+	    "mkstemp %s", template);
+	CHERIBSDTEST_CHECK_SYSCALL(unlink(template));
+	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
+	return fd;
+}
+
 /*
  * Tests to check that tags are ... or aren't ... preserved for various page
  * types.  'Anonymous' pages provided by the VM subsystem should always
@@ -170,10 +181,16 @@ CHERIBSDTEST(vm_notag_mprotect_no_cap,
 }
 
 static void
-mmap_check_bad_protections(int prot, int expected_errno)
+mmap_check_bad_protections_fd(int prot, int fd, int expected_errno)
 {
 	CHERIBSDTEST_CHECK_CALL_ERROR(mmap(NULL, getpagesize(),
-	    prot, MAP_ANON, -1, 0), expected_errno);
+	    prot, fd == -1 ? MAP_ANON : MAP_SHARED, fd, 0), expected_errno);
+}
+
+static void
+mmap_check_bad_protections(int prot, int expected_errno)
+{
+	mmap_check_bad_protections_fd(prot, -1, expected_errno);
 }
 
 CHERIBSDTEST(vm_mmap_diallowed_prot,
@@ -190,6 +207,11 @@ CHERIBSDTEST(vm_mmap_diallowed_prot,
 	/* Disallowed explicit capability protection combinations */
 	mmap_check_bad_protections(PROT_CAP, ENOTSUP);
 	mmap_check_bad_protections(PROT_MAX(PROT_CAP), ENOTSUP);
+
+	int fd = CHERIBSDTEST_CHECK_SYSCALL(create_tempfile());
+	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
+	mmap_check_bad_protections_fd(PROT_READ|PROT_WRITE|PROT_CAP, fd,
+	    EACCES);
 
 	cheribsdtest_success();
 }
@@ -554,17 +576,6 @@ CHERIBSDTEST(vm_tag_dev_zero_private,
 	int fd = CHERIBSDTEST_CHECK_SYSCALL(open("/dev/zero", O_RDWR));
 	mmap_and_check_tag_stored(fd, PROT_READ | PROT_WRITE, MAP_PRIVATE);
 	cheribsdtest_success();
-}
-
-static int
-create_tempfile(void)
-{
-	char template[] = "/tmp/cheribsdtest.XXXXXXXX";
-	int fd = CHERIBSDTEST_CHECK_SYSCALL2(mkstemp(template),
-	    "mkstemp %s", template);
-	CHERIBSDTEST_CHECK_SYSCALL(unlink(template));
-	CHERIBSDTEST_CHECK_SYSCALL(ftruncate(fd, getpagesize()));
-	return fd;
 }
 
 /*

--- a/lib/libsys/mmap.2
+++ b/lib/libsys/mmap.2
@@ -30,7 +30,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 19, 2026
+.Dd June 23, 2026
 .Dt MMAP 2
 .Os
 .Sh NAME
@@ -505,6 +505,12 @@ and
 argument and
 .Fa fd
 was not open for writing.
+.It Bq Er EACCES
+The flags
+.Dv PROT_CAP
+and
+.Dv MAP_SHARED
+were specified.
 .It Bq Er EBADF
 The
 .Fa fd

--- a/sys/kern/vfs_vnops.c
+++ b/sys/kern/vfs_vnops.c
@@ -2980,6 +2980,8 @@ vn_mmap(struct file *fp, vm_map_t map, vm_pointer_t *addr,
 			maxprot |= VM_PROT_WRITE;
 		else if ((prot & VM_PROT_WRITE) != 0)
 			return (EACCES);
+		if (((prot | cap_maxprot) & VM_PROT_CAP) != 0)
+			return (EACCES);
 	} else {
 		maxprot |= VM_PROT_WRITE;
 		cap_maxprot |= VM_PROT_WRITE;


### PR DESCRIPTION
This is sufficient to avoid a panic in the test case derived from @bsdphk's report in https://github.com/CTSRD-CHERI/cheribsd/pull/884#issuecomment-4581864774

We could probably use some fuzzing here to find additional missing cases.