### PR TITLE
Reduce noise in global bounds tests on RISC-V

### DIFF
--- a/bin/cheribsdtest/arm64/cheribsdtest_md.h
+++ b/bin/cheribsdtest/arm64/cheribsdtest_md.h
@@ -50,7 +50,6 @@
 
 #ifndef __CHERI_PURE_CAPABILITY__
 /* The Morello compiler currently sets bounds on globals. */
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS	NULL
 #define	XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC	NULL
 #define	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN	NULL
 #endif

--- a/bin/cheribsdtest/arm64/cheribsdtest_md.h
+++ b/bin/cheribsdtest/arm64/cheribsdtest_md.h
@@ -49,9 +49,8 @@
 #define	SI_CODE_STORELOCAL	PROT_CHERI_PERM
 
 #ifndef __CHERI_PURE_CAPABILITY__
-/* The Morello compiler currently sets bounds on globals. */
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC	NULL
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN	NULL
+/* The Morello compiler currently sets bounds on globals in hybrid. */
+#define	HAS_HYBRID_BOUNDS_GLOBALS
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -145,18 +145,18 @@ struct cheri_test {
 	const char	*ct_flaky_reason;
 };
 
-#define	_CHERIBSDTEST_DECLARE(func, desc, ...)				\
+#define	_CHERIBSDTEST_DECLARE(func, desc, line, ...)			\
 	static void func(void);						\
-	static struct cheri_test __CONCAT(__cheri_test, __LINE__) = {	\
+	static struct cheri_test __CONCAT(__cheri_test, line) = {	\
 		.ct_name = #func,					\
 		.ct_desc = (desc),					\
 		.ct_func = func,					\
 		__VA_ARGS__						\
 	};								\
-	DATA_SET(cheri_tests_set, __CONCAT(__cheri_test, __LINE__))
+	DATA_SET(cheri_tests_set, __CONCAT(__cheri_test, line))
 
 #define	CHERIBSDTEST(func, desc, ...)					\
-	_CHERIBSDTEST_DECLARE(func, (desc), __VA_ARGS__);		\
+	_CHERIBSDTEST_DECLARE(func, (desc), __COUNTER__, __VA_ARGS__);	\
 	static void func(void)
 
 /* Enum for different modes of spawning a child process */

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -106,24 +106,6 @@ extern struct cheribsdtest_child_state *ccsp;
 #define	SI_CODE_STORELOCAL	PROT_CHERI_STORELOCAL
 #endif
 
-#ifndef	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN
-#ifdef __CHERI_PURE_CAPABILITY__
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN	NULL
-#else
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN \
-    "Bounds not supported for extern globals in hybrid ABI"
-#endif
-#endif
-
-#ifndef	XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC
-#ifdef __CHERI_PURE_CAPABILITY__
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC	NULL
-#else
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC \
-    "Bounds not supported for static globals in hybrid ABI"
-#endif
-#endif
-
 #ifndef XFAIL_VARARG_BOUNDS
 #define	XFAIL_VARARG_BOUNDS	NULL
 #endif

--- a/bin/cheribsdtest/cheribsdtest.h
+++ b/bin/cheribsdtest/cheribsdtest.h
@@ -106,15 +106,6 @@ extern struct cheribsdtest_child_state *ccsp;
 #define	SI_CODE_STORELOCAL	PROT_CHERI_STORELOCAL
 #endif
 
-#ifndef	XFAIL_HYBRID_BOUNDS_GLOBALS
-#ifdef __CHERI_PURE_CAPABILITY__
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS	NULL
-#else
-#define	XFAIL_HYBRID_BOUNDS_GLOBALS \
-    "Bounds not supported for globals in hybrid ABI"
-#endif
-#endif
-
 #ifndef	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN
 #ifdef __CHERI_PURE_CAPABILITY__
 #define	XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN	NULL

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -67,9 +67,30 @@
  * globals should have the correct dynamic sizes in their underlying
  * capabilities.
  *
- * XXXRW: For now, no expectations about non-CheriABI code.
+ * XXXRW: For now, no expectations about non-CheriABI code.  Morello
+ * LLVM enforces similar semantics to CheriABI in hybrid (but with
+ * some fragile quirks), but other LLVM implementations do not provide
+ * identical semantics to CheriABI.
+ *
+ * For an example of a fragile quirk, compare these two functions:
+ *
+ * static int x;
+ *
+ * int * __capability foo() {
+ *     return (__cheri_tocap int * __capability)&x;
+ * }
+ *
+ * int * __capability bar() {
+ *     int *p = &x;
+ *     return (__cheri_tocap int * __capability)p;
+ * }
+ *
+ * In Morello LLVM, foo() always returns a bounded capability from the
+ * GOT, but bar() returns either an unbounded capability derived from
+ * DDC (-O0) or a bounded capablity from the GOT (-O1 or higher).
  */
 
+#if defined(__CHERI_PURE_CAPABILITY__) || defined(HAS_HYBRID_BOUNDS_GLOBALS)
 /*
  * Template for a test function, which assumes there is a global (test) and
  * corresponding statically initialised pointer (testp).  Check that both
@@ -79,7 +100,6 @@
 #define TEST_BOUNDS(test, desc, ...)						\
 	CHERIBSDTEST(bounds_##test,				\
 	"Check bounds on " desc,					\
-	.ct_xfail_reason = XFAIL_HYBRID_BOUNDS_GLOBALS_STATIC,		\
 	__VA_ARGS__)							\
 	{                                                               \
 		void *__capability allocation =                         \
@@ -484,7 +504,6 @@ TEST_BOUNDS(extern_global_array65536, "extern global uint8_t[16] (C size)");
 #define	TEST_DYNAMIC_BOUNDS(test, type, ...)				\
 	CHERIBSDTEST(bounds_##test,				\
 	"Check bounds on extern global " #type " (dynamic size)",	\
-	.ct_xfail_reason = XFAIL_HYBRID_BOUNDS_GLOBALS_EXTERN,		\
 	__VA_ARGS__)							\
 	{								\
 		void * __capability allocation =			\
@@ -501,3 +520,4 @@ TEST_DYNAMIC_BOUNDS(extern_global_uint64, uint64_t);
 TEST_DYNAMIC_BOUNDS(extern_global_array1, uint8_t[1]);
 TEST_DYNAMIC_BOUNDS(extern_global_array65537, uint8_t[65537]);
 TEST_DYNAMIC_BOUNDS(extern_global_array256, uint8_t[256]);
+#endif

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -104,24 +104,24 @@ test_bounds_impl(void *__capability allocation, void *__capability global_ptr, s
 	/* Global offset. */
 	if (allocation_offset != 0)
 		cheribsdtest_failure_errx(
-		    "global: non-zero offset (%ju)", allocation_offset);
+		    "local pointer: non-zero offset (%ju)", allocation_offset);
 
 	/* Global length. */
 	if (allocation_len != rounded_size)
 		cheribsdtest_failure_errx(
-		    "global: incorrect length (expected %ju, "
+		    "local pointer: incorrect length (expected %ju, "
 		    "rounded from %ju, got %ju)",
 		    rounded_size, size, allocation_len);
 
 	/* Pointer offset. */
 	if (pointer_offset != 0)
 		cheribsdtest_failure_errx(
-		    "pointer: non-zero offset (%ju)", pointer_offset);
+		    "global pointer: non-zero offset (%ju)", pointer_offset);
 
 	/* Pointer length. */
 	if (pointer_len != rounded_size)
 		cheribsdtest_failure_errx(
-		    "pointer: incorrect length (expected %ju, "
+		    "global pointer: incorrect length (expected %ju, "
 		    "rounded from %ju, got %ju)",
 		    rounded_size, size, pointer_len);
 	cheribsdtest_success();

