### PR TITLE
link_elf: Assume we should always honour PCC bounds

### DIFF
--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -461,13 +461,12 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 	const Elf_Rel *rel;
 	const Elf_Rela *rela;
 	int error;
-#if __has_feature(capabilities)
-	bool use_code_bounds = false;
+#ifdef __CHERI_PURE_CAPABILITY__
+	const bool use_code_bounds = true;
+#elif __has_feature(capabilities)
+	const bool use_code_bounds = false;
 #endif
 
-#ifdef __CHERI_PURE_CAPABILITY__
-	use_code_bounds = (lf->flags & LINKER_FILE_PCC_BOUNDS) != 0;
-#endif
 	switch (type) {
 	case ELF_RELOC_REL:
 		rel = (const Elf_Rel *)data;
@@ -767,33 +766,10 @@ arm64_exec_protect(struct image_params *imgp, int flags __unused)
 void __nosanitizecoverage
 elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 {
-	const Elf_Ehdr *hdr;
-	const Elf_Phdr *phdr, *phlimit;
 	const Elf_Rela *rela = NULL, *rela_end;
 	Elf_Addr *fragment;
 	uintptr_t cap;
 	size_t rela_size = 0;
-	bool use_code_bounds = false;
-
-	/* See if there is an ELF header is at KERNBASE. */
-	hdr = data_cap;
-	if (IS_ELF(*hdr) &&
-	    hdr->e_ident[EI_CLASS] == ELF_TARG_CLASS &&
-	    hdr->e_ident[EI_DATA] == ELF_TARG_DATA &&
-	    hdr->e_ident[EI_VERSION] == EV_CURRENT &&
-	    hdr->e_machine == ELF_TARG_MACH &&
-	    hdr->e_version == ELF_TARG_VER &&
-	    hdr->e_phentsize == sizeof(Elf_Phdr) &&
-	    ELF_IS_CHERI(hdr)) {
-		phdr = (const Elf_Phdr *)((const char *)hdr + hdr->e_phoff);
-		phlimit = phdr + hdr->e_phnum;
-		for (; phdr < phlimit; phdr++) {
-			if (phdr->p_type == PT_CHERI_PCC) {
-				use_code_bounds = true;
-				break;
-			}
-		}
-	}
 
 	for (; dynp->d_tag != DT_NULL; dynp++) {
 		switch (dynp->d_tag) {
@@ -818,8 +794,7 @@ elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 			fragment = (Elf_Addr *)cheri_address_set(data_cap,
 			    rela->r_offset);
 			cap = build_cap_from_fragment(fragment, 0,
-			    rela->r_addend, data_cap, code_cap,
-			    use_code_bounds);
+			    rela->r_addend, data_cap, code_cap, true);
 			*((uintptr_t *)fragment) = cap;
 			break;
 		}

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -514,11 +514,7 @@ ef_create_pcc_caps(elf_file_t ef, const Elf_Phdr *phstart,
 		}
 	}
 
-	if (ef->npcc_caps == 0)
-		return (true);
-
 	valid = true;
-	ef->lf.flags |= LINKER_FILE_PCC_BOUNDS;
 	i = 0;
 	ef->pcc_caps = mallocarray(ef->npcc_caps, sizeof(*ef->pcc_caps),
 	    M_LINKER, M_WAITOK | M_ZERO);
@@ -2337,9 +2333,7 @@ link_elf_reloc_local(linker_file_t lf)
 		data_cap = cheri_perms_and(ef->mapbase, CHERI_PERMS_KERNEL_DATA);
 		if (init_linker_file_cap_relocs(ef->caprelocs,
 		    (char *)ef->caprelocs + ef->caprelocssize, data_cap,
-		    (ptraddr_t)ef->address,
-		    (lf->flags & LINKER_FILE_PCC_BOUNDS) != 0,
-		    resolve_cap_reloc, ef) != 0)
+		    (ptraddr_t)ef->address, true, resolve_cap_reloc, ef) != 0)
 			return (ENOEXEC);
 	}
 #endif
@@ -2432,31 +2426,6 @@ elf_lookup_ifunc(linker_file_t lf, Elf_Size symidx, int deps __unused,
 	return (ENOENT);
 }
 
-#ifdef __CHERI_PURE_CAPABILITY__
-/*
- * Set LINKER_FILE_PCC_BOUNDS but don't allocate pcc_caps[].
- */
-static void
-preload_check_for_pcc_caps(elf_file_t ef)
-{
-	const Elf_Ehdr *hdr;
-	const Elf_Phdr *phdr, *phlimit;
-
-	if (!have_phdrs(ef))
-		return;
-
-	hdr = (const Elf_Ehdr *)ef->mapbase;
-	phdr = (const Elf_Phdr *)((const char *)hdr + hdr->e_phoff);
-	phlimit = phdr + hdr->e_phnum;
-	for (; phdr < phlimit; phdr++) {
-		if (phdr->p_type == PT_CHERI_PCC) {
-			ef->lf.flags |= LINKER_FILE_PCC_BOUNDS;
-			return;
-		}
-	}
-}
-#endif
-
 void
 link_elf_ireloc(void)
 {
@@ -2484,7 +2453,6 @@ link_elf_ireloc(void)
 	ef->address = cheri_address_set(kernel_root_cap, 0);
 	ef->mapbase = cheri_bounds_set(ef->address + KERNBASE,
 	    (ptraddr_t)_end - KERNBASE);
-	preload_check_for_pcc_caps(ef);
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #endif
 	parse_dynamic(ef);

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -398,7 +398,7 @@ va:
 	cincoffset ca1, ca0, t1
 	candperm ca2, cs0, t0
 	mv	a3, zero
-	mv	a4, zero		/* TODO: true for PT_CHERI_PCC */
+	li	a4, 1
 	cllc	ca5, _C_LABEL(kernel_cap_relocs_cb)
 	csetflags ca6, ca5, zero
 	ccall	_C_LABEL(init_linker_file_cap_relocs)

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -77,9 +77,6 @@ struct linker_file {
     int			flags;
 #define LINKER_FILE_LINKED	0x1	/* file has been fully linked */
 #define LINKER_FILE_MODULES	0x2	/* file has >0 modules at preload */
-#ifdef __CHERI_PURE_CAPABILITY__
-#define	LINKER_FILE_PCC_BOUNDS	0x4	/* use PCC bounds from relative relocations */
-#endif
     TAILQ_ENTRY(linker_file) link;	/* list of all loaded files */
     char*		filename;	/* file which was loaded */
     char*		pathname;	/* file name with full path */


### PR DESCRIPTION
Currently we only do so if PT_CHERI_PCC is present. However, this relies
on being able to find the program headers in memory to determine this,
which is not available on RISC-V thanks to the layout required for SBI
direct boot. Since we have a dependency on a new enough toolchain for
TGOT-based TLS support when doing make buildworld in current CheriBSD
trees we can assume that correct PCC bounds will be emitted by the
toolchain linking the kernel and modules (unlike userspace where we have
to consider binary compatibility with objects from the previous CheriBSD
release).
