### PR TITLE
Centralize disabling blocks compiler feature for CHERI LLVM

### DIFF
--- a/lib/libc/tests/gen/Makefile
+++ b/lib/libc/tests/gen/Makefile
@@ -8,10 +8,7 @@ ATF_TESTS_C+=		fmtmsg_test
 ATF_TESTS_C+=		fnmatch2_test
 ATF_TESTS_C+=		fpclassify2_test
 .if ${COMPILER_FEATURES:Mblocks}
-.if !${MACHINE_ABI:Mpurecap}
-# See https://github.com/CTSRD-CHERI/llvm-project/issues/671
 ATF_TESTS_C+=		fts_blocks_test
-.endif
 .endif
 ATF_TESTS_C+=		fts_options_test
 ATF_TESTS_C+=		ftw_test
@@ -19,10 +16,7 @@ ATF_TESTS_C+=		getentropy_test
 ATF_TESTS_C+=		getmntinfo_test
 ATF_TESTS_C+=		glob2_test
 .if ${COMPILER_FEATURES:Mblocks}
-.if !${MACHINE_ABI:Mpurecap}
-# See https://github.com/CTSRD-CHERI/llvm-project/issues/671
 ATF_TESTS_C+=		glob_blocks_test
-.endif
 .endif
 ATF_TESTS_C+=		makecontext_test
 ATF_TESTS_C+=		popen_test

--- a/lib/libc/tests/stdlib/Makefile
+++ b/lib/libc/tests/stdlib/Makefile
@@ -10,10 +10,7 @@ ATF_TESTS_C+=		mergesort_test
 ATF_TESTS_C+=		timsort_test
 ATF_TESTS_C+=		qsort_test
 .if ${COMPILER_FEATURES:Mblocks}
-.if !${MACHINE_ABI:Mpurecap}
-# See https://github.com/CTSRD-CHERI/llvm-project/issues/671
 ATF_TESTS_C+=		qsort_b_test
-.endif
 .endif
 ATF_TESTS_C+=		qsort_r_compat_test
 ATF_TESTS_C+=		qsort_r_test

--- a/share/mk/bsd.compiler.mk
+++ b/share/mk/bsd.compiler.mk
@@ -265,7 +265,10 @@ ${X_}COMPILER_FEATURES+=	c++20
 ${X_}COMPILER_FEATURES+=	init-all
 .endif
 .if ${${X_}COMPILER_TYPE} == "clang"
+# CHERI LLVM compilers don't support blocks yet
+.if !${MACHINE_ABI:Mpurecap}
 ${X_}COMPILER_FEATURES+=	blocks
+.endif
 ${X_}COMPILER_FEATURES+=	retpoline
 # PR257638 lld fails with BE compressed debug.  Fixed in main but external tool
 # chains will initially not have the fix.  For now limit the feature to LE


### PR DESCRIPTION
- **bsd.compiler.mk: CHERI LLVM doesn't support blocks yet**
- **libc: Revert local diffs to disable tests using blocks for purecap**
