### PR TITLE
Revert "dtrace: Add a sysctl to block loading of dtrace.ko in CHERI kernels"

### DIFF
--- a/sys/cddl/dev/dtrace/dtrace_modevent.c
+++ b/sys/cddl/dev/dtrace/dtrace_modevent.c
@@ -28,18 +28,6 @@ dtrace_modevent(module_t mod __unused, int type, void *data __unused)
 
 	switch (type) {
 	case MOD_LOAD:
-		if (!dtrace_enabled) {
-			printf(
-    "DTrace is experimental on this platform and is disabled by default.\n");
-			printf(
-    "Set the debug.dtrace_enabled sysctl to 1 to allow dtrace.ko to load.\n");
-			printf(
-    "Be prepared for bugs and kernel panics if you use DTrace.\n");
-			printf(
-    "Please report bugs at https://github.com/CTSRD-CHERI/cheribsd");
-			return (ENOTSUP);
-		}
-
 		break;
 
 	case MOD_UNLOAD:

--- a/sys/kern/kern_dtrace.c
+++ b/sys/kern/kern_dtrace.c
@@ -48,14 +48,6 @@ FEATURE(kdtrace_hooks,
 
 static MALLOC_DEFINE(M_KDTRACE, "kdtrace", "DTrace hooks");
 
-#if __has_feature(capabilities)
-int dtrace_enabled = 0;
-#else
-int dtrace_enabled = 1;
-#endif
-SYSCTL_INT(_debug, OID_AUTO, dtrace_enabled, CTLFLAG_RWTUN, &dtrace_enabled, 0,
-    "DTrace enabled");
-
 /* Hooks used in the machine-dependent trap handlers. */
 dtrace_trap_func_t		dtrace_trap_func;
 dtrace_doubletrap_func_t	dtrace_doubletrap_func;

--- a/sys/sys/dtrace_bsd.h
+++ b/sys/sys/dtrace_bsd.h
@@ -175,6 +175,4 @@ void	kdtrace_thread_dtor(struct thread *td);
 uint64_t	dtrace_gethrtime(void);
 uint64_t	dtrace_gethrestime(void);
 
-extern int dtrace_enabled;
-
 #endif /* _SYS_DTRACE_BSD_H */


### PR DESCRIPTION
DTrace for CHERI has increasingly been used and matured over the past
one and a half years, so make it as available as normal.

This reverts commit db7bca63113bb6733c670e0194aec1747236cb34.
