### PR TITLE
Backport patches for recent FreeBSD SAs

### DIFF
--- a/etc/mtree/BSD.tests.dist
+++ b/etc/mtree/BSD.tests.dist
@@ -884,6 +884,8 @@
             ..
             routing
             ..
+            wg
+            ..
         ..
         netgraph
         ..

--- a/sys/dev/wg/wg_crypto.c
+++ b/sys/dev/wg/wg_crypto.c
@@ -230,6 +230,8 @@ chacha20poly1305_encrypt_mbuf(struct mbuf *m, const uint64_t nonce,
 	crp.crp_cipher_key = key;
 	crp.crp_callback = crypto_callback;
 	ret = crypto_dispatch(&crp);
+	if (ret == 0)
+		ret = crp.crp_etype;
 	crypto_destroyreq(&crp);
 	return (ret);
 }
@@ -253,6 +255,8 @@ chacha20poly1305_decrypt_mbuf(struct mbuf *m, const uint64_t nonce,
 	crp.crp_cipher_key = key;
 	crp.crp_callback = crypto_callback;
 	ret = crypto_dispatch(&crp);
+	if (ret == 0)
+		ret = crp.crp_etype;
 	crypto_destroyreq(&crp);
 	if (ret)
 		return (ret);
@@ -270,9 +274,14 @@ crypto_init(void)
 		.csp_cipher_klen = CHACHA20POLY1305_KEY_SIZE,
 		.csp_flags = CSP_F_SEPARATE_AAD | CSP_F_SEPARATE_OUTPUT
 	};
-	int ret = crypto_newsession(&chacha20_poly1305_sid, &csp, CRYPTOCAP_F_SOFTWARE);
+	int ret = crypto_newsession(&chacha20_poly1305_sid, &csp,
+	    CRYPTOCAP_F_SOFTWARE);
 	if (ret != 0)
 		return (ret);
+	if (!CRYPTO_SESS_SYNC(chacha20_poly1305_sid)) {
+		crypto_freesession(chacha20_poly1305_sid);
+		return (ENXIO);
+	}
 	return (0);
 }
 

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -2023,6 +2023,8 @@ typedef void (*segment_callback)(vm_map_entry_t, void *);
 struct phdr_closure {
 	Elf_Phdr *phdr;		/* Program header to fill in */
 	Elf_Off offset;		/* Offset of segment in core file */
+	int numsegs;		/* Maximum number of segments */
+	int nextseg;		/* Next segment to fill in */
 };
 
 struct note_info {
@@ -2151,10 +2153,15 @@ __elfN(coredump)(struct thread *td, struct vnode *vp, off_t limit, int flags)
         }
 
 	/*
-	 * Allocate memory for building the header, fill it up,
-	 * and write it out following the notes.
+	 * Allocate memory for building the header, fill it up, and write it out
+	 * following the notes.
+	 *
+	 * Note that a process sharing our vmspace might be concurrently
+	 * mutating the map, in which case we could populate fewer than
+	 * seginfo.count headers.  Zero the buffer to ensure that unpopulated
+	 * headers are still initialized.
 	 */
-	hdr = malloc(hdrsize, M_TEMP, M_WAITOK);
+	hdr = malloc(hdrsize, M_TEMP, M_WAITOK | M_ZERO);
 	error = __elfN(corehdr)(&params, seginfo.count, hdr, hdrsize, &notelst,
 	    notesz, flags);
 
@@ -2226,6 +2233,11 @@ cb_put_phdr(vm_map_entry_t entry, void *closure)
 	struct phdr_closure *phc = (struct phdr_closure *)closure;
 	Elf_Phdr *phdr = phc->phdr;
 
+	if (phc->nextseg >= phc->numsegs) {
+		/* Only write as many headers as we have space for. */
+		return;
+	}
+
 	phc->offset = round_page(phc->offset);
 
 	phdr->p_type = PT_LOAD;
@@ -2238,6 +2250,8 @@ cb_put_phdr(vm_map_entry_t entry, void *closure)
 
 	phc->offset += phdr->p_filesz;
 	phc->phdr++;
