### PR TITLE
loader.efi: Work around bogus ExitBootServices and md_copymodules ordering

### DIFF
--- a/stand/efi/loader/copy.c
+++ b/stand/efi/loader/copy.c
@@ -180,7 +180,18 @@ out:
 
 #define	EFI_STAGING_2M_ALIGN	1
 
-#if defined(__amd64__) || defined(__i386__)
+/*
+ * XXX: Add slop for Morello to ensure staging has space to copyin metadata.
+ * bi_load does not call md_copymodules until after bi_load_efi_data, which
+ * calls ExitBootServices, and we can't move that currently (nor even do a
+ * dummy copyin to grow staging if needed) since bi_load_efi_data itself adds
+ * metadata, dependent on the memory map that can change when trying to call
+ * ExitBootServices. This needs unpicking upstream, so for now work around this
+ * slop that should be enough for all sensible use cases. For example, booting
+ * a 237-compartment ARC kernel with a ZFS rootfs has been seen to pass about
+ * 230 KiB of metadata.
+ */
+#if defined(__amd64__) || defined(__i386__) || defined(__aarch64__)
 #define	EFI_STAGING_SLOP	M(8)
 #else
 #define	EFI_STAGING_SLOP	0


### PR DESCRIPTION
I have observed GENERIC-MORELLO-PURECAP-COMPARTMENTS-ARC booting fine
when located in /boot/kernel as the default kernel, but not when located
in /boot/kernel.GENERIC-MORELLO-PURECAP-COMPARTMENTS-ARC. This turned
out to be due to the panic in efi_check_space being encountered (which
unfortunately cannot print its message to the console, since it happens
after ExitBootServices), as we had run out of staging area when trying
to copyin all the metadata (with the length of the kernel directory
presumably perturbing our exact environment and/or metadata in order to
cause the issue only to be encountered for some paths), and do so after
ExitBootServices, not before. Fixing this ordering such that we at least
explicitly pre-allocate enough staging area before ExitBootServices is
awkward and something to do upstream, but downstream we can work around
this by adding slop like x86 has for other reasons, and the current
amount of slop x86 uses is many times more than we seem to need for all
the metadata that an ARC kernel with a ZFS rootfs needs, so will
hopefully prove reliable.
