### PR TITLE
Fixes for make tinderbox

### DIFF
--- a/libexec/rtld-elf/powerpc/reloc.c
+++ b/libexec/rtld-elf/powerpc/reloc.c
@@ -367,9 +367,7 @@ done:
 	 * Synchronize icache for executable segments in case we made
 	 * any changes.
 	 */
-	for (phdr = obj->phdr;
-	    (const char *)phdr < (const char *)obj->phdr + obj->phsize;
-	    phdr++) {
+	for (phdr = obj->phdr; phdr < obj->phdr + obj->phnum; phdr++) {
 		if (phdr->p_type == PT_LOAD && (phdr->p_flags & PF_X) != 0) {
 			__syncicache(obj->relocbase + phdr->p_vaddr,
 			    phdr->p_memsz);

--- a/libexec/rtld-elf/powerpc64/reloc.c
+++ b/libexec/rtld-elf/powerpc64/reloc.c
@@ -364,9 +364,7 @@ done:
 	 * Synchronize icache for executable segments in case we made
 	 * any changes.
 	 */
-	for (phdr = obj->phdr;
-	    (const char *)phdr < (const char *)obj->phdr + obj->phsize;
-	    phdr++) {
+	for (phdr = obj->phdr; phdr < obj->phdr + obj->phnum; phdr++) {
 		if (phdr->p_type == PT_LOAD && (phdr->p_flags & PF_X) != 0) {
 			__syncicache(obj->relocbase + phdr->p_vaddr,
 			    phdr->p_memsz);

--- a/sys/arm/arm/elf_machdep.c
+++ b/sys/arm/arm/elf_machdep.c
@@ -55,6 +55,7 @@
 #include "opt_stack.h"          /* for OPT_STACK */
 
 static bool elf32_arm_abi_supported(const struct image_params *,
+    const Elf32_Ehdr *, const Elf32_Phdr *,
     const int32_t *, const uint32_t *);
 
 u_long elf_hwcap;

--- a/sys/cddl/dev/dtrace/amd64/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/amd64/dtrace_isa.c
@@ -470,7 +470,7 @@ dtrace_getstackdepth(int aframes)
 		return depth - aframes;
 }
 
-ulong_t
+uintptr_t
 dtrace_getreg(struct trapframe *frame, uint_t reg)
 {
 	/* This table is dependent on reg.d. */

--- a/sys/cddl/dev/dtrace/arm/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/arm/dtrace_isa.c
@@ -155,7 +155,7 @@ dtrace_getstackdepth(int aframes)
 		return depth - aframes;
 }
 
-ulong_t
+uintptr_t
 dtrace_getreg(struct trapframe *frame, uint_t reg)
 {
 	printf("IMPLEMENT ME: %s\n", __func__);

--- a/sys/cddl/dev/dtrace/i386/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/i386/dtrace_isa.c
@@ -496,7 +496,7 @@ dtrace_getstackdepth(int aframes)
 		return depth - aframes;
 }
 
-ulong_t
+uintptr_t
 dtrace_getreg(struct trapframe *frame, uint_t reg)
 {
 	struct pcb *pcb;

--- a/sys/cddl/dev/dtrace/powerpc/dtrace_isa.c
+++ b/sys/cddl/dev/dtrace/powerpc/dtrace_isa.c
@@ -529,7 +529,7 @@ dtrace_getstackdepth(int aframes)
 	return (depth - aframes);
 }
 
-ulong_t
+uintptr_t
 dtrace_getreg(struct trapframe *frame, uint_t reg)
 {
 	if (reg < 32)

--- a/sys/contrib/openzfs/module/nvpair/nvpair.c
+++ b/sys/contrib/openzfs/module/nvpair/nvpair.c
@@ -3246,7 +3246,8 @@ nvs_xdr_nvl_fini(nvstream_t *nvs)
  * xdrproc_t-compatible callbacks for xdr_array()
  */
 
-#if (defined(__FreeBSD_version) && __FreeBSD_version >= 1600010) || \
+#if (defined(__CheriBSD_version) && __CheriBSD_version > 20250301) || \
+    (defined(__FreeBSD_version) && __FreeBSD_version >= 1600010) || \
     defined(_KERNEL) && defined(__linux__) /* Linux kernel */
 
 #define	NVS_BUILD_XDRPROC_T(type)		\
@@ -3256,7 +3257,7 @@ nvs_xdr_nvp_##type(XDR *xdrs, void *ptr)	\
 	return (xdr_##type(xdrs, ptr));		\
 }
 
-#elif !defined(_KERNEL) && defined(XDR_CONTROL) /* tirpc */
+#elif !defined(_KERNEL) && defined(XDR_CONTROL) /* tirpc, FreeBSD < 16 */
 
 #define	NVS_BUILD_XDRPROC_T(type)		\
 static bool_t					\
@@ -3272,7 +3273,7 @@ nvs_xdr_nvp_##type(XDR *xdrs, ...)		\
 	return (xdr_##type(xdrs, ptr));		\
 }
 
-#else /* FreeBSD, sunrpc */
+#else /* FreeBSD kernel < 16, sunrpc */
 
 #define	NVS_BUILD_XDRPROC_T(type)		\
 static bool_t					\

--- a/sys/contrib/openzfs/module/os/freebsd/spl/spl_uio.c
+++ b/sys/contrib/openzfs/module/os/freebsd/spl/spl_uio.c
@@ -173,7 +173,7 @@ zfs_uio_release_stable_pages(zfs_uio_t *uio)
  * written to and must be given write access.
  */
 static int
-zfs_uio_hold_pages(unsigned long start, size_t len, int nr_pages,
+zfs_uio_hold_pages(void *start, size_t len, int nr_pages,
     zfs_uio_rw_t rw, vm_page_t *pages)
 {
 	vm_map_t map;
@@ -184,8 +184,13 @@ zfs_uio_hold_pages(unsigned long start, size_t len, int nr_pages,
 	ASSERT3S(len, >, 0);
 
 	prot = rw == UIO_READ ? (VM_PROT_READ | VM_PROT_WRITE) : VM_PROT_READ;
+#ifdef __CheriBSD_version
 	count = vm_fault_quick_hold_pages(map, start, len, prot, pages,
 	    nr_pages);
+#else
+	count = vm_fault_quick_hold_pages(map, (uintptr_t)start, len, prot, pages,
+	    nr_pages);
+#endif
 
 	return (count);
 }
@@ -208,7 +213,7 @@ zfs_uio_free_dio_pages(zfs_uio_t *uio, zfs_uio_rw_t rw)
 }
 
 static int
-zfs_uio_get_user_pages(unsigned long start, int nr_pages,
+zfs_uio_get_user_pages(void *start, int nr_pages,
     size_t len, zfs_uio_rw_t rw, vm_page_t *pages)
 {
 	int count;
@@ -229,12 +234,12 @@ zfs_uio_get_user_pages(unsigned long start, int nr_pages,
 static int
 zfs_uio_iov_step(struct iovec v, zfs_uio_t *uio, int *numpages)
 {
-	unsigned long addr = (unsigned long)(v.iov_base);
+	void *addr = (v.iov_base);
 	size_t len = v.iov_len;
 	int n = DIV_ROUND_UP(len, PAGE_SIZE);
 
 	int res = zfs_uio_get_user_pages(
-	    P2ALIGN_TYPED(addr, PAGE_SIZE, unsigned long), n, len,
+	    rounddown2(addr, PAGE_SIZE), n, len,
 	    zfs_uio_rw(uio), &uio->uio_dio.pages[uio->uio_dio.npages]);
 
 	if (res != n)

--- a/sys/dev/iscsi/iscsi.c
+++ b/sys/dev/iscsi/iscsi.c
@@ -1758,8 +1758,8 @@ iscsi_ioctl_daemon_connect(struct iscsi_softc *sc,
 	sx_sunlock(&sc->sc_lock);
 
 	if (idc->idc_from_addrlen > 0) {
-		error = getsockaddr(&from_sa, USER_PTR(idc->idc_from_addr,
-		    idc->idc_from_addrlen), idc->idc_from_addrlen);
+		error = getsockaddr(&from_sa, idc->idc_from_addr,
+		    idc->idc_from_addrlen);
 		if (error != 0) {
 			ISCSI_SESSION_WARN(is,
 			    "getsockaddr failed with error %d", error);
@@ -1768,8 +1768,7 @@ iscsi_ioctl_daemon_connect(struct iscsi_softc *sc,
 	} else {
 		from_sa = NULL;
 	}
-	error = getsockaddr(&to_sa, USER_PTR(idc->idc_to_addr,
-	    idc->idc_to_addrlen), idc->idc_to_addrlen);
+	error = getsockaddr(&to_sa, idc->idc_to_addr, idc->idc_to_addrlen);
 	if (error != 0) {
 		ISCSI_SESSION_WARN(is, "getsockaddr failed with error %d",
 		    error);

--- a/sys/riscv/include/cpufunc.h
+++ b/sys/riscv/include/cpufunc.h
@@ -44,7 +44,7 @@ breakpoint(void)
 
 #ifdef _KERNEL
 
-#include <sys/_null.h>
+#include <sys/stddef.h>
 
 #include <machine/riscvreg.h>
 


### PR DESCRIPTION
As I've done occasionally in the past, I ran make tinderbox on the tree to clean up normally-untested architectures and configs. The iscsi change is particularly notable (and there's even a memcpy that looks like it should be a copyin in iscsi_ioctl_daemon), and the ZFS changes are a bit annoying, but otherwise pretty straightforward. The tree isn't entirely clean when built with CHERI LLVM, for two reasons:
1. amd64 GENERIC-KASAN, arm64 GENERIC-KASAN and arm64 GENERIC-KMSAN all fail with compiler crashes that at some point we should track down (weirdly, not amd64 GENERIC-KMSAN)
2. i386 kernels that enable KDTRACE_HOOKS (which, of all the universe ones, is all but LINT, for unknown reasons) don't build, due to depending on "Ws" inline asm constraint support for SDT probes, which requires LLVM 18 ("i" does not work with Clang on i386 unlike all other architectures, likely a bug that should be hunted down, but doesn't help LLVM <18 where that bug exists but Ws does not)
But not much we can do about that, and in theory once those get resolved in the toolchain all configs will build, as hopefully all the others give enough coverage of any code that gets built after those points of failure.