### PR TITLE
subr_module: Extend preloaded module data bounds to include header

### DIFF
--- a/sys/kern/subr_module.c
+++ b/sys/kern/subr_module.c
@@ -206,8 +206,8 @@ preload_search_info(caddr_t mod, int inf)
 	 * data.
 	 */
 	if (hdr[0] == inf)
-	    return (cheri_kern_bounds_set(curp + (sizeof(uint32_t) * 2),
-	        hdr[1]));
+	    return (cheri_kern_bounds_set(curp, hdr[1] + sizeof(uint32_t) * 2)
+		+ sizeof(uint32_t) * 2);
 
 	/* skip to next field */
 	next = sizeof(uint32_t) * 2 + hdr[1];


### PR DESCRIPTION
It's explicitly documented here that the caller can read the size in the
header just before the returned pointer, so our bounds need to include
that, and we probably should also include the type to go with it (even
though presumably you know what type you just asked for...). This is in
fact relied on by link_elf_locate_exidx_preload, though that's a 32-bit
Arm function so not relevant for CHERI, but nevertheless we should do
the right thing in case other uses arise for reading the header.

Fixes:	19058c7f4702 ("purecap-kernel: Set bounds on pointers to preload data.")
