### PR TITLE
cross-build: Work around __unused macro conflicts with glibc headers

### DIFF
--- a/tools/build/cross-build/include/linux/sys/types.h
+++ b/tools/build/cross-build/include/linux/sys/types.h
@@ -56,7 +56,10 @@ typedef uint16_t __uint16_t;
 typedef uint8_t  __uint8_t;
 #endif
 
+/* <bits/struct_mutex.h> contains a member named __unused. */
+#include "../__unused_workaround_start.h"
 #include_next <sys/types.h>
+#include "../__unused_workaround_end.h"
 
 /*
  * stddef.h for both gcc and clang will define __size_t when size_t has


### PR DESCRIPTION
When building CheriBSD on modern Linux hosts, FreeBSD's __unused macro interferes with glibc headers that use __unused as a struct member name:(e.g. inside pthread_mutex_t). This causes build failures like "excess elements in scalar initializer" during __GTHREAD_MUTEX_INIT.

This commit wraps the inclusion of the host's sys/types.h with __unused_workaround_start.h and __unused_workaround_end.h to temporarily undefine the macro during host header parsing.