### PR TITLE
link_elf: Derive most pointers in elf_init rather than locore

### DIFF
--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -326,61 +326,24 @@ virtdone:
 	/*
 	 * Initialize kernel's ELF file.
 	 *
-	 * Statically relocate dependencies of dynamic relocation routines and
-	 * pass them as arguments to the relocation routines. The dependencies
-	 * must be reachable from DDC and PCC at this stage.
-	 *
 	 * In a purecap kernel, also relocate the kernel itself to construct
 	 * valid capabilities.
 	 */
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	ldr	x0, =~CHERI_PERMS_KERNEL_DATA
-	mrs	c2, ddc
-	clrperm	c2, c2, x0
-#endif
-
-	adrp	PTR(0), elf_kernel_file
-	add	PTR(0), PTR(0), :lo12:elf_kernel_file
-
-	adrp	PTR(1), _DYNAMIC
-	add	PTR(1), PTR(1), :lo12:_DYNAMIC
-
-	adrp	PTR(4), elf_kernel_plts
-	add	PTR(4), PTR(4), :lo12:elf_kernel_plts
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	scvalue c0, c2, x0
-	scvalue	c1, c2, x1
-#ifdef CHERI_COMPARTMENTALIZE_KERNEL
-	gclim	x3, c2
-#else
-	ldr	x3, =_end
-#endif
-	scvalue	c4, c2, x4
-
-#ifdef CHERI_COMPARTMENTALIZE_KERNEL
-	adrp	c5, elf_kernel_compartments
-	add	c5, c5, :lo12:elf_kernel_compartments
-
-	adrp	c6, compartment_lastid
-	add	c6, c6, :lo12:compartment_lastid
-
-	adrp	c7, elf_kernel_pccs
-	add	c7, c7, :lo12:elf_kernel_pccs
-
-	scvalue	c5, c2, x5
-	scvalue	c6, c2, x6
-	scvalue	c7, c2, x7
-#endif
-
 	/*
 	 * Pass DDC without restrictions. We use it as a relocation base that
 	 * must be both executable and writable (for ifunc resolvers).
 	 */
-	mrs	c2, ddc
+	mrs	c0, ddc
 #else
-	mov	x2, 0
+	mov	x0, 0
+#endif
+
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+	gclim	x1, c0
+#else
+	ldr	x1, =_end
 #endif
 
 	bl	elf_init

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -86,6 +86,10 @@
 #include <ddb/db_ctf.h>
 #endif
 
+#if !__has_feature(capabilities) && !defined(CHERI_RODATA_PTR)
+#define	CHERI_RODATA_PTR(x)	(&(*x))
+#endif
+
 /*
  * Maximum number of program headers not related to extra compartments.
  */
@@ -735,22 +739,38 @@ SYSCTL_ULONG(_kern, OID_AUTO, relbase_address, CTLFLAG_RD,
 	&kern_relbase, 0, "Kernel relocated base address");
 
 void
