### PR TITLE
Remove AT_BASE compat shims

### DIFF
--- a/libexec/rtld-elf/aarch64/reloc.c
+++ b/libexec/rtld-elf/aarch64/reloc.c
@@ -207,7 +207,7 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
-	const Elf_Phdr *phdr = NULL;
+	Elf_Phdr *phdr = NULL;
 	const Elf_Rela *rela = NULL, *relalim;
 	size_t phnum = 0;
 	unsigned long relasz;
@@ -233,6 +233,10 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 			break;
 		}
 	}
+
+	/* Derive from AT_PHDR instead of AT_BASE in the direct-exec case. */
+	if (cheri_is_address_inbounds(phdr, (uintptr_t)relocbase))
+		relocbase = cheri_address_copy(phdr, relocbase);
 
 	for (; phnum > 0; phdr++, phnum--) {
 		if (phdr->p_type == PT_CHERI_PCC) {

--- a/libexec/rtld-elf/riscv/reloc.c
+++ b/libexec/rtld-elf/riscv/reloc.c
@@ -104,7 +104,7 @@ void
 _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 {
 	caddr_t relocbase = NULL;
-	const Elf_Phdr *phdr = NULL;
+	Elf_Phdr *phdr = NULL;
 	const struct capreloc *caprelocs = NULL, *caprelocslim;
 	Elf_Addr caprelocssz = 0;
 	size_t phnum = 0;
@@ -129,6 +129,10 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Auxinfo *aux)
 			break;
 		}
 	}
