### PR TITLE
Assume presence of PT_CHERI_PCC

### DIFF
--- a/lib/csu/aarch64/caprel.h
+++ b/lib/csu/aarch64/caprel.h
@@ -37,7 +37,7 @@
 static __always_inline uintcap_t
 init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
     const void * __capability text_rodata_cap, Elf_Addr base_addr,
-    Elf_Size addend, bool use_code_bounds)
+    Elf_Size addend)
 {
 	uintcap_t cap;
 	Elf_Addr address, len;
@@ -50,7 +50,9 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)text_rodata_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, base_addr + address);
-	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
+#ifndef __CHERI_PURE_CAPABILITY__
+	if (perms != MORELLO_FRAG_EXECUTABLE)
+#endif
 		cap = cheri_bounds_set(cap, len);
 	cap = cheri_perms_clear(cap, CAP_RELOC_REMOVE_PERMS);
 
@@ -72,8 +74,7 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 
 static __always_inline void
 elf_reloc(const Elf_Rela *rela, void * __capability data_cap,
-    const void * __capability code_cap, Elf_Addr relocbase,
-    bool use_code_bounds)
+    const void * __capability code_cap, Elf_Addr relocbase)
 {
 	Elf_Addr addr;
 	Elf_Addr *where;
@@ -95,7 +96,7 @@ elf_reloc(const Elf_Rela *rela, void * __capability data_cap,
 	where = (Elf_Addr *)addr;
 #endif
 	*(uintcap_t *)(void *)where = init_cap_from_fragment(where, data_cap,
-	    code_cap, relocbase, rela->r_addend, use_code_bounds);
+	    code_cap, relocbase, rela->r_addend);
 }
 
 #endif /* __CAPREL_H__ */