-elf_init(elf_file_t ef, Elf_Dyn *dynp, void *relocbase, ptraddr_t baseend,
-    elf_plt_t plts
-#ifdef CHERI_COMPARTMENTALIZE_KERNEL
-    , elf_compartment_t compartments, u_long *lastidp, elf_pcc_t pccs
-#endif
-    )
+elf_init(void *relocbase, ptraddr_t baseend)
 {
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
 	linker_file_t lf;
 	const Elf_Ehdr *hdr;
 	const Elf_Phdr *phlimit, *phdr, *phtable;
+	elf_compartment_t compartments;
+	u_long *lastidp;
+	elf_pcc_t pccs;
 #endif
 #ifdef __CHERI_PURE_CAPABILITY__
 	void *code_cap, *data_cap;
 #endif
+	elf_file_t ef;
+	Elf_Dyn *dynp;
+	elf_plt_t plts;
 	int error;
+
+#define	RELOCBASE_DATA_PTR(p) \
+	(__typeof__((0, p)))cheri_kern_address_set(cheri_kern_perms_and( \
+	    relocbase, CHERI_PERMS_KERNEL_DATA), \
+	    (ptraddr_t)CHERI_RODATA_PTR(p))
+	ef = RELOCBASE_DATA_PTR(__unbounded_addressof(elf_kernel_file));
+	dynp = (Elf_Dyn *)RELOCBASE_DATA_PTR(__unbounded_addressof(_DYNAMIC));
+	plts = RELOCBASE_DATA_PTR(__builtin_no_change_bounds(elf_kernel_plts));
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+	compartments = RELOCBASE_DATA_PTR(__builtin_no_change_bounds(
+	    elf_kernel_compartments));
+	lastidp = RELOCBASE_DATA_PTR(__unbounded_addressof(compartment_lastid));
+	pccs = RELOCBASE_DATA_PTR(__builtin_no_change_bounds(elf_kernel_pccs));
+#endif
+#undef	RELOCBASE_DATA_PTR
 
 	/*
 	 * Initialize an ELF file object for the kernel.

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -391,30 +391,15 @@ va:
 	/*
 	 * Initialize kernel's ELF file.
 	 *
-	 * Statically relocate dependencies of dynamic relocation routines and
-	 * pass them as arguments to the relocation routines. The dependencies
-	 * must be reachable from DDC and PCC at this stage.
-	 *
 	 * Also, relocate the kernel itself to construct valid capabilities.
 	 */
-
-	li	a2, CHERI_PERMS_KERNEL_DATA
-	candperm ca2, cs0, a2
-
-	cllc	ca0, _C_LABEL(elf_kernel_file)
-	cllc	ca1, _C_LABEL(_DYNAMIC)
-	cllc	ca3, _C_LABEL(_end)
-	cllc	ca4, _C_LABEL(elf_kernel_plts)
-
-	csetaddr ca0, ca2, a0
-	csetaddr ca1, ca2, a1
-	csetaddr ca4, ca2, a4
+	cllc	ca1, _C_LABEL(_end)
 
 	/*
 	 * Pass DDC without restrictions. We use it as a relocation base that
 	 * must be both executable and writable.
 	 */
-	cmove	ca2, cs0
+	cmove	ca0, cs0
 
 	cllc	cra, _C_LABEL(elf_init)
 	cjalr	cra
@@ -462,11 +447,8 @@ va:
 	/*
 	 * Initialize kernel's ELF file.
 	 */
-	la	a0, _C_LABEL(elf_kernel_file)
-	la	a1, _C_LABEL(_DYNAMIC)
-	mv	a2, zero
-	la	a3, _C_LABEL(_end)
-	la	a4, _C_LABEL(elf_kernel_plts)
+	mv	a0, zero
+	la	a1, _C_LABEL(_end)
 	call	_C_LABEL(elf_init)
 
 #if __has_feature(capabilities)

--- a/sys/sys/compartment.h
+++ b/sys/sys/compartment.h
@@ -69,6 +69,8 @@ STAILQ_HEAD(compartment_list, compartment);
 
 extern struct compartment compartments0[KERNEL_MAXC18NS];
 
+extern u_long compartment_lastid;
+
 void compartment_metadata_create(u_long id, const char *name, uintcap_t base,
     elf_compartment_t elf_compartment);
 void compartment_metadata_insert(struct compartment *compartment);

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -345,12 +345,7 @@ extern int kld_debug;
 typedef int elf_lookup_fn(linker_file_t, Elf_Size, int, uintptr_t *);
 
 /* Support functions */
-void	elf_init(elf_file_t ef, Elf_Dyn *dynp, void *relocbase,
-	    ptraddr_t baseend, elf_plt_t plts
-#ifdef CHERI_COMPARTMENTALIZE_KERNEL
-	    , elf_compartment_t compartments, u_long *lastidp, elf_pcc_t pccs
-#endif
-	);
+void	elf_init(void *relocbase, ptraddr_t baseend);
 void	elf_init_data(void);
 bool	elf_is_ifunc_reloc(Elf_Size r_info);
 int	elf_reloc(linker_file_t _lf, char *base, const void *_rel, int _type,


### PR DESCRIPTION
Once we have relocbase we can use it with CHERI_RODATA_PTR to derive
whatever writable capabilities to globals we need early in boot prior to
relocation processing, greatly simplifying the interface and making it
no longer dependent on whether compartmentalisation is in use.
