### PR TITLE
Pass program headers in module metadata from loader and use in link_elf

### DIFF
--- a/stand/common/load_elf.c
+++ b/stand/common/load_elf.c
@@ -705,6 +705,9 @@ __elfN(loadimage)(struct preloaded_file *fp, elf_file_t ef, uint64_t off)
 	}
 	lastaddr = roundup(lastaddr, sizeof(long));
 
+	file_addmetadata(fp, MODINFOMD_PHDR, ehdr->e_phnum * sizeof(*phdr),
+	    phdr);
+
 	/*
 	 * Get the section headers.  We need this for finding the .ctors
 	 * section as well as for loading any symbols.  Both may be hard

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -478,15 +478,25 @@ ef_symbol_address(elf_file_t ef, const Elf_Sym *sym)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 /*
- * Find a copy of the module's program headers by probing for a valid ELF
- * executable header at ef->mapbase that we can then follow.
+ * Find a copy of the module's program headers, either from module metadata or
+ * by probing for a valid ELF executable header at ef->mapbase that we can then
+ * follow.
  *
  * NB: RISC-V kernels do not map phdrs into memory.
  */
 static const Elf_Phdr *
-preload_search_phdrs(elf_file_t ef, size_t *phnum)
+preload_search_phdrs(elf_file_t ef, size_t *phnum, caddr_t modptr)
 {
 	const Elf_Ehdr *hdr;
+	uint32_t *modinfo;
+
+	modinfo = (uint32_t *)preload_search_info(modptr,
+	    MODINFO_METADATA | MODINFOMD_PHDR);
+	if (modinfo != NULL) {
+		/* Size of metadata; see preload_search_info */
+		*phnum = modinfo[-1] / sizeof(Elf_Phdr);
+		return ((const Elf_Phdr *)modinfo);
+	}
 
 	hdr = (const Elf_Ehdr *)ef->mapbase;
 	if (IS_ELF(*hdr) &&
@@ -560,12 +570,12 @@ ef_create_pcc_caps(elf_file_t ef, const Elf_Phdr *phstart,
 }
 
 static bool
-preload_init_pcc_caps(elf_file_t ef)
+preload_init_pcc_caps(elf_file_t ef, caddr_t modptr)
 {
 	const Elf_Phdr *phdr;
 	size_t phnum;
 
-	phdr = preload_search_phdrs(ef, &phnum);
+	phdr = preload_search_phdrs(ef, &phnum, modptr);
 	if (phdr == NULL)
 		return (true);
 
@@ -672,7 +682,7 @@ link_elf_init(void* arg)
 	ef->address = cheri_address_set(kernel_root_cap, 0);
 	ef->mapbase = cheri_bounds_set(ef->address + KERNBASE,
 	    (ptraddr_t)_end - KERNBASE);
-	if (!preload_init_pcc_caps(ef))
+	if (!preload_init_pcc_caps(ef, preload_kmdp))
 		panic("%s: Can't create PCC caps for kernel", __func__);
 #endif /* __CHERI_PURE_CAPABILITY__ */
 #endif
@@ -1184,7 +1194,7 @@ link_elf_link_preload(linker_class_t cls, const char *filename,
 	ef->address = cheri_perms_and(ef->address, CHERI_PERMS_KERNEL_CODE |
 	    CHERI_PERMS_KERNEL_DATA);
 	ef->mapbase = ef->address;
-	if (!preload_init_pcc_caps(ef)) {
+	if (!preload_init_pcc_caps(ef, modptr)) {
 		error = ENOEXEC;
 		goto out;
 	}

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -478,23 +478,30 @@ ef_symbol_address(elf_file_t ef, const Elf_Sym *sym)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 /*
- * Check for a valid ELF executable header at ef->mapbase.
+ * Find a copy of the module's program headers by probing for a valid ELF
+ * executable header at ef->mapbase that we can then follow.
  *
  * NB: RISC-V kernels do not map phdrs into memory.
  */
-static bool
-have_phdrs(elf_file_t ef)
+static const Elf_Phdr *
+preload_search_phdrs(elf_file_t ef, size_t *phnum)
 {
 	const Elf_Ehdr *hdr;
+
 	hdr = (const Elf_Ehdr *)ef->mapbase;
-	return (IS_ELF(*hdr) &&
+	if (IS_ELF(*hdr) &&
 	    hdr->e_ident[EI_CLASS] == ELF_TARG_CLASS &&
 	    hdr->e_ident[EI_DATA] == ELF_TARG_DATA &&
 	    hdr->e_ident[EI_VERSION] == EV_CURRENT &&
 	    hdr->e_machine == ELF_TARG_MACH &&
 	    hdr->e_version == ELF_TARG_VER &&
 	    hdr->e_phentsize == sizeof(Elf_Phdr) &&
-	    ELF_IS_CHERI(hdr));
+	    ELF_IS_CHERI(hdr)) {
+		*phnum = hdr->e_phnum;
+		return ((const Elf_Phdr *)((const char *)hdr + hdr->e_phoff));
+	}
+
+	return (NULL);
 }
 
 static bool
@@ -555,15 +562,14 @@ ef_create_pcc_caps(elf_file_t ef, const Elf_Phdr *phstart,
 static bool
 preload_init_pcc_caps(elf_file_t ef)
 {
-	const Elf_Ehdr *hdr;
 	const Elf_Phdr *phdr;
+	size_t phnum;
 
-	if (!have_phdrs(ef))
+	phdr = preload_search_phdrs(ef, &phnum);
+	if (phdr == NULL)
 		return (true);
 
-	hdr = (const Elf_Ehdr *)ef->mapbase;
-	phdr = (const Elf_Phdr *)((const char *)hdr + hdr->e_phoff);
-	return (ef_create_pcc_caps(ef, phdr, phdr + hdr->e_phnum));
+	return (ef_create_pcc_caps(ef, phdr, phdr + phnum));
 }
 #endif
 

--- a/sys/kern/subr_module.c
+++ b/sys/kern/subr_module.c
@@ -457,6 +457,9 @@ preload_modinfo_type(struct sbuf *sbp, int type)
 		sbuf_cat(sbp, "MODINFOMD_SPLASH");
 		break;
 #endif
+	case MODINFOMD_PHDR:
+		sbuf_cat(sbp, "MODINFOMD_PHDR");
+		break;
 #ifdef MODINFOMD_BOOT_HARTID
 	case MODINFOMD_BOOT_HARTID:
 		sbuf_cat(sbp, "MODINFOMD_BOOT_HARTID");
@@ -534,6 +537,7 @@ preload_modinfo_value(struct sbuf *sbp, uint32_t *bptr, int type, int len)
 #ifdef MODINFOMD_EFI_MAP
 	case MODINFO_METADATA | MODINFOMD_EFI_MAP:
 #endif
+	case MODINFO_METADATA | MODINFOMD_PHDR:
 		/* Don't print data buffers. */
 		sbuf_cat(sbp, "buffer contents omitted");
 		break;

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -260,6 +260,7 @@ void linker_kldload_unbusy(int flags);
 #define MODINFOMD_KEYBUF	0x000d		/* Crypto key intake buffer */
 #define MODINFOMD_FONT		0x000e		/* Console font */
 #define MODINFOMD_SPLASH	0x000f		/* Console splash screen */
+#define MODINFOMD_PHDR		0x0c01		/* program headers */
 #define MODINFOMD_NOCOPY	0x8000		/* don't copy this metadata to the kernel */
 
 #define MODINFOMD_DEPLIST	(0x4001 | MODINFOMD_NOCOPY)	/* depends on */


### PR DESCRIPTION
Depends on #2668, #2670 and #2671 (all present in this PR as an initial octopus merge).

- link_elf: Turn have_phdrs into preload_search_phdrs
- subr_module: Define a new MODINFOMD_PHDR
- stand: Pass loaded program headers in new MODINFOMD_PHDR module metadata
- link_elf: Search new module metadata for program headers