--- a/lib/csu/aarch64/crt1_c.c
+++ b/lib/csu/aarch64/crt1_c.c
@@ -77,7 +77,7 @@ __process_cap_relocs(char *env[])
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			crt_init_globals(phdr, phnum, NULL, NULL, NULL);
+			crt_init_globals(phdr, phnum, NULL, NULL);
 		}
 	}
 }

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -123,8 +123,7 @@ _start(void *auxv,
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		crt_init_globals(at_phdr, at_phnum, &data_cap, &code_cap,
-		    NULL);
+		crt_init_globals(at_phdr, at_phnum, &data_cap, &code_cap);
 #endif
 	/* We can access global variables now. */
 

--- a/lib/csu/aarch64c/crt1_c.c
+++ b/lib/csu/aarch64c/crt1_c.c
@@ -63,13 +63,12 @@ void _start(void *, void (*)(void), struct Struct_Obj_Entry *) __dead2 __exporte
 Elf_Auxinfo *__auxargs;
 
 /*
- * The entry function, C part. This performs the bulk of program initialisation
+ * The entry function, C part. This performs the bulk of program initialization
  * before handing off to main().
  *
- * Note: If we want to support tight function bounds, it is important that
- * function calls and global variable accesses are only be made after
+ * Note: It is important that global variable accesses are only made after
  * crt_init_globals() has completed (as this initializes the capabilities to
- * globals and functions in the captable, which is used for all function calls).
+ * globals in the GOT).
  * This restriction only applies to statically linked binaries since the dynamic
  * linker takes care of initialization otherwise.
  */
@@ -98,9 +97,6 @@ _start(void *auxv,
 
 	/*
 	 * Digest the auxiliary vector for local use.
-	 *
-	 * Note: this file must be compiled with -fno-jump-tables to avoid use
-	 * of the captable before crt_init_globals() has been called.
 	 */
 	for (Elf_Auxinfo *auxp = auxv; auxp->a_type != AT_NULL; auxp++) {
 		if (auxp->a_type == AT_ARGV) {
@@ -118,7 +114,7 @@ _start(void *auxv,
 		}
 	}
 
-	/* For -pie executables rtld will initialize the __cap_relocs */
+	/* For -pie executables, rtld will process relocations. */
 #ifndef PIC
 	/*
 	 * crt_init_globals must be called before accessing any globals.
@@ -130,7 +126,7 @@ _start(void *auxv,
 		crt_init_globals(at_phdr, at_phnum, &data_cap, &code_cap,
 		    NULL);
 #endif
-	/* We can access global variables/make function calls now. */
+	/* We can access global variables now. */
 
 	__auxargs = auxv; /* Store the global auxargs pointer */
 

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -75,15 +75,8 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum __unused,
 	const struct capreloc *stop_relocs;
 #ifndef __CHERI_PURE_CAPABILITY__
 	const Elf_Phdr *phlimit = phdr + phnum;
-	Elf_Addr text_start = (Elf_Addr)-1l;
-	Elf_Addr text_end = 0;
-	Elf_Addr readonly_start = (Elf_Addr)-1l;
-	Elf_Addr readonly_end = 0;
-	Elf_Addr writable_start = (Elf_Addr)-1l;
-	Elf_Addr writable_end = 0;
-	bool have_rodata_segment = false;
-	bool have_text_segment = false;
-	bool have_data_segment = false;
+	Elf_Addr base_addr = (Elf_Addr)-1l;
+	Elf_Addr end_addr = 0;
 #endif
 	bool use_code_bounds = false;
 	void * __capability data_cap;
@@ -94,134 +87,36 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum __unused,
 	/*
 	 * The capabilities for `phdr` and the current PCC should be
 	 * constrained to the executable for purecap.  Trust
-	 * relocations to further narrow bounds as needed.
-	 *
+	 * relocations to further narrow code bounds as needed.
 	 */
 	use_code_bounds = true;
-	code_cap = cheri_pcc_get();
 	data_cap = __DECONST(void *, phdr);
+#else
+	/* Bound the data capability to the executable image */
+	for (const Elf_Phdr *ph = phdr; ph < phlimit; ph++) {
+		if (ph->p_type != PT_LOAD)
+			continue;
+
+		base_addr = MIN(base_addr, ph->p_vaddr);
+		end_addr = MAX(end_addr, ph->p_vaddr + ph->p_memsz);
+	}
+
+	data_cap = cheri_ddc_get();
+	data_cap = cheri_address_set(data_cap, base_addr);
+	data_cap = cheri_bounds_set(data_cap, end_addr - base_addr);
+#endif
+
+	code_cap = cheri_pcc_get();
 	data_cap = cheri_perms_clear(data_cap, CHERI_PERM_EXECUTE |
 	    CHERI_PERM_SW_VMEM);
 	rodata_cap = cheri_perms_clear(data_cap, CHERI_PERM_STORE |
 #ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
 	    CHERI_PERM_STORE_CAP |
 #endif
-	    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
+	    CHERI_PERM_STORE_LOCAL_CAP);
 
 #ifdef CHERI_INIT_RELA
 	crt_init_rela(code_cap, data_cap);
-#endif
-#else
-	/* Attempt to bound the data capability to only the writable segment */
-	for (const Elf_Phdr *ph = phdr; ph < phlimit; ph++) {
-		if (ph->p_type != PT_LOAD && ph->p_type != PT_GNU_RELRO) {
-			/* Static binaries should not have a PT_DYNAMIC phdr */
-			if (ph->p_type == PT_DYNAMIC) {
-				__builtin_trap();
-				break;
-			}
-			continue;
-		}
-		/*
-		 * We found a PT_LOAD or PT_GNU_RELRO phdr. PT_GNU_RELRO will
-		 * be a subset of a matching PT_LOAD but we need to add the
-		 * range from PT_GNU_RELRO to the constant capability since
-		 * __cap_relocs could have some constants pointing to the relro
-		 * section. The phdr for the matching PT_LOAD has PF_R|PF_W so
-		 * it would not be added to the readonly if we didn't also
-		 * parse PT_GNU_RELRO.
-		 */
-		Elf_Addr seg_start = ph->p_vaddr;
-		Elf_Addr seg_end = seg_start + ph->p_memsz;
-		if ((ph->p_flags & PF_X)) {
-			/* text segment */
-			have_text_segment = true;
-			text_start = MIN(text_start, seg_start);
-			text_end = MAX(text_end, seg_end);
-		} else if ((ph->p_flags & PF_W)) {
-			/* data segment */
-			have_data_segment = true;
-			writable_start = MIN(writable_start, seg_start);
-			writable_end = MAX(writable_end, seg_end);
-		} else {
-			have_rodata_segment = true;
-			/* read-only segment (not always present) */
-			readonly_start = MIN(readonly_start, seg_start);
-			readonly_end = MAX(readonly_end, seg_end);
-		}
-	}
-
-	if (!have_text_segment) {
-		/* No text segment??? Must be an error somewhere else. */
-		__builtin_trap();
-	}
-	if (!have_rodata_segment) {
-		/*
-		 * Note: If we don't have a separate rodata segment we also
-		 * need to include the text segment in the rodata cap. This is
-		 * required since all constants will be part of the read/exec
-		 * segment instead of a separate read-only one.
-		 */
-		readonly_start = text_start;
-		readonly_end = text_end;
-	}
-	if (!have_data_segment) {
-		/*
-		 * There cannot be any capabilities to initialize if there
-		 * is no data segment. Set all to NULL to catch errors.
-		 *
-		 * Note: RELRO segment will be part of a R/W PT_LOAD.
-		 */
-		code_cap = NULL;
-		data_cap = NULL;
-		rodata_cap = NULL;
-	} else {
-		/* Check that ranges are well-formed */
-		if (writable_end < writable_start ||
-		    readonly_end < readonly_start ||
-		    text_end < text_start)
-			__builtin_trap();
-
-		/* Abort if text and writeable overlap: */
-		if (MAX(writable_start, text_start) <
-		    MIN(writable_end, text_end)) {
-			/* TODO: should we allow a single RWX segment? */
-			__builtin_trap();
-		}
-
-		data_cap = cheri_ddc_get();
-		data_cap = cheri_perms_clear(data_cap,
-		   CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
-
-		code_cap = cheri_pcc_get();
-		rodata_cap = cheri_perms_clear(data_cap,
-		    CHERI_PERM_STORE |
-#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
-		    CHERI_PERM_STORE_CAP |
-#endif
-		    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
-
-		data_cap = cheri_address_set(data_cap, writable_start);
-		rodata_cap = cheri_address_set(rodata_cap, readonly_start);
-
-		/* TODO: should we use exact setbounds? */
-		data_cap =
-		    cheri_bounds_set(data_cap, writable_end - writable_start);
-		rodata_cap =
-		    cheri_bounds_set(rodata_cap, readonly_end - readonly_start);
-
-		if (!cheri_tag_get(data_cap))
-			__builtin_trap();
-		if (!cheri_tag_get(rodata_cap))
-			__builtin_trap();
-		if (!cheri_tag_get(code_cap))
-			__builtin_trap();
-	}
-
-#ifdef CHERI_INIT_RELA
-	crt_init_rela(code_cap, cheri_perms_clear(cheri_ddc_get(),
-	    CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM));
-#endif
 #endif
 
 	start_relocs = CHERI_RODATA_PTR(__start___cap_relocs);

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -88,8 +88,7 @@ crt_init_rela(const Elf_Phdr *phdr __unused, const Elf_Phdr *phlimit __unused)
 static __always_inline void
 crt_init_globals(const Elf_Phdr *phdr, long phnum,
     void * __capability *data_cap_out,
-    const void * __capability *code_cap_out,
-    const void * __capability *rodata_cap_out)
+    const void * __capability *code_cap_out)
 {
 	const Elf_Phdr *phlimit = phdr + phnum;
 	const struct capreloc *start_relocs;
@@ -264,6 +263,4 @@ handle_relocs:
 		*data_cap_out = data_cap;
 	if (code_cap_out)
 		*code_cap_out = code_cap;
-	if (rodata_cap_out)
-		*rodata_cap_out = rodata_cap;
 }

--- a/lib/csu/common-cheri/crt_init_globals.c
+++ b/lib/csu/common-cheri/crt_init_globals.c
@@ -45,33 +45,14 @@ extern const Elf_Rela __weak_symbol __rela_dyn_start[] __hidden;
 extern const Elf_Rela __weak_symbol __rela_dyn_end[] __hidden;
 
 static __always_inline void
-crt_init_rela(const Elf_Phdr *phdr __unused, const Elf_Phdr *phlimit __unused)
+crt_init_rela(const void * __capability code_cap, void * __capability data_cap)
 {
 	const Elf_Rela *rela, *relalim;
-	void * __capability data_cap;
-	const void * __capability code_cap;
-	bool use_code_bounds = false;
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	data_cap = __DECONST(void *, phdr);
-	for (const Elf_Phdr *ph = phdr; ph < phlimit; ph++) {
-		if (ph->p_type == PT_CHERI_PCC) {
-			use_code_bounds = true;
-			break;
-		}
-	}
-#else
-	data_cap = cheri_ddc_get();
-#endif
-	data_cap = cheri_perms_clear(data_cap,
-	    CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
-
-	code_cap = cheri_pcc_get();
 
 	rela = CHERI_RODATA_PTR(__rela_dyn_start);
 	relalim = CHERI_RODATA_PTR(__rela_dyn_end);
 	for (; rela < relalim; rela++)
-		elf_reloc(rela, data_cap, code_cap, 0, use_code_bounds);
+		elf_reloc(rela, data_cap, code_cap, 0);
 }
 #endif
 
@@ -86,31 +67,51 @@ crt_init_rela(const Elf_Phdr *phdr __unused, const Elf_Phdr *phlimit __unused)
 
 /* This is __always_inline since it is called before globals have been set up */
 static __always_inline void
-crt_init_globals(const Elf_Phdr *phdr, long phnum,
+crt_init_globals(const Elf_Phdr *phdr, long phnum __unused,
     void * __capability *data_cap_out,
     const void * __capability *code_cap_out)
 {
-	const Elf_Phdr *phlimit = phdr + phnum;
 	const struct capreloc *start_relocs;
 	const struct capreloc *stop_relocs;
+#ifndef __CHERI_PURE_CAPABILITY__
+	const Elf_Phdr *phlimit = phdr + phnum;
 	Elf_Addr text_start = (Elf_Addr)-1l;
 	Elf_Addr text_end = 0;
 	Elf_Addr readonly_start = (Elf_Addr)-1l;
 	Elf_Addr readonly_end = 0;
 	Elf_Addr writable_start = (Elf_Addr)-1l;
 	Elf_Addr writable_end = 0;
-	bool use_code_bounds = false;
 	bool have_rodata_segment = false;
 	bool have_text_segment = false;
 	bool have_data_segment = false;
+#endif
+	bool use_code_bounds = false;
 	void * __capability data_cap;
 	const void * __capability code_cap;
 	const void * __capability rodata_cap;
 
-#ifdef CHERI_INIT_RELA
-	crt_init_rela(phdr, phlimit);
+#ifdef __CHERI_PURE_CAPABILITY__
+	/*
+	 * The capabilities for `phdr` and the current PCC should be
+	 * constrained to the executable for purecap.  Trust
+	 * relocations to further narrow bounds as needed.
+	 *
+	 */
+	use_code_bounds = true;
+	code_cap = cheri_pcc_get();
+	data_cap = __DECONST(void *, phdr);
+	data_cap = cheri_perms_clear(data_cap, CHERI_PERM_EXECUTE |
+	    CHERI_PERM_SW_VMEM);
+	rodata_cap = cheri_perms_clear(data_cap, CHERI_PERM_STORE |
+#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
+	    CHERI_PERM_STORE_CAP |
 #endif
+	    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
 
+#ifdef CHERI_INIT_RELA
+	crt_init_rela(code_cap, data_cap);
+#endif
+#else
 	/* Attempt to bound the data capability to only the writable segment */
 	for (const Elf_Phdr *ph = phdr; ph < phlimit; ph++) {
 		if (ph->p_type != PT_LOAD && ph->p_type != PT_GNU_RELRO) {
@@ -119,8 +120,6 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 				__builtin_trap();
 				break;
 			}
-			if (ph->p_type == PT_CHERI_PCC)
-				use_code_bounds = true;
 			continue;
 		}
 		/*
@@ -151,34 +150,6 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 			readonly_end = MAX(readonly_end, seg_end);
 		}
 	}
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	/*
-	 * Pure capability executables with multiple compartments
-	 * might have multiple writable and executable segments.
-	 * However, the capabilities for `phdr` and the current PCC
-	 * should be constrained to the executable.  Trust relocations
-	 * to further narrow bounds as needed.
-	 *
-	 * XXX: Once PT_CHERI_PCC is required for pure capability
-	 * binaries, the purecap version of this function should be
-	 * simplified such that the phdrs are only examined for
-	 * hybrid.
-	 */
-	if (use_code_bounds) {
-		code_cap = cheri_pcc_get();
-		data_cap = __DECONST(void *, phdr);
-		data_cap = cheri_perms_clear(data_cap,
-		    CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
-		rodata_cap = cheri_perms_clear(data_cap,
-		    CHERI_PERM_STORE |
-#ifdef HAS_CHERI_PERM_LOAD_STORE_CAP
-		    CHERI_PERM_STORE_CAP |
-#endif
-		    CHERI_PERM_STORE_LOCAL_CAP | CHERI_PERM_SW_VMEM);
-		goto handle_relocs;
-	}
-#endif
 
 	if (!have_text_segment) {
 		/* No text segment??? Must be an error somewhere else. */
@@ -218,11 +189,7 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 			__builtin_trap();
 		}
 
-#ifdef __CHERI_PURE_CAPABILITY__
-		data_cap = __DECONST(void *, phdr);
-#else
 		data_cap = cheri_ddc_get();
-#endif
 		data_cap = cheri_perms_clear(data_cap,
 		   CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM);
 
@@ -251,9 +218,12 @@ crt_init_globals(const Elf_Phdr *phdr, long phnum,
 			__builtin_trap();
 	}
 
-#ifdef __CHERI_PURE_CAPABILITY__
-handle_relocs:
+#ifdef CHERI_INIT_RELA
+	crt_init_rela(code_cap, cheri_perms_clear(cheri_ddc_get(),
+	    CHERI_PERM_EXECUTE | CHERI_PERM_SW_VMEM));
 #endif
+#endif
+
 	start_relocs = CHERI_RODATA_PTR(__start___cap_relocs);
 	stop_relocs = CHERI_RODATA_PTR(__stop___cap_relocs);
 

--- a/lib/csu/riscv/crt1_c.c
+++ b/lib/csu/riscv/crt1_c.c
@@ -83,7 +83,7 @@ __start(int argc, char **argv, char **env, void (*cleanup)(void))
 		}
 
 		if (phdr != NULL && phnum != 0) {
-			crt_init_globals(phdr, phnum, NULL, NULL, NULL);
+			crt_init_globals(phdr, phnum, NULL, NULL);
 		}
 	}
 #endif

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -118,8 +118,7 @@ _start(void *auxv,
 	 * not span the readonly segment or text segment.
 	 */
 	if (!has_dynamic_linker)
-		crt_init_globals(at_phdr, at_phnum, &data_cap, &code_cap,
-		    NULL);
+		crt_init_globals(at_phdr, at_phnum, &data_cap, &code_cap);
 #endif
 	/* We can access global variables now. */
 

--- a/lib/csu/riscv64c/crt1_c.c
+++ b/lib/csu/riscv64c/crt1_c.c
@@ -58,13 +58,12 @@ void _start(void *, void (*)(void), struct Struct_Obj_Entry *) __dead2 __exporte
 Elf_Auxinfo *__auxargs;
 
 /*
- * The entry function, C part. This performs the bulk of program initialisation
+ * The entry function, C part. This performs the bulk of program initialization
  * before handing off to main().
  *
- * Note: If we want to support tight function bounds, it is important that
- * function calls and global variable accesses are only be made after
+ * Note: It is important that global variable accesses are only made after
  * crt_init_globals() has completed (as this initializes the capabilities to
- * globals and functions in the captable, which is used for all function calls).
+ * globals in the GOT).
  * This restriction only applies to statically linked binaries since the dynamic
  * linker takes care of initialization otherwise.
  */
@@ -93,9 +92,6 @@ _start(void *auxv,
 
 	/*
 	 * Digest the auxiliary vector for local use.
-	 *
-	 * Note: this file must be compiled with -fno-jump-tables to avoid use
-	 * of the captable before crt_init_globals() has been called.
 	 */
 	for (Elf_Auxinfo *auxp = auxv; auxp->a_type != AT_NULL; auxp++) {
 		if (auxp->a_type == AT_ARGV) {
@@ -113,7 +109,7 @@ _start(void *auxv,
 		}
 	}
 
-	/* For -pie executables rtld will initialize the __cap_relocs */
+	/* For -pie executables, rtld will process relocations. */
 #ifndef PIC
 	/*
 	 * crt_init_globals must be called before accessing any globals.
@@ -125,7 +121,7 @@ _start(void *auxv,
 		crt_init_globals(at_phdr, at_phnum, &data_cap, &code_cap,
 		    NULL);
 #endif
-	/* We can access global variables/make function calls now. */
+	/* We can access global variables now. */
 
 	__auxargs = auxv; /* Store the global auxargs pointer */
 

--- a/lib/libc/csu/aarch64/reloc.c
+++ b/lib/libc/csu/aarch64/reloc.c
@@ -123,16 +123,8 @@ crt1_handle_rela(const Elf_Rela *r, void *data_cap, const void *code_cap)
 		where = (uintptr_t *)((uintptr_t)data_cap +
 		    (r->r_offset - (ptraddr_t)data_cap));
 		fragment = (Elf_Addr *)where;
-		/*
-		 * XXX: See libexec/rtld-elf/aarch64/reloc.c. Unlike there we
-		 * can ignore the ET_DYN case.
-		 */
-		if ((Elf_Ssize)fragment[0] == r->r_addend)
-			ptr = (uintptr_t)code_cap +
-			    (r->r_addend - (ptraddr_t)code_cap);
-		else
-			ptr = init_cap_from_fragment(fragment, data_cap,
-			    code_cap, 0, r->r_addend, use_code_bounds);
+		ptr = init_cap_from_fragment(fragment, data_cap,
+		    code_cap, 0, r->r_addend, use_code_bounds);
 		target = ((ifunc_resolver_t)ptr)(0, 0, 0, 0, 0, 0, 0, 0);
 		*where = target;
 		break;

--- a/lib/libc/csu/aarch64/reloc.c
+++ b/lib/libc/csu/aarch64/reloc.c
@@ -27,37 +27,9 @@
 
 #include <sys/cdefs.h>
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#include <stdbool.h>
-
-static bool use_code_bounds;
-#endif
-
 static void
 ifunc_init(const Elf_Auxinfo *aux __unused)
 {
-#ifdef __CHERI_PURE_CAPABILITY__
-	const Elf_Phdr *phdr;
-	long phnum;
-
-	/* Digest the auxiliary vector. */
-	for (; aux->a_type != AT_NULL; aux++) {
-		switch (aux->a_type) {
-		case AT_PHDR:
-			phdr = aux->a_un.a_ptr;
-			break;
-		case AT_PHNUM:
-			phnum = aux->a_un.a_val;
-			break;
-		}
-	}
-	for (const Elf_Phdr *ph = phdr; ph < phdr + phnum; ph++) {
-		if (ph->p_type == PT_CHERI_PCC) {
-			use_code_bounds = true;
-			break;
-		}
-	}
-#endif
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -73,7 +45,7 @@ ifunc_init(const Elf_Auxinfo *aux __unused)
 static uintcap_t
 init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
     const void * __capability text_rodata_cap, Elf_Addr base_addr,
-    Elf_Size addend, bool use_code_bounds)
+    Elf_Size addend)
 {
 	uintcap_t cap;
 	Elf_Addr address, len;
@@ -86,8 +58,7 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)text_rodata_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, base_addr + address);
-	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
-		cap = cheri_bounds_set(cap, len);
+	cap = cheri_bounds_set(cap, len);
 	cap = cheri_perms_clear(cap, CHERI_PERM_SW_VMEM);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
@@ -124,7 +95,7 @@ crt1_handle_rela(const Elf_Rela *r, void *data_cap, const void *code_cap)
 		    (r->r_offset - (ptraddr_t)data_cap));
 		fragment = (Elf_Addr *)where;
 		ptr = init_cap_from_fragment(fragment, data_cap,
-		    code_cap, 0, r->r_addend, use_code_bounds);
+		    code_cap, 0, r->r_addend);
 		target = ((ifunc_resolver_t)ptr)(0, 0, 0, 0, 0, 0, 0, 0);
 		*where = target;
 		break;
@@ -143,7 +114,7 @@ crt1_handle_tgot_rela(const Elf_Rela *r, void *tgot, Elf_Addr init, void *tls)
 		    (r->r_offset - init));
 		fragment = (Elf_Addr *)where;
 		*where = init_cap_from_fragment(fragment, tls,
-		    NULL, (ptraddr_t)tls, 0, true);
+		    NULL, (ptraddr_t)tls, 0);
 		break;
 	}
 }

--- a/lib/libc/csu/riscv/reloc.c
+++ b/lib/libc/csu/riscv/reloc.c
@@ -23,45 +23,17 @@
 
 static unsigned long elf_hwcap;
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#include <stdbool.h>
-
-static bool use_code_bounds;
-#endif
-
 static void
 ifunc_init(const Elf_Auxinfo *aux)
 {
-#ifdef __CHERI_PURE_CAPABILITY__
-	const Elf_Phdr *phdr;
-	long phnum;
-#endif
-
 	/* Digest the auxiliary vector. */
 	for (; aux->a_type != AT_NULL; aux++) {
 		switch (aux->a_type) {
 		case AT_HWCAP:
 			elf_hwcap = (uint32_t)aux->a_un.a_val;
 			break;
-#ifdef __CHERI_PURE_CAPABILITY__
-		case AT_PHDR:
-			phdr = aux->a_un.a_ptr;
-			break;
-		case AT_PHNUM:
-			phnum = aux->a_un.a_val;
-			break;
-#endif
 		}
 	}
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	for (const Elf_Phdr *ph = phdr; ph < phdr + phnum; ph++) {
-		if (ph->p_type == PT_CHERI_PCC) {
-			use_code_bounds = true;
-			break;
-		}
-	}
-#endif
 }
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -89,7 +61,7 @@ crt1_handle_capreloc(const struct capreloc *r, void *data_cap,
 		ptr = (uintptr_t)cheri_perms_and(code_cap,
 		    function_pointer_permissions_mask);
 		ptr = cheri_address_set(ptr, r->object);
-		if (use_code_bounds && r->size != 0)
+		if (r->size != 0)
 			ptr = cheri_bounds_set(ptr, r->size);
 		ptr += r->offset;
 		ptr = cheri_sentry_create(ptr);

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -697,33 +697,9 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 	where = (uintptr_t *)(obj->relocbase + rela->r_offset);
 #ifdef __CHERI_PURE_CAPABILITY__
 	fragment = (Elf_Addr *)where;
-	/*
-	 * XXX: Morello LLVM commit 94e1dbac broke R_MORELLO_IRELATIVE ABI.
-	 * This horrible hack exists to support both old and new ABIs.
-	 *
-	 * Old ABI:
-	 *   - Treat as R_AARCH64_IRELATIVE (addend is symbol value)
-	 *   - Fragment contents either all zero (for ET_DYN) or base set to
-	 *     the addend and length set to the symbol size (which we don't
-	 *     have to hand).
-	 *
-	 * New ABI:
-	 *   - Same representation as R_MORELLO_RELATIVE
-	 *
-	 * Thus, probe for something that looks like the old ABI and hope
-	 * that's reliable enough until the commit is old enough that we can
-	 * assume the new ABI and ditch this.
-	 *
-	 * See also: lib/csu/aarch64c/reloc.c and sys/arm64/arm64/elf_machdep.c
-	 */
-	if ((fragment[0] == 0 && fragment[1] == 0) ||
-	    (Elf_Ssize)fragment[0] == rela->r_addend)
-		ptr = (uintptr_t)pcc_cap(obj, rela->r_addend);
-	else
-		ptr = init_cap_from_fragment(fragment, obj->relocbase,
-		    pcc_cap(obj, fragment[0]),
-		    (Elf_Addr)(uintptr_t)obj->relocbase,
-		    rela->r_addend, use_code_bounds);
+	ptr = init_cap_from_fragment(fragment, obj->relocbase,
+	    pcc_cap(obj, fragment[0]), (Elf_Addr)(uintptr_t)obj->relocbase,
+	    rela->r_addend, use_code_bounds);
 #else
 	ptr = (uintptr_t)(obj->relocbase + rela->r_addend);
 #endif

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -467,9 +467,6 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 	const Elf_Rela *relalim;
 	const Elf_Rela *rela;
 	const Elf_Sym *def, *sym;
-#ifdef __CHERI_PURE_CAPABILITY__
-	const char *pcc;
-#endif
 	bool lazy;
 
 	relalim = (const Elf_Rela *)((const char *)plt->rela + plt->relasize);
@@ -505,9 +502,8 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 			}
 			if (lazy) {
 #ifdef __CHERI_PURE_CAPABILITY__
-				pcc = pcc_cap(obj, fragment[0]);
 				*where = init_cap_from_fragment(fragment,
-				    obj->relocbase, pcc,
+				    obj->relocbase, get_codesegment_cap(obj),
 				    (Elf_Addr)(uintptr_t)obj->relocbase,
 				    rela->r_addend);
 #else
@@ -654,7 +650,7 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 #ifdef __CHERI_PURE_CAPABILITY__
 	fragment = (Elf_Addr *)where;
 	ptr = init_cap_from_fragment(fragment, obj->relocbase,
-	    pcc_cap(obj, fragment[0]), (Elf_Addr)(uintptr_t)obj->relocbase,
+	    get_codesegment_cap(obj), (Elf_Addr)(uintptr_t)obj->relocbase,
 	    rela->r_addend);
 #else
 	ptr = (uintptr_t)(obj->relocbase + rela->r_addend);
@@ -933,14 +929,14 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 		case R_MORELLO_RELATIVE:
 			*(uintcap_t *)(void *)where =
 			    init_cap_from_fragment(where, data_cap,
-				pcc_cap(obj, where[0]),
+				get_codesegment_cap(obj),
 				(Elf_Addr)(uintptr_t)obj->relocbase,
 				rela->r_addend);
 			break;
 		case R_MORELLO_FUNC_RELATIVE:
 			*(uintcap_t *)(void *)where =
 			    init_cap_from_fragment(where, data_cap,
-				pcc_cap(obj, where[0]),
+				get_codesegment_cap(obj),
 				(Elf_Addr)(uintptr_t)obj->relocbase,
 				rela->r_addend);
 #ifdef CHERI_LIB_C18N

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -529,8 +529,6 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 			if (lazy) {
 #ifdef __CHERI_PURE_CAPABILITY__
 				pcc = pcc_cap(obj, fragment[0]);
-				pcc = cheri_perms_clear(pcc,
-				    FUNC_PTR_REMOVE_PERMS);
 				*where = init_cap_from_fragment(fragment,
 				    obj->relocbase, pcc,
 				    (Elf_Addr)(uintptr_t)obj->relocbase,

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -528,31 +528,13 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 			}
 			if (lazy) {
 #ifdef __CHERI_PURE_CAPABILITY__
-				/*
-				 * Old ABI:
-				 *   - Treat as R_AARCH64_JUMP_SLOT
-				 *
-				 * New ABI:
-				 *   - Same representation as
-				 *     R_MORELLO_RELATIVE
-				 *
-				 * Determine which this is based on
-				 * whether there's non-zero metadata
-				 * next to the address. Remove once
-				 * the new ABI is old enough that we
-				 * can assume it is in use.
-				 */
 				pcc = pcc_cap(obj, fragment[0]);
 				pcc = cheri_perms_clear(pcc,
 				    FUNC_PTR_REMOVE_PERMS);
-				if (fragment[1] == 0)
-					*where = cheri_sentry_create(
-					    (uintptr_t)pcc);
-				else
-					*where = init_cap_from_fragment(
-					    fragment, obj->relocbase, pcc,
-					    (Elf_Addr)(uintptr_t)obj->relocbase,
-					    rela->r_addend, use_code_bounds);
+				*where = init_cap_from_fragment(fragment,
+				    obj->relocbase, pcc,
+				    (Elf_Addr)(uintptr_t)obj->relocbase,
+				    rela->r_addend, use_code_bounds);
 #else
 				*where += (Elf_Addr)obj->relocbase;
 #endif

--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -160,7 +160,7 @@ init_pltgot(Plt_Entry *plt)
 static uintcap_t
 init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
     const void * __capability pcc_cap, Elf_Addr base_addr,
-    Elf_Size addend, bool use_code_bounds)
+    Elf_Size addend)
 {
 	uintcap_t cap;
 	Elf_Addr address, len;
@@ -173,8 +173,7 @@ init_cap_from_fragment(const Elf_Addr *fragment, void * __capability data_cap,
 	cap = perms == MORELLO_FRAG_EXECUTABLE ?
 	    (uintcap_t)pcc_cap : (uintcap_t)data_cap;
 	cap = cheri_address_set(cap, base_addr + address);
-	if (perms != MORELLO_FRAG_EXECUTABLE || use_code_bounds)
-		cap = cheri_bounds_set(cap, len);
+	cap = cheri_bounds_set(cap, len);
 	cap = cheri_perms_clear(cap, CAP_RELOC_REMOVE_PERMS);
 
 	if (perms == MORELLO_FRAG_EXECUTABLE || perms == MORELLO_FRAG_RODATA) {
@@ -207,36 +206,15 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
-	const Elf_Phdr *phdr = NULL;
 	const Elf_Rela *rela = NULL, *relalim;
-	size_t phnum = 0;
 	unsigned long relasz;
 	Elf_Addr *where;
 	void *pcc;
-	bool use_code_bounds = false;
 
 	for (; aux->a_type != AT_NULL; aux++) {
 		switch (aux->a_type) {
 		case AT_BASE:
 			relocbase = aux->a_un.a_ptr;
-			break;
-		case AT_PHDR:
-			phdr = aux->a_un.a_ptr;
-			break;
-		case AT_PHNUM:
-			phnum = aux->a_un.a_val;
-			break;
-		case AT_PHENT:
-			/* NB: Can't use assert() here. */
-			if (aux->a_un.a_val != sizeof(*phdr))
-				__builtin_trap();
-			break;
-		}
-	}
-
-	for (; phnum > 0; phdr++, phnum--) {
-		if (phdr->p_type == PT_CHERI_PCC) {
-			use_code_bounds = true;
 			break;
 		}
 	}
@@ -268,7 +246,7 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 			where = (Elf_Addr *)(relocbase + rela->r_offset);
 			*(uintcap_t *)where = init_cap_from_fragment(where,
 			    relocbase, pcc, (Elf_Addr)(uintptr_t)relocbase,
-			    rela->r_addend, use_code_bounds);
+			    rela->r_addend);
 			break;
 		default:
 			__builtin_trap();
@@ -491,7 +469,6 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 	const Elf_Sym *def, *sym;
 #ifdef __CHERI_PURE_CAPABILITY__
 	const char *pcc;
-	bool use_code_bounds = obj->npcc_caps != 0;
 #endif
 	bool lazy;
 
@@ -532,7 +509,7 @@ reloc_plt(Plt_Entry *plt, int flags, RtldLockState *lockstate)
 				*where = init_cap_from_fragment(fragment,
 				    obj->relocbase, pcc,
 				    (Elf_Addr)(uintptr_t)obj->relocbase,
-				    rela->r_addend, use_code_bounds);
+				    rela->r_addend);
 #else
 				*where += (Elf_Addr)obj->relocbase;
 #endif
@@ -671,7 +648,6 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 	uintptr_t *where, target, ptr;
 #ifdef __CHERI_PURE_CAPABILITY__
 	Elf_Addr *fragment;
-	bool use_code_bounds = obj->npcc_caps != 0;
 #endif
 
 	where = (uintptr_t *)(obj->relocbase + rela->r_offset);
@@ -679,7 +655,7 @@ reloc_iresolve_one(Obj_Entry *obj, const Elf_Rela *rela,
 	fragment = (Elf_Addr *)where;
 	ptr = init_cap_from_fragment(fragment, obj->relocbase,
 	    pcc_cap(obj, fragment[0]), (Elf_Addr)(uintptr_t)obj->relocbase,
-	    rela->r_addend, use_code_bounds);
+	    rela->r_addend);
 #else
 	ptr = (uintptr_t)(obj->relocbase + rela->r_addend);
 #endif
@@ -845,7 +821,6 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 	Elf_Addr *where, symval;
 #if __has_feature(capabilities)
 	void * __capability data_cap;
-	bool use_code_bounds = false;
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
@@ -855,7 +830,6 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 	 */
 	if (obj == obj_rtld)
 		return (0);
-	use_code_bounds = obj->npcc_caps != 0;
 #endif
 
 #if __has_feature(capabilities)
@@ -961,14 +935,14 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 			    init_cap_from_fragment(where, data_cap,
 				pcc_cap(obj, where[0]),
 				(Elf_Addr)(uintptr_t)obj->relocbase,
-				rela->r_addend, use_code_bounds);
+				rela->r_addend);
 			break;
 		case R_MORELLO_FUNC_RELATIVE:
 			*(uintcap_t *)(void *)where =
 			    init_cap_from_fragment(where, data_cap,
 				pcc_cap(obj, where[0]),
 				(Elf_Addr)(uintptr_t)obj->relocbase,
-				rela->r_addend, use_code_bounds);
+				rela->r_addend);
 #ifdef CHERI_LIB_C18N
 			*(void **)where = tramp_intern(NULL, RTLD_COMPART_ID,
 			    &(struct tramp_data) {
@@ -1182,7 +1156,7 @@ reloc_tgot(Obj_Entry *obj, struct tcb *tcb, void *tgot, int flags,
 			if (tls == NULL)
 				tls = get_block(tcb, obj->tlsindex);
 			val = init_cap_from_fragment(fragment, tls, NULL,
-			    (Elf_Addr)tls, 0, true);
+			    (Elf_Addr)tls, 0);
 		}
 		*where = val;
 	}

--- a/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
@@ -48,10 +48,6 @@
 #define	CAP_RELOC_REMOVE_PERMS						\
 	(CHERI_PERM_SW_VMEM)
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#define can_use_tight_pcc_bounds(obj) ((obj)->npcc_caps != 0)
-#endif
-
 /*
  * Create a pointer to a function.
  */

--- a/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/aarch64/rtld_cheri_machdep.h
@@ -57,16 +57,13 @@
  */
 static inline dlfunc_t __capability
 make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
-    bool tight_bounds, size_t addend)
+    size_t addend)
 {
 	const void * __capability ret;
 
 	ret = pcc_cap(defobj, def->st_value);
 	/* Remove store and seal permissions */
 	ret = cheri_perms_clear(ret, FUNC_PTR_REMOVE_PERMS);
-	if (tight_bounds) {
-		ret = cheri_bounds_set(ret, def->st_size);
-	}
 	/*
 	 * Note: The addend is required for C++ exceptions since capabilities
 	 * for catch blocks point to the middle of a function.
@@ -84,8 +81,7 @@ static inline dlfunc_t __capability
 make_function_cap_with_addend(const Elf_Sym *def,
     const struct Struct_Obj_Entry *defobj, size_t addend)
 {
-	/* TODO: ABIs with tight bounds */
-	return make_code_cap(def, defobj, /*tight_bounds=*/false, addend);
+	return make_code_cap(def, defobj, addend);
 }
 
 static inline dlfunc_t __capability