+
+	/* Derive from AT_PHDR instead of AT_BASE in the direct-exec case. */
+	if (cheri_is_address_inbounds(phdr, (uintptr_t)relocbase))
+		relocbase = cheri_address_copy(phdr, relocbase);
 
 	for (; phnum > 0; phdr++, phnum--) {
 		if (phdr->p_type == PT_CHERI_PCC) {

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3141,7 +3141,9 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-	objtmp.text_rodata_cap = objtmp.relocbase;
+	/* Derive text_rodata_cap from the current PCC rather than AT_BASE. */
+	objtmp.text_rodata_cap = cheri_address_copy(cheri_pcc_get(),
+	    objtmp.relocbase);
 	fix_obj_mapping_cap_permissions(&objtmp, "RTLD");
 	if (!create_pcc_caps(&objtmp, "RTLD"))
 		rtld_die();

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3187,14 +3187,18 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	obj_rtld.path = xstrdup(ld_path_rtld);
 
 	parse_rtld_phdr(&obj_rtld);
-#ifndef __CHERI_PURE_CAPABILITY__
+#ifdef __CHERI_PURE_CAPABILITY__
 	/*
-	 * We would need VMMAP permissions on AT_BASE to call mprotect(). Since
-	 * this only marks one page as read-only and we have CHERI to enforce
-	 * access, don't bother calling mprotect for RTLD.
+	 * Older CheriBSD kernels do not include VMMAP permissions on
+	 * AT_BASE which is needed to call mprotect().
 	 */
+	if ((cheri_perms_get(obj_rtld.relocbase) & CHERI_PERM_SW_VMEM) == 0)
+		goto skip_relro;
+#endif
 	if (obj_enforce_relro(&obj_rtld) == -1)
 		rtld_die();
+#ifdef __CHERI_PURE_CAPABILITY__
+skip_relro:
 #endif
 
 	r_debug.r_version = R_DEBUG_VERSION;

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3113,6 +3113,19 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	const Elf_Dyn *dyn_soname;
 	const Elf_Dyn *dyn_runpath;
 
+#ifdef __CHERI_PURE_CAPABILITY__
+	/*
+	 * In the direct-exec case, derive mapbase from AT_PHDR rather
+	 * than AT_BASE.
+	 */
+	if (aux_info[AT_PHDR] != NULL &&
+	    cheri_is_address_inbounds(aux_info[AT_PHDR]->a_un.a_ptr,
+	    (uintptr_t)mapbase)) {
+		mapbase = cheri_address_copy(aux_info[AT_PHDR]->a_un.a_ptr,
+		    mapbase);
+	}
+#endif
+
 	/*
 	 * Conjure up an Obj_Entry structure for the dynamic linker.
 	 *

--- a/libexec/rtld-elf/rtld.c
+++ b/libexec/rtld-elf/rtld.c
@@ -3187,19 +3187,8 @@ init_rtld(caddr_t mapbase, Elf_Auxinfo **aux_info)
 	obj_rtld.path = xstrdup(ld_path_rtld);
 
 	parse_rtld_phdr(&obj_rtld);
-#ifdef __CHERI_PURE_CAPABILITY__
-	/*
-	 * Older CheriBSD kernels do not include VMMAP permissions on
-	 * AT_BASE which is needed to call mprotect().
-	 */
-	if ((cheri_perms_get(obj_rtld.relocbase) & CHERI_PERM_SW_VMEM) == 0)
-		goto skip_relro;
-#endif
 	if (obj_enforce_relro(&obj_rtld) == -1)
 		rtld_die();
-#ifdef __CHERI_PURE_CAPABILITY__
-skip_relro:
-#endif
 
 	r_debug.r_version = R_DEBUG_VERSION;
 	r_debug.r_brk = make_rtld_local_function_pointer(r_debug_state);

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1860,7 +1860,7 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 			 * uses AT_BASE which must be RWX as noted below.
 			 */
 			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
-			    CHERI_CAP_USER_CODE_PERMS);
+			    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
 		}
 	} else {
 		/*
@@ -1873,7 +1873,8 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 		 * can be relaxed to RW (similar to AT_PHDR).
 		 */
 		exec_base = interp_cap(imgp, args,
-		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS);
+		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS |
+		    CHERI_PERM_SW_VMEM);
 	}
 	AUXARGS_ENTRY_PTR(pos, AT_BASE, cheri_address_set(exec_base,
 	    args->base));

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1849,27 +1849,28 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	if (imgp->interp_end == 0) {
 		if (args->hdr_etype != ET_DYN) {
 			/*
-			 * For statically linked (but not static-PIE, i.e.
-			 * currently only RTLD direct exec), AT_BASE should be
-			 * untagged args->base (zero) rather than a massively
-			 * out-of-bounds capability with address zero that may
-			 * or may not be tagged.
+			 * Static PDEs don't use AT_BASE as a
+			 * capability root so it can be null-derived.
 			 */
-			exec_base = (void *__capability)(uintcap_t)args->base;
+			exec_base = NULL;
 		} else {
 			/*
-			 * For static-PIE we need AT_BASE for relocations and
-			 * therefore needs to be RWX.
-			 * TODO: should probably use AT_ENTRY/AT_PHDR instead.
+			 * Static PIEs generally use AT_ENTRY/AT_PHDR for
+			 * relocations.  However, the direct-exec rtld case
+			 * uses AT_BASE which must be RWX as noted below.
 			 */
 			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
 			    CHERI_CAP_USER_CODE_PERMS);
 		}
 	} else {
 		/*
-		 * XXX: AT_BASE is both writable and executable to permit
-		 * textrel fixups.
-		 * TODO: should probably use AT_ENTRY/AT_PHDR instead.
+		 * XXX: AT_BASE is both writable and executable because rtld
+		 * uses it as a single root to derive capabilities for rtld
+		 * itself.
+		 *
+		 * TODO: rtld should be fixed to derive code capabilities
+		 * from the initial PCC (similar to AT_ENTRY) and then this
+		 * can be relaxed to RW (similar to AT_PHDR).
 		 */
 		exec_base = interp_cap(imgp, args,
 		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS);

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1857,23 +1857,19 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 			/*
 			 * Static PIEs generally use AT_ENTRY/AT_PHDR for
 			 * relocations.  However, the direct-exec rtld case
-			 * uses AT_BASE which must be RWX as noted below.
+			 * uses AT_BASE which must be RW as noted below.
 			 */
 			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
-			    CHERI_CAP_USER_CODE_PERMS | CHERI_PERM_SW_VMEM);
+			    CHERI_PERM_SW_VMEM);
 		}
 	} else {
 		/*
-		 * XXX: AT_BASE is both writable and executable because rtld
-		 * uses it as a single root to derive capabilities for rtld
-		 * itself.
-		 *
-		 * TODO: rtld should be fixed to derive code capabilities
-		 * from the initial PCC (similar to AT_ENTRY) and then this
-		 * can be relaxed to RW (similar to AT_PHDR).
+		 * AT_BASE is used by rtld to process its own
+		 * relocations and to derive data capabilities similar
+		 * to AT_PHDR.  rtld uses the initial PCC to derive
+		 * code capabilities similar to AT_ENTRY.
 		 */
-		exec_base = interp_cap(imgp, args,
-		    CHERI_CAP_USER_DATA_PERMS | CHERI_CAP_USER_CODE_PERMS |
+		exec_base = interp_cap(imgp, args, CHERI_CAP_USER_DATA_PERMS |
 		    CHERI_PERM_SW_VMEM);
 	}
 	AUXARGS_ENTRY_PTR(pos, AT_BASE, cheri_address_set(exec_base,

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -1847,21 +1847,11 @@ __elfN(freebsd_copyout_auxargs)(struct image_params *imgp, uintcap_t base)
 	AUXARGS_ENTRY_PTR(pos, AT_ENTRY, entry);
 
 	if (imgp->interp_end == 0) {
-		if (args->hdr_etype != ET_DYN) {
-			/*
-			 * Static PDEs don't use AT_BASE as a
-			 * capability root so it can be null-derived.
-			 */
-			exec_base = NULL;
-		} else {
-			/*
-			 * Static PIEs generally use AT_ENTRY/AT_PHDR for
-			 * relocations.  However, the direct-exec rtld case
-			 * uses AT_BASE which must be RW as noted below.
-			 */
-			exec_base = prog_cap(imgp, CHERI_CAP_USER_DATA_PERMS |
-			    CHERI_PERM_SW_VMEM);
-		}
+		/*
+		 * Static binaries don't use AT_BASE as a
+		 * capability root so it can be null-derived.
+		 */
+		exec_base = NULL;
 	} else {
 		/*
 		 * AT_BASE is used by rtld to process its own


### PR DESCRIPTION
- **imgact_elf: Drop execute permissions from AT_BASE**
- **imgact_elf: Use null-derived AT_BASE for all static binaries**
- **rtld: Remove RELRO-related compat shim for older kernels**
