### PR TITLE
rtld-elf: Make _rtld_unw_setcontext go via the GOT for data access

### DIFF
--- a/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
+++ b/libexec/rtld-elf/aarch64/rtld_c18n_asm.S
@@ -57,7 +57,9 @@ END(_rtld_unw_getcontext_epilogue)
  * mode). Otherwise, call _rtld_unw_setcontext_impl via a trampoline.
  */
 ENTRY(_rtld_unw_setcontext)
-	ldr	c16, _rtld_unw_setcontext_ptr
+	adrp	c16, :got:_rtld_unw_setcontext_ptr
+	ldr	c16, [c16, :got_lo12:_rtld_unw_setcontext_ptr]
+	ldr	c16, [c16]
 	cbnz	w16, 1f
 	/*
 	 * FIXME: llvm-libunwind specific ABI. This should be better specified.


### PR DESCRIPTION
_rtld_unw_setcontext_ptr is writable data so lives in .data which is
outside PCC bounds in newer Morello LLVM[1], and fails to link with an
error in very new Morello LLVM[2] due to this being a PCC-relative
direct acess (previously the special relocation for this instruction was
missed and not treated as such). Get a properly-bounded capability via
the GOT instead.

Note that this is a direct commit to releng/25.03 as dev retired this
compatibility shim in 7fe13598fc70 ("c18n: Remove all compatibility code
for old libunwind").

[1] As of 6c55c004faec ("[ELF][Cheri] Adjust section ranks to minimise
    PT_CHERI_PCC") or, given this is rtld where there will be no PLT
    entries, more likely 38f8428248ed ("[ELF][CHERI] Output a
    PT_CHERI_PCC segment for CheriABI binaries and DSOs")

[2] As of 37f9b5670b45 ("[ELF] Add R_MORELLO_VADREF to the list of
    relocations needing PCC bounds")

Fixes:	7033001ad712 ("c18n: Make _rtld_unw_setcontext callable via function pointer")