--- a/libexec/rtld-elf/cheri/cheri_reloc.c
+++ b/libexec/rtld-elf/cheri/cheri_reloc.c
@@ -49,7 +49,6 @@ process___cap_relocs(Obj_Entry *obj)
 	struct capreloc *end_relocs =
 	    (struct capreloc *)(obj->cap_relocs + obj->cap_relocs_size);
 	char * __capability data_base = get_datasegment_cap(obj);
-	bool tight_pcc_bounds;
 
 	if (obj->cap_relocs_processed) {
 		dbg("__cap_relocs for %s have already been processed!",
@@ -60,12 +59,6 @@ process___cap_relocs(Obj_Entry *obj)
 
 	dbg("Processing %lu __cap_relocs for %s (data base = %#lp)\n",
 	    end_relocs - start_relocs, obj->path, data_base);
-
-#ifdef __CHERI_PURE_CAPABILITY__
-	tight_pcc_bounds = can_use_tight_pcc_bounds(obj);
-#else
-	tight_pcc_bounds = false;
-#endif
 
 	for (const struct capreloc *reloc = start_relocs; reloc < end_relocs;
 	     reloc++) {
@@ -97,11 +90,10 @@ process___cap_relocs(Obj_Entry *obj)
 			cap = (uintcap_t)pcc_cap(obj, reloc->object);
 			cap = cheri_perms_clear(cap, FUNC_PTR_REMOVE_PERMS);
 
-			/*
-			 * Do not set tight bounds for functions
-			 * (unless we are in the plt ABI).
-			 */
-			can_set_bounds = tight_pcc_bounds;
+#ifndef __CHERI_PURE_CAPABILITY__
+			/* Do not set tight bounds for functions in hybrid. */
+			can_set_bounds = false;
+#endif
 		} else if (reloc->permissions == constant_reloc_flag) {
 			 /* read-only data pointer */
 			cap = (uintcap_t)data_base + reloc->object;
@@ -139,7 +131,6 @@ process_ifunc___cap_relocs(Obj_Entry *obj)
 	struct capreloc *start_relocs = (struct capreloc *)obj->cap_relocs;
 	struct capreloc *end_relocs =
 	    (struct capreloc *)(obj->cap_relocs + obj->cap_relocs_size);
-	bool tight_pcc_bounds = can_use_tight_pcc_bounds(obj);
 
 	dbg("Processing %lu __cap_relocs for %s IFUNCs\n",
 	    end_relocs - start_relocs, obj->path);
@@ -157,7 +148,7 @@ process_ifunc___cap_relocs(Obj_Entry *obj)
 		cap = (uintcap_t)pcc_cap(obj, reloc->object);
 		cap = cheri_perms_clear(cap,
 		    FUNC_PTR_REMOVE_PERMS | CAP_RELOC_REMOVE_PERMS);
-		if (tight_pcc_bounds && reloc->size != 0)
+		if (reloc->size != 0)
 			cap = cheri_bounds_set(cap, reloc->size);
 		cap += reloc->offset;
 		cap = cheri_sentry_create(cap);

--- a/libexec/rtld-elf/cheri/cheri_reloc.c
+++ b/libexec/rtld-elf/cheri/cheri_reloc.c
@@ -145,7 +145,7 @@ process_ifunc___cap_relocs(Obj_Entry *obj)
 		    (function_reloc_flag | indirect_reloc_flag))
 			continue;
 
-		cap = (uintcap_t)pcc_cap(obj, reloc->object);
+		cap = (uintcap_t)get_codesegment_cap(obj) + reloc->object;
 		cap = cheri_perms_clear(cap,
 		    FUNC_PTR_REMOVE_PERMS | CAP_RELOC_REMOVE_PERMS);
 		if (reloc->size != 0)

--- a/libexec/rtld-elf/map_object.c
+++ b/libexec/rtld-elf/map_object.c
@@ -430,7 +430,8 @@ map_object(int fd, const char *path, const struct stat *sb, bool ismain,
 #endif
 	if (hdr->e_entry != 0) {
 #ifdef __CHERI_PURE_CAPABILITY__
-		obj->entry = (const void *)pcc_cap(obj, hdr->e_entry);
+		obj->entry = (const void *)(get_codesegment_cap(obj) +
+		    hdr->e_entry);
 #else
 		obj->entry = (const void *)(obj->relocbase + hdr->e_entry);
 #endif

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -104,35 +104,14 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
-	const Elf_Phdr *phdr = NULL;
 	const struct capreloc *caprelocs = NULL, *caprelocslim;
 	Elf_Addr caprelocssz = 0;
-	size_t phnum = 0;
 	void *pcc;
-	bool use_code_bounds = false;
 
 	for (; aux->a_type != AT_NULL; aux++) {
 		switch (aux->a_type) {
 		case AT_BASE:
 			relocbase = aux->a_un.a_ptr;
-			break;
-		case AT_PHDR:
-			phdr = aux->a_un.a_ptr;
-			break;
-		case AT_PHNUM:
-			phnum = aux->a_un.a_val;
-			break;
-		case AT_PHENT:
-			/* NB: Can't use assert() here. */
-			if (aux->a_un.a_val != sizeof(*phdr))
-				__builtin_trap();
-			break;
-		}
-	}
-
-	for (; phnum > 0; phdr++, phnum--) {
-		if (phdr->p_type == PT_CHERI_PCC) {
-			use_code_bounds = true;
 			break;
 		}
 	}
@@ -150,10 +129,9 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 	caprelocs = cheri_bounds_set(caprelocs, caprelocssz);
 	caprelocslim = (const struct capreloc *)((const char *)caprelocs + caprelocssz);
 	pcc = __builtin_cheri_program_counter_get();
-	/* TODO: allow using tight bounds for RTLD */
 	cheri_init_globals_impl(caprelocs, caprelocslim,
 	    /*data_cap=*/relocbase, /*code_cap=*/pcc, /*rodata_cap=*/pcc,
-	    /*tight_code_bounds=*/use_code_bounds, (Elf_Addr)relocbase);
+	    /*tight_code_bounds=*/true, (Elf_Addr)relocbase);
 }
 #endif /* __CHERI_PURE_CAPABILITY__ */
 

--- a/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
@@ -45,10 +45,6 @@
 #define	CAP_RELOC_REMOVE_PERMS						\
 	(CHERI_PERM_SW_VMEM)
 
-#ifdef __CHERI_PURE_CAPABILITY__
-#define can_use_tight_pcc_bounds(obj) ((obj)->npcc_caps != 0)
-#endif
-
 /*
  * Create a pointer to a function.
  */

--- a/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
+++ b/libexec/rtld-elf/riscv/rtld_cheri_machdep.h
@@ -51,21 +51,16 @@
 
 /*
  * Create a pointer to a function.
- * Important: this is not necessarily callable! For ABIs with tight bounds we
- * need to load CGP first -> use make_function_pointer() instead.
  */
 static inline dlfunc_t __capability
 make_code_cap(const Elf_Sym *def, const struct Struct_Obj_Entry *defobj,
-    bool tight_bounds, size_t addend)
+    size_t addend)
 {
 	const void * __capability ret;
 
 	ret = pcc_cap(defobj, def->st_value);
 	/* Remove store and seal permissions */
 	ret = cheri_perms_clear(ret, FUNC_PTR_REMOVE_PERMS);
-	if (tight_bounds) {
-		ret = cheri_bounds_set(ret, def->st_size);
-	}
 	/*
 	 * Note: The addend is required for C++ exceptions since capabilities
 	 * for catch blocks point to the middle of a function.
@@ -83,8 +78,7 @@ static inline dlfunc_t __capability
 make_function_cap_with_addend(const Elf_Sym *def,
     const struct Struct_Obj_Entry *defobj, size_t addend)
 {
-	/* TODO: ABIs with tight bounds */
-	return make_code_cap(def, defobj, /*tight_bounds=*/false, addend);
+	return make_code_cap(def, defobj, addend);
 }
 
 static inline dlfunc_t __capability

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -1613,20 +1613,14 @@ create_pcc_caps(Obj_Entry *obj, const char *name)
 
 /*
  * Returns a code pointer to the instruction at the relative offset
- * into the mapped object.  If the object includes PCC bounds via
- * PT_CHERI_PCC headers, the pointer uses the bounds from the relevant
- * header.  Otherwise the pointer uses bounds for the entire object.
+ * into the mapped object.  The pointer uses the bounds from the
+ * relevant PT_CHERI_PCC segment.
  */
 const char *
 pcc_cap(const Obj_Entry *obj, Elf_Off offset)
 {
 	Elf_Addr addr;
 	const char *pcc_cap;
-
-	if (obj->npcc_caps == 0) {
-		pcc_cap = obj->text_rodata_cap + offset;
-		return (cheri_perms_clear(pcc_cap, CAP_RELOC_REMOVE_PERMS));
-	}
 
 	addr = (Elf_Addr)(uintptr_t)obj->relocbase + offset;
 	for (unsigned long i = 0; i < obj->npcc_caps; i++) {

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -597,19 +597,22 @@ void dump_Elf_Rel(Obj_Entry *, const Elf_Rel *, u_long);
 void dump_Elf_Rela(Obj_Entry *, const Elf_Rela *, u_long);
 
 #ifdef __CHERI_PURE_CAPABILITY__
+#define get_codesegment_cap(obj)					\
+	(cheri_clearperm((obj)->text_rodata_cap, CAP_RELOC_REMOVE_PERMS))
 #define get_datasegment_cap(obj)				\
 	(cheri_perms_clear((obj)->relocbase, CAP_RELOC_REMOVE_PERMS))
 #elif __has_feature(capabilities)
-#define pcc_cap(obj, offset)					\
-	(const char * __capability)cheri_bounds_set(		\
+#define get_codesegment_cap(obj)				\
+	(const char * __capability)cheri_setbounds(		\
 	    cheri_address_set(cheri_pcc_get(),			\
-	        (ptraddr_t)(uintptr_t)obj->mapbase + (offset)),	\
+	        (ptraddr_t)(uintptr_t)obj->mapbase),		\
 	    obj->mapsize)
 #define get_datasegment_cap(obj)				\
 	(char * __capability)cheri_bounds_set(			\
 	    cheri_address_set(cheri_ddc_get(),		\
 	        (ptraddr_t)(uintptr_t)obj->mapbase),		\
 	    obj->mapsize)
+#define	pcc_cap(obj, offset)	(get_codesegment_cap((obj)) + (offset))
 #endif
 
 __END_DECLS

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -431,15 +431,14 @@ build_reloc_cap(Elf_Addr addr, Elf_Addr size, uint8_t perms, Elf_Addr offset,
 #ifdef __CHERI_PURE_CAPABILITY__
 static uintcap_t __nosanitizecoverage
 build_cap_from_fragment(Elf_Addr *fragment, Elf_Addr relocbase, Elf_Addr offset,
-    void * __capability data_cap, const void * __capability code_cap,
-    bool use_code_bounds)
+    void * __capability data_cap, const void * __capability code_cap)
 {
 	Elf_Addr addr, size;
 	uint8_t perms;
 
 	decode_fragment(fragment, relocbase, &addr, &size, &perms);
 	return (build_reloc_cap(addr, size, perms, offset, data_cap, code_cap,
-	    use_code_bounds));
+	    true));
 }
 #endif
 #endif
@@ -617,7 +616,7 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		break;
 	case R_MORELLO_IRELATIVE:
 		addr = build_cap_from_fragment(where, (Elf_Addr)relocbase,
-		    rela->r_addend, relocbase, relocbase, use_code_bounds);
+		    rela->r_addend, relocbase, relocbase);
 		addr = ((uintptr_t (*)(void))addr)();
 		*(uintptr_t *)where = addr;
 		break;
