### PR TITLE
Bring in security patches from 20260630

### DIFF
--- a/contrib/netbsd-tests/lib/libc/locale/t_iconv.c
+++ b/contrib/netbsd-tests/lib/libc/locale/t_iconv.c
@@ -117,6 +117,26 @@ static const struct sample {
 			0x82,0x42,0x79,0x65, 0x2e
 		},
 		0, 0, NULL },
+	/* 馬 from CNS 11643-1 */
+	[9] = { "UTF-8", 3, (const char[3]){0xe9,0xa6,0xac},
+		"ISO-2022-CN", 8,
+		(const char[8]){0x1b,0x24,0x29,0x47,0x0e,0x58,0x6b,0x0f},
+		0, 0, NULL },
+	/* 馬毦 shifting from CNS 11643-1 to CNS 11643-2 */
+	[10] = { "UTF-8", 6, (const char[6]){0xe9,0xa6,0xac,0xe6,0xaf,0xa6},
+		"ISO-2022-CN", 16,
+		(const char[16]){
+			/* ESC $ ) G (shift G1 to CNS 11643 plane 1) */
+			0x1b,0x24,0x29,0x47,
+			0x0e,	   /* GL is G1 from now on */
+			0x58,0x6b, /* 馬 */
+			/* ESC $ * H (shift G2 to CNS 11643 plane 2) */
+			0x1b,0x24,0x2a,0x48,
+			0x1b,0x4e, /* GL is G2 for next char */
+			0x30,0x21, /* 毦 */
+			0x0f,	   /* GL is G0 from now on */
+		},
+		0, 0, "PR lib/59019: various iconv issues ([case 10: ISO-2022-CN to UTF-8 14/6] iconv: Illegal byte sequence (85))" },
 };
 
 #ifdef MIN

--- a/contrib/netbsd-tests/lib/libc/locale/t_iconv.c
+++ b/contrib/netbsd-tests/lib/libc/locale/t_iconv.c
@@ -1,0 +1,355 @@
+/*	$NetBSD$	*/
+
+/*-
+ * Copyright (c) 2025 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * iconv(3)
+ */
+
+#include <sys/cdefs.h>
+__RCSID("$NetBSD: t_mbrtoc8.c,v 1.3 2024/08/20 17:43:09 riastradh Exp $");
+
+#include <atf-c.h>
+#include <errno.h>
+#include <iconv.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "h_macros.h"
+
+static const struct sample {
+	const char	*src_codeset;
+	size_t		nsrc;
+	const char	*src;
+	const char	*dst_codeset;
+	size_t		ndst;
+	const char	*dst;
+	size_t		ninval;
+	size_t		ninval_rev;
+	const char	*xfail;
+#define	IRREVERSIBLE	((size_t)-1)
+} samples[] = {
+	[0] = { "us-ascii", 6, "hello",
+		"us-ascii", 6, "hello",
+		0, 0, NULL },
+	/* LATIN SMALL LETTER E WITH ACUTE ACCENT */
+	[1] = { "iso-8859-1", 1, (const char[1]){0xe9},
+		"UTF-8", 2, (const char[2]){0xc3,0xa9},
+		0, 0, NULL },
+	/* LEFT CURLY BRACKET */
+	[2] = { "UTF-8", 2, (const char[2]){0x00,0x7b},
+		"ZW", 6, (const char[6]){0x00,0x7a,0x57,0x20,0x7b,0x0a},
+		0, 0, NULL },
+	/* LATIN SMALL LETTER O, TILDE */
+	[3] = { "UTF-8", 2, (const char[2]){0x4f,0x7e},
+		"VIQR", 3, (const char[3]){0x4f,0x5c,0x7e},
+		0, 0, NULL },
+	/* LEFT CURLY BRACKET (optionally encoded in UTF-7) */
+	[4] = { "UTF-7", 1, (const char[1]){0x7b},
+		"UTF-8", 1, (const char[1]){0x7b},
+		0, IRREVERSIBLE, NULL },
+	[5] = { "UTF-7", 4, "+AHs-",
+		"UTF-8", 1, (const char[1]){0x7b},
+		0, 0, NULL },
+	/* éclair */
+	[6] = { "UTF-7", 10, "+AOk-clair",
+		"UTF-8", 7, (const char[7]){
+			0xc3,0xa9,0x63,0x6c,0x61,0x69,0x72,
+		},
+		0, 0, NULL },
+	[7] = { "HZ", 55,	/* RFC 1843, Sec. 4, Example 1 */
+		"The next sentence is in GB.~{<:Ky2;S{#,NpJ)l6HK!#~}Bye.",
+		"UTF-8", 61, (const char[61]) {
+			0x54,0x68,0x65,0x20, 0x6e,0x65,0x78,0x74,
+			0x20,0x73,0x65,0x6e, 0x74,0x65,0x6e,0x63,
+			0x65,0x20,0x69,0x73, 0x20,0x69,0x6e,0x20,
+			0x47,0x42,0x2e,0xe5, 0xb7,0xb1,0xe6,0x89,
+			0x80,0xe4,0xb8,0x8d, 0xe6,0xac,0xb2,0xef,
+			0xbc,0x8c,0xe5,0x8b, 0xbf,0xe6,0x96,0xbd,
+			0xe6,0x96,0xbc,0xe4, 0xba,0xba,0xe3,0x80,
+			0x82,0x42,0x79,0x65, 0x2e
+		},
+		0, 0, NULL },
+	/* Same as above but with HZ8 instead of HZ. */
+	[8] = { "HZ8", 55, (const char[55]) {
+			0x54,0x68,0x65,0x20,0x6e,0x65,0x78,0x74,
+			0x20,0x73,0x65,0x6e,0x74,0x65,0x6e,0x63,
+			0x65,0x20,0x69,0x73,0x20,0x69,0x6e,0x20,
+			0x47,0x42,0x2e,0x7e,0x7b,0xbc,0xba,0xcb,
+			0xf9,0xb2,0xbb,0xd3,0xfb,0xa3,0xac,0xce,
+			0xf0,0xca,0xa9,0xec,0xb6,0xc8,0xcb,0xa1,
+			0xa3,0x7e,0x7d,0x42,0x79,0x65,0x2e
+		},
+		"UTF-8", 61, (const char[61]) {
+			0x54,0x68,0x65,0x20, 0x6e,0x65,0x78,0x74,
+			0x20,0x73,0x65,0x6e, 0x74,0x65,0x6e,0x63,
+			0x65,0x20,0x69,0x73, 0x20,0x69,0x6e,0x20,
+			0x47,0x42,0x2e,0xe5, 0xb7,0xb1,0xe6,0x89,
+			0x80,0xe4,0xb8,0x8d, 0xe6,0xac,0xb2,0xef,
+			0xbc,0x8c,0xe5,0x8b, 0xbf,0xe6,0x96,0xbd,
+			0xe6,0x96,0xbc,0xe4, 0xba,0xba,0xe3,0x80,
+			0x82,0x42,0x79,0x65, 0x2e
+		},
+		0, 0, NULL },
+};
+
+#ifdef MIN
+#undef MIN
+#endif
+#define	MIN(x, y)	((x) < (y) ? (x) : (y))
+
+static void
+test_sample_bounded(const char *title, const struct sample *S,
+    size_t nsrc, size_t ndst)
+{
+	char inbuf[4096], inguard = arc4random();
+	char outbuf[4096], outguard = arc4random();
+	iconv_t C;
+	char *src0, *src, *dst0, *dst;
+	size_t srcleft0, srcleft, dstleft0, dstleft;
+	size_t ninval;
+	int error;
+
+	ATF_REQUIRE_MSG(S->nsrc < sizeof(inbuf) - 2, "[%s]", title);
+	ATF_REQUIRE_MSG(S->ndst < sizeof(outbuf) - 2, "[%s]", title);
+
+	memset(inbuf, inguard, sizeof(inbuf));
+	memset(outbuf, outguard, sizeof(outbuf));
+	src = src0 = inbuf + 1;
+	memcpy(src, S->src, nsrc);
+	dst = dst0 = outbuf + 1;
+	srcleft = srcleft0 = nsrc;
+	dstleft = dstleft0 = ndst;
+
+	C = iconv_open(S->dst_codeset, S->src_codeset);
+	if (C == (iconv_t)-1) {
+		error = errno;
+		atf_tc_fail_nonfatal("[%s] iconv_open: %s (%d)", title,
+		    strerror(error), error);
+		return;
+	}
+
+	ninval = iconv(C, &src, &srcleft, &dst, &dstleft);
+	if (ninval == (size_t)-1) {
+		error = errno;
+		/*
+		 * Incomplete input manifests as EINVAL -- ignore that,
+		 * unless we're trying the full-size input.
+		 *
+		 * Truncated output manifests as E2BIG -- ignore that,
+		 * unless we're trying the full-size output.
+		 */
+		if ((error != EINVAL || nsrc == S->nsrc) &&
+		    (error != E2BIG || ndst == S->ndst)) {
+			atf_tc_fail_nonfatal("[%s] iconv: %s (%d)",
+			    title, strerror(error), error);
+			goto next;
+		}
+	} else if (ninval != S->ninval) {
+		error = errno;
+		atf_tc_fail_nonfatal("[%s] iconv:"
+		    " %zu invalid, expected %zu",
+		    title, ninval, S->ninval);
+	}
+
+	ATF_CHECK_MSG(src0 <= src && src <= src0 + srcleft0, "[%s] iconv:"
+	    " src went from %p to %p, expected [%p,%p]",
+	    title, src0, src, src0, src0 + srcleft0);
+	ATF_CHECK_MSG(srcleft <= srcleft0, "[%s] iconv:"
+	    " srcleft went from %zu to %zu",
+	    title, srcleft0, srcleft);
+	ATF_CHECK_MSG(dst0 <= dst && dst <= dst0 + dstleft0, "[%s] iconv:"
+	    " dst went from %p to %p, expected [%p,%p]",
+	    title, dst0, dst, dst0, dst0 + dstleft0);
+	ATF_CHECK_MSG(dstleft <= dstleft0, "[%s] iconv:"
+	    " dstleft went from %zu to %zu",
+	    title, dstleft0, dstleft);
+	if (memcmp(dst0, S->dst, MIN(ndst, dstleft0 - dstleft)) != 0) {
+		size_t k;
+
+		atf_tc_fail_nonfatal("[%s] iconv: bad conv", title);
+		fprintf(stderr, "[%s] input:    ", title);
+		for (k = 0; k < nsrc; k++)
+			fprintf(stderr, " %02x", (unsigned char)S->src[k]);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "[%s] expected: ", title);
+		for (k = 0; k < ndst; k++)
+			fprintf(stderr, " %02x", (unsigned char)S->dst[k]);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "[%s] got:      ", title);
+		for (k = 0; k < ndst; k++)
+			fprintf(stderr, " %02x", (unsigned char)dst0[k]);
+		fprintf(stderr, "\n");
+	}
+
+next:	if (dst0[-1] != outguard) {
+		atf_tc_fail_nonfatal("[%s] iconv overran before buffer:"
+		    " dst0[-1] = 0x%02x, expected 0x%02x",
+		    title, dst0[-1], outguard);
+	}
+	if (dst0[ndst] != outguard) {
+		atf_tc_fail_nonfatal("[%s] iconv overran after buffer:"
+		    " dst0[ndst=%zu] = 0x%02x, expected 0x%02x",
+		    title, ndst, dst0[ndst], outguard);
+	}
+	if (dst[0] != outguard) {
+		atf_tc_fail_nonfatal("[%s] iconv overran past updated dst:"
+		    " dst[0] = 0x%02x, expected 0x%02x",
+		    title, dst[0], outguard);
+	}
+
+	if (iconv_close(C) == -1) {
+		error = errno;
+		atf_tc_fail_nonfatal("[%s] iconv_close: %s (%d)",
+		    title, strerror(error), error);
+	}
+}
+
+static void
+test_sample(const char *title, const struct sample *S)
+{
+	char buf[128];
+	size_t nsrc, ndst;
+
+	fprintf(stderr, "test %s from %s to %s\n",
+	    title, S->src_codeset, S->dst_codeset);
+
+	for (nsrc = 0; nsrc <= S->nsrc; nsrc++) {
+		snprintf(buf, sizeof(buf), "%s %zu/%zu", title, nsrc, S->ndst);
+		test_sample_bounded(buf, S, nsrc, S->ndst);
+	}
+
+	for (ndst = 0; ndst <= S->ndst; ndst++) {
+		snprintf(buf, sizeof(buf), "%s %zu/%zu", title, S->nsrc, ndst);
+		test_sample_bounded(buf, S, S->nsrc, ndst);
+	}
+}
+
+ATF_TC(iconv_samples);
+ATF_TC_HEAD(iconv_samples, tc)
+{
+
+	atf_tc_set_md_var(tc, "descr", "Test iconv on various fixed samples");
+}
+ATF_TC_BODY(iconv_samples, tc)
+{
+	unsigned i;
+
+	for (i = 0; i < __arraycount(samples); i++) {
+		const struct sample *S = &samples[i];
+		struct sample reverse = {
+			.src_codeset = S->dst_codeset,
+			.dst_codeset = S->src_codeset,
+			.nsrc = S->ndst,
+			.src = S->dst,
+			.ndst = S->nsrc,
+			.dst = S->src,
+			.ninval = S->ninval_rev,
+		};
+		char buf[128];
+
+		if (S->xfail)
+			atf_tc_expect_fail("%s", S->xfail);
+
+		snprintf(buf, sizeof(buf), "case %u: %s to %s", i,
+		    S->src_codeset, S->dst_codeset);
+		test_sample(buf, S);
+		if (S->ninval_rev != IRREVERSIBLE) {
+			snprintf(buf, sizeof(buf), "case %u: %s to %s", i,
+			    S->dst_codeset, S->src_codeset);
+			test_sample(buf, &reverse);
+		}
+
+		if (S->xfail)
+			atf_tc_expect_pass();
+	}
+}
+
+ATF_TC(iconv_pr59019_hz8);
+ATF_TC_HEAD(iconv_pr59019_hz8, tc)
+{
+
+	atf_tc_set_md_var(tc, "descr", "Truncated HZ8 input from PR 59019");
+}
+ATF_TC_BODY(iconv_pr59019_hz8, tc)
+{
+	const char title[] = "iconv_pr59019_hz8";
+	char in[4] = "\x7e\x7b\x7e\x7e";	/* ~{~~ */
+	char out[4096], guard = arc4random();
+	char *src0, *src, *dst0, *dst;
+	size_t srcleft0, srcleft, dstleft0, dstleft;
+	iconv_t C;
+	size_t ninval;
+
+	memset(out, guard, sizeof(out));
+
+	REQUIRE_LIBC((C = iconv_open(/*to*/"UTF-8", /*from*/"HZ8")),
+	    (iconv_t)-1);
+
+	src = src0 = in;
+	srcleft = srcleft0 = sizeof(in);
+	dst = dst0 = out + 1;
+	dstleft = dstleft0 = sizeof(out) - 2;
+
+	ninval = iconv(C, &src, &srcleft, &dst, &dstleft);
+
+	/*
+	 * XXX Not actually 100% sure this is the correct result -- I
+	 * can't find a reference for the HZ8 encoding.
+	 */
+	ATF_CHECK_EQ_MSG(ninval, (size_t)-1, "[%s] iconv: ninval=%zu", title,
+	    ninval);
+
+	ATF_CHECK_MSG(src0 <= src && src <= src0 + srcleft0, "[%s] iconv:"
+	    " src went from %p to %p, expected [%p,%p)",
+	    title, src0, src, src0, src0 + srcleft0);
+	ATF_CHECK_MSG(srcleft <= srcleft0, "[%s] iconv:"
+	    " srcleft went from %zu to %zu",
+	    title, srcleft0, srcleft);
+	ATF_CHECK_MSG(dst0 <= dst && dst <= dst0 + dstleft0, "[%s] iconv:"
+	    " dst went from %p to %p, expected [%p,%p)",
+	    title, dst0, dst, dst0, dst0 + dstleft0);
+	ATF_CHECK_MSG(dstleft <= dstleft0, "[%s] iconv:"
+	    " dstleft went from %zu to %zu",
+	    title, dstleft0, dstleft);
+
+	ATF_CHECK_EQ(dst0[-1], guard);
+	ATF_CHECK_EQ(dst0[dstleft0], guard);
+
+	RL(iconv_close(C));
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+
+	ATF_TP_ADD_TC(tp, iconv_pr59019_hz8);
+	ATF_TP_ADD_TC(tp, iconv_samples);
+
+	return atf_no_error();
+}

