### PR TITLE
Remove the remaining bits of interrupt-parent support

### DIFF
--- a/lib/libdevinfo/devinfo.3
+++ b/lib/libdevinfo/devinfo.3
@@ -34,7 +34,6 @@
 .Nm devinfo_handle_to_resource ,
 .Nm devinfo_handle_to_rman ,
 .Nm devinfo_foreach_device_child ,
-.Nm devinfo_foreach_device_intr_child ,
 .Nm devinfo_foreach_device_resource ,
 .Nm devinfo_foreach_rman_resource ,
 .Nm devinfo_foreach_rman
@@ -55,12 +54,6 @@
 .Fn devinfo_handle_to_rman "devinfo_handle_t handle"
 .Ft int
 .Fo devinfo_foreach_device_child
-.Fa "struct devinfo_dev *parent"
-.Fa "int \*[lp]*fn\*[rp]\*[lp]struct devinfo_dev *child, void *arg\*[rp]"
-.Fa "void *arg"
-.Fc
-.Ft int
-.Fo devinfo_foreach_device_intr_child
 .Fa "struct devinfo_dev *parent"
 .Fa "int \*[lp]*fn\*[rp]\*[lp]struct devinfo_dev *child, void *arg\*[rp]"
 .Fa "void *arg"
@@ -168,11 +161,9 @@ is passed the constant
 it will return the handle to the root of the device tree.
 .Pp
 .Fn devinfo_foreach_device_child
-and
-.Fn devinfo_foreach_device_intr_child
-invoke its callback argument
+invokes its callback argument
 .Fa fn
-on every device which is an immediate child or interrupt child of
+on every device which is an immediate child of
 .Fa device .
 The
 .Fa fn

--- a/lib/libdevinfo/devinfo.c
+++ b/lib/libdevinfo/devinfo.c
@@ -482,25 +482,6 @@ devinfo_foreach_device_child(struct devinfo_dev *parent,
 }
 
 /*
- * Iterate over the interrupt children of a device, calling (fn) on each.
- * If (fn) returns nonzero, abort the scan and return.
- */
-int
-devinfo_foreach_device_intr_child(struct devinfo_dev *parent, 
-    int (* fn)(struct devinfo_dev *child, void *arg), 
-    void *arg)
-{
-	struct devinfo_i_dev	*dd;
-	int				error;
-
-	TAILQ_FOREACH(dd, &devinfo_dev, dd_link)
-	    if (dd->dd_dev.dd_intr_parent == parent->dd_handle)
-		    if ((error = fn(&dd->dd_dev, arg)) != 0)
-			    return(error);
-	return(0);
-}
-
-/*
  * Iterate over all the resources owned by a device, calling (fn) on each.
  * If (fn) returns nonzero, abort the scan and return.
  */

--- a/lib/libdevinfo/devinfo.h
+++ b/lib/libdevinfo/devinfo.h
@@ -50,7 +50,6 @@ struct devinfo_dev {
 	uint32_t		dd_devflags;	/* API flags */
 	uint16_t		dd_flags;	/* internal dev flags */
 	devinfo_state_t		dd_state;	/* attachment state of dev */
-	devinfo_handle_t	dd_intr_parent;	/* Interrupt parent */
 };
 
 struct devinfo_rman {
@@ -104,15 +103,6 @@ extern struct devinfo_rman
  */
 extern int
 	devinfo_foreach_device_child(struct devinfo_dev *parent, 
-	    int (* fn)(struct devinfo_dev *child, void *arg), 
-	    void *arg);
-
-/*
- * Iterate over the interrupt children of a device, calling (fn) on each.  If
- * If (fn) returns nonzero, abort the scan and return.
- */
-extern int
-	devinfo_foreach_device_intr_child(struct devinfo_dev *parent, 
 	    int (* fn)(struct devinfo_dev *child, void *arg), 
 	    void *arg);
 

--- a/usr.sbin/devinfo/devinfo.c
+++ b/usr.sbin/devinfo/devinfo.c
@@ -45,7 +45,6 @@
 #include <libxo/xo.h>
 #include "devinfo.h"
 
-static bool	iflag;
 static bool	rflag;
 static bool	vflag;
 static int	open_tag_count;
@@ -197,10 +196,6 @@ print_device_rman_resources(struct devinfo_rman *rman, void *arg)
 	ia->indent = 0;
 	if (devinfo_foreach_rman_resource(rman,
 	    print_device_matching_resource, ia) != 0) {
-		/* XXX: Resources should have types... */
-		if (iflag && !rflag &&
-		    strncmp("Interrupt", rman->dm_desc, 9) != 0)
-			goto skip;
 
 		/* there are, print header */
 		safe_desc = xml_safe_string(rman->dm_desc);
@@ -216,7 +211,6 @@ print_device_rman_resources(struct devinfo_rman *rman, void *arg)
 		xo_close_list(safe_desc);
 		free(safe_desc);
 	}
-skip:
 	ia->indent = indent;
 	return(0);
 }
@@ -263,7 +257,7 @@ print_device_props(struct devinfo_dev *dev)
 }
 
 /*
- * Print information about a device and its children.
+ * Print information about a device.
  */
 static int
 print_device(struct devinfo_dev *dev, void *arg)
@@ -283,7 +277,7 @@ print_device(struct devinfo_dev *dev, void *arg)
 
 		print_device_props(dev);
 		xo_emit("\n");
-		if (iflag || rflag) {
+		if (rflag) {
 			ia.indent = indent + 4;
 			ia.arg = dev;
 			devinfo_foreach_rman(print_device_rman_resources,
@@ -291,12 +285,8 @@ print_device(struct devinfo_dev *dev, void *arg)
 		}
 	}
 
-	if (iflag)
-		ret = (devinfo_foreach_device_intr_child(dev, print_device,
-		    (void *)((char *)arg + 2)));
-	else
-		ret = (devinfo_foreach_device_child(dev, print_device,
-		    (void *)((char *)arg + 2)));
+	ret = (devinfo_foreach_device_child(dev, print_device,
+	    (void *)((char *)arg + 2)));
 
 	if (printit) {
 		xo_close_container(devname);
@@ -463,11 +453,8 @@ main(int argc, char *argv[])
 	}
 
 	uflag = false;
-	while ((c = getopt(argc, argv, "ip:ruv")) != -1) {
+	while ((c = getopt(argc, argv, "p:ruv")) != -1) {
 		switch(c) {
-		case 'i':
-			iflag = true;
-			break;
 		case 'p':
 			path = optarg;
 			break;
@@ -510,11 +497,7 @@ main(int argc, char *argv[])
 	} else {
 		/* print device hierarchy */
 		xo_open_container("device-information");
-		if (iflag)
-			devinfo_foreach_device_intr_child(root, print_device,
-			    NULL);
-		else
-			devinfo_foreach_device_child(root, print_device, NULL);
+		devinfo_foreach_device_child(root, print_device, (void *)0);
 		xo_close_container("device-information");
 	}
 


### PR DESCRIPTION
The last remaining kernel bits were removed back in 2018 after the
removal of MIPS (though the export of the info from the kernel was
broken even earlier).  While this does remove a symbol from
libdevinfo, it shouldn't be used by anything other than devinfo(8), so
should be harmless.

This reverts commit 2df63e70d0a071d3efe61bc0698b60cbc4003164.