@@ -784,7 +783,7 @@ elf_reloc_self(const Elf_Dyn *dynp, void *data_cap, const void *code_cap)
 			fragment = (Elf_Addr *)cheri_address_set(data_cap,
 			    rela->r_offset);
 			cap = build_cap_from_fragment(fragment, 0,
-			    rela->r_addend, data_cap, code_cap, true);
+			    rela->r_addend, data_cap, code_cap);
 			*((uintptr_t *)fragment) = cap;
 			break;
 		}

--- a/sys/arm64/arm64/elf_machdep.c
+++ b/sys/arm64/arm64/elf_machdep.c
@@ -616,18 +616,8 @@ elf_reloc_internal(linker_file_t lf, char *relocbase, const void *data,
 		*(uintptr_t *)where = addr;
 		break;
 	case R_MORELLO_IRELATIVE:
-		/* XXX: See libexec/rtld-elf/aarch64/reloc.c. */
-		if ((where[0] == 0 && where[1] == 0) ||
-		    (Elf_Ssize)where[0] == rela->r_addend) {
-			addr = (uintptr_t)(relocbase + rela->r_addend);
-			addr = cheri_perms_clear(addr, CHERI_PERM_SEAL |
-			    CHERI_PERM_STORE | CHERI_PERM_STORE_CAP |
-			    CHERI_PERM_STORE_LOCAL_CAP);
-			addr = cheri_sentry_create(addr);
-		} else
-			addr = build_cap_from_fragment(where,
-			    (Elf_Addr)relocbase, rela->r_addend,
-			    relocbase, relocbase, use_code_bounds);
+		addr = build_cap_from_fragment(where, (Elf_Addr)relocbase,
+		    rela->r_addend, relocbase, relocbase, use_code_bounds);
 		addr = ((uintptr_t (*)(void))addr)();
 		*(uintptr_t *)where = addr;
 		break;

--- a/sys/cheri/cheri.h
+++ b/sys/cheri/cheri.h
@@ -173,7 +173,7 @@ typedef void (cap_relocs_cb)(void *arg, bool function, bool constant,
 
 int	init_linker_file_cap_relocs(const void *start_relocs,
 	    const void *stop_relocs, void *data_cap, ptraddr_t base_addr,
-	    bool can_set_code_bounds, cap_relocs_cb *cb, void *cb_arg);
+	    cap_relocs_cb *cb, void *cb_arg);
 #endif
 #endif /* !_KERNEL */
 

--- a/sys/cheri/cheri_cap_relocs.c
+++ b/sys/cheri/cheri_cap_relocs.c
@@ -65,15 +65,14 @@ typedef void (cap_relocs_cb)(void *arg, bool function, bool constant,
 
 int	init_linker_file_cap_relocs(const void *start_relocs,
 	    const void *stop_relocs, void *data_cap, ptraddr_t base_addr,
-	    bool can_set_code_bounds, cap_relocs_cb *cb, void *cb_arg);
+	    cap_relocs_cb *cb, void *cb_arg);
 
 /* Can't include <sys/systm.h>. */
 int	printf(const char *, ...) __printflike(1, 2);
 
 int
 init_linker_file_cap_relocs(const void *start_relocs, const void *stop_relocs,
-    void *data_cap, ptraddr_t base_addr, bool can_set_code_bounds,
-    cap_relocs_cb *cb, void *cb_arg)
+    void *data_cap, ptraddr_t base_addr, cap_relocs_cb *cb, void *cb_arg)
 {
 	/*
 	 * This cannot use cheri_init_globals_impl directly as symbols
@@ -103,7 +102,7 @@ init_linker_file_cap_relocs(const void *start_relocs, const void *stop_relocs,
 			return (-1);
 		}
 		cb(cb_arg, function, constant, reloc->object, &src);
-		if ((!function || can_set_code_bounds) && reloc->size != 0)
+		if (reloc->size != 0)
 			src = __builtin_cheri_bounds_set(src, reloc->size);
 		src = (char *)src + reloc->offset;
 		if (function) {

--- a/sys/kern/link_elf.c
+++ b/sys/kern/link_elf.c
@@ -438,9 +438,6 @@ ef_pcc_cap(elf_file_t ef, ptraddr_t offset)
 	caddr_t pcc_cap;
 	Elf_Addr addr;
 
-	if (ef->npcc_caps == 0)
-		return (ef->mapbase);
-
 	addr = (Elf_Addr)ef->address + offset;
 	for (size_t i = 0; i < ef->npcc_caps; i++) {
 		pcc_cap = ef->pcc_caps[i];
@@ -521,14 +518,28 @@ ef_create_pcc_caps(elf_file_t ef, const Elf_Phdr *phstart,
 	const Elf_Phdr *phdr;
 	caddr_t pcc_cap;
 	size_t i, j;
-	bool valid;
+	bool has_text, valid;
 
+	has_text = false;
 	for (phdr = phstart; phdr < phlimit; phdr++) {
 		switch (phdr->p_type) {
+		case PT_LOAD:
+			if ((phdr->p_flags & PF_X) != 0)
+				has_text = true;
+			break;
 		case PT_CHERI_PCC:
 			ef->npcc_caps++;
 			break;
 		}
+	}
+
+	if (ef->npcc_caps == 0) {
+		if (has_text) {
+			printf("%s: Missing PT_CHERI_PCC segment\n",
+			    ef->lf.filename);
+			return (false);
+		}
+		return (true);
 	}
 
 	valid = true;
@@ -576,8 +587,14 @@ preload_init_pcc_caps(elf_file_t ef, caddr_t modptr)
 	size_t phnum;
 
 	phdr = preload_search_phdrs(ef, &phnum, modptr);
-	if (phdr == NULL)
+	if (phdr == NULL) {
+		/* Create a single PCC cap entry as a fallback. */
+		ef->npcc_caps = 1;
+		ef->pcc_caps = mallocarray(ef->npcc_caps, sizeof(*ef->pcc_caps),
+		    M_LINKER, M_WAITOK | M_ZERO);
+		ef->pcc_caps[0] = ef->mapbase;
 		return (true);
+	}
 
 	return (ef_create_pcc_caps(ef, phdr, phdr + phnum));
 }
