### PR TITLE
Initial DTrace FBT support in compartmentalized kernels

### DIFF
--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -425,8 +425,8 @@ build_reloc_cap(Elf_Addr addr, Elf_Addr size, uint8_t perms, Elf_Addr offset,
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
 		if (iskernel) {
 			/*
-			 * We call a kernel-specific variant because
-			 * linker_kernel_file does not exist yet.
+			 * Call a kernel-specific variant because
+			 * linker_kernel_file might not exist yet.
 			 */
 			cap = (uintptr_t)compartment_entry_for_kernel(
 			    (uintptr_t)cap);
@@ -620,28 +620,12 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 			__asm__("" : "+r" (addend));
 			addr += addend;
 		}
-#ifdef CHERI_COMPARTMENTALIZE_KERNEL
-		if ((cheri_getperm(addr) & CHERI_PERM_EXECUTE) != 0) {
-			if (lf == linker_kernel_file) {
-				addr = (uintptr_t)
-				    compartment_entry_for_kernel(addr);
-			} else {
-				addr = (uintptr_t)compartment_entry(addr);
-			}
-		}
-#endif
 		*(uintptr_t *)where = addr;
 		break;
 	case R_MORELLO_JUMP_SLOT:
 		error = lookup(lf, symidx, 1, &addr);
 		if (error != 0)
 			return (-1);
-#ifdef CHERI_COMPARTMENTALIZE_KERNEL
-		if (lf == linker_kernel_file)
-			addr = (uintptr_t)compartment_entry_for_kernel(addr);
-		else
-			addr = (uintptr_t)compartment_entry(addr);
-#endif
 		*(uintptr_t *)where = addr;
 		break;
 	case R_MORELLO_IRELATIVE:

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -457,10 +457,13 @@ init_compartments0(vm_pointer_t compartments0_stacks,
 	unsigned int ii;
 
 	thread0.td_compartments = (void *)compartments0_array;
-	thread0.td_compartments_maxid = KERNEL_MAXC18NS - 1;
-	for (ii = 0; ii < KERNEL_MAXC18NS; ii++) {
-		compartment = &compartments0[ii];
-		stack = compartments0_stacks + ii * (kstack_pages * PAGE_SIZE);
+	thread0.td_compartments_maxid = COMPARTMENT_FIRST_ID +
+	    KERNEL_MAXC18NS - 1;
+	for (ii = COMPARTMENT_FIRST_ID; ii <= thread0.td_compartments_maxid;
+	    ii++) {
+		compartment = &compartments0[TD_CIDNDX(ii)];
+		stack = compartments0_stacks + TD_CIDNDX(ii) *
+		    (kstack_pages * PAGE_SIZE);
 		stack = cheri_setbounds(stack, kstack_pages * PAGE_SIZE);
 		compartment_init_stack(compartment, stack);
 	}

--- a/sys/arm64/arm64/mp_machdep.c
+++ b/sys/arm64/arm64/mp_machdep.c
@@ -539,7 +539,7 @@ start_cpu(u_int cpuid, uint64_t target_cpu, int domain, vm_paddr_t release_addr)
 	} else {
 		pa = pmap_extract(kernel_pmap,
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
-		    (vm_offset_t)executive_get_function((uintptr_t)mpentry_psci)
+		    (vm_offset_t)compartment_target((uintptr_t)mpentry_psci)
 #else
 		    (vm_offset_t)mpentry_psci
 #endif

--- a/sys/arm64/arm64/vm_machdep.c
+++ b/sys/arm64/arm64/vm_machdep.c
@@ -150,7 +150,7 @@ cpu_fork(struct thread *td1, struct proc *p2,
 	td2->td_pcb->pcb_x[PCB_X20] = (uintptr_t)td2;
 	td2->td_pcb->pcb_x[PCB_LR] =
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
-	    (uintptr_t)executive_get_function((uintptr_t)fork_trampoline);
+	    (uintptr_t)compartment_target((uintptr_t)fork_trampoline);
 #else
 	    (uintptr_t)fork_trampoline;
 #endif
@@ -240,7 +240,7 @@ cpu_copy_thread(struct thread *td, struct thread *td0)
 	td->td_pcb->pcb_x[PCB_X20] = (uintptr_t)td;
 	td->td_pcb->pcb_x[PCB_LR] =
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
-	    (uintptr_t)executive_get_function((uintptr_t)fork_trampoline);
+	    (uintptr_t)compartment_target((uintptr_t)fork_trampoline);
 #else
 	    (uintptr_t)fork_trampoline;
 #endif

--- a/sys/arm64/include/param.h
+++ b/sys/arm64/include/param.h
@@ -126,9 +126,9 @@
 #define	KERNEL_MAXPCCS		KERNEL_MAXPLTS
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
 /*
- * Maximum number of compartments (except for the default) in the kernel binary.
+ * Maximum number of compartments (including the default) in the kernel binary.
  */
-#define	KERNEL_MAXC18NS		(KERNEL_MAXPLTS - 1)
+#define	KERNEL_MAXC18NS		KERNEL_MAXPLTS
 
 #define	COMPARTMENT_ENTRY_PAGES	7500	/* pages of compartment entries */
 #endif

--- a/sys/arm64/include/stack.h
+++ b/sys/arm64/include/stack.h
@@ -67,8 +67,8 @@ kstack_contains(struct thread *td, vm_offset_t va, size_t len)
 		return (true);
 
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
-	for (ii = 0; ii <= td->td_compartments_maxid; ii++) {
-		compartment = td->td_compartments[ii];
+	for (ii = COMPARTMENT_FIRST_ID; ii <= td->td_compartments_maxid; ii++) {
+		compartment = td->td_compartments[TD_CIDNDX(ii)];
 		if (compartment == NULL)
 			continue;
 		/*

--- a/sys/cddl/dev/dtrace/aarch64/dtrace_subr.c
+++ b/sys/cddl/dev/dtrace/aarch64/dtrace_subr.c
@@ -324,17 +324,30 @@ dtrace_store64(uint64_t *addr, struct trapframe *frame, u_int reg)
 static int
 dtrace_invop_start(struct trapframe *frame)
 {
+#ifdef __CHERI_PURE_CAPABILITY__
+	uintcap_t *cspp;
+#endif
 	int data, invop, tmp;
 
 	invop = dtrace_invop(frame->tf_elr, frame, frame->tf_x[0]);
 
+#ifdef __CHERI_PURE_CAPABILITY__
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+	if ((cheri_getperm(frame->tf_elr) & CHERI_PERM_EXECUTIVE) != 0)
+		cspp = &frame->tf_sp;
+	else
+		cspp = &frame->tf_rcsp;
+#else
+	cspp = &frame->tf_sp;
+#endif
+#endif
 	tmp = (invop & LDP_STP_MASK);
 #ifdef __CHERI_PURE_CAPABILITY__
 	if (tmp == STP_C_PREIND) {
 		uintcap_t *csp;
 		int arg1, arg2, offs;
 
-		csp = (uintcap_t *)frame->tf_sp;
+		csp = (uintcap_t *)*cspp;
 		arg1 = (invop >> ARG1_SHIFT) & ARG1_MASK;
 		arg2 = (invop >> ARG2_SHIFT) & ARG2_MASK;
 		offs = (invop >> OFFSET_SHIFT) & OFFSET_MASK;
@@ -346,7 +359,7 @@ dtrace_invop_start(struct trapframe *frame)
 		dtrace_storecap(csp + 1, frame, arg2);
 
 		/* Update the stack pointer and program counter to continue */
-		frame->tf_sp = (uintcap_t)csp;
+		*cspp = (uintcap_t)csp;
 		frame->tf_elr += INSN_SIZE;
 		return (0);
 	}
@@ -392,7 +405,7 @@ dtrace_invop_start(struct trapframe *frame)
 
 #ifdef __CHERI_PURE_CAPABILITY__
 	if ((invop & SUBC_MASK) == SUBC_INSTR) {
-		frame->tf_sp -= (invop >> SUB_IMM_SHIFT) & SUB_IMM_MASK;
+		*cspp -= (invop >> SUB_IMM_SHIFT) & SUB_IMM_MASK;
 		frame->tf_elr += INSN_SIZE;
 		return (0);
 	}

--- a/sys/cddl/dev/fbt/aarch64/fbt_isa.c
+++ b/sys/cddl/dev/fbt/aarch64/fbt_isa.c
@@ -32,6 +32,7 @@
 #include <sys/param.h>
 
 #include <sys/dtrace.h>
+#include <sys/compartment.h>
 
 #include "fbt.h"
 
@@ -120,7 +121,12 @@ fbt_unseal_symval(linker_symval_t *sym)
 	extern void * __capability sentry_unsealcap;
 	uintcap_t val;
 
-	val = cheri_unseal((uintcap_t)sym->value, sentry_unsealcap);
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+	val = (uintcap_t)compartment_target((uintptr_t)sym->value);
+#else
+	val = (uintcap_t)sym->value;
+#endif
+	val = cheri_unseal(val, sentry_unsealcap);
 	val = cheri_perms_and(val, CHERI_PERM_LOAD);
 	return (val);
 }
@@ -149,8 +155,10 @@ fbt_provide_module_function(linker_file_t lf, int symindx,
 	 * Instrumenting certain exception handling functions can lead to FBT
 	 * recursion, so exclude from instrumentation.
 	 */
-	 if (strcmp(name, "handle_el1h_sync") == 0 ||
-	    strcmp(name, "do_el1h_sync") == 0)
+	if (strcmp(name, "handle_el1h_sync") == 0 ||
+	    strcmp(name, "do_el1h_sync") == 0 ||
+	    strcmp(name, "handle_el1t_sync") == 0 ||
+	    strcmp(name, "do_el1t_sync") == 0)
 		return (0);
 
 #ifdef __CHERI_PURE_CAPABILITY__

--- a/sys/cddl/dev/fbt/fbt.c
+++ b/sys/cddl/dev/fbt/fbt.c
@@ -161,6 +161,21 @@ fbt_excluded(const char *name)
 		return (1);
 #endif
 
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+	/*
+	 * The compartment ABI and its callees cannot be instrumented. They can
+	 * be called by a probe if the probe's callees are in different
+	 * compartments.
+	 *
+	 * XXXKW: This list is incomplete and currently there is no way to
+	 * reliably complete it. The trampolines use mutex(9) that pulls many
+	 * dependencies that we must get rid off. Before then, profiling fbt:::
+	 * will not work.
+	 */
+	if (strncmp(name, "compartment_", sizeof("compartment_") - 1) == 0)
+		return (1);
+#endif
+
 	return (0);
 }
 

--- a/sys/kern/kern_compartment.c
+++ b/sys/kern/kern_compartment.c
@@ -393,17 +393,12 @@ compartment_linkup(struct compartment *compartment, u_long id,
 {
 
 	EXECUTIVE_ASSERT();
+	KASSERT(id <= td->td_compartments_maxid,
+	    ("%s: id %lu exceeds the maximum value %lu", __func__, id,
+	     td->td_compartments_maxid));
 
 	compartment->c_id = id;
 	compartment->c_thread = td;
-
-	if (compartment->c_id > td->td_compartments_maxid) {
-		td->td_compartments_maxid = compartment_lastid;
-		td->td_compartments = realloc(td->td_compartments,
-		    (TD_CIDNDX(td->td_compartments_maxid) + 1) *
-		    sizeof(*td->td_compartments), M_COMPARTMENT, M_NOWAIT |
-		    M_USE_RESERVE | M_ZERO);
-	}
 	td->td_compartments[TD_CIDNDX(compartment->c_id)] = compartment;
 
 }

--- a/sys/kern/kern_compartment.c
+++ b/sys/kern/kern_compartment.c
@@ -673,7 +673,7 @@ compartment_entry(uintptr_t func)
 }
 
 void *
-executive_get_function(uintptr_t func)
+compartment_target(uintptr_t func)
 {
 	struct compartment_trampoline *trampoline;
 
@@ -686,8 +686,6 @@ executive_get_function(uintptr_t func)
 	    func & ~0x1);
 	trampoline = __containerof((char (*)[])trampoline,
 	    struct compartment_trampoline, ct_code);
-	KASSERT(trampoline->ct_type == TRAMPOLINE_TYPE_EXECUTIVE_ENTRY,
-	    ("Invalid trampoline type"));
 
 	return ((void *)trampoline->ct_compartment_func);
 }

--- a/sys/kern/kern_compartment.c
+++ b/sys/kern/kern_compartment.c
@@ -112,7 +112,7 @@ struct compartment_trampoline {
 extern int early_boot;
 #endif
 
-u_long compartment_lastid = COMPARTMENT_KERNEL_ID;
+u_long compartment_lastid = COMPARTMENT_FIRST_ID;
 static uma_zone_t compartment_zone;
 #ifdef CHERI_COMPARTMENT_STATS
 static u_long compartment_maxnid;
@@ -400,11 +400,11 @@ compartment_linkup(struct compartment *compartment, u_long id,
 	if (compartment->c_id > td->td_compartments_maxid) {
 		td->td_compartments_maxid = compartment_lastid;
 		td->td_compartments = realloc(td->td_compartments,
-		    (td->td_compartments_maxid + 1) *
+		    (TD_CIDNDX(td->td_compartments_maxid) + 1) *
 		    sizeof(*td->td_compartments), M_COMPARTMENT, M_NOWAIT |
 		    M_USE_RESERVE | M_ZERO);
 	}
-	td->td_compartments[compartment->c_id] = compartment;
+	td->td_compartments[TD_CIDNDX(compartment->c_id)] = compartment;
 
 }
 
@@ -508,7 +508,8 @@ compartment_destroy(struct compartment *compartment)
 #endif
 
 	if (compartment->c_thread != NULL) {
-		compartment->c_thread->td_compartments[compartment->c_id] = NULL;
+		compartment->c_thread->td_compartments[TD_CIDNDX(compartment->c_id)] =
+		    NULL;
 	}
 
 	vm_compartment_dispose(compartment);
@@ -530,7 +531,10 @@ compartment_entry_stackptr(u_long id, int type)
 		compartment_trampoline_counters[type]++;
 #endif
 
-	compartment = curthread->td_compartments[id];
+	if (id <= curthread->td_compartments_maxid)
+		compartment = curthread->td_compartments[TD_CIDNDX(id)];
+	else
+		compartment = NULL;
 	if (compartment == NULL)
 		compartment = compartment_create(curthread, id, true);
 	return (compartment->c_kstackptr);
@@ -714,13 +718,13 @@ DB_COMMAND_FLAGS(c18nstat, db_c18nstat, DB_CMD_MEMSAFE)
 	    ADDRESS_WIDTH - 7, ' ', "CID", "CNAME", "PID", "TID", "COMM",
 	    "TDNAME");
 	if (verbose) {
-		ii = COMPARTMENT_KERNEL_ID;
+		ii = COMPARTMENT_FIRST_ID;
 	} else {
 		db_printf("*%*c %6lu %-20s %5s %6s %-20s %-20s\n",
-		    ADDRESS_WIDTH - 1, ' ', (u_long)COMPARTMENT_KERNEL_ID,
-		    compartment_metadata[COMPARTMENT_KERNEL_ID]->cm_name,
+		    ADDRESS_WIDTH - 1, ' ', (u_long)COMPARTMENT_FIRST_ID,
+		    compartment_metadata[COMPARTMENT_FIRST_ID]->cm_name,
 		    "*", "*", "*", "*");
-		ii = COMPARTMENT_KERNEL_ID + 1;
+		ii = COMPARTMENT_FIRST_ID + 1;
 	}
 #undef	ADDRESS_WIDTH
 	for (; ii <= compartment_lastid; ii++) {

--- a/sys/kern/kern_compartment.c
+++ b/sys/kern/kern_compartment.c
@@ -134,9 +134,7 @@ compartment_trampoline_compare(struct compartment_trampoline *a,
 	    (ptraddr_t)b->ct_compartment_func);
 }
 
-RB_HEAD(compartment_tree, compartment_trampoline) compartment_trampolines =
-    RB_INITIALIZER(&compartment_trampolines);
-RB_GENERATE_STATIC(compartment_tree, compartment_trampoline, ct_node,
+RB_GENERATE_STATIC(compartment_trampoline_tree, compartment_trampoline, ct_node,
     compartment_trampoline_compare);
 
 static struct mtx compartment_trampolines_lock;
@@ -363,6 +361,19 @@ SYSINIT(compartment_metadata_init, SI_SUB_KLD, SI_ORDER_FIRST,
     compartment_metadata_init, NULL);
 #endif
 
+void
+compartment_trampoline_tree_remove_all(struct compartment_trampoline_tree *tree)
+{
+	struct compartment_trampoline *tmptrampoline, *trampoline;
+
+	RB_FOREACH_SAFE(trampoline, compartment_trampoline_tree, tree,
+	    tmptrampoline) {
+		RB_REMOVE(compartment_trampoline_tree, tree, trampoline);
+		free(trampoline, M_COMPARTMENT);
+	}
+	KASSERT(RB_EMPTY(tree), ("%s: tree is not empty.", __func__));
+}
+
 u_long
 compartment_id_create(const char *name, uintcap_t base,
     elf_compartment_t elf_compartment)
@@ -531,6 +542,7 @@ compartment_trampoline_create(const linker_file_t lf, int type, void *data,
 {
 	struct compartment_trampoline *trampoline, *oldtrampoline;
 	struct compartment_trampoline tmptrampoline;
+	struct compartment_trampoline_tree *tree;
 	uintcap_t dstfunc;
 	u_long dstid;
 
@@ -539,18 +551,16 @@ compartment_trampoline_create(const linker_file_t lf, int type, void *data,
 	    ("%s: linker file cannot be NULL", __func__));
 
 	elf_compartment_entry(lf, func, &dstid, &dstfunc);
+	tree = elf_compartment_trampoline_tree(lf);
 
 	tmptrampoline.ct_compartment_func = dstfunc;
-	oldtrampoline = RB_FIND(compartment_tree, &compartment_trampolines,
+	oldtrampoline = RB_FIND(compartment_trampoline_tree, tree,
 	    &tmptrampoline);
 	if (oldtrampoline != NULL) {
 		trampoline = oldtrampoline;
 		goto out;
 	}
 
-	/*
-	 * TODO: Free the trampoline.
-	 */
 	if (!early_boot) {
 		trampoline = malloc_exec(size, M_COMPARTMENT, M_NOWAIT |
 		    M_USE_RESERVE | M_ZERO);
@@ -579,18 +589,13 @@ compartment_trampoline_create(const linker_file_t lf, int type, void *data,
 	if (!early_boot) {
 		cpu_dcache_wb_range(trampoline, (vm_size_t)size);
 		cpu_icache_sync_range(trampoline, (vm_size_t)size);
-
-		mtx_lock(&compartment_trampolines_lock);
 	}
 
-	oldtrampoline = RB_INSERT(compartment_tree, &compartment_trampolines,
+	oldtrampoline = RB_INSERT(compartment_trampoline_tree, tree,
 	    trampoline);
 	KASSERT(oldtrampoline == NULL,
 	    ("Trampoline for 0x%#lp already exists",
 	    (void *)trampoline->ct_compartment_func));
-
-	if (!early_boot)
-		mtx_unlock(&compartment_trampolines_lock);
 
 out:
 	/*

--- a/sys/kern/kern_thread.c
+++ b/sys/kern/kern_thread.c
@@ -854,10 +854,10 @@ thread_free_compartments(struct thread *td)
 {
 	u_long ii;
 
-	for (ii = 0; ii <= td->td_compartments_maxid; ii++) {
-		if (td->td_compartments[ii] == NULL)
+	for (ii = COMPARTMENT_FIRST_ID; ii <= td->td_compartments_maxid; ii++) {
+		if (td->td_compartments[TD_CIDNDX(ii)] == NULL)
 			continue;
-		compartment_destroy(td->td_compartments[ii]);
+		compartment_destroy(td->td_compartments[TD_CIDNDX(ii)]);
 	}
 	free(td->td_compartments, M_COMPARTMENT);
 	td->td_compartments = NULL;

--- a/sys/kern/kern_thread.c
+++ b/sys/kern/kern_thread.c
@@ -846,6 +846,23 @@ thread_alloc_compartments(struct thread *td)
 	KASSERT(td->td_compartments_maxid == 0,
 	    ("thread_alloc_compartments called on a thread with existing compartments"));
 
+	/*
+	 * XXXKW: Overallocate the array to allow linking compartments of
+	 * modules that could be dynamically loaded during a thread's lifetime
+	 * and which are called by the thread due to:
+	 * - an IPI (e.g., dtraceall.ko and its dependencies create 11
+	 *   compartments, including dtrace.ko that issues an IPI on SYSINIT())
+	 * This is a temporary workaround. There are most likely other cases
+	 * that are not considered yet (e.g., operations on a file stored in
+	 * a file system that is handled by a dynamically loaded module).
+	 * The correct implementation should not involve a data structure that
+	 * requires expanding while a thread is in a critical section (e.g., on
+	 * IPI).
+	 */
+	td->td_compartments_maxid = compartment_lastid + 16;
+	td->td_compartments = realloc(td->td_compartments,
+	    (TD_CIDNDX(td->td_compartments_maxid) + 1) *
+	    sizeof(*td->td_compartments), M_COMPARTMENT, M_NOWAIT | M_ZERO);
 	return (link_elf_create_compartments(linker_kernel_file, td));
 }
 

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -887,7 +887,7 @@ elf_init(void *relocbase, ptraddr_t baseend, caddr_t mdp __unused)
 		}
 	}
 	if (error == 0) {
-		error = elf_compartment_init_default(ef, COMPARTMENT_KERNEL_ID,
+		error = elf_compartment_init_default(ef, COMPARTMENT_FIRST_ID,
 		    NULL, ef->address,
 #ifdef RELOCATABLE_KERNEL
 		    -(intptr_t)ef->address
@@ -948,7 +948,7 @@ link_elf_init(void* arg)
 	struct compartment *compartment;
 #endif
 	elf_compartment_t ec;
-	unsigned int compartmentii;
+	unsigned int ii;
 #endif
 
 	linker_file_register(linker_kernel_file, &link_elf_class);
@@ -968,9 +968,8 @@ link_elf_init(void* arg)
 	    cheri_setaddress((uintcap_t)ec->pcc, (ptraddr_t)ec->start),
 	    ec);
 #endif
-	for (compartmentii = 0; compartmentii < elf_kernel_file.ncompartments;
-	    compartmentii++) {
-		ec = &elf_kernel_file.compartments[compartmentii];
+	for (ii = 0; ii < elf_kernel_file.ncompartments; ii++) {
+		ec = &elf_kernel_file.compartments[ii];
 		ec->filename = elf_kernel_filename;
 #ifdef CHERI_COMPARTMENT_STATS
 		compartment_metadata_create(ec->id, ec->name,
@@ -979,9 +978,9 @@ link_elf_init(void* arg)
 #endif
 	}
 #ifdef CHERI_COMPARTMENT_STATS
-	for (compartmentii = 0; compartmentii <= thread0.td_compartments_maxid;
-	    compartmentii++) {
-		compartment = thread0.td_compartments[compartmentii];
+	for (ii = COMPARTMENT_FIRST_ID; ii <= thread0.td_compartments_maxid;
+	    ii++) {
+		compartment = thread0.td_compartments[TD_CIDNDX(ii)];
 		if (compartment == NULL)
 			continue;
 		compartment_metadata_insert(compartment);
@@ -1755,7 +1754,7 @@ link_elf_linkup_compartments(linker_file_t lf, struct compartment *compartments,
 	unsigned int compartmentii;
 
 	ef = (elf_file_t)lf;
-	if (ef->ncompartments > ncompartments + 1) {
+	if (ef->ncompartments + 1 /* default */ > ncompartments) {
 		panic("%s: too many compartments defined in the file",
 		    __func__);
 	}

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -211,6 +211,7 @@ struct elf_file {
 	struct elf_compartment defcompartment;
 	unsigned int	ncompartments;
 	struct elf_compartment *compartments;
+	struct compartment_trampoline_tree compartment_trampolines;
 #endif
 };
 
@@ -877,6 +878,7 @@ elf_init(void *relocbase, ptraddr_t baseend, caddr_t mdp __unused)
 #endif
 		    );
 	}
+	RB_INIT(&ef->compartment_trampolines);
 #endif
 	if (error != 0) {
 		panic("%s: Can't initialize the kernel ELF file", __func__);
@@ -2346,6 +2348,15 @@ elf_compartment_entry(linker_file_t lf, uintcap_t ptr, u_long *idp,
 	cap = cheri_sealentry(cap);
 	*ptrp = (uintptr_t)cap;
 }
+
+struct compartment_trampoline_tree *
+elf_compartment_trampoline_tree(linker_file_t lf)
+{
+	elf_file_t ef;
+
+	ef = (elf_file_t)lf;
+	return (&ef->compartment_trampolines);
+}
 #endif
 
 Elf_Addr
@@ -2408,6 +2419,7 @@ link_elf_unload_file(linker_file_t file)
 	elf_cpu_unload_file(file);
 
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL
+	compartment_trampoline_tree_remove_all(&ef->compartment_trampolines);
 	free(ef->compartments, M_LINKER);
 	free(ef->pccs, M_LINKER);
 #endif

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -519,16 +519,34 @@ ef_address(elf_file_t ef, ptraddr_t offset)
  * its permissions and bounds.
  */
 static caddr_t
-make_capability(const Elf_Sym *sym, caddr_t val)
+make_capability(elf_file_t ef, const Elf_Sym *sym, caddr_t val)
 {
 	switch (ELF_ST_TYPE(sym->st_info)) {
 	case STT_FUNC:
 	case STT_GNU_IFUNC:
-		val = cheri_perms_and(val, CHERI_PERMS_KERNEL_CODE);
+		val = cheri_perms_and(val,
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+		    CHERI_PERMS_KERNEL_EXECUTIVE_CODE
+#else
+		    CHERI_PERMS_KERNEL_CODE
+#endif
+		    );
 #ifdef CHERI_FLAGS_CAP_MODE
 		val = cheri_flags_set(val, CHERI_FLAGS_CAP_MODE);
 #endif
 		val = cheri_sentry_create(val);
+#ifdef CHERI_COMPARTMENTALIZE_KERNEL
+		if (ef == (elf_file_t)linker_kernel_file) {
+			/*
+			 * Call a kernel-specific variant because
+			 * linker_kernel_file might not exist yet.
+			 */
+			val = (caddr_t)
+			    compartment_entry_for_kernel((uintptr_t)val);
+		} else {
+			val = (caddr_t)compartment_entry((uintptr_t)val);
+		}
+#endif
 		break;
 	default:
 		val = cheri_bounds_set(val, sym->st_size);
@@ -578,7 +596,7 @@ ef_symbol_address(elf_file_t ef, const Elf_Sym *sym)
 	}
 
 	val = cheri_address_set(base, (ptraddr_t)ef->address + sym->st_value);
-	return (make_capability(sym, val));
+	return (make_capability(ef, sym, val));
 #else
 	return (ef_address(ef, sym->st_value));
 #endif
@@ -2969,14 +2987,14 @@ elf_lookup(linker_file_t lf, Elf_Size symidx, int deps, uintptr_t *res)
 	if (elf_set_find(&set_pcpu_list, addr, &start, &base)) {
 		addr = (ptraddr_t)addr - (ptraddr_t)start + base;
 #ifdef __CHERI_PURE_CAPABILITY__
-		addr = make_capability(sym, addr);
+		addr = make_capability(ef, sym, addr);
 #endif
 	}
 #ifdef VIMAGE
 	else if (elf_set_find(&set_vnet_list, addr, &start, &base)) {
 		addr = (ptraddr_t)addr - (ptraddr_t)start + base;
 #ifdef __CHERI_PURE_CAPABILITY__
-		addr = make_capability(sym, addr);
+		addr = make_capability(ef, sym, addr);
 #endif
 	}
 #endif

--- a/sys/sys/compartment.h
+++ b/sys/sys/compartment.h
@@ -66,6 +66,7 @@ struct compartment {
 };
 
 STAILQ_HEAD(compartment_list, compartment);
+RB_HEAD(compartment_trampoline_tree, compartment_trampoline);
 
 extern struct compartment compartments0[KERNEL_MAXC18NS];
 
@@ -74,6 +75,9 @@ extern u_long compartment_lastid;
 void compartment_metadata_create(u_long id, const char *name, uintcap_t base,
     elf_compartment_t elf_compartment);
 void compartment_metadata_insert(struct compartment *compartment);
+
+void compartment_trampoline_tree_remove_all(
+    struct compartment_trampoline_tree *tree);
 
 void compartment_cpu_cache_fill(u_int cpuid);
 

--- a/sys/sys/compartment.h
+++ b/sys/sys/compartment.h
@@ -93,7 +93,7 @@ void compartment_destroy(struct compartment *compartment);
 void compartment_trampoline_destroy(uintptr_t func);
 void *compartment_entry_for_kernel(uintptr_t func);
 void *compartment_entry(uintptr_t func);
-void *executive_get_function(uintptr_t func);
+void *compartment_target(uintptr_t func);
 
 #ifdef MALLOC_DECLARE
 MALLOC_DECLARE(M_COMPARTMENT);

--- a/sys/sys/compartment.h
+++ b/sys/sys/compartment.h
@@ -43,9 +43,11 @@
 #include <machine/compartment.h>
 
 /*
- * A compartment identifier for the kernel itself.
+ * A compartment identifier for the default compartment in the kernel binary.
  */
-#define	COMPARTMENT_KERNEL_ID			1
+#define	COMPARTMENT_FIRST_ID			1
+
+#define	TD_CIDNDX(id)				(id - COMPARTMENT_FIRST_ID)
 
 #define	TRAMPOLINE_TYPE_COMPARTMENT_ENTRY	0
 #define	TRAMPOLINE_TYPE_EXECUTIVE_ENTRY	1

--- a/sys/sys/linker.h
+++ b/sys/sys/linker.h
@@ -355,6 +355,7 @@ int	elf_reloc_local(linker_file_t _lf, char *base, const void *_rel,
 bool	elf_compartment_isdefault(linker_file_t lf, uintcap_t ptr);
 void	elf_compartment_entry(linker_file_t lf, uintcap_t ptr, u_long *idp,
 	    uintptr_t *ptrp);
+struct compartment_trampoline_tree *elf_compartment_trampoline_tree(linker_file_t lf);
 Elf_Addr elf_relocaddr(linker_file_t _lf, Elf_Addr addr);
 bool	elf_is_preloaded(linker_file_t lf);
 #ifdef CHERI_COMPARTMENTALIZE_KERNEL


### PR DESCRIPTION
The current implementation allows to profile functions with DTrace that are not used by compartment_create() -- except for mutex(9) and PCPU/DPCP accessors. I must replace mutex(9) with another locking primitive to synchronise the usage of the compartment stack cache and then correctly exclude all symbols used by the trampolines in FBT. That is a more complex task and currently I want to allow profiling symbols other than the problematic as well as un-break kernel-c18n which does not work on Morello hardware due to trying to realloc thread.td_compartments while loading usb_template.ko, the same reason why dtrace.ko cannot be loaded.