--- a/lib/libc/gen/memfd_create.c
+++ b/lib/libc/gen/memfd_create.c
@@ -95,14 +95,23 @@ memfd_create(const char *name, unsigned int flags)
 	npgs = getpagesizes(pgs, nitems(pgs));
 	if (npgs == -1)
 		goto clean;
-	pgsize = (size_t)1 << ((flags & MFD_HUGE_MASK) >> MFD_HUGE_SHIFT);
-	for (pgidx = 0; pgidx < npgs; pgidx++) {
-		if (pgsize == pgs[pgidx])
-			break;
-	}
-	if (pgidx == npgs) {
-		errno = EOPNOTSUPP;
+	else if (npgs == 1) {
+		errno = ENOSYS;
 		goto clean;
+	}
+
+	if ((flags & MFD_HUGE_MASK) == 0) {
+		pgidx = 1;
+	} else {
+		pgsize = 1UL << ((flags & MFD_HUGE_MASK) >> MFD_HUGE_SHIFT);
+		for (pgidx = 1; pgidx < npgs; pgidx++) {
+			if (pgsize == pgs[pgidx])
+				break;
+		}
+		if (pgidx == npgs) {
+			errno = EOPNOTSUPP;
+			goto clean;
+		}
 	}
 
 	memset(&slc, 0, sizeof(slc));

--- a/lib/libc/tests/locale/Makefile
+++ b/lib/libc/tests/locale/Makefile
@@ -21,6 +21,7 @@ ATF_TESTS_C+=		wctomb_2_test
 
 # Note: io_test requires zh_TW.Big5 locale (see ^/head@r315568)
 #NETBSD_ATF_TESTS_C=	io_test
+NETBSD_ATF_TESTS_C+=	iconv_test
 NETBSD_ATF_TESTS_C+=	mbrtowc_test
 NETBSD_ATF_TESTS_C+=	mbstowcs_test
 NETBSD_ATF_TESTS_C+=	mbsnrtowcs_test

--- a/lib/libiconv_modules/HZ/citrus_hz.c
+++ b/lib/libiconv_modules/HZ/citrus_hz.c
@@ -132,7 +132,7 @@ typedef struct {
 typedef struct {
 	escape_t	*inuse;
 	int		 chlen;
-	char		 ch[ROWCOL_MAX];
+	char		 ch[4 + ROWCOL_MAX];
 } _HZState;
 
 #define _CEI_TO_EI(_cei_)		(&(_cei_)->ei)

--- a/lib/libiconv_modules/HZ/citrus_hz.c
+++ b/lib/libiconv_modules/HZ/citrus_hz.c
@@ -262,6 +262,8 @@ _citrus_HZ_mbrtowc_priv(_HZEncodingInfo * __restrict ei,
 				tail = psenc->chlen = 0;
 				continue;
 			}
+			if (graphic == NULL)
+				break;
 		} else if (ch & 0x80) {
 			if (graphic != GR(psenc->inuse))
 				break;

--- a/lib/libiconv_modules/ISO2022/citrus_iso2022.c
+++ b/lib/libiconv_modules/ISO2022/citrus_iso2022.c
@@ -129,7 +129,7 @@ typedef struct {
 #define _FUNCNAME(m)			_citrus_ISO2022_##m
 #define _ENCODING_INFO			_ISO2022EncodingInfo
 #define _ENCODING_STATE			_ISO2022State
-#define _ENCODING_MB_CUR_MAX(_ei_)	MB_LEN_MAX
+#define _ENCODING_MB_CUR_MAX(_ei_)	10
 #define _ENCODING_IS_STATE_DEPENDENT	1
 #define _STATE_NEEDS_EXPLICIT_INIT(_ps_)	\
     (!((_ps_)->flags & _ISO2022STATE_FLAG_INITIALIZED))
@@ -1012,7 +1012,7 @@ _ISO2022_sputwchar(_ISO2022EncodingInfo * __restrict ei, wchar_t wc,
 {
 	_ISO2022Charset cs;
 	char *p;
-	char tmp[MB_LEN_MAX];
+	char tmp[10];
 	size_t len;
 	int bit8, i = 0, target;
 	unsigned char mask;
@@ -1177,7 +1177,7 @@ _citrus_ISO2022_put_state_reset(_ISO2022EncodingInfo * __restrict ei,
     size_t * __restrict nresult)
 {
 	char *result;
-	char buf[MB_LEN_MAX];
+	char buf[10];
 	size_t len;
 	int ret;
 
@@ -1206,7 +1206,7 @@ _citrus_ISO2022_wcrtomb_priv(_ISO2022EncodingInfo * __restrict ei,
     _ISO2022State * __restrict psenc, size_t * __restrict nresult)
 {
 	char *result;
-	char buf[MB_LEN_MAX];
+	char buf[10];
 	size_t len;
 	int ret;
 

--- a/lib/libiconv_modules/UTF7/citrus_utf7.c
+++ b/lib/libiconv_modules/UTF7/citrus_utf7.c
@@ -296,7 +296,7 @@ done:
 
 static int
 _citrus_UTF7_utf16tomb(_UTF7EncodingInfo * __restrict ei,
-    char * __restrict s, size_t n __unused, uint16_t u16,
+    char * __restrict s, size_t n, uint16_t u16,
     _UTF7State * __restrict psenc, size_t * __restrict nresult)
 {
 	int bits, i;
@@ -336,6 +336,8 @@ _citrus_UTF7_utf16tomb(_UTF7EncodingInfo * __restrict ei,
 			psenc->ch[psenc->chlen++] = base64[i];
 		}
 	}
+	if (n < (size_t)psenc->chlen)
+		return (E2BIG);
 	memcpy(s, psenc->ch, psenc->chlen);
 	*nresult = psenc->chlen;
 	psenc->chlen = 0;
@@ -352,6 +354,8 @@ _citrus_UTF7_wcrtomb_priv(_UTF7EncodingInfo * __restrict ei,
 	uint16_t u16[2];
 	int err, i, len;
 	size_t nr, siz;
+	char buf[8], *bufp = buf;
+	_UTF7State psenc_save = *psenc;
 
 	u32 = (uint32_t)wchar;
 	if (u32 <= UTF16_MAX) {
@@ -367,14 +371,20 @@ _citrus_UTF7_wcrtomb_priv(_UTF7EncodingInfo * __restrict ei,
 		return (EILSEQ);
 	}
 	siz = 0;
+	if (n > sizeof(buf))
+		n = sizeof(buf);
 	for (i = 0; i < len; ++i) {
-		err = _citrus_UTF7_utf16tomb(ei, s, n, u16[i], psenc, &nr);
-		if (err != 0)
-			return (err); /* XXX: state has been modified */
-		s += nr;
+		err = _citrus_UTF7_utf16tomb(ei, bufp, n, u16[i], psenc, &nr);
+		if (err != 0) {
+			*nresult = (size_t)-1;
+			*psenc = psenc_save; /* restore state */
+			return (err);
+		}
+		bufp += nr;
 		n -= nr;
 		siz += nr;
 	}
+	memcpy(s, buf, siz);
 	*nresult = siz;
 
 	return (0);

--- a/lib/libiconv_modules/VIQR/citrus_viqr.c
+++ b/lib/libiconv_modules/VIQR/citrus_viqr.c
@@ -323,7 +323,11 @@ _citrus_VIQR_wcrtomb_priv(_VIQREncodingInfo * __restrict ei,
 	int ch = 0;
 
 	switch (psenc->chlen) {
-	case 0: case 1:
+	case 0:
+		break;
+	case 1:
+		if (n-- < 1)
+			goto e2big;
 		break;
 	default:
 		return (EINVAL);

--- a/lib/libiconv_modules/ZW/citrus_zw.c
+++ b/lib/libiconv_modules/ZW/citrus_zw.c
@@ -263,9 +263,12 @@ _citrus_ZW_wcrtomb_priv(_ZWEncodingInfo * __restrict ei __unused,
 		ch = (unsigned char)wc;
 		switch (psenc->charset) {
 		case NONE:
-			if (ch == '\0' || ch == '\n')
+			if (ch == '\0' || ch == '\n') {
+				if (n < 1)
+					return (E2BIG);
+				n -= 1;
 				psenc->ch[psenc->chlen++] = ch;
-			else {
+			} else {
 				if (n < 4)
 					return (E2BIG);
 				n -= 4;

--- a/lib/libiconv_modules/iconv_std/citrus_iconv_std.c
+++ b/lib/libiconv_modules/iconv_std/citrus_iconv_std.c
@@ -29,6 +29,7 @@
  */
 
 #include <sys/cdefs.h>
+#include <sys/param.h>
 #include <sys/endian.h>
 #include <sys/queue.h>
 
@@ -36,6 +37,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -423,17 +425,21 @@ _citrus_iconv_std_iconv_init_context(struct _citrus_iconv *cv)
 	const struct _citrus_iconv_std_shared *is = cv->cv_shared->ci_closure;
 	struct _citrus_iconv_std_context *sc;
 	char *ptr;
-	size_t sz, szpsdst, szpssrc;
+	size_t sz, szctx, szpsdst, szpssrc;
 
-	szpssrc = _stdenc_get_state_size(is->is_src_encoding);
-	szpsdst = _stdenc_get_state_size(is->is_dst_encoding);
+	szpssrc = roundup2(_stdenc_get_state_size(is->is_src_encoding),
+	    _Alignof(max_align_t));
+	szpsdst = roundup2(_stdenc_get_state_size(is->is_dst_encoding),
+	    _Alignof(max_align_t));
+	szctx = roundup2(sizeof(struct _citrus_iconv_std_context),
+	    _Alignof(max_align_t));
 
-	sz = (szpssrc + szpsdst)*2 + sizeof(struct _citrus_iconv_std_context);
+	sz = szctx + 2 * (szpssrc + szpsdst);
 	sc = malloc(sz);
 	if (sc == NULL)
 		return (errno);
 
-	ptr = (char *)&sc[1];
+	ptr = (char *)sc + szctx;
 	if (szpssrc > 0)
 		init_encoding(&sc->sc_src_encoding, is->is_src_encoding,
 		    ptr, ptr+szpssrc);

--- a/lib/libsys/shm_open.2
+++ b/lib/libsys/shm_open.2
@@ -26,7 +26,7 @@
 .\" OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 30, 2023
+.Dd March 26, 2025
 .Dt SHM_OPEN 2
 .Os
 .Sh NAME
@@ -342,7 +342,25 @@ Allow adding seals to the resulting file descriptor using the
 .Xr fcntl 2
 command.
 .It Dv MFD_HUGETLB
-This flag is currently unsupported.
+Create a memfd backed by a
+.Dq largepage
+object.
+One of the
+.Dv MFD_HUGE_*
+flags defined in
+.In sys/mman.h
+may be included to specify a fixed size.
+If a specific size is not requested, the smallest supported large page size is
+selected.
+.Pp
+The behavior documented above for the
+.Fn shm_create_largepage
+.Fa psind
+argument also applies to largepage objects created by
+.Fn memfd_create ,
+and the
+.Dv SHM_LARGEPAGE_ALLOC_DEFAULT
+policy will always be used.
 .El
 .Sh RETURN VALUES
 If successful,
@@ -457,17 +475,22 @@ argument was too long.
 .Pp
 An invalid or unsupported flag was included in
 .Fa flags .
+.It Bq Er EINVAL
+A hugetlb mapping was requested, but
+.Dv MFD_HUGETLB
+was not specified in
+.Fa flags .
 .It Bq Er EMFILE
 The process has already reached its limit for open file descriptors.
 .It Bq Er ENFILE
 The system file table is full.
 .It Bq Er ENOSYS
-In
-.Fa memfd_create ,
 .Dv MFD_HUGETLB
 was specified in
 .Fa flags ,
 and this system does not support forced hugetlb mappings.
+.It Bq Er EOPNOTSUPP
+This system does not support the requested hugetlb page size.
 .El
 .Pp
 .Fn shm_open

--- a/sys/compat/freebsd32/freebsd32_misc.c
+++ b/sys/compat/freebsd32/freebsd32_misc.c
@@ -696,7 +696,7 @@ static int
 freebsd32_kevent_copyout(void *arg, struct kevent *kevp, int count)
 {
 	struct freebsd32_kevent_args *uap;
-	struct kevent32	ks32[KQ_NEVENTS];
+	struct kevent32	ks32[KQ_NEVENTS] = {};
 	int i, error;
 
 	KASSERT(count <= KQ_NEVENTS, ("count (%d) > KQ_NEVENTS", count));

--- a/sys/compat/linux/linux_misc.c
+++ b/sys/compat/linux/linux_misc.c
@@ -750,6 +750,7 @@ linux_common_wait(struct thread *td, idtype_t idtype, int id, int *statusp,
 		error = linux_copyout_rusage(&wru.wru_self, rup);
 	if (error == 0 && infop != NULL && td->td_retval[0] != 0) {
 		sig = bsd_to_linux_signal(siginfo.si_signo);
+		memset(&lsi, 0, sizeof(lsi));
 		siginfo_to_lsiginfo(&siginfo, &lsi, sig);
 		error = copyout(&lsi, infop, sizeof(lsi));
 	}

--- a/sys/kern/kern_sig.c
+++ b/sys/kern/kern_sig.c
@@ -2876,7 +2876,7 @@ ptrace_syscallreq(struct thread *td, struct proc *p,
 	td->td_errno = nerror;
 
 	if (audited)
-		AUDIT_SYSCALL_EXIT(error, td);
+		AUDIT_SYSCALL_EXIT(tsr->ts_ret.sr_error, td);
 	if (!sy_thr_static)
 		syscall_thread_exit(td, se);
 }

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -2146,10 +2146,13 @@ shm_fspacectl(struct file *fp, int cmd, off_t *offset, off_t *length, int flags,
 	    ("shm_fspacectl: non-zero flags"));
 	KASSERT(*offset >= 0 && *length > 0 && *length <= OFF_MAX - *offset,
 	    ("shm_fspacectl: offset/length overflow or underflow"));
-	error = EINVAL;
+
 	shmfd = fp->f_data;
 	off = *offset;
 	len = *length;
+
+	if (shm_largepage(shmfd))
+		return (ENOTSUP);
 
 	rl_cookie = shm_rangelock_wlock(shmfd, off, off + len);
 	switch (cmd) {

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -791,7 +791,7 @@ shm_dotruncate_largepage(struct shmfd *shmfd, off_t length, void *rl_cookie)
 	vm_pindex_t oldobjsz __unused;
 	int aflags, error, i, psind, try;
 
-	KASSERT(length >= 0, ("shm_dotruncate: length < 0"));
+	KASSERT(length >= 0, ("shm_dotruncate_largepage: length < 0"));
 	object = shmfd->shm_object;
 	VM_OBJECT_ASSERT_WLOCKED(object);
 	rangelock_cookie_assert(rl_cookie, RA_WLOCKED);
@@ -1313,15 +1313,13 @@ kern_shm_open2(struct thread *td, const char * __capability userpath,
 			if (error == 0 &&
 			    (flags & (O_ACCMODE | O_TRUNC)) ==
 			    (O_RDWR | O_TRUNC)) {
-				VM_OBJECT_WLOCK(shmfd->shm_object);
 #ifdef MAC
 				error = mac_posixshm_check_truncate(
-					td->td_ucred, fp->f_cred, shmfd);
+				    td->td_ucred, fp->f_cred, shmfd);
 				if (error == 0)
 #endif
-					error = shm_dotruncate_locked(shmfd, 0,
+					error = shm_dotruncate_cookie(shmfd, 0,
 					    rl_cookie);
-				VM_OBJECT_WUNLOCK(shmfd->shm_object);
 			}
 			if (error == 0) {
 				/*

--- a/sys/kern/uipc_shm.c
+++ b/sys/kern/uipc_shm.c
@@ -328,6 +328,7 @@ static void
 shm_largepage_phys_ctor(vm_object_t object, vm_prot_t prot,
     vm_ooffset_t foff, struct ucred *cred)
 {
+	object->flags |= OBJ_PG_DTOR;
 }
 
 static void
@@ -335,16 +336,32 @@ shm_largepage_phys_dtor(vm_object_t object)
 {
 	int psind;
 
+	VM_OBJECT_WLOCK(object);
 	psind = object->un_pager.phys.data_val;
 	if (psind != 0) {
+		struct pctrie_iter pages;
+		vm_page_t m;
+		bool removed __diagused;
+
+		vm_page_iter_init(&pages, object);
+restart:
+		VM_RADIX_FOREACH(m, &pages) {
+			if (!vm_page_busy_acquire(m, VM_ALLOC_WAITFAIL)) {
+				pctrie_iter_reset(&pages);
+				goto restart;
+			}
+			removed = vm_page_iter_remove(&pages, m);
+			KASSERT(!removed, ("%s: page %p not wired", __func__, m));
+			vm_page_unwire(m, PQ_NONE);
+		}
 		atomic_subtract_long(&count_largepages[psind],
 		    object->size / (pagesizes[psind] / PAGE_SIZE));
-		vm_wire_sub(object->size);
 	} else {
 		KASSERT(object->size == 0,
 		    ("largepage phys obj %p not initialized bit size %#jx > 0",
 		    object, (uintmax_t)object->size));
 	}
+	VM_OBJECT_WUNLOCK(object);
 }
 
 static const struct phys_pager_ops shm_largepage_phys_ops = {
@@ -823,7 +840,7 @@ shm_dotruncate_largepage(struct shmfd *shmfd, off_t length, void *rl_cookie)
 	if ((shmfd->shm_seals & F_SEAL_GROW) != 0)
 		return (EPERM);
 
-	aflags = VM_ALLOC_NORMAL | VM_ALLOC_ZERO;
+	aflags = VM_ALLOC_NORMAL | VM_ALLOC_ZERO | VM_ALLOC_WIRED;
 	if (shmfd->shm_lp_alloc_policy == SHM_LARGEPAGE_ALLOC_NOWAIT)
 		aflags |= VM_ALLOC_WAITFAIL;
 	try = 0;
@@ -871,7 +888,6 @@ shm_dotruncate_largepage(struct shmfd *shmfd, off_t length, void *rl_cookie)
 		object->size += OFF_TO_IDX(pagesizes[psind]);
 		shmfd->shm_size += pagesizes[psind];
 		atomic_add_long(&count_largepages[psind], 1);
-		vm_wire_add(atop(pagesizes[psind]));
 	}
 	return (0);
 }

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -2021,16 +2021,17 @@ sys_unlink(struct thread *td, struct unlink_args *uap)
 
 int
 kern_funlinkat_ex(struct thread *td, int dfd, const char * __capability path,
-    int fd, int flag, enum uio_seg pathseg, ino_t oldinum)
+    int fd, int flags, enum uio_seg pathseg, ino_t oldinum)
 {
 
-	if ((flag & ~(AT_REMOVEDIR | AT_RESOLVE_BENEATH)) != 0)
+	if ((flags & ~(AT_REMOVEDIR | AT_RESOLVE_BENEATH)) != 0)
 		return (EINVAL);
 
-	if ((flag & AT_REMOVEDIR) != 0)
-		return (kern_frmdirat(td, dfd, path, fd, UIO_USERSPACE, 0));
+	if ((flags & AT_REMOVEDIR) != 0)
+		return (kern_frmdirat(td, dfd, path, fd, pathseg,
+		    flags & ~AT_REMOVEDIR));
 
-	return (kern_funlinkat(td, dfd, path, fd, UIO_USERSPACE, 0, 0));
+	return (kern_funlinkat(td, dfd, path, fd, pathseg, flags, 0));
 }
 
 #ifndef _SYS_SYSPROTO_H_

--- a/sys/netinet/libalias/alias_smedia.c
+++ b/sys/netinet/libalias/alias_smedia.c
@@ -104,8 +104,9 @@
 #include <sys/kernel.h>
 #include <sys/module.h>
 #else
-#include <errno.h>
 #include <sys/types.h>
+#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #endif
@@ -128,9 +129,9 @@
 #define RTSP_CONTROL_PORT_NUMBER_2 7070
 #define TFTP_PORT_NUMBER 69
 
-static void
-AliasHandleRtspOut(struct libalias *, struct ip *, struct alias_link *,
-    int maxpacketsize);
+static void AliasHandleRtspOut(struct libalias *, struct ip *,
+    struct alias_link *, size_t);
+
 static int
 fingerprint(struct libalias *la, struct alias_data *ah)
 {
@@ -154,7 +155,8 @@ protohandler(struct libalias *la, struct ip *pip, struct alias_data *ah)
 	if (ntohs(*ah->dport) == TFTP_PORT_NUMBER)
 		FindRtspOut(la, pip->ip_src, pip->ip_dst,
 		    *ah->sport, *ah->aport, IPPROTO_UDP);
-	else AliasHandleRtspOut(la, pip, ah->lnk, ah->maxpktsize);
+	else
+		AliasHandleRtspOut(la, pip, ah->lnk, ah->maxpktsize);
 	return (0);
 }
 
@@ -208,13 +210,15 @@ MODULE_DEPEND(alias_smedia, libalias, 1, 1, 1);
 
 #define ISDIGIT(a) (((a) >= '0') && ((a) <= '9'))
 
-static int
-search_string(char *data, int dlen, const char *search_str)
+static ssize_t
+search_string(char *data, size_t dlen, const char *search_str)
 {
-	int i, j, k;
-	int search_str_len;
+	size_t i, j, k;
+	size_t search_str_len;
 
 	search_str_len = strlen(search_str);
+	if (search_str_len > dlen)
+		return (-1);
 	for (i = 0; i < dlen - search_str_len; i++) {
 		for (j = i, k = 0; j < dlen - search_str_len; j++, k++) {
 			if (data[j] != search_str[k] &&
@@ -230,18 +234,21 @@ search_string(char *data, int dlen, const char *search_str)
 static int
 alias_rtsp_out(struct libalias *la, struct ip *pip,
     struct alias_link *lnk,
-    char *data,
+    char *data, size_t maxlen,
     const char *port_str)
 {
-	int hlen, tlen, dlen;
+	size_t hlen, tlen, dlen;
+	size_t i, j;
 	struct tcphdr *tc;
-	int i, j, pos, state, port_dlen, new_dlen, delta;
+	int delta, state;
+	ssize_t pos, slen;
+	size_t new_dlen, port_dlen, port_slen;
 	u_short p[2], new_len;
 	u_short sport, eport, base_port;
 	u_short salias = 0, ealias = 0, base_alias = 0;
 	const char *transport_str = "transport:";
-	char newdata[2048], *port_data, *port_newdata, stemp[80];
-	int links_created = 0, pkt_updated = 0;
+	char *newdata, *port_data;
+	bool links_created = false, pkt_updated = false;
 	struct alias_link *rtsp_lnk = NULL;
 	struct in_addr null_addr;
 
@@ -250,6 +257,9 @@ alias_rtsp_out(struct libalias *la, struct ip *pip,
 	hlen = (pip->ip_hl + tc->th_off) << 2;
 	tlen = ntohs(pip->ip_len);
 	dlen = tlen - hlen;
+	if (hlen > tlen || tlen > maxlen)
+		return (-1);
+	port_slen = strlen(port_str);
 
 	/* Find keyword, "Transport: " */
 	pos = search_string(data, dlen, transport_str);
@@ -259,17 +269,21 @@ alias_rtsp_out(struct libalias *la, struct ip *pip,
 	port_data = data + pos;
 	port_dlen = dlen - pos;
 
+	/* Allocate temporary buffer */
+	maxlen -= hlen;
+	if ((newdata = malloc(maxlen)) == NULL)
+		return (-1);
 	memcpy(newdata, data, pos);
-	port_newdata = newdata + pos;
+	new_dlen = pos;
 
-	while (port_dlen > (int)strlen(port_str)) {
+	while (port_dlen > port_slen) {
 		/* Find keyword, appropriate port string */
 		pos = search_string(port_data, port_dlen, port_str);
-		if (pos < 0)
+		if (pos < 0 || (size_t)pos + 1 > maxlen - new_dlen)
 			break;
 
-		memcpy(port_newdata, port_data, pos + 1);
-		port_newdata += (pos + 1);
+		memcpy(newdata + new_dlen, port_data, pos + 1);
+		new_dlen += pos + 1;
 
 		p[0] = p[1] = 0;
 		sport = eport = 0;
@@ -300,7 +314,7 @@ alias_rtsp_out(struct libalias *la, struct ip *pip,
 				eport = htons(p[1]);
 
 				if (!links_created) {
-					links_created = 1;
+					links_created = true;
 					/*
 					 * Find an even numbered port
 					 * number base that satisfies the
@@ -349,24 +363,30 @@ alias_rtsp_out(struct libalias *la, struct ip *pip,
 					ealias = htons(base_alias + (RTSP_PORT_GROUP - 1));
 				}
 				if (salias && rtsp_lnk) {
-					pkt_updated = 1;
+					pkt_updated = true;
 
 					/* Copy into IP packet */
-					sprintf(stemp, "%d", ntohs(salias));
-					memcpy(port_newdata, stemp, strlen(stemp));
-					port_newdata += strlen(stemp);
+					slen = snprintf(newdata + new_dlen,
+					    maxlen - new_dlen, "%d", ntohs(salias));
+					if (slen < 0 || slen >= maxlen - new_dlen)
+						goto fail;
+					new_dlen += slen;
 
 					if (eport != 0) {
-						*port_newdata = '-';
-						port_newdata++;
+						if (new_dlen == maxlen)
+							goto fail;
+						newdata[new_dlen++] = '-';
 
 						/* Copy into IP packet */
-						sprintf(stemp, "%d", ntohs(ealias));
-						memcpy(port_newdata, stemp, strlen(stemp));
-						port_newdata += strlen(stemp);
+						slen = snprintf(newdata + new_dlen,
+						    maxlen - new_dlen, "%d", ntohs(ealias));
+						if (slen < 0 || slen >= maxlen - new_dlen)
+							goto fail;
+						new_dlen += slen;
 					}
-					*port_newdata = ';';
-					port_newdata++;
+					if (new_dlen == maxlen)
+						goto fail;
+					newdata[new_dlen++] = ';';
 				}
 				state++;
 				break;
@@ -380,20 +400,20 @@ alias_rtsp_out(struct libalias *la, struct ip *pip,
 	}
 
 	if (!pkt_updated)
-		return (-1);
-
-	memcpy(port_newdata, port_data, port_dlen);
-	port_newdata += port_dlen;
-	*port_newdata = '\0';
+		goto fail;
 
 	/* Create new packet */
-	new_dlen = port_newdata - newdata;
+	if (new_dlen + port_dlen > maxlen)
+		goto fail;
+	memmove(data + new_dlen, port_data, port_dlen);
 	memcpy(data, newdata, new_dlen);
+	new_dlen += port_dlen;
+	free(newdata);
 
 	SetAckModified(lnk);
 	tc = (struct tcphdr *)ip_next(pip);
 	delta = GetDeltaSeqOut(tc->th_seq, lnk);
-	AddSeq(lnk, delta + new_dlen - dlen, pip->ip_hl, pip->ip_len,
+	AddSeq(lnk, delta + (int)(new_dlen - dlen), pip->ip_hl, pip->ip_len,
 	    tc->th_seq, tc->th_off);
 
 	new_len = htons(hlen + new_dlen);
@@ -407,6 +427,9 @@ alias_rtsp_out(struct libalias *la, struct ip *pip,
 	tc->th_sum = TcpChecksum(pip);
 #endif
 	return (0);
+fail:
+	free(newdata);
+	return (-1);
 }
 
 /* Support the protocol used by early versions of RealPlayer */
@@ -415,13 +438,13 @@ static int
 alias_pna_out(struct libalias *la, struct ip *pip,
     struct alias_link *lnk,
     char *data,
-    int dlen)
+    size_t dlen)
 {
 	struct alias_link *pna_links;
-	u_short msg_id, msg_len;
 	char *work;
-	u_short alias_port, port;
 	struct tcphdr *tc;
+	u_short msg_id, msg_len;
+	u_short alias_port, port;
 
 	work = data;
 	work += 5;
@@ -433,7 +456,7 @@ alias_pna_out(struct libalias *la, struct ip *pip,
 		if (ntohs(msg_id) == 0) /* end of options */
 			return (0);
 
-		if ((ntohs(msg_id) == 1) || (ntohs(msg_id) == 7)) {
+		if (ntohs(msg_id) == 1 || ntohs(msg_id) == 7) {
 			memcpy(&port, work, 2);
 			(void)FindUdpTcpOut(la, pip->ip_src, GetDestAddress(lnk),
 			    port, 0, IPPROTO_UDP, 1, &pna_links);
@@ -462,22 +485,23 @@ alias_pna_out(struct libalias *la, struct ip *pip,
 }
 
 static void
-AliasHandleRtspOut(struct libalias *la, struct ip *pip, struct alias_link *lnk, int maxpacketsize)
+AliasHandleRtspOut(struct libalias *la, struct ip *pip, struct alias_link *lnk,
+    size_t maxlen)
 {
-	int hlen, tlen, dlen;
 	struct tcphdr *tc;
 	char *data;
 	const char *setup = "SETUP", *pna = "PNA", *str200 = "200";
 	const char *okstr = "OK", *client_port_str = "client_port";
 	const char *server_port_str = "server_port";
-	int i, parseOk;
-
-	(void)maxpacketsize;
+	size_t hlen, tlen, dlen;
+	size_t i;
 
 	tc = (struct tcphdr *)ip_next(pip);
 	hlen = (pip->ip_hl + tc->th_off) << 2;
 	tlen = ntohs(pip->ip_len);
 	dlen = tlen - hlen;
+	if (hlen > tlen || tlen > maxlen)
+		return;
 
 	data = (char *)pip;
 	data += hlen;
@@ -485,13 +509,14 @@ AliasHandleRtspOut(struct libalias *la, struct ip *pip, struct alias_link *lnk, 
 	/* When aliasing a client, check for the SETUP request */
 	if ((ntohs(tc->th_dport) == RTSP_CONTROL_PORT_NUMBER_1) ||
 	    (ntohs(tc->th_dport) == RTSP_CONTROL_PORT_NUMBER_2)) {
-		if (dlen >= (int)strlen(setup) &&
+		if (dlen >= strlen(setup) &&
 		    memcmp(data, setup, strlen(setup)) == 0) {
-			alias_rtsp_out(la, pip, lnk, data, client_port_str);
+			alias_rtsp_out(la, pip, lnk, data, maxlen,
+			    client_port_str);
 			return;
 		}
 
-		if (dlen >= (int)strlen(pna) &&
+		if (dlen >= strlen(pna) &&
 		    memcmp(data, pna, strlen(pna)) == 0)
 			alias_pna_out(la, pip, lnk, data, dlen);
 	} else {
@@ -499,24 +524,21 @@ AliasHandleRtspOut(struct libalias *la, struct ip *pip, struct alias_link *lnk, 
 		 * When aliasing a server, check for the 200 reply
 		 * Accommodate varying number of blanks between 200 & OK
 		 */
-
-		if (dlen >= (int)strlen(str200)) {
-			for (parseOk = 0, i = 0;
-			    i <= dlen - (int)strlen(str200);
-			    i++)
-				if (memcmp(&data[i], str200, strlen(str200)) == 0) {
-					parseOk = 1;
-					break;
-				}
-
-			if (parseOk) {
-				i += strlen(str200);	/* skip string found */
-				while (data[i] == ' ')	/* skip blank(s) */
+		if (dlen < strlen(str200) + 1 + strlen(okstr))
+			return;
+		for (i = 0; i <= dlen - strlen(str200) - 1; i++) {
+			if (memcmp(&data[i], str200, strlen(str200)) == 0 &&
+			    data[i + strlen(str200)] == ' ') {
+				i += strlen(str200);	/* skip 200 */
+				while (i < dlen && data[i] == ' ')	/* skip blank(s) */
 					i++;
-
-				if ((dlen - i) >= (int)strlen(okstr))
-					if (memcmp(&data[i], okstr, strlen(okstr)) == 0)
-						alias_rtsp_out(la, pip, lnk, data, server_port_str);
+				if (dlen - i >= strlen(okstr)) {
+					if (memcmp(&data[i], okstr, strlen(okstr)) == 0) {
+						alias_rtsp_out(la, pip, lnk, data,
+						    maxlen, server_port_str);
+						break;
+					}
+				}
 			}
 		}
 	}

--- a/sys/netinet/tcp_stacks/rack.c
+++ b/sys/netinet/tcp_stacks/rack.c
@@ -24317,6 +24317,7 @@ process_opt:
 		INP_WUNLOCK(inp);
 		return (ENOPROTOOPT);
 	}
+	rack = (struct tcp_rack *)tp->t_fb_ptr;
 	if (rack->defer_options && (rack->gp_ready == 0) &&
 	    (sopt->sopt_name != TCP_DEFER_OPTIONS) &&
 	    (sopt->sopt_name != TCP_HYBRID_PACING) &&

--- a/sys/opencrypto/ktls_ocf.c
+++ b/sys/opencrypto/ktls_ocf.c
@@ -498,12 +498,13 @@ ktls_ocf_tls_cbc_decrypt(struct ktls_session *tls,
 	iov = malloc(iovcnt * sizeof(*iov), M_KTLS_OCF, M_WAITOK);
 	IOVEC_INIT(&iov[0], &ad, sizeof(ad));
 	skip = sizeof(*hdr) + AES_BLOCK_LEN;
-	for (i = 1, n = m; n != NULL; i++, n = n->m_next) {
+	for (i = 1, n = m; n != NULL; n = n->m_next) {
 		if (n->m_len < skip) {
 			skip -= n->m_len;
 			continue;
 		}
 		IOVEC_INIT(&iov[i], mtod(n, char *) + skip, n->m_len - skip);
+		i++;
 		skip = 0;
 	}
 	uio.uio_iov = iov;

--- a/sys/vm/device_pager.c
+++ b/sys/vm/device_pager.c
@@ -213,7 +213,8 @@ again:
 			object1 = NULL;
 			object->handle = handle;
 			object->un_pager.devp.ops = ops;
-			TAILQ_INIT(&object->un_pager.devp.devp_pglist);
+			if (object->type == OBJT_DEVICE)
+				vm_object_set_flag(object, OBJ_PG_DTOR);
 			TAILQ_INSERT_TAIL(&dev_pager_object_list, object,
 			    pager_object_list);
 			mtx_unlock(&dev_pager_mtx);
@@ -325,15 +326,12 @@ dev_pager_free_page(vm_object_t object, vm_page_t m)
 	KASSERT((object->type == OBJT_DEVICE &&
 	    (m->oflags & VPO_UNMANAGED) != 0),
 	    ("Managed device or page obj %p m %p", object, m));
-	TAILQ_REMOVE(&object->un_pager.devp.devp_pglist, m, plinks.q);
 	vm_page_putfake(m);
 }
 
 static void
 dev_pager_dealloc(vm_object_t object)
 {
-	vm_page_t m;
-
 	VM_OBJECT_WUNLOCK(object);
 	object->un_pager.devp.ops->cdev_pg_dtor(object->un_pager.devp.handle);
 
@@ -343,15 +341,25 @@ dev_pager_dealloc(vm_object_t object)
 	VM_OBJECT_WLOCK(object);
 
 	if (object->type == OBJT_DEVICE) {
-		/*
-		 * Free up our fake pages.
-		 */
-		while ((m = TAILQ_FIRST(&object->un_pager.devp.devp_pglist))
-		    != NULL) {
-			if (vm_page_busy_acquire(m, VM_ALLOC_WAITFAIL) == 0)
-				continue;
+		struct pctrie_iter pages;
+		vm_page_t m;
 
-			dev_pager_free_page(object, m);
+		vm_page_iter_init(&pages, object);
+restart:
+		VM_RADIX_FOREACH(m, &pages) {
+			if (!vm_page_busy_acquire(m, VM_ALLOC_WAITFAIL)) {
+				pctrie_iter_reset(&pages);
+				goto restart;
+			}
+			if (vm_page_iter_remove(&pages, m)) {
+				/*
+				 * We could end up with invalid pages installed
+				 * by the generic page fault handler.  Typically
+				 * these are replaced by the device pager.
+				 */
+				vm_page_free(m);
+			} else if ((m->flags & PG_FICTITIOUS) != 0)
+				dev_pager_free_page(object, m);
 		}
 	}
 	object->handle = NULL;
@@ -380,10 +388,6 @@ dev_pager_getpages(vm_object_t object, vm_page_t *ma, int count, int *rbehind,
 		    (object->type == OBJT_MGTDEVICE &&
 		     (ma[0]->oflags & VPO_UNMANAGED) == 0),
 		    ("Wrong page type %p %p", ma[0], object));
-		if (object->type == OBJT_DEVICE) {
-			TAILQ_INSERT_TAIL(&object->un_pager.devp.devp_pglist,
-			    ma[0], plinks.q);
-		}
 		if (rbehind)
 			*rbehind = 0;
 		if (rahead)

--- a/sys/vm/vm_object.h
+++ b/sys/vm/vm_object.h
@@ -135,7 +135,6 @@ struct vm_object {
 		 *	devp_pglist - list of allocated pages
 		 */
 		struct {
-			TAILQ_HEAD(, vm_page) devp_pglist;
 			const struct cdev_pager_ops *ops;
 			void *handle;
 		} devp;

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -4289,6 +4289,9 @@ vm_page_unwire_managed(vm_page_t m, uint8_t nqueue, bool noreuse)
 {
 	u_int old;
 
+	KASSERT(nqueue < PQ_COUNT,
+	    ("vm_page_unwire: invalid queue %u request for page %p",
+	    nqueue, m));
 	KASSERT((m->oflags & VPO_UNMANAGED) == 0,
 	    ("%s: page %p is unmanaged", __func__, m));
 
@@ -4347,17 +4350,15 @@ vm_page_unwire_managed(vm_page_t m, uint8_t nqueue, bool noreuse)
 void
 vm_page_unwire(vm_page_t m, uint8_t nqueue)
 {
-
-	KASSERT(nqueue < PQ_COUNT,
-	    ("vm_page_unwire: invalid queue %u request for page %p",
-	    nqueue, m));
+        KASSERT(nqueue < PQ_COUNT || nqueue == PQ_NONE,
+            ("%s: invalid queue %u request for page %p", __func__, nqueue, m));
 
 	if ((m->oflags & VPO_UNMANAGED) != 0) {
 		if (vm_page_unwire_noq(m) && m->ref_count == 0)
 			vm_page_free(m);
-		return;
+	} else {
+		vm_page_unwire_managed(m, nqueue, false);
 	}
-	vm_page_unwire_managed(m, nqueue, false);
 }
 
 /*
@@ -4531,13 +4532,15 @@ vm_page_release_toq(vm_page_t m, uint8_t nqueue, const bool noreuse)
 void
 vm_page_release(vm_page_t m, int flags)
 {
-	vm_object_t object;
-
-	KASSERT((m->oflags & VPO_UNMANAGED) == 0,
-	    ("vm_page_release: page %p is unmanaged", m));
+	if ((m->oflags & VPO_UNMANAGED) != 0) {
+		vm_page_unwire(m, PQ_NONE);
+		return;
+	}
 
 	if ((flags & VPR_TRYFREE) != 0) {
 		for (;;) {
+			vm_object_t object;
+
 			object = atomic_load_ptr(&m->object);
 			if (object == NULL)
 				break;

--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -1346,8 +1346,10 @@ vm_page_putfake(vm_page_t m)
 	KASSERT((m->oflags & VPO_UNMANAGED) != 0, ("managed %p", m));
 	KASSERT((m->flags & PG_FICTITIOUS) != 0,
 	    ("vm_page_putfake: bad page %p", m));
-	vm_page_assert_xbusied(m);
-	vm_page_busy_free(m);
+	if (m->object != NULL) {
+		vm_page_assert_xbusied(m);
+		vm_page_busy_free(m);
+	}
 	uma_zfree(fakepg_zone, m);
 }
 

--- a/tests/sys/kern/Makefile
+++ b/tests/sys/kern/Makefile
@@ -32,6 +32,7 @@ ATF_TESTS_C+=	procdesc
 ATF_TESTS_C+=	ptrace_test
 TEST_METADATA.ptrace_test+=		timeout="15"
 ATF_TESTS_C+=	reaper
+ATF_TESTS_C+=	resolve_beneath_test
 ATF_TESTS_C+=	sched_affinity
 ATF_TESTS_C+=	shutdown_dgram
 ATF_TESTS_C+=	sigaltstack

--- a/tests/sys/kern/ktls_test.c
+++ b/tests/sys/kern/ktls_test.c
@@ -303,6 +303,15 @@ fd_set_blocking(int fd)
 	ATF_REQUIRE(fcntl(fd, F_SETFL, flags) != -1);
 }
 
+static void
+tcp_nodelay(int fd)
+{
+	int nodelay = 1;
+
+	ATF_REQUIRE(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &nodelay,
+	    sizeof(nodelay)) == 0);
+}
+
 static bool
 cbc_crypt(const EVP_CIPHER *cipher, const char *key, const char *iv,
     const char *input, char *output, size_t size, int enc)
@@ -1920,6 +1929,55 @@ test_ktls_receive_bad_size(const atf_tc_t *tc, struct tls_enable *en,
 	close_sockets_ignore_errors(sockets);
 }
 
+static void
+test_ktls_receive_split_record(const atf_tc_t *tc, struct tls_enable *en,
+    uint64_t seqno, size_t len, size_t first_len)
+{
+	char *plaintext, *received, *outbuf;
+	size_t outbuf_cap, outbuf_len;
+	ssize_t rv;
+	int sockets[2];
+
+	ATF_REQUIRE(len <= TLS_MAX_MSG_SIZE_V10_2);
+
+	plaintext = alloc_buffer(len);
+	received = malloc(len);
+	outbuf_cap = tls_header_len(en) + len + tls_trailer_len(en);
+	outbuf = malloc(outbuf_cap);
+
+	ATF_REQUIRE_MSG(open_sockets(tc, sockets), "failed to create sockets");
+
+	ATF_REQUIRE(setsockopt(sockets[0], IPPROTO_TCP, TCP_RXTLS_ENABLE, en,
+	    sizeof(*en)) == 0);
+	check_tls_mode(tc, sockets[0], TCP_RXTLS_MODE);
+
+	fd_set_blocking(sockets[0]);
+	fd_set_blocking(sockets[1]);
+
+	outbuf_len = encrypt_tls_record(tc, en, TLS_RLTYPE_APP, seqno,
+	    plaintext, len, outbuf, outbuf_cap, 0);
+	ATF_REQUIRE(first_len < outbuf_len);
+
+	tcp_nodelay(sockets[1]);
+	rv = write(sockets[1], outbuf, first_len);
+	ATF_REQUIRE_INTEQ((ssize_t)(first_len), rv);
+
+	rv = write(sockets[1], outbuf + first_len, outbuf_len - first_len);
+	ATF_REQUIRE_INTEQ((ssize_t)(outbuf_len - first_len), rv);
+
+	rv = ktls_receive_tls_record(en, sockets[0], TLS_RLTYPE_APP, received,
+	    len);
+	ATF_REQUIRE_INTEQ((ssize_t)len, rv);
+
+	ATF_REQUIRE(memcmp(plaintext, received, len) == 0);
+
+	free(outbuf);
+	free(received);
+	free(plaintext);
+
+	close_sockets(sockets);
+}
+
 #define	TLS_10_TESTS(M)							\
 	M(aes128_cbc_1_0_sha1, CRYPTO_AES_CBC, 128 / 8,			\
 	    CRYPTO_SHA1_HMAC, TLS_MINOR_VER_ZERO)			\
@@ -2360,6 +2418,26 @@ ATF_TC_BODY(ktls_receive_##cipher_name##_##name, tc)			\
 	    auth_alg, minor, name)					\
 	ATF_TP_ADD_TC(tp, ktls_receive_##cipher_name##_##name);
 
+#define GEN_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, name, len, first_len)		\
+ATF_TC_WITHOUT_HEAD(ktls_receive_##cipher_name##_split_##name);		\
+ATF_TC_BODY(ktls_receive_##cipher_name##_split_##name, tc)		\
+{									\
+	struct tls_enable en;						\
+	uint64_t seqno;							\
+									\
+	ATF_REQUIRE_KTLS();						\
+	seqno = random();						\
+	build_tls_enable(tc, cipher_alg, key_size, auth_alg, minor,	\
+	    seqno, &en);						\
+	test_ktls_receive_split_record(tc, &en, seqno, len, first_len);	\
+	free_tls_enable(&en);						\
+}
+
+#define ADD_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, name)				\
+	ATF_TP_ADD_TC(tp, ktls_receive_##cipher_name##_split_##name);
+
 #define GEN_RECEIVE_TESTS(cipher_name, cipher_alg, key_size, auth_alg,	\
 	    minor)							\
 	GEN_RECEIVE_APP_DATA_TEST(cipher_name, cipher_alg, key_size,	\
@@ -2381,7 +2459,22 @@ ATF_TC_BODY(ktls_receive_##cipher_name##_##name, tc)			\
 	    tls_minimum_record_payload(&en) - 1)			\
 	GEN_RECEIVE_BAD_SIZE_TEST(cipher_name, cipher_alg, key_size,	\
 	    auth_alg, minor, oversized_record,				\
-	    TLS_MAX_MSG_SIZE_V10_2 * 2)
+	    TLS_MAX_MSG_SIZE_V10_2 * 2)					\
+	GEN_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, header, 64,			\
+	    sizeof(struct tls_record_layer));				\
+	GEN_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, full_header, 64,			\
+	    tls_header_len(&en));					\
+	GEN_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, half, 64,			\
+	    tls_header_len(&en) + 32);					\
+	GEN_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, trailer_start, 64,		\
+	    tls_header_len(&en) + 64);					\
+	GEN_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, trailer_middle, 64,		\
+	    tls_header_len(&en) + 64 + tls_trailer_len(&en) / 2);
 
 #define ADD_RECEIVE_TESTS(cipher_name, cipher_alg, key_size, auth_alg,	\
 	    minor)							\
@@ -2402,7 +2495,17 @@ ATF_TC_BODY(ktls_receive_##cipher_name##_##name, tc)			\
 	ADD_RECEIVE_BAD_SIZE_TEST(cipher_name, cipher_alg, key_size,	\
 	    auth_alg, minor, small_record)				\
 	ADD_RECEIVE_BAD_SIZE_TEST(cipher_name, cipher_alg, key_size,	\
-	    auth_alg, minor, oversized_record)
+	    auth_alg, minor, oversized_record)				\
+	ADD_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, header)				\
+	ADD_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, full_header)			\
+	ADD_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, half)				\
+	ADD_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, trailer_start)			\
+	ADD_RECEIVE_SPLIT_RECORD_TEST(cipher_name, cipher_alg,		\
+	    key_size, auth_alg, minor, trailer_middle)			\
 
 /*
  * For each supported cipher suite, run several receive tests:
@@ -2425,6 +2528,9 @@ ATF_TC_BODY(ktls_receive_##cipher_name##_##name, tc)			\
  *   size
  *
  * - a test with an oversized TLS record
+ *
+ * - tests of a single record whose data is split across two writes,
+ *   with each test using a different split point
  */
 AES_CBC_NONZERO_TESTS(GEN_RECEIVE_TESTS);
 AES_GCM_TESTS(GEN_RECEIVE_TESTS);

--- a/tests/sys/kern/resolve_beneath_test.c
+++ b/tests/sys/kern/resolve_beneath_test.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 The FreeBSD Foundation
+ *
+ * This software was written by Mark Johnston under sponsorship from
+ * the FreeBSD Foundation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sys/stat.h>
+#include <sys/mount.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <atf-c.h>
+
+/*
+ * Verify that AT_RESOLVE_BENEATH is respected by various system calls.
+ */
+
+static int
+setup(void)
+{
+	int fd, tfd;
+
+	ATF_REQUIRE_EQ(0, mkdir("base", 0755));
+	ATF_REQUIRE_EQ(0, mkdir("outside", 0755));
+	ATF_REQUIRE((tfd = open("outside/target", O_CREAT | O_WRONLY, 0644)) >=
+	    0);
+	ATF_REQUIRE(close(tfd) == 0);
+	ATF_REQUIRE_EQ(0, mkdir("outside/dir", 0755));
+	ATF_REQUIRE((tfd = open("base/file", O_CREAT | O_WRONLY, 0644)) >= 0);
+	ATF_REQUIRE(close(tfd) == 0);
+	ATF_REQUIRE_EQ(0, mkdir("base/subdir", 0755));
+	ATF_REQUIRE((fd = open("base", O_DIRECTORY | O_RDONLY)) >= 0);
+	return (fd);
+}
+
+ATF_TC_WITHOUT_HEAD(faccessat_beneath);
+ATF_TC_BODY(faccessat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    faccessat(fd, "file", F_OK, AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    faccessat(fd, "../outside/target", F_OK,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(chflagsat_beneath);
+ATF_TC_BODY(chflagsat_beneath, tc)
+{
+	int fd, ret;
+
+	fd = setup();
+	ret = chflagsat(fd, "file", UF_NODUMP, AT_RESOLVE_BENEATH);
+	if (ret != 0)
+		ATF_REQUIRE_EQ(EOPNOTSUPP, errno);
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    chflagsat(fd, "../outside/target", UF_NODUMP,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(fchmodat_beneath);
+ATF_TC_BODY(fchmodat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    fchmodat(fd, "file", 0644, AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    fchmodat(fd, "../outside/target", 0644,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(fchownat_beneath);
+ATF_TC_BODY(fchownat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    fchownat(fd, "file", -1, -1, AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    fchownat(fd, "../outside/target", 0, 0,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(utimensat_beneath);
+ATF_TC_BODY(utimensat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    utimensat(fd, "file", NULL, AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    utimensat(fd, "../outside/target", NULL,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(linkat_beneath);
+ATF_TC_BODY(linkat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    linkat(fd, "file", fd, "hardlink", AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    linkat(fd, "../outside/target", fd, "hardlink2",
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(unlinkat_beneath);
+ATF_TC_BODY(unlinkat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    unlinkat(fd, "file", AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    unlinkat(fd, "../outside/target",
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(unlinkat_rmdir_beneath);
+ATF_TC_BODY(unlinkat_rmdir_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    unlinkat(fd, "subdir",
+	    AT_REMOVEDIR | AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    unlinkat(fd, "../outside/dir",
+	    AT_REMOVEDIR | AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE_EQ(0, access("outside/dir", F_OK));
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(funlinkat_beneath);
+ATF_TC_BODY(funlinkat_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    funlinkat(fd, "file", FD_NONE, AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    funlinkat(fd, "../outside/target", FD_NONE,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC_WITHOUT_HEAD(funlinkat_rmdir_beneath);
+ATF_TC_BODY(funlinkat_rmdir_beneath, tc)
+{
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0, mkdir("base/subdir2", 0755));
+	ATF_REQUIRE_EQ(0,
+	    funlinkat(fd, "subdir2", FD_NONE,
+	    AT_REMOVEDIR | AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    funlinkat(fd, "../outside/dir", FD_NONE,
+	    AT_REMOVEDIR | AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE_EQ(0, access("outside/dir", F_OK));
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TC(getfhat_beneath);
+ATF_TC_HEAD(getfhat_beneath, tc)
+{
+	atf_tc_set_md_var(tc, "require.user", "root");
+}
+ATF_TC_BODY(getfhat_beneath, tc)
+{
+	fhandle_t fh;
+	int fd;
+
+	fd = setup();
+	ATF_REQUIRE_EQ(0,
+	    getfhat(fd, "file", &fh, AT_RESOLVE_BENEATH));
+	ATF_REQUIRE_ERRNO(ENOTCAPABLE,
+	    getfhat(fd, "../outside/target", &fh,
+	    AT_RESOLVE_BENEATH) == -1);
+	ATF_REQUIRE(close(fd) == 0);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, faccessat_beneath);
+	ATF_TP_ADD_TC(tp, chflagsat_beneath);
+	ATF_TP_ADD_TC(tp, fchmodat_beneath);
+	ATF_TP_ADD_TC(tp, fchownat_beneath);
+	ATF_TP_ADD_TC(tp, utimensat_beneath);
+	ATF_TP_ADD_TC(tp, linkat_beneath);
+	ATF_TP_ADD_TC(tp, unlinkat_beneath);
+	ATF_TP_ADD_TC(tp, unlinkat_rmdir_beneath);
+	ATF_TP_ADD_TC(tp, funlinkat_beneath);
+	ATF_TP_ADD_TC(tp, funlinkat_rmdir_beneath);
+	ATF_TP_ADD_TC(tp, getfhat_beneath);
+	return (atf_no_error());
+}

--- a/tests/sys/netinet/libalias/Makefile
+++ b/tests/sys/netinet/libalias/Makefile
@@ -3,6 +3,10 @@ PACKAGE=	tests
 TESTSDIR=	${TESTSBASE}/sys/netinet/libalias
 BINDIR=		${TESTSDIR}
 
+PLAIN_TESTS_C+=	smedia
+
+LIBADD.smedia+=	sbuf
+
 ATF_TESTS_C+=	1_instance	\
 		2_natout	\
 		3_natin		\

--- a/tests/sys/netinet/libalias/smedia.c
+++ b/tests/sys/netinet/libalias/smedia.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 The FreeBSD Foundation
+ *
+ * This software was developed by Mark Johnston under sponsorship from
+ * the FreeBSD Foundation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*
+ * A minimal regression test for a buffer overflow in alias_rtsp_out().
+ */
+
+#include <sys/types.h>
+#include <sys/sbuf.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/tcp_var.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <alias.h>
+
+int
+main(void)
+{
+	uint8_t *packet;
+	struct ip ip;
+	struct tcphdr tcp;
+	struct sbuf sb;
+	struct libalias *la;
+
+	sbuf_new(&sb, NULL, 0, SBUF_AUTOEXTEND);
+	sbuf_printf(&sb, "SETUP rtsp://example.com/media.mp4 RTSP/1.0\r\n");
+	sbuf_printf(&sb, "CSeq: 1\r\n");
+	sbuf_printf(&sb, "Transport: RTP/AVP;unicast;");
+	for (int i = 0; i < 200; i++)
+		sbuf_printf(&sb, "client_port=%d-%d;", 2 * i, 2 * i + 1);
+	sbuf_printf(&sb, "\r\n\r\n");
+	sbuf_finish(&sb);
+
+	memset(&tcp, 0, sizeof(tcp));
+	tcp.th_sport = htons(1234);
+	tcp.th_dport = htons(554);
+	tcp.th_off = 5;
+
+	memset(&ip, 0, sizeof(ip));
+	ip.ip_v = IPVERSION;
+	ip.ip_hl = sizeof(ip) / 4;
+	ip.ip_len = htons(sizeof(ip) + sizeof(tcp) + sbuf_len(&sb));
+	ip.ip_id = htons(1);
+	ip.ip_ttl = 64;
+	ip.ip_p = IPPROTO_TCP;
+	ip.ip_src.s_addr = inet_addr("127.0.0.1");
+	ip.ip_dst.s_addr = inet_addr("127.0.0.2");
+
+	packet = malloc(sizeof(ip) + sizeof(tcp) + sbuf_len(&sb));
+	memcpy(packet, &ip, sizeof(ip));
+	memcpy(packet + sizeof(ip), &tcp, sizeof(tcp));
+	memcpy(packet + sizeof(ip) + sizeof(tcp), sbuf_data(&sb),
+	    sbuf_len(&sb));
+
+	la = LibAliasInit(NULL);
+	LibAliasSetAddress(la,
+	    (struct in_addr){.s_addr = inet_addr("127.0.0.1")});
+	if (LibAliasOut(la, packet, sizeof(ip) + sizeof(tcp) + sbuf_len(&sb)) !=
+	    PKT_ALIAS_OK)
+		return (1);
+	LibAliasUninit(la);
+	return (0);
+}

--- a/tests/sys/posixshm/memfd_test.c
+++ b/tests/sys/posixshm/memfd_test.c
@@ -34,6 +34,8 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include "posixshm.h"
+
 ATF_TC_WITHOUT_HEAD(basic);
 ATF_TC_BODY(basic, tc)
 {
@@ -277,6 +279,38 @@ ATF_TC_BODY(immutable_seals, tc)
 	close(fd);
 }
 
+ATF_TC_WITHOUT_HEAD(hugetlb);
+ATF_TC_BODY(hugetlb, tc)
+{
+	size_t ps[MAXPAGESIZES], pgsize;
+	int fd, pscnt;
+
+	pscnt = pagesizes(ps, false);
+#define	MFD_HUGE_SUPPORTED(sz)	(sz <= (1 << 24))
+#define	MFD_HUGE_FLAGS(sz) (((ffsl(sz) - 1U) << MFD_HUGE_SHIFT) & MFD_HUGE_MASK)
+	for (int psidx = 1; psidx < pscnt; psidx++) {
+		pgsize = ps[psidx];
+
+		if (!MFD_HUGE_SUPPORTED(pgsize))
+			continue;
+
+		ATF_REQUIRE_MSG((fd = memfd_create("...",
+		    MFD_HUGETLB | MFD_HUGE_FLAGS(pgsize))) != -1,
+		    "Creating a %zu-size hugetlb memfd", pgsize);
+	}
+
+	fd = memfd_create("...", MFD_HUGETLB);
+	if (pscnt == 1) {
+		ATF_REQUIRE_MSG(fd == -1,
+		    "Creating an unspecified hugetlb memfd without large page support");
+		ATF_REQUIRE(errno == ENOSYS);
+	} else {
+		ATF_REQUIRE_MSG(fd != -1,
+		    "Creating an unspecified hugetlb memfd with large page support");
+		close(fd);
+	}
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 
@@ -289,5 +323,6 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, get_seals);
 	ATF_TP_ADD_TC(tp, dup_seals);
 	ATF_TP_ADD_TC(tp, immutable_seals);
+	ATF_TP_ADD_TC(tp, hugetlb);
 	return (atf_no_error());
 }

--- a/tests/sys/posixshm/posixshm.h
+++ b/tests/sys/posixshm/posixshm.h
@@ -1,0 +1,45 @@
+/*-
+ *
+ * Copyright (c) 2020 Klara, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/mman.h>
+
+#include <stdbool.h>
+
+static int
+pagesizes(size_t ps[MAXPAGESIZES], bool required)
+{
+	int pscnt;
+
+	pscnt = getpagesizes(ps, MAXPAGESIZES);
+	ATF_REQUIRE_MSG(pscnt != -1, "getpagesizes failed; errno=%d", errno);
+	ATF_REQUIRE_MSG(ps[0] != 0, "psind 0 is %zu", ps[0]);
+	ATF_REQUIRE_MSG(pscnt <= MAXPAGESIZES, "invalid pscnt %d", pscnt);
+	if (pscnt == 1 && required)
+		atf_tc_skip("no large page support");
+	return (pscnt);
+}
+

--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -1962,6 +1962,43 @@ ATF_TC_BODY(largepage_reopen, tc)
 	    "close failed; errno=%d", errno);
 }
 
+ATF_TC_WITHOUT_HEAD(largepage_truncate);
+ATF_TC_BODY(largepage_truncate, tc)
+{
+	size_t ps[MAXPAGESIZES];
+	int fd, psind;
+
+	(void)pagesizes(ps, true);
+	psind = 1;
+
+	gen_test_path();
+	fd = shm_create_largepage(test_path, O_CREAT | O_RDWR, psind,
+	    SHM_LARGEPAGE_ALLOC_DEFAULT, 0600);
+	if (fd < 0 && errno == ENOTTY)
+		atf_tc_skip("no large page support");
+	ATF_REQUIRE_MSG(fd >= 0, "shm_create_largepage failed; error=%d", errno);
+
+	ATF_REQUIRE_MSG(ftruncate(fd, ps[psind]) == 0,
+	    "ftruncate failed; error=%d", errno);
+
+	ATF_REQUIRE_MSG(close(fd) == 0, "close failed; error=%d", errno);
+
+	fd = shm_open(test_path, O_RDWR | O_TRUNC, 0);
+	ATF_REQUIRE_MSG(fd == -1, "shm_open(O_TRUNC) should have failed");
+	ATF_REQUIRE_ERRNO(ENOTSUP, fd == -1);
+
+	fd = shm_open(test_path, O_RDWR, 0);
+	ATF_REQUIRE_MSG(fd >= 0, "shm_open failed; error=%d", errno);
+
+	ATF_REQUIRE_MSG(ftruncate(fd, ps[psind]) == 0,
+	    "ftruncate to same size failed; error=%d", errno);
+
+	ATF_REQUIRE_MSG(shm_unlink(test_path) == 0,
+	    "shm_unlink failed; errno=%d", errno);
+	ATF_REQUIRE_MSG(close(fd) == 0,
+	    "close failed; errno=%d", errno);
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, remap_object);
@@ -2010,6 +2047,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, largepage_minherit);
 	ATF_TP_ADD_TC(tp, largepage_pipe);
 	ATF_TP_ADD_TC(tp, largepage_reopen);
+	ATF_TP_ADD_TC(tp, largepage_truncate);
 
 	return (atf_no_error());
 }

--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -1360,6 +1360,27 @@ ATF_TC_BODY(largepage_config, tc)
 	ATF_REQUIRE(close(fd) == 0);
 }
 
+ATF_TC_WITHOUT_HEAD(largepage_fspacectl);
+ATF_TC_BODY(largepage_fspacectl, tc)
+{
+	struct spacectl_range range;
+	size_t ps[MAXPAGESIZES];
+	int fd, pscnt;
+
+	pscnt = pagesizes(ps, true);
+
+	for (int i = 1; i < pscnt; i++) {
+		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
+
+		range.r_offset = 0;
+		range.r_len = ps[i];
+		ATF_REQUIRE_ERRNO(ENOTSUP,
+		    fspacectl(fd, SPACECTL_DEALLOC, &range, 0, &range) == -1);
+
+		ATF_REQUIRE(close(fd) == 0);
+	}
+}
+
 ATF_TC_WITHOUT_HEAD(largepage_mmap);
 ATF_TC_BODY(largepage_mmap, tc)
 {
@@ -1979,6 +2000,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, mmap_prot);
 	ATF_TP_ADD_TC(tp, largepage_basic);
 	ATF_TP_ADD_TC(tp, largepage_config);
+	ATF_TP_ADD_TC(tp, largepage_fspacectl);
 	ATF_TP_ADD_TC(tp, largepage_mmap);
 	ATF_TP_ADD_TC(tp, largepage_munmap);
 	ATF_TP_ADD_TC(tp, largepage_madvise);

--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -49,6 +49,8 @@
 
 #include <atf-c.h>
 
+#include "posixshm.h"
+
 #define	TEST_PATH_LEN	256
 static char test_path[TEST_PATH_LEN];
 static char test_path2[TEST_PATH_LEN];
@@ -1239,20 +1241,6 @@ shm_open_large(int psind, int policy, size_t sz)
 	return (fd);
 }
 
-static int
-pagesizes(size_t ps[MAXPAGESIZES])
-{
-	int pscnt;
-
-	pscnt = getpagesizes(ps, MAXPAGESIZES);
-	ATF_REQUIRE_MSG(pscnt != -1, "getpagesizes failed; errno=%d", errno);
-	ATF_REQUIRE_MSG(ps[0] != 0, "psind 0 is %zu", ps[0]);
-	ATF_REQUIRE_MSG(pscnt <= MAXPAGESIZES, "invalid pscnt %d", pscnt);
-	if (pscnt == 1)
-		atf_tc_skip("no large page support");
-	return (pscnt);
-}
-
 ATF_TC_WITHOUT_HEAD(largepage_basic);
 ATF_TC_BODY(largepage_basic, tc)
 {
@@ -1261,7 +1249,7 @@ ATF_TC_BODY(largepage_basic, tc)
 	size_t ps[MAXPAGESIZES];
 	int error, fd, pscnt;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	zeroes = calloc(1, ps[0]);
 	ATF_REQUIRE(zeroes != NULL);
 	for (int i = 1; i < pscnt; i++) {
@@ -1317,7 +1305,7 @@ ATF_TC_BODY(largepage_config, tc)
 	size_t ps[MAXPAGESIZES + 1]; /* silence warnings if MAXPAGESIZES == 1 */
 	int error, fd;
 
-	(void)pagesizes(ps);
+	(void)pagesizes(ps, true);
 
 	fd = shm_open(SHM_ANON, O_CREAT | O_RDWR, 0);
 	ATF_REQUIRE_MSG(fd >= 0, "shm_open failed; error=%d", errno);
@@ -1379,7 +1367,7 @@ ATF_TC_BODY(largepage_mmap, tc)
 	size_t ps[MAXPAGESIZES];
 	int fd, pscnt;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
 
@@ -1475,7 +1463,7 @@ ATF_TC_BODY(largepage_munmap, tc)
 	size_t ps[MAXPAGESIZES], ps1;
 	int fd, pscnt;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
 		ps1 = ps[i - 1];
@@ -1526,7 +1514,7 @@ ATF_TC_BODY(largepage_madvise, tc)
 	size_t ps[MAXPAGESIZES];
 	int fd, pscnt;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
 		addr = mmap(NULL, ps[i], PROT_READ | PROT_WRITE, MAP_SHARED, fd,
@@ -1595,7 +1583,7 @@ ATF_TC_BODY(largepage_mlock, tc)
 	    "sysctlbyname(vm.stats.vm.v_user_wire_count) failed; error=%d",
 	    errno);
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		if (ps[i] / ps[0] > max_wired - wired) {
 			/* Cannot wire past the limit. */
@@ -1638,7 +1626,7 @@ ATF_TC_BODY(largepage_msync, tc)
 	size_t ps[MAXPAGESIZES];
 	int fd, pscnt;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
 		addr = mmap(NULL, ps[i], PROT_READ | PROT_WRITE, MAP_SHARED, fd,
@@ -1697,7 +1685,7 @@ ATF_TC_BODY(largepage_mprotect, tc)
 	size_t ps[MAXPAGESIZES];
 	int fd, pscnt;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		/*
 		 * Reserve a contiguous region in the address space to avoid
@@ -1775,7 +1763,7 @@ ATF_TC_BODY(largepage_minherit, tc)
 	pid_t child;
 	int fd, pscnt, status;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 	for (int i = 1; i < pscnt; i++) {
 		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
 		addr = mmap(NULL, ps[i], PROT_READ | PROT_WRITE, MAP_SHARED, fd,
@@ -1863,7 +1851,7 @@ ATF_TC_BODY(largepage_pipe, tc)
 	int fd, pfd[2], pscnt, status;
 	pid_t child;
 
-	pscnt = pagesizes(ps);
+	pscnt = pagesizes(ps, true);
 
 	for (int i = 1; i < pscnt; i++) {
 		fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT, ps[i]);
@@ -1916,7 +1904,7 @@ ATF_TC_BODY(largepage_reopen, tc)
 	size_t ps[MAXPAGESIZES];
 	int fd, psind;
 
-	(void)pagesizes(ps);
+	(void)pagesizes(ps, true);
 	psind = 1;
 
 	gen_test_path();

--- a/tests/sys/posixshm/posixshm_test.c
+++ b/tests/sys/posixshm/posixshm_test.c
@@ -33,6 +33,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/sysctl.h>
@@ -1962,6 +1963,93 @@ ATF_TC_BODY(largepage_reopen, tc)
 	    "close failed; errno=%d", errno);
 }
 
+static unsigned char
+largepage_sendfile_expected(size_t off)
+{
+
+	return ((unsigned char)(off * 131 + (off >> 8)));
+}
+
+ATF_TC_WITHOUT_HEAD(largepage_sendfile);
+ATF_TC_BODY(largepage_sendfile, tc)
+{
+	static const int flags[] = { 0, SF_NOCACHE };
+	char *addr;
+	off_t sbytes;
+	size_t ps[MAXPAGESIZES];
+	int error, fd, pscnt, sd[2], status;
+	pid_t child;
+
+	pscnt = pagesizes(ps, true);
+
+	for (int i = 1; i < pscnt; i++) {
+		for (int fi = 0; fi < (int)nitems(flags); fi++) {
+			fd = shm_open_large(i, SHM_LARGEPAGE_ALLOC_DEFAULT,
+			    ps[i]);
+			addr = mmap(NULL, ps[i], PROT_READ | PROT_WRITE,
+			    MAP_SHARED, fd, 0);
+			ATF_REQUIRE_MSG(addr != MAP_FAILED,
+			    "mmap(%zu bytes) failed; error=%d", ps[i], errno);
+
+			/* Fill with a verifiable pattern. */
+			for (size_t j = 0; j < ps[i]; j++)
+				addr[j] = largepage_sendfile_expected(j);
+
+			ATF_REQUIRE(socketpair(PF_LOCAL, SOCK_STREAM, 0,
+			    sd) == 0);
+
+			child = fork();
+			ATF_REQUIRE_MSG(child != -1,
+			    "fork() failed; error=%d", errno);
+			if (child == 0) {
+				char buf[BUFSIZ];
+				ssize_t len;
+				size_t off, resid;
+
+				(void)close(sd[0]);
+				off = 0;
+				for (resid = ps[i]; resid > 0; resid -= len) {
+					len = read(sd[1], buf, sizeof(buf));
+					if (len <= 0)
+						_exit(1);
+					for (ssize_t k = 0; k < len; k++) {
+						if ((unsigned char)buf[k] !=
+						    largepage_sendfile_expected(
+						    off + k))
+							_exit(2);
+					}
+					off += len;
+				}
+				_exit(0);
+			}
+			ATF_REQUIRE(close(sd[1]) == 0);
+
+			sbytes = 0;
+			error = sendfile(fd, sd[0], 0, ps[i], NULL, &sbytes,
+			    flags[fi]);
+			ATF_REQUIRE_MSG(error == 0,
+			    "sendfile() failed; error=%d flags=%#x",
+			    errno, flags[fi]);
+			ATF_REQUIRE_MSG(sbytes == (off_t)ps[i],
+			    "sendfile() short; sbytes=%jd expected=%zu flags=%#x",
+			    (intmax_t)sbytes, ps[i], flags[fi]);
+
+			ATF_REQUIRE(close(sd[0]) == 0);
+
+			ATF_REQUIRE_MSG(waitpid(child, &status, 0) == child,
+			    "waitpid() failed; error=%d", errno);
+			ATF_REQUIRE_MSG(WIFEXITED(status),
+			    "child killed by signal %d", WTERMSIG(status));
+			ATF_REQUIRE_MSG(WEXITSTATUS(status) == 0,
+			    "child exited with status %d (flags=%#x)",
+			    WEXITSTATUS(status), flags[fi]);
+
+			ATF_REQUIRE(munmap(addr, ps[i]) == 0);
+			ATF_REQUIRE(close(fd) == 0);
+		}
+	}
+}
+
 ATF_TC_WITHOUT_HEAD(largepage_truncate);
 ATF_TC_BODY(largepage_truncate, tc)
 {
@@ -2047,6 +2135,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, largepage_minherit);
 	ATF_TP_ADD_TC(tp, largepage_pipe);
 	ATF_TP_ADD_TC(tp, largepage_reopen);
+	ATF_TP_ADD_TC(tp, largepage_sendfile);
 	ATF_TP_ADD_TC(tp, largepage_truncate);
 
 	return (atf_no_error());

--- a/tests/sys/vm/mmap_test.c
+++ b/tests/sys/vm/mmap_test.c
@@ -362,6 +362,35 @@ ATF_TC_BODY(mmap__maxprot_shm, tc)
 	ATF_REQUIRE(close(fd) == 0);
 }
 
+/* A regression test for a bug in the device pager. */
+ATF_TC_WITHOUT_HEAD(mmap__device_reinsert);
+ATF_TC_BODY(mmap__device_reinsert, tc)
+{
+	void *p;
+	int fd;
+
+	fd = open("/dev/devstat", O_RDONLY);
+	ATF_REQUIRE(fd >= 0);
+
+	p = mmap(NULL, getpagesize(), PROT_READ, MAP_SHARED, fd, 0);
+	ATF_REQUIRE(p != MAP_FAILED);
+
+	/*
+	 * Use mlock() to trigger a fault, since msync() will not actually
+	 * remove the page from the process page tables.
+	 */
+	ATF_REQUIRE(mlock(p, getpagesize()) == 0);
+	ATF_REQUIRE(munlock(p, getpagesize()) == 0);
+	ATF_REQUIRE(msync(p, getpagesize(), MS_INVALIDATE) == 0);
+	ATF_REQUIRE(mlock(p, getpagesize()) == 0);
+	ATF_REQUIRE(munlock(p, getpagesize()) == 0);
+	ATF_REQUIRE(msync(p, getpagesize(), MS_INVALIDATE) == 0);
+	ATF_REQUIRE(mlock(p, getpagesize()) == 0);
+	ATF_REQUIRE(munlock(p, getpagesize()) == 0);
+
+	ATF_REQUIRE(munmap(p, getpagesize()) == 0);
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, mmap__map_at_zero);
@@ -371,6 +400,7 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, mmap__write_only);
 	ATF_TP_ADD_TC(tp, mmap__maxprot_basic);
 	ATF_TP_ADD_TC(tp, mmap__maxprot_shm);
+	ATF_TP_ADD_TC(tp, mmap__device_reinsert);
 
 	return (atf_no_error());
 }


### PR DESCRIPTION
SA-26:39.execve is omitted here since it's a large patch set, I will port it separately.

The changes applied cleanly for the most part. The posixshm changes needed a bit of extra massaging. The iconv tests revealed a bug in iconv which could cause CHERI faults when converting between encodings; I included a separate patch which fixes that, and which should be upstreamed in some form.