+
+	phc->nextseg++;
 }
 
 #if __has_feature(capabilities)
@@ -2540,6 +2554,8 @@ __elfN(puthdr)(struct thread *td, void *hdr, size_t hdrsize, int numsegs,
 	/* All the writable segments from the program. */
 	phc.phdr = phdr;
 	phc.offset = round_page(hdrsize + notesz);
+	phc.numsegs = numsegs;
+	phc.nextseg = 0;
 	each_dumpable_segment(td, cb_put_phdr, &phc, flags);
 #if __has_feature(capabilities)
 	each_dumpable_segment(td, cb_put_memtag_phdr, &phc, flags);

--- a/sys/kern/sysv_sem.c
+++ b/sys/kern/sysv_sem.c
@@ -870,25 +870,20 @@ kern_semctl(struct thread *td, int semid, int semnum, int cmd,
 		 * won't work for SETALL since we can't copyin() more
 		 * data than the user specified as we may return a
 		 * spurious EFAULT.
-		 *
-		 * Note that the number of semaphores in a set is
-		 * fixed for the life of that set.  The only way that
-		 * the 'count' could change while are blocked in
-		 * malloc() is if this semaphore set were destroyed
-		 * and a new one created with the same index.
-		 * However, semvalid() will catch that due to the
-		 * sequence number unless exactly 0x8000 (or a
-		 * multiple thereof) semaphore sets for the same index
-		 * are created and destroyed while we are in malloc!
-		 *
 		 */
+		if ((error = semvalid(semid, rpr, semakptr)) != 0)
+			goto done2;
 		count = semakptr->u.sem_nsems;
 		mtx_unlock(sema_mtxp);
 		array = malloc(sizeof(*array) * count, M_TEMP, M_WAITOK);
 		mtx_lock(sema_mtxp);
 		if ((error = semvalid(semid, rpr, semakptr)) != 0)
 			goto done2;
-		KASSERT(count == semakptr->u.sem_nsems, ("nsems changed"));
+		if (count != semakptr->u.sem_nsems) {
+			/* Unlikely, but possible. */
+			error = EAGAIN;
+			goto done2;
+		}
 		if ((error = ipcperm(td, &semakptr->u.sem_perm, IPC_R)))
 			goto done2;
 		for (i = 0; i < semakptr->u.sem_nsems; i++)
@@ -931,10 +926,8 @@ kern_semctl(struct thread *td, int semid, int semnum, int cmd,
 		break;
 
 	case SETALL:
-		/*
-		 * See comment on GETALL for why 'count' shouldn't change
-		 * and why we require a userland buffer.
-		 */
+		if ((error = semvalid(semid, rpr, semakptr)) != 0)
+			goto done2;
 		count = semakptr->u.sem_nsems;
 		mtx_unlock(sema_mtxp);
 		array = malloc(sizeof(*array) * count, M_TEMP, M_WAITOK);
@@ -944,7 +937,11 @@ kern_semctl(struct thread *td, int semid, int semnum, int cmd,
 			break;
 		if ((error = semvalid(semid, rpr, semakptr)) != 0)
 			goto done2;
-		KASSERT(count == semakptr->u.sem_nsems, ("nsems changed"));
+		if (count != semakptr->u.sem_nsems) {
+			/* Unlikely, but possible. */
+			error = EAGAIN;
+			goto done2;
+		}
 		if ((error = ipcperm(td, &semakptr->u.sem_perm, IPC_W)))
 			goto done2;
 		for (i = 0; i < semakptr->u.sem_nsems; i++) {
@@ -1508,12 +1505,11 @@ semexit_myhook(void *arg, struct proc *p)
 
 			mtx_lock(sema_mtxp);
 			if ((semakptr->u.sem_perm.mode & SEM_ALLOC) == 0 ||
-			    (semakptr->u.sem_perm.seq != seq)) {
+			    semakptr->u.sem_perm.seq != seq ||
+			    semakptr->u.sem_nsems <= semnum) {
 				mtx_unlock(sema_mtxp);
 				continue;
 			}
-			if (semnum >= semakptr->u.sem_nsems)
-				panic("semexit - semnum out of range");
 
 			DPRINTF((
 			    "semexit:  %p id=%d num=%d(adj=%d) ; sem=%d\n",

--- a/sys/opencrypto/crypto.c
+++ b/sys/opencrypto/crypto.c
@@ -61,6 +61,7 @@
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/counter.h>
+#include <sys/fail.h>
 #include <sys/kernel.h>
 #include <sys/kthread.h>
 #include <sys/linker.h>
@@ -144,6 +145,9 @@ static	struct mtx crypto_q_mtx;
 
 SYSCTL_NODE(_kern, OID_AUTO, crypto, CTLFLAG_RW, 0,
     "In-kernel cryptography");
+
+static SYSCTL_NODE(_debug_fail_point, OID_AUTO, crypto, CTLFLAG_RW, 0,
+    "OCF fail points");
 
 /*
  * Taskqueue used to dispatch the crypto requests submitted with
@@ -1672,6 +1676,18 @@ crypto_done(struct cryptop *crp)
 	KASSERT((crp->crp_flags & CRYPTO_F_DONE) == 0,
 		("crypto_done: op already done, flags 0x%x", crp->crp_flags));
 	crp->crp_flags |= CRYPTO_F_DONE;
+
+	if (crp->crp_etype == 0) {
+		switch (crp->crp_session->csp.csp_mode) {
+		case CSP_MODE_DIGEST:
+		case CSP_MODE_AEAD:
+			if ((crp->crp_op & CRYPTO_OP_VERIFY_DIGEST) != 0)
+				KFAIL_POINT_CODE(_debug_fail_point_crypto,
+				    inject_badmsg, crp->crp_etype = EBADMSG);
+			break;
+		}
+	}
+
 	if (crp->crp_etype != 0)
 		CRYPTOSTAT_INC(cs_errs);
 

--- a/tests/sys/net/Makefile
+++ b/tests/sys/net/Makefile
@@ -19,6 +19,7 @@ ATF_TESTS_SH+=	if_wg
 
 TESTS_SUBDIRS+=	bpf
 TESTS_SUBDIRS+=	if_ovpn
+TESTS_SUBDIRS+=	wg
 TESTS_SUBDIRS+=	routing
 
 .if !${MACHINE_ABI:Mpurecap}

--- a/tests/sys/net/wg/Makefile
+++ b/tests/sys/net/wg/Makefile
@@ -1,0 +1,10 @@
+PACKAGE=	tests
+
+TESTSDIR=	${TESTSBASE}/sys/net/wg
+BINDIR=		${TESTSDIR}
+
+ATF_TESTS_SH+=	if_wg_nojail
+
+TEST_METADATA.if_wg_nojail=	is_exclusive=true
+
+.include <bsd.test.mk>

--- a/tests/sys/net/wg/if_wg_nojail.sh
+++ b/tests/sys/net/wg/if_wg_nojail.sh
@@ -1,0 +1,111 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2021 The FreeBSD Foundation
+#
+# This software was developed by Mark Johnston under sponsorship
+# from the FreeBSD Foundation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+. $(atf_get_srcdir)/../../common/vnet.subr
+
+atf_test_case "wg_bad_decrypt" "cleanup"
+wg_bad_decrypt_head()
+{
+	atf_set descr 'Create a wg(4) tunnel over an epair and inject a decryption error'
+	atf_set require.user root
+	#atf_set require.kmods if_wg
+}
+
+wg_bad_decrypt_body()
+{
+	local epair pri1 pri2 pub1 pub2 wg1 wg2
+        local endpoint1 endpoint2 tunnel1 tunnel2
+
+	pri1=$(wg genkey)
+	pri2=$(wg genkey)
+
+	endpoint1=192.168.2.1
+	endpoint2=192.168.2.2
+	tunnel1=169.254.0.1
+	tunnel2=169.254.0.2
+
+	epair=$(vnet_mkepair)
+
+	vnet_init
+
+	vnet_mkjail wgtest1 ${epair}a
+	vnet_mkjail wgtest2 ${epair}b
+
+	jexec wgtest1 ifconfig ${epair}a ${endpoint1}/24 up
+	jexec wgtest2 ifconfig ${epair}b ${endpoint2}/24 up
+
+	wg1=$(jexec wgtest1 ifconfig wg create)
+	echo "$pri1" | jexec wgtest1 wg set $wg1 listen-port 12345 \
+	    private-key /dev/stdin
+	pub1=$(jexec wgtest1 wg show $wg1 public-key)
+	wg2=$(jexec wgtest2 ifconfig wg create)
+	echo "$pri2" | jexec wgtest2 wg set $wg2 listen-port 12345 \
+	    private-key /dev/stdin
+	pub2=$(jexec wgtest2 wg show $wg2 public-key)
+
+	atf_check -s exit:0 -o ignore \
+	    jexec wgtest1 wg set $wg1 peer "$pub2" \
+	    endpoint ${endpoint2}:12345 allowed-ips ${tunnel2}/32
+	atf_check -s exit:0 \
+	    jexec wgtest1 ifconfig $wg1 inet ${tunnel1}/24 up
+
+	atf_check -s exit:0 -o ignore \
+	    jexec wgtest2 wg set $wg2 peer "$pub1" \
+	    endpoint ${endpoint1}:12345 allowed-ips ${tunnel1}/32
+	atf_check -s exit:0 \
+	    jexec wgtest2 ifconfig $wg2 inet ${tunnel2}/24 up
+
+	# Generous timeout since the handshake takes some time.
+	atf_check -s exit:0 -o ignore jexec wgtest1 ping -c 1 -t 5 $tunnel2
+
+	# No receive errors before injection
+	ierrs=$(netstat -j wgtest2 -I $wg2 --libxo json,pretty | \
+			awk '/received-errors/ { print $2 }')
+	atf_check_equal "0," "$ierrs"
+
+	# Trigger a decryption error
+	atf_check -s exit:0 -o ignore \
+	    sysctl debug.fail_point.crypto.inject_badmsg="1*return"
+
+	atf_check -s exit:2 -o ignore jexec wgtest1 ping -c 1 -t 5 $tunnel2
+
+	ierrs=$(netstat -j wgtest2 -I $wg2 --libxo json,pretty | \
+			awk '/received-errors/ { print $2 }')
+	atf_check_equal "1," "$ierrs"
+}
+
+wg_bad_decrypt_cleanup()
+{
+	vnet_cleanup
+}
+
+atf_init_test_cases()
+{
+	atf_add_test_case "wg_bad_decrypt"
+}


### PR DESCRIPTION
CheriBSD isn't subject to [SA-26:50.kqueue](https://www.freebsd.org/security/advisories/FreeBSD-SA-26:50.kqueue.asc), [SA-26:51.ktimer](https://www.freebsd.org/security/advisories/FreeBSD-SA-26:51.ktimer.asc), or [SA-26:53.ktrace](https://www.freebsd.org/security/advisories/FreeBSD-SA-26:53.ktrace.asc) as it's missing the upstream commits which introduced the corresponding bugs. So, this consists of patches for [SA-26:52.if_wg](https://www.freebsd.org/security/advisories/FreeBSD-SA-26:52.if_wg.asc), [SA-26:54.sysvsem](https://www.freebsd.org/security/advisories/FreeBSD-SA-26:54.sysvsem.asc), and [SA-26:55.elf](https://www.freebsd.org/security/advisories/FreeBSD-SA-26:55.elf.asc).

I did not backport the EN patches: CheriBSD is already quite behind on tzdata updates, so the patch for [SA-26:18.tzdata](https://www.freebsd.org/security/advisories/FreeBSD-EN-26:18.tzdata.asc) does not apply; [SA-26:19.zfs](https://www.freebsd.org/security/advisories/FreeBSD-EN-26:19.zfs.asc) addresses a race condition involving zvol creation and it seems unlikely that any CheriBSD users will hit it.