### PR TITLE
rtld-elf: Error, not silently ignore, copy relocations in purecap executables

### DIFF
--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -277,6 +277,7 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 }
 #endif /* __CHERI_PURE_CAPABILITY__ */
 
+#ifndef __CHERI_PURE_CAPABILITY__
 int
 do_copy_relocations(Obj_Entry *dstobj)
 {
@@ -333,6 +334,7 @@ do_copy_relocations(Obj_Entry *dstobj)
 
 	return (0);
 }
+#endif /* !__CHERI_PURE_CAPABILITY__ */
 
 #if !defined(TLS_TGOT) || defined(TLS_TGOT_COMPAT)
 struct tls_data {
@@ -1039,6 +1041,11 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 #endif
 			break;
 		case R_AARCH64_COPY:
+#ifdef __CHERI_PURE_CAPABILITY__
+			_rtld_error("%s: Unexpected R_AARCH64_COPY "
+			    "relocation in pure-capability object", obj->path);
+			return (-1);
+#else
 			/*
 			 * These are deferred until all other relocations have
 			 * been done. All we do here is make sure that the
@@ -1051,6 +1058,7 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 				return (-1);
 			}
 			break;
+#endif
 #ifdef __CHERI_PURE_CAPABILITY__
 		case R_MORELLO_TLSDESC:
 #else

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -157,6 +157,7 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 }
 #endif /* __CHERI_PURE_CAPABILITY__ */
 
+#ifndef __CHERI_PURE_CAPABILITY__
 int
 do_copy_relocations(Obj_Entry *dstobj)
 {
@@ -214,6 +215,7 @@ do_copy_relocations(Obj_Entry *dstobj)
 
 	return (0);
 }
+#endif /* !__CHERI_PURE_CAPABILITY__ */
 
 /*
  * Process the PLT relocations.
@@ -508,6 +510,11 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 			*where += (Elf_Addr)defobj->tlsindex;
 			break;
 		case R_RISCV_COPY:
+#ifdef __CHERI_PURE_CAPABILITY__
+			_rtld_error("%s: Unexpected R_RISCV_COPY "
+			    "relocation in pure-capability object", obj->path);
+			return (-1);
+#else
 			/*
 			 * These are deferred until all other relocations have
 			 * been done. All we do here is make sure that the
@@ -520,6 +527,7 @@ reloc_non_plt(Obj_Entry *obj, Obj_Entry *obj_rtld, int flags,
 				return (-1);
 			}
 			break;
+#endif
 		case R_RISCV_TLS_DTPREL64:
 #ifndef TLS_TGOT
 			def = find_symdef(symnum, obj, &defobj, flags, cache,

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -694,7 +694,9 @@ bool check_elf_headers(const Elf_Ehdr *hdr, const char *path);
 /*
  * MD function declarations.
  */
+#ifndef __CHERI_PURE_CAPABILITY__
 int do_copy_relocations(Obj_Entry *);
+#endif
 int reloc_non_plt(Obj_Entry *, Obj_Entry *, int flags,
     struct Struct_RtldLockState *);
 int reloc_plt(Plt_Entry *, int flags, struct Struct_RtldLockState *);


### PR DESCRIPTION
Codasip's LLVM 20 currently ends up emitting copy relocations for the
crunched cheribsdbox against a few symbols, including __stdoutp and
__stderrp. Currently we just don't call do_copy_relocations for purecap
executables, but reloc_non_plt is still written as if we do, so such
cases are silently ignored and we end up with the memory always being
zeroed.

Whilst here, #ifndef out do_copy_relocations itself for purecap so it's
clear there is no such support regardless of where you look, rather than
needing to look inside _rtld and find the #ifndef around the call.
