### PR TITLE
Bump __CheriBSD_version to 20260710

### DIFF
--- a/sys/sys/param.h
+++ b/sys/sys/param.h
@@ -87,7 +87,7 @@
  * FreeBSD.
  */
 #undef __CheriBSD_version
-#define __CheriBSD_version 20260417
+#define __CheriBSD_version 20260710
 
 /*
  * __FreeBSD_kernel__ indicates that this system uses the kernel of FreeBSD,


### PR DESCRIPTION
I propose we merge this the moment we have aarch64 and aarch64c packages deployed without waiting for debug aarch64c and aarch64cb packages, but we cut the release when all repositories are deployed.

aarch64 and aarch64c packages are deployed now.