### PR TITLE
compartmentalization.7: Mention unwinding-related APIs explicitly

### DIFF
--- a/share/man/man7/compartmentalization.7
+++ b/share/man/man7/compartmentalization.7
@@ -218,6 +218,8 @@ can access the program headers of all loaded libraries.
 .It
 .Xr elf_aux_info 3
 can return highly privileged pointers.
+.It
+unwinding-related APIs can cross compartment boundaries.
 .El
 .Sh AUTHORS
 .An Dapeng Gao Aq Mt dapeng.gao@cl.cam.ac.uk


### PR DESCRIPTION
Given libunwind is called libgcc_s/libgcc_eh on FreeBSD, mentioning it might be a bit confusing. We also don't have .Lb support for any of these, nor do I believe there are manpages for functions we could .Xr, so this just uses vague English instead.

Fixes:	https://github.com/CTSRD-CHERI/cheribsd/issues/2235