### PR TITLE
Don't imply PROT_CAP for MAP_ANON|MAP_SHARED

### DIFF
--- a/bin/cheribsdtest/cheribsdtest.c
+++ b/bin/cheribsdtest/cheribsdtest.c
@@ -954,7 +954,7 @@ main(int argc, char *argv[])
 	 * failure status.
 	 */
 	assert(sizeof(*ccsp) <= (size_t)getpagesize());
-	ccsp = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE,
+	ccsp = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE | PROT_CAP,
 	    MAP_ANON | MAP_SHARED, -1, 0);
 	if (ccsp == MAP_FAILED)
 		err(EX_OSERR, "mmap");

--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -705,9 +705,12 @@ kern_mmap(struct thread *td, const struct mmap_req *mrp)
 		/*
 		 * Mapping blank space is trivial.
 		 */
+		if ((flags & MAP_SHARED) == 0) {
+			prot = VM_PROT_ADD_CAP(prot);
+			max_prot = VM_PROT_ADD_CAP(max_prot);
+		}
 		error = vm_mmap_object(&vms->vm_map, &addr, max_addr, size,
-		    VM_PROT_ADD_CAP(prot), VM_PROT_ADD_CAP(max_prot), flags,
-		    NULL, pos, FALSE, td);
+		    prot, max_prot, flags, NULL, pos, FALSE, td);
 	} else {
 		/*
 		 * Mapping file, get fp for validation and don't let the


### PR DESCRIPTION
Creation of mapping to share capabilities needs to be explicit to ensure the program means to do so.

Note: this should not be merged prior to the upcoming release as it's possible it will be moderately disruptive.

