### PR TITLE
Various cleanups around AT_BASE

### DIFF
--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -206,6 +206,7 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
+	Elf_Phdr *phdr = NULL;
 	const Elf_Rela *rela = NULL, *relalim;
 	unsigned long relasz;
 	Elf_Addr *where;
@@ -216,8 +217,16 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 		case AT_BASE:
 			relocbase = aux->a_un.a_ptr;
 			break;
+		case AT_PHDR:
+			phdr = aux->a_un.a_ptr;
+			break;
 		}
 	}
+
+	/* Derive from AT_PHDR instead of AT_BASE in the direct-exec case. */
+	if ((ptraddr_t)relocbase + CHERI_RODATA_PTR(&__ehdr_start)->e_phoff ==
+	    (ptraddr_t)phdr)
+		relocbase = cheri_address_copy(phdr, relocbase);
 
 	for (; dynp->d_tag != DT_NULL; dynp++) {
 		switch (dynp->d_tag) {

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -104,6 +104,7 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
+	Elf_Phdr *phdr = NULL;
 	const struct capreloc *caprelocs = NULL, *caprelocslim;
 	Elf_Addr caprelocssz = 0;
 	void *pcc;
@@ -113,8 +114,16 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 		case AT_BASE:
 			relocbase = aux->a_un.a_ptr;
 			break;
+		case AT_PHDR:
+			phdr = aux->a_un.a_ptr;
+			break;
 		}
 	}
+
+	/* Derive from AT_PHDR instead of AT_BASE in the direct-exec case. */
+	if ((ptraddr_t)relocbase + CHERI_RODATA_PTR(&__ehdr_start)->e_phoff ==
+	    (ptraddr_t)phdr)
+		relocbase = cheri_address_copy(phdr, relocbase);
 
 	for (; dynp->d_tag != DT_NULL; dynp++) {
 		switch (dynp->d_tag) {

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3107,6 +3107,19 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	const Elf_Dyn *dyn_soname;
 	const Elf_Dyn *dyn_runpath;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	/*
+	 * In the direct-exec case, derive mapbase from AT_PHDR rather
+	 * than AT_BASE.
+	 */
+	if (aux_info[AT_PHDR] != NULL &&
+	    (ptraddr_t)mapbase + CHERI_RODATA_PTR(&__ehdr_start)->e_phoff ==
+	    (ptraddr_t)aux_info[AT_PHDR]->a_un.a_ptr) {
+		mapbase = cheri_address_copy(aux_info[AT_PHDR]->a_un.a_ptr,
+		    mapbase);
+	}
+#endif
+
 	/*
 	 * Conjure up an Obj_Entry structure for the dynamic linker.
 	 *

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3135,7 +3135,9 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	objtmp.text_rodata_cap = objtmp.relocbase;
+	/* Derive text_rodata_cap from the current PCC rather than AT_BASE. */
+	objtmp.text_rodata_cap = cheri_address_copy(cheri_pcc_get(),
+	    objtmp.relocbase);
 	fix_obj_mapping_cap_permissions(&objtmp, "RTLD");
 	if (!create_pcc_caps(&objtmp, "RTLD"))
 		rtld_die();

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3181,14 +3181,18 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	obj_rtld.path = xstrdup(ld_path_rtld);
 
 	parse_rtld_phdr(&obj_rtld);
-#ifndef __CHERI_PURE_CAPABILITY__
+#ifdef __CHERI_PURE_CAPABILITY__
 	/*
-	 * We would need VMMAP permissions on AT_BASE to call mprotect(). Since
-	 * this only marks one page as read-only and we have CHERI to enforce
-	 * access, don't bother calling mprotect for RTLD.
+	 * Older CheriBSD kernels do not include VMMAP permissions on
+	 * AT_BASE which is needed to call mprotect().
 	 */
+	if ((cheri_perms_get(obj_rtld.relocbase) & CHERI_PERM_SW_VMEM) == 0)
+		goto skip_relro;
+#endif
 	if (obj_enforce_relro(&obj_rtld) == -1)
 		rtld_die();
+#ifdef __CHERI_PURE_CAPABILITY__
+skip_relro:
 #endif
 
 	r_debug.r_version = R_DEBUG_VERSION;

--- a/libexec/rtld-elf/rtld.h
+++ b/libexec/rtld-elf/rtld.h
@@ -123,6 +123,9 @@ extern size_t ld_static_tls_extra;
 #ifdef TLS_TGOT
 extern size_t ld_static_tgot_extra;
 #endif
+#ifdef __CHERI_PURE_CAPABILITY__
+extern Elf_Ehdr __ehdr_start;
+#endif
 
 extern int npagesizes;
 extern size_t *pagesizes;

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1860,7 +1860,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 			 * uses AT_BASE which must be RWX as noted below.
 			 */
 			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
-			    CHERI_CAP_USER_CODE_PERMS);
+			    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
 		}
 	} else {
 		/*
@@ -1873,7 +1873,8 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 		 * can be relaxed to RW (similar to AT_PHDR).
 		 */
 		exec_base = interp_cap(imgp, args,
-		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS);
+		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS |
+		    CHERI_PERM_SW_VMEM);
 	}
 	AUXARGS_ENTRY_PTR(pos, AT_BASE, cheri_address_set(exec_base,
 	    args->base));

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1849,27 +1849,28 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	if (imgp->interp_end == 0) {
 		if (args->hdr_etype != ET_DYN) {
 			/*
-			 * For statically linked (but not static-PIE, i.e.
-			 * currently only RTLD direct exec), AT_BASE should be
-			 * untagged args->base (zero) rather than a massively
-			 * out-of-bounds capability with address zero that may
-			 * or may not be tagged.
+			 * Static PDEs don't use AT_BASE as a
+			 * capability root so it can be null-derived.
 			 */
-			exec_base = (void *__capability)(uintcap_t)args->base;
+			exec_base = NULL;
 		} else {
 			/*
-			 * For static-PIE we need AT_BASE for relocations and
-			 * therefore needs to be RWX.
-			 * TODO: should probably use AT_ENTRY/AT_PHDR instead.
+			 * Static PIEs generally use AT_ENTRY/AT_PHDR for
+			 * relocations.  However, the direct-exec rtld case
+			 * uses AT_BASE which must be RWX as noted below.
 			 */
 			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
 			    CHERI_CAP_USER_CODE_PERMS);
 		}
 	} else {
 		/*
-		 * XXX: AT_BASE is both writable and executable to permit
-		 * textrel fixups.
-		 * TODO: should probably use AT_ENTRY/AT_PHDR instead.
+		 * XXX: AT_BASE is both writable and executable because rtld
+		 * uses it as a single root to derive capabilities for rtld
+		 * itself.
+		 *
+		 * TODO: rtld should be fixed to derive code capabilities
+		 * from the initial PCC (similar to AT_ENTRY) and then this
+		 * can be relaxed to RW (similar to AT_PHDR).
 		 */
 		exec_base = interp_cap(imgp, args,
 		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS);


### PR DESCRIPTION
- **imgact_elf.c: Update commentary on AT_BASE, no functional change**
- **rtld: Derive rtld's text_rodata_cap from the initial PCC instead of AT_BASE**
- **DNM rtld: Drop execute permissions from AT_BASE**
- **rtld: Use AT_PHDR to derive data capabilities in the direct-exec case**
- **DNM imgact_elf: Use null-derived AT_BASE for all static binaries**
- **imgact_elf: Set SW_VMEM in AT_BASE to permit rtld to enforce RELRO on itself**
- **DNM rtld: Re-enable RELRO on rtld for pure-cap**
