### PR TITLE
More cleanups to SYSV SHM

### DIFF
--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -498,11 +498,18 @@ kern_shmat_locked(struct thread *td, int shmid,
 			if ((shmflg & SHM_RDONLY) == 0)
 				reqperm |= CHERI_PERM_STORE;
 
-			/* XXX: require that a reservation exists. */
 			/* Handle any rounding above */
 			shmaddr = cheri_address_set(shmaddr, attach_va);
 			if (!cheri_can_access(shmaddr, reqperm, size))
 				return (EPROT);
+
+			/*
+			 * vm_map_find() will verify that this is
+			 * covered by an existing reservation.
+			 */
+#ifdef __CHERI_PURE_CAPABILITY__
+			attach_va = (vm_pointer_t)shmaddr;
+#endif
 		} else {
 			/* As with mmap, untagged implies exclusive. */
 			if ((shmflg & SHM_REMAP) != 0)

--- a/sys/kern/sysv_shm.c
+++ b/sys/kern/sysv_shm.c
@@ -570,11 +570,8 @@ kern_shmat_locked(struct thread *td, int shmid,
 #endif
 
 		/* Set appropriate permissions. */
-		if ((shmflg & SHM_RDONLY) != 0)
-			perm = CHERI_PERMS_USERSPACE_RODATA;
-		else
-			perm = CHERI_PERMS_USERSPACE_DATA;
-		perm |= CHERI_PERM_SW_VMEM;
+		perm = vm_prot2perms(cheri_perms_get(retaddr),
+		    (shmflg & SHM_RDONLY) != 0 ? VM_PROT_READ : VM_PROT_RW);
 		retaddr = cheri_perms_and(retaddr, perm);
 		td->td_retval[0] = retaddr;
 	} else

--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -2580,8 +2580,9 @@ vm_map_find_name_locked(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
 {
 	vm_offset_t alignment, curr_min_addr, min_addr, vaddr;
 	int gap, pidx, rv, try;
-	bool cluster, en_aslr, update_anon;
+	bool cluster, en_aslr, existing_reservation, update_anon;
 	vm_pointer_t reservation;
+	vm_offset_t reservation_id;
 	const vm_size_t unpadded_length = length;
 
 	KASSERT((cow & MAP_STACK_AREA) == 0 || object == NULL,
@@ -2611,6 +2612,7 @@ vm_map_find_name_locked(vm_map_t map, vm_object_t object, vm_ooffset_t offset,
 	}
 #endif
 
+	existing_reservation = false;
 	en_aslr = (map->flags & MAP_ASLR) != 0;
 	update_anon = cluster = clustering_anon_allowed(*addr, cow) &&
 	    (map->flags & MAP_IS_SUB_MAP) == 0 && max_addr == 0 &&
@@ -2729,16 +2731,27 @@ again:
 	} else if ((cow & MAP_REMAP) != 0) {
 		if (!vm_map_range_valid(map, vaddr, vaddr + length))
 			return (KERN_INVALID_ADDRESS);
+		if ((map->flags & MAP_RESERVATIONS) != 0) {
+			rv = vm_map_reservation_get(map, vaddr, length,
+			    &reservation_id);
+			if (rv != KERN_SUCCESS)
+				return (rv);
+			reservation = *addr;
+			existing_reservation = true;
+		}
 		rv = vm_map_delete(map, vaddr, vaddr + length, true);
 		if (rv != KERN_SUCCESS)
 			return (rv);
 	}
 
-	reservation = vaddr;
-	rv = vm_map_reservation_create_locked(map, &reservation,
-	    length, max);
-	if (rv != KERN_SUCCESS)
-		return (rv);
+	if (!existing_reservation) {
+		reservation = vaddr;
+		rv = vm_map_reservation_create_locked(map, &reservation,
+		    length, max);
+		if (rv != KERN_SUCCESS)
+			return (rv);
+		reservation_id = reservation;
+	}
 
 	/*
 	 * The guard mapping must have PROT_NONE maxprot but the capability we
@@ -2754,10 +2767,11 @@ again:
 	} else {
 		rv = vm_map_insert_name(map, object, offset, reservation,
 		    reservation + unpadded_length, prot, max, cow,
-		    reservation, name);
+		    reservation_id, name);
 	}
 	if (rv != KERN_SUCCESS) {
-		vm_map_reservation_delete_locked(map, reservation);
+		if (!existing_reservation)
+			vm_map_reservation_delete_locked(map, reservation);
 		return (rv);
 	}
 

--- a/usr.bin/kdump/kdump.c
+++ b/usr.bin/kdump/kdump.c
@@ -1332,7 +1332,7 @@ ktrsyscall_freebsd(struct ktr_syscall *ktr, register_t **resip,
 				print_number(ip, narg, c);
 				print_number(ip, narg, c);
 				putchar(',');
-				print_mask_arg(sysdecode_shmat_flags, *ip);
+				print_mask_arg0(sysdecode_shmat_flags, *ip);
 				ip++;
 				narg--;
 				break;


### PR DESCRIPTION
- **sysv_shm: Use vm_prot2perms to compute capability permissions**
- **kdump: Treat a flags argument of 0 to shmat as valid**
- **vm_map: Re-use the existing reservation for COW_REMAP**