--- a/bin/cheribsdtest/cheribsdtest_bounds_globals.c
+++ b/bin/cheribsdtest/cheribsdtest_bounds_globals.c
@@ -90,6 +90,37 @@
  * DDC (-O0) or a bounded capablity from the GOT (-O1 or higher).
  */
 
+#ifndef __CHERI_PURE_CAPABILITY__
+/*
+ * Ensure that hybrid capabilities have the same address as a
+ * non-capability pointer and sufficiently large (but not necessarily
+ * exact) bounds.
+ */
+#define	TEST_HYBRID_CAP(test, desc)					\
+	CHERIBSDTEST(hybrid_cap_##test,					\
+	"Check hybrid capability to " desc)				\
+	{								\
+		void *__capability cap =				\
+		    (__cheri_tocap void * __capability)&(test);		\
+		test_hybrid_cap_impl(cap, &(test), sizeof(test));	\
+	}
+
+static void
+test_hybrid_cap_impl(void *__capability cap, void *ptr, size_t size)
+{
+	/* Capability address should match integer pointer. */
+	CHERIBSDTEST_CHECK_EQ_LONG(cheri_address_get(cap), (uintptr_t)ptr);
+
+	CHERIBSDTEST_VERIFY(cheri_is_address_inbounds(cap, (uintptr_t)ptr));
+	CHERIBSDTEST_VERIFY(cheri_is_address_inbounds(cap, (uintptr_t)ptr +
+	    size - 1));
+
+	cheribsdtest_success();
+}
+#else
+#define	TEST_HYBRID_CAP(test, desc)
+#endif
+
 #if defined(__CHERI_PURE_CAPABILITY__) || defined(HAS_HYBRID_BOUNDS_GLOBALS)
 /*
  * Template for a test function, which assumes there is a global (test) and
@@ -97,10 +128,9 @@
  * taking a pointer to the global, and using the existing pointer, return
  * offsets and sizes as desired.
  */