@@ -2349,7 +2366,7 @@ link_elf_reloc_local(linker_file_t lf)
 		data_cap = cheri_perms_and(ef->mapbase, CHERI_PERMS_KERNEL_DATA);
 		if (init_linker_file_cap_relocs(ef->caprelocs,
 		    (char *)ef->caprelocs + ef->caprelocssize, data_cap,
-		    (ptraddr_t)ef->address, true, resolve_cap_reloc, ef) != 0)
+		    (ptraddr_t)ef->address, resolve_cap_reloc, ef) != 0)
 			return (ENOEXEC);
 	}
 #endif

--- a/sys/riscv/riscv/locore.S
+++ b/sys/riscv/riscv/locore.S
@@ -398,9 +398,8 @@ va:
 	cincoffset ca1, ca0, t1
 	candperm ca2, cs0, t0
 	mv	a3, zero
-	li	a4, 1
-	cllc	ca5, _C_LABEL(kernel_cap_relocs_cb)
-	csetflags ca6, ca5, zero
+	cllc	ca4, _C_LABEL(kernel_cap_relocs_cb)
+	csetflags ca5, ca4, zero
 	ccall	_C_LABEL(init_linker_file_cap_relocs)
 
 	/* Initialize capabilities. */


### PR DESCRIPTION
- **csu: Replace references to the captable with the GOT instead**
- **csu: Remove unused rodata_cap_out argument from crt_init_globals**
- **csu: Assume PT_CHERI_PCC and bounded code pointers for pure-cap**
- **libc/csu: Assume bounded code pointers for pure-cap**
- **rtld: Assume PT_CHERI_PCC and bounded code pointers for pure-cap**
- **sys: Assume PT_CHERI_PCC and bounded code pointers for pure-cap**
