### PR TITLE
Drop local changes to disable tests when running on softfp

### DIFF
--- a/lib/libc/tests/stdio/printfloat_test.c
+++ b/lib/libc/tests/stdio/printfloat_test.c
@@ -259,9 +259,7 @@ ATF_TC_BODY(padding_and_decimal_point_placement, tc)
 ATF_TC_WITHOUT_HEAD(decimal_rounding);
 ATF_TC_BODY(decimal_rounding, tc)
 {
-#ifndef _FLOAT_IEEE754
-	atf_tc_skip("Test not applicable on this architecture.");
-#else
+
 	ATF_REQUIRE(setlocale(LC_NUMERIC, "C"));
 
 	fesetround(FE_DOWNWARD);
@@ -287,7 +285,6 @@ ATF_TC_BODY(decimal_rounding, tc)
 	testfmt("-4.438", "%.3f", -4.4375);
 	testfmt("4.438", "%.3Lf", 4.4375L);
 	testfmt("-4.438", "%.3Lf", -4.4375L);
-#endif /* _FLOAT_IEEE754 */
 }
 
 ATF_TC_WITHOUT_HEAD(hexadecimal_floating_point);

--- a/lib/libc/tests/stdio/scanfloat_test.c
+++ b/lib/libc/tests/stdio/scanfloat_test.c
@@ -200,10 +200,6 @@ ATF_TC_BODY(infinities_and_nans, tc)
 ATF_TC_WITHOUT_HEAD(rounding_tests);
 ATF_TC_BODY(rounding_tests, tc)
 {
-#ifndef _FLOAT_IEEE754
-	atf_tc_skip("Test not applicable on this architecture.");
-#else
-
 	long double ld = 0.0;
 	double d = 0.0;
 
@@ -278,15 +274,11 @@ ATF_TC_BODY(rounding_tests, tc)
 	/* Extra digits in a denormal shouldn't break anything. */
 	ATF_REQUIRE_EQ(1, sscanf("0x1.2345678p-1050", "%le", &d));
 	ATF_CHECK(d == 0x1.234568p-1050);
-#endif /* _FLOAT_IEEE754 */
 }
 
 ATF_TC_WITHOUT_HEAD(strtod);
 ATF_TC_BODY(strtod, tc)
 {
-#ifndef _FLOAT_IEEE754
-	atf_tc_skip("Test not applicable on this architecture.");
-#else
 	char *endp;
 
 	ATF_REQUIRE(setlocale(LC_NUMERIC, "C"));
@@ -307,7 +299,6 @@ ATF_TC_BODY(strtod, tc)
 	ATF_REQUIRE_EQ(0, fesetround(FE_TONEAREST));
 	ATF_CHECK(strtof("3.5e38", &endp) == INFINITY);
 	ATF_CHECK(strtod("2e308", &endp) == INFINITY);
-#endif /* _FLOAT_IEEE754 */
 }
 
 ATF_TP_ADD_TCS(tp)

--- a/lib/msun/tests/trig_test.c
+++ b/lib/msun/tests/trig_test.c
@@ -85,9 +85,6 @@ ATF_TC_HEAD(special, tc)
 }
 ATF_TC_BODY(special, tc)
 {
-#ifndef	_FLOAT_IEEE754
-atf_tc_skip("Test not applicable on this architecture.");
-#else
 
 	/* Values at 0 should be exact. */
 	testall(tan, 0.0, 0.0, ALL_STD_EXCEPT, 0);
@@ -109,7 +106,6 @@ atf_tc_skip("Test not applicable on this architecture.");
 	testall(tan, NAN, NAN, ALL_STD_EXCEPT, 0);
 	testall(sin, NAN, NAN, ALL_STD_EXCEPT, 0);
 	testall(cos, NAN, NAN, ALL_STD_EXCEPT, 0);
-#endif /* _FLOAT_IEEE754 */
 }
 
 #ifndef __i386__


### PR DESCRIPTION
Both CheriBSD and FreeBSD no longer support any soft-float userspace
ABIs.

This reverts commit db7b518dba2180d7ca56c8ac3b2e1414ebe11feb.
This reverts commit c7d69ddacf7571ffb5d383dd90be58c5dcba33a2.