-#define TEST_BOUNDS(test, desc, ...)						\
-	CHERIBSDTEST(bounds_##test,				\
-	"Check bounds on " desc,					\
-	__VA_ARGS__)							\
+#define	TEST_CAP_BOUNDS(test, desc)					\
+	CHERIBSDTEST(bounds_##test,					\
+	"Check bounds on " desc)					\
 	{                                                               \
 		void *__capability allocation =                         \
 		    (__cheri_tocap void *__capability) & test;          \
@@ -146,6 +176,13 @@ test_bounds_impl(void *__capability allocation, void *__capability global_ptr, s
 		    rounded_size, size, pointer_len);
 	cheribsdtest_success();
 }
+#else
+#define	TEST_CAP_BOUNDS(test, desc)
+#endif
+
+#define	TEST_BOUNDS(test, desc)						\
+	TEST_CAP_BOUNDS(test, desc);					\
+	TEST_HYBRID_CAP(test, desc)
 
 /*
  * Basic integer types.
@@ -493,6 +530,26 @@ TEST_BOUNDS(extern_global_uint32, "extern global uint32_t (C size)");
 TEST_BOUNDS(extern_global_array7, "extern global uint8_t[7] (C size)");
 TEST_BOUNDS(extern_global_array16, "extern global uint8_t[16] (C size)");
 TEST_BOUNDS(extern_global_array65536, "extern global uint8_t[16] (C size)");
+
+#ifndef __CHERI_PURE_CAPABILITY__
+/*
+ * Ensure that hybrid capabilities have the same address as a
+ * non-capability pointer and sufficiently large (but not necessarily
+ * exact) bounds.
+ */
+#define	TEST_DYNAMIC_HYBRID_CAP(test, type)				\
+	CHERIBSDTEST(hybrid_cap_##test,					\
+	"Check hybrid capability to extern global " #type " (dynamic size)") \
+	{								\
+		void *__capability cap =				\
+		    (__cheri_tocap void * __capability)&(test);		\
+		test_hybrid_cap_impl(cap, &(test), sizeof(type));	\
+	}
+#else
+#define	TEST_DYNAMIC_HYBRID_CAP(test, type)
+#endif
+
+#if defined(__CHERI_PURE_CAPABILITY__) || defined(HAS_HYBRID_BOUNDS_GLOBALS)
 /*
  * Template for a test function, which assumes there is a global (test) and
  * corresponding statically initialised pointer (testp).  Check that both
@@ -501,15 +558,21 @@ TEST_BOUNDS(extern_global_array65536, "extern global uint8_t[16] (C size)");
  * from which to generate a size, whereas above we assume the C type of the
  * variable is a correct source of size information.
  */
-#define	TEST_DYNAMIC_BOUNDS(test, type, ...)				\
-	CHERIBSDTEST(bounds_##test,				\
-	"Check bounds on extern global " #type " (dynamic size)",	\
-	__VA_ARGS__)							\
+#define	TEST_DYNAMIC_CAP_BOUNDS(test, type)				\
+	CHERIBSDTEST(bounds_##test,					\
+	"Check bounds on extern global " #type " (dynamic size)")	\
 	{								\
 		void * __capability allocation =			\
 		    (__cheri_tocap void * __capability)&test;		\
 		test_bounds_impl(allocation, test##p, sizeof(type));	\
 	}
+#else
+#define	TEST_DYNAMIC_CAP_BOUNDS(test, type)
+#endif
+
+#define	TEST_DYNAMIC_BOUNDS(test, desc)					\
+	TEST_DYNAMIC_CAP_BOUNDS(test, desc);				\
+	TEST_DYNAMIC_HYBRID_CAP(test, desc)
 
 /*
  * Checks to ensure we are using linker-provided size information, and not C
@@ -520,4 +583,3 @@ TEST_DYNAMIC_BOUNDS(extern_global_uint64, uint64_t);
 TEST_DYNAMIC_BOUNDS(extern_global_array1, uint8_t[1]);
 TEST_DYNAMIC_BOUNDS(extern_global_array65537, uint8_t[65537]);
 TEST_DYNAMIC_BOUNDS(extern_global_array256, uint8_t[256]);
-#endif


### PR DESCRIPTION
- **cheribsdtest: Adjust labels on global bounds tests**
- **cheribsdtest: Remove unused macro**
- **cheribsdtest: Don't check bounds on globals for hybrid other than Morello**
- **cheribsdtest: Use __COUNTER__ instead of __LINE__**
- **cheribsdtest: Add hybrid-specific tests for capability pointers to globals